### PR TITLE
[Share 2.0] Allow recipient to be passed in to getShareById

### DIFF
--- a/lib/private/share20/defaultshareprovider.php
+++ b/lib/private/share20/defaultshareprovider.php
@@ -251,6 +251,7 @@ class DefaultShareProvider implements IShareProvider {
 
 	/**
 	 * Get all children of this share
+	 * FIXME: remove once https://github.com/owncloud/core/pull/21660 is in
 	 *
 	 * @param \OCP\Share\IShare $parent
 	 * @return IShare[]
@@ -265,12 +266,11 @@ class DefaultShareProvider implements IShareProvider {
 			->andWhere(
 				$qb->expr()->in(
 					'share_type',
-					[
-						$qb->expr()->literal(\OCP\Share::SHARE_TYPE_USER),
-						$qb->expr()->literal(\OCP\Share::SHARE_TYPE_GROUP),
-						$qb->expr()->literal(\OCP\Share::SHARE_TYPE_LINK),
-						$qb->expr()->literal(self::SHARE_TYPE_USERGROUP),
-					]
+					$qb->createNamedParameter([
+						\OCP\Share::SHARE_TYPE_USER,
+						\OCP\Share::SHARE_TYPE_GROUP,
+						\OCP\Share::SHARE_TYPE_LINK,
+					], IQueryBuilder::PARAM_INT_ARRAY)
 				)
 			)
 			->orderBy('id');

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -746,14 +746,9 @@ class Manager implements IManager {
 	}
 
 	/**
-	 * Retrieve a share by the share id
-	 *
-	 * @param string $id
-	 * @return Share
-	 *
-	 * @throws ShareNotFound
+	 * @inheritdoc
 	 */
-	public function getShareById($id) {
+	public function getShareById($id, $recipient = null) {
 		if ($id === null) {
 			throw new ShareNotFound();
 		}
@@ -761,7 +756,7 @@ class Manager implements IManager {
 		list($providerId, $id) = $this->splitFullId($id);
 		$provider = $this->factory->getProvider($providerId);
 
-		$share = $provider->getShareById($id);
+		$share = $provider->getShareById($id, $recipient);
 
 		return $share;
 	}

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -612,6 +612,7 @@ class Manager implements IManager {
 
 	/**
 	 * Delete all the children of this share
+	 * FIXME: remove once https://github.com/owncloud/core/pull/21660 is in
 	 *
 	 * @param \OCP\Share\IShare $share
 	 * @return \OCP\Share\IShare[] List of deleted shares

--- a/lib/public/share/imanager.php
+++ b/lib/public/share/imanager.php
@@ -101,14 +101,18 @@ interface IManager {
 	public function getSharedWith(IUser $user, $shareType, $node = null, $limit = 50, $offset = 0);
 
 	/**
-	 * Retrieve a share by the share id
+	 * Retrieve a share by the share id.
+	 * If the recipient is set make sure to retrieve the file for that user.
+	 * This makes sure that if a user has moved/deleted a group share this
+	 * is reflected.
 	 *
 	 * @param string $id
-	 * @return Share
+	 * @param IUser|null $recipient
+	 * @return IShare
 	 * @throws ShareNotFound
 	 * @since 9.0.0
 	 */
-	public function getShareById($id);
+	public function getShareById($id, $recipient = null);
 
 	/**
 	 * Get the share by token possible with password

--- a/lib/public/share/ishareprovider.php
+++ b/lib/public/share/ishareprovider.php
@@ -97,11 +97,12 @@ interface IShareProvider {
 	 * Get share by id
 	 *
 	 * @param int $id
+	 * @param IUser|null $recipient
 	 * @return \OCP\Share\IShare
 	 * @throws ShareNotFound
 	 * @since 9.0.0
 	 */
-	public function getShareById($id);
+	public function getShareById($id, $recipient = null);
 
 	/**
 	 * Get shares for a given path


### PR DESCRIPTION
Allow retrieving a share by id for a given recipient.
For group shares this might have a different target and/or permissions.

CC: @PVince81 @schiesbn @nickvergessen @DeepDiver1975 
