### PR TITLE
Fix system tags proppatch with booleans

### DIFF
--- a/apps/dav/lib/systemtag/systemtagplugin.php
+++ b/apps/dav/lib/systemtag/systemtagplugin.php
@@ -199,11 +199,11 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 		});
 
 		$propFind->handle(self::USERVISIBLE_PROPERTYNAME, function() use ($node) {
-			return (int)$node->getSystemTag()->isUserVisible();
+			return $node->getSystemTag()->isUserVisible() ? 'true' : 'false';
 		});
 
 		$propFind->handle(self::USERASSIGNABLE_PROPERTYNAME, function() use ($node) {
-			return (int)$node->getSystemTag()->isUserAssignable();
+			return $node->getSystemTag()->isUserAssignable() ? 'true' : 'false';
 		});
 	}
 
@@ -236,11 +236,13 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 			}
 
 			if (isset($props[self::USERVISIBLE_PROPERTYNAME])) {
-				$userVisible = (bool)$props[self::USERVISIBLE_PROPERTYNAME];
+				$propValue = $props[self::USERVISIBLE_PROPERTYNAME];
+				$userVisible = ($propValue !== 'false' && $propValue !== '0');
 			}
 
 			if (isset($props[self::USERASSIGNABLE_PROPERTYNAME])) {
-				$userAssignable = (bool)$props[self::USERASSIGNABLE_PROPERTYNAME];
+				$propValue = $props[self::USERASSIGNABLE_PROPERTYNAME];
+				$userAssignable = ($propValue !== 'false' && $propValue !== '0');
 			}
 
 			$node->update($name, $userVisible, $userAssignable);

--- a/apps/dav/tests/unit/systemtag/systemtagplugin.php
+++ b/apps/dav/tests/unit/systemtag/systemtagplugin.php
@@ -77,8 +77,8 @@ class SystemTagPlugin extends \Test\TestCase {
 			200 => [
 				self::ID_PROPERTYNAME => '1',
 				self::DISPLAYNAME_PROPERTYNAME => 'Test',
-				self::USERVISIBLE_PROPERTYNAME => 1,
-				self::USERASSIGNABLE_PROPERTYNAME => 1,
+				self::USERVISIBLE_PROPERTYNAME => 'true',
+				self::USERASSIGNABLE_PROPERTYNAME => 'true',
 			]
 		];
 
@@ -133,8 +133,8 @@ class SystemTagPlugin extends \Test\TestCase {
 		// properties to set
 		$propPatch = new \Sabre\DAV\PropPatch(array(
 			self::DISPLAYNAME_PROPERTYNAME => 'Test changed',
-			self::USERVISIBLE_PROPERTYNAME => 0,
-			self::USERASSIGNABLE_PROPERTYNAME => 1,
+			self::USERVISIBLE_PROPERTYNAME => 'false',
+			self::USERASSIGNABLE_PROPERTYNAME => 'true',
 		));
 
 		$this->plugin->handleUpdateProperties(

--- a/core/js/oc-backbone-webdav.js
+++ b/core/js/oc-backbone-webdav.js
@@ -127,11 +127,16 @@
 		var key;
 		for (key in attrs) {
 			var changedProp = davProperties[key];
+			var value = attrs[key];
 			if (!changedProp) {
 				console.warn('No matching DAV property for property "' + key);
-				continue;
+				changedProp = key;
 			}
-			props[changedProp] = attrs[key];
+			if (_.isBoolean(value) || _.isNumber(value)) {
+				// convert to string
+				value = '' + value;
+			}
+			props[changedProp] = value;
 		}
 		return props;
 	}

--- a/core/js/systemtags/systemtagmodel.js
+++ b/core/js/systemtags/systemtagmodel.js
@@ -37,8 +37,8 @@
 			return {
 				id: data.id,
 				name: data.name,
-				userVisible: data.userVisible === true || data.userVisible === '1',
-				userAssignable: data.userAssignable === true || data.userAssignable === '1'
+				userVisible: data.userVisible === true || data.userVisible === 'true',
+				userAssignable: data.userAssignable === true || data.userAssignable === 'true'
 			};
 		}
 	});

