### PR TITLE
Limit comment size to 1000 in UI

### DIFF
--- a/apps/comments/css/comments.css
+++ b/apps/comments/css/comments.css
@@ -14,7 +14,7 @@
 
 #commentsTabView .newCommentForm .message {
 	width: 90%;
-	resize: none;
+	resize: vertical;
 }
 
 #commentsTabView .newCommentForm .submitLoading {
@@ -75,6 +75,14 @@
 
 #commentsTabView .comment.disabled .action {
 	visibility: hidden;
+}
+
+#commentsTabView .message.error {
+	color: #e9322d;
+	border-color: #e9322d;
+	-webkit-box-shadow: 0 0 6px #f8b9b7;
+	-moz-box-shadow: 0 0 6px #f8b9b7;
+	box-shadow: 0 0 6px #f8b9b7;
 }
 
 .app-files .action-comment>img {


### PR DESCRIPTION
Whenever the limit is almost reached (90% of the length), a tooltip will
appear.

Once the limit is exceeded, the "Post" button will be disabled and the
field will become red.

Ref: https://github.com/owncloud/core/issues/16328#issuecomment-179120807

Please review @blizzz @MorrisJobke @nickvergessen @rullzer @icewind1991 @karlitschek @jancborchardt 

@blizzz we should probably also add a limit in the API ?
