### PR TITLE
Public link downloads should work on instance on non default port

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -155,11 +155,7 @@ OCA.Sharing.PublicApp = {
 			this.fileList.getDownloadUrl = function (filename, dir, isDir) {
 				var path = dir || this.getCurrentDirectory();
 				if (filename && !_.isArray(filename) && !isDir) {
-					var portPart = '';
-					if (OC.getPort()) {
-						portPart = ':' + OC.getPort();
-					}
-					return OC.getProtocol() + '://' + token + '@' + OC.getHost() + portPart + OC.getRootPath() + '/public.php/webdav' + OC.joinPaths(path, filename);
+					return OC.getProtocol() + '://' + token + '@' + OC.getHost() + OC.getRootPath() + '/public.php/webdav' + OC.joinPaths(path, filename);
 				}
 				if (_.isArray(filename)) {
 					filename = JSON.stringify(filename);

--- a/apps/files_sharing/tests/js/publicAppSpec.js
+++ b/apps/files_sharing/tests/js/publicAppSpec.js
@@ -21,13 +21,12 @@
 
 describe('OCA.Sharing.PublicApp tests', function() {
 	var App = OCA.Sharing.PublicApp;
-	var hostStub, portStub, protocolStub, webrootStub;
+	var hostStub, protocolStub, webrootStub;
 	var $preview;
 
 	beforeEach(function() {
 		protocolStub = sinon.stub(OC, 'getProtocol').returns('https');
-		hostStub = sinon.stub(OC, 'getHost').returns('example.com');
-		portStub = sinon.stub(OC, 'getPort').returns(9876);
+		hostStub = sinon.stub(OC, 'getHost').returns('example.com:9876');
 		webrootStub = sinon.stub(OC, 'getRootPath').returns('/owncloud');
 		$preview = $('<div id="preview"></div>');
 		$('#testArea').append($preview);
@@ -41,7 +40,6 @@ describe('OCA.Sharing.PublicApp tests', function() {
 	afterEach(function() {
 		protocolStub.restore();
 		hostStub.restore();
-		portStub.restore();
 		webrootStub.restore();
 	});
 
@@ -91,7 +89,7 @@ describe('OCA.Sharing.PublicApp tests', function() {
 		it('Uses public webdav endpoint', function() {
 			expect(fakeServer.requests.length).toEqual(1);
 			expect(fakeServer.requests[0].method).toEqual('PROPFIND');
-			expect(fakeServer.requests[0].url).toEqual('https://example.com/owncloud/public.php/webdav/subdir');
+			expect(fakeServer.requests[0].url).toEqual('https://example.com:9876/owncloud/public.php/webdav/subdir');
 			expect(fakeServer.requests[0].requestHeaders.Authorization).toEqual('Basic c2g0dG9rOm51bGw=');
 		});
 

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -243,14 +243,31 @@ var OC={
 	},
 
 	/**
-	 * Returns the host name used to access this ownCloud instance
+	 * Returns the host used to access this ownCloud instance
+	 * Host is sometimes the same as the hostname but now always.
 	 *
-	 * @return {string} host name
+	 * Examples:
+	 * http://example.com => example.com
+	 * https://example.com => exmaple.com
+	 * http://example.com:8080 => example.com:8080
+	 *
+	 * @return {string} host
 	 *
 	 * @since 8.2
 	 */
 	getHost: function() {
 		return window.location.host;
+	},
+
+	/**
+	 * Returns the hostname used to access this ownCloud instance
+	 * The hostname is always stripped of the port
+	 *
+	 * @return {string} hostname
+	 * @since 9.0
+	 */
+	getHostName: function() {
+		return window.location.hostname;
 	},
 
 	/**


### PR DESCRIPTION
We constructed the download url from the host and the port. But the host can already contain the port. Which would lead to urls containing <host>:<port>:<port> which were of course not valid!
- Updated unit tests

CC: @PVince81 @nickvergessen @MorrisJobke 
