### PR TITLE
Activities for comments

### DIFF
--- a/apps/comments/activity/extension.php
+++ b/apps/comments/activity/extension.php
@@ -1,0 +1,282 @@
+<?php
+/**
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Comments\Activity;
+
+use OCP\Activity\IExtension;
+use OCP\Activity\IManager;
+use OCP\Comments\ICommentsManager;
+use OCP\Comments\NotFoundException;
+use OCP\IL10N;
+use OCP\L10N\IFactory;
+
+/**
+ * Class Extension
+ *
+ * @package OCA\Comments\Activity
+ */
+class Extension implements IExtension {
+	const APP_NAME = 'comments';
+
+	const ADD_COMMENT_SUBJECT = 'add_comment_subject';
+	const ADD_COMMENT_MESSAGE = 'add_comment_message';
+
+	/** @var IFactory */
+	protected $languageFactory;
+
+	/** @var IManager */
+	protected $activityManager;
+
+	/** @var ICommentsManager */
+	protected $commentsManager;
+
+	/**
+	 * @param IFactory $languageFactory
+	 * @param IManager $activityManager
+	 * @param ICommentsManager $commentsManager
+	 */
+	public function __construct(IFactory $languageFactory, IManager $activityManager, ICommentsManager $commentsManager) {
+		$this->languageFactory = $languageFactory;
+		$this->activityManager = $activityManager;
+		$this->commentsManager = $commentsManager;
+	}
+
+	protected function getL10N($languageCode = null) {
+		return $this->languageFactory->get(self::APP_NAME, $languageCode);
+	}
+
+	/**
+	 * The extension can return an array of additional notification types.
+	 * If no additional types are to be added false is to be returned
+	 *
+	 * @param string $languageCode
+	 * @return array|false
+	 */
+	public function getNotificationTypes($languageCode) {
+		$l = $this->getL10N($languageCode);
+
+		return array(
+			self::APP_NAME => (string) $l->t('<strong>Comments</strong> for files'),
+		);
+	}
+
+	/**
+	 * For a given method additional types to be displayed in the settings can be returned.
+	 * In case no additional types are to be added false is to be returned.
+	 *
+	 * @param string $method
+	 * @return array|false
+	 */
+	public function getDefaultTypes($method) {
+		return $method === self::METHOD_STREAM ? [self::APP_NAME] : false;
+	}
+
+	/**
+	 * A string naming the css class for the icon to be used can be returned.
+	 * If no icon is known for the given type false is to be returned.
+	 *
+	 * @param string $type
+	 * @return string|false
+	 */
+	public function getTypeIcon($type) {
+		switch ($type) {
+			case self::APP_NAME:
+				return false;
+		}
+
+		return false;
+	}
+
+	/**
+	 * The extension can translate a given message to the requested languages.
+	 * If no translation is available false is to be returned.
+	 *
+	 * @param string $app
+	 * @param string $text
+	 * @param array $params
+	 * @param boolean $stripPath
+	 * @param boolean $highlightParams
+	 * @param string $languageCode
+	 * @return string|false
+	 */
+	public function translate($app, $text, $params, $stripPath, $highlightParams, $languageCode) {
+		if ($app !== self::APP_NAME) {
+			return false;
+		}
+
+		$l = $this->getL10N($languageCode);
+
+		if ($this->activityManager->isFormattingFilteredObject()) {
+			$translation = $this->translateShort($text, $l, $params);
+			if ($translation !== false) {
+				return $translation;
+			}
+		}
+
+		return $this->translateLong($text, $l, $params);
+	}
+
+	/**
+	 * @param string $text
+	 * @param IL10N $l
+	 * @param array $params
+	 * @return bool|string
+	 */
+	protected function translateShort($text, IL10N $l, array $params) {
+
+		switch ($text) {
+			case self::ADD_COMMENT_SUBJECT:
+				return (string) $l->t('%1$s commented', $params);
+			case self::ADD_COMMENT_MESSAGE:
+				return $this->convertParameterToComment($params[0], 120);
+		}
+
+		return false;
+	}
+
+	/**
+	 * @param string $text
+	 * @param IL10N $l
+	 * @param array $params
+	 * @return bool|string
+	 */
+	protected function translateLong($text, IL10N $l, array $params) {
+
+		switch ($text) {
+			case self::ADD_COMMENT_SUBJECT:
+				return (string) $l->t('%1$s commented on %2$s', $params);
+			case self::ADD_COMMENT_MESSAGE:
+				return $this->convertParameterToComment($params[0]);
+		}
+
+		return false;
+	}
+
+	/**
+	 * The extension can define the type of parameters for translation
+	 *
+	 * Currently known types are:
+	 * * file		=> will strip away the path of the file and add a tooltip with it
+	 * * username	=> will add the avatar of the user
+	 *
+	 * @param string $app
+	 * @param string $text
+	 * @return array|false
+	 */
+	public function getSpecialParameterList($app, $text) {
+		if ($app === self::APP_NAME) {
+			switch ($text) {
+				case self::ADD_COMMENT_SUBJECT:
+					return [
+						0 => 'username',
+						1 => 'file',
+					];
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * The extension can define the parameter grouping by returning the index as integer.
+	 * In case no grouping is required false is to be returned.
+	 *
+	 * @param array $activity
+	 * @return integer|false
+	 */
+	public function getGroupParameter($activity) {
+		return false;
+	}
+
+	/**
+	 * The extension can define additional navigation entries. The array returned has to contain two keys 'top'
+	 * and 'apps' which hold arrays with the relevant entries.
+	 * If no further entries are to be added false is no be returned.
+	 *
+	 * @return array|false
+	 */
+	public function getNavigation() {
+		return false;
+	}
+
+	/**
+	 * The extension can check if a custom filter (given by a query string like filter=abc) is valid or not.
+	 *
+	 * @param string $filterValue
+	 * @return boolean
+	 */
+	public function isFilterValid($filterValue) {
+		return false;
+	}
+
+	/**
+	 * The extension can filter the types based on the filter if required.
+	 * In case no filter is to be applied false is to be returned unchanged.
+	 *
+	 * @param array $types
+	 * @param string $filter
+	 * @return array|false
+	 */
+	public function filterNotificationTypes($types, $filter) {
+		return false;
+	}
+
+	/**
+	 * For a given filter the extension can specify the sql query conditions including parameters for that query.
+	 * In case the extension does not know the filter false is to be returned.
+	 * The query condition and the parameters are to be returned as array with two elements.
+	 * E.g. return array('`app` = ? and `message` like ?', array('mail', 'ownCloud%'));
+	 *
+	 * @param string $filter
+	 * @return array|false
+	 */
+	public function getQueryForFilter($filter) {
+		return false;
+	}
+
+	/**
+	 * @param string $parameter
+	 * @return string
+	 */
+	protected function convertParameterToComment($parameter, $maxLength = 0) {
+		if (preg_match('/^\<parameter\>(\d*)\<\/parameter\>$/', $parameter, $matches)) {
+			try {
+				$comment = $this->commentsManager->get((int) $matches[1]);
+				$message = $comment->getMessage();
+				$message = str_replace("\n", '<br />', str_replace(['<', '>'], ['&lt;', '&gt;'], $message));
+
+				if ($maxLength && isset($message[$maxLength + 20])) {
+					$findSpace = strpos($message, ' ', $maxLength);
+					if ($findSpace !== false && $findSpace < $maxLength + 20) {
+						return substr($message, 0, $findSpace) . '…';
+					}
+					return substr($message, 0, $maxLength + 20) . '…';
+				}
+
+				return $message;
+			} catch (NotFoundException $e) {
+				return '';
+			}
+		}
+
+		return '';
+	}
+}

--- a/apps/comments/activity/extension.php
+++ b/apps/comments/activity/extension.php
@@ -26,6 +26,7 @@ use OCP\Activity\IManager;
 use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException;
 use OCP\IL10N;
+use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
 
 /**
@@ -48,15 +49,20 @@ class Extension implements IExtension {
 	/** @var ICommentsManager */
 	protected $commentsManager;
 
+	/** @var IURLGenerator */
+	protected $URLGenerator;
+
 	/**
 	 * @param IFactory $languageFactory
 	 * @param IManager $activityManager
 	 * @param ICommentsManager $commentsManager
+	 * @param IURLGenerator $URLGenerator
 	 */
-	public function __construct(IFactory $languageFactory, IManager $activityManager, ICommentsManager $commentsManager) {
+	public function __construct(IFactory $languageFactory, IManager $activityManager, ICommentsManager $commentsManager, IURLGenerator $URLGenerator) {
 		$this->languageFactory = $languageFactory;
 		$this->activityManager = $activityManager;
 		$this->commentsManager = $commentsManager;
+		$this->URLGenerator = $URLGenerator;
 	}
 
 	protected function getL10N($languageCode = null) {
@@ -214,7 +220,17 @@ class Extension implements IExtension {
 	 * @return array|false
 	 */
 	public function getNavigation() {
-		return false;
+		$l = $this->getL10N();
+		return [
+			'apps' => [],
+			'top' => [
+				self::APP_NAME => [
+					'id' => self::APP_NAME,
+					'name' => (string) $l->t('Comments'),
+					'url' => $this->URLGenerator->linkToRoute('activity.Activities.showList', ['filter' => self::APP_NAME]),
+				],
+			],
+		];
 	}
 
 	/**
@@ -224,7 +240,7 @@ class Extension implements IExtension {
 	 * @return boolean
 	 */
 	public function isFilterValid($filterValue) {
-		return false;
+		return $filterValue === self::APP_NAME;
 	}
 
 	/**
@@ -236,6 +252,9 @@ class Extension implements IExtension {
 	 * @return array|false
 	 */
 	public function filterNotificationTypes($types, $filter) {
+		if ($filter === self::APP_NAME) {
+			return array_intersect($types, [self::APP_NAME]);
+		}
 		return false;
 	}
 

--- a/apps/comments/activity/listener.php
+++ b/apps/comments/activity/listener.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Comments\Activity;
+
+use OCP\Activity\IManager;
+use OCP\App\IAppManager;
+use OCP\Comments\CommentsEvent;
+use OCP\Files\Config\IMountProviderCollection;
+use OCP\Files\IRootFolder;
+use OCP\Files\Node;
+use OCP\IUser;
+use OCP\IUserSession;
+use OCP\Share;
+
+class Listener {
+	/** @var IManager */
+	protected $activityManager;
+	/** @var IUserSession */
+	protected $session;
+	/** @var \OCP\App\IAppManager */
+	protected $appManager;
+	/** @var \OCP\Files\Config\IMountProviderCollection */
+	protected $mountCollection;
+	/** @var \OCP\Files\IRootFolder */
+	protected $rootFolder;
+
+	/**
+	 * Listener constructor.
+	 *
+	 * @param IManager $activityManager
+	 * @param IUserSession $session
+	 * @param IAppManager $appManager
+	 * @param IMountProviderCollection $mountCollection
+	 * @param IRootFolder $rootFolder
+	 */
+	public function __construct(IManager $activityManager,
+								IUserSession $session,
+								IAppManager $appManager,
+								IMountProviderCollection $mountCollection,
+								IRootFolder $rootFolder) {
+		$this->activityManager = $activityManager;
+		$this->session = $session;
+		$this->appManager = $appManager;
+		$this->mountCollection = $mountCollection;
+		$this->rootFolder = $rootFolder;
+	}
+
+	/**
+	 * @param CommentsEvent $event
+	 */
+	public function commentEvent(CommentsEvent $event) {
+		if ($event->getComment()->getObjectType() !== 'files'
+			|| !in_array($event->getEvent(), [CommentsEvent::EVENT_ADD])
+			|| !$this->appManager->isInstalled('activity')) {
+			// Comment not for file, not adding a comment or no activity-app enabled (save the energy)
+			return;
+		}
+
+		// Get all mount point owners
+		$cache = $this->mountCollection->getMountCache();
+		$mounts = $cache->getMountsForFileId($event->getComment()->getObjectId());
+		if (empty($mounts)) {
+			return;
+		}
+
+		$users = [];
+		foreach ($mounts as $mount) {
+			$owner = $mount->getUser()->getUID();
+			$ownerFolder = $this->rootFolder->getUserFolder($owner);
+			$nodes = $ownerFolder->getById($event->getComment()->getObjectId());
+			if (!empty($nodes)) {
+				/** @var Node $node */
+				$node = array_shift($nodes);
+				$path = $node->getPath();
+				if (strpos($path, '/' . $owner . '/files/') === 0) {
+					$path = substr($path, strlen('/' . $owner . '/files'));
+				}
+				// Get all users that have access to the mount point
+				$users = array_merge($users, Share::getUsersSharingFile($path, $owner, true, true));
+			}
+		}
+
+		$actor = $this->session->getUser();
+		if ($actor instanceof IUser) {
+			$actor = $actor->getUID();
+		} else {
+			$actor = '';
+		}
+
+		$activity = $this->activityManager->generateEvent();
+		$activity->setApp(Extension::APP_NAME)
+			->setType(Extension::APP_NAME)
+			->setAuthor($actor)
+			->setObject($event->getComment()->getObjectType(), $event->getComment()->getObjectId())
+			->setMessage(Extension::ADD_COMMENT_MESSAGE, [
+				$event->getComment()->getId(),
+			]);
+
+		foreach ($users as $user => $path) {
+			$activity->setAffectedUser($user);
+
+			$activity->setSubject(Extension::ADD_COMMENT_SUBJECT, [
+				$actor,
+				$path,
+			]);
+			$this->activityManager->publish($activity);
+		}
+	}
+}

--- a/apps/comments/appinfo/app.php
+++ b/apps/comments/appinfo/app.php
@@ -33,3 +33,20 @@ $eventDispatcher->addListener(
 		\OCP\Util::addStyle('comments', 'comments');
 	}
 );
+
+$activityManager = \OC::$server->getActivityManager();
+$activityManager->registerExtension(function() {
+	$application = new \OCP\AppFramework\App('comments');
+	/** @var \OCA\Comments\Activity\Extension $extension */
+	$extension = $application->getContainer()->query('OCA\Comments\Activity\Extension');
+	return $extension;
+});
+
+$managerListener = function(\OCP\Comments\CommentsEvent $event) use ($activityManager) {
+	$application = new \OCP\AppFramework\App('comments');
+	/** @var \OCA\Comments\Activity\Listener $listener */
+	$listener = $application->getContainer()->query('OCA\Comments\Activity\Listener');
+	$listener->commentEvent($event);
+};
+
+$eventDispatcher->addListener(\OCP\Comments\CommentsEvent::EVENT_ADD, $managerListener);

--- a/apps/comments/appinfo/info.xml
+++ b/apps/comments/appinfo/info.xml
@@ -6,8 +6,11 @@
 	<licence>AGPL</licence>
 	<author>Arthur Shiwon, Vincent Petry</author>
 	<default_enable/>
-	<version>0.1</version>
+	<version>0.2</version>
 	<dependencies>
 		<owncloud min-version="9.0" max-version="9.0" />
 	</dependencies>
+	<types>
+		<logging/>
+	</types>
 </info>

--- a/lib/private/appframework/dependencyinjection/dicontainer.php
+++ b/lib/private/appframework/dependencyinjection/dicontainer.php
@@ -104,6 +104,10 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return $this->getServer()->getCapabilitiesManager();
 		});
 
+		$this->registerService('OCP\Comments\ICommentsManager', function($c) {
+			return $this->getServer()->getCommentsManager();
+		});
+
 		$this->registerService('OCP\\IConfig', function($c) {
 			return $this->getServer()->getConfig();
 		});

--- a/lib/private/comments/manager.php
+++ b/lib/private/comments/manager.php
@@ -436,12 +436,6 @@ class Manager implements ICommentsManager {
 			// Ignore exceptions, we just don't fire a hook then
 			$comment = null;
 		}
-		if ($comment instanceof IComment) {
-			$this->dispatcher->dispatch(CommentsEvent::EVENT_DELETE, new CommentsEvent(
-				CommentsEvent::EVENT_DELETE,
-				$comment
-			));
-		}
 
 		$qb = $this->dbConn->getQueryBuilder();
 		$query = $qb->delete('comments')
@@ -455,6 +449,14 @@ class Manager implements ICommentsManager {
 			$this->logger->logException($e, ['app' => 'core_comments']);
 			return false;
 		}
+
+		if ($affectedRows > 0 && $comment instanceof IComment) {
+			$this->dispatcher->dispatch(CommentsEvent::EVENT_DELETE, new CommentsEvent(
+				CommentsEvent::EVENT_DELETE,
+				$comment
+			));
+		}
+
 		return ($affectedRows > 0);
 	}
 

--- a/lib/private/comments/managerfactory.php
+++ b/lib/private/comments/managerfactory.php
@@ -52,7 +52,8 @@ class ManagerFactory implements ICommentsManagerFactory {
 		return new Manager(
 			$this->serverContainer->getDatabaseConnection(),
 			$this->serverContainer->getLogger(),
-			$this->serverContainer->getConfig()
+			$this->serverContainer->getConfig(),
+			$this->serverContainer->getEventDispatcher()
 		);
 	}
 }

--- a/lib/public/comments/commentsevent.php
+++ b/lib/public/comments/commentsevent.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Comments;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class CommentsEvent
+ *
+ * @package OCP\Comments
+ * @since 9.0.0
+ */
+class CommentsEvent extends Event {
+
+	const EVENT_ADD = 'OCP\Comments\ICommentsManager::addComment';
+	const EVENT_UPDATE = 'OCP\Comments\ICommentsManager::updateComment';
+	const EVENT_DELETE = 'OCP\Comments\ICommentsManager::deleteComment';
+
+	/** @var string */
+	protected $event;
+	/** @var IComment */
+	protected $comment;
+
+	/**
+	 * DispatcherEvent constructor.
+	 *
+	 * @param string $event
+	 * @param IComment $comment
+	 * @since 9.0.IComment
+	 */
+	public function __construct($event, IComment $comment) {
+		$this->event = $event;
+		$this->comment = $comment;
+	}
+
+	/**
+	 * @return string
+	 * @since 9.0.0
+	 */
+	public function getEvent() {
+		return $this->event;
+	}
+
+	/**
+	 * @return IComment
+	 * @since 9.0.0
+	 */
+	public function getComment() {
+		return $this->comment;
+	}
+}

--- a/lib/public/comments/icommentsmanager.php
+++ b/lib/public/comments/icommentsmanager.php
@@ -149,7 +149,7 @@ interface ICommentsManager {
 	public function delete($id);
 
 	/**
-	 * saves the comment permanently and returns it
+	 * saves the comment permanently
 	 *
 	 * if the supplied comment has an empty ID, a new entry comment will be
 	 * saved and the instance updated with the new ID.


### PR DESCRIPTION
- Adding a comment triggers an activity
- There is a filter in the activity app to show only comment activities
- Comments are shorten in the sidebar activity stream to avoid problems and keep an overview.

@blizzz 
@PVince81 which issue holds this task?
### Activity page

![activity_-_owncloud_-_2016-02-05_11 32 16](https://cloud.githubusercontent.com/assets/213943/12843836/3dd81322-cbfc-11e5-92e1-f070c5dd0d30.png)
### Sidebar

![files_-_owncloud_-_2016-02-05_11 32 57](https://cloud.githubusercontent.com/assets/213943/12843851/51017150-cbfc-11e5-9c53-1451bfbf5757.png)
