### PR TITLE
Make sure fileinfo exists when calling getCheckSum in node API

### DIFF
--- a/lib/private/files/node/file.php
+++ b/lib/private/files/node/file.php
@@ -169,6 +169,6 @@ class File extends Node implements \OCP\Files\File {
 	 * @inheritdoc
 	 */
 	public function getChecksum() {
-		return $this->fileInfo->getChecksum();
+		return $this->getFileInfo()->getChecksum();
 	}
 }

--- a/lib/public/files/file.php
+++ b/lib/public/files/file.php
@@ -84,4 +84,14 @@ interface File extends Node {
 	 * @since 6.0.0
 	 */
 	public function hash($type, $raw = false);
+
+	/**
+	 * Get the stored checksum for this file
+	 *
+	 * @return string
+	 * @since 9.0.0
+	 * @throws InvalidPathException
+	 * @throws NotFoundException
+	 */
+	public function getChecksum();
 }


### PR DESCRIPTION
Found when doing a REPORT call here https://github.com/owncloud/core/pull/22112 where I'm using the Node object instead of FileInfo, so the internal file info might not be resolved yet.

Please review @icewind1991 @rullzer
