### PR TITLE
Update old password hashed for link shares on access

### DIFF
--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -819,7 +819,9 @@ class Manager implements IManager {
 		}
 
 		if (!empty($newHash)) {
-			//TODO update hash!
+			$share->setPassword($newHash);
+			$provider = $this->factory->getProviderForType($share->getShareType());
+			$provider->update($share);
 		}
 
 		return true;

--- a/tests/lib/share20/managertest.php
+++ b/tests/lib/share20/managertest.php
@@ -1645,6 +1645,27 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertTrue($this->manager->checkPassword($share, 'password'));
 	}
 
+	public function testCheckPasswordUpdateShare() {
+		$share = $this->manager->newShare();
+		$share->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setPassword('passwordHash');
+
+		$this->hasher->method('verify')->with('password', 'passwordHash', '')
+			->will($this->returnCallback(function($pass, $hash, &$newHash) {
+				$newHash = 'newHash';
+
+				return true;
+			}));
+
+		$this->defaultProvider->expects($this->once())
+			->method('update')
+			->with($this->callback(function (\OCP\Share\IShare $share) {
+				return $share->getPassword() === 'newHash';
+			}));
+
+		$this->assertTrue($this->manager->checkPassword($share, 'password'));
+	}
+
 	/**
 	 * @expectedException Exception
 	 * @expectedExceptionMessage The Share API is disabled


### PR DESCRIPTION
Finally Fixes https://github.com/owncloud/core/issues/16594

Pretty trivial with the new share manager ;)

CC: @LukasReschke @MorrisJobke @schiesbn @DeepDiver1975 @nickvergessen @PVince81 

To test have a look at https://github.com/owncloud/core/blob/master/lib/private/security/hasher.php

So you either need to generate an old password with `password_hash`. But the easier solution is to hash with `sha1`
