### PR TITLE
types shall always be plural

### DIFF
--- a/lib/private/comments/comment.php
+++ b/lib/private/comments/comment.php
@@ -242,7 +242,7 @@ class Comment implements IComment {
 	/**
 	 * sets (overwrites) the actor type and id
 	 *
-	 * @param string $actorType e.g. 'user'
+	 * @param string $actorType e.g. 'users'
 	 * @param string $actorId e.g. 'zombie234'
 	 * @return IComment
 	 * @since 9.0.0
@@ -328,7 +328,7 @@ class Comment implements IComment {
 	/**
 	 * sets (overwrites) the object of the comment
 	 *
-	 * @param string $objectType e.g. 'file'
+	 * @param string $objectType e.g. 'files'
 	 * @param string $objectId e.g. '16435'
 	 * @return IComment
 	 * @since 9.0.0

--- a/lib/private/comments/manager.php
+++ b/lib/private/comments/manager.php
@@ -384,7 +384,7 @@ class Manager implements ICommentsManager {
 	 * saved in the used data storage. Use save() after setting other fields
 	 * of the comment (e.g. message or verb).
 	 *
-	 * @param string $actorType the actor type (e.g. 'user')
+	 * @param string $actorType the actor type (e.g. 'users')
 	 * @param string $actorId a user id
 	 * @param string $objectType the object type the comment is attached to
 	 * @param string $objectId the object id the comment is attached to
@@ -533,7 +533,7 @@ class Manager implements ICommentsManager {
 	 * removes references to specific actor (e.g. on user delete) of a comment.
 	 * The comment itself must not get lost/deleted.
 	 *
-	 * @param string $actorType the actor type (e.g. 'user')
+	 * @param string $actorType the actor type (e.g. 'users')
 	 * @param string $actorId a user id
 	 * @return boolean
 	 * @since 9.0.0
@@ -560,7 +560,7 @@ class Manager implements ICommentsManager {
 	/**
 	 * deletes all comments made of a specific object (e.g. on file delete)
 	 *
-	 * @param string $objectType the object type (e.g. 'file')
+	 * @param string $objectType the object type (e.g. 'files')
 	 * @param string $objectId e.g. the file id
 	 * @return boolean
 	 * @since 9.0.0

--- a/lib/private/user/user.php
+++ b/lib/private/user/user.php
@@ -210,7 +210,7 @@ class User implements IUser {
 			// Delete the users entry in the storage table
 			\OC\Files\Cache\Storage::remove('home::' . $this->uid);
 
-			\OC::$server->getCommentsManager()->deleteReferencesOfActor('user', $this->uid);
+			\OC::$server->getCommentsManager()->deleteReferencesOfActor('users', $this->uid);
 			\OC::$server->getCommentsManager()->deleteReadMarksFromUser($this);
 		}
 

--- a/lib/public/comments/icomment.php
+++ b/lib/public/comments/icomment.php
@@ -161,7 +161,7 @@ interface IComment {
 	/**
 	 * sets (overwrites) the actor type and id
 	 *
-	 * @param string $actorType e.g. 'user'
+	 * @param string $actorType e.g. 'users'
 	 * @param string $actorId e.g. 'zombie234'
 	 * @return IComment
 	 * @since 9.0.0
@@ -223,7 +223,7 @@ interface IComment {
 	/**
 	 * sets (overwrites) the object of the comment
 	 *
-	 * @param string $objectType e.g. 'file'
+	 * @param string $objectType e.g. 'files'
 	 * @param string $objectId e.g. '16435'
 	 * @return IComment
 	 * @since 9.0.0

--- a/lib/public/comments/icommentsmanager.php
+++ b/lib/public/comments/icommentsmanager.php
@@ -39,7 +39,7 @@ interface ICommentsManager {
 	 *
 	 * User interfaces shall show "Deleted user" as display name, if needed.
 	 */
-	const DELETED_USER = 'deleted_user';
+	const DELETED_USER = 'deleted_users';
 
 	/**
 	 * returns a comment instance
@@ -127,7 +127,7 @@ interface ICommentsManager {
 	 * saved in the used data storage. Use save() after setting other fields
 	 * of the comment (e.g. message or verb).
 	 *
-	 * @param string $actorType the actor type (e.g. 'user')
+	 * @param string $actorType the actor type (e.g. 'users')
 	 * @param string $actorId a user id
 	 * @param string $objectType the object type the comment is attached to
 	 * @param string $objectId the object id the comment is attached to
@@ -170,10 +170,10 @@ interface ICommentsManager {
 	 * removes references to specific actor (e.g. on user delete) of a comment.
 	 * The comment itself must not get lost/deleted.
 	 *
-	 * A 'user' type actor (type and id) should get replaced by the
+	 * A 'users' type actor (type and id) should get replaced by the
 	 * value of the DELETED_USER constant of this interface.
 	 *
-	 * @param string $actorType the actor type (e.g. 'user')
+	 * @param string $actorType the actor type (e.g. 'users')
 	 * @param string $actorId a user id
 	 * @return boolean
 	 * @since 9.0.0
@@ -183,7 +183,7 @@ interface ICommentsManager {
 	/**
 	 * deletes all comments made of a specific object (e.g. on file delete)
 	 *
-	 * @param string $objectType the object type (e.g. 'file')
+	 * @param string $objectType the object type (e.g. 'files')
 	 * @param string $objectId e.g. the file id
 	 * @return boolean
 	 * @since 9.0.0

--- a/tests/lib/comments/comment.php
+++ b/tests/lib/comments/comment.php
@@ -15,10 +15,10 @@ class Test_Comments_Comment extends TestCase
 		$childrenCount = 6;
 		$message = 'I like to comment comment';
 		$verb = 'comment';
-		$actor = ['type' => 'user', 'id' => 'alice'];
+		$actor = ['type' => 'users', 'id' => 'alice'];
 		$creationDT = new \DateTime();
 		$latestChildDT = new \DateTime('yesterday');
-		$object = ['type' => 'file', 'id' => 'file64'];
+		$object = ['type' => 'files', 'id' => 'file64'];
 
 		$comment
 			->setId($id)
@@ -87,11 +87,11 @@ class Test_Comments_Comment extends TestCase
 	public function roleSetterProvider() {
 		return [
 			['Actor', true, true],
-			['Actor', 'user', true],
+			['Actor', 'users', true],
 			['Actor', true, 'alice'],
 			['Actor', ' ', ' '],
 			['Object', true, true],
-			['Object', 'file', true],
+			['Object', 'files', true],
 			['Object', true, 'file64'],
 			['Object', ' ', ' '],
 		];

--- a/tests/lib/comments/manager.php
+++ b/tests/lib/comments/manager.php
@@ -35,13 +35,13 @@ class Test_Comments_Manager extends TestCase
 					'parent_id'					=> $qb->createNamedParameter($parentId),
 					'topmost_parent_id' 		=> $qb->createNamedParameter($topmostParentId),
 					'children_count' 			=> $qb->createNamedParameter(2),
-					'actor_type' 				=> $qb->createNamedParameter('user'),
+					'actor_type' 				=> $qb->createNamedParameter('users'),
 					'actor_id' 					=> $qb->createNamedParameter('alice'),
 					'message' 					=> $qb->createNamedParameter('nice one'),
 					'verb' 						=> $qb->createNamedParameter('comment'),
 					'creation_timestamp' 		=> $qb->createNamedParameter($creationDT, 'datetime'),
 					'latest_child_timestamp'	=> $qb->createNamedParameter($latestChildDT, 'datetime'),
-					'object_type' 				=> $qb->createNamedParameter('file'),
+					'object_type' 				=> $qb->createNamedParameter('files'),
 					'object_id' 				=> $qb->createNamedParameter('file64'),
 			])
 			->execute();
@@ -83,13 +83,13 @@ class Test_Comments_Manager extends TestCase
 					'parent_id'					=> $qb->createNamedParameter('2'),
 					'topmost_parent_id' 		=> $qb->createNamedParameter('1'),
 					'children_count' 			=> $qb->createNamedParameter(2),
-					'actor_type' 				=> $qb->createNamedParameter('user'),
+					'actor_type' 				=> $qb->createNamedParameter('users'),
 					'actor_id' 					=> $qb->createNamedParameter('alice'),
 					'message' 					=> $qb->createNamedParameter('nice one'),
 					'verb' 						=> $qb->createNamedParameter('comment'),
 					'creation_timestamp' 		=> $qb->createNamedParameter($creationDT, 'datetime'),
 					'latest_child_timestamp'	=> $qb->createNamedParameter($latestChildDT, 'datetime'),
-					'object_type' 				=> $qb->createNamedParameter('file'),
+					'object_type' 				=> $qb->createNamedParameter('files'),
 					'object_id' 				=> $qb->createNamedParameter('file64'),
 			])
 			->execute();
@@ -102,11 +102,11 @@ class Test_Comments_Manager extends TestCase
 		$this->assertSame($comment->getParentId(), '2');
 		$this->assertSame($comment->getTopmostParentId(), '1');
 		$this->assertSame($comment->getChildrenCount(), 2);
-		$this->assertSame($comment->getActorType(), 'user');
+		$this->assertSame($comment->getActorType(), 'users');
 		$this->assertSame($comment->getActorId(), 'alice');
 		$this->assertSame($comment->getMessage(), 'nice one');
 		$this->assertSame($comment->getVerb(), 'comment');
-		$this->assertSame($comment->getObjectType(), 'file');
+		$this->assertSame($comment->getObjectType(), 'files');
 		$this->assertSame($comment->getObjectId(), 'file64');
 		$this->assertEquals($comment->getCreationDateTime(), $creationDT);
 		$this->assertEquals($comment->getLatestChildDateTime(), $latestChildDT);
@@ -207,7 +207,7 @@ class Test_Comments_Manager extends TestCase
 		$this->addDatabaseEntry(0, 0);
 
 		$manager = $this->getManager();
-		$comments = $manager->getForObject('file', 'file64');
+		$comments = $manager->getForObject('files', 'file64');
 
 		$this->assertTrue(is_array($comments));
 		$this->assertSame(count($comments), 1);
@@ -227,7 +227,7 @@ class Test_Comments_Manager extends TestCase
 		$manager = $this->getManager();
 		$offset = 0;
 		do {
-			$comments = $manager->getForObject('file', 'file64', 3, $offset);
+			$comments = $manager->getForObject('files', 'file64', 3, $offset);
 
 			$this->assertTrue(is_array($comments));
 			foreach($comments as $comment) {
@@ -247,7 +247,7 @@ class Test_Comments_Manager extends TestCase
 		$id2 = $this->addDatabaseEntry(2, 2, new \DateTime('-2 hours'));
 
 		$manager = $this->getManager();
-		$comments = $manager->getForObject('file', 'file64', 0, 0, new \DateTime('-4 hours'));
+		$comments = $manager->getForObject('files', 'file64', 0, 0, new \DateTime('-4 hours'));
 
 		$this->assertSame(count($comments), 2);
 		$this->assertSame($comments[0]->getId(), strval($id2));
@@ -266,7 +266,7 @@ class Test_Comments_Manager extends TestCase
 		$manager = $this->getManager();
 		$offset = 0;
 		do {
-			$comments = $manager->getForObject('file', 'file64', 3, $offset, new \DateTime('-4 hours'));
+			$comments = $manager->getForObject('files', 'file64', 3, $offset, new \DateTime('-4 hours'));
 
 			$this->assertTrue(is_array($comments));
 			foreach($comments as $comment) {
@@ -290,7 +290,7 @@ class Test_Comments_Manager extends TestCase
 		$amount = $manager->getNumberOfCommentsForObject('untype', '00');
 		$this->assertSame($amount, 0);
 
-		$amount = $manager->getNumberOfCommentsForObject('file', 'file64');
+		$amount = $manager->getNumberOfCommentsForObject('files', 'file64');
 		$this->assertSame($amount, 4);
 	}
 
@@ -357,8 +357,8 @@ class Test_Comments_Manager extends TestCase
 		$manager = $this->getManager();
 		$comment = new \OC\Comments\Comment();
 		$comment
-			->setActor('user', 'alice')
-			->setObject('file', 'file64')
+			->setActor('users', 'alice')
+			->setObject('files', 'file64')
 			->setMessage('very beautiful, I am impressed!')
 			->setVerb('comment');
 
@@ -377,8 +377,8 @@ class Test_Comments_Manager extends TestCase
 		$manager = $this->getManager();
 		$comment = new \OC\Comments\Comment();
 		$comment
-				->setActor('user', 'alice')
-				->setObject('file', 'file64')
+				->setActor('users', 'alice')
+				->setObject('files', 'file64')
 				->setMessage('very beautiful, I am impressed!')
 				->setVerb('comment');
 
@@ -398,8 +398,8 @@ class Test_Comments_Manager extends TestCase
 		$manager = $this->getManager();
 		$comment = new \OC\Comments\Comment();
 		$comment
-				->setActor('user', 'alice')
-				->setObject('file', 'file64')
+				->setActor('users', 'alice')
+				->setObject('files', 'file64')
 				->setMessage('very beautiful, I am impressed!')
 				->setVerb('comment');
 
@@ -428,8 +428,8 @@ class Test_Comments_Manager extends TestCase
 		for($i = 0; $i < 3; $i++) {
 			$comment = new \OC\Comments\Comment();
 			$comment
-					->setActor('user', 'alice')
-					->setObject('file', 'file64')
+					->setActor('users', 'alice')
+					->setObject('files', 'file64')
 					->setParentId(strval($id))
 					->setMessage('full ack')
 					->setVerb('comment')
@@ -450,7 +450,7 @@ class Test_Comments_Manager extends TestCase
 		[
 			['', ''],
 			[1, 'alice'],
-			['user', 1],
+			['users', 1],
 		];
 	}
 
@@ -473,10 +473,10 @@ class Test_Comments_Manager extends TestCase
 
 		// just to make sure they are really set, with correct actor data
 		$comment = $manager->get(strval($ids[1]));
-		$this->assertSame($comment->getActorType(), 'user');
+		$this->assertSame($comment->getActorType(), 'users');
 		$this->assertSame($comment->getActorId(), 'alice');
 
-		$wasSuccessful = $manager->deleteReferencesOfActor('user', 'alice');
+		$wasSuccessful = $manager->deleteReferencesOfActor('users', 'alice');
 		$this->assertTrue($wasSuccessful);
 
 		foreach($ids as $id) {
@@ -487,7 +487,7 @@ class Test_Comments_Manager extends TestCase
 
 		// actor info is gone from DB, but when database interaction is alright,
 		// we still expect to get true back
-		$wasSuccessful = $manager->deleteReferencesOfActor('user', 'alice');
+		$wasSuccessful = $manager->deleteReferencesOfActor('users', 'alice');
 		$this->assertTrue($wasSuccessful);
 	}
 
@@ -496,7 +496,7 @@ class Test_Comments_Manager extends TestCase
 		$this->assertTrue($user instanceof \OCP\IUser);
 
 		$manager = \OC::$server->getCommentsManager();
-		$comment = $manager->create('user', $user->getUID(), 'file', 'file64');
+		$comment = $manager->create('users', $user->getUID(), 'files', 'file64');
 		$comment
 			->setMessage('Most important comment I ever left on the Internet.')
 			->setVerb('comment');
@@ -516,7 +516,7 @@ class Test_Comments_Manager extends TestCase
 				[
 						['', ''],
 						[1, 'file64'],
-						['file', 1],
+						['files', 1],
 				];
 	}
 
@@ -539,10 +539,10 @@ class Test_Comments_Manager extends TestCase
 
 		// just to make sure they are really set, with correct actor data
 		$comment = $manager->get(strval($ids[1]));
-		$this->assertSame($comment->getObjectType(), 'file');
+		$this->assertSame($comment->getObjectType(), 'files');
 		$this->assertSame($comment->getObjectId(), 'file64');
 
-		$wasSuccessful = $manager->deleteCommentsAtObject('file', 'file64');
+		$wasSuccessful = $manager->deleteCommentsAtObject('files', 'file64');
 		$this->assertTrue($wasSuccessful);
 
 		$verified = 0;
@@ -557,7 +557,7 @@ class Test_Comments_Manager extends TestCase
 
 		// actor info is gone from DB, but when database interaction is alright,
 		// we still expect to get true back
-		$wasSuccessful = $manager->deleteCommentsAtObject('file', 'file64');
+		$wasSuccessful = $manager->deleteCommentsAtObject('files', 'file64');
 		$this->assertTrue($wasSuccessful);
 	}
 


### PR DESCRIPTION
Should fix https://github.com/owncloud/core/issues/22052

@PVince81 please note, the deleted user type is now also harmonized to plural
