### PR TITLE
Fix versions path as share recipient when different than owner path

### DIFF
--- a/apps/files_versions/ajax/getVersions.php
+++ b/apps/files_versions/ajax/getVersions.php
@@ -41,6 +41,11 @@ if( $versions ) {
 
 	$versions = array_slice($versions, $start, $count);
 
+	// remove owner path from request to not disclose it to the recipient
+	foreach ($versions as $version) {
+		unset($version['path']);
+	}
+
 	\OCP\JSON::success(array('data' => array('versions' => $versions, 'endReached' => $endReached)));
 
 } else {

--- a/apps/files_versions/js/versioncollection.js
+++ b/apps/files_versions/js/versioncollection.js
@@ -73,12 +73,13 @@
 		},
 
 		parse: function(result) {
+			var fullPath = this._fileInfo.getFullPath();
 			var results = _.map(result.data.versions, function(version) {
 				var revision = parseInt(version.version, 10);
 				return {
 					id: revision,
 					name: version.name,
-					fullPath: version.path,
+					fullPath: fullPath,
 					timestamp: revision,
 					size: version.size
 				};


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/22073

Note: I didn't want to change the value of "path" from owner's path to recipient's path in the versions API because that one is also used internally for other callers of `getVersions()`. So best is to leave the stuff working as it did and use the recipient's path where we already know it.

Please review @rullzer @schiesbn @LukasReschke @nickvergessen @MorrisJobke 

Note: this will need a backport to 8.2
