### PR TITLE
[stable8.2] Make enable_avatars setting more robust

### DIFF
--- a/core/js/config.php
+++ b/core/js/config.php
@@ -140,7 +140,7 @@ $array = array(
 			'session_keepalive'	=> \OCP\Config::getSystemValue('session_keepalive', true),
 			'version'			=> implode('.', OC_Util::getVersion()),
 			'versionstring'		=> OC_Util::getVersionString(),
-			'enable_avatars'	=> \OC::$server->getConfig()->getSystemValue('enable_avatars', true),
+			'enable_avatars'	=> \OC::$server->getConfig()->getSystemValue('enable_avatars', true) === true,
 			'lost_password_link'=> \OC::$server->getConfig()->getSystemValue('lost_password_link', null),
 		)
 	),

--- a/lib/private/templatelayout.php
+++ b/lib/private/templatelayout.php
@@ -124,7 +124,7 @@ class OC_TemplateLayout extends OC_Template {
 			$this->assign('user_displayname', $userDisplayName);
 			$this->assign('user_uid', OC_User::getUser());
 			$this->assign('appsmanagement_active', $appsMgmtActive);
-			$this->assign('enableAvatars', $this->config->getSystemValue('enable_avatars', true));
+			$this->assign('enableAvatars', $this->config->getSystemValue('enable_avatars', true) === true);
 			$this->assign('userAvatarSet', \OC_Helper::userAvatarSet(OC_User::getUser()));
 		} else if ($renderAs == 'error') {
 			parent::__construct('core', 'layout.guest', '', false);

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -147,7 +147,7 @@ $tmpl->assign('activelanguage', $userLang);
 $tmpl->assign('passwordChangeSupported', OC_User::canUserChangePassword(OC_User::getUser()));
 $tmpl->assign('displayNameChangeSupported', OC_User::canUserChangeDisplayName(OC_User::getUser()));
 $tmpl->assign('displayName', OC_User::getDisplayName());
-$tmpl->assign('enableAvatars', $config->getSystemValue('enable_avatars', true));
+$tmpl->assign('enableAvatars', $config->getSystemValue('enable_avatars', true) === true);
 $tmpl->assign('avatarChangeSupported', OC_User::canUserChangeAvatar(OC_User::getUser()));
 $tmpl->assign('certs', $certificateManager->listCertificates());
 $tmpl->assign('showCertificates', $enableCertImport);

--- a/settings/users.php
+++ b/settings/users.php
@@ -100,7 +100,7 @@ $tmpl->assign('quota_preset', $quotaPreset);
 $tmpl->assign('default_quota', $defaultQuota);
 $tmpl->assign('defaultQuotaIsUserDefined', $defaultQuotaIsUserDefined);
 $tmpl->assign('recoveryAdminEnabled', $recoveryAdminEnabled);
-$tmpl->assign('enableAvatars', \OC::$server->getConfig()->getSystemValue('enable_avatars', true));
+$tmpl->assign('enableAvatars', \OC::$server->getConfig()->getSystemValue('enable_avatars', true) === true);
 
 $tmpl->assign('show_storage_location', $config->getAppValue('core', 'umgmt_show_storage_location', 'false'));
 $tmpl->assign('show_last_login', $config->getAppValue('core', 'umgmt_show_last_login', 'false'));


### PR DESCRIPTION
- handles the setting in the same way everywhere
- fixes #21949 
- backport of #21953 - approval: https://github.com/owncloud/core/pull/21953#issuecomment-175654251

@DeepDiver1975 @PVince81 @nickvergessen @LukasReschke Please review
