### PR TITLE
Gracefull handle link shares rename hook

### DIFF
--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -73,6 +73,12 @@ class Shared_Updater {
 	 */
 	static private function moveShareToShare($path) {
 		$userFolder = \OC::$server->getUserFolder();
+
+		// If the user folder can't be constructed (e.g. link share) just return.
+		if ($userFolder === null) {
+			return;
+		}
+
 		$src = $userFolder->get($path);
 
 		$type = $src instanceof \OCP\Files\File ? 'file' : 'folder';


### PR DESCRIPTION
Fixes #21678

The hook is called on all renames. However when we use a link share
the getUserFolder fails. We now just opt out.

Before: moving of items in public link shares would return an error
After: Sun is shining, birds are singing... and all is well in the world

CC: @SergioBertolinSG @PVince81 @schiesbn @nickvergessen @MorrisJobke 
