### PR TITLE
setting to skip migration tests by default

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1196,6 +1196,15 @@ $CONFIG = array(
 'debug' => false,
 
 /**
+ * Skips the migration test during upgrades
+ *
+ * If this is set to true the migration test are deactivated during upgrade.
+ * This is only recommended in installations where upgrade tests are run in
+ * advance with the same data on a test system.
+ */
+'update.skip-migration-test' => false,
+
+/**
  * This entry is just here to show a warning in case somebody copied the sample
  * configuration. DO NOT ADD THIS SWITCH TO YOUR CONFIGURATION!
  *

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -50,6 +50,12 @@ if (OC::checkUpgrade(false)) {
 			\OC::$server->getIntegrityCodeChecker(),
 			$logger
 	);
+
+	if ($config->getSystemValue('update.skip-migration-test', false)) {
+		$eventSource->send('success', (string)$l->t('Migration tests are skipped - "update.skip-migration-test" is activated in config.php'));
+		$updater->setSimulateStepEnabled(false);
+	}
+
 	$incompatibleApps = [];
 	$disabledThirdPartyApps = [];
 

--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -99,6 +99,12 @@ class Upgrade extends Command {
 		$updateStepEnabled = true;
 		$skip3rdPartyAppsDisable = false;
 
+		if ($this->config->getSystemValue('update.skip-migration-test', false)) {
+			$output->writeln(
+				'<info>"skip-migration-test" is activated via config.php</info>'
+			);
+			$simulateStepEnabled = false;
+		}
 		if ($input->getOption('skip-migration-test')) {
 			$simulateStepEnabled = false;
 		}


### PR DESCRIPTION
- ~~if you install owncloud via package it is not
  possible to skip migration tests~~ Not done anymore in the packages.
- this also allows to disable migration tests for
  an instance by default

As discussed yesterday with @msrex and @felixboehm it would be very useful to be able to skip the migration tests via a setting, because then you don't need to remember to add the setting on every command run. Usually if you set up an instance and do backups yourself this will not change during the usage of the instance.

cc @LukasReschke @nickvergessen @PVince81 
