### PR TITLE
Fix system tag filter AND condition

### DIFF
--- a/apps/dav/lib/connector/sabre/filesreportplugin.php
+++ b/apps/dav/lib/connector/sabre/filesreportplugin.php
@@ -211,7 +211,7 @@ class FilesReportPlugin extends ServerPlugin {
 	 */
 	public function processFilterRules($filterRules) {
 		$ns = '{' . $this::NS_OWNCLOUD . '}';
-		$resultFileIds = [];
+		$resultFileIds = null;
 		$systemTagIds = [];
 		foreach ($filterRules as $filterRule) {
 			if ($filterRule['name'] === $ns . 'systemtag') {
@@ -240,14 +240,20 @@ class FilesReportPlugin extends ServerPlugin {
 			$fileIds = $this->tagMapper->getObjectIdsForTags($systemTagId, 'files');
 
 			if (empty($fileIds)) {
+				// This tag has no files, nothing can ever show up
 				return [];
 			}
 
 			// first run ?
-			if (empty($resultFileIds)) {
+			if ($resultFileIds === null) {
 				$resultFileIds = $fileIds;
 			} else {
 				$resultFileIds = array_intersect($resultFileIds, $fileIds);
+			}
+
+			if (empty($resultFileIds)) {
+				// Empty intersection, nothing can show up anymore
+				return [];
 			}
 		}
 		return $resultFileIds;

--- a/apps/dav/lib/connector/sabre/filesreportplugin.php
+++ b/apps/dav/lib/connector/sabre/filesreportplugin.php
@@ -239,6 +239,11 @@ class FilesReportPlugin extends ServerPlugin {
 		foreach ($systemTagIds as $systemTagId) {
 			$fileIds = $this->tagMapper->getObjectIdsForTags($systemTagId, 'files');
 
+			if (empty($fileIds)) {
+				return [];
+			}
+
+			// first run ?
 			if (empty($resultFileIds)) {
 				$resultFileIds = $fileIds;
 			} else {

--- a/apps/dav/tests/unit/connector/sabre/filesreportplugin.php
+++ b/apps/dav/tests/unit/connector/sabre/filesreportplugin.php
@@ -395,6 +395,28 @@ class FilesReportPlugin extends \Test\TestCase {
 		$this->assertEquals(['222'], array_values($this->plugin->processFilterRules($rules)));
 	}
 
+	public function testProcessFilterRulesAndConditionWithOneEmptyResult() {
+		$this->groupManager->expects($this->any())
+			->method('isAdmin')
+			->will($this->returnValue(true));
+
+		$this->tagMapper->expects($this->at(0))
+			->method('getObjectIdsForTags')
+			->with('123')
+			->will($this->returnValue(['111', '222']));
+		$this->tagMapper->expects($this->at(1))
+			->method('getObjectIdsForTags')
+			->with('456')
+			->will($this->returnValue([]));
+
+		$rules = [
+			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '123'],
+			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '456'],
+		];
+
+		$this->assertEquals([], array_values($this->plugin->processFilterRules($rules)));
+	}
+
 	public function testProcessFilterRulesInvisibleTagAsAdmin() {
 		$this->groupManager->expects($this->any())
 			->method('isAdmin')


### PR DESCRIPTION
If one of the results is empty, no need to do array_intersect and return
an empty result directly.

Fixes issue when filtering by a tag that has no results together with another tag that has results (AND condition)

Please review @nickvergessen @rullzer @blizzz @icewind1991 
