### PR TITLE
Delete a link share if it is expired on access

### DIFF
--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -22,6 +22,7 @@
 namespace OC\Share20;
 
 use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
 use OCP\IUserManager;
 use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
@@ -795,7 +796,11 @@ class Manager implements IManager {
 					if ($share->getExpirationDate() !== null &&
 						$share->getExpirationDate() <= $today
 					) {
-						$this->deleteShare($share);
+						try {
+							$this->deleteShare($share);
+						} catch (NotFoundException $e) {
+							//Ignore since this basically means the share is deleted
+						}
 						continue;
 					}
 					$added++;

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -803,6 +803,14 @@ class Manager implements IManager {
 
 		$share = $provider->getShareById($id, $recipient);
 
+		// Validate link shares expiration date
+		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK &&
+			$share->getExpirationDate() !== null &&
+			$share->getExpirationDate() <= new \DateTime()) {
+			$this->deleteShare($share);
+			throw new ShareNotFound();
+		}
+
 		return $share;
 	}
 

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -831,7 +831,11 @@ class Manager implements IManager {
 
 		$share = $provider->getShareByToken($token);
 
-		//TODO check if share expired
+		if ($share->getExpirationDate() !== null &&
+			$share->getExpirationDate() <= new \DateTime()) {
+			$this->deleteShare($share);
+			throw new ShareNotFound();
+		}
 
 		return $share;
 	}

--- a/lib/public/share/ishareprovider.php
+++ b/lib/public/share/ishareprovider.php
@@ -101,7 +101,7 @@ interface IShareProvider {
 	 * @param bool $reshares Also get the shares where $user is the owner instead of just the shares where $user is the initiator
 	 * @param int $limit The maximum number of shares to be returned, -1 for all shares
 	 * @param int $offset
-	 * @return \OCP\Share\IShare Share[]
+	 * @return \OCP\Share\IShare[]
 	 * @since 9.0.0
 	 */
 	public function getSharesBy($userId, $shareType, $node, $reshares, $limit, $offset);

--- a/tests/lib/share20/managertest.php
+++ b/tests/lib/share20/managertest.php
@@ -501,6 +501,33 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	/**
+	 * @expectedException \OCP\Share\Exceptions\ShareNotFound
+	 */
+	public function testGetExpiredShareById() {
+		$manager = $this->createManagerMock()
+			->setMethods(['deleteShare'])
+			->getMock();
+
+		$date = new \DateTime();
+		$date->setTime(0,0,0);
+
+		$share = $this->manager->newShare();
+		$share->setExpirationDate($date)
+			->setShareType(\OCP\Share::SHARE_TYPE_LINK);
+
+		$this->defaultProvider->expects($this->once())
+			->method('getShareById')
+			->with('42')
+			->willReturn($share);
+
+		$manager->expects($this->once())
+			->method('deleteShare')
+			->with($share);
+
+		$manager->getShareById('default:42');
+	}
+
+	/**
 	 * @expectedException        InvalidArgumentException
 	 * @expectedExceptionMessage Passwords are enforced for link shares
 	 */

--- a/tests/lib/share20/managertest.php
+++ b/tests/lib/share20/managertest.php
@@ -1700,6 +1700,109 @@ class ManagerTest extends \Test\TestCase {
 		$manager->createShare($share);
 	}
 
+	public function testGetSharesBy() {
+		$share = $this->manager->newShare();
+
+		$node = $this->getMock('OCP\Files\Folder');
+
+		$this->defaultProvider->expects($this->once())
+			->method('getSharesBy')
+			->with(
+				$this->equalTo('user'),
+				$this->equalTo(\OCP\Share::SHARE_TYPE_USER),
+				$this->equalTo($node),
+				$this->equalTo(true),
+				$this->equalTo(1),
+				$this->equalTo(1)
+			)->willReturn([$share]);
+
+		$shares = $this->manager->getSharesBy('user', \OCP\Share::SHARE_TYPE_USER, $node, true, 1, 1);
+
+		$this->assertCount(1, $shares);
+		$this->assertSame($share, $shares[0]);
+	}
+
+	/**
+	 * Test to ensure we correctly remove expired link shares
+	 *
+	 * We have 8 Shares and we want the 3 first valid shares.
+	 * share 3-6 and 8 are expired. Thus at the end of this test we should
+	 * have received share 1,2 and 7. And from the manager. Share 3-6 should be
+	 * deleted (as they are evaluated). but share 8 should still be there.
+	 */
+	public function testGetSharesByExpiredLinkShares() {
+		$manager = $this->createManagerMock()
+			->setMethods(['deleteShare'])
+			->getMock();
+
+		/** @var \OCP\Share\IShare[] $shares */
+		$shares = [];
+
+		/*
+		 * This results in an array of 8 IShare elements
+		 */
+		for ($i = 0; $i < 8; $i++) {
+			$share = $this->manager->newShare();
+			$share->setId($i);
+			$shares[] = $share;
+		}
+
+		$today = new \DateTime();
+		$today->setTime(0,0,0);
+
+		/*
+		 * Set the expiration date to today for some shares
+		 */
+		$shares[2]->setExpirationDate($today);
+		$shares[3]->setExpirationDate($today);
+		$shares[4]->setExpirationDate($today);
+		$shares[5]->setExpirationDate($today);
+
+		/** @var \OCP\Share\IShare[] $i */
+		$shares2 = [];
+		for ($i = 0; $i < 8; $i++) {
+			$shares2[] = clone $shares[$i];
+		}
+
+		$node = $this->getMock('OCP\Files\File');
+
+		/*
+		 * Simulate the getSharesBy call.
+		 */
+		$this->defaultProvider
+			->method('getSharesBy')
+			->will($this->returnCallback(function($uid, $type, $node, $reshares, $limit, $offset) use (&$shares2) {
+				return array_slice($shares2, $offset, $limit);
+			}));
+
+		/*
+		 * Simulate the deleteShare call.
+		 */
+		$manager->method('deleteShare')
+			->will($this->returnCallback(function($share) use (&$shares2) {
+				for($i = 0; $i < count($shares2); $i++) {
+					if ($shares2[$i]->getId() === $share->getId()) {
+						array_splice($shares2, $i, 1);
+						break;
+					}
+				}
+			}));
+
+		$res = $manager->getSharesBy('user', \OCP\Share::SHARE_TYPE_LINK, $node, true, 3, 0);
+
+		$this->assertCount(3, $res);
+		$this->assertEquals($shares[0]->getId(), $res[0]->getId());
+		$this->assertEquals($shares[1]->getId(), $res[1]->getId());
+		$this->assertEquals($shares[6]->getId(), $res[2]->getId());
+
+		$this->assertCount(4, $shares2);
+		$this->assertEquals(0, $shares2[0]->getId());
+		$this->assertEquals(1, $shares2[1]->getId());
+		$this->assertEquals(6, $shares2[2]->getId());
+		$this->assertEquals(7, $shares2[3]->getId());
+		$this->assertSame($today, $shares[3]->getExpirationDate());
+	}
+
 	public function testGetShareByToken() {
 		$factory = $this->getMock('\OCP\Share\IProviderFactory');
 


### PR DESCRIPTION
If we access a link share we should check if it has expired already.
If so we should remove it and throw a ShareNotFound exception.

CC: @nickvergessen @schiesbn @PVince81 @DeepDiver1975 
