### PR TITLE
Move update notification code into app

### DIFF
--- a/apps/updatenotification/appinfo/app.php
+++ b/apps/updatenotification/appinfo/app.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @author Lukas Reschke <lukas@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+if(\OC::$server->getConfig()->getSystemValue('updatechecker', true) === true) {
+	$updater = new \OC\Updater(
+		\OC::$server->getHTTPHelper(),
+		\OC::$server->getConfig(),
+		\OC::$server->getIntegrityCodeChecker()
+	);
+	$updateChecker = new \OCA\UpdateNotification\UpdateChecker(
+		$updater
+	);
+
+	$userObject = \OC::$server->getUserSession()->getUser();
+	if($userObject !== null) {
+		if(\OC::$server->getGroupManager()->isAdmin($userObject->getUID()) && $updateChecker->getUpdateState() !== []) {
+			\OCP\Util::addScript('updatenotification', 'notification');
+			OC_Hook::connect('\OCP\Config', 'js', $updateChecker, 'getJavaScript');
+		}
+	}
+}

--- a/apps/updatenotification/appinfo/info.xml
+++ b/apps/updatenotification/appinfo/info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<info>
+	<id>updatenotification</id>
+	<name>Update notification</name>
+	<description>Displays update notifications for ownCloud.</description>
+	<licence>AGPL</licence>
+	<author>Lukas Reschke</author>
+	<version>0.1.0</version>
+	<default_enable/>
+	<dependencies>
+		<owncloud min-version="9.0" max-version="9.0" />
+	</dependencies>
+</info>

