### PR TITLE
Even single shares are returned as array

### DIFF
--- a/apps/files_sharing/api/share20ocs.php
+++ b/apps/files_sharing/api/share20ocs.php
@@ -170,7 +170,7 @@ class Share20OCS {
 
 		if ($this->canAccessShare($share)) {
 			$share = $this->formatShare($share);
-			return new \OC_OCS_Result($share);
+			return new \OC_OCS_Result([$share]);
 		} else {
 			return new \OC_OCS_Result(null, 404, 'wrong share ID, share doesn\'t exist.');
 		}

--- a/apps/files_sharing/tests/api/share20ocstest.php
+++ b/apps/files_sharing/tests/api/share20ocstest.php
@@ -387,7 +387,7 @@ class Share20OCSTest extends \Test\TestCase {
 			['group', $group],
 		]));
 
-		$expected = new \OC_OCS_Result($result);
+		$expected = new \OC_OCS_Result([$result]);
 		$this->assertEquals($expected->getData(), $ocs->getShare($share->getId())->getData());
 	}
 


### PR DESCRIPTION
When fetching a single share using ../shares/<ID> we should still return
an array of shares.

Fixes #22189 

@davivel please verify :)

CC: @schiesbn @nickvergessen @PVince81 @DeepDiver1975 @MorrisJobke @LukasReschke 
