### PR TITLE
[Share 2.0] Properly handle user deleted group shares

### DIFF
--- a/apps/files_sharing/api/share20ocs.php
+++ b/apps/files_sharing/api/share20ocs.php
@@ -335,7 +335,9 @@ class Share20OCS {
 
 		$formatted = [];
 		foreach ($shares as $share) {
-			$formatted[] = $this->formatShare($share);
+			if ($this->canAccessShare($share)) {
+				$formatted[] = $this->formatShare($share);
+			}
 		}
 
 		return new \OC_OCS_Result($formatted);
@@ -430,6 +432,11 @@ class Share20OCS {
 	 * @return bool
 	 */
 	protected function canAccessShare(IShare $share) {
+		// A file with permissions 0 can't be accessed by us. So Don't show it
+		if ($share->getPermissions() === 0) {
+			return false;
+		}
+
 		// Owner of the file and the sharer of the file can always get share
 		if ($share->getShareOwner() === $this->currentUser ||
 			$share->getSharedBy() === $this->currentUser

--- a/lib/private/share20/defaultshareprovider.php
+++ b/lib/private/share20/defaultshareprovider.php
@@ -697,7 +697,7 @@ class DefaultShareProvider implements IShareProvider {
 		$stmt->closeCursor();
 
 		if ($data !== false) {
-			$share->setPermissions($data['permissions']);
+			$share->setPermissions((int)$data['permissions']);
 			$share->setTarget($data['file_target']);
 		}
 

--- a/tests/lib/share20/defaultshareprovidertest.php
+++ b/tests/lib/share20/defaultshareprovidertest.php
@@ -943,13 +943,13 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->assertCount(1, $share);
 
 		$share = $share[0];
-		$this->assertEquals($id, $share->getId());
-		$this->assertEquals($group, $share->getSharedWith());
-		$this->assertEquals($owner, $share->getShareOwner());
-		$this->assertEquals($initiator, $share->getSharedBy());
-		$this->assertEquals(\OCP\Share::SHARE_TYPE_GROUP, $share->getShareType());
-		$this->assertEquals(0, $share->getPermissions());
-		$this->assertEquals('userTarget', $share->getTarget());
+		$this->assertSame($id, $share->getId());
+		$this->assertSame($group, $share->getSharedWith());
+		$this->assertSame($owner, $share->getShareOwner());
+		$this->assertSame($initiator, $share->getSharedBy());
+		$this->assertSame(\OCP\Share::SHARE_TYPE_GROUP, $share->getShareType());
+		$this->assertSame(0, $share->getPermissions());
+		$this->assertSame('userTarget', $share->getTarget());
 	}
 
 	public function testGetSharesBy() {


### PR DESCRIPTION
### Assume:
1. `user1` is in `group1`
2. `user0` shares a file/folder with `group1`
3. `user1` fetches shared with me
4. `user1` deletes the file/folder
5. `user1` fetches shared with me
### Before:

At 3 the group share is returned as is.
At step 5 the the modified group share is returned (with permissions set to 0).
### After:

At 3 the group share is returned as is.
At step 5 no share is returned.

@SergioBertolinSG can I ask you to write intergration tests for this?

Easy one to review: @schiesbn @PVince81 @nickvergessen @DeepDiver1975 @LukasReschke 
