### PR TITLE
Comments WebDAV adjustements

### DIFF
--- a/apps/dav/lib/comments/commentsplugin.php
+++ b/apps/dav/lib/comments/commentsplugin.php
@@ -88,7 +88,7 @@ class CommentsPlugin extends ServerPlugin {
 		$this->server->xml->namespaceMap[self::NS_OWNCLOUD] = 'oc';
 
 		$this->server->xml->classMap['DateTime'] = function(Writer $writer, \DateTime $value) {
-			$writer->write($value->format('Y-m-d H:i:s'));
+			$writer->write(\Sabre\HTTP\toDate($value));
 		};
 
 		$this->server->on('report', [$this, 'onReport']);

--- a/apps/dav/lib/comments/commentsplugin.php
+++ b/apps/dav/lib/comments/commentsplugin.php
@@ -2,7 +2,7 @@
 /**
  * @author Arthur Schiwon <blizzz@owncloud.com>
  *
- * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify
@@ -88,7 +88,7 @@ class CommentsPlugin extends ServerPlugin {
 		$this->server->xml->namespaceMap[self::NS_OWNCLOUD] = 'oc';
 
 		$this->server->xml->classMap['DateTime'] = function(Writer $writer, \DateTime $value) {
-			$writer->write($value->format('Y-m-d H:m:i'));
+			$writer->write($value->format('Y-m-d H:i:s'));
 		};
 
 		$this->server->on('report', [$this, 'onReport']);

--- a/apps/dav/lib/connector/sabre/commentpropertiesplugin.php
+++ b/apps/dav/lib/connector/sabre/commentpropertiesplugin.php
@@ -105,7 +105,7 @@ class CommentPropertiesPlugin extends ServerPlugin {
 			return null;
 		}
 		$href = substr_replace($href, '/dav/', $entryPoint);
-		$href .= 'comments/files/' . $node->getId();
+		$href .= 'comments/files/' . rawurldecode($node->getId());
 		return $href;
 	}
 

--- a/apps/dav/lib/connector/sabre/commentpropertiesplugin.php
+++ b/apps/dav/lib/connector/sabre/commentpropertiesplugin.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * @author Arthur Schiwon <blizzz@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Connector\Sabre;
+
+use OCP\Comments\ICommentsManager;
+use OCP\IUserSession;
+use Sabre\DAV\PropFind;
+use Sabre\DAV\ServerPlugin;
+
+class CommentPropertiesPlugin extends ServerPlugin {
+
+	const PROPERTY_NAME_HREF   = '{http://owncloud.org/ns}comments-href';
+	const PROPERTY_NAME_COUNT  = '{http://owncloud.org/ns}comments-count';
+	const PROPERTY_NAME_UNREAD = '{http://owncloud.org/ns}comments-unread';
+
+	/** @var  \Sabre\DAV\Server */
+	protected $server;
+
+	/** @var ICommentsManager */
+	private $commentsManager;
+
+	/** @var IUserSession */
+	private $userSession;
+
+	public function __construct(ICommentsManager $commentsManager, IUserSession $userSession) {
+		$this->commentsManager = $commentsManager;
+		$this->userSession = $userSession;
+	}
+
+	/**
+	 * This initializes the plugin.
+	 *
+	 * This function is called by Sabre\DAV\Server, after
+	 * addPlugin is called.
+	 *
+	 * This method should set up the required event subscriptions.
+	 *
+	 * @param \Sabre\DAV\Server $server
+	 * @return void
+	 */
+	function initialize(\Sabre\DAV\Server $server) {
+		$this->server = $server;
+		$this->server->on('propFind', array($this, 'handleGetProperties'));
+	}
+
+	/**
+	 * Adds tags and favorites properties to the response,
+	 * if requested.
+	 *
+	 * @param PropFind $propFind
+	 * @param \Sabre\DAV\INode $node
+	 * @return void
+	 */
+	public function handleGetProperties(
+		PropFind $propFind,
+		\Sabre\DAV\INode $node
+	) {
+		if (!($node instanceof File) && !($node instanceof Directory)) {
+			return;
+		}
+
+		$propFind->handle(self::PROPERTY_NAME_COUNT, function() use ($node) {
+			return $this->commentsManager->getNumberOfCommentsForObject('files', strval($node->getId()));
+		});
+
+		$propFind->handle(self::PROPERTY_NAME_HREF, function() use ($node) {
+			return $this->getCommentsLink($node);
+		});
+
+		$propFind->handle(self::PROPERTY_NAME_UNREAD, function() use ($node) {
+			return $this->getUnreadCount($node);
+		});
+	}
+
+	/**
+	 * returns a reference to the comments node
+	 *
+	 * @param Node $node
+	 * @return mixed|string
+	 */
+	public function getCommentsLink(Node $node) {
+		$href =  $this->server->getBaseUri();
+		$entryPoint = strrpos($href, '/webdav/');
+		if($entryPoint === false) {
+			// in case we end up somewhere else, unexpectedly.
+			return null;
+		}
+		$href = substr_replace($href, '/dav/', $entryPoint);
+		$href .= 'comments/files/' . $node->getId();
+		return $href;
+	}
+
+	/**
+	 * returns the number of unread comments for the currently logged in user
+	 * on the given file or directory node
+	 *
+	 * @param Node $node
+	 * @return Int|null
+	 */
+	public function getUnreadCount(Node $node) {
+		$user = $this->userSession->getUser();
+		if(is_null($user)) {
+			return null;
+		}
+
+		$lastRead = $this->commentsManager->getReadMark('files', strval($node->getId()), $user);
+
+		return $this->commentsManager->getNumberOfCommentsForObject('files', strval($node->getId()), $lastRead);
+	}
+
+}

