### PR TITLE
[stable8.2] occ command can only be called from ownCloud root directory

### DIFF
--- a/console.php
+++ b/console.php
@@ -64,6 +64,16 @@ try {
 		}
 	}
 
+	$oldWorkingDir = getcwd();
+	if ($oldWorkingDir === false) {
+		echo "This script can be run from the ownCloud root directory only." . PHP_EOL;
+		echo "Can't determine current working dir - the script will continue to work but be aware of the above fact." . PHP_EOL;
+	} else if ($oldWorkingDir !== __DIR__ && !chdir(__DIR__)) {
+		echo "This script can be run from the ownCloud root directory only." . PHP_EOL;
+		echo "Can't change to ownCloud root diretory." . PHP_EOL;
+		exit(1);
+	}
+
 	$application = new Application(\OC::$server->getConfig());
 	$application->loadCommands(new ConsoleOutput());
 	$application->run();


### PR DESCRIPTION
- this changes into the ownCloud root directory and then should run just fine
- avoids weird error messages that are caused by this
- backport of #21251 
- approval in https://github.com/owncloud/core/pull/21251#issuecomment-181532097

@PVince81 @dragotin @nickvergessen @LukasReschke Please review
