### PR TITLE
Make checksum propfind future proof

### DIFF
--- a/apps/dav/lib/connector/sabre/checksumlist.php
+++ b/apps/dav/lib/connector/sabre/checksumlist.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\Connector\Sabre;
+
+use Sabre\Xml\XmlSerializable;
+use Sabre\Xml\Element;
+use Sabre\Xml\Writer;
+
+/**
+ * Checksumlist property
+ *
+ * This property contains multiple "checksum" elements, each containing a
+ * checksum name.
+ */
+class ChecksumList implements XmlSerializable {
+	const NS_OWNCLOUD = 'http://owncloud.org/ns';
+
+	/** @var string[] of TYPE:CHECKSUM */
+	private $checksums;
+
+	/**
+	 * @param string $checksum
+	 */
+	public function __construct($checksum) {
+		$this->checksums = explode(',', $checksum);
+	}
+
+	/**
+	 * The xmlSerialize metod is called during xml writing.
+	 *
+	 * Use the $writer argument to write its own xml serialization.
+	 *
+	 * An important note: do _not_ create a parent element. Any element
+	 * implementing XmlSerializble should only ever write what's considered
+	 * its 'inner xml'.
+	 *
+	 * The parent of the current element is responsible for writing a
+	 * containing element.
+	 *
+	 * This allows serializers to be re-used for different element names.
+	 *
+	 * If you are opening new elements, you must also close them again.
+	 *
+	 * @param Writer $writer
+	 * @return void
+	 */
+	function xmlSerialize(Writer $writer) {
+
+		foreach ($this->checksums as $checksum) {
+			$writer->writeElement('{' . self::NS_OWNCLOUD . '}checksum', $checksum);
+		}
+	}
+}

--- a/apps/dav/lib/connector/sabre/filesplugin.php
+++ b/apps/dav/lib/connector/sabre/filesplugin.php
@@ -47,7 +47,7 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 	const LASTMODIFIED_PROPERTYNAME = '{DAV:}lastmodified';
 	const OWNER_ID_PROPERTYNAME = '{http://owncloud.org/ns}owner-id';
 	const OWNER_DISPLAY_NAME_PROPERTYNAME = '{http://owncloud.org/ns}owner-display-name';
-	const CHECKSUM_PROPERTYNAME = '{http://owncloud.org/ns}checksum';
+	const CHECKSUMS_PROPERTYNAME = '{http://owncloud.org/ns}checksums';
 
 	/**
 	 * Reference to main server object
@@ -108,7 +108,7 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 		$server->protectedProperties[] = self::DOWNLOADURL_PROPERTYNAME;
 		$server->protectedProperties[] = self::OWNER_ID_PROPERTYNAME;
 		$server->protectedProperties[] = self::OWNER_DISPLAY_NAME_PROPERTYNAME;
-		$server->protectedProperties[] = self::CHECKSUM_PROPERTYNAME;
+		$server->protectedProperties[] = self::CHECKSUMS_PROPERTYNAME;
 
 		// normally these cannot be changed (RFC4918), but we want them modifiable through PROPPATCH
 		$allowedProperties = ['{DAV:}getetag'];
@@ -248,13 +248,9 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 				return false;
 			});
 
-			$propFind->handle(self::CHECKSUM_PROPERTYNAME, function() use ($node) {
+			$propFind->handle(self::CHECKSUMS_PROPERTYNAME, function() use ($node) {
 				$checksum = $node->getChecksum();
-
-				if ($checksum === null) {
-					return '';
-				}
-				return $checksum;
+				return new ChecksumList($checksum);
 			});
 
 		}


### PR DESCRIPTION
The checksum PR from https://github.com/owncloud/core/pull/21997 returns a propfind like:

``` xml
<oc:checksum>TYPE:CHECKSUM</oc:checksum>
```

Which if we will ever support multiple cheksums results in:

``` xml
<oc:checksum>TYPE1:CHECKSUM1,TYPE2:CHECKSUM2</oc:checksum>
```

Which is not very webdavvy.

This PR moves that to:

``` xml
<oc:checksums>
  <oc:checksum>TYPE1:CHECKSUM1</oc:checksum>
  <oc:checksum>TYPE2:CHECKSUM2</oc:checksum>
</oc:checksum>
```

Which is a bit more future proof.

Testing is basically the same as: https://github.com/owncloud/core/pull/21997#issuecomment-178602078 with the exception that your propfind file should contain:

``` xml
<?xml version="1.0"?>
<a:propfind xmlns:a="DAV:">
<a:prop xmlns:oc="http://owncloud.org/ns">
    <oc:checksums/>
</a:prop>
</a:propfind>
```

CC: @PVince81 @dragotin @MorrisJobke @nickvergessen
