### PR TITLE
Fix certain images prevented from being displayed with ini_set('gd.jpeg_ignore_warning', 1);

### DIFF
--- a/lib/private/image.php
+++ b/lib/private/image.php
@@ -512,6 +512,7 @@ class OC_Image implements \OCP\IImage {
 				break;
 			case IMAGETYPE_JPEG:
 				if (imagetypes() & IMG_JPG) {
+					ini_set('gd.jpeg_ignore_warning', 1);
 					$this->resource = imagecreatefromjpeg($imagePath);
 				} else {
 					$this->logger->debug('OC_Image->loadFromFile, JPG images not supported: ' . $imagePath, array('app' => 'core'));


### PR DESCRIPTION
Fixes certain jpeg images that were not displayed. Forces jpegs to be displayed whether or not gd thinks they are damaged. Many images, damaged or not were being tagged as damaged.

Example of owncloud log:
`imagecreatefromjpeg(): gd-jpeg, libjpeg: recoverable error: Premature end of JPEG file at ochome/lib/private/image.php#513`
