### PR TITLE
Background cleanup job for system and user tag orphaned when file was deleted

### DIFF
--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -7,7 +7,7 @@
 	<author>Robin Appelman, Vincent Petry</author>
 	<standalone/>
 	<default_enable/>
-	<version>1.4.1</version>
+	<version>1.4.2</version>
 	<types>
 		<filesystem/>
 	</types>

--- a/apps/files/appinfo/install.php
+++ b/apps/files/appinfo/install.php
@@ -20,7 +20,5 @@
  */
 
 // Cron job for scanning user storages
-$jobList = \OC::$server->getJobList();
-$job = 'OCA\Files\BackgroundJob\ScanFiles';
-\OC::$server->getJobList()->add($job);
-
+\OC::$server->getJobList()->add('OCA\Files\BackgroundJob\ScanFiles');
+\OC::$server->getJobList()->add('OCA\Files\BackgroundJob\DeleteOrphanedTagsJob');

--- a/apps/files/appinfo/update.php
+++ b/apps/files/appinfo/update.php
@@ -98,15 +98,5 @@ if ($installedVersion === '1.1.9' && (
 }
 
 // Add cron job for scanning user storages
-$jobList = \OC::$server->getJobList();
-$job = 'OCA\Files\BackgroundJob\ScanFiles';
-\OC::$server->getJobList()->add($job);
-
-/**
- * migrate old constant DEBUG to new config value 'debug'
- *
- * TODO: remove this in ownCloud 8.3
- */
-if(defined('DEBUG') && DEBUG === true) {
-	\OC::$server->getConfig()->setSystemValue('debug', true);
-}
+\OC::$server->getJobList()->add('OCA\Files\BackgroundJob\ScanFiles');
+\OC::$server->getJobList()->add('OCA\Files\BackgroundJob\DeleteOrphanedTagsJob');

--- a/apps/files/lib/backgroundjob/deleteorphanedtagsjob.php
+++ b/apps/files/lib/backgroundjob/deleteorphanedtagsjob.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files\BackgroundJob;
+
+use OC\BackgroundJob\TimedJob;
+
+/**
+ * Delete all share entries that have no matching entries in the file cache table.
+ */
+class DeleteOrphanedTagsJob extends TimedJob {
+
+	/** @var \OCP\IDBConnection */
+	protected $connection;
+
+	/** @var \OCP\ILogger */
+	protected $logger;
+
+	/**
+	 * Default interval in minutes
+	 *
+	 * @var int $defaultIntervalMin
+	 **/
+	protected $defaultIntervalMin = 60;
+
+	/**
+	 * sets the correct interval for this timed job
+	 */
+	public function __construct() {
+		$this->interval = $this->defaultIntervalMin * 60;
+		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->logger = \OC::$server->getLogger();
+	}
+
+	/**
+	 * Makes the background job do its work
+	 *
+	 * @param array $argument unused argument
+	 */
+	public function run($argument) {
+		$this->cleanSystemTags();
+		$this->cleanUserTags();
+	}
+
+	/**
+	 * Deleting orphaned system tag mappings
+	 *
+	 * @return int Number of deleted entries
+	 */
+	protected function cleanSystemTags() {
+		$subQuery = $this->connection->getQueryBuilder();
+		$subQuery->select($subQuery->expr()->literal('1'))
+			->from('filecache', 'f')
+			->where($subQuery->expr()->eq('objectid', 'f.fileid'));
+
+		$query = $this->connection->getQueryBuilder();
+		$deletedEntries = $query->delete('systemtag_object_mapping')
+			->where($query->expr()->eq('objecttype', $query->expr()->literal('files')))
+			->andWhere($query->expr()->isNull($query->createFunction('(' . $subQuery->getSql() . ')')))
+			->execute();
+
+		$this->logger->debug("$deletedEntries orphaned system tag relations deleted", ['app' => 'DeleteOrphanedTagsJob']);
+		return $deletedEntries;
+	}
+
+	/**
+	 * Deleting orphaned user tag mappings
+	 *
+	 * @return int Number of deleted entries
+	 */
+	protected function cleanUserTags() {
+		$subQuery = $this->connection->getQueryBuilder();
+		$subQuery->select($subQuery->expr()->literal('1'))
+			->from('filecache', 'f')
+			->where($subQuery->expr()->eq('objid', 'f.fileid'));
+
+		$query = $this->connection->getQueryBuilder();
+		$deletedEntries = $query->delete('vcategory_to_object')
+			->where($query->expr()->eq('type', $query->expr()->literal('files')))
+			->andWhere($query->expr()->isNull($query->createFunction('(' . $subQuery->getSql() . ')')))
+			->execute();
+
+		$this->logger->debug("$deletedEntries orphaned user tag relations deleted", ['app' => 'DeleteOrphanedTagsJob']);
+		return $deletedEntries;
+	}
+
+}

--- a/apps/files/tests/backgroundjob/DeleteOrphanedTagsJobTest.php
+++ b/apps/files/tests/backgroundjob/DeleteOrphanedTagsJobTest.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files\Tests\BackgroundJob;
+
+use OCA\Files\BackgroundJob\DeleteOrphanedTagsJob;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+
+/**
+ * Class DeleteOrphanedTagsJobTest
+ *
+ * @group DB
+ *
+ * @package Test\BackgroundJob
+ */
+class DeleteOrphanedTagsJobTest extends \Test\TestCase {
+
+	/** @var \OCP\IDBConnection */
+	protected $connection;
+
+	protected function setup() {
+		parent::setUp();
+		$this->connection = \OC::$server->getDatabaseConnection();
+	}
+
+	protected function cleanMapping($table) {
+		$query = $this->connection->getQueryBuilder();
+		$query->delete($table)->execute();
+	}
+
+	protected function getMappings($table) {
+		$query = $this->connection->getQueryBuilder();
+		$query->select('*')
+			->from($table);
+		$result = $query->execute();
+		$mapping = $result->fetchAll();
+		$result->closeCursor();
+
+		return $mapping;
+	}
+
+	/**
+	 * Test clearing orphaned system tag mappings
+	 */
+	public function testClearSystemTagMappings() {
+		$this->cleanMapping('systemtag_object_mapping');
+
+		$query = $this->connection->getQueryBuilder();
+		$query->insert('filecache')
+			->values([
+				'storage' => $query->createNamedParameter(1337, IQueryBuilder::PARAM_INT),
+				'path' => $query->createNamedParameter('apps/files/tests/deleteorphanedtagsjobtest.php'),
+				'path_hash' => $query->createNamedParameter(md5('apps/files/tests/deleteorphanedtagsjobtest.php')),
+			])->execute();
+		$fileId = $query->getLastInsertId();
+
+		// Existing file
+		$query = $this->connection->getQueryBuilder();
+		$query->insert('systemtag_object_mapping')
+			->values([
+				'objectid' => $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT),
+				'objecttype' => $query->createNamedParameter('files'),
+				'systemtagid' => $query->createNamedParameter(1337, IQueryBuilder::PARAM_INT),
+			])->execute();
+
+		// Non-existing file
+		$query = $this->connection->getQueryBuilder();
+		$query->insert('systemtag_object_mapping')
+			->values([
+				'objectid' => $query->createNamedParameter($fileId + 1, IQueryBuilder::PARAM_INT),
+				'objecttype' => $query->createNamedParameter('files'),
+				'systemtagid' => $query->createNamedParameter(1337, IQueryBuilder::PARAM_INT),
+			])->execute();
+
+		$mapping = $this->getMappings('systemtag_object_mapping');
+		$this->assertCount(2, $mapping);
+
+		$job = new DeleteOrphanedTagsJob();
+		$this->invokePrivate($job, 'cleanSystemTags');
+
+		$mapping = $this->getMappings('systemtag_object_mapping');
+		$this->assertCount(1, $mapping);
+
+		$query = $this->connection->getQueryBuilder();
+		$query->delete('filecache')
+			->where($query->expr()->eq('fileid', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)))
+			->execute();
+		$this->cleanMapping('systemtag_object_mapping');
+	}
+
+	/**
+	 * Test clearing orphaned system tag mappings
+	 */
+	public function testClearUserTagMappings() {
+		$this->cleanMapping('vcategory_to_object');
+
+		$query = $this->connection->getQueryBuilder();
+		$query->insert('filecache')
+			->values([
+				'storage' => $query->createNamedParameter(1337, IQueryBuilder::PARAM_INT),
+				'path' => $query->createNamedParameter('apps/files/tests/deleteorphanedtagsjobtest.php'),
+				'path_hash' => $query->createNamedParameter(md5('apps/files/tests/deleteorphanedtagsjobtest.php')),
+			])->execute();
+		$fileId = $query->getLastInsertId();
+
+		// Existing file
+		$query = $this->connection->getQueryBuilder();
+		$query->insert('vcategory_to_object')
+			->values([
+				'objid' => $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT),
+				'type' => $query->createNamedParameter('files'),
+				'categoryid' => $query->createNamedParameter(1337, IQueryBuilder::PARAM_INT),
+			])->execute();
+
+		// Non-existing file
+		$query = $this->connection->getQueryBuilder();
+		$query->insert('vcategory_to_object')
+			->values([
+				'objid' => $query->createNamedParameter($fileId + 1, IQueryBuilder::PARAM_INT),
+				'type' => $query->createNamedParameter('files'),
+				'categoryid' => $query->createNamedParameter(1337, IQueryBuilder::PARAM_INT),
+			])->execute();
+
+		$mapping = $this->getMappings('vcategory_to_object');
+		$this->assertCount(2, $mapping);
+
+		$job = new DeleteOrphanedTagsJob();
+		$this->invokePrivate($job, 'cleanUserTags');
+
+		$mapping = $this->getMappings('vcategory_to_object');
+		$this->assertCount(1, $mapping);
+
+		$query = $this->connection->getQueryBuilder();
+		$query->delete('filecache')
+			->where($query->expr()->eq('fileid', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)))
+			->execute();
+		$this->cleanMapping('vcategory_to_object');
+	}
+
+}


### PR DESCRIPTION
Whenever a file was deleted (also from trash), the tag mapping is
pointing at a fileid that doesn't exist any more.

This cleanup job will delete such orphaned mapping entries.

This applies for BOTH system tags and user tags (like favorite).

To test:
1. Create a file "test.txt" in the web UI
2. Inspect the "tr" element to find its "data-id" (the file id)
3. Mark the file "test.txt" as favorite
4. Add a system tag "test1" to this file using the right sidebar
5. `select * from oc_vcategory_to_object where objid=$fileid` => 1 result
6. `select * from oc_systemtag_object_mapping where objectid=$fileid` => 1 result
7. Delete the file "test.txt"
8. Empty trashbin
9. Reset the cleanup job: `update oc_jobs set last_run=0 where class='OCA\\Files\\Lib\\DeleteOrphanedTagsJob'`
10. Run "cron.php"
11. Rerun the two selects from above: no results

Please review @nickvergessen @icewind1991 @rullzer @blizzz 
