### PR TITLE
Update the migration step to include federated shares

### DIFF
--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -10,7 +10,7 @@ Turning the feature off removes shared files and folders on the server for all s
 	<licence>AGPL</licence>
 	<author>Michael Gapczynski, Bjoern Schiessle</author>
 	<default_enable/>
-	<version>0.9.0</version>
+	<version>0.9.1</version>
 	<types>
 		<filesystem/>
 	</types>

--- a/apps/files_sharing/appinfo/update.php
+++ b/apps/files_sharing/appinfo/update.php
@@ -25,7 +25,7 @@ use OCA\Files_Sharing\Migration;
 $installedVersion = \OC::$server->getConfig()->getAppValue('files_sharing', 'installed_version');
 
 // Migration OC8.2 -> OC9
-if (version_compare($installedVersion, '0.9.0', '<')) {
+if (version_compare($installedVersion, '0.9.1', '<')) {
 	$m = new Migration(\OC::$server->getDatabaseConnection());
 	$m->removeReShares();
 	$m->updateInitiatorInfo();

--- a/apps/files_sharing/lib/migration.php
+++ b/apps/files_sharing/lib/migration.php
@@ -142,7 +142,8 @@ class Migration {
 					[
 						\OCP\Share::SHARE_TYPE_USER,
 						\OCP\Share::SHARE_TYPE_GROUP,
-						\OCP\Share::SHARE_TYPE_LINK
+						\OCP\Share::SHARE_TYPE_LINK,
+						\OCP\Share::SHARE_TYPE_REMOTE,
 					],
 					Connection::PARAM_INT_ARRAY
 				)
@@ -185,7 +186,8 @@ class Migration {
 					[
 						\OCP\Share::SHARE_TYPE_USER,
 						\OCP\Share::SHARE_TYPE_GROUP,
-						\OCP\Share::SHARE_TYPE_LINK
+						\OCP\Share::SHARE_TYPE_LINK,
+						\OCP\Share::SHARE_TYPE_REMOTE,
 					],
 					Connection::PARAM_INT_ARRAY
 				)

--- a/apps/files_sharing/tests/migrationtest.php
+++ b/apps/files_sharing/tests/migrationtest.php
@@ -209,6 +209,23 @@ class MigrationTest extends TestCase {
 		$this->assertSame(1,
 			$query->execute()
 		);
+		$parent = $query->getLastInsertId();
+		// third re-share, should be attached to the first user share after migration
+		$query->setParameter('share_type', \OCP\Share::SHARE_TYPE_REMOTE)
+			->setParameter('share_with', 'user@server.com')
+			->setParameter('uid_owner', 'user3')
+			->setParameter('uid_initiator', '')
+			->setParameter('parent', $parent)
+			->setParameter('item_type', 'file')
+			->setParameter('item_source', '2')
+			->setParameter('item_target', '/2')
+			->setParameter('file_source', 2)
+			->setParameter('file_target', '/foobar')
+			->setParameter('permissions', 31)
+			->setParameter('stime', time());
+		$this->assertSame(1,
+			$query->execute()
+		);
 	}
 
 	public function testRemoveReShares() {
@@ -221,7 +238,7 @@ class MigrationTest extends TestCase {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')->from($this->table)->orderBy('id');
 		$result = $query->execute()->fetchAll();
-		$this->assertSame(8, count($result));
+		$this->assertSame(9, count($result));
 
 		// shares which shouldn't be modified
 		for ($i = 0; $i < 4; $i++) {
@@ -238,7 +255,7 @@ class MigrationTest extends TestCase {
 		$this->assertEmpty($result[5]['uid_initiator']);
 		$this->assertNull($result[5]['parent']);
 		// flatted re-shares
-		for($i = 6; $i < 8; $i++) {
+		for($i = 6; $i < 9; $i++) {
 			$this->assertSame('owner2', $result[$i]['uid_owner']);
 			$user = 'user' . ($i - 5);
 			$this->assertSame($user, $result[$i]['uid_initiator']);


### PR DESCRIPTION
We did not include the federated shares in the migration step. This is added now.
This makes sure that past federated shares are part of the new share behaviour and that they always have an initiator set.

Thanks for spotting @DeepDiver1975 

CC: @schiesbn @nickvergessen @PVince81 @MorrisJobke 
