### PR TITLE
Comments DAV methods for read mark manipulation (mark comments of a file as read) + return isUnread status

### DIFF
--- a/apps/dav/lib/comments/entitycollection.php
+++ b/apps/dav/lib/comments/entitycollection.php
@@ -51,6 +51,7 @@ class EntityCollection extends RootCollection {
 	 * @param ICommentsManager $commentsManager
 	 * @param Folder $fileRoot
 	 * @param IUserManager $userManager
+	 * @param IUserSession $userSession
 	 * @param ILogger $logger
 	 */
 	public function __construct(
@@ -59,6 +60,7 @@ class EntityCollection extends RootCollection {
 		ICommentsManager $commentsManager,
 		Folder $fileRoot,
 		IUserManager $userManager,
+		IUserSession $userSession,
 		ILogger $logger
 	) {
 		foreach(['id', 'name'] as $property) {
@@ -73,6 +75,7 @@ class EntityCollection extends RootCollection {
 		$this->fileRoot = $fileRoot;
 		$this->logger = $logger;
 		$this->userManager = $userManager;
+		$this->userSession = $userSession;
 	}
 
 	/**
@@ -97,7 +100,13 @@ class EntityCollection extends RootCollection {
 	function getChild($name) {
 		try {
 			$comment = $this->commentsManager->get($name);
-			return new CommentNode($this->commentsManager, $comment, $this->userManager, $this->logger);
+			return new CommentNode(
+				$this->commentsManager,
+				$comment,
+				$this->userManager,
+				$this->userSession,
+				$this->logger
+			);
 		} catch (\OCP\Comments\NotFoundException $e) {
 			throw new NotFound();
 		}
@@ -125,7 +134,13 @@ class EntityCollection extends RootCollection {
 		$comments = $this->commentsManager->getForObject($this->name, $this->id, $limit, $offset, $datetime);
 		$result = [];
 		foreach($comments as $comment) {
-			$result[] = new CommentNode($this->commentsManager, $comment, $this->userManager, $this->logger);
+			$result[] = new CommentNode(
+				$this->commentsManager,
+				$comment,
+				$this->userManager,
+				$this->userSession,
+				$this->logger
+			);
 		}
 		return $result;
 	}

--- a/apps/dav/lib/comments/entitycollection.php
+++ b/apps/dav/lib/comments/entitycollection.php
@@ -25,7 +25,9 @@ use OCP\Comments\ICommentsManager;
 use OCP\Files\Folder;
 use OCP\ILogger;
 use OCP\IUserManager;
+use OCP\IUserSession;
 use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\PropPatch;
 
 /**
  * Class EntityCollection
@@ -35,7 +37,9 @@ use Sabre\DAV\Exception\NotFound;
  *
  * @package OCA\DAV\Comments
  */
-class EntityCollection extends RootCollection {
+class EntityCollection extends RootCollection implements \Sabre\DAV\IProperties {
+	const PROPERTY_NAME_READ_MARKER  = '{http://owncloud.org/ns}readMarker';
+
 	/** @var  Folder */
 	protected $fileRoot;
 
@@ -158,6 +162,38 @@ class EntityCollection extends RootCollection {
 		} catch (\OCP\Comments\NotFoundException $e) {
 			return false;
 		}
+	}
+
+	/**
+	 * Sets the read marker to the specified date for the logged in user
+	 *
+	 * @param \DateTime $value
+	 * @return bool
+	 */
+	public function setReadMarker($value) {
+		$dateTime = new \DateTime($value);
+		$user = $this->userSession->getUser();
+		$this->commentsManager->setReadMark($this->name, $this->id, $dateTime, $user);
+		return true;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	function propPatch(PropPatch $propPatch) {
+		$propPatch->handle(self::PROPERTY_NAME_READ_MARKER, [$this, 'setReadMarker']);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	function getProperties($properties) {
+		$marker = null;
+		$user = $this->userSession->getUser();
+		if(!is_null($user)) {
+			$marker = $this->commentsManager->getReadMark($this->name, $this->id, $user);
+		}
+		return [self::PROPERTY_NAME_READ_MARKER => $marker];
 	}
 }
 

--- a/apps/dav/lib/comments/entitytypecollection.php
+++ b/apps/dav/lib/comments/entitytypecollection.php
@@ -25,6 +25,7 @@ use OCP\Comments\ICommentsManager;
 use OCP\Files\Folder;
 use OCP\ILogger;
 use OCP\IUserManager;
+use OCP\IUserSession;
 use Sabre\DAV\Exception\MethodNotAllowed;
 use Sabre\DAV\Exception\NotFound;
 
@@ -51,6 +52,7 @@ class EntityTypeCollection extends RootCollection {
 	 * @param ICommentsManager $commentsManager
 	 * @param Folder $fileRoot
 	 * @param IUserManager $userManager
+	 * @param IUserSession $userSession
 	 * @param ILogger $logger
 	 */
 	public function __construct(
@@ -58,6 +60,7 @@ class EntityTypeCollection extends RootCollection {
 		ICommentsManager $commentsManager,
 		Folder $fileRoot,
 		IUserManager $userManager,
+		IUserSession $userSession,
 		ILogger $logger
 	) {
 		$name = trim($name);
@@ -69,6 +72,7 @@ class EntityTypeCollection extends RootCollection {
 		$this->fileRoot = $fileRoot;
 		$this->logger = $logger;
 		$this->userManager = $userManager;
+		$this->userSession = $userSession;
 	}
 
 	/**
@@ -91,6 +95,7 @@ class EntityTypeCollection extends RootCollection {
 			$this->commentsManager,
 			$this->fileRoot,
 			$this->userManager,
+			$this->userSession,
 			$this->logger
 		);
 	}

--- a/apps/dav/lib/comments/rootcollection.php
+++ b/apps/dav/lib/comments/rootcollection.php
@@ -98,6 +98,7 @@ class RootCollection implements ICollection {
 			$this->commentsManager,
 			$userFolder,
 			$this->userManager,
+			$this->userSession,
 			$this->logger
 		);
 	}

--- a/apps/dav/tests/unit/comments/entitycollection.php
+++ b/apps/dav/tests/unit/comments/entitycollection.php
@@ -28,6 +28,7 @@ class EntityCollection extends \Test\TestCase {
 	protected $userManager;
 	protected $logger;
 	protected $collection;
+	protected $userSession;
 
 	public function setUp() {
 		parent::setUp();
@@ -35,6 +36,7 @@ class EntityCollection extends \Test\TestCase {
 		$this->commentsManager = $this->getMock('\OCP\Comments\ICommentsManager');
 		$this->folder = $this->getMock('\OCP\Files\Folder');
 		$this->userManager = $this->getMock('\OCP\IUserManager');
+		$this->userSession = $this->getMock('\OCP\IUserSession');
 		$this->logger = $this->getMock('\OCP\ILogger');
 
 		$this->collection = new \OCA\DAV\Comments\EntityCollection(
@@ -43,6 +45,7 @@ class EntityCollection extends \Test\TestCase {
 			$this->commentsManager,
 			$this->folder,
 			$this->userManager,
+			$this->userSession,
 			$this->logger
 		);
 	}

--- a/apps/dav/tests/unit/comments/entitytypecollection.php
+++ b/apps/dav/tests/unit/comments/entitytypecollection.php
@@ -30,6 +30,7 @@ class EntityTypeCollection extends \Test\TestCase {
 	protected $userManager;
 	protected $logger;
 	protected $collection;
+	protected $userSession;
 
 	public function setUp() {
 		parent::setUp();
@@ -37,6 +38,7 @@ class EntityTypeCollection extends \Test\TestCase {
 		$this->commentsManager = $this->getMock('\OCP\Comments\ICommentsManager');
 		$this->folder = $this->getMock('\OCP\Files\Folder');
 		$this->userManager = $this->getMock('\OCP\IUserManager');
+		$this->userSession = $this->getMock('\OCP\IUserSession');
 		$this->logger = $this->getMock('\OCP\ILogger');
 
 		$this->collection = new \OCA\DAV\Comments\EntityTypeCollection(
@@ -44,6 +46,7 @@ class EntityTypeCollection extends \Test\TestCase {
 			$this->commentsManager,
 			$this->folder,
 			$this->userManager,
+			$this->userSession,
 			$this->logger
 		);
 	}

--- a/lib/private/comments/manager.php
+++ b/lib/private/comments/manager.php
@@ -629,9 +629,15 @@ class Manager implements ICommentsManager {
 		$affectedRows = $qb
 			->update('comments_read_markers')
 			->set('user_id',         $values['user_id'])
-			->set('marker_datetime', $values['marker_datetime'], 'datetime')
+			->set('marker_datetime', $values['marker_datetime'])
 			->set('object_type',     $values['object_type'])
 			->set('object_id',       $values['object_id'])
+			->where($qb->expr()->eq('user_id', $qb->createParameter('user_id')))
+			->andWhere($qb->expr()->eq('object_type', $qb->createParameter('object_type')))
+			->andWhere($qb->expr()->eq('object_id', $qb->createParameter('object_id')))
+			->setParameter('user_id', $user->getUID(), \PDO::PARAM_STR)
+			->setParameter('object_type', $objectType, \PDO::PARAM_STR)
+			->setParameter('object_id', $objectId, \PDO::PARAM_STR)
 			->execute();
 
 		if ($affectedRows > 0) {


### PR DESCRIPTION
Resolves #22010 

A PROPFIND against a file or comment node will return an "isUnread" property on every comment.

A PROPPATCH against a file node will set the "read mark" for the file comments to the value specified.

See below for examples.
### PROPFIND

`$ curl -u master:master -i --data-binary "@propfind.xml" -X PROPFIND  -H "Content-Type: application/json" http://zara.owncloud.bzoc/master/remote.php/dav/comments/files/4779`

with  propfind.xml as:

``` xml
<?xml version="1.0" encoding="utf-8" ?>
<D:propfind xmlns:D="DAV:" xmlns:oc="http://owncloud.org/ns" >
  <D:prop>
    <D:href/>
    <oc:comment/>
    <oc:message/>
    <oc:actorId/>
    <oc:actorType/>
    <oc:creationDateTime/>
    <oc:actorDisplayName/>
    <oc:isUnread/>
  </D:prop>
</D:propfind>
```

results in

``` xml
<?xml version="1.0"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:cal="urn:ietf:params:xml:ns:caldav" xmlns:cs="http://calendarserver.org/ns/" xmlns:card="urn:ietf:params:xml:ns:carddav" xmlns:oc="http://owncloud.org/ns">
 <d:response>
  <d:href>/master/remote.php/dav/comments/files/4779/</d:href>
  <d:propstat>
   <d:prop>
    <d:href/>
    <oc:comment/>
    <oc:message/>
    <oc:actorId/>
    <oc:actorType/>
    <oc:creationDateTime/>
    <oc:actorDisplayName/>
    <oc:isUnread/>
   </d:prop>
   <d:status>HTTP/1.1 404 Not Found</d:status>
  </d:propstat>
 </d:response>
 <d:response>
  <d:href>/master/remote.php/dav/comments/files/4779/1</d:href>
  <d:propstat>
   <d:prop>
    <oc:message>Om nom nom</oc:message>
    <oc:actorId>master</oc:actorId>
    <oc:actorType>users</oc:actorType>
    <oc:creationDateTime>Tue, 02 Feb 2016 13:35:21 GMT</oc:creationDateTime>
    <oc:actorDisplayName>Master Mastersen</oc:actorDisplayName>
    <oc:isUnread>true</oc:isUnread>
   </d:prop>
   <d:status>HTTP/1.1 200 OK</d:status>
  </d:propstat>
  <d:propstat>
   <d:prop>
    <d:href/>
    <oc:comment/>
   </d:prop>
   <d:status>HTTP/1.1 404 Not Found</d:status>
  </d:propstat>
 </d:response>
</d:multistatus>
```
### PROPPATCH

`curl -u master:master -i --data-binary "@proppatch.readmark.xml" -X PROPPATCH  -H "Content-Type: application/json" http://zara.owncloud.bzoc/master/remote.php/dav/comments/files/4779`

with  proppatch.readmark.xml as:

``` xml
<?xml version="1.0" encoding="utf-8" ?>
<D:propertyupdate xmlns:D="DAV:" xmlns:oc="http://owncloud.org/ns" >
  <D:set>
    <D:prop>
      <oc:readMarker>Mon, 01 Feb 2016 17:21:15 +0100</oc:readMarker>
    </D:prop>
  </D:set>
</D:propertyupdate>
```

succeeds with

``` xml
<?xml version="1.0"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:cal="urn:ietf:params:xml:ns:caldav" xmlns:cs="http://calendarserver.org/ns/" xmlns:card="urn:ietf:params:xml:ns:carddav" xmlns:oc="http://owncloud.org/ns">
 <d:response>
  <d:href>/master/remote.php/dav/comments/files/4779</d:href>
  <d:propstat>
   <d:prop>
    <oc:readMarker/>
   </d:prop>
   <d:status>HTTP/1.1 200 OK</d:status>
  </d:propstat>
 </d:response>
</d:multistatus>
```
