### PR TITLE
Fix part file partial cache logic in encryption code

### DIFF
--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -129,9 +129,15 @@ class Encryption extends Wrapper {
 		if (isset($this->unencryptedSize[$fullPath])) {
 			$size = $this->unencryptedSize[$fullPath];
 			// update file cache
+			if ($info) {
+				$info = $info->getData();
+			} else {
+				$info = [];
+			}
+
 			$info['encrypted'] = true;
 			$info['size'] = $size;
-			$this->getCache()->put($path, $info->getData());
+			$this->getCache()->put($path, $info);
 
 			return $size;
 		}


### PR DESCRIPTION
The encryption code uses partial cache entries for the part file (which
are not stored in the database) but are useful for other parts of the
code to retrieve the file size again.

This means that in the fixed code $info was empty, so getData() could
not be called.

The fix makes sure to support both cases when the cache entry exists and
doesn't.

Fixes https://github.com/owncloud/core/issues/22125

Please review @LukasReschke @schiesbn @icewind1991 @nickvergessen 
