### PR TITLE
Harden updater authentication

### DIFF
--- a/apps/updatenotification/controller/admincontroller.php
+++ b/apps/updatenotification/controller/admincontroller.php
@@ -77,8 +77,8 @@ class AdminController extends Controller {
 		$this->config->setAppValue('core', 'updater.secret.created', $this->timeFactory->getTime());
 
 		// Create a new token
-		$newToken = $this->secureRandom->generate(32);
-		$this->config->setSystemValue('updater.secret', $newToken);
+		$newToken = $this->secureRandom->generate(64);
+		$this->config->setSystemValue('updater.secret', password_hash($newToken, PASSWORD_DEFAULT));
 
 		return new DataResponse($newToken);
 	}

--- a/apps/updatenotification/lib/resettokenbackgroundjob.php
+++ b/apps/updatenotification/lib/resettokenbackgroundjob.php
@@ -67,7 +67,8 @@ class ResetTokenBackgroundJob extends TimedJob {
 	 * @param $argument
 	 */
 	protected function run($argument) {
-		if($this->timeFactory->getTime() - $this->config->getAppValue('core', 'updater.secret.created', $this->timeFactory->getTime()) >= 86400) {
+		// Delete old tokens after 2 days
+		if($this->timeFactory->getTime() - $this->config->getAppValue('core', 'updater.secret.created', $this->timeFactory->getTime()) >= 172800) {
 			$this->config->deleteSystemValue('updater.secret');
 		}
 	}

--- a/apps/updatenotification/tests/controller/AdminControllerTest.php
+++ b/apps/updatenotification/tests/controller/AdminControllerTest.php
@@ -77,12 +77,12 @@ class AdminControllerTest extends TestCase {
 		$this->secureRandom
 			->expects($this->once())
 			->method('generate')
-			->with(32)
+			->with(64)
 			->willReturn('MyGeneratedToken');
 		$this->config
 			->expects($this->once())
 			->method('setSystemValue')
-			->with('updater.secret', 'MyGeneratedToken');
+			->with('updater.secret');
 		$this->timeFactory
 			->expects($this->once())
 			->method('getTime')


### PR DESCRIPTION
- Reset tokens after 2 days
- Used BCrypt for storing the password in the config.php. This makes it substantially harder in case of a leakage of the token to bruteforce it. In the future we can evaluate also an HMAC including the IP. That's a bit tricker though at the moment considering that we support reverse proxies. Didn't feel brave enough to touch that dragon now as well ;)

Reason behind this that if somebody is able to read the config file somehow this won't immediately result in a RCE.

<hr/>

Requires https://github.com/owncloud/updater/pull/239
