### PR TITLE
apps/files: add scanSingle and scanBatch to api

### DIFF
--- a/apps/files/appinfo/routes.php
+++ b/apps/files/appinfo/routes.php
@@ -48,6 +48,20 @@ $application->registerRoutes(
 				'verb' => 'GET',
 				'requirements' => array('tagName' => '.+'),
 			),
+                        array(
+                                'name' => 'API#scanSingle',
+                                'url' => '/api/v1/scan/{path}',
+                                'verb' => 'GET',
+                                'requirements' => array('path' => '.+'),
+                        ),
+                        array(
+                                'name' => 'API#scanBatch',
+                                'url' => '/api/v1/scan',
+                                'verb' => 'POST',
+                        ),
+                        array(
+                                'name' => 'API#getFilesByTag',
+
 			[
 				'name' => 'view#index',
 				'url' => '/',

--- a/apps/files/appinfo/routes.php
+++ b/apps/files/appinfo/routes.php
@@ -59,9 +59,6 @@ $application->registerRoutes(
                                 'url' => '/api/v1/scan',
                                 'verb' => 'POST',
                         ),
-                        array(
-                                'name' => 'API#getFilesByTag',
-
 			[
 				'name' => 'view#index',
 				'url' => '/',

--- a/apps/files/controller/apicontroller.php
+++ b/apps/files/controller/apicontroller.php
@@ -154,6 +154,8 @@ class ApiController extends Controller {
         /**
          * Scans a single path
          *
+	 * @NoCSRFRequired
+	 *
          * @param string $path path to scan
          * @return DataResponse
          */
@@ -172,6 +174,8 @@ class ApiController extends Controller {
         /**
          * Scans paths listed in $path_list
          *
+	 * @NoCSRFRequired
+	 *
          * @param array|string $path_list array of paths
          * @return DataResponse
          */


### PR DESCRIPTION
This is an _experimental_ implementation of an api for file scanning.

Two commands are added to the apps/files api:

**GET /api/v1/scan/path/to/file/to/scan**
Initiate a scan for a single path
returns: number of folders/files scanned

**POST /api/v1/scan**
POST data: array 'path_list' of paths to scan
returns: number of folders/files scanned

In theory both commands could return error counts for invalid user or invalid path, but for some reason the exceptions (_ForbiddenException_ and _InvalidArgumentException_) which _$scanner_ is supposed to throw do not get thrown (or are caught in flight) when it gets fed with nonsensical paths.

The entry points are currently not marked with _@noadminrequired_ (ie. only admin users can initiate scans), this mostly to keep normal users from loading the system with unnecessary scans.

This code was ported from 8.2.2 to master without testing as I currently do not have a running instance of the latter. Try before you buy...
