### PR TITLE
Make sure user has access to file for system tag operations

### DIFF
--- a/apps/dav/lib/rootcollection.php
+++ b/apps/dav/lib/rootcollection.php
@@ -68,7 +68,8 @@ class RootCollection extends SimpleCollection {
 			\OC::$server->getSystemTagManager(),
 			\OC::$server->getSystemTagObjectMapper(),
 			\OC::$server->getUserSession(),
-			\OC::$server->getGroupManager()
+			\OC::$server->getGroupManager(),
+			\OC::$server->getRootFolder()
 		);
 		$commentsCollection = new Comments\RootCollection(
 			\OC::$server->getCommentsManager(),

--- a/apps/dav/lib/systemtag/systemtagplugin.php
+++ b/apps/dav/lib/systemtag/systemtagplugin.php
@@ -104,12 +104,7 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 		$path = $request->getPath();
 
 		// Making sure the node exists
-		try {
-			$node = $this->server->tree->getNodeForPath($path);
-		} catch (NotFound $e) {
-			return null;
-		}
-
+		$node = $this->server->tree->getNodeForPath($path);
 		if ($node instanceof SystemTagsByIdCollection || $node instanceof SystemTagsObjectMappingCollection) {
 			$data = $request->getBodyAsString();
 

--- a/apps/dav/lib/systemtag/systemtagsrelationscollection.php
+++ b/apps/dav/lib/systemtag/systemtagsrelationscollection.php
@@ -28,6 +28,7 @@ use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\SimpleCollection;
 use OCP\IUserSession;
 use OCP\IGroupManager;
+use OCP\Files\IRootFolder;
 
 class SystemTagsRelationsCollection extends SimpleCollection {
 
@@ -38,12 +39,14 @@ class SystemTagsRelationsCollection extends SimpleCollection {
 	 * @param ISystemTagObjectMapper $tagMapper
 	 * @param IUserSession $userSession
 	 * @param IGroupManager $groupManager
+	 * @param IRootFolder $fileRoot
 	 */
 	public function __construct(
 		ISystemTagManager $tagManager,
 		ISystemTagObjectMapper $tagMapper,
 		IUserSession $userSession,
-		IGroupManager $groupManager
+		IGroupManager $groupManager,
+		IRootFolder $fileRoot
 	) {
 		$children = [
 			new SystemTagsObjectTypeCollection(
@@ -51,7 +54,8 @@ class SystemTagsRelationsCollection extends SimpleCollection {
 				$tagManager,
 				$tagMapper,
 				$userSession,
-				$groupManager
+				$groupManager,
+				$fileRoot
 			),
 		];
 

--- a/apps/dav/tests/unit/systemtag/systemtagplugin.php
+++ b/apps/dav/tests/unit/systemtag/systemtagplugin.php
@@ -272,6 +272,40 @@ class SystemTagPlugin extends \Test\TestCase {
 	}
 
 	/**
+	 * @expectedException \Sabre\DAV\Exception\NotFound
+	 */
+	public function testCreateTagToUnknownNode() {
+		$systemTag = new SystemTag(1, 'Test', true, false);
+
+		$node = $this->getMockBuilder('\OCA\DAV\SystemTag\SystemTagsObjectMappingCollection')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->tree->expects($this->any())
+			->method('getNodeForPath')
+			->will($this->throwException(new \Sabre\DAV\Exception\NotFound()));
+
+		$this->tagManager->expects($this->never())
+			->method('createTag');
+
+		$node->expects($this->never())
+			->method('createFile');
+
+		$request = $this->getMockBuilder('Sabre\HTTP\RequestInterface')
+				->disableOriginalConstructor()
+				->getMock();
+		$response = $this->getMockBuilder('Sabre\HTTP\ResponseInterface')
+				->disableOriginalConstructor()
+				->getMock();
+
+		$request->expects($this->once())
+			->method('getPath')
+			->will($this->returnValue('/systemtags-relations/files/12'));
+
+		$this->plugin->httpPost($request, $response);
+	}
+
+	/**
 	 * @dataProvider nodeClassProvider
 	 * @expectedException Sabre\DAV\Exception\Conflict
 	 */


### PR DESCRIPTION
Fixes DAV's SystemTagsObjectTypeCollection to not give access to files
where the current user doesn't have access to.

To test:
- `curl -D - -X POST -H "Content-Type: application/json" -d '{"name":"test relation z", "userVisible": true, "userAssignable": true}' http://root:admin@localhost/owncloud/remote.php/dav/systemtags-relations/files/3/` where 3 is the fileid of an accessible file for "root", check Content-Location header for tag id of newly created tag
- same POST where the file id is from another user => must fail with 404
- `curl -D - -X PUT http://root:admin@localhost/owncloud/remote.php/dav/systemtags-relations/files/$fileId/$tagId`. Replace $tagId with the tag id from above. Replace $fileId with a fileid accessible by root
- same PUT but with file id from another user

POST is covered by the SystemTagsPlugin and any other operation is going through `getChild` to access subnodes. So the fact that `getChild` blocks access to unknown file ids will block any operations there.

Please review @Blizzz @LukasReschke @icewind1991 @DeepDiver1975 

Fix #22061 
