### PR TITLE
Avoid error message in log during setup because of existing data dir

### DIFF
--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -194,7 +194,9 @@ class Setup {
 		// Create data directory to test whether the .htaccess works
 		// Notice that this is not necessarily the same data directory as the one
 		// that will effectively be used.
-		@mkdir($dataDir);
+		if(!file_exists($dataDir)) {
+			@mkdir($dataDir);
+		}
 		$htAccessWorking = true;
 		if (is_dir($dataDir) && is_writable($dataDir)) {
 			// Protect data directory here, so we can test if the protection is working


### PR DESCRIPTION
cc @nickvergessen @LukasReschke 

Avoids this during setup:

```
{"reqId":"cNOhn3FopIIXd65gJJu1","remoteAddr":"::1","app":"PHP","message":"mkdir(): File exists at \/Users\/morrisjobke\/Projects\/owncloud\/master\/lib\/private\/setup.php#197","level":0,"time":"2016-01-26T17:43:28+00:00","method":"GET","url":"\/master\/index.php\/apps\/files\/"}
```
