### PR TITLE
Add global --no-warnings option to occ…

### DIFF
--- a/console.php
+++ b/console.php
@@ -27,6 +27,7 @@
  */
 
 use OC\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 define('OC_CONSOLE', 1);
@@ -81,7 +82,7 @@ try {
 	}
 
 	$application = new Application(\OC::$server->getConfig(), \OC::$server->getEventDispatcher(), \OC::$server->getRequest());
-	$application->loadCommands(new ConsoleOutput());
+	$application->loadCommands(new ArgvInput(), new ConsoleOutput());
 	$application->run();
 } catch (Exception $ex) {
 	echo "An unhandled exception has been thrown:" . PHP_EOL;


### PR DESCRIPTION
…in order not to pollute output with global warnings.

Originating from https://github.com/owncloud/core/pull/22170#issuecomment-180483353

Messages like `ownCloud or one of the apps require upgrade - only a limited number of commands are available
You may use your browser or the occ upgrade command to do the upgrade` are undesired under certain conditions so they can be switched off by passing optional `--no-warnings` parameter:

```
deo@jah-mobile:~/public_html/oc-tmp> ./occ status
ownCloud or one of the apps require upgrade - only a limited number of commands are available
You may use your browser or the occ upgrade command to do the upgrade
  - installed: true
  - version: 9.0.0.10
  - versionstring: 9.0 pre alpha
  - edition: 
deo@jah-mobile:~/public_html/oc-tmp> ./occ status --no-warnings
  - installed: true
  - version: 9.0.0.10
  - versionstring: 9.0 pre alpha
  - edition: 
```
