### PR TITLE
Add check for content

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -194,7 +194,7 @@
 			}
 			var afterCall = function(xhr) {
 				var messages = [];
-				if (xhr.status !== 403 && xhr.status !== 307 && xhr.status !== 301) {
+				if (xhr.status !== 403 && xhr.status !== 307 && xhr.status !== 301 && xhr.responseText === '') {
 					messages.push({
 						msg: t('core', 'Your data directory and your files are probably accessible from the Internet. The .htaccess file is not working. We strongly suggest that you configure your web server in a way that the data directory is no longer accessible or you move the data directory outside the web server document root.'),
 						type: OC.SetupChecks.MESSAGE_TYPE_ERROR


### PR DESCRIPTION
The response may be a redirect which is always followed by jQuery. Thus leading to false positives depending on the server configuration (e.g. when it issues a 302)

To prevent that there is also a check performed on the response content.

@vincchan @PVince81 Please review.
