### PR TITLE
Limit comment message to 1k chars

### DIFF
--- a/apps/dav/lib/comments/commentnode.php
+++ b/apps/dav/lib/comments/commentnode.php
@@ -24,9 +24,11 @@ namespace OCA\DAV\Comments;
 
 use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
+use OCP\Comments\MessageTooLongException;
 use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use Sabre\DAV\Exception\BadRequest;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\MethodNotAllowed;
 use Sabre\DAV\PropPatch;
@@ -168,6 +170,7 @@ class CommentNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 	 *
 	 * @param $propertyValue
 	 * @return bool
+	 * @throws BadRequest
 	 * @throws Forbidden
 	 */
 	public function updateComment($propertyValue) {
@@ -178,6 +181,10 @@ class CommentNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 			return true;
 		} catch (\Exception $e) {
 			$this->logger->logException($e, ['app' => 'dav/comments']);
+			if($e instanceof MessageTooLongException) {
+				$msg = 'Message exceeds allowed character limit of ';
+				throw new BadRequest($msg . IComment::MAX_MESSAGE_LENGTH, 0, $e);
+			}
 			return false;
 		}
 	}

--- a/apps/dav/lib/comments/commentsplugin.php
+++ b/apps/dav/lib/comments/commentsplugin.php
@@ -242,6 +242,9 @@ class CommentsPlugin extends ServerPlugin {
 			return $comment;
 		} catch (\InvalidArgumentException $e) {
 			throw new BadRequest('Invalid input values', 0, $e);
+		} catch (\OCP\Comments\MessageTooLongException $e) {
+			$msg = 'Message exceeds allowed character limit of ';
+			throw new BadRequest($msg . \OCP\Comments\IComment::MAX_MESSAGE_LENGTH, 0,	$e);
 		}
 	}
 

--- a/lib/private/comments/comment.php
+++ b/lib/private/comments/comment.php
@@ -22,6 +22,7 @@ namespace OC\Comments;
 
 use OCP\Comments\IComment;
 use OCP\Comments\IllegalIDChangeException;
+use OCP\Comments\MessageTooLongException;
 
 class Comment implements IComment {
 
@@ -184,13 +185,18 @@ class Comment implements IComment {
 	 *
 	 * @param string $message
 	 * @return IComment
+	 * @throws MessageTooLongException
 	 * @since 9.0.0
 	 */
 	public function setMessage($message) {
 		if(!is_string($message)) {
 			throw new \InvalidArgumentException('String expected.');
 		}
-		$this->data['message'] = trim($message);
+		$message = trim($message);
+		if(mb_strlen($message, 'UTF-8') > IComment::MAX_MESSAGE_LENGTH) {
+			throw new MessageTooLongException('Comment message must not exceed ' . IComment::MAX_MESSAGE_LENGTH . ' characters');
+		}
+		$this->data['message'] = $message;
 		return $this;
 	}
 

--- a/lib/public/comments/icomment.php
+++ b/lib/public/comments/icomment.php
@@ -29,6 +29,7 @@ namespace OCP\Comments;
  * @since 9.0.0
  */
 interface IComment {
+	const MAX_MESSAGE_LENGTH = 1000;
 
 	/**
 	 * returns the ID of the comment
@@ -119,8 +120,12 @@ interface IComment {
 	/**
 	 * sets the message of the comment and returns itself
 	 *
+	 * When the given message length exceeds MAX_MESSAGE_LENGTH an
+	 * MessageTooLongException shall be thrown.
+	 *
 	 * @param string $message
 	 * @return IComment
+	 * @throws MessageTooLongException
 	 * @since 9.0.0
 	 */
 	public function setMessage($message);

--- a/lib/public/comments/messagetoolongexception.php
+++ b/lib/public/comments/messagetoolongexception.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @author Arthur Schiwon <blizzz@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCP\Comments;
+
+/**
+ * Exception for not found entity
+ * @since 9.0.0
+ */
+class MessageTooLongException extends \Exception {}

--- a/lib/public/comments/messagetoolongexception.php
+++ b/lib/public/comments/messagetoolongexception.php
@@ -21,7 +21,7 @@
 namespace OCP\Comments;
 
 /**
- * Exception for not found entity
+ * Exception thrown when a comment message exceeds the allowed character limit
  * @since 9.0.0
  */
-class MessageTooLongException extends \Exception {}
+class MessageTooLongException extends \OverflowException {}

--- a/tests/lib/comments/comment.php
+++ b/tests/lib/comments/comment.php
@@ -2,6 +2,7 @@
 
 namespace Test\Comments;
 
+use OCP\Comments\IComment;
 use Test\TestCase;
 
 class Test_Comments_Comment extends TestCase
@@ -105,6 +106,15 @@ class Test_Comments_Comment extends TestCase
 		$comment = new \OC\Comments\Comment();
 		$setter = 'set' . $role;
 		$comment->$setter($type, $id);
+	}
+
+	/**
+	 * @expectedException \OCP\Comments\MessageTooLongException
+	 */
+	public function testSetUberlongMessage() {
+		$comment = new \OC\Comments\Comment();
+		$msg = str_pad('', IComment::MAX_MESSAGE_LENGTH + 1, 'x');
+		$comment->setMessage($msg);
 	}
 
 


### PR DESCRIPTION
Enforces that a provided message length is no longer than 1k characters. Backend companion to https://github.com/owncloud/core/pull/22163#issuecomment-180431700

Please review @PVince81 @icewind1991 @nickvergessen 