--- a/core/js/tests/specs/oc-backbone-webdavSpec.js
+++ b/core/js/tests/specs/oc-backbone-webdavSpec.js
@@ -51,6 +51,17 @@ describe('Backbone Webdav extension', function() {
 				davProperties: {
 					'firstName': '{http://owncloud.org/ns}first-name',
 					'lastName': '{http://owncloud.org/ns}last-name',
+					'age': '{http://owncloud.org/ns}age',
+					'married': '{http://owncloud.org/ns}married'
+				},
+				parse: function(data) {
+					return {
+						id: data.id,
+						firstName: data.firstName,
+						lastName: data.lastName,
+						age: parseInt(data.age, 10),
+						married: data.married === 'true' || data.married === true
+					};
 				}
 			});
 			TestCollection = OC.Backbone.Collection.extend({
@@ -111,7 +122,9 @@ describe('Backbone Webdav extension', function() {
 			expect(davClientPropFindStub.getCall(0).args[1])
 				.toEqual([
 					'{http://owncloud.org/ns}first-name',
-					'{http://owncloud.org/ns}last-name'
+					'{http://owncloud.org/ns}last-name',
+					'{http://owncloud.org/ns}age',
+					'{http://owncloud.org/ns}married'
 				]);
 			expect(davClientPropFindStub.getCall(0).args[2])
 				.toEqual(1);
@@ -212,9 +225,20 @@ describe('Backbone Webdav extension', function() {
 				davProperties: {
 					'firstName': '{http://owncloud.org/ns}first-name',
 					'lastName': '{http://owncloud.org/ns}last-name',
+					'age': '{http://owncloud.org/ns}age', // int
+					'married': '{http://owncloud.org/ns}married', // bool
 				},
 				url: function() {
 					return 'http://example.com/owncloud/remote.php/test/' + this.id;
+				},
+				parse: function(data) {
+					return {
+						id: data.id,
+						firstName: data.firstName,
+						lastName: data.lastName,
+						age: parseInt(data.age, 10),
+						married: data.married === 'true' || data.married === true
+					};
 				}
 			});
 		});
@@ -223,11 +247,15 @@ describe('Backbone Webdav extension', function() {
 			var model = new TestModel({
 				id: '123',
 				firstName: 'Hello',
-				lastName: 'World'
+				lastName: 'World',
+				age: 32,
+				married: false
 			});
 
 			model.save({
-				firstName: 'Hey'
+				firstName: 'Hey',
+				age: 33,
+				married: true
 			});
 
 			expect(davClientPropPatchStub.calledOnce).toEqual(true);
@@ -235,7 +263,9 @@ describe('Backbone Webdav extension', function() {
 				.toEqual('http://example.com/owncloud/remote.php/test/123');
 			expect(davClientPropPatchStub.getCall(0).args[1])
 				.toEqual({
-					'{http://owncloud.org/ns}first-name': 'Hey'
+					'{http://owncloud.org/ns}first-name': 'Hey',
+					'{http://owncloud.org/ns}age': '33',
+					'{http://owncloud.org/ns}married': 'true'
 				});
 			expect(davClientPropPatchStub.getCall(0).args[2]['X-Requested-With'])
 				.toEqual('XMLHttpRequest');
@@ -247,6 +277,8 @@ describe('Backbone Webdav extension', function() {
 
 			expect(model.id).toEqual('123');
 			expect(model.get('firstName')).toEqual('Hey');
+			expect(model.get('age')).toEqual(33);
+			expect(model.get('married')).toEqual(true);
 		});
 
 		it('uses PROPFIND to fetch single model', function() {
@@ -262,7 +294,9 @@ describe('Backbone Webdav extension', function() {
 			expect(davClientPropFindStub.getCall(0).args[1])
 				.toEqual([
 					'{http://owncloud.org/ns}first-name',
-					'{http://owncloud.org/ns}last-name'
+					'{http://owncloud.org/ns}last-name',
+					'{http://owncloud.org/ns}age',
+					'{http://owncloud.org/ns}married'
 				]);
 			expect(davClientPropFindStub.getCall(0).args[2])
 				.toEqual(0);
@@ -277,7 +311,9 @@ describe('Backbone Webdav extension', function() {
 						status: 'HTTP/1.1 200 OK',
 						properties: {
 							'{http://owncloud.org/ns}first-name': 'Hello',
-							'{http://owncloud.org/ns}last-name': 'World'
+							'{http://owncloud.org/ns}last-name': 'World',
+							'{http://owncloud.org/ns}age': '35',
+							'{http://owncloud.org/ns}married': 'true'
 						}
 					}]
 				}
@@ -286,6 +322,8 @@ describe('Backbone Webdav extension', function() {
 			expect(model.id).toEqual('123');
 			expect(model.get('firstName')).toEqual('Hello');
 			expect(model.get('lastName')).toEqual('World');
+			expect(model.get('age')).toEqual(35);
+			expect(model.get('married')).toEqual(true);
 		});
 		it('makes a DELETE request to destroy model', function() {
 			var model = new TestModel({


### PR DESCRIPTION
Backbone webdav adapter now converts booleans and ints to strings for PROPPATCH.

Fixed system tags to use "true" / "false" strings for booleans instead
of 1 / 0.

@nickvergessen @Blizzz @icewind1991 @rullzer please review.
