### PR TITLE
provide info about plugin, and do not run commit ourselves on proppatch

### DIFF
--- a/apps/dav/lib/comments/commentnode.php
+++ b/apps/dav/lib/comments/commentnode.php
@@ -170,7 +170,6 @@ class CommentNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 	function propPatch(PropPatch $propPatch) {
 		// other properties than 'message' are read only
 		$propPatch->handle('{'.self::NS_OWNCLOUD.'}message', [$this, 'updateComment']);
-		$propPatch->commit();
 	}
 
 	/**

--- a/apps/dav/lib/comments/commentsplugin.php
+++ b/apps/dav/lib/comments/commentsplugin.php
@@ -43,6 +43,7 @@ class CommentsPlugin extends ServerPlugin {
 	// namespace
 	const NS_OWNCLOUD = 'http://owncloud.org/ns';
 
+	const REPORT_NAME            = '{http://owncloud.org/ns}filter-comments';
 	const REPORT_PARAM_LIMIT     = '{http://owncloud.org/ns}limit';
 	const REPORT_PARAM_OFFSET    = '{http://owncloud.org/ns}offset';
 	const REPORT_PARAM_TIMESTAMP = '{http://owncloud.org/ns}datetime';
@@ -125,6 +126,18 @@ class CommentsPlugin extends ServerPlugin {
 	}
 
 	/**
+	 * Returns a list of reports this plugin supports.
+	 *
+	 * This will be used in the {DAV:}supported-report-set property.
+	 *
+	 * @param string $uri
+	 * @return array
+	 */
+	public function getSupportedReportSet($uri) {
+		return [self::REPORT_NAME];
+	}
+
+	/**
 	 * REPORT operations to look for comments
 	 *
 	 * @param string $reportName
@@ -136,7 +149,7 @@ class CommentsPlugin extends ServerPlugin {
 	 */
 	public function onReport($reportName, $report, $uri) {
 		$node = $this->server->tree->getNodeForPath($uri);
-		if(!$node instanceof EntityCollection) {
+		if(!$node instanceof EntityCollection || $reportName !== self::REPORT_NAME) {
 			throw new ReportNotSupported();
 		}
 		$args = ['limit' => 0, 'offset' => 0, 'datetime' => null];

--- a/apps/dav/tests/unit/comments/commentnode.php
+++ b/apps/dav/tests/unit/comments/commentnode.php
@@ -114,9 +114,6 @@ class CommentsNode extends \Test\TestCase {
 			->method('handle')
 			->with('{http://owncloud.org/ns}message');
 
-		$propPatch->expects($this->once())
-			->method('commit');
-
 		$this->node->propPatch($propPatch);
 	}
 

--- a/apps/dav/tests/unit/comments/commentsplugin.php
+++ b/apps/dav/tests/unit/comments/commentsplugin.php
@@ -517,7 +517,26 @@ class CommentsPlugin extends \Test\TestCase {
 			->will($this->returnValue($path));
 		$this->plugin->initialize($this->server);
 
-		$this->plugin->onReport('', [], '/' . $path);
+		$this->plugin->onReport(CommentsPluginImplementation::REPORT_NAME, [], '/' . $path);
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\ReportNotSupported
+	 */
+	public function testOnReportInvalidReportName() {
+		$path = 'comments/files/42';
+
+		$this->tree->expects($this->any())
+			->method('getNodeForPath')
+			->with('/' . $path)
+			->will($this->returnValue($this->getMock('\Sabre\DAV\INode')));
+
+		$this->server->expects($this->any())
+			->method('getRequestUri')
+			->will($this->returnValue($path));
+		$this->plugin->initialize($this->server);
+
+		$this->plugin->onReport('{whoever}whatever', [], '/' . $path);
 	}
 
 	public function testOnReportDateTimeEmpty() {
@@ -572,7 +591,7 @@ class CommentsPlugin extends \Test\TestCase {
 		$this->server->httpResponse = $response;
 		$this->plugin->initialize($this->server);
 
-		$this->plugin->onReport('', $parameters, '/' . $path);
+		$this->plugin->onReport(CommentsPluginImplementation::REPORT_NAME, $parameters, '/' . $path);
 	}
 
 	public function testOnReport() {
@@ -627,7 +646,7 @@ class CommentsPlugin extends \Test\TestCase {
 		$this->server->httpResponse = $response;
 		$this->plugin->initialize($this->server);
 
-		$this->plugin->onReport('', $parameters, '/' . $path);
+		$this->plugin->onReport(CommentsPluginImplementation::REPORT_NAME, $parameters, '/' . $path);
 	}
 
 


### PR DESCRIPTION
`getSupportedReportSet` need for compliance reasons, cf https://github.com/owncloud/core/issues/20264#issuecomment-175133636

With that move, I also enforced the check of the report name. I.e. your XML you send with report must contain "filter-comments" as report name, like

``` xml
<?xml version="1.0" encoding="utf-8" ?>
<oc:filter-comments xmlns:D="DAV:" xmlns:oc="http://owncloud.org/ns" >
  <oc:limit>22</oc:limit>
  <oc:offset>0</oc:offset>
  <oc:datetime>2016-01-21 18:47:30</oc:datetime>
</oc:filter-comments>
```

remove `commit()` call on proppatch, cf. https://github.com/owncloud/core/pull/21664#discussion_r50864286

 @PVince81 @evert Thumbs? :)
