### PR TITLE
Block shares that dont have the correct source permissions

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -46,6 +46,7 @@ use Icewind\Streams\CallbackWrapper;
 use OC\Files\Mount\MoveableMount;
 use OC\Files\Storage\Storage;
 use OC\User\User;
+use OCP\Constants;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\FileNameTooLongException;
 use OCP\Files\InvalidCharacterInPathException;
@@ -1335,7 +1336,7 @@ class View {
 
 			$data = $this->getCacheEntry($storage, $internalPath, $directory);
 
-			if (!$data instanceof ICacheEntry || !isset($data['fileid'])) {
+			if (!$data instanceof ICacheEntry || !isset($data['fileid']) || !($data->getPermissions() && Constants::PERMISSION_READ)) {
 				return [];
 			}
 
@@ -1385,7 +1386,7 @@ class View {
 						$rootEntry = $subCache->get('');
 					}
 
-					if ($rootEntry) {
+					if ($rootEntry && ($rootEntry->getPermissions() && Constants::PERMISSION_READ)) {
 						$relativePath = trim(substr($mountPoint, $dirLength), '/');
 						if ($pos = strpos($relativePath, '/')) {
 							//mountpoint inside subfolder add size to the correct folder


### PR DESCRIPTION
If the source file no longer has the share permissions it removes the share permissions from the permissions returned from the shared storage and cache.

Additionally it hides mounts without read permissions from the directory listings and prevents any operation on a shared storage without the correct permissions.

To test you'll need to remove the share permissions from the database on a shared file or folder or you can try using https://github.com/owncloud/core/pull/20903

cc @PVince81 @rullzer 