--- a/apps/dav/lib/connector/sabre/serverfactory.php
+++ b/apps/dav/lib/connector/sabre/serverfactory.php
@@ -134,6 +134,7 @@ class ServerFactory {
 
 			if($this->userSession->isLoggedIn()) {
 				$server->addPlugin(new \OCA\DAV\Connector\Sabre\TagsPlugin($objectTree, $this->tagManager));
+				$server->addPlugin(new \OCA\DAV\Connector\Sabre\CommentPropertiesPlugin(\OC::$server->getCommentsManager(), $this->userSession));
 				// custom properties plugin must be the last one
 				$server->addPlugin(
 					new \Sabre\DAV\PropertyStorage\Plugin(

--- a/apps/dav/tests/unit/connector/sabre/commentpropertiesplugin.php
+++ b/apps/dav/tests/unit/connector/sabre/commentpropertiesplugin.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * @author Arthur Schiwon <blizzz@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Unit\Connector\Sabre;
+
+use \OCA\DAV\Connector\Sabre\CommentPropertiesPlugin as CommentPropertiesPluginImplementation;
+
+class CommentsPropertiesPlugin extends \Test\TestCase {
+
+	/** @var  CommentPropertiesPluginImplementation */
+	protected $plugin;
+	protected $commentsManager;
+	protected $userSession;
+	protected $server;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->commentsManager = $this->getMock('\OCP\Comments\ICommentsManager');
+		$this->userSession = $this->getMock('\OCP\IUserSession');
+
+		$this->server = $this->getMockBuilder('\Sabre\DAV\Server')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->plugin = new CommentPropertiesPluginImplementation($this->commentsManager, $this->userSession);
+		$this->plugin->initialize($this->server);
+	}
+
+	public function nodeProvider() {
+		$mocks = [];
+		foreach(['\OCA\DAV\Connector\Sabre\File', '\OCA\DAV\Connector\Sabre\Directory', '\Sabre\DAV\INode'] as $class) {
+			$mocks[] = 	$this->getMockBuilder($class)
+				->disableOriginalConstructor()
+				->getMock();
+		}
+
+		return [
+			[$mocks[0], true],
+			[$mocks[1], true],
+			[$mocks[2], false]
+		];
+	}
+
+	/**
+	 * @dataProvider nodeProvider
+	 * @param $node
+	 * @param $expectedSuccessful
+	 */
+	public function testHandleGetProperties($node, $expectedSuccessful) {
+		$propFind = $this->getMockBuilder('\Sabre\DAV\PropFind')
+			->disableOriginalConstructor()
+			->getMock();
+
+		if($expectedSuccessful) {
+			$propFind->expects($this->exactly(3))
+				->method('handle');
+		} else {
+			$propFind->expects($this->never())
+				->method('handle');
+		}
+
+		$this->plugin->handleGetProperties($propFind, $node);
+	}
+
+	public function baseUriProvider() {
+		return [
+			['owncloud/remote.php/webdav/', '4567', 'owncloud/remote.php/dav/comments/files/4567'],
+			['owncloud/remote.php/wicked/', '4567', null]
+		];
+	}
+
+	/**
+	 * @dataProvider baseUriProvider
+	 * @param $baseUri
+	 * @param $fid
+	 * @param $expectedHref
+	 */
+	public function testGetCommentsLink($baseUri, $fid, $expectedHref) {
+		$node = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\File')
+			->disableOriginalConstructor()
+			->getMock();
+		$node->expects($this->any())
+			->method('getId')
+			->will($this->returnValue($fid));
+
+		$this->server->expects($this->once())
+			->method('getBaseUri')
+			->will($this->returnValue($baseUri));
+
+		$href = $this->plugin->getCommentsLink($node);
+		$this->assertSame($expectedHref, $href);
+	}
+
+	public function userProvider() {
+		return [
+			[$this->getMock('\OCP\IUser')],
+			[null]
+		];
+	}
+
+	/**
+	 * @dataProvider userProvider
+	 * @param $user
+	 */
+	public function testGetUnreadCount($user) {
+		$node = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\File')
+			->disableOriginalConstructor()
+			->getMock();
+		$node->expects($this->any())
+			->method('getId')
+			->will($this->returnValue('4567'));
+
+		$this->userSession->expects($this->once())
+			->method('getUser')
+			->will($this->returnValue($user));
+
+		$this->commentsManager->expects($this->any())
+			->method('getNumberOfCommentsForObject')
+			->will($this->returnValue(42));
+
+		$unread = $this->plugin->getUnreadCount($node);
+		if(is_null($user)) {
+			$this->assertNull($unread);
+		} else {
+			$this->assertSame($unread, 42);
+		}
+	}
+
+}

--- a/db_structure.xml
+++ b/db_structure.xml
@@ -1582,6 +1582,49 @@
 
 	<table>
 		<!--
+		default place to store per user and object read markers
+		-->
+		<name>*dbprefix*comments_read_markers</name>
+
+		<declaration>
+
+			<field>
+				<name>user_id</name>
+				<type>text</type>
+				<default></default>
+				<notnull>true</notnull>
+				<length>64</length>
+			</field>
+
+			<field>
+				<name>marker_datetime</name>
+				<type>timestamp</type>
+				<default></default>
+				<notnull>false</notnull>
+			</field>
+
+			<field>
+				<name>object_type</name>
+				<type>text</type>
+				<default></default>
+				<notnull>true</notnull>
+				<length>64</length>
+			</field>
+
+			<field>
+				<name>object_id</name>
+				<type>text</type>
+				<default></default>
+				<notnull>true</notnull>
+				<length>64</length>
+			</field>
+
+		</declaration>
+
+	</table>
+
+	<table>
+		<!--
 		Encrypted credentials storage
 		-->
 		<name>*dbprefix*credentials</name>

--- a/lib/private/comments/managerfactory.php
+++ b/lib/private/comments/managerfactory.php
@@ -51,7 +51,8 @@ class ManagerFactory implements ICommentsManagerFactory {
 	public function getManager() {
 		return new Manager(
 			$this->serverContainer->getDatabaseConnection(),
-			$this->serverContainer->getLogger()
+			$this->serverContainer->getLogger(),
+			$this->serverContainer->getConfig()
 		);
 	}
 }

--- a/lib/private/user/user.php
+++ b/lib/private/user/user.php
@@ -211,6 +211,7 @@ class User implements IUser {
 			\OC\Files\Cache\Storage::remove('home::' . $this->uid);
 
 			\OC::$server->getCommentsManager()->deleteReferencesOfActor('user', $this->uid);
+			\OC::$server->getCommentsManager()->deleteReadMarksFromUser($this);
 		}
 
 		if ($this->emitter) {

--- a/lib/public/comments/icommentsmanager.php
+++ b/lib/public/comments/icommentsmanager.php
@@ -215,4 +215,23 @@ interface ICommentsManager {
 	 */
 	public function getReadMark($objectType, $objectId, \OCP\IUser $user);
 
+	/**
+	 * deletes the read markers for the specified user
+	 *
+	 * @param \OCP\IUser $user
+	 * @return bool
+	 * @since 9.0.0
+	 */
+	public function deleteReadMarksFromUser(\OCP\IUser $user);
+
+	/**
+	 * deletes the read markers on the specified object
+	 *
+	 * @param string $objectType
+	 * @param string $objectId
+	 * @return bool
+	 * @since 9.0.0
+	 */
+	public function deleteReadMarksOnObject($objectType, $objectId);
+
 }

--- a/lib/public/comments/icommentsmanager.php
+++ b/lib/public/comments/icommentsmanager.php
@@ -115,10 +115,12 @@ interface ICommentsManager {
 	/**
 	 * @param $objectType string the object type, e.g. 'files'
 	 * @param $objectId string the id of the object
+	 * @param \DateTime $notOlderThan optional, timestamp of the oldest comments
+	 * that may be returned
 	 * @return Int
 	 * @since 9.0.0
 	 */
-	public function getNumberOfCommentsForObject($objectType, $objectId);
+	public function getNumberOfCommentsForObject($objectType, $objectId, \DateTime $notOlderThan = null);
 
 	/**
 	 * creates a new comment and returns it. At this point of time, it is not
@@ -187,5 +189,30 @@ interface ICommentsManager {
 	 * @since 9.0.0
 	 */
 	public function deleteCommentsAtObject($objectType, $objectId);
+
+	/**
+	 * sets the read marker for a given file to the specified date for the
+	 * provided user
+	 *
+	 * @param string $objectType
+	 * @param string $objectId
+	 * @param \DateTime $dateTime
+	 * @param \OCP\IUser $user
+	 * @since 9.0.0
+	 */
+	public function setReadMark($objectType, $objectId, \DateTime $dateTime, \OCP\IUser $user);
+
+	/**
+	 * returns the read marker for a given file to the specified date for the
+	 * provided user. It returns null, when the marker is not present, i.e.
+	 * no comments were marked as read.
+	 *
+	 * @param string $objectType
+	 * @param string $objectId
+	 * @param \OCP\IUser $user
+	 * @return \DateTime|null
+	 * @since 9.0.0
+	 */
+	public function getReadMark($objectType, $objectId, \OCP\IUser $user);
 
 }

--- a/tests/lib/comments/fakemanager.php
+++ b/tests/lib/comments/fakemanager.php
@@ -19,7 +19,7 @@ class FakeManager implements \OCP\Comments\ICommentsManager {
 		\DateTime $notOlderThan = null
 	) {}
 
-	public function getNumberOfCommentsForObject($objectType, $objectId) {}
+	public function getNumberOfCommentsForObject($objectType, $objectId, \DateTime $notOlderThan = null) {}
 
 	public function create($actorType, $actorId, $objectType, $objectId) {}
 
@@ -30,4 +30,8 @@ class FakeManager implements \OCP\Comments\ICommentsManager {
 	public function deleteReferencesOfActor($actorType, $actorId) {}
 
 	public function deleteCommentsAtObject($objectType, $objectId) {}
+
+	public function setReadMark($objectType, $objectId, \DateTime $dateTime, \OCP\IUser $user) {}
+
+	public function getReadMark($objectType, $objectId, \OCP\IUser $user) {}
 }

--- a/tests/lib/comments/fakemanager.php
+++ b/tests/lib/comments/fakemanager.php
@@ -34,4 +34,8 @@ class FakeManager implements \OCP\Comments\ICommentsManager {
 	public function setReadMark($objectType, $objectId, \DateTime $dateTime, \OCP\IUser $user) {}
 
 	public function getReadMark($objectType, $objectId, \OCP\IUser $user) {}
+
+	public function deleteReadMarksFromUser(\OCP\IUser $user) {}
+
+	public function deleteReadMarksOnObject($objectType, $objectId) {}
 }

--- a/tests/lib/comments/manager.php
+++ b/tests/lib/comments/manager.php
@@ -561,4 +561,20 @@ class Test_Comments_Manager extends TestCase
 		$this->assertTrue($wasSuccessful);
 	}
 
+	public function testSetMarkRead() {
+		$user = $this->getMock('\OCP\IUser');
+		$user->expects($this->any())
+			->method('getUID')
+			->will($this->returnValue('alice'));
+
+		$dateTimeSet = new \DateTime();
+
+		$manager = $this->getManager();
+		$manager->setReadMark('files', '36', $dateTimeSet, $user);
+
+		$dateTimeGet = $manager->getReadMark('files', '36',  $user);
+
+		$this->assertEquals($dateTimeGet, $dateTimeSet);
+	}
+
 }

--- a/tests/lib/comments/manager.php
+++ b/tests/lib/comments/manager.php
@@ -570,11 +570,64 @@ class Test_Comments_Manager extends TestCase
 		$dateTimeSet = new \DateTime();
 
 		$manager = $this->getManager();
-		$manager->setReadMark('files', '36', $dateTimeSet, $user);
+		$manager->setReadMark('robot', '36', $dateTimeSet, $user);
 
-		$dateTimeGet = $manager->getReadMark('files', '36',  $user);
+		$dateTimeGet = $manager->getReadMark('robot', '36',  $user);
 
 		$this->assertEquals($dateTimeGet, $dateTimeSet);
+	}
+
+	public function testSetMarkReadUpdate() {
+		$user = $this->getMock('\OCP\IUser');
+		$user->expects($this->any())
+			->method('getUID')
+			->will($this->returnValue('alice'));
+
+		$dateTimeSet = new \DateTime('yesterday');
+
+		$manager = $this->getManager();
+		$manager->setReadMark('robot', '36', $dateTimeSet, $user);
+
+		$dateTimeSet = new \DateTime('today');
+		$manager->setReadMark('robot', '36', $dateTimeSet, $user);
+
+		$dateTimeGet = $manager->getReadMark('robot', '36',  $user);
+
+		$this->assertEquals($dateTimeGet, $dateTimeSet);
+	}
+
+	public function testReadMarkDeleteUser() {
+		$user = $this->getMock('\OCP\IUser');
+		$user->expects($this->any())
+			->method('getUID')
+			->will($this->returnValue('alice'));
+
+		$dateTimeSet = new \DateTime();
+
+		$manager = $this->getManager();
+		$manager->setReadMark('robot', '36', $dateTimeSet, $user);
+
+		$manager->deleteReadMarksFromUser($user);
+		$dateTimeGet = $manager->getReadMark('robot', '36',  $user);
+
+		$this->assertNull($dateTimeGet);
+	}
+
+	public function testReadMarkDeleteObject() {
+		$user = $this->getMock('\OCP\IUser');
+		$user->expects($this->any())
+			->method('getUID')
+			->will($this->returnValue('alice'));
+
+		$dateTimeSet = new \DateTime();
+
+		$manager = $this->getManager();
+		$manager->setReadMark('robot', '36', $dateTimeSet, $user);
+
+		$manager->deleteReadMarksOnObject('robot', '36');
+		$dateTimeGet = $manager->getReadMark('robot', '36',  $user);
+
+		$this->assertNull($dateTimeGet);
 	}
 
 }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 0, 0, 7);
