### PR TITLE
Add info about share initiator to webview

### DIFF
--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -21,7 +21,7 @@
 			'        {{#if avatarEnabled}}' +
 			'        <div class="avatar {{#if modSeed}}imageplaceholderseed{{/if}}" data-username="{{shareWith}}" {{#if modSeed}}data-seed="{{shareWith}} {{shareType}}"{{/if}}></div>' +
 			'        {{/if}}' +
-			'        <span class="username">{{shareWithDisplayName}}</span>' +
+			'        <span class="username" title="{{sharedBy}}" >{{shareWithDisplayName}}</span>' +
 			'        {{#if mailNotificationEnabled}} {{#unless isRemoteShare}}' +
 			'        <input id="mail-{{cid}}-{{shareWith}}" type="checkbox" name="mailNotification" class="mailNotification checkbox" {{#if wasMailSent}}checked="checked"{{/if}} />' +
 			'        <label for="mail-{{cid}}-{{shareWith}}">{{notifyByMailLabel}}</label>' +
@@ -105,6 +105,17 @@
 			var shareWith = this.model.getShareWith(shareIndex);
 			var shareWithDisplayName = this.model.getShareWithDisplayName(shareIndex);
 			var shareType = this.model.getShareType(shareIndex);
+			var owner = this.model.getShareOwner(shareIndex);
+			var ownerDisplayName = this.model.getShareOwnerDisplayName(shareIndex);
+			var initiator = this.model.getShareInitiator(shareIndex);
+			var initiatorDisplayName = this.model.getShareInitiatorDisplayName(shareIndex);
+
+			var sharedBy;
+			if (owner === initiator) {
+				sharedBy = t('core', 'shared by you');
+			} else {
+				sharedBy = t('core', 'shared by {initiator}', {initiator: initiatorDisplayName});
+			}
 
 			var hasPermissionOverride = {};
 			if (shareType === OC.Share.SHARE_TYPE_GROUP) {
@@ -127,6 +138,11 @@
 				wasMailSent: this.model.notificationMailWasSent(shareIndex),
 				shareWith: shareWith,
 				shareWithDisplayName: shareWithDisplayName,
+				owner: owner,
+				ownerDisplayName: ownerDisplayName,
+				initiator: initiator,
+				initiatorDisplayName: initiatorDisplayName,
+				sharedBy: sharedBy,
 				shareType: shareType,
 				shareId: this.model.get('shares')[shareIndex].id,
 				modSeed: shareType !== OC.Share.SHARE_TYPE_USER,

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -46,6 +46,10 @@
 	 * @property {string} mail_send
 	 * @property {Date} expiration optional?
 	 * @property {number} stime optional?
+	 * @property {string} uid_file_owner
+	 * @property {string} displayname_file_owner
+	 * @property {string} uid_owner
+	 * @property {string} displayname_owner
 	 */
 
 	/**
@@ -387,6 +391,58 @@
 				throw "Unknown Share";
 			}
 			return share.share_with_displayname;
+		},
+
+		/**
+		 * @param shareIndex
+		 * @returns {number}
+		 */
+		getShareOwner: function(shareIndex) {
+			/** @type OC.Share.Types.ShareInfo **/
+			var share = this.get('shares')[shareIndex];
+			if(!_.isObject(share)) {
+				throw "Unknown Share";
+			}
+			return share.uid_file_owner;
+		},
+
+		/**
+		 * @param shareIndex
+		 * @returns {number}
+		 */
+		getShareOwnerDisplayName: function(shareIndex) {
+			/** @type OC.Share.Types.ShareInfo **/
+			var share = this.get('shares')[shareIndex];
+			if(!_.isObject(share)) {
+				throw "Unknown Share";
+			}
+			return share.displayname_file_owner;
+		},
+
+		/**
+		 * @param shareIndex
+		 * @returns {number}
+		 */
+		getShareInitiator: function(shareIndex) {
+			/** @type OC.Share.Types.ShareInfo **/
+			var share = this.get('shares')[shareIndex];
+			if(!_.isObject(share)) {
+				throw "Unknown Share";
+			}
+			return share.uid_owner;
+		},
+
+		/**
+		 * @param shareIndex
+		 * @returns {number}
+		 */
+		getShareInitiatorDisplayName: function(shareIndex) {
+			/** @type OC.Share.Types.ShareInfo **/
+			var share = this.get('shares')[shareIndex];
+			if(!_.isObject(share)) {
+				throw "Unknown Share";
+			}
+			return share.displayname_owner;
 		},
 
 		getShareType: function(shareIndex) {


### PR DESCRIPTION
Since the owner now always has the entire overview of the recipients of a share. We should somehow show this info.

@owncloud/designers please have a look.

For some reason my mouse pointer was not captured. But it is hovering over the displayname:
![1](https://cloud.githubusercontent.com/assets/45821/12911150/938c91f0-cf10-11e5-87ce-6d79aed9b357.png)
![2](https://cloud.githubusercontent.com/assets/45821/12911151/9390719e-cf10-11e5-961c-e17cab5720e6.png)

CC: @PVince81 @nickvergessen @MorrisJobke @schiesbn
