### PR TITLE
Direct links to Google Drive/Dropbox configuration pages from external storage config

### DIFF
--- a/apps/files_external/css/settings.css
+++ b/apps/files_external/css/settings.css
@@ -18,6 +18,11 @@ td.mountPoint, td.backend { width:160px; }
 #addMountPoint>td.applicable { visibility:hidden; }
 #addMountPoint>td.hidden { visibility:hidden; }
 
+#externalStorage .icon-settings {
+	padding: 11px 20px;
+	vertical-align: text-bottom;
+}
+
 #selectBackend {
 	margin-left: -10px;
 	width: 150px;

--- a/apps/files_external/css/settings.css
+++ b/apps/files_external/css/settings.css
@@ -45,6 +45,10 @@ td.mountPoint, td.backend { width:160px; }
 	margin-right: 6px;
 }
 
+#externalStorage td.configuration input.disabled-success {
+	background-color: rgba(134, 255, 110, 0.9);
+}
+
 
 #externalStorage td.applicable div.chzn-container {
 	position: relative;

--- a/apps/files_external/js/dropbox.js
+++ b/apps/files_external/js/dropbox.js
@@ -11,17 +11,19 @@ $(document).ready(function() {
 
 	OCA.External.Settings.mountConfig.whenSelectBackend(function($tr, backend, onCompletion) {
 		if (backend === 'dropbox') {
-			var config = $tr.find('.configuration');
+			var backendEl = $tr.find('.backend');
 			var el = $(document.createElement('a'))
 				.attr('href', generateUrl($tr))
 				.attr('target', '_blank')
-				.text(t('files_external', 'Dropbox Configuration') + ' ↗')
+				.attr('title', t('files_external', 'Dropbox App Configuration'))
+				.addClass('icon-settings svg')
 			;
 			el.on('click', function(event) {
 				var a = $(event.target);
-				a.attr('href', generateUrl($(this).parent()));
+				a.attr('href', generateUrl($(this).closest('tr')));
 			});
-			config.append(el);
+			el.tooltip({placement: 'top'});
+			backendEl.append(el);
 		}
 	});
 

--- a/apps/files_external/js/dropbox.js
+++ b/apps/files_external/js/dropbox.js
@@ -1,0 +1,28 @@
+$(document).ready(function() {
+
+	function generateUrl($tr) {
+		var app_key = $tr.find('[data-parameter="app_key"]').val();
+		if (app_key) {
+			return 'https://www.dropbox.com/developers/apps/info/' + app_key;
+		} else {
+			return 'https://www.dropbox.com/developers/apps';
+		}
+	}
+
+	OCA.External.Settings.mountConfig.whenSelectBackend(function($tr, backend, onCompletion) {
+		if (backend === 'dropbox') {
+			var config = $tr.find('.configuration');
+			var el = $(document.createElement('a'))
+				.attr('href', generateUrl($tr))
+				.attr('target', '_blank')
+				.text(t('files_external', 'Dropbox Configuration') + ' ↗')
+			;
+			el.on('click', function(event) {
+				var a = $(event.target);
+				a.attr('href', generateUrl($(this).parent()));
+			});
+			config.append(el);
+		}
+	});
+
+});

--- a/apps/files_external/js/gdrive.js
+++ b/apps/files_external/js/gdrive.js
@@ -7,17 +7,19 @@ $(document).ready(function() {
 
 	OCA.External.Settings.mountConfig.whenSelectBackend(function($tr, backend, onCompletion) {
 		if (backend === 'googledrive') {
-			var config = $tr.find('.configuration');
+			var backendEl = $tr.find('.backend');
 			var el = $(document.createElement('a'))
 				.attr('href', generateUrl($tr))
 				.attr('target', '_blank')
-				.text(t('files_external', 'Google Drive Configuration') + ' ↗')
+				.attr('title', t('files_external', 'Google Drive App Configuration'))
+				.addClass('icon-settings svg')
 			;
 			el.on('click', function(event) {
 				var a = $(event.target);
-				a.attr('href', generateUrl($(this).parent()));
+				a.attr('href', generateUrl($(this).closest('tr')));
 			});
-			config.append(el);
+			el.tooltip({placement: 'top'});
+			backendEl.append(el);
 		}
 	});
 

--- a/apps/files_external/js/gdrive.js
+++ b/apps/files_external/js/gdrive.js
@@ -1,0 +1,24 @@
+$(document).ready(function() {
+
+	function generateUrl($tr) {
+		// no mapping between client ID and Google 'project', so we always load the same URL
+		return 'https://console.developers.google.com/';
+	}
+
+	OCA.External.Settings.mountConfig.whenSelectBackend(function($tr, backend, onCompletion) {
+		if (backend === 'googledrive') {
+			var config = $tr.find('.configuration');
+			var el = $(document.createElement('a'))
+				.attr('href', generateUrl($tr))
+				.attr('target', '_blank')
+				.text(t('files_external', 'Google Drive Configuration') + ' ↗')
+			;
+			el.on('click', function(event) {
+				var a = $(event.target);
+				a.attr('href', generateUrl($(this).parent()));
+			});
+			config.append(el);
+		}
+	});
+
+});

--- a/apps/files_external/js/oauth1.js
+++ b/apps/files_external/js/oauth1.js
@@ -1,5 +1,9 @@
 $(document).ready(function() {
 
+	function displayGranted($tr) {
+		$tr.find('.configuration input.auth-param').attr('disabled', 'disabled').addClass('disabled-success');
+	}
+
 	OCA.External.Settings.mountConfig.whenSelectAuthMechanism(function($tr, authMechanism, scheme, onCompletion) {
 		if (authMechanism === 'oauth1::oauth1') {
 			var config = $tr.find('.configuration');
@@ -13,8 +17,7 @@ $(document).ready(function() {
 			onCompletion.then(function() {
 				var configured = $tr.find('[data-parameter="configured"]');
 				if ($(configured).val() == 'true') {
-					$tr.find('.configuration input.auth-param').attr('disabled', 'disabled');
-					$tr.find('.configuration').append('<span id="access" style="padding-left:0.5em;">'+t('files_external', 'Access granted')+'</span>');
+					displayGranted($tr);
 				} else {
 					var app_key = $tr.find('.configuration [data-parameter="app_key"]').val();
 					var app_secret = $tr.find('.configuration [data-parameter="app_secret"]').val();
@@ -33,8 +36,7 @@ $(document).ready(function() {
 									$(configured).val('true');
 									OCA.External.Settings.mountConfig.saveStorageConfig($tr, function(status) {
 										if (status) {
-											$tr.find('.configuration input.auth-param').attr('disabled', 'disabled');
-											$tr.find('.configuration').append('<span id="access" style="padding-left:0.5em;">'+t('files_external', 'Access granted')+'</span>');
+											displayGranted($tr);
 										}
 									});
 								} else {

--- a/apps/files_external/js/oauth1.js
+++ b/apps/files_external/js/oauth1.js
@@ -13,7 +13,7 @@ $(document).ready(function() {
 			onCompletion.then(function() {
 				var configured = $tr.find('[data-parameter="configured"]');
 				if ($(configured).val() == 'true') {
-					$tr.find('.configuration input').attr('disabled', 'disabled');
+					$tr.find('.configuration input.auth-param').attr('disabled', 'disabled');
 					$tr.find('.configuration').append('<span id="access" style="padding-left:0.5em;">'+t('files_external', 'Access granted')+'</span>');
 				} else {
 					var app_key = $tr.find('.configuration [data-parameter="app_key"]').val();
@@ -33,7 +33,7 @@ $(document).ready(function() {
 									$(configured).val('true');
 									OCA.External.Settings.mountConfig.saveStorageConfig($tr, function(status) {
 										if (status) {
-											$tr.find('.configuration input').attr('disabled', 'disabled');
+											$tr.find('.configuration input.auth-param').attr('disabled', 'disabled');
 											$tr.find('.configuration').append('<span id="access" style="padding-left:0.5em;">'+t('files_external', 'Access granted')+'</span>');
 										}
 									});

--- a/apps/files_external/js/oauth2.js
+++ b/apps/files_external/js/oauth2.js
@@ -1,5 +1,9 @@
 $(document).ready(function() {
 
+	function displayGranted($tr) {
+		$tr.find('.configuration input.auth-param').attr('disabled', 'disabled').addClass('disabled-success');
+	}
+
 	OCA.External.Settings.mountConfig.whenSelectAuthMechanism(function($tr, authMechanism, scheme, onCompletion) {
 		if (authMechanism === 'oauth2::oauth2') {
 			var config = $tr.find('.configuration');
@@ -13,9 +17,7 @@ $(document).ready(function() {
 			onCompletion.then(function() {
 				var configured = $tr.find('[data-parameter="configured"]');
 				if ($(configured).val() == 'true') {
-					$tr.find('.configuration input.auth-param').attr('disabled', 'disabled');
-					$tr.find('.configuration').append($('<span/>').attr('id', 'access')
-							.text(t('files_external', 'Access granted')));
+					displayGranted($tr);
 				} else {
 					var client_id = $tr.find('.configuration [data-parameter="client_id"]').val();
 					var client_secret = $tr.find('.configuration [data-parameter="client_secret"]')
@@ -43,10 +45,7 @@ $(document).ready(function() {
 											$(configured).val('true');
 											OCA.External.Settings.mountConfig.saveStorageConfig($tr, function(status) {
 												if (status) {
-													$tr.find('.configuration input.auth-param').attr('disabled', 'disabled');
-													$tr.find('.configuration').append($('<span/>')
-															.attr('id', 'access')
-															.text(t('files_external', 'Access granted')));
+													displayGranted($tr);
 												}
 											});
 										} else {

--- a/apps/files_external/js/oauth2.js
+++ b/apps/files_external/js/oauth2.js
@@ -13,7 +13,7 @@ $(document).ready(function() {
 			onCompletion.then(function() {
 				var configured = $tr.find('[data-parameter="configured"]');
 				if ($(configured).val() == 'true') {
-					$tr.find('.configuration input').attr('disabled', 'disabled');
+					$tr.find('.configuration input.auth-param').attr('disabled', 'disabled');
 					$tr.find('.configuration').append($('<span/>').attr('id', 'access')
 							.text(t('files_external', 'Access granted')));
 				} else {
@@ -43,7 +43,7 @@ $(document).ready(function() {
 											$(configured).val('true');
 											OCA.External.Settings.mountConfig.saveStorageConfig($tr, function(status) {
 												if (status) {
-													$tr.find('.configuration input').attr('disabled', 'disabled');
+													$tr.find('.configuration input.auth-param').attr('disabled', 'disabled');
 													$tr.find('.configuration').append($('<span/>')
 															.attr('id', 'access')
 															.text(t('files_external', 'Access granted')));

--- a/apps/files_external/lib/auth/oauth1/oauth1.php
+++ b/apps/files_external/lib/auth/oauth1/oauth1.php
@@ -46,7 +46,7 @@ class OAuth1 extends AuthMechanism {
 				(new DefinitionParameter('token_secret', 'token_secret'))
 					->setType(DefinitionParameter::VALUE_HIDDEN),
 			])
-			->setCustomJs('oauth1')
+			->addCustomJs('oauth1')
 		;
 	}
 

--- a/apps/files_external/lib/auth/oauth2/oauth2.php
+++ b/apps/files_external/lib/auth/oauth2/oauth2.php
@@ -44,7 +44,7 @@ class OAuth2 extends AuthMechanism {
 				(new DefinitionParameter('token', 'token'))
 					->setType(DefinitionParameter::VALUE_HIDDEN),
 			])
-			->setCustomJs('oauth2')
+			->addCustomJs('oauth2')
 		;
 	}
 

--- a/apps/files_external/lib/auth/publickey/rsa.php
+++ b/apps/files_external/lib/auth/publickey/rsa.php
@@ -52,7 +52,7 @@ class RSA extends AuthMechanism {
 				(new DefinitionParameter('private_key', 'private_key'))
 					->setType(DefinitionParameter::VALUE_HIDDEN),
 			])
-			->setCustomJs('public_key')
+			->addCustomJs('public_key')
 		;
 	}
 

--- a/apps/files_external/lib/backend/dropbox.php
+++ b/apps/files_external/lib/backend/dropbox.php
@@ -44,6 +44,7 @@ class Dropbox extends Backend {
 				// all parameters handled in OAuth1 mechanism
 			])
 			->addAuthScheme(AuthMechanism::SCHEME_OAUTH1)
+			->addCustomJs('dropbox')
 			->setLegacyAuthMechanism($legacyAuth)
 		;
 	}

--- a/apps/files_external/lib/backend/google.php
+++ b/apps/files_external/lib/backend/google.php
@@ -44,6 +44,7 @@ class Google extends Backend {
 				// all parameters handled in OAuth2 mechanism
 			])
 			->addAuthScheme(AuthMechanism::SCHEME_OAUTH2)
+			->addCustomJs('gdrive')
 			->setLegacyAuthMechanism($legacyAuth)
 		;
 	}

--- a/apps/files_external/lib/backend/legacybackend.php
+++ b/apps/files_external/lib/backend/legacybackend.php
@@ -84,7 +84,7 @@ class LegacyBackend extends Backend {
 			$this->setPriority($definition['priority']);
 		}
 		if (isset($definition['custom'])) {
-			$this->setCustomJs($definition['custom']);
+			$this->addCustomJs($definition['custom']);
 		}
 		if (isset($definition['has_dependencies']) && $definition['has_dependencies']) {
 			$this->hasDependencies = true;

--- a/apps/files_external/lib/frontenddefinitiontrait.php
+++ b/apps/files_external/lib/frontenddefinitiontrait.php
@@ -36,8 +36,8 @@ trait FrontendDefinitionTrait {
 	/** @var DefinitionParameter[] parameters for mechanism */
 	private $parameters = [];
 
-	/** @var string|null custom JS */
-	private $customJs = null;
+	/** @var string[] custom JS */
+	private $customJs = [];
 
 	/**
 	 * @return string
@@ -92,7 +92,7 @@ trait FrontendDefinitionTrait {
 	}
 
 	/**
-	 * @return string|null
+	 * @return string[]
 	 */
 	public function getCustomJs() {
 		return $this->customJs;
@@ -102,8 +102,18 @@ trait FrontendDefinitionTrait {
 	 * @param string $custom
 	 * @return self
 	 */
+	public function addCustomJs($custom) {
+		$this->customJs[] = $custom;
+		return $this;
+	}
+
+	/**
+	 * @param string $custom
+	 * @return self
+	 * @deprecated 9.1.0, use addCustomJs() instead
+	 */
 	public function setCustomJs($custom) {
-		$this->customJs = $custom;
+		$this->customJs = [$custom];
 		return $this;
 	}
 
@@ -121,10 +131,8 @@ trait FrontendDefinitionTrait {
 		$data = [
 			'name' => $this->getText(),
 			'configuration' => $configuration,
+			'custom' => $this->getCustomJs(),
 		];
-		if (isset($this->customJs)) {
-			$data['custom'] = $this->getCustomJs();
-		}
 		return $data;
 	}
 

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -1,5 +1,6 @@
 <?php
 	use \OCA\Files_External\Lib\Backend\Backend;
+	use \OCA\Files_External\Lib\Auth\AuthMechanism;
 	use \OCA\Files_External\Lib\DefinitionParameter;
 	use \OCA\Files_External\Service\BackendService;
 
@@ -16,13 +17,16 @@
 	// load custom JS
 	foreach ($_['backends'] as $backend) {
 		/** @var Backend $backend */
-		if ($backend->getCustomJs()) {
-			script('files_external', $backend->getCustomJs());
+		$scripts = $backend->getCustomJs();
+		foreach ($scripts as $script) {
+			script('files_external', $script);
 		}
 	}
 	foreach ($_['authMechanisms'] as $authMechanism) {
-		if ($authMechanism->getCustomJs()) {
-			script('files_external', $authMechanism->getCustomJs());
+		/** @var AuthMechanism $authMechanism */
+		$scripts = $authMechanism->getCustomJs();
+		foreach ($scripts as $script) {
+			script('files_external', $script);
 		}
 	}
 

--- a/apps/files_external/tests/backend/legacybackendtest.php
+++ b/apps/files_external/tests/backend/legacybackendtest.php
@@ -62,7 +62,7 @@ class LegacyBackendTest extends \Test\TestCase {
 		$this->assertEquals('\OCA\Files_External\Tests\Backend\LegacyBackendTest', $backend->getStorageClass());
 		$this->assertEquals('Backend text', $backend->getText());
 		$this->assertEquals(123, $backend->getPriority());
-		$this->assertEquals('foo/bar.js', $backend->getCustomJs());
+		$this->assertContains('foo/bar.js', $backend->getCustomJs());
 		$this->assertArrayHasKey('builtin', $backend->getAuthSchemes());
 		$this->assertEquals($auth, $backend->getLegacyAuthMechanism());
 

--- a/apps/files_external/tests/frontenddefinitiontraittest.php
+++ b/apps/files_external/tests/frontenddefinitiontraittest.php
@@ -33,12 +33,14 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 		$trait = $this->getMockForTrait('\OCA\Files_External\Lib\FrontendDefinitionTrait');
 		$trait->setText('test');
 		$trait->addParameters([$param]);
-		$trait->setCustomJs('foo/bar.js');
+		$trait->addCustomJs('foo/bar.js');
+		$trait->addCustomJs('bar/foo.js');
 
 		$json = $trait->jsonSerializeDefinition();
 
 		$this->assertEquals('test', $json['name']);
-		$this->assertEquals('foo/bar.js', $json['custom']);
+		$this->assertContains('foo/bar.js', $json['custom']);
+		$this->assertContains('bar/foo.js', $json['custom']);
 
 		$configuration = $json['configuration'];
 		$this->assertArrayHasKey('foo', $configuration);


### PR DESCRIPTION
There always seemed to be a disconnect between setting up a Google Drive/Dropbox storage on ownCloud and setting it up on the hosting provider (setting up an app etc). This PR adds a button to those backends that open the relevant configuration page directly, making it easier to use. @carlaschroder You'll probably like this

However, there's a problem that the buttons appear at the beginning of the configuration section, before the authentication fields. There's probably some fancy CSS that would fix it, or maybe we need to create a `div` within the configuration cell that always remains at the end, but I don't have time to implement that. I wanted to get the changes as far as I got pushed here.

cc @PVince81 @icewind1991 
