### PR TITLE
Improved error handling

### DIFF
--- a/apps/federation/api/ocsauthapi.php
+++ b/apps/federation/api/ocsauthapi.php
@@ -99,7 +99,7 @@ class OCSAuthAPI {
 		$token = $this->request->getParam('token');
 
 		if ($this->trustedServers->isTrustedServer($url) === false) {
-			$this->logger->log(\OCP\Util::ERROR, 'remote server not trusted (' . $url . ') while requesting shared secret');
+			$this->logger->log(\OCP\Util::ERROR, 'remote server not trusted (' . $url . ') while requesting shared secret', ['app' => 'federation']);
 			return new \OC_OCS_Result(null, HTTP::STATUS_FORBIDDEN);
 		}
 
@@ -107,7 +107,7 @@ class OCSAuthAPI {
 		// token wins
 		$localToken = $this->dbHandler->getToken($url);
 		if (strcmp($localToken, $token) > 0) {
-			$this->logger->log(\OCP\Util::ERROR, 'remote server (' . $url . ') presented lower token');
+			$this->logger->log(\OCP\Util::ERROR, 'remote server (' . $url . ') presented lower token', ['app' => 'federation']);
 			return new \OC_OCS_Result(null, HTTP::STATUS_FORBIDDEN);
 		}
 
@@ -134,12 +134,12 @@ class OCSAuthAPI {
 		$token = $this->request->getParam('token');
 
 		if ($this->trustedServers->isTrustedServer($url) === false) {
-			$this->logger->log(\OCP\Util::ERROR, 'remote server not trusted (' . $url . ') while getting shared secret');
+			$this->logger->log(\OCP\Util::ERROR, 'remote server not trusted (' . $url . ') while getting shared secret', ['app' => 'federation']);
 			return new \OC_OCS_Result(null, HTTP::STATUS_FORBIDDEN);
 		}
 
 		if ($this->isValidToken($url, $token) === false) {
-			$this->logger->log(\OCP\Util::ERROR, 'remote server (' . $url . ') didn\'t send a valid token (got ' . $token . ') while getting shared secret');
+			$this->logger->log(\OCP\Util::ERROR, 'remote server (' . $url . ') didn\'t send a valid token (got ' . $token . ') while getting shared secret', ['app' => 'federation']);
 			return new \OC_OCS_Result(null, HTTP::STATUS_FORBIDDEN);
 		}
 

--- a/apps/federation/backgroundjob/getsharedsecret.php
+++ b/apps/federation/backgroundjob/getsharedsecret.php
@@ -151,6 +151,9 @@ class GetSharedSecret extends QueuedJob{
 		} catch (ClientException $e) {
 			$status = $e->getCode();
 			$this->logger->logException($e);
+		} catch (\Exception $e) {
+			$status = HTTP::STATUS_INTERNAL_SERVER_ERROR;
+			$this->logger->logException($e);
 		}
 
 		// if we received a unexpected response we try again later

--- a/apps/federation/backgroundjob/requestsharedsecret.php
+++ b/apps/federation/backgroundjob/requestsharedsecret.php
@@ -149,6 +149,9 @@ class RequestSharedSecret extends QueuedJob {
 		} catch (ClientException $e) {
 			$status = $e->getCode();
 			$this->logger->logException($e);
+		} catch (\Exception $e) {
+			$status = HTTP::STATUS_INTERNAL_SERVER_ERROR;
+			$this->logger->logException($e);
 		}
 
 		// if we received a unexpected response we try again later


### PR DESCRIPTION
- Improved error messages for federated sharing
- catch all exceptions, not only ClientException, e.g. in case of a server time out a ConnectionException could happen as well

@MorrisJobke I improved this stuff while trying to re-produce https://github.com/owncloud/core/issues/21929. I couldn't reproduce the issue but maybe you can give this PR a try if it changes anything for you. Especially the part that the background job was removed to early could be fixed with the additional catch-block.