+$OC_Version = array(9, 0, 0, 8);
 
 // The human readable string
 $OC_VersionString = '9.0 pre alpha';


### PR DESCRIPTION
Resolves #20266 

Good thing, I did not need to touch file-specific stuff, but could just add another plugin for the dav part.

But I also needed following: thinking about the read marker per user, it is not just enough to store just one timestamp, but it needs also a file relation. I kept this in the preferences table for now, but it's probably a better idea to introduce another table for this. Opinions?

Also, I needed to extend the API for reading and setting the marker.
- [X] Clean up of markers when user was deleted
- [ ] ~~Clean up of markers when file was deleted~~ Comes later, together with comments cleanup

Example request XML:

``` xml
<?xml version="1.0" encoding="utf-8" ?>
<D:propfind xmlns:D="DAV:" xmlns:oc="http://owncloud.org/ns" >
  <D:prop>
    <D:getetag/>
    <oc:comments-count/>
    <oc:comments-href/>
    <oc:comments-unread/>
  </D:prop>
</D:propfind>
```

Example request via curl:

```
curl -u user:pswd -i --data-binary "@propfind.files.xml" -X PROPFIND  -H "Content-Type: application/json" http://my.owncloud.tld/master/remote.php/webdav/clementine-art-XW2738.jpg
```

Example result XML:

``` xml
<?xml version="1.0"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">
 <d:response>
  <d:href>/master/remote.php/webdav/clementine-art-XW2738.jpg</d:href>
  <d:propstat>
   <d:prop>
    <d:getetag>&quot;315ac4ffc5feb2f2676a5def72091d8a&quot;</d:getetag>
    <oc:comments-count>2</oc:comments-count>
    <oc:comments-href>/master/remote.php/dav/comments/files/4607</oc:comments-href>
    <oc:comments-unread>1</oc:comments-unread>
   </d:prop>
   <d:status>HTTP/1.1 200 OK</d:status>
  </d:propstat>
 </d:response>
</d:multistatus>

```

@PVince81 @DeepDiver1975 @nickvergessen 
