### PR TITLE
Only set the default expiration date on share creation

### DIFF
--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -322,8 +322,12 @@ class Manager implements IManager {
 		$existingShares = $provider->getSharesByPath($share->getNode());
 		foreach($existingShares as $existingShare) {
 			// Ignore if it is the same share
-			if ($existingShare->getFullId() === $share->getFullId()) {
-				continue;
+			try {
+				if ($existingShare->getFullId() === $share->getFullId()) {
+					continue;
+				}
+			} catch (\UnexpectedValueException $e) {
+				//Shares are not identical
 			}
 
 			// Identical share already existst
@@ -569,7 +573,11 @@ class Manager implements IManager {
 			throw new \Exception('The Share API is disabled');
 		}
 
-		$originalShare = $this->getShareById($share->getFullId());
+		try {
+			$originalShare = $this->getShareById($share->getFullId());
+		} catch (\UnexpectedValueException $e) {
+			throw new \InvalidArgumentException('Share does not have a full id');
+		}
 
 		// We can't change the share type!
 		if ($share->getShareType() !== $originalShare->getShareType()) {
@@ -674,10 +682,15 @@ class Manager implements IManager {
 	 *
 	 * @param \OCP\Share\IShare $share
 	 * @throws ShareNotFound
+	 * @throws \InvalidArgumentException
 	 */
 	public function deleteShare(\OCP\Share\IShare $share) {
 		// Just to make sure we have all the info
-		$share = $this->getShareById($share->getFullId());
+		try {
+			$share = $this->getShareById($share->getFullId());
+		} catch (\UnexpectedValueException $e) {
+			throw new \InvalidArgumentException('Share does not have a full id');
+		}
 
 		$formatHookParams = function(\OCP\Share\IShare $share) {
 			// Prepare hook

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -261,7 +261,14 @@ class Manager implements IManager {
 		}
 
 		// If expiredate is empty set a default one if there is a default
-		if ($share->getFullId() === null && $expirationDate === null && $this->shareApiLinkDefaultExpireDate()) {
+		$fullId = null;
+		try {
+			$fullId = $share->getFullId();
+		} catch (\UnexpectedValueException $e) {
+			// This is a new share
+		}
+
+		if ($fullId === null && $expirationDate === null && $this->shareApiLinkDefaultExpireDate()) {
 			$expirationDate = new \DateTime();
 			$expirationDate->setTime(0,0,0);
 			$expirationDate->add(new \DateInterval('P'.$this->shareApiLinkDefaultExpireDays().'D'));
@@ -360,8 +367,12 @@ class Manager implements IManager {
 		$provider = $this->factory->getProviderForType(\OCP\Share::SHARE_TYPE_GROUP);
 		$existingShares = $provider->getSharesByPath($share->getNode());
 		foreach($existingShares as $existingShare) {
-			if ($existingShare->getFullId() === $share->getFullId()) {
-				continue;
+			try {
+				if ($existingShare->getFullId() === $share->getFullId()) {
+					continue;
+				}
+			} catch (\UnexpectedValueException $e) {
+				//It is a new share so just continue
 			}
 
 			if ($existingShare->getSharedWith() === $share->getSharedWith()) {

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -261,7 +261,7 @@ class Manager implements IManager {
 		}
 
 		// If expiredate is empty set a default one if there is a default
-		if ($expirationDate === null && $this->shareApiLinkDefaultExpireDate()) {
+		if ($share->getFullId() === null && $expirationDate === null && $this->shareApiLinkDefaultExpireDate()) {
 			$expirationDate = new \DateTime();
 			$expirationDate->setTime(0,0,0);
 			$expirationDate->add(new \DateInterval('P'.$this->shareApiLinkDefaultExpireDays().'D'));

--- a/lib/private/share20/share.php
+++ b/lib/private/share20/share.php
@@ -90,6 +90,9 @@ class Share implements \OCP\Share\IShare {
 	 * @inheritdoc
 	 */
 	public function getFullId() {
+		if ($this->providerId === null || $this->id === null) {
+			return null;
+		}
 		return $this->providerId . ':' . $this->id;
 	}
 

--- a/lib/private/share20/share.php
+++ b/lib/private/share20/share.php
@@ -91,7 +91,7 @@ class Share implements \OCP\Share\IShare {
 	 */
 	public function getFullId() {
 		if ($this->providerId === null || $this->id === null) {
-			return null;
+			throw new \UnexpectedValueException;
 		}
 		return $this->providerId . ':' . $this->id;
 	}

--- a/lib/public/share/ishare.php
+++ b/lib/public/share/ishare.php
@@ -46,7 +46,7 @@ interface IShare {
 	 * Get the full share id. This is the <providerid>:<internalid>.
 	 * The full id is unique in the system.
 	 *
-	 * @return string
+	 * @return string|null null is returned when the fullId can't be constructed
 	 * @since 9.0.0
 	 */
 	public function getFullId();

--- a/lib/public/share/ishare.php
+++ b/lib/public/share/ishare.php
@@ -46,8 +46,9 @@ interface IShare {
 	 * Get the full share id. This is the <providerid>:<internalid>.
 	 * The full id is unique in the system.
 	 *
-	 * @return string|null null is returned when the fullId can't be constructed
+	 * @return string
 	 * @since 9.0.0
+	 * @throws \UnexpectedValueException If the fullId could not be constructed
 	 */
 	public function getFullId();
 

--- a/tests/lib/share20/managertest.php
+++ b/tests/lib/share20/managertest.php
@@ -890,6 +890,22 @@ class ManagerTest extends \Test\TestCase {
 		$this->invokePrivate($this->manager, 'validateExpirationDate', [$share]);
 	}
 
+	public function testValidateExpirationDateExistingShareNoDefault() {
+		$share = $this->manager->newShare();
+
+		$share->setId('42')->setProviderId('foo');
+
+		$this->config->method('getAppValue')
+			->will($this->returnValueMap([
+				['core', 'shareapi_default_expire_date', 'no', 'yes'],
+				['core', 'shareapi_expire_after_n_days', '7', '6'],
+			]));
+
+		$this->invokePrivate($this->manager, 'validateExpirationDate', [$share]);
+
+		$this->assertEquals(null, $share->getExpirationDate());
+	}
+
 	/**
 	 * @expectedException Exception
 	 * @expectedExceptionMessage Only sharing with group members is allowed


### PR DESCRIPTION
Fixes #19685

The default expiration date should only be set when we create a new
share. So if a share is created and the expiration date is unset. And
after that the password is updated the expiration date should remain
unset.

CC: @MorrisJobke @PVince81 @nickvergessen @schiesbn 
