### PR TITLE
[Share 2.0] Allow moving of shares

### DIFF
--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -715,6 +715,25 @@ class Manager implements IManager {
 	}
 
 	/**
+	 * @inheritdoc
+	 */
+	public function moveShare(\OCP\Share\IShare $share, IUser $recipient) {
+		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
+			throw new \InvalidArgumentException('Can\'t change target of link share');
+		}
+
+		if (($share->getShareType() === \OCP\Share::SHARE_TYPE_USER && $share->getSharedWith() !== $recipient) ||
+			($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP && !$share->getSharedWith()->inGroup($recipient))) {
+			throw new \InvalidArgumentException('Invalid recipient');
+		}
+
+		list($providerId, ) = $this->splitFullId($share->getId());
+		$provider = $this->factory->getProvider($providerId);
+
+		$provider->move($share, $recipient);
+	}
+
+	/**
 	 * Get shares shared by (initiated) by the provided user.
 	 *
 	 * @param IUser $user

--- a/lib/public/share/imanager.php
+++ b/lib/public/share/imanager.php
@@ -37,13 +37,15 @@ interface IManager {
 	 * Create a Share
 	 *
 	 * @param IShare $share
-	 * @return Share The share object
+	 * @return IShare The share object
 	 * @since 9.0.0
 	 */
 	public function createShare(IShare $share);
 
 	/**
-	 * Update a share
+	 * Update a share.
+	 * The target of the share can't be changed this way: use moveShare
+	 * The share can't be removed this way (permission 0): use deleteShare
 	 *
 	 * @param IShare $share
 	 * @return IShare The share object
@@ -71,6 +73,18 @@ interface IManager {
 	 * @since 9.0.0
 	 */
 	public function deleteFromSelf(IShare $share, IUser $recipient);
+
+	/**
+	 * Move the share as a recipient of the share.
+	 * This is updating the share target. So where the recipient has the share mounted.
+	 *
+	 * @param IShare $share
+	 * @param IUser $recipient
+	 * @return IShare
+	 * @throws \InvalidArgumentException If $share is a link share or the $recipient does not match
+	 * @since 9.0.0
+	 */
+	public function moveShare(IShare $share, IUser $recipient);
 
 	/**
 	 * Get shares shared by (initiated) by the provided user.
@@ -118,7 +132,7 @@ interface IManager {
 	 * Get the share by token possible with password
 	 *
 	 * @param string $token
-	 * @return Share
+	 * @return IShare
 	 * @throws ShareNotFound
 	 * @since 9.0.0
 	 */

--- a/lib/public/share/ishareprovider.php
+++ b/lib/public/share/ishareprovider.php
@@ -80,6 +80,19 @@ interface IShareProvider {
 	public function deleteFromSelf(\OCP\Share\IShare $share, IUser $recipient);
 
 	/**
+	 * Move a share as a recipient.
+	 * This is updating the share target. Thus the mount point of the recipient.
+	 * This may require special handling. If a user moves a group share
+	 * the target should only be changed for them.
+	 *
+	 * @param \OCP\Share\IShare $share
+	 * @param IUser $recipient
+	 * @return \OCP\Share\IShare
+	 * @since 9.0.0
+	 */
+	public function move(\OCP\Share\IShare $share, IUser $recipient);
+
+	/**
 	 * Get all shares by the given user
 	 *
 	 * @param IUser $user

--- a/tests/lib/share20/managertest.php
+++ b/tests/lib/share20/managertest.php
@@ -1887,6 +1887,79 @@ class ManagerTest extends \Test\TestCase {
 
 		$manager->updateShare($share);
 	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 * @expectedExceptionMessage Can't change target of link share
+	 */
+	public function testMoveShareLink() {
+		$share = $this->manager->newShare();
+		$share->setShareType(\OCP\Share::SHARE_TYPE_LINK);
+
+		$recipient = $this->getMock('\OCP\IUser');
+
+		$this->manager->moveShare($share, $recipient);
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 * @expectedExceptionMessage Invalid recipient
+	 */
+	public function testMoveShareUserNotRecipient() {
+		$share = $this->manager->newShare();
+		$share->setShareType(\OCP\Share::SHARE_TYPE_USER);
+
+		$sharedWith = $this->getMock('\OCP\IUser');
+		$share->setSharedWith($sharedWith);
+
+		$recipient = $this->getMock('\OCP\IUser');
+
+		$this->manager->moveShare($share, $recipient);
+	}
+
+	public function testMoveShareUser() {
+		$share = $this->manager->newShare();
+		$share->setShareType(\OCP\Share::SHARE_TYPE_USER);
+
+		$recipient = $this->getMock('\OCP\IUser');
+		$share->setSharedWith($recipient);
+
+		$this->defaultProvider->method('move')->with($share, $recipient)->will($this->returnArgument(0));
+
+		$this->manager->moveShare($share, $recipient);
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 * @expectedExceptionMessage Invalid recipient
+	 */
+	public function testMoveShareGroupNotRecipient() {
+		$share = $this->manager->newShare();
+		$share->setShareType(\OCP\Share::SHARE_TYPE_GROUP);
+
+		$sharedWith = $this->getMock('\OCP\IGroup');
+		$share->setSharedWith($sharedWith);
+
+		$recipient = $this->getMock('\OCP\IUser');
+		$sharedWith->method('inGroup')->with($recipient)->willReturn(false);
+
+		$this->manager->moveShare($share, $recipient);
+	}
+
+	public function testMoveShareGroup() {
+		$share = $this->manager->newShare();
+		$share->setShareType(\OCP\Share::SHARE_TYPE_GROUP);
+
+		$sharedWith = $this->getMock('\OCP\IGroup');
+		$share->setSharedWith($sharedWith);
+
+		$recipient = $this->getMock('\OCP\IUser');
+		$sharedWith->method('inGroup')->with($recipient)->willReturn(true);
+
+		$this->defaultProvider->method('move')->with($share, $recipient)->will($this->returnArgument(0));
+
+		$this->manager->moveShare($share, $recipient);
+	}
 }
 
 class DummyPassword {


### PR DESCRIPTION
Requires: https://github.com/owncloud/core/pull/22005

The share manager now allows recipients of a share to move that share.
The default share providers handles the special share type for usergroup shares (so a user moves their instance of a group share).

This is required to move more internal stuff over to the share manager. So we dont' have to queries by hand when moving a share.
- [x] Unit tests
