### PR TITLE
Add path filter to OCS Share API shared_with_me=true

### DIFF
--- a/apps/files_sharing/api/share20ocs.php
+++ b/apps/files_sharing/api/share20ocs.php
@@ -329,9 +329,13 @@ class Share20OCS {
 		return new \OC_OCS_Result($share);
 	}
 
-	private function getSharedWithMe() {
-		$userShares = $this->shareManager->getSharedWith($this->currentUser, \OCP\Share::SHARE_TYPE_USER, -1, 0);
-		$groupShares = $this->shareManager->getSharedWith($this->currentUser, \OCP\Share::SHARE_TYPE_GROUP, -1, 0);
+	/**
+	 * @param \OCP\Files\File|\OCP\Files\Folder $node
+	 * @return \OC_OCS_Result
+	 */
+	private function getSharedWithMe($node = null) {
+		$userShares = $this->shareManager->getSharedWith($this->currentUser, \OCP\Share::SHARE_TYPE_USER, $node, -1, 0);
+		$groupShares = $this->shareManager->getSharedWith($this->currentUser, \OCP\Share::SHARE_TYPE_GROUP, $node, -1, 0);
 
 		$shares = array_merge($userShares, $groupShares);
 
@@ -390,10 +394,6 @@ class Share20OCS {
 		$subfiles = $this->request->getParam('subfiles');
 		$path = $this->request->getParam('path', null);
 
-		if ($sharedWithMe === 'true') {
-			return $this->getSharedWithMe();
-		}
-
 		if ($path !== null) {
 			$userFolder = $this->rootFolder->getUserFolder($this->currentUser->getUID());
 			try {
@@ -401,6 +401,10 @@ class Share20OCS {
 			} catch (\OCP\Files\NotFoundException $e) {
 				return new \OC_OCS_Result(null, 404, 'wrong path, file/folder doesn\'t exist');
 			}
+		}
+
+		if ($sharedWithMe === 'true') {
+			return $this->getSharedWithMe($path);
 		}
 
 		if ($subfiles === 'true') {

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -313,6 +313,28 @@ Feature: sharing
     And the HTTP status code should be "200"
     And last share_id is included in the answer
 
+  Scenario: Sharee can see the filtered share
+    Given user "user0" exists
+    And user "user1" exists
+    And file "textfile0.txt" of user "user0" is shared with user "user1"
+    And file "textfile1.txt" of user "user0" is shared with user "user1"
+    And As an "user1"
+    When sending "GET" to "/apps/files_sharing/api/v1/shares?shared_with_me=true&path=textfile1 (2).txt"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And last share_id is included in the answer
+
+  Scenario: Sharee can't see the share that is filtered out
+    Given user "user0" exists
+    And user "user1" exists
+    And file "textfile0.txt" of user "user0" is shared with user "user1"
+    And file "textfile1.txt" of user "user0" is shared with user "user1"
+    And As an "user1"
+    When sending "GET" to "/apps/files_sharing/api/v1/shares?shared_with_me=true&path=textfile0 (2).txt"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And last share_id is not included in the answer
+
   Scenario: Sharee can see the group share
     Given As an "admin"
     And user "user0" exists

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -21,6 +21,7 @@
 
 namespace OC\Share20;
 
+use OCP\Files\Node;
 use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
 use OC\Share20\Exception\BackendError;
@@ -722,18 +723,12 @@ class Manager implements IManager {
 	}
 
 	/**
-	 * Get shares shared with $user.
-	 *
-	 * @param IUser $user
-	 * @param int $shareType
-	 * @param int $limit The maximum number of shares returned, -1 for all
-	 * @param int $offset
-	 * @return \OCP\Share\IShare[]
+	 * @inheritdoc
 	 */
-	public function getSharedWith(IUser $user, $shareType, $limit = 50, $offset = 0) {
+	public function getSharedWith(IUser $user, $shareType, $node = null, $limit = 50, $offset = 0) {
 		$provider = $this->factory->getProviderForType($shareType);
 
-		return $provider->getSharedWith($user, $shareType, $limit, $offset);
+		return $provider->getSharedWith($user, $shareType, $node, $limit, $offset);
 	}
 
 	/**

--- a/lib/public/share/imanager.php
+++ b/lib/public/share/imanager.php
@@ -88,15 +88,17 @@ interface IManager {
 
 	/**
 	 * Get shares shared with $user.
+	 * Filter by $node if provided
 	 *
 	 * @param IUser $user
 	 * @param int $shareType
+	 * @param File|Folder|null $node
 	 * @param int $limit The maximum number of shares returned, -1 for all
 	 * @param int $offset
 	 * @return IShare[]
 	 * @since 9.0.0
 	 */
-	public function getSharedWith(IUser $user, $shareType, $limit = 50, $offset = 0);
+	public function getSharedWith(IUser $user, $shareType, $node = null, $limit = 50, $offset = 0);
 
 	/**
 	 * Retrieve a share by the share id

--- a/lib/public/share/ishareprovider.php
+++ b/lib/public/share/ishareprovider.php
@@ -23,6 +23,7 @@ namespace OCP\Share;
 
 use OC\Share20\Exception\ShareNotFound;
 use OC\Share20\Exception\BackendError;
+use OCP\Files\Node;
 use OCP\IUser;
 
 /**
@@ -116,12 +117,13 @@ interface IShareProvider {
 	 *
 	 * @param IUser $user get shares where this user is the recipient
 	 * @param int $shareType
+	 * @param Node|null $node
 	 * @param int $limit The max number of entries returned, -1 for all
 	 * @param int $offset
 	 * @return \OCP\Share\IShare[]
 	 * @since 9.0.0
 	 */
-	public function getSharedWith(IUser $user, $shareType, $limit, $offset);
+	public function getSharedWith(IUser $user, $shareType, $node, $limit, $offset);
 
 	/**
 	 * Get a share by token


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/22019

All the clients should also benefit from this when trying to obtain the maximum permissions of a path. @davivel @ckamm 

The filter is rather straight forward.

CC: @MorrisJobke @PVince81 @nickvergessen @DeepDiver1975 @schiesbn 
