### PR TITLE
Allow creating tags where another one with same prefix exists

### DIFF
--- a/core/js/systemtags/systemtagsinputfield.js
+++ b/core/js/systemtags/systemtagsinputfield.js
@@ -320,7 +320,9 @@
 		 */
 		_createSearchChoice: function(term) {
 			term = term.trim();
-			if (this.collection.filterByName(term).length) {
+			if (this.collection.filter(function(entry) {
+					return entry.get('name') === term;
+				}).length) {
 				return;
 			}
 			if (!this._newTag) {

--- a/core/js/tests/specs/systemtags/systemtagsinputfieldSpec.js
+++ b/core/js/tests/specs/systemtags/systemtagsinputfieldSpec.js
@@ -83,6 +83,15 @@ describe('OC.SystemTags.SystemTagsInputField tests', function() {
 				expect(result.userVisible).toEqual(true);
 				expect(result.userAssignable).toEqual(true);
 			});
+			it('creates dummy tag when user types non-matching name even with prefix of existing tag', function() {
+				var opts = select2Stub.getCall(0).args[0];
+				var result = opts.createSearchChoice('ab');
+				expect(result.id).toEqual(-1);
+				expect(result.name).toEqual('ab');
+				expect(result.isNew).toEqual(true);
+				expect(result.userVisible).toEqual(true);
+				expect(result.userAssignable).toEqual(true);
+			});
 			it('creates the real tag and fires select event after user selects the dummy tag', function() {
 				var selectHandler = sinon.stub();
 				view.on('select', selectHandler);


### PR DESCRIPTION
When creating a new entry, compare the full tag name and not only the
prefix.

Fixes https://github.com/owncloud/core/issues/22064

@SergioBertolinSG
