### PR TITLE
cache reader should turn back values that were assoc array to assoc a…

### DIFF
--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -206,7 +206,13 @@ class Connection extends LDAPUtility {
 		}
 		$key = $this->getCacheKey($key);
 
-		return json_decode(base64_decode($this->cache->get($key)));
+		$value = json_decode(base64_decode($this->cache->get($key)));
+		if($value instanceof \stdClass) {
+			// originally an associative array
+			$value = (array)$value;
+		}
+
+		return $value;
 	}
 
 	/**


### PR DESCRIPTION
…rrays again

Fixes #21896 (see for reproduction steps there as well)

please review @owncloud/ldap 

@karlitschek ok to backport?
