### PR TITLE
When a user is removed we should remove the right shares

### DIFF
--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -480,13 +480,18 @@ Feature: sharing
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
 
-
-
-
-
-
-
-
-
-
-
+  Scenario: Keep usergroup shares (#22143)
+    Given As an "admin"
+    And user "user0" exists
+    And user "user1" exists
+    And user "user2" exists
+    And group "group" exists
+    And user "user1" belongs to group "group"
+    And user "user2" belongs to group "group"
+    And user "user0" created a folder "/TMP"
+    And file "TMP" of user "user0" is shared with group "group"
+    And user "user1" created a folder "/myFOLDER"
+    And User "user1" moves file "/TMP" to "/myFOLDER/myTMP"
+    And user "user2" does not exist
+    And user "user1" should see following elements
+      | /myFOLDER/myTMP/ |

--- a/lib/private/share/hooks.php
+++ b/lib/private/share/hooks.php
@@ -38,7 +38,7 @@ class Hooks extends \OC\Share\Constants {
 	public static function post_deleteUser($arguments) {
 		// Delete any items shared with the deleted user
 		$query = \OC_DB::prepare('DELETE FROM `*PREFIX*share`'
-			.' WHERE `share_with` = ? AND `share_type` = ? OR `share_type` = ?');
+			.' WHERE `share_with` = ? AND (`share_type` = ? OR `share_type` = ?)');
 		$query->execute(array($arguments['uid'], self::SHARE_TYPE_USER, self::$shareTypeGroupUserUnique));
 		// Delete any items the deleted user shared
 		$query = \OC_DB::prepare('SELECT `id` FROM `*PREFIX*share` WHERE `uid_owner` = ?');


### PR DESCRIPTION
Fixes: #12385 
- This means all the shares directly shared with them
- Or all group shares having a special share with them

This patch fixes the operator precedece (AND before OR).
So before this patch:

(share_with = <deleted user> AND share_type = 0) OR share_type=2

So it deleted all user specific shares

Now:
share_with = <deleted user> AND (share_type = 0 OR (share_type=2)

CC: @PVince81 @schiesbn @nickvergessen @DeepDiver1975 @LukasReschke @MorrisJobke 
