### PR TITLE
Fix validation of inputs that aren't text

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -59,10 +59,24 @@ function highlightBorder($element, highlight) {
 	return highlight;
 }
 
+function isInputValid($input) {
+	var optional = $input.hasClass('optional');
+	switch ($input.attr('type')) {
+		case 'text':
+		case 'password':
+			if ($input.val() === '' && !optional) {
+				return false;
+			}
+			break;
+	}
+	return true;
+}
+
 function highlightInput($input) {
-	if ($input.attr('type') === 'text' || $input.attr('type') === 'password') {
-		return highlightBorder($input,
-			($input.val() === '' && !$input.hasClass('optional')));
+	switch ($input.attr('type')) {
+		case 'text':
+		case 'password':
+			return highlightBorder($input, !isInputValid($input));
 	}
 }
 
@@ -952,7 +966,7 @@ MountConfigListView.prototype = _.extend({
 			if ($input.attr('type') === 'button') {
 				return;
 			}
-			if ($input.val() === '' && !$input.hasClass('optional')) {
+			if (!isInputValid($input)) {
 				missingOptions.push(parameter);
 				return;
 			}


### PR DESCRIPTION
This caused storages containing a checkbox input to not get checked when loading the settings, since `.val()` on a checkbox returns an empty string, and the JS thinks the storage is missing non-optional parameters. It also paves the way for better validation of other input types.

To test:
1. Create a storage with some checkbox parameters (inception ownCloud is suitable)
2. Configure storage and notice the green dot
3. Reload the page, notice no status indicator of any kind
4. With this PR, green dot appears again on page load

cc @PVince81 @icewind1991 
