### PR TITLE
Allow to delete the email address in user management

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -732,24 +732,20 @@ $(document).ready(function () {
 			.focus()
 			.keypress(function (event) {
 				if (event.keyCode === 13) {
-					if ($(this).val().length > 0) {
-						$tr.data('mailAddress', $input.val());
-						$input.blur();
-						$.ajax({
-							type: 'PUT',
-							url: OC.generateUrl('/settings/users/{id}/mailAddress', {id: uid}),
-							data: {
-								mailAddress: $(this).val()
-							}
-						}).fail(function (result) {
-							OC.Notification.show(result.responseJSON.data.message);
-							// reset the values
-							$tr.data('mailAddress', mailAddress);
-							$tr.children('.mailAddress').children('span').text(mailAddress);
-						});
-					} else {
-						$input.blur();
-					}
+					$tr.data('mailAddress', $input.val());
+					$input.blur();
+					$.ajax({
+						type: 'PUT',
+						url: OC.generateUrl('/settings/users/{id}/mailAddress', {id: uid}),
+						data: {
+							mailAddress: $(this).val()
+						}
+					}).fail(function (result) {
+						OC.Notification.show(result.responseJSON.data.message);
+						// reset the values
+						$tr.data('mailAddress', mailAddress);
+						$tr.children('.mailAddress').children('span').text(mailAddress);
+					});
 				}
 			})
 			.blur(function () {


### PR DESCRIPTION
@PVince81 @nickvergessen @LukasReschke @butonic Please review

steps:
- delete the email address of a user by set it to `''`(empty string)
- before: it was reset to the previous email address
- after: the email address is deleted

@karlitschek I would like to backport this at least to stable8.2
