### PR TITLE
[Share 2.0] Pass around userid/groupid/federatedid

### DIFF
--- a/apps/files_sharing/api/share20ocs.php
+++ b/apps/files_sharing/api/share20ocs.php
@@ -26,35 +26,41 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\Files\IRootFolder;
+use OCP\Share\IManager;
 
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\Exceptions\GenericShareException;
 
 class Share20OCS {
 
-	/** @var \OC\Share20\Manager */
+	/** @var IManager */
 	private $shareManager;
-
 	/** @var IGroupManager */
 	private $groupManager;
-
 	/** @var IUserManager */
 	private $userManager;
-
 	/** @var IRequest */
 	private $request;
-
 	/** @var IRootFolder */
 	private $rootFolder;
-
 	/** @var IUrlGenerator */
 	private $urlGenerator;
-
 	/** @var IUser */
 	private $currentUser;
 
+	/**
+	 * Share20OCS constructor.
+	 *
+	 * @param IManager $shareManager
+	 * @param IGroupManager $groupManager
+	 * @param IUserManager $userManager
+	 * @param IRequest $request
+	 * @param IRootFolder $rootFolder
+	 * @param IURLGenerator $urlGenerator
+	 * @param IUser $currentUser
+	 */
 	public function __construct(
-			\OC\Share20\Manager $shareManager,
+			IManager $shareManager,
 			IGroupManager $groupManager,
 			IUserManager $userManager,
 			IRequest $request,
@@ -78,22 +84,24 @@ class Share20OCS {
 	 * @return array
 	 */
 	protected function formatShare(\OCP\Share\IShare $share) {
+		$sharedBy = $this->userManager->get($share->getSharedBy());
+		$shareOwner = $this->userManager->get($share->getShareOwner());
 		$result = [
 			'id' => $share->getId(),
 			'share_type' => $share->getShareType(),
-			'uid_owner' => $share->getSharedBy()->getUID(),
-			'displayname_owner' => $share->getSharedBy()->getDisplayName(),
+			'uid_owner' => $share->getSharedBy(),
+			'displayname_owner' => $sharedBy->getDisplayName(),
 			'permissions' => $share->getPermissions(),
 			'stime' => $share->getShareTime()->getTimestamp(),
 			'parent' => null,
 			'expiration' => null,
 			'token' => null,
-			'uid_file_owner' => $share->getShareOwner()->getUID(),
-			'displayname_file_owner' => $share->getShareOwner()->getDisplayName(),
+			'uid_file_owner' => $share->getShareOwner(),
+			'displayname_file_owner' => $shareOwner->getDisplayName(),
 		];
 
 		$node = $share->getNode();
-		$result['path'] = $this->rootFolder->getUserFolder($share->getShareOwner()->getUID())->getRelativePath($node->getPath());
+		$result['path'] = $this->rootFolder->getUserFolder($share->getShareOwner())->getRelativePath($node->getPath());
 		if ($node instanceOf \OCP\Files\Folder) {
 			$result['item_type'] = 'folder';
 		} else {
@@ -107,13 +115,12 @@ class Share20OCS {
 		$result['file_target'] = $share->getTarget();
 
 		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER) {
-			$sharedWith = $share->getSharedWith();
+			$sharedWith = $this->userManager->get($share->getSharedWith());
 			$result['share_with'] = $sharedWith->getUID();
 			$result['share_with_displayname'] = $sharedWith->getDisplayName();
 		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
-			$sharedWith = $share->getSharedWith();
-			$result['share_with'] = $sharedWith->getGID();
-			$result['share_with_displayname'] = $sharedWith->getGID();
+			$result['share_with'] = $share->getSharedWith();
+			$result['share_with_displayname'] = $share->getSharedWith();
 		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
 
 			$result['share_with'] = $share->getPassword();
@@ -250,14 +257,14 @@ class Share20OCS {
 			if ($shareWith === null || !$this->userManager->userExists($shareWith)) {
 				return new \OC_OCS_Result(null, 404, 'please specify a valid user');
 			}
-			$share->setSharedWith($this->userManager->get($shareWith));
+			$share->setSharedWith($shareWith);
 			$share->setPermissions($permissions);
 		} else if ($shareType === \OCP\Share::SHARE_TYPE_GROUP) {
 			// Valid group is required to share
 			if ($shareWith === null || !$this->groupManager->groupExists($shareWith)) {
 				return new \OC_OCS_Result(null, 404, 'please specify a valid group');
 			}
-			$share->setSharedWith($this->groupManager->get($shareWith));
+			$share->setSharedWith($shareWith);
 			$share->setPermissions($permissions);
 		} else if ($shareType === \OCP\Share::SHARE_TYPE_LINK) {
 			//Can we even share links?
@@ -313,7 +320,7 @@ class Share20OCS {
 		}
 
 		$share->setShareType($shareType);
-		$share->setSharedBy($this->currentUser);
+		$share->setSharedBy($this->currentUser->getUID());
 
 		try {
 			$share = $this->shareManager->createShare($share);
@@ -333,8 +340,8 @@ class Share20OCS {
 	 * @return \OC_OCS_Result
 	 */
 	private function getSharedWithMe($node = null) {
-		$userShares = $this->shareManager->getSharedWith($this->currentUser, \OCP\Share::SHARE_TYPE_USER, $node, -1, 0);
-		$groupShares = $this->shareManager->getSharedWith($this->currentUser, \OCP\Share::SHARE_TYPE_GROUP, $node, -1, 0);
+		$userShares = $this->shareManager->getSharedWith($this->currentUser->getUID(), \OCP\Share::SHARE_TYPE_USER, $node, -1, 0);
+		$groupShares = $this->shareManager->getSharedWith($this->currentUser->getUID(), \OCP\Share::SHARE_TYPE_GROUP, $node, -1, 0);
 
 		$shares = array_merge($userShares, $groupShares);
 
@@ -361,9 +368,9 @@ class Share20OCS {
 		/** @var \OCP\Share\IShare[] $shares */
 		$shares = [];
 		foreach ($nodes as $node) {
-			$shares  = array_merge($shares, $this->shareManager->getSharesBy($this->currentUser, \OCP\Share::SHARE_TYPE_USER, $node, false, -1, 0));
-			$shares = array_merge($shares, $this->shareManager->getSharesBy($this->currentUser, \OCP\Share::SHARE_TYPE_GROUP, $node, false, -1, 0));
-			$shares  = array_merge($shares, $this->shareManager->getSharesBy($this->currentUser, \OCP\Share::SHARE_TYPE_LINK, $node, false, -1, 0));
+			$shares  = array_merge($shares, $this->shareManager->getSharesBy($this->currentUser->getUID(), \OCP\Share::SHARE_TYPE_USER, $node, false, -1, 0));
+			$shares = array_merge($shares, $this->shareManager->getSharesBy($this->currentUser->getUID(), \OCP\Share::SHARE_TYPE_GROUP, $node, false, -1, 0));
+			$shares  = array_merge($shares, $this->shareManager->getSharesBy($this->currentUser->getUID(), \OCP\Share::SHARE_TYPE_LINK, $node, false, -1, 0));
 			//TODO: Add federated shares
 
 		}
@@ -417,9 +424,9 @@ class Share20OCS {
 		}
 
 		// Get all shares
-		$userShares = $this->shareManager->getSharesBy($this->currentUser, \OCP\Share::SHARE_TYPE_USER, $path, $reshares, -1, 0);
-		$groupShares = $this->shareManager->getSharesBy($this->currentUser, \OCP\Share::SHARE_TYPE_GROUP, $path, $reshares, -1, 0);
-		$linkShares = $this->shareManager->getSharesBy($this->currentUser, \OCP\Share::SHARE_TYPE_LINK, $path, $reshares, -1, 0);
+		$userShares = $this->shareManager->getSharesBy($this->currentUser->getUID(), \OCP\Share::SHARE_TYPE_USER, $path, $reshares, -1, 0);
+		$groupShares = $this->shareManager->getSharesBy($this->currentUser->getUID(), \OCP\Share::SHARE_TYPE_GROUP, $path, $reshares, -1, 0);
+		$linkShares = $this->shareManager->getSharesBy($this->currentUser->getUID(), \OCP\Share::SHARE_TYPE_LINK, $path, $reshares, -1, 0);
 		//TODO: Add federated shares
 
 		$shares = array_merge($userShares, $groupShares, $linkShares);
@@ -538,14 +545,6 @@ class Share20OCS {
 		return new \OC_OCS_Result($this->formatShare($share));
 	}
 
-	public function validatePermissions($permissions) {
-		if ($permissions < 0 || $permissions > \OCP\Constants::PERMISSION_ALL) {
-			return false;
-		}
-
-
-	}
-
 	/**
 	 * @param \OCP\Share\IShare $share
 	 * @return bool
@@ -557,21 +556,23 @@ class Share20OCS {
 		}
 
 		// Owner of the file and the sharer of the file can always get share
-		if ($share->getShareOwner() === $this->currentUser ||
-			$share->getSharedBy() === $this->currentUser
+		if ($share->getShareOwner() === $this->currentUser->getUID() ||
+			$share->getSharedBy() === $this->currentUser->getUID()
 		) {
 			return true;
 		}
 
 		// If the share is shared with you (or a group you are a member of)
 		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER &&
-			$share->getSharedWith() === $this->currentUser) {
+			$share->getSharedWith() === $this->currentUser->getUID()) {
 			return true;
 		}
 
-		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP &&
-			$share->getSharedWith()->inGroup($this->currentUser)) {
-			return true;
+		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
+			$sharedWith = $this->groupManager->get($share->getSharedWith());
+			if ($sharedWith->inGroup($this->currentUser)) {
+				return true;
+			}
 		}
 
 		return false;

--- a/apps/files_sharing/lib/controllers/sharecontroller.php
+++ b/apps/files_sharing/lib/controllers/sharecontroller.php
@@ -232,8 +232,8 @@ class ShareController extends Controller {
 		}
 
 		$shareTmpl = [];
-		$shareTmpl['displayName'] = $share->getShareOwner()->getDisplayName();
-		$shareTmpl['owner'] = $share->getShareOwner()->getUID();
+		$shareTmpl['displayName'] = $this->userManager->get($share->getShareOwner())->getDisplayName();
+		$shareTmpl['owner'] = $share->getShareOwner();
 		$shareTmpl['filename'] = $share->getNode()->getName();
 		$shareTmpl['directory_path'] = $share->getTarget();
 		$shareTmpl['mimetype'] = $share->getNode()->getMimetype();
@@ -320,7 +320,7 @@ class ShareController extends Controller {
 			}
 		}
 
-		$userFolder = $this->rootFolder->getUserFolder($share->getShareOwner()->getUID());
+		$userFolder = $this->rootFolder->getUserFolder($share->getShareOwner());
 		$originalSharePath = $userFolder->getRelativePath($share->getNode()->getPath());
 
 		// Single file share
@@ -330,7 +330,7 @@ class ShareController extends Controller {
 			$event->setApp('files_sharing')
 				->setType(Activity::TYPE_PUBLIC_LINKS)
 				->setSubject(Activity::SUBJECT_PUBLIC_SHARED_FILE_DOWNLOADED, [$userFolder->getRelativePath($share->getNode()->getPath())])
-				->setAffectedUser($share->getShareOwner()->getUID())
+				->setAffectedUser($share->getShareOwner())
 				->setObject('files', $share->getNode()->getId(), $userFolder->getRelativePath($share->getNode()->getPath()));
 			$this->activityManager->publish($event);
 		}
@@ -356,7 +356,7 @@ class ShareController extends Controller {
 				$event->setApp('files_sharing')
 					->setType(Activity::TYPE_PUBLIC_LINKS)
 					->setSubject(Activity::SUBJECT_PUBLIC_SHARED_FILE_DOWNLOADED, [$userFolder->getRelativePath($node->getPath())])
-					->setAffectedUser($share->getShareOwner()->getUID())
+					->setAffectedUser($share->getShareOwner())
 					->setObject('files', $node->getId(), $userFolder->getRelativePath($node->getPath()));
 				$this->activityManager->publish($event);
 			} else if (!empty($files_list)) {
@@ -369,7 +369,7 @@ class ShareController extends Controller {
 					$event = $this->activityManager->generateEvent();
 					$event->setApp('files_sharing')
 						->setType(Activity::TYPE_PUBLIC_LINKS)
-						->setAffectedUser($share->getShareOwner()->getUID())
+						->setAffectedUser($share->getShareOwner())
 						->setObject('files', $subNode->getId(), $userFolder->getRelativePath($subNode->getPath()));
 
 					if ($subNode instanceof \OCP\Files\File) {
@@ -386,7 +386,7 @@ class ShareController extends Controller {
 				$event->setApp('files_sharing')
 					->setType(Activity::TYPE_PUBLIC_LINKS)
 					->setSubject(Activity::SUBJECT_PUBLIC_SHARED_FOLDER_DOWNLOADED, [$userFolder->getRelativePath($node->getPath())])
-					->setAffectedUser($share->getShareOwner()->getUID())
+					->setAffectedUser($share->getShareOwner())
 					->setObject('files', $node->getId(), $userFolder->getRelativePath($node->getPath()));
 				$this->activityManager->publish($event);
 			}
@@ -394,7 +394,7 @@ class ShareController extends Controller {
 
 		/* FIXME: We should do this all nicely in OCP */
 		OC_Util::tearDownFS();
-		OC_Util::setupFS($share->getShareOwner()->getUID());
+		OC_Util::setupFS($share->getShareOwner());
 
 		/**
 		 * this sets a cookie to be able to recognize the start of the download

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -617,7 +617,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getMountManager(),
 				$c->getGroupManager(),
 				$c->getL10N('core'),
-				$factory
+				$factory,
+				$c->getUserManager()
 			);
 
 			return $manager;

--- a/lib/private/share20/defaultshareprovider.php
+++ b/lib/private/share20/defaultshareprovider.php
@@ -29,7 +29,6 @@ use OC\Share20\Exception\BackendError;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\NotFoundException;
 use OCP\IGroup;
-use OCP\IUser;
 use OCP\IGroupManager;
 use OCP\IUserManager;
 use OCP\Files\IRootFolder;
@@ -102,14 +101,10 @@ class DefaultShareProvider implements IShareProvider {
 
 		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER) {
 			//Set the UID of the user we share with
-			/** @var IUser $sharedWith */
-			$sharedWith = $share->getSharedWith();
-			$qb->setValue('share_with', $qb->createNamedParameter($sharedWith->getUID()));
+			$qb->setValue('share_with', $qb->createNamedParameter($share->getSharedWith()));
 		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
 			//Set the GID of the group we share with
-			/** @var IGroup $sharedWith */
-			$sharedWith = $share->getSharedWith();
-			$qb->setValue('share_with', $qb->createNamedParameter($sharedWith->getGID()));
+			$qb->setValue('share_with', $qb->createNamedParameter($share->getSharedWith()));
 		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
 			//Set the token of the share
 			$qb->setValue('token', $qb->createNamedParameter($share->getToken()));
@@ -143,10 +138,10 @@ class DefaultShareProvider implements IShareProvider {
 		$qb->setValue('permissions', $qb->createNamedParameter($share->getPermissions()));
 
 		// Set who created this share
-		$qb->setValue('uid_initiator', $qb->createNamedParameter($share->getSharedBy()->getUID()));
+		$qb->setValue('uid_initiator', $qb->createNamedParameter($share->getSharedBy()));
 
 		// Set who is the owner of this file/folder (and this the owner of the share)
-		$qb->setValue('uid_owner', $qb->createNamedParameter($share->getShareOwner()->getUID()));
+		$qb->setValue('uid_owner', $qb->createNamedParameter($share->getShareOwner()));
 
 		// Set the file target
 		$qb->setValue('file_target', $qb->createNamedParameter($share->getTarget()));
@@ -192,9 +187,9 @@ class DefaultShareProvider implements IShareProvider {
 			$qb = $this->dbConn->getQueryBuilder();
 			$qb->update('share')
 				->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())))
-				->set('share_with', $qb->createNamedParameter($share->getSharedWith()->getUID()))
-				->set('uid_owner', $qb->createNamedParameter($share->getShareOwner()->getUID()))
-				->set('uid_initiator', $qb->createNamedParameter($share->getSharedBy()->getUID()))
+				->set('share_with', $qb->createNamedParameter($share->getSharedWith()))
+				->set('uid_owner', $qb->createNamedParameter($share->getShareOwner()))
+				->set('uid_initiator', $qb->createNamedParameter($share->getSharedBy()))
 				->set('permissions', $qb->createNamedParameter($share->getPermissions()))
 				->set('item_source', $qb->createNamedParameter($share->getNode()->getId()))
 				->set('file_source', $qb->createNamedParameter($share->getNode()->getId()))
@@ -203,8 +198,8 @@ class DefaultShareProvider implements IShareProvider {
 			$qb = $this->dbConn->getQueryBuilder();
 			$qb->update('share')
 				->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())))
-				->set('uid_owner', $qb->createNamedParameter($share->getShareOwner()->getUID()))
-				->set('uid_initiator', $qb->createNamedParameter($share->getSharedBy()->getUID()))
+				->set('uid_owner', $qb->createNamedParameter($share->getShareOwner()))
+				->set('uid_initiator', $qb->createNamedParameter($share->getSharedBy()))
 				->set('permissions', $qb->createNamedParameter($share->getPermissions()))
 				->set('item_source', $qb->createNamedParameter($share->getNode()->getId()))
 				->set('file_source', $qb->createNamedParameter($share->getNode()->getId()))
@@ -216,8 +211,8 @@ class DefaultShareProvider implements IShareProvider {
 			$qb = $this->dbConn->getQueryBuilder();
 			$qb->update('share')
 				->where($qb->expr()->eq('parent', $qb->createNamedParameter($share->getId())))
-				->set('uid_owner', $qb->createNamedParameter($share->getShareOwner()->getUID()))
-				->set('uid_initiator', $qb->createNamedParameter($share->getSharedBy()->getUID()))
+				->set('uid_owner', $qb->createNamedParameter($share->getShareOwner()))
+				->set('uid_initiator', $qb->createNamedParameter($share->getSharedBy()))
 				->set('item_source', $qb->createNamedParameter($share->getNode()->getId()))
 				->set('file_source', $qb->createNamedParameter($share->getNode()->getId()))
 				->execute();
@@ -237,8 +232,8 @@ class DefaultShareProvider implements IShareProvider {
 			$qb->update('share')
 				->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())))
 				->set('share_with', $qb->createNamedParameter($share->getPassword()))
-				->set('uid_owner', $qb->createNamedParameter($share->getShareOwner()->getUID()))
-				->set('uid_initiator', $qb->createNamedParameter($share->getSharedBy()->getUID()))
+				->set('uid_owner', $qb->createNamedParameter($share->getShareOwner()))
+				->set('uid_initiator', $qb->createNamedParameter($share->getSharedBy()))
 				->set('permissions', $qb->createNamedParameter($share->getPermissions()))
 				->set('item_source', $qb->createNamedParameter($share->getNode()->getId()))
 				->set('file_source', $qb->createNamedParameter($share->getNode()->getId()))
@@ -255,7 +250,7 @@ class DefaultShareProvider implements IShareProvider {
 	 * FIXME: remove once https://github.com/owncloud/core/pull/21660 is in
 	 *
 	 * @param \OCP\Share\IShare $parent
-	 * @return IShare[]
+	 * @return \OCP\Share\IShare[]
 	 */
 	public function getChildren(\OCP\Share\IShare $parent) {
 		$children = [];
@@ -311,17 +306,17 @@ class DefaultShareProvider implements IShareProvider {
 	 * this means we need a special entry in the share db.
 	 *
 	 * @param \OCP\Share\IShare $share
-	 * @param IUser $recipient
+	 * @param string $recipient UserId of recipient
 	 * @throws BackendError
 	 * @throws ProviderException
 	 */
-	public function deleteFromSelf(\OCP\Share\IShare $share, IUser $recipient) {
+	public function deleteFromSelf(\OCP\Share\IShare $share, $recipient) {
 		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
 
-			/** @var IGroup $group */
-			$group = $share->getSharedWith();
+			$group = $this->groupManager->get($share->getSharedWith());
+			$user = $this->userManager->get($recipient);
 
-			if (!$group->inGroup($recipient)) {
+			if (!$group->inGroup($user)) {
 				throw new ProviderException('Recipient not in receiving group');
 			}
 
@@ -330,7 +325,7 @@ class DefaultShareProvider implements IShareProvider {
 			$stmt = $qb->select('*')
 				->from('share')
 				->where($qb->expr()->eq('share_type', $qb->createNamedParameter(self::SHARE_TYPE_USERGROUP)))
-				->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($recipient->getUID())))
+				->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($recipient)))
 				->andWhere($qb->expr()->eq('parent', $qb->createNamedParameter($share->getId())))
 				->execute();
 
@@ -349,9 +344,9 @@ class DefaultShareProvider implements IShareProvider {
 				$qb->insert('share')
 					->values([
 						'share_type' => $qb->createNamedParameter(self::SHARE_TYPE_USERGROUP),
-						'share_with' => $qb->createNamedParameter($recipient->getUID()),
-						'uid_owner' => $qb->createNamedParameter($share->getShareOwner()->getUID()),
-						'uid_initiator' => $qb->createNamedParameter($share->getSharedBy()->getUID()),
+						'share_with' => $qb->createNamedParameter($recipient),
+						'uid_owner' => $qb->createNamedParameter($share->getShareOwner()),
+						'uid_initiator' => $qb->createNamedParameter($share->getSharedBy()),
 						'parent' => $qb->createNamedParameter($share->getId()),
 						'item_type' => $qb->createNamedParameter($type),
 						'item_source' => $qb->createNamedParameter($share->getNode()->getId()),
@@ -387,7 +382,7 @@ class DefaultShareProvider implements IShareProvider {
 	/**
 	 * @inheritdoc
 	 */
-	public function move(\OCP\Share\IShare $share, IUser $recipient) {
+	public function move(\OCP\Share\IShare $share, $recipient) {
 		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER) {
 			// Just update the target
 			$qb = $this->dbConn->getQueryBuilder();
@@ -403,7 +398,7 @@ class DefaultShareProvider implements IShareProvider {
 			$stmt = $qb->select('id')
 				->from('share')
 				->where($qb->expr()->eq('share_type', $qb->createNamedParameter(self::SHARE_TYPE_USERGROUP)))
-				->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($recipient->getUID())))
+				->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($recipient)))
 				->andWhere($qb->expr()->eq('parent', $qb->createNamedParameter($share->getId())))
 				->setMaxResults(1)
 				->execute();
@@ -417,9 +412,9 @@ class DefaultShareProvider implements IShareProvider {
 				$qb->insert('share')
 					->values([
 						'share_type' => $qb->createNamedParameter(self::SHARE_TYPE_USERGROUP),
-						'share_with' => $qb->createNamedParameter($recipient->getUID()),
-						'uid_owner' => $qb->createNamedParameter($share->getShareOwner()->getUID()),
-						'uid_initiator' => $qb->createNamedParameter($share->getSharedBy()->getUID()),
+						'share_with' => $qb->createNamedParameter($recipient),
+						'uid_owner' => $qb->createNamedParameter($share->getShareOwner()),
+						'uid_initiator' => $qb->createNamedParameter($share->getSharedBy()),
 						'parent' => $qb->createNamedParameter($share->getId()),
 						'item_type' => $qb->createNamedParameter($share->getNode() instanceof File ? 'file' : 'folder'),
 						'item_source' => $qb->createNamedParameter($share->getNode()->getId()),
@@ -444,7 +439,7 @@ class DefaultShareProvider implements IShareProvider {
 	/**
 	 * Get all shares by the given user. Sharetype and path can be used to filter.
 	 *
-	 * @param IUser $user
+	 * @param string $userId
 	 * @param int $shareType
 	 * @param \OCP\Files\File|\OCP\Files\Folder $node
 	 * @param bool $reshares Also get the shares where $user is the owner instead of just the shares where $user is the initiator
@@ -452,7 +447,7 @@ class DefaultShareProvider implements IShareProvider {
 	 * @param int $offset
 	 * @return Share[]
 	 */
-	public function getSharesBy(IUser $user, $shareType, $node, $reshares, $limit, $offset) {
+	public function getSharesBy($userId, $shareType, $node, $reshares, $limit, $offset) {
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->select('*')
 			->from('share');
@@ -465,21 +460,21 @@ class DefaultShareProvider implements IShareProvider {
 		if ($reshares === false) {
 			//Special case for old shares created via the web UI
 			$or1 = $qb->expr()->andX(
-				$qb->expr()->eq('uid_owner', $qb->createNamedParameter($user->getUID())),
+				$qb->expr()->eq('uid_owner', $qb->createNamedParameter($userId)),
 				$qb->expr()->isNull('uid_initiator')
 			);
 
 			$qb->andWhere(
 				$qb->expr()->orX(
-					$qb->expr()->eq('uid_initiator', $qb->createNamedParameter($user->getUID())),
+					$qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId)),
 					$or1
 				)
 			);
 		} else {
 			$qb->andWhere(
 				$qb->expr()->orX(
-					$qb->expr()->eq('uid_owner', $qb->createNamedParameter($user->getUID())),
-					$qb->expr()->eq('uid_initiator', $qb->createNamedParameter($user->getUID()))
+					$qb->expr()->eq('uid_owner', $qb->createNamedParameter($userId)),
+					$qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId))
 				)
 			);
 		}
@@ -508,7 +503,7 @@ class DefaultShareProvider implements IShareProvider {
 	/**
 	 * @inheritdoc
 	 */
-	public function getShareById($id, $recipient = null) {
+	public function getShareById($id, $recipientId = null) {
 		$qb = $this->dbConn->getQueryBuilder();
 
 		$qb->select('*')
@@ -540,8 +535,8 @@ class DefaultShareProvider implements IShareProvider {
 		}
 
 		// If the recipient is set for a group share resolve to that user
-		if ($recipient !== null && $share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
-			$share = $this->resolveGroupShare($share, $recipient);
+		if ($recipientId !== null && $share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
+			$share = $this->resolveGroupShare($share, $recipientId);
 		}
 
 		return $share;
@@ -551,7 +546,7 @@ class DefaultShareProvider implements IShareProvider {
 	 * Get shares for a given path
 	 *
 	 * @param \OCP\Files\Node $path
-	 * @return IShare[]
+	 * @return \OCP\Share\IShare[]
 	 */
 	public function getSharesByPath(Node $path) {
 		$qb = $this->dbConn->getQueryBuilder();
@@ -578,7 +573,7 @@ class DefaultShareProvider implements IShareProvider {
 	/**
 	 * @inheritdoc
 	 */
-	public function getSharedWith(IUser $user, $shareType, $node, $limit, $offset) {
+	public function getSharedWith($userId, $shareType, $node, $limit, $offset) {
 		/** @var Share[] $shares */
 		$shares = [];
 
@@ -598,7 +593,7 @@ class DefaultShareProvider implements IShareProvider {
 			$qb->setFirstResult($offset);
 
 			$qb->where($qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_USER)));
-			$qb->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($user->getUID())));
+			$qb->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($userId)));
 
 			// Filter by node if provided
 			if ($node !== null) {
@@ -613,6 +608,7 @@ class DefaultShareProvider implements IShareProvider {
 			$cursor->closeCursor();
 
 		} else if ($shareType === \OCP\Share::SHARE_TYPE_GROUP) {
+			$user = $this->userManager->get($userId);
 			$allGroups = $this->groupManager->getUserGroups($user);
 
 			/** @var Share[] $shares2 */
@@ -666,7 +662,7 @@ class DefaultShareProvider implements IShareProvider {
  			 * TODO: Optmize this!
  			 */
 			foreach($shares2 as $share) {
-				$shares[] = $this->resolveGroupShare($share, $user);
+				$shares[] = $this->resolveGroupShare($share, $userId);
 			}
 		} else {
 			throw new BackendError('Invalid backend');
@@ -680,7 +676,7 @@ class DefaultShareProvider implements IShareProvider {
 	 * Get a share by token
 	 *
 	 * @param string $token
-	 * @return IShare
+	 * @return \OCP\Share\IShare
 	 * @throws ShareNotFound
 	 */
 	public function getShareByToken($token) {
@@ -727,17 +723,9 @@ class DefaultShareProvider implements IShareProvider {
 		$share->setShareTime($shareTime);
 
 		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER) {
-			$sharedWith = $this->userManager->get($data['share_with']);
-			if ($sharedWith === null) {
-				throw new InvalidShare();
-			}
-			$share->setSharedWith($sharedWith);
+			$share->setSharedWith($data['share_with']);
 		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
-			$sharedWith = $this->groupManager->get($data['share_with']);
-			if ($sharedWith === null) {
-				throw new InvalidShare();
-			}
-			$share->setSharedWith($sharedWith);
+			$share->setSharedWith($data['share_with']);
 		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
 			$share->setPassword($data['share_with']);
 			$share->setToken($data['token']);
@@ -745,24 +733,15 @@ class DefaultShareProvider implements IShareProvider {
 
 		if ($data['uid_initiator'] === null) {
 			//OLD SHARE
-			$sharedBy = $this->userManager->get($data['uid_owner']);
-			if ($sharedBy === null) {
-				throw new InvalidShare();
-			}
-			$share->setSharedBy($sharedBy);
+			$share->setSharedBy($data['uid_owner']);
 			$path = $this->getNode($share->getSharedBy(), (int)$data['file_source']);
 
 			$owner = $path->getOwner();
-			$share->setShareOwner($owner);
+			$share->setShareOwner($owner->getUID());
 		} else {
 			//New share!
-			$sharedBy = $this->userManager->get($data['uid_initiator']);
-			$shareOwner = $this->userManager->get($data['uid_owner']);
-			if ($sharedBy === null || $shareOwner === null) {
-				throw new InvalidShare();
-			}
-			$share->setSharedBy($sharedBy);
-			$share->setShareOwner($shareOwner);
+			$share->setSharedBy($data['uid_initiator']);
+			$share->setShareOwner($data['uid_owner']);
 		}
 
 		$path = $this->getNode($share->getShareOwner(), (int)$data['file_source']);
@@ -781,14 +760,14 @@ class DefaultShareProvider implements IShareProvider {
 	/**
 	 * Get the node with file $id for $user
 	 *
-	 * @param IUser $user
+	 * @param string $user The userId
 	 * @param int $id
 	 * @return \OCP\Files\File|\OCP\Files\Folder
 	 * @throws InvalidShare
 	 */
-	private function getNode(IUser $user, $id) {
+	private function getNode($user, $id) {
 		try {
-			$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+			$userFolder = $this->rootFolder->getUserFolder($user);
 		} catch (NotFoundException $e) {
 			throw new InvalidShare();
 		}
@@ -806,18 +785,18 @@ class DefaultShareProvider implements IShareProvider {
 	 * Resolve a group share to a user specific share
 	 * Thus if the user moved their group share make sure this is properly reflected here.
 	 *
-	 * @param Share $share
-	 * @param IUser $user
+	 * @param \OCP\Share\IShare $share
+	 * @param string $userId
 	 * @return Share Returns the updated share if one was found else return the original share.
 	 */
-	private function resolveGroupShare(Share $share, IUser $user) {
+	private function resolveGroupShare(\OCP\Share\IShare $share, $userId) {
 		$qb = $this->dbConn->getQueryBuilder();
 
 		$stmt = $qb->select('*')
 			->from('share')
 			->where($qb->expr()->eq('parent', $qb->createNamedParameter($share->getId())))
 			->andWhere($qb->expr()->eq('share_type', $qb->createNamedParameter(self::SHARE_TYPE_USERGROUP)))
-			->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($user->getUID())))
+			->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($userId)))
 			->setMaxResults(1)
 			->execute();
 

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -21,7 +21,7 @@
 
 namespace OC\Share20;
 
-use OCP\Files\Node;
+use OCP\IUserManager;
 use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
 use OC\Share20\Exception\BackendError;
@@ -34,7 +34,6 @@ use OCP\Files\Mount\IMountManager;
 use OCP\IGroupManager;
 use OCP\Files\File;
 use OCP\Files\Folder;
-use OCP\IUser;
 
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\Exceptions\GenericShareException;
@@ -68,6 +67,9 @@ class Manager implements IManager {
 	/** @var IL10N */
 	private $l;
 
+	/** @var IUserManager */
+	private $userManager;
+
 	/**
 	 * Manager constructor.
 	 *
@@ -79,6 +81,7 @@ class Manager implements IManager {
 	 * @param IGroupManager $groupManager
 	 * @param IL10N $l
 	 * @param IProviderFactory $factory
+	 * @param IUserManager $userManager
 	 */
 	public function __construct(
 			ILogger $logger,
@@ -88,7 +91,8 @@ class Manager implements IManager {
 			IMountManager $mountManager,
 			IGroupManager $groupManager,
 			IL10N $l,
-			IProviderFactory $factory
+			IProviderFactory $factory,
+			IUserManager $userManager
 	) {
 		$this->logger = $logger;
 		$this->config = $config;
@@ -98,6 +102,7 @@ class Manager implements IManager {
 		$this->groupManager = $groupManager;
 		$this->l = $l;
 		$this->factory = $factory;
+		$this->userManager = $userManager;
 	}
 
 	/**
@@ -150,13 +155,13 @@ class Manager implements IManager {
 	protected function generalCreateChecks(\OCP\Share\IShare $share) {
 		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER) {
 			// We expect a valid user as sharedWith for user shares
-			if (!($share->getSharedWith() instanceof \OCP\IUser)) {
-				throw new \InvalidArgumentException('SharedWith should be an IUser');
+			if (!$this->userManager->userExists($share->getSharedWith())) {
+				throw new \InvalidArgumentException('SharedWith is not a valid user');
 			}
 		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
 			// We expect a valid group as sharedWith for group shares
-			if (!($share->getSharedWith() instanceof \OCP\IGroup)) {
-				throw new \InvalidArgumentException('SharedWith should be an IGroup');
+			if (!$this->groupManager->groupExists($share->getSharedWith())) {
+				throw new \InvalidArgumentException('SharedWith is not a valid group');
 			}
 		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
 			if ($share->getSharedWith() !== null) {
@@ -173,7 +178,8 @@ class Manager implements IManager {
 		}
 
 		// Cannot share with yourself
-		if ($share->getSharedWith() === $share->getSharedBy()) {
+		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER &&
+			$share->getSharedWith() === $share->getSharedBy()) {
 			throw new \InvalidArgumentException('Can\'t share with yourself');
 		}
 
@@ -215,7 +221,7 @@ class Manager implements IManager {
 	 * Validate if the expiration date fits the system settings
 	 *
 	 * @param \OCP\Share\IShare $share The share to validate the expiration date of
-	 * @return \DateTime|null The expiration date or null if $expireDate was null and it is not required
+	 * @return \OCP\Share\IShare The expiration date or null if $expireDate was null and it is not required
 	 * @throws GenericShareException
 	 * @throws \InvalidArgumentException
 	 * @throws \Exception
@@ -285,10 +291,12 @@ class Manager implements IManager {
 	protected function userCreateChecks(\OCP\Share\IShare $share) {
 		// Check if we can share with group members only
 		if ($this->shareWithGroupMembersOnly()) {
+			$sharedBy = $this->userManager->get($share->getSharedBy());
+			$sharedWith = $this->userManager->get($share->getSharedWith());
 			// Verify we can share with this user
 			$groups = array_intersect(
-					$this->groupManager->getUserGroupIds($share->getSharedBy()),
-					$this->groupManager->getUserGroupIds($share->getSharedWith())
+					$this->groupManager->getUserGroupIds($sharedBy),
+					$this->groupManager->getUserGroupIds($sharedWith)
 			);
 			if (empty($groups)) {
 				throw new \Exception('Only sharing with group members is allowed');
@@ -314,10 +322,13 @@ class Manager implements IManager {
 			}
 
 			// The share is already shared with this user via a group share
-			if ($existingShare->getShareType() === \OCP\Share::SHARE_TYPE_GROUP &&
-					$existingShare->getSharedWith()->inGroup($share->getSharedWith()) &&
-					$existingShare->getShareOwner() !== $share->getShareOwner()) {
-				throw new \Exception('Path already shared with this user');
+			if ($existingShare->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
+				$group = $this->groupManager->get($existingShare->getSharedWith());
+				$user = $this->userManager->get($share->getSharedWith());
+
+				if ($group->inGroup($user) && $existingShare->getShareOwner() !== $share->getShareOwner()) {
+					throw new \Exception('Path already shared with this user');
+				}
 			}
 		}
 	}
@@ -331,7 +342,9 @@ class Manager implements IManager {
 	protected function groupCreateChecks(\OCP\Share\IShare $share) {
 		// Verify if the user can share with this group
 		if ($this->shareWithGroupMembersOnly()) {
-			if (!$share->getSharedWith()->inGroup($share->getSharedBy())) {
+			$sharedBy = $this->userManager->get($share->getSharedBy());
+			$sharedWith = $this->groupManager->get($share->getSharedWith());
+			if (!$sharedWith->inGroup($sharedBy)) {
 				throw new \Exception('Only sharing within your own groups is allowed');
 			}
 		}
@@ -468,10 +481,11 @@ class Manager implements IManager {
 		$this->pathCreateChecks($share->getNode());
 
 		// On creation of a share the owner is always the owner of the path
-		$share->setShareOwner($share->getNode()->getOwner());
+		$share->setShareOwner($share->getNode()->getOwner()->getUID());
 
 		// Cannot share with the owner
-		if ($share->getSharedWith() === $share->getShareOwner()) {
+		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER &&
+			$share->getSharedWith() === $share->getShareOwner()) {
 			throw new \InvalidArgumentException('Can\'t share with the share owner');
 		}
 
@@ -480,16 +494,6 @@ class Manager implements IManager {
 		$target = \OC\Files\Filesystem::normalizePath($target);
 		$share->setTarget($target);
 
-		//Get sharewith for hooks
-		$sharedWith = null;
-		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER) {
-			$sharedWith = $share->getSharedWith()->getUID();
-		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
-			$sharedWith = $share->getSharedWith()->getGID();
-		} else {
-			$sharedWith = $share->getSharedWith();
-		}
-
 		// Pre share hook
 		$run = true;
 		$error = '';
@@ -497,13 +501,13 @@ class Manager implements IManager {
 			'itemType' => $share->getNode() instanceof \OCP\Files\File ? 'file' : 'folder',
 			'itemSource' => $share->getNode()->getId(),
 			'shareType' => $share->getShareType(),
-			'uidOwner' => $share->getSharedBy()->getUID(),
+			'uidOwner' => $share->getSharedBy(),
 			'permissions' => $share->getPermissions(),
 			'fileSource' => $share->getNode()->getId(),
 			'expiration' => $share->getExpirationDate(),
 			'token' => $share->getToken(),
 			'itemTarget' => $share->getTarget(),
-			'shareWith' => $sharedWith,
+			'shareWith' => $share->getSharedWith(),
 			'run' => &$run,
 			'error' => &$error,
 		];
@@ -521,13 +525,13 @@ class Manager implements IManager {
 			'itemType' => $share->getNode() instanceof \OCP\Files\File ? 'file' : 'folder',
 			'itemSource' => $share->getNode()->getId(),
 			'shareType' => $share->getShareType(),
-			'uidOwner' => $share->getSharedBy()->getUID(),
+			'uidOwner' => $share->getSharedBy(),
 			'permissions' => $share->getPermissions(),
 			'fileSource' => $share->getNode()->getId(),
 			'expiration' => $share->getExpirationDate(),
 			'token' => $share->getToken(),
 			'id' => $share->getId(),
-			'shareWith' => $sharedWith,
+			'shareWith' => $share->getSharedWith(),
 			'itemTarget' => $share->getTarget(),
 			'fileTarget' => $share->getTarget(),
 		];
@@ -542,6 +546,7 @@ class Manager implements IManager {
 	 *
 	 * @param \OCP\Share\IShare $share
 	 * @return \OCP\Share\IShare The share object
+	 * @throws \InvalidArgumentException
 	 */
 	public function updateShare(\OCP\Share\IShare $share) {
 		$expirationDateUpdated = false;
@@ -564,7 +569,8 @@ class Manager implements IManager {
 		}
 
 		// Cannot share with the owner
-		if ($share->getSharedWith() === $share->getShareOwner()) {
+		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER &&
+			$share->getSharedWith() === $share->getShareOwner()) {
 			throw new \InvalidArgumentException('Can\'t share with the share owner');
 		}
 
@@ -606,7 +612,7 @@ class Manager implements IManager {
 				'itemType' => $share->getNode() instanceof \OCP\Files\File ? 'file' : 'folder',
 				'itemSource' => $share->getNode()->getId(),
 				'date' => $share->getExpirationDate(),
-				'uidOwner' => $share->getSharedBy()->getUID(),
+				'uidOwner' => $share->getSharedBy(),
 			]);
 		}
 
@@ -651,9 +657,9 @@ class Manager implements IManager {
 			$shareType = $share->getShareType();
 			$sharedWith = '';
 			if ($shareType === \OCP\Share::SHARE_TYPE_USER) {
-				$sharedWith = $share->getSharedWith()->getUID();
+				$sharedWith = $share->getSharedWith();
 			} else if ($shareType === \OCP\Share::SHARE_TYPE_GROUP) {
-				$sharedWith = $share->getSharedWith()->getGID();
+				$sharedWith = $share->getSharedWith();
 			} else if ($shareType === \OCP\Share::SHARE_TYPE_REMOTE) {
 				$sharedWith = $share->getSharedWith();
 			}
@@ -665,7 +671,7 @@ class Manager implements IManager {
 				'shareType'  => $shareType,
 				'shareWith'  => $sharedWith,
 				'itemparent' => $share->getParent(),
-				'uidOwner'   => $share->getSharedBy()->getUID(),
+				'uidOwner'   => $share->getSharedBy(),
 				'fileSource' => $share->getNode()->getId(),
 				'fileTarget' => $share->getTarget()
 			];
@@ -706,38 +712,45 @@ class Manager implements IManager {
 	 * handle this.
 	 *
 	 * @param \OCP\Share\IShare $share
-	 * @param IUser $recipient
+	 * @param string $recipientId
 	 */
-	public function deleteFromSelf(\OCP\Share\IShare $share, IUser $recipient) {
-		list($providerId, $id) = $this->splitFullId($share->getId());
+	public function deleteFromSelf(\OCP\Share\IShare $share, $recipientId) {
+		list($providerId, ) = $this->splitFullId($share->getId());
 		$provider = $this->factory->getProvider($providerId);
 
-		$provider->deleteFromSelf($share, $recipient);
+		$provider->deleteFromSelf($share, $recipientId);
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function moveShare(\OCP\Share\IShare $share, IUser $recipient) {
+	public function moveShare(\OCP\Share\IShare $share, $recipientId) {
 		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
 			throw new \InvalidArgumentException('Can\'t change target of link share');
 		}
 
-		if (($share->getShareType() === \OCP\Share::SHARE_TYPE_USER && $share->getSharedWith() !== $recipient) ||
-			($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP && !$share->getSharedWith()->inGroup($recipient))) {
+		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER && $share->getSharedWith() !== $recipientId) {
 			throw new \InvalidArgumentException('Invalid recipient');
+		}
+
+		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
+			$sharedWith = $this->groupManager->get($share->getSharedWith());
+			$recipient = $this->userManager->get($recipientId);
+			if (!$sharedWith->inGroup($recipient)) {
+				throw new \InvalidArgumentException('Invalid recipient');
+			}
 		}
 
 		list($providerId, ) = $this->splitFullId($share->getId());
 		$provider = $this->factory->getProvider($providerId);
 
-		$provider->move($share, $recipient);
+		$provider->move($share, $recipientId);
 	}
 
 	/**
 	 * Get shares shared by (initiated) by the provided user.
 	 *
-	 * @param IUser $user
+	 * @param string $userId
 	 * @param int $shareType
 	 * @param \OCP\Files\File|\OCP\Files\Folder $path
 	 * @param bool $reshares
@@ -745,7 +758,7 @@ class Manager implements IManager {
 	 * @param int $offset
 	 * @return \OCP\Share\IShare[]
 	 */
-	public function getSharesBy(IUser $user, $shareType, $path = null, $reshares = false, $limit = 50, $offset = 0) {
+	public function getSharesBy($userId, $shareType, $path = null, $reshares = false, $limit = 50, $offset = 0) {
 		if ($path !== null &&
 				!($path instanceof \OCP\Files\File) &&
 				!($path instanceof \OCP\Files\Folder)) {
@@ -754,16 +767,16 @@ class Manager implements IManager {
 
 		$provider = $this->factory->getProviderForType($shareType);
 
-		return $provider->getSharesBy($user, $shareType, $path, $reshares, $limit, $offset);
+		return $provider->getSharesBy($userId, $shareType, $path, $reshares, $limit, $offset);
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function getSharedWith(IUser $user, $shareType, $node = null, $limit = 50, $offset = 0) {
+	public function getSharedWith($userId, $shareType, $node = null, $limit = 50, $offset = 0) {
 		$provider = $this->factory->getProviderForType($shareType);
 
-		return $provider->getSharedWith($user, $shareType, $node, $limit, $offset);
+		return $provider->getSharedWith($userId, $shareType, $node, $limit, $offset);
 	}
 
 	/**
@@ -955,10 +968,10 @@ class Manager implements IManager {
 	 *
 	 * TODO: Deprecate fuction from OC_Util
 	 *
-	 * @param IUser $user
+	 * @param string $userId
 	 * @return bool
 	 */
-	public function sharingDisabledForUser(IUser $user) {
+	public function sharingDisabledForUser($userId) {
 		if ($this->config->getAppValue('core', 'shareapi_exclude_groups', 'no') === 'yes') {
 			$groupsList = $this->config->getAppValue('core', 'shareapi_exclude_groups_list', '');
 			$excludedGroups = json_decode($groupsList);
@@ -967,6 +980,7 @@ class Manager implements IManager {
 				$newValue = json_encode($excludedGroups);
 				$this->config->setAppValue('core', 'shareapi_exclude_groups_list', $newValue);
 			}
+			$user = $this->userManager->get($userId);
 			$usersGroups = $this->groupManager->getUserGroupIds($user);
 			if (!empty($usersGroups)) {
 				$remainingGroups = array_diff($usersGroups, $excludedGroups);

--- a/lib/private/share20/share.php
+++ b/lib/private/share20/share.php
@@ -121,6 +121,9 @@ class Share implements \OCP\Share\IShare {
 	 * @inheritdoc
 	 */
 	public function setSharedWith($sharedWith) {
+		if (!is_string($sharedWith)) {
+			throw new \InvalidArgumentException();
+		}
 		$this->sharedWith = $sharedWith;
 		return $this;
 	}
@@ -170,6 +173,9 @@ class Share implements \OCP\Share\IShare {
 	 * @inheritdoc
 	 */
 	public function setSharedBy($sharedBy) {
+		if (!is_string($sharedBy)) {
+			throw new \InvalidArgumentException();
+		}
 		//TODO checks
 		$this->sharedBy = $sharedBy;
 
@@ -188,6 +194,9 @@ class Share implements \OCP\Share\IShare {
 	 * @inheritdoc
 	 */
 	public function setShareOwner($shareOwner) {
+		if (!is_string($shareOwner)) {
+			throw new \InvalidArgumentException();
+		}
 		//TODO checks
 
 		$this->shareOwner = $shareOwner;

--- a/lib/public/share/imanager.php
+++ b/lib/public/share/imanager.php
@@ -69,27 +69,27 @@ interface IManager {
 	 * handle this.
 	 *
 	 * @param IShare $share
-	 * @param IUser $recipient
+	 * @param string $recipientId
 	 * @since 9.0.0
 	 */
-	public function deleteFromSelf(IShare $share, IUser $recipient);
+	public function deleteFromSelf(IShare $share, $recipientId);
 
 	/**
 	 * Move the share as a recipient of the share.
 	 * This is updating the share target. So where the recipient has the share mounted.
 	 *
 	 * @param IShare $share
-	 * @param IUser $recipient
+	 * @param string $recipientId
 	 * @return IShare
 	 * @throws \InvalidArgumentException If $share is a link share or the $recipient does not match
 	 * @since 9.0.0
 	 */
-	public function moveShare(IShare $share, IUser $recipient);
+	public function moveShare(IShare $share, $recipientId);
 
 	/**
 	 * Get shares shared by (initiated) by the provided user.
 	 *
-	 * @param IUser $user
+	 * @param string $userId
 	 * @param int $shareType
 	 * @param \OCP\Files\File|\OCP\Files\Folder $path
 	 * @param bool $reshares
@@ -98,13 +98,13 @@ interface IManager {
 	 * @return IShare[]
 	 * @since 9.0.0
 	 */
-	public function getSharesBy(IUser $user, $shareType, $path = null, $reshares = false, $limit = 50, $offset = 0);
+	public function getSharesBy($userId, $shareType, $path = null, $reshares = false, $limit = 50, $offset = 0);
 
 	/**
 	 * Get shares shared with $user.
 	 * Filter by $node if provided
 	 *
-	 * @param IUser $user
+	 * @param string $userId
 	 * @param int $shareType
 	 * @param File|Folder|null $node
 	 * @param int $limit The maximum number of shares returned, -1 for all
@@ -112,7 +112,7 @@ interface IManager {
 	 * @return IShare[]
 	 * @since 9.0.0
 	 */
-	public function getSharedWith(IUser $user, $shareType, $node = null, $limit = 50, $offset = 0);
+	public function getSharedWith($userId, $shareType, $node = null, $limit = 50, $offset = 0);
 
 	/**
 	 * Retrieve a share by the share id.
@@ -223,10 +223,10 @@ interface IManager {
 	/**
 	 * Check if sharing is disabled for the given user
 	 *
-	 * @param IUser $user
+	 * @param string $userId
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function sharingDisabledForUser(IUser $user);
+	public function sharingDisabledForUser($userId);
 
 }

--- a/lib/public/share/ishare.php
+++ b/lib/public/share/ishare.php
@@ -89,7 +89,7 @@ interface IShare {
 	/**
 	 * Set the receiver of this share.
 	 *
-	 * @param IUser|IGroup
+	 * @param string $sharedWith
 	 * @return \OCP\Share\IShare The modified object
 	 * @since 9.0.0
 	 */
@@ -98,7 +98,7 @@ interface IShare {
 	/**
 	 * Get the receiver of this share.
 	 *
-	 * @return IUser|IGroup
+	 * @return string
 	 * @since 9.0.0
 	 */
 	public function getSharedWith();
@@ -142,7 +142,7 @@ interface IShare {
 	/**
 	 * Set the sharer of the path.
 	 *
-	 * @param IUser $sharedBy
+	 * @param string $sharedBy
 	 * @return \OCP\Share\IShare The modified object
 	 * @since 9.0.0
 	 */
@@ -151,7 +151,7 @@ interface IShare {
 	/**
 	 * Get share sharer
 	 *
-	 * @return IUser
+	 * @return string
 	 * @since 9.0.0
 	 */
 	public function getSharedBy();
@@ -159,7 +159,7 @@ interface IShare {
 	/**
 	 * Set the original share owner (who owns the path that is shared)
 	 *
-	 * @param IUser
+	 * @param string $shareOwner
 	 * @return \OCP\Share\IShare The modified object
 	 * @since 9.0.0
 	 */
@@ -168,7 +168,7 @@ interface IShare {
 	/**
 	 * Get the original share owner (who owns the path that is shared)
 	 *
-	 * @return IUser
+	 * @return string
 	 * @since 9.0.0
 	 */
 	public function getShareOwner();

--- a/lib/public/share/ishareprovider.php
+++ b/lib/public/share/ishareprovider.php
@@ -129,7 +129,7 @@ interface IShareProvider {
 	/**
 	 * Get shared with the given user
 	 *
-	 * @param stromg $userId get shares where this user is the recipient
+	 * @param string $userId get shares where this user is the recipient
 	 * @param int $shareType
 	 * @param Node|null $node
 	 * @param int $limit The max number of entries returned, -1 for all

--- a/lib/public/share/ishareprovider.php
+++ b/lib/public/share/ishareprovider.php
@@ -74,10 +74,10 @@ interface IShareProvider {
 	 * share from their self then the original group share should still exist.
 	 *
 	 * @param \OCP\Share\IShare $share
-	 * @param IUser $recipient
+	 * @param string $recipient UserId of the recipient
 	 * @since 9.0.0
 	 */
-	public function deleteFromSelf(\OCP\Share\IShare $share, IUser $recipient);
+	public function deleteFromSelf(\OCP\Share\IShare $share, $recipient);
 
 	/**
 	 * Move a share as a recipient.
@@ -86,36 +86,36 @@ interface IShareProvider {
 	 * the target should only be changed for them.
 	 *
 	 * @param \OCP\Share\IShare $share
-	 * @param IUser $recipient
+	 * @param string $recipient userId of recipient
 	 * @return \OCP\Share\IShare
 	 * @since 9.0.0
 	 */
-	public function move(\OCP\Share\IShare $share, IUser $recipient);
+	public function move(\OCP\Share\IShare $share, $recipient);
 
 	/**
 	 * Get all shares by the given user
 	 *
-	 * @param IUser $user
+	 * @param string $userId
 	 * @param int $shareType
 	 * @param \OCP\Files\File|\OCP\Files\Folder $node
 	 * @param bool $reshares Also get the shares where $user is the owner instead of just the shares where $user is the initiator
 	 * @param int $limit The maximum number of shares to be returned, -1 for all shares
 	 * @param int $offset
-	 * @return \OCP\Share\I Share[]
+	 * @return \OCP\Share\IShare Share[]
 	 * @since 9.0.0
 	 */
-	public function getSharesBy(IUser $user, $shareType, $node, $reshares, $limit, $offset);
+	public function getSharesBy($userId, $shareType, $node, $reshares, $limit, $offset);
 
 	/**
 	 * Get share by id
 	 *
 	 * @param int $id
-	 * @param IUser|null $recipient
+	 * @param string|null $recipientId
 	 * @return \OCP\Share\IShare
 	 * @throws ShareNotFound
 	 * @since 9.0.0
 	 */
-	public function getShareById($id, $recipient = null);
+	public function getShareById($id, $recipientId = null);
 
 	/**
 	 * Get shares for a given path
@@ -129,7 +129,7 @@ interface IShareProvider {
 	/**
 	 * Get shared with the given user
 	 *
-	 * @param IUser $user get shares where this user is the recipient
+	 * @param stromg $userId get shares where this user is the recipient
 	 * @param int $shareType
 	 * @param Node|null $node
 	 * @param int $limit The max number of entries returned, -1 for all
@@ -137,7 +137,7 @@ interface IShareProvider {
 	 * @return \OCP\Share\IShare[]
 	 * @since 9.0.0
 	 */
-	public function getSharedWith(IUser $user, $shareType, $node, $limit, $offset);
+	public function getSharedWith($userId, $shareType, $node, $limit, $offset);
 
 	/**
 	 * Get a share by token

--- a/tests/lib/share20/defaultshareprovidertest.php
+++ b/tests/lib/share20/defaultshareprovidertest.php
@@ -157,21 +157,13 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				['shareOwner', $shareOwnerFolder],
 			]));
 
-		$this->userManager
-			->method('get')
-			->will($this->returnValueMap([
-				['sharedWith', $sharedWith],
-				['sharedBy', $sharedBy],
-				['shareOwner', $shareOwner],
-			]));
-
 		$share = $this->provider->getShareById($id);
 
 		$this->assertEquals($id, $share->getId());
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_USER, $share->getShareType());
-		$this->assertEquals($sharedWith, $share->getSharedWith());
-		$this->assertEquals($sharedBy, $share->getSharedBy());
-		$this->assertEquals($shareOwner, $share->getShareOwner());
+		$this->assertEquals('sharedWith', $share->getSharedWith());
+		$this->assertEquals('sharedBy', $share->getSharedBy());
+		$this->assertEquals('shareOwner', $share->getShareOwner());
 		$this->assertEquals($ownerPath, $share->getNode());
 		$this->assertEquals(13, $share->getPermissions());
 		$this->assertEquals(null, $share->getToken());
@@ -221,25 +213,13 @@ class DefaultShareProviderTest extends \Test\TestCase {
 						['shareOwner', $shareOwnerFolder],
 				]));
 
-		$this->userManager
-			->method('get')
-			->will($this->returnValueMap([
-				['sharedBy', $sharedBy],
-				['shareOwner', $shareOwner],
-			]));
-		$this->groupManager
-			->expects($this->once())
-			->method('get')
-			->with('sharedWith')
-			->willReturn($sharedWith);
-
 		$share = $this->provider->getShareById($id);
 
 		$this->assertEquals($id, $share->getId());
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_GROUP, $share->getShareType());
-		$this->assertEquals($sharedWith, $share->getSharedWith());
-		$this->assertEquals($sharedBy, $share->getSharedBy());
-		$this->assertEquals($shareOwner, $share->getShareOwner());
+		$this->assertEquals('sharedWith', $share->getSharedWith());
+		$this->assertEquals('sharedBy', $share->getSharedBy());
+		$this->assertEquals('shareOwner', $share->getShareOwner());
 		$this->assertEquals($ownerPath, $share->getNode());
 		$this->assertEquals(13, $share->getPermissions());
 		$this->assertEquals(null, $share->getToken());
@@ -271,13 +251,13 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		]));
 		$this->groupManager->method('get')->with('group0')->willReturn($group0);
 
-		$share = $this->provider->getShareById($id, $user1);
+		$share = $this->provider->getShareById($id, 'user1');
 
 		$this->assertEquals($id, $share->getId());
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_GROUP, $share->getShareType());
-		$this->assertSame($group0, $share->getSharedWith());
-		$this->assertSame($user0, $share->getSharedBy());
-		$this->assertSame($user0, $share->getShareOwner());
+		$this->assertSame('group0', $share->getSharedWith());
+		$this->assertSame('user0', $share->getSharedBy());
+		$this->assertSame('user0', $share->getShareOwner());
 		$this->assertSame($node, $share->getNode());
 		$this->assertEquals(0, $share->getPermissions());
 		$this->assertEquals(null, $share->getToken());
@@ -339,8 +319,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->assertEquals($id, $share->getId());
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_LINK, $share->getShareType());
 		$this->assertEquals('sharedWith', $share->getPassword());
-		$this->assertEquals($sharedBy, $share->getSharedBy());
-		$this->assertEquals($shareOwner, $share->getShareOwner());
+		$this->assertEquals('sharedBy', $share->getSharedBy());
+		$this->assertEquals('shareOwner', $share->getShareOwner());
 		$this->assertEquals($ownerPath, $share->getNode());
 		$this->assertEquals(13, $share->getPermissions());
 		$this->assertEquals('token', $share->getToken());
@@ -559,9 +539,9 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		//Child1
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_USER, $children[0]->getShareType());
-		$this->assertEquals($user1, $children[0]->getSharedWith());
-		$this->assertEquals($user2, $children[0]->getSharedBy());
-		$this->assertEquals($shareOwner, $children[0]->getShareOwner());
+		$this->assertEquals('user1', $children[0]->getSharedWith());
+		$this->assertEquals('user2', $children[0]->getSharedBy());
+		$this->assertEquals('shareOwner', $children[0]->getShareOwner());
 		$this->assertEquals($ownerPath, $children[0]->getNode());
 		$this->assertEquals(2, $children[0]->getPermissions());
 		$this->assertEquals(null, $children[0]->getToken());
@@ -570,9 +550,9 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		//Child2
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_GROUP, $children[1]->getShareType());
-		$this->assertEquals($group1, $children[1]->getSharedWith());
-		$this->assertEquals($user3, $children[1]->getSharedBy());
-		$this->assertEquals($shareOwner, $children[1]->getShareOwner());
+		$this->assertEquals('group1', $children[1]->getSharedWith());
+		$this->assertEquals('user3', $children[1]->getSharedBy());
+		$this->assertEquals('shareOwner', $children[1]->getShareOwner());
 		$this->assertEquals($ownerPath, $children[1]->getNode());
 		$this->assertEquals(4, $children[1]->getPermissions());
 		$this->assertEquals(null, $children[1]->getToken());
@@ -583,20 +563,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	public function testCreateUserShare() {
 		$share = new \OC\Share20\Share();
 
-		$sharedWith = $this->getMock('OCP\IUser');
-		$sharedWith->method('getUID')->willReturn('sharedWith');
-		$sharedBy = $this->getMock('OCP\IUser');
-		$sharedBy->method('getUID')->willReturn('sharedBy');
 		$shareOwner = $this->getMock('OCP\IUser');
 		$shareOwner->method('getUID')->WillReturn('shareOwner');
-
-		$this->userManager
-			->method('get')
-			->will($this->returnValueMap([
-				['sharedWith', $sharedWith],
-				['sharedBy', $sharedBy],
-				['shareOwner', $shareOwner],
-			]));
 
 		$path = $this->getMock('\OCP\Files\File');
 		$path->method('getId')->willReturn(100);
@@ -619,9 +587,9 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->willReturn([$path]);
 
 		$share->setShareType(\OCP\Share::SHARE_TYPE_USER);
-		$share->setSharedWith($sharedWith);
-		$share->setSharedBy($sharedBy);
-		$share->setShareOwner($shareOwner);
+		$share->setSharedWith('sharedWith');
+		$share->setSharedBy('sharedBy');
+		$share->setShareOwner('shareOwner');
 		$share->setNode($path);
 		$share->setPermissions(1);
 		$share->setTarget('/target');
@@ -631,9 +599,9 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->assertNotNull($share2->getId());
 		$this->assertSame('ocinternal:'.$share2->getId(), $share2->getFullId());
 		$this->assertSame(\OCP\Share::SHARE_TYPE_USER, $share2->getShareType());
-		$this->assertSame($sharedWith, $share2->getSharedWith());
-		$this->assertSame($sharedBy, $share2->getSharedBy());
-		$this->assertSame($shareOwner, $share2->getShareOwner());
+		$this->assertSame('sharedWith', $share2->getSharedWith());
+		$this->assertSame('sharedBy', $share2->getSharedBy());
+		$this->assertSame('shareOwner', $share2->getShareOwner());
 		$this->assertSame(1, $share2->getPermissions());
 		$this->assertSame('/target', $share2->getTarget());
 		$this->assertLessThanOrEqual(new \DateTime(), $share2->getShareTime());
@@ -643,23 +611,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	public function testCreateGroupShare() {
 		$share = new \OC\Share20\Share();
 
-		$sharedWith = $this->getMock('OCP\IGroup');
-		$sharedWith->method('getGID')->willReturn('sharedWith');
-		$sharedBy = $this->getMock('OCP\IUser');
-		$sharedBy->method('getUID')->willReturn('sharedBy');
-		$shareOwner = $this->getMock('OCP\IUser');
-		$shareOwner->method('getUID')->WillReturn('shareOwner');
-
-		$this->userManager
-			->method('get')
-			->will($this->returnValueMap([
-				['sharedBy', $sharedBy],
-				['shareOwner', $shareOwner],
-			]));
-		$this->groupManager
-			->method('get')
-			->with('sharedWith')
-			->willReturn($sharedWith);
+		$shareOwner = $this->getMock('\OCP\IUser');
+		$shareOwner->method('getUID')->willReturn('shareOwner');
 
 		$path = $this->getMock('\OCP\Files\Folder');
 		$path->method('getId')->willReturn(100);
@@ -682,9 +635,9 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->willReturn([$path]);
 
 		$share->setShareType(\OCP\Share::SHARE_TYPE_GROUP);
-		$share->setSharedWith($sharedWith);
-		$share->setSharedBy($sharedBy);
-		$share->setShareOwner($shareOwner);
+		$share->setSharedWith('sharedWith');
+		$share->setSharedBy('sharedBy');
+		$share->setShareOwner('shareOwner');
 		$share->setNode($path);
 		$share->setPermissions(1);
 		$share->setTarget('/target');
@@ -694,9 +647,9 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->assertNotNull($share2->getId());
 		$this->assertSame('ocinternal:'.$share2->getId(), $share2->getFullId());
 		$this->assertSame(\OCP\Share::SHARE_TYPE_GROUP, $share2->getShareType());
-		$this->assertSame($sharedWith, $share2->getSharedWith());
-		$this->assertSame($sharedBy, $share2->getSharedBy());
-		$this->assertSame($shareOwner, $share2->getShareOwner());
+		$this->assertSame('sharedWith', $share2->getSharedWith());
+		$this->assertSame('sharedBy', $share2->getSharedBy());
+		$this->assertSame('shareOwner', $share2->getShareOwner());
 		$this->assertSame(1, $share2->getPermissions());
 		$this->assertSame('/target', $share2->getTarget());
 		$this->assertLessThanOrEqual(new \DateTime(), $share2->getShareTime());
@@ -706,17 +659,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	public function testCreateLinkShare() {
 		$share = new \OC\Share20\Share();
 
-		$sharedBy = $this->getMock('OCP\IUser');
-		$sharedBy->method('getUID')->willReturn('sharedBy');
-		$shareOwner = $this->getMock('OCP\IUser');
-		$shareOwner->method('getUID')->WillReturn('shareOwner');
-
-		$this->userManager
-				->method('get')
-				->will($this->returnValueMap([
-						['sharedBy', $sharedBy],
-						['shareOwner', $shareOwner],
-				]));
+		$shareOwner = $this->getMock('\OCP\IUser');
+		$shareOwner->method('getUID')->willReturn('shareOwner');
 
 		$path = $this->getMock('\OCP\Files\Folder');
 		$path->method('getId')->willReturn(100);
@@ -739,8 +683,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				->willReturn([$path]);
 
 		$share->setShareType(\OCP\Share::SHARE_TYPE_LINK);
-		$share->setSharedBy($sharedBy);
-		$share->setShareOwner($shareOwner);
+		$share->setSharedBy('sharedBy');
+		$share->setShareOwner('shareOwner');
 		$share->setNode($path);
 		$share->setPermissions(1);
 		$share->setPassword('password');
@@ -754,8 +698,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->assertNotNull($share2->getId());
 		$this->assertSame('ocinternal:'.$share2->getId(), $share2->getFullId());
 		$this->assertSame(\OCP\Share::SHARE_TYPE_LINK, $share2->getShareType());
-		$this->assertSame($sharedBy, $share2->getSharedBy());
-		$this->assertSame($shareOwner, $share2->getShareOwner());
+		$this->assertSame('sharedBy', $share2->getSharedBy());
+		$this->assertSame('shareOwner', $share2->getShareOwner());
 		$this->assertSame(1, $share2->getPermissions());
 		$this->assertSame('/target', $share2->getTarget());
 		$this->assertLessThanOrEqual(new \DateTime(), $share2->getShareTime());
@@ -783,17 +727,6 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$qb->execute();
 		$id = $qb->getLastInsertId();
 
-		$owner = $this->getMock('\OCP\IUser');
-		$owner->method('getUID')->willReturn('shareOwner');
-		$initiator = $this->getMock('\OCP\IUser');
-		$initiator->method('getUID')->willReturn('sharedBy');
-
-		$this->userManager->method('get')
-			->will($this->returnValueMap([
-				['sharedBy', $initiator],
-				['shareOwner', $owner],
-			]));
-
 		$file = $this->getMock('\OCP\Files\File');
 
 		$this->rootFolder->method('getUserFolder')->with('shareOwner')->will($this->returnSelf());
@@ -801,8 +734,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$share = $this->provider->getShareByToken('secrettoken');
 		$this->assertEquals($id, $share->getId());
-		$this->assertSame($owner, $share->getShareOwner());
-		$this->assertSame($initiator, $share->getSharedBy());
+		$this->assertSame('shareOwner', $share->getShareOwner());
+		$this->assertSame('sharedBy', $share->getSharedBy());
 		$this->assertSame('secrettoken', $share->getToken());
 		$this->assertSame('password', $share->getPassword());
 		$this->assertSame(null, $share->getSharedWith());
@@ -845,31 +778,18 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			]);
 		$this->assertEquals(1, $qb->execute());
 
-		$user = $this->getMock('\OCP\IUser');
-		$user->method('getUID')->willReturn('sharedWith');
-		$owner = $this->getMock('\OCP\IUser');
-		$owner->method('getUID')->willReturn('shareOwner');
-		$initiator = $this->getMock('\OCP\IUser');
-		$initiator->method('getUID')->willReturn('sharedBy');
-
-		$this->userManager->method('get')->willReturnMap([
-			['sharedWith', $user],
-			['shareOwner', $owner],
-			['sharedBy', $initiator],
-		]);
-
 		$file = $this->getMock('\OCP\Files\File');
 		$this->rootFolder->method('getUserFolder')->with('shareOwner')->will($this->returnSelf());
 		$this->rootFolder->method('getById')->with(42)->willReturn([$file]);
 
-		$share = $this->provider->getSharedWith($user, \OCP\Share::SHARE_TYPE_USER, null, 1 , 0);
+		$share = $this->provider->getSharedWith('sharedWith', \OCP\Share::SHARE_TYPE_USER, null, 1 , 0);
 		$this->assertCount(1, $share);
 
 		$share = $share[0];
 		$this->assertEquals($id, $share->getId());
-		$this->assertEquals($user, $share->getSharedWith());
-		$this->assertEquals($owner, $share->getShareOwner());
-		$this->assertEquals($initiator, $share->getSharedBy());
+		$this->assertEquals('sharedWith', $share->getSharedWith());
+		$this->assertEquals('shareOwner', $share->getShareOwner());
+		$this->assertEquals('sharedBy', $share->getSharedBy());
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_USER, $share->getShareType());
 	}
 
@@ -922,6 +842,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$initiator->method('getUID')->willReturn('sharedBy');
 
 		$this->userManager->method('get')->willReturnMap([
+			['sharedWith', $user],
 			['shareOwner', $owner],
 			['sharedBy', $initiator],
 		]);
@@ -932,14 +853,14 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->rootFolder->method('getUserFolder')->with('shareOwner')->will($this->returnSelf());
 		$this->rootFolder->method('getById')->with(42)->willReturn([$file]);
 
-		$share = $this->provider->getSharedWith($user, \OCP\Share::SHARE_TYPE_GROUP, null, 20 , 1);
+		$share = $this->provider->getSharedWith('sharedWith', \OCP\Share::SHARE_TYPE_GROUP, null, 20 , 1);
 		$this->assertCount(1, $share);
 
 		$share = $share[0];
 		$this->assertEquals($id, $share->getId());
-		$this->assertEquals($group, $share->getSharedWith());
-		$this->assertEquals($owner, $share->getShareOwner());
-		$this->assertEquals($initiator, $share->getSharedBy());
+		$this->assertEquals('sharedWith', $share->getSharedWith());
+		$this->assertEquals('shareOwner', $share->getShareOwner());
+		$this->assertEquals('sharedBy', $share->getSharedBy());
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_GROUP, $share->getShareType());
 	}
 
@@ -1007,6 +928,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$initiator->method('getUID')->willReturn('sharedBy');
 
 		$this->userManager->method('get')->willReturnMap([
+			['user', $user],
 			['shareOwner', $owner],
 			['sharedBy', $initiator],
 		]);
@@ -1017,14 +939,14 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->rootFolder->method('getUserFolder')->with('shareOwner')->will($this->returnSelf());
 		$this->rootFolder->method('getById')->with(42)->willReturn([$file]);
 
-		$share = $this->provider->getSharedWith($user, \OCP\Share::SHARE_TYPE_GROUP, null, -1, 0);
+		$share = $this->provider->getSharedWith('user', \OCP\Share::SHARE_TYPE_GROUP, null, -1, 0);
 		$this->assertCount(1, $share);
 
 		$share = $share[0];
 		$this->assertSame($id, $share->getId());
-		$this->assertSame($group, $share->getSharedWith());
-		$this->assertSame($owner, $share->getShareOwner());
-		$this->assertSame($initiator, $share->getSharedBy());
+		$this->assertSame('sharedWith', $share->getSharedWith());
+		$this->assertSame('shareOwner', $share->getShareOwner());
+		$this->assertSame('sharedBy', $share->getSharedBy());
 		$this->assertSame(\OCP\Share::SHARE_TYPE_GROUP, $share->getShareType());
 		$this->assertSame(0, $share->getPermissions());
 		$this->assertSame('userTarget', $share->getTarget());
@@ -1051,14 +973,14 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->rootFolder->method('getUserFolder')->with('user1')->will($this->returnSelf());
 		$this->rootFolder->method('getById')->with(43)->willReturn([$file]);
 
-		$share = $this->provider->getSharedWith($user0, \OCP\Share::SHARE_TYPE_USER, $file, -1, 0);
+		$share = $this->provider->getSharedWith('user0', \OCP\Share::SHARE_TYPE_USER, $file, -1, 0);
 		$this->assertCount(1, $share);
 
 		$share = $share[0];
 		$this->assertEquals($id, $share->getId());
-		$this->assertSame($user0, $share->getSharedWith());
-		$this->assertSame($user1, $share->getShareOwner());
-		$this->assertSame($user1, $share->getSharedBy());
+		$this->assertSame('user0', $share->getSharedWith());
+		$this->assertSame('user1', $share->getShareOwner());
+		$this->assertSame('user1', $share->getSharedBy());
 		$this->assertSame($file, $share->getNode());
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_USER, $share->getShareType());
 	}
@@ -1090,14 +1012,14 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->rootFolder->method('getUserFolder')->with('user1')->will($this->returnSelf());
 		$this->rootFolder->method('getById')->with(43)->willReturn([$node]);
 
-		$share = $this->provider->getSharedWith($user0, \OCP\Share::SHARE_TYPE_GROUP, $node, -1, 0);
+		$share = $this->provider->getSharedWith('user0', \OCP\Share::SHARE_TYPE_GROUP, $node, -1, 0);
 		$this->assertCount(1, $share);
 
 		$share = $share[0];
 		$this->assertEquals($id, $share->getId());
-		$this->assertSame($group0, $share->getSharedWith());
-		$this->assertSame($user1, $share->getShareOwner());
-		$this->assertSame($user1, $share->getSharedBy());
+		$this->assertSame('group0', $share->getSharedWith());
+		$this->assertSame('user1', $share->getShareOwner());
+		$this->assertSame('user1', $share->getSharedBy());
 		$this->assertSame($node, $share->getNode());
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_GROUP, $share->getShareType());
 	}
@@ -1133,31 +1055,18 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			]);
 		$this->assertEquals(1, $qb->execute());
 
-		$user = $this->getMock('\OCP\IUser');
-		$user->method('getUID')->willReturn('sharedWith');
-		$owner = $this->getMock('\OCP\IUser');
-		$owner->method('getUID')->willReturn('shareOwner');
-		$initiator = $this->getMock('\OCP\IUser');
-		$initiator->method('getUID')->willReturn('sharedBy');
-
-		$this->userManager->method('get')->willReturnMap([
-			['sharedWith', $user],
-			['shareOwner', $owner],
-			['sharedBy', $initiator],
-		]);
-
 		$file = $this->getMock('\OCP\Files\File');
 		$this->rootFolder->method('getUserFolder')->with('shareOwner')->will($this->returnSelf());
 		$this->rootFolder->method('getById')->with(42)->willReturn([$file]);
 
-		$share = $this->provider->getSharesBy($initiator, \OCP\Share::SHARE_TYPE_USER, null, false, 1, 0);
+		$share = $this->provider->getSharesBy('sharedBy', \OCP\Share::SHARE_TYPE_USER, null, false, 1, 0);
 		$this->assertCount(1, $share);
 
 		$share = $share[0];
 		$this->assertEquals($id, $share->getId());
-		$this->assertEquals($user, $share->getSharedWith());
-		$this->assertEquals($owner, $share->getShareOwner());
-		$this->assertEquals($initiator, $share->getSharedBy());
+		$this->assertEquals('sharedWith', $share->getSharedWith());
+		$this->assertEquals('shareOwner', $share->getShareOwner());
+		$this->assertEquals('sharedBy', $share->getSharedBy());
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_USER, $share->getShareType());
 		$this->assertEquals(13, $share->getPermissions());
 		$this->assertEquals('myTarget', $share->getTarget());
@@ -1194,32 +1103,19 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			]);
 		$this->assertEquals(1, $qb->execute());
 
-		$user = $this->getMock('\OCP\IUser');
-		$user->method('getUID')->willReturn('sharedWith');
-		$owner = $this->getMock('\OCP\IUser');
-		$owner->method('getUID')->willReturn('shareOwner');
-		$initiator = $this->getMock('\OCP\IUser');
-		$initiator->method('getUID')->willReturn('sharedBy');
-
-		$this->userManager->method('get')->willReturnMap([
-			['sharedWith', $user],
-			['shareOwner', $owner],
-			['sharedBy', $initiator],
-		]);
-
 		$file = $this->getMock('\OCP\Files\File');
 		$file->method('getId')->willReturn(42);
 		$this->rootFolder->method('getUserFolder')->with('shareOwner')->will($this->returnSelf());
 		$this->rootFolder->method('getById')->with(42)->willReturn([$file]);
 
-		$share = $this->provider->getSharesBy($initiator, \OCP\Share::SHARE_TYPE_USER, $file, false, 1, 0);
+		$share = $this->provider->getSharesBy('sharedBy', \OCP\Share::SHARE_TYPE_USER, $file, false, 1, 0);
 		$this->assertCount(1, $share);
 
 		$share = $share[0];
 		$this->assertEquals($id, $share->getId());
-		$this->assertEquals($user, $share->getSharedWith());
-		$this->assertEquals($owner, $share->getShareOwner());
-		$this->assertEquals($initiator, $share->getSharedBy());
+		$this->assertEquals('sharedWith', $share->getSharedWith());
+		$this->assertEquals('shareOwner', $share->getShareOwner());
+		$this->assertEquals('sharedBy', $share->getSharedBy());
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_USER, $share->getShareType());
 		$this->assertEquals(13, $share->getPermissions());
 		$this->assertEquals('myTarget', $share->getTarget());
@@ -1256,41 +1152,28 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->assertEquals(1, $qb->execute());
 		$id2 = $qb->getLastInsertId();
 
-		$user = $this->getMock('\OCP\IUser');
-		$user->method('getUID')->willReturn('sharedWith');
-		$owner = $this->getMock('\OCP\IUser');
-		$owner->method('getUID')->willReturn('shareOwner');
-		$initiator = $this->getMock('\OCP\IUser');
-		$initiator->method('getUID')->willReturn('sharedBy');
-
-		$this->userManager->method('get')->willReturnMap([
-			['sharedWith', $user],
-			['shareOwner', $owner],
-			['sharedBy', $initiator],
-		]);
-
 		$file = $this->getMock('\OCP\Files\File');
 		$file->method('getId')->willReturn(42);
 		$this->rootFolder->method('getUserFolder')->with('shareOwner')->will($this->returnSelf());
 		$this->rootFolder->method('getById')->with(42)->willReturn([$file]);
 
-		$shares = $this->provider->getSharesBy($owner, \OCP\Share::SHARE_TYPE_USER, null, true, -1, 0);
+		$shares = $this->provider->getSharesBy('shareOwner', \OCP\Share::SHARE_TYPE_USER, null, true, -1, 0);
 		$this->assertCount(2, $shares);
 
 		$share = $shares[0];
 		$this->assertEquals($id1, $share->getId());
-		$this->assertSame($user, $share->getSharedWith());
-		$this->assertSame($owner, $share->getShareOwner());
-		$this->assertSame($owner, $share->getSharedBy());
+		$this->assertSame('sharedWith', $share->getSharedWith());
+		$this->assertSame('shareOwner', $share->getShareOwner());
+		$this->assertSame('shareOwner', $share->getSharedBy());
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_USER, $share->getShareType());
 		$this->assertEquals(13, $share->getPermissions());
 		$this->assertEquals('myTarget', $share->getTarget());
 
 		$share = $shares[1];
 		$this->assertEquals($id2, $share->getId());
-		$this->assertSame($user, $share->getSharedWith());
-		$this->assertSame($owner, $share->getShareOwner());
-		$this->assertSame($initiator, $share->getSharedBy());
+		$this->assertSame('sharedWith', $share->getSharedWith());
+		$this->assertSame('shareOwner', $share->getShareOwner());
+		$this->assertSame('sharedBy', $share->getSharedBy());
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_USER, $share->getShareType());
 		$this->assertEquals(0, $share->getPermissions());
 		$this->assertEquals('userTarget', $share->getTarget());
@@ -1334,7 +1217,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$share = $this->provider->getShareById($id);
 
-		$this->provider->deleteFromSelf($share, $user2);
+		$this->provider->deleteFromSelf($share, 'user2');
 
 		$qb = $this->dbConn->getQueryBuilder();
 		$stmt = $qb->select('*')
@@ -1405,7 +1288,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$share = $this->provider->getShareById($id);
 
-		$this->provider->deleteFromSelf($share, $user2);
+		$this->provider->deleteFromSelf($share, 'user2');
 
 		$qb = $this->dbConn->getQueryBuilder();
 		$stmt = $qb->select('*')
@@ -1465,7 +1348,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$share = $this->provider->getShareById($id);
 
-		$this->provider->deleteFromSelf($share, $user2);
+		$this->provider->deleteFromSelf($share, 'user2');
 	}
 
 	public function testDeleteFromSelfUser() {
@@ -1501,7 +1384,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$share = $this->provider->getShareById($id);
 
-		$this->provider->deleteFromSelf($share, $user2);
+		$this->provider->deleteFromSelf($share, 'user2');
 
 		$qb = $this->dbConn->getQueryBuilder();
 		$stmt = $qb->select('*')
@@ -1627,18 +1510,18 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$share = $this->provider->getShareById($id);
 
-		$share->setSharedWith($users['user3']);
-		$share->setSharedBy($users['user4']);
-		$share->setShareOwner($users['user5']);
+		$share->setSharedWith('user3');
+		$share->setSharedBy('user4');
+		$share->setShareOwner('user5');
 		$share->setNode($file2);
 		$share->setPermissions(1);
 
 		$share2 = $this->provider->update($share);
 
 		$this->assertEquals($id, $share2->getId());
-		$this->assertSame($users['user3'], $share2->getSharedWith());
-		$this->assertSame($users['user4'], $share2->getSharedBy());
-		$this->assertSame($users['user5'], $share2->getShareOwner());
+		$this->assertSame('user3', $share2->getSharedWith());
+		$this->assertSame('user4', $share2->getSharedBy());
+		$this->assertSame('user5', $share2->getShareOwner());
 		$this->assertSame(1, $share2->getPermissions());
 	}
 
@@ -1677,8 +1560,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$share = $this->provider->getShareById($id);
 
 		$share->setPassword('password');
-		$share->setSharedBy($users['user4']);
-		$share->setShareOwner($users['user5']);
+		$share->setSharedBy('user4');
+		$share->setShareOwner('user5');
 		$share->setNode($file2);
 		$share->setPermissions(1);
 
@@ -1686,8 +1569,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$this->assertEquals($id, $share2->getId());
 		$this->assertEquals('password', $share->getPassword());
-		$this->assertSame($users['user4'], $share2->getSharedBy());
-		$this->assertSame($users['user5'], $share2->getShareOwner());
+		$this->assertSame('user4', $share2->getSharedBy());
+		$this->assertSame('user5', $share2->getShareOwner());
 		$this->assertSame(1, $share2->getPermissions());
 	}
 
@@ -1726,8 +1609,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$share = $this->provider->getShareById($id);
 
 		$share->setPassword(null);
-		$share->setSharedBy($users['user4']);
-		$share->setShareOwner($users['user5']);
+		$share->setSharedBy('user4');
+		$share->setShareOwner('user5');
 		$share->setNode($file2);
 		$share->setPermissions(1);
 
@@ -1735,8 +1618,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$this->assertEquals($id, $share2->getId());
 		$this->assertEquals(null, $share->getPassword());
-		$this->assertSame($users['user4'], $share2->getSharedBy());
-		$this->assertSame($users['user5'], $share2->getShareOwner());
+		$this->assertSame('user4', $share2->getSharedBy());
+		$this->assertSame('user5', $share2->getShareOwner());
 		$this->assertSame(1, $share2->getPermissions());
 	}
 
@@ -1787,9 +1670,9 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$share = $this->provider->getShareById($id);
 
-		$share->setSharedWith($groups['group0']);
-		$share->setSharedBy($users['user4']);
-		$share->setShareOwner($users['user5']);
+		$share->setSharedWith('group0');
+		$share->setSharedBy('user4');
+		$share->setShareOwner('user5');
 		$share->setNode($file2);
 		$share->setPermissions(1);
 
@@ -1797,9 +1680,9 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$this->assertEquals($id, $share2->getId());
 		// Group shares do not allow updating the recipient
-		$this->assertSame($groups['group0'], $share2->getSharedWith());
-		$this->assertSame($users['user4'], $share2->getSharedBy());
-		$this->assertSame($users['user5'], $share2->getShareOwner());
+		$this->assertSame('group0', $share2->getSharedWith());
+		$this->assertSame('user4', $share2->getSharedBy());
+		$this->assertSame('user5', $share2->getShareOwner());
 		$this->assertSame(1, $share2->getPermissions());
 	}
 
@@ -1856,9 +1739,9 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$share = $this->provider->getShareById($id);
 
-		$share->setSharedWith($groups['group0']);
-		$share->setSharedBy($users['user4']);
-		$share->setShareOwner($users['user5']);
+		$share->setSharedWith('group0');
+		$share->setSharedBy('user4');
+		$share->setShareOwner('user5');
 		$share->setNode($file2);
 		$share->setPermissions(1);
 
@@ -1866,9 +1749,9 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$this->assertEquals($id, $share2->getId());
 		// Group shares do not allow updating the recipient
-		$this->assertSame($groups['group0'], $share2->getSharedWith());
-		$this->assertSame($users['user4'], $share2->getSharedBy());
-		$this->assertSame($users['user5'], $share2->getShareOwner());
+		$this->assertSame('group0', $share2->getSharedWith());
+		$this->assertSame('user4', $share2->getSharedBy());
+		$this->assertSame('user5', $share2->getShareOwner());
 		$this->assertSame(1, $share2->getPermissions());
 
 		$qb = $this->dbConn->getQueryBuilder();
@@ -1949,18 +1832,18 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->rootFolder->method('getUserFolder')->with('user1')->will($this->returnSelf());
 		$this->rootFolder->method('getById')->willReturn([$folder]);
 
-		$share = $this->provider->getShareById($id, $user0);
+		$share = $this->provider->getShareById($id, 'user0');
 
 		$share->setTarget('/newTarget');
-		$this->provider->move($share, $user0);
+		$this->provider->move($share, 'user0');
 
-		$share = $this->provider->getShareById($id, $user0);
+		$share = $this->provider->getShareById($id, 'user0');
 		$this->assertSame('/newTarget', $share->getTarget());
 
 		$share->setTarget('/ultraNewTarget');
-		$this->provider->move($share, $user0);
+		$this->provider->move($share, 'user0');
 
-		$share = $this->provider->getShareById($id, $user0);
+		$share = $this->provider->getShareById($id, 'user0');
 		$this->assertSame('/ultraNewTarget', $share->getTarget());
 	}
 }


### PR DESCRIPTION
Me and @schiesbn has a call yesterday since he is implementing the federatedsharemanager.

Basically we came to the conclusion that by passing around the userId/groupId/federatedId the endpoints that use it can fetch the right objects from the desired managers. But we can have more generic code at other places.

The first commit is the real change. The rest are just fixes for mainly the tests...

@schiesbn please have a look.
