### PR TITLE
[Share 2.0] When deleting a group share delete children

### DIFF
--- a/lib/private/share20/defaultshareprovider.php
+++ b/lib/private/share20/defaultshareprovider.php
@@ -288,21 +288,21 @@ class DefaultShareProvider implements IShareProvider {
 	 * Delete a share
 	 *
 	 * @param \OCP\Share\IShare $share
-	 * @throws BackendError
 	 */
 	public function delete(\OCP\Share\IShare $share) {
-		// Fetch share to make sure it exists
-		$share = $this->getShareById($share->getId());
-
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->delete('share')
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())));
-	
-		try {
-			$qb->execute();
-		} catch (\Exception $e) {
-			throw new BackendError();
+
+		/*
+		 * If the share is a group share delete all possible
+		 * user defined groups shares.
+		 */
+		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
+			$qb->orWhere($qb->expr()->eq('parent', $qb->createNamedParameter($share->getId())));
 		}
+
+		$qb->execute();
 	}
 
 	/**


### PR DESCRIPTION
For group shares we can have children. Those are custom shares when a user has moved or deleted a group share. Those also have to be deleted if the group share is removed.

CC: @schiesbn @nickvergessen @DeepDiver1975 @LukasReschke @PVince81 
