### PR TITLE
Only show link spinner if the share exists

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -139,8 +139,8 @@
 					this.$el.find('.linkPassText').focus();
 				}
 			} else {
-				$loading.removeClass('hidden');
 				if (this.model.get('linkShare').isLinkShare) {
+					$loading.removeClass('hidden');
 					this.model.removeLinkShare();
 				} else {
 					this.$el.find('.linkPass').slideToggle(OC.menuSpeed);


### PR DESCRIPTION
1. password enforced
2. toggle link share
3. do not enter password but toggle link share again.

In this case there is no share. So we just remove the fields. But we should also not show the spinner as we are not waiting for the server.

Fixes #21726

CC:  @Woodwergs @davitol @PVince81 @MorrisJobke @nickvergessen 
