### PR TITLE
Hide updater.secret from occ output by default

### DIFF
--- a/lib/private/systemconfig.php
+++ b/lib/private/systemconfig.php
@@ -41,6 +41,7 @@ class SystemConfig {
 		'mail_smtppassword' => true,
 		'passwordsalt' => true,
 		'secret' => true,
+		'updater.secret' => true,
 		'ldap_agent_password' => true,
 		'objectstore' => ['arguments' => ['password' => true]],
 	];


### PR DESCRIPTION
We should not have people post that value to us.

@karlitschek @VicDeo 
