### PR TITLE
More sharing hooks for extended auditing

### DIFF
--- a/apps/files_sharing/lib/controllers/sharecontroller.php
+++ b/apps/files_sharing/lib/controllers/sharecontroller.php
@@ -30,7 +30,6 @@
 namespace OCA\Files_Sharing\Controllers;
 
 use OC;
-use OC\Files\Filesystem;
 use OC_Files;
 use OC_Util;
 use OCP;
@@ -71,7 +70,7 @@ class ShareController extends Controller {
 	protected $logger;
 	/** @var OCP\Activity\IManager */
 	protected $activityManager;
-	/** @var OC\Share20\Manager */
+	/** @var OCP\Share\IManager */
 	protected $shareManager;
 	/** @var ISession */
 	protected $session;
@@ -88,7 +87,7 @@ class ShareController extends Controller {
 	 * @param IUserManager $userManager
 	 * @param ILogger $logger
 	 * @param OCP\Activity\IManager $activityManager
-	 * @param \OC\Share20\Manager $shareManager
+	 * @param \OCP\Share\IManager $shareManager
 	 * @param ISession $session
 	 * @param IPreview $previewManager
 	 * @param IRootFolder $rootFolder
@@ -100,7 +99,7 @@ class ShareController extends Controller {
 								IUserManager $userManager,
 								ILogger $logger,
 								\OCP\Activity\IManager $activityManager,
-								\OC\Share20\Manager $shareManager,
+								\OCP\Share\IManager $shareManager,
 								ISession $session,
 								IPreview $previewManager,
 								IRootFolder $rootFolder) {
@@ -193,11 +192,10 @@ class ShareController extends Controller {
 	/**
 	 * throws hooks when a share is attempted to be accessed
 	 *
-	 * @param \OC\Share20\Share|string $share the Share instance if available,
+	 * @param \OCP\Share\IShare|string $share the Share instance if available,
 	 * otherwise token
 	 * @param int $errorCode
 	 * @param string $errorMessage
-	 * @throws NotFoundException
 	 * @throws OC\HintException
 	 * @throws OC\ServerNotAvailableException
 	 */
@@ -205,12 +203,12 @@ class ShareController extends Controller {
 		$itemType = $itemSource = $uidOwner = '';
 		$token = $share;
 		$exception = null;
-		if($share instanceof \OC\Share20\Share) {
+		if($share instanceof \OCP\Share\IShare) {
 			try {
 				$token = $share->getToken();
 				$uidOwner = $share->getSharedBy();
-				$itemType = $share->getNode() instanceof \OCP\Files\File ? 'file' : 'folder';
-				$itemSource = $share->getNode()->getId();
+				$itemType = $share->getNodeType();
+				$itemSource = $share->getNodeId();
 			} catch (\Exception $e) {
 				// we log what we know and pass on the exception afterwards
 				$exception = $e;

--- a/apps/files_sharing/tests/controller/sharecontroller.php
+++ b/apps/files_sharing/tests/controller/sharecontroller.php
@@ -218,8 +218,12 @@ class ShareControllerTest extends \Test\TestCase {
 	}
 
 	public function testAuthenticateInvalidPassword() {
+		$node = $this->getMock('\OCP\Files\File');
+		$node->method('getId')->willReturn(100);
+
 		$share = \OC::$server->getShareManager()->newShare();
-		$share->setId(42);
+		$share->setId(42)
+			->setNode($node);
 
 		$this->shareManager
 			->expects($this->once())

--- a/apps/files_sharing/tests/controller/sharecontroller.php
+++ b/apps/files_sharing/tests/controller/sharecontroller.php
@@ -218,12 +218,12 @@ class ShareControllerTest extends \Test\TestCase {
 	}
 
 	public function testAuthenticateInvalidPassword() {
-		$node = $this->getMock('\OCP\Files\File');
-		$node->method('getId')->willReturn(100);
-
 		$share = \OC::$server->getShareManager()->newShare();
-		$share->setId(42)
-			->setNode($node);
+		$share->setNodeId(100)
+			->setNodeType('file')
+			->setToken('token')
+			->setSharedBy('initiator')
+			->setId(42);
 
 		$this->shareManager
 			->expects($this->once())
@@ -240,6 +240,20 @@ class ShareControllerTest extends \Test\TestCase {
 		$this->session
 			->expects($this->never())
 			->method('set');
+
+		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['access'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'share_link_access',  $hookListner, 'access');
+
+		$hookListner->expects($this->once())
+			->method('access')
+			->with($this->callback(function(array $data) {
+				return $data['itemType'] === 'file' &&
+					$data['itemSource'] === 100 &&
+					$data['uidOwner'] === 'initiator' &&
+					$data['token'] === 'token' &&
+					$data['errorCode'] === 403 &&
+					$data['errorMessage'] === 'Wrong password';
+			}));
 
 		$response = $this->shareController->authenticate('token', 'invalidpassword');
 		$expectedResponse =  new TemplateResponse($this->appName, 'authenticate', array('wrongpw' => true), 'guest');

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -595,9 +595,17 @@ class Manager implements IManager {
 				if ($share->getPassword() !== null) {
 					$share->setPassword($this->hasher->hash($share->getPassword()));
 				}
+
+				\OC_Hook::emit('OCP\Share', 'post_update_password', [
+					'itemType' => $share->getNode() instanceof \OCP\Files\File ? 'file' : 'folder',
+					'itemSource' => $share->getNode()->getId(),
+					'uidOwner' => $share->getSharedBy(),
+					'token' => $share->getToken(),
+					'disabled' => is_null($share->getPassword()),
+				]);
 			}
 
-			if ($share->getExpirationDate() !== $originalShare->getExpirationDate()) {
+			if ($share->getExpirationDate() != $originalShare->getExpirationDate()) {
 				//Verify the expiration date
 				$this->validateExpirationDate($share);
 				$expirationDateUpdated = true;

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -595,14 +595,6 @@ class Manager implements IManager {
 				if ($share->getPassword() !== null) {
 					$share->setPassword($this->hasher->hash($share->getPassword()));
 				}
-
-				\OC_Hook::emit('OCP\Share', 'post_update_password', [
-					'itemType' => $share->getNode() instanceof \OCP\Files\File ? 'file' : 'folder',
-					'itemSource' => $share->getNode()->getId(),
-					'uidOwner' => $share->getSharedBy(),
-					'token' => $share->getToken(),
-					'disabled' => is_null($share->getPassword()),
-				]);
 			}
 
 			if ($share->getExpirationDate() != $originalShare->getExpirationDate()) {
@@ -624,6 +616,16 @@ class Manager implements IManager {
 				'itemSource' => $share->getNode()->getId(),
 				'date' => $share->getExpirationDate(),
 				'uidOwner' => $share->getSharedBy(),
+			]);
+		}
+
+		if ($share->getPassword() !== $originalShare->getPassword()) {
+			\OC_Hook::emit('OCP\Share', 'post_update_password', [
+				'itemType' => $share->getNode() instanceof \OCP\Files\File ? 'file' : 'folder',
+				'itemSource' => $share->getNode()->getId(),
+				'uidOwner' => $share->getSharedBy(),
+				'token' => $share->getToken(),
+				'disabled' => is_null($share->getPassword()),
 			]);
 		}
 

--- a/lib/private/share20/share.php
+++ b/lib/private/share20/share.php
@@ -163,6 +163,7 @@ class Share implements \OCP\Share\IShare {
 		}
 
 		$this->nodeType = $type;
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
Two new hooks: share_link_access and post_update_password

and a bugfix, object instances cannot be compared with ===

Please review @rullzer @schiesbn @PVince81 
