### PR TITLE
pass parameter in the right order to syncRemoteAddressBook()

### DIFF
--- a/apps/federation/lib/syncfederationaddressbooks.php
+++ b/apps/federation/lib/syncfederationaddressbooks.php
@@ -46,7 +46,7 @@ class SyncFederationAddressBooks {
 					'{DAV:}displayname' => $url
 			];
 			try {
-				$newToken = $this->syncService->syncRemoteAddressBook($url, 'system', $sharedSecret, $syncToken, $targetPrincipal, $targetBookId, $targetBookProperties);
+				$newToken = $this->syncService->syncRemoteAddressBook($url, 'system', $sharedSecret, $syncToken, $targetBookId, $targetPrincipal, $targetBookProperties);
 				if ($newToken !== $syncToken) {
 					$this->dbHandler->setServerStatus($url, TrustedServers::STATUS_OK, $newToken);
 				}


### PR DESCRIPTION
fix issue discovered here: https://github.com/owncloud/core/pull/21988#issuecomment-178003605

cc @DeepDiver1975 