--- a/apps/updatenotification/js/notification.js
+++ b/apps/updatenotification/js/notification.js
@@ -15,8 +15,8 @@
  */
 $(document).ready(function(){
 	var head = $('html > head'),
-		version = head.data('update-version'),
-		docLink = head.data('update-link'),
+		version = oc_updateState.updateVersion,
+		docLink = oc_updateState.updateLink,
 		text = t('core', '{version} is available. Get more information on how to update.', {version: version}),
 		element = $('<a>').attr('href', docLink).text(text);
 

--- a/apps/updatenotification/lib/updatechecker.php
+++ b/apps/updatenotification/lib/updatechecker.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @author Lukas Reschke <lukas@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\UpdateNotification;
+
+use OC\Updater;
+
+class UpdateChecker {
+	/** @var Updater */
+	private $updater;
+
+	/**
+	 * @param Updater $updater
+	 */
+	public function __construct(Updater $updater) {
+		$this->updater = $updater;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getUpdateState() {
+		$data = $this->updater->check();
+		$result = [];
+
+		if(isset($data['version']) && $data['version'] !== '' && $data['version'] !== []) {
+			$result['updateAvailable'] = true;
+			$result['updateVersion'] = $data['versionstring'];
+			if(substr($data['web'], 0, 8) === 'https://') {
+				$result['updateLink'] = $data['web'];
+			}
+
+			return $result;
+		}
+
+		return [];
+	}
+
+	/**
+	 * @param array $data
+	 */
+	public function getJavaScript(array $data) {
+		$data['array']['oc_updateState'] =  json_encode([
+			'updateAvailable' => true,
+			'updateVersion' => $this->getUpdateState()['updateVersion'],
+			'updateLink' => isset($this->getUpdateState()['updateLink']) ? $this->getUpdateState()['updateLink'] : '',
+		]);
+	}
+}

--- a/apps/updatenotification/tests/UpdateCheckerTest.php
+++ b/apps/updatenotification/tests/UpdateCheckerTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @author Lukas Reschke <lukas@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\UpdateNotification\Tests;
+
+use OC\Updater;
+use OCA\UpdateNotification\UpdateChecker;
+use Test\TestCase;
+
+class UpdateCheckerTest extends TestCase {
+	/** @var Updater */
+	private $updater;
+	/** @var UpdateChecker */
+	private $updateChecker;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->updater = $this->getMockBuilder('\OC\Updater')
+			->disableOriginalConstructor()->getMock();
+		$this->updateChecker = new UpdateChecker($this->updater);
+	}
+
+	public function testGetUpdateStateWithUpdateAndInvalidLink() {
+		$this->updater
+			->expects($this->once())
+			->method('check')
+			->willReturn([
+				'version' => 123,
+				'versionstring' => 'ownCloud 123',
+				'web'=> 'javascript:alert(1)',
+			]);
+
+		$expected = [
+			'updateAvailable' => true,
+			'updateVersion' => 'ownCloud 123',
+		];
+		$this->assertSame($expected, $this->updateChecker->getUpdateState());
+	}
+
+	public function testGetUpdateStateWithUpdateAndValidLink() {
+		$this->updater
+			->expects($this->once())
+			->method('check')
+			->willReturn([
+				'version' => 123,
+				'versionstring' => 'ownCloud 123',
+				'web'=> 'https://owncloud.org/myUrl',
+			]);
+
+		$expected = [
+			'updateAvailable' => true,
+			'updateVersion' => 'ownCloud 123',
+			'updateLink' => 'https://owncloud.org/myUrl',
+		];
+		$this->assertSame($expected, $this->updateChecker->getUpdateState());
+	}
+
+	public function testGetUpdateStateWithoutUpdate() {
+		$this->updater
+			->expects($this->once())
+			->method('check')
+			->willReturn([]);
+
+		$expected = [];
+		$this->assertSame($expected, $this->updateChecker->getUpdateState());
+	}
+}

--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -291,6 +291,7 @@ Feature: provisioning
 			| files_versions |
 			| provisioning_api |
 			| systemtags |
+			| updatenotification |
 
 	Scenario: get app info
 		Given As an "admin"

--- a/core/shipped.json
+++ b/core/shipped.json
@@ -31,7 +31,7 @@
     "sharepoint",
     "systemtags",
     "templateeditor",
-    "updater",
+    "updatenotification",
     "user_external",
     "user_ldap",
     "user_shibboleth",

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -2,11 +2,7 @@
 <!--[if lte IE 8]><html class="ng-csp ie ie8 lte9 lte8" data-placeholder-focus="false" lang="<?php p($_['language']); ?>" ><![endif]-->
 <!--[if IE 9]><html class="ng-csp ie ie9 lte9" data-placeholder-focus="false" lang="<?php p($_['language']); ?>" ><![endif]-->
 <!--[if (gt IE 9)|!(IE)]><!--><html class="ng-csp" data-placeholder-focus="false" lang="<?php p($_['language']); ?>" ><!--<![endif]-->
-	<head data-user="<?php p($_['user_uid']); ?>" data-user-displayname="<?php p($_['user_displayname']); ?>" data-requesttoken="<?php p($_['requesttoken']); ?>"
-		<?php if ($_['updateAvailable']): ?>
-			data-update-version="<?php p($_['updateVersion']); ?>" data-update-link="<?php p($_['updateLink']); ?>"
-		<?php endif; ?>
-		>
+	<head data-user="<?php p($_['user_uid']); ?>" data-user-displayname="<?php p($_['user_displayname']); ?>" data-requesttoken="<?php p($_['requesttoken']); ?>">
 		<meta charset="utf-8">
 		<title>
 			<?php

--- a/lib/private/templatelayout.php
+++ b/lib/private/templatelayout.php
@@ -70,31 +70,6 @@ class TemplateLayout extends \OC_Template {
 				$this->assign('bodyid', 'body-user');
 			}
 
-			// Update notification
-			if($this->config->getSystemValue('updatechecker', true) === true &&
-				\OC_User::isAdminUser(\OC_User::getUser())) {
-				$updater = new \OC\Updater(
-						\OC::$server->getHTTPHelper(),
-						\OC::$server->getConfig(),
-						\OC::$server->getIntegrityCodeChecker(),
-						\OC::$server->getLogger()
-				);
-				$data = $updater->check();
-
-				if(isset($data['version']) && $data['version'] != '' and $data['version'] !== Array()) {
-					$this->assign('updateAvailable', true);
-					$this->assign('updateVersion', $data['versionstring']);
-					if(substr($data['web'], 0, 8) === 'https://') {
-						$this->assign('updateLink', $data['web']);
-					}
-					\OCP\Util::addScript('core', 'update-notification');
-				} else {
-					$this->assign('updateAvailable', false); // No update available or not an admin user
-				}
-			} else {
-				$this->assign('updateAvailable', false); // Update check is disabled
-			}
-
 			// Code integrity notification
 			$integrityChecker = \OC::$server->getIntegrityCodeChecker();
 			if(!$integrityChecker->hasPassedCheck()) {


### PR DESCRIPTION
Moves the update notification code in a single app. This is required since we want to use SSO for the new updater and for this have some code running in ownCloud as well (and we don't want that in core necessarily). This app can provide that in the future, right now it's only the update notification itself. Will continue working on the SSO right away but wanted to keep the PR small.

Furthermore also makes some more code unit-testable...

This is for the following bar in the top: 
![2016-02-09_13-05-26](https://cloud.githubusercontent.com/assets/878997/12915853/44183c8c-cf2e-11e5-97a6-2c7c787e0508.png)

@karlitschek @VicDeo @DeepDiver1975 Please review.
