### PR TITLE
In case the hint of the HintException is empty we better use the exce…

### DIFF
--- a/lib/private/hintexception.php
+++ b/lib/private/hintexception.php
@@ -38,6 +38,9 @@ class HintException extends \Exception {
 	}
 
 	public function getHint() {
+		if (empty($this->hint)) {
+			return $this->message;
+		}
 		return $this->hint;
 	}
 }


### PR DESCRIPTION
…ption message

with this fix:

![bildschirmfoto von 2016-01-27 10-10-20](https://cloud.githubusercontent.com/assets/1005065/12608754/3803946e-c4de-11e5-85b5-2d37dbd5916d.png)

without:

![bildschirmfoto von 2016-01-27 10-11-25](https://cloud.githubusercontent.com/assets/1005065/12608785/5da9d052-c4de-11e5-87a4-798b06ee6515.png)
