### PR TITLE
Fix elementToFile to also return path when defined

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -815,6 +815,10 @@
 			if (mountType) {
 				data.mountType = mountType;
 			}
+			var path = $el.attr('data-path');
+			if (path) {
+				data.path = path;
+			}
 			return data;
 		},
 

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2521,6 +2521,12 @@ describe('OCA.Files.FileList tests', function() {
 			expect(fileInfo.size).toEqual(12);
 			expect(fileInfo.mimetype).toEqual('text/plain');
 			expect(fileInfo.type).toEqual('file');
+			expect(fileInfo.path).not.toBeDefined();
+		});
+		it('adds path attribute if available', function() {
+			$tr.attr('data-path', '/subdir');
+			var fileInfo = fileList.elementToFile($tr);
+			expect(fileInfo.path).toEqual('/subdir');
 		});
 	});
 	describe('new file menu', function() {


### PR DESCRIPTION
Fixes issue when opening the share dialog for a file inside the favorite
list, and the file is from a subfolder

Steps:
1. Create a file in a subdir as "sub/test.txt"
2. Mark the file as favorite
3. Go to "Favorites" list
4. Click on "Share" for that file

Before: share dialog borked bada boom :bomb: 
After: share dialog works

Please review @rullzer @blizzz @icewind1991 @schiesbn 
