### PR TITLE
[stable8.2] Heal unencrypted file sizes at download time

### DIFF
--- a/lib/private/files/stream/encryption.php
+++ b/lib/private/files/stream/encryption.php
@@ -386,6 +386,8 @@ class Encryption extends Wrapper {
 	public function stream_seek($offset, $whence = SEEK_SET) {
 
 		$return = false;
+		// don't try to fix unencrypted size on fseek
+		$this->mustFixUnencryptedSize = false;
 
 		switch ($whence) {
 			case SEEK_SET:

--- a/lib/private/files/stream/encryption.php
+++ b/lib/private/files/stream/encryption.php
@@ -322,13 +322,7 @@ class Encryption extends Wrapper {
 
 		// gather data to repair unencrypted size
 		if ($this->mustFixUnencryptedSize) {
-			// strlen is expensive, so check with isset if the length is the max size
-			if (isset($result[$this->unencryptedBlockSize])) {
-				$this->fixedUnencryptedSize += $this->unencryptedBlockSize;
-			} else {
-				// use strlen for the remaining block
-				$this->fixedUnencryptedSize += strlen($result);
-			}
+			$this->fixedUnencryptedSize += strlen($result);
 		}
 		return $result;
 


### PR DESCRIPTION
Whenever the unencrypted size is -1 or equal to the encrypted size,
interpret this as an error and enable a repair routine inside the
encryption stream wrapper.

The repair routine will count how many bytes of decrypted content was
returned and then update the cache when closing the stream.

This fix is very specific to encryption but has the advantage of not impairing (slowing down) the regular download cases.

@MorrisJobke @icewind1991 @schiesbn 
- [ ] backport approval (after testing)
- [ ] add unit tests

Fixes https://github.com/owncloud/core/issues/21751 but only for encryption
