### PR TITLE
Share2 ocs fix passing empty strings

### DIFF
--- a/apps/files_sharing/api/share20ocs.php
+++ b/apps/files_sharing/api/share20ocs.php
@@ -272,12 +272,12 @@ class Share20OCS {
 			if ($publicUpload === 'true') {
 				// Check if public upload is allowed
 				if (!$this->shareManager->shareApiLinkAllowPublicUpload()) {
-					return new \OC_OCS_Result(null, 403, '"public upload disabled by the administrator');
+					return new \OC_OCS_Result(null, 403, 'public upload disabled by the administrator');
 				}
 
 				// Public upload can only be set for folders
 				if ($path instanceof \OCP\Files\File) {
-					return new \OC_OCS_Result(null, 404, '"public upload is only possible for public shared folders');
+					return new \OC_OCS_Result(null, 404, 'public upload is only possible for public shared folders');
 				}
 
 				$share->setPermissions(
@@ -290,12 +290,16 @@ class Share20OCS {
 			}
 
 			// Set password
-			$share->setPassword($this->request->getParam('password', null));
+			$password = $this->request->getParam('password', '');
+
+			if ($password !== '') {
+				$share->setPassword($password);
+			}
 
 			//Expire date
-			$expireDate = $this->request->getParam('expireDate', null);
+			$expireDate = $this->request->getParam('expireDate', '');
 
-			if ($expireDate !== null) {
+			if ($expireDate !== '') {
 				try {
 					$expireDate = $this->parseDate($expireDate);
 					$share->setExpirationDate($expireDate);

--- a/apps/files_sharing/api/share20ocs.php
+++ b/apps/files_sharing/api/share20ocs.php
@@ -456,9 +456,9 @@ class Share20OCS {
 		}
 
 		$permissions = $this->request->getParam('permissions', null);
-		$password = $this->request->getParam('password', '');
+		$password = $this->request->getParam('password', null);
 		$publicUpload = $this->request->getParam('publicUpload', null);
-		$expireDate = $this->request->getParam('expireDate', '');
+		$expireDate = $this->request->getParam('expireDate', null);
 
 		/*
 		 * expirationdate, password and publicUpload only make sense for link shares
@@ -470,7 +470,7 @@ class Share20OCS {
 
 			if ($expireDate === '') {
 				$share->setExpirationDate(null);
-			} else {
+			} else if ($expireDate !== null) {
 				try {
 					$expireDate = $this->parseDate($expireDate);
 				} catch (\Exception $e) {
@@ -481,7 +481,7 @@ class Share20OCS {
 
 			if ($password === '') {
 				$share->setPassword(null);
-			} else {
+			} else if ($password !== null) {
 				$share->setPassword($password);
 			}
 


### PR DESCRIPTION
More sanity checks and better parsing in the OCS Api endpoint. Needed for https://github.com/owncloud/core/pull/21860
- passing `password` or `expireDate` as empty strings. Is not handled proplery
- more sanity checks
- more unit tests

CC: @PVince81 @DeepDiver1975 @schiesbn @nickvergessen @LukasReschke 
