### PR TITLE
Stop spamming me.

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -18,6 +18,7 @@
   "userBlacklist": [
     "owncloud-bot",
     "scrutinizer-auto-fixer",
-    "th3fallen"
+    "th3fallen",
+    "zander"
   ]
 }


### PR DESCRIPTION
Honestly, the bot should be improved, if a person hasn't contributed for
a long time it really doens't make sense to email him.
I would also argue that altering the .gitignore doesn't make me an
expert on that file. So classes of files really should not cause
the mention bot spamming me.
