### PR TITLE
Federates shares have to set a file_target

### DIFF
--- a/apps/federatedfilesharing/lib/federatedshareprovider.php
+++ b/apps/federatedfilesharing/lib/federatedshareprovider.php
@@ -194,6 +194,12 @@ class FederatedShareProvider implements IShareProvider {
 			->setValue('token', $qb->createNamedParameter($token))
 			->setValue('stime', $qb->createNamedParameter(time()));
 
+		/*
+		 * Added to fix https://github.com/owncloud/core/issues/22215
+		 * Can be removed once we get rid of ajax/share.php
+		 */
+		$qb->setValue('file_target', $qb->createNamedParameter(''));
+
 		$qb->execute();
 		$id = $qb->getLastInsertId();
 


### PR DESCRIPTION
The old code path is still used to get the sharing info in the webui.
This requires the file_target to be set. This does not mean anything
for federated shares.

Fixes #22215 

CC: @PVince81 @nickvergessen @schiesbn @MorrisJobke @DeepDiver1975 
