### PR TITLE
Comments: mark all read via DAV

### DIFF
--- a/apps/dav/lib/comments/entitycollection.php
+++ b/apps/dav/lib/comments/entitycollection.php
@@ -26,6 +26,7 @@ use OCP\Files\Folder;
 use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use Sabre\DAV\Exception\BadRequest;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\PropPatch;
 
@@ -169,10 +170,15 @@ class EntityCollection extends RootCollection implements \Sabre\DAV\IProperties 
 	 *
 	 * @param \DateTime $value
 	 * @return bool
+	 * @throws BadRequest
 	 */
-	public function setReadMarker($value) {
-		$dateTime = new \DateTime($value);
-		$user = $this->userSession->getUser();
+	public function setReadMark($value) {
+		try {
+			$dateTime = new \DateTime($value);
+			$user = $this->userSession->getUser();
+		} catch(\Exception $e) {
+			throw new BadRequest($e->getMessage(), 0, $e);
+		}
 		$this->commentsManager->setReadMark($this->name, $this->id, $dateTime, $user);
 		return true;
 	}
@@ -181,7 +187,7 @@ class EntityCollection extends RootCollection implements \Sabre\DAV\IProperties 
 	 * @inheritdoc
 	 */
 	function propPatch(PropPatch $propPatch) {
-		$propPatch->handle(self::PROPERTY_NAME_READ_MARKER, [$this, 'setReadMarker']);
+		$propPatch->handle(self::PROPERTY_NAME_READ_MARKER, [$this, 'setReadMark']);
 	}
 
 	/**

--- a/apps/dav/tests/unit/comments/entitycollection.php
+++ b/apps/dav/tests/unit/comments/entitycollection.php
@@ -21,6 +21,8 @@
 
 namespace OCA\DAV\Tests\Unit\Comments;
 
+use Sabre\DAV\Exception\BadRequest;
+
 class EntityCollection extends \Test\TestCase {
 
 	protected $commentsManager;
@@ -112,5 +114,27 @@ class EntityCollection extends \Test\TestCase {
 			->will($this->throwException(new \OCP\Comments\NotFoundException()));
 
 		$this->assertFalse($this->collection->childExists('44'));
+	}
+
+	public function testSetReadMark() {
+		$this->commentsManager->expects($this->once())
+			->method('setReadMark');
+
+		$this->userSession->expects($this->once())
+			->method('getUser')
+			->will($this->returnValue($this->getMock('\OCP\IUser')));
+
+		$dateTime = new \DateTime();
+		$this->collection->setReadMark($dateTime->format('r'));
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\BadRequest
+	 */
+	public function testSetReadMarkInvalidInput() {
+		$this->commentsManager->expects($this->never())
+			->method('setReadMark');
+
+		$this->collection->setReadMark('foobar');
 	}
 }

--- a/apps/dav/tests/unit/comments/entitytypecollection.php
+++ b/apps/dav/tests/unit/comments/entitytypecollection.php
@@ -94,4 +94,26 @@ class EntityTypeCollection extends \Test\TestCase {
 	public function testGetChildren() {
 		$this->collection->getChildren();
 	}
+
+	public function testSetReadMark() {
+		$this->commentsManager->expects($this->once())
+			->method('setReadMark');
+
+		$this->userSession->expects($this->once())
+			->method('getUser')
+			->will($this->returnValue($this->getMock('\OCP\IUser')));
+
+		$dateTime = new \DateTime();
+		$this->collection->setReadMarks($dateTime->format('r'));
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\BadRequest
+	 */
+	public function testSetReadMarkInvalidInput() {
+		$this->commentsManager->expects($this->never())
+			->method('setReadMark');
+
+		$this->collection->setReadMarks('foobar');
+	}
 }

--- a/db_structure.xml
+++ b/db_structure.xml
@@ -1623,7 +1623,7 @@
 				<name>object_id</name>
 				<type>text</type>
 				<default></default>
-				<notnull>true</notnull>
+				<notnull>false</notnull>
 				<length>64</length>
 			</field>
 

--- a/lib/public/comments/icommentsmanager.php
+++ b/lib/public/comments/icommentsmanager.php
@@ -194,8 +194,11 @@ interface ICommentsManager {
 	 * sets the read marker for a given file to the specified date for the
 	 * provided user
 	 *
+	 * If $objectId is null, all marks within the given object type must be
+	 * set to the provided datetime.
+	 *
 	 * @param string $objectType
-	 * @param string $objectId
+	 * @param string|null $objectId
 	 * @param \DateTime $dateTime
 	 * @param \OCP\IUser $user
 	 * @since 9.0.0

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 0, 0, 9);
+$OC_Version = array(9, 0, 0, 10);
 
 // The human readable string
 $OC_VersionString = '9.0 pre alpha';


### PR DESCRIPTION
Solves the remaining, second TODO of #22010 

Proppatch against an object type collection, like files, while set all known and the fallback marker to the specified date and time:

`curl -u master:master -i --data-binary "@proppatch.readmark.xml" -X PROPPATCH  -H "Content-Type: application/json" http://zara.owncloud.bzoc/master/remote.php/dav/comments/files/`

with  proppatch.readmark.xml as:

``` xml
<?xml version="1.0" encoding="utf-8" ?>
<D:propertyupdate xmlns:D="DAV:" xmlns:oc="http://owncloud.org/ns" >
  <D:set>
    <D:prop>
      <oc:readMarker>Mon, 01 Feb 2016 17:21:15 +0100</oc:readMarker>
    </D:prop>
  </D:set>
</D:propertyupdate>
```

succeeds with

``` xml
<?xml version="1.0"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:cal="urn:ietf:params:xml:ns:caldav" xmlns:cs="http://calendarserver.org/ns/" xmlns:card="urn:ietf:params:xml:ns:carddav" xmlns:oc="http://owncloud.org/ns">
 <d:response>
  <d:href>/master/remote.php/dav/comments/files</d:href>
  <d:propstat>
   <d:prop>
    <oc:readMarker/>
   </d:prop>
   <d:status>HTTP/1.1 200 OK</d:status>
  </d:propstat>
 </d:response>
</d:multistatus>
```

A comment that was formerly reported as "isUnread" should have this property now set to false, if the provided oc:readMarker property in the proppatch is more recent that the createion date of that comment.  
