### PR TITLE
use the correct version of the encrypted file

### DIFF
--- a/apps/encryption/lib/crypto/encryption.php
+++ b/apps/encryption/lib/crypto/encryption.php
@@ -236,7 +236,7 @@ class Encryption implements IEncryptionModule {
 			} else {
 				$version = $this->version + 1;
 			}
-			$this->keyManager->setVersion($this->path, $this->version+1, new View());
+			$this->keyManager->setVersion($this->path, $version, new View());
 			if (!empty($this->writeCache)) {
 				$result = $this->crypt->symmetricEncryptFileContent($this->writeCache, $this->fileKey, $version, $position);
 				$this->writeCache = '';


### PR DESCRIPTION
I have no concrete bug for this. All tests I did work before and after this change, still I think that this is the right behavior.

see this PR/discussion for more details and how the bug was introduced: https://github.com/owncloud/core/pull/21557#discussion_r52384938

cc @PVince81 @LukasReschke 
