### PR TITLE
scan the file in the write lock when uploading over dav

### DIFF
--- a/apps/dav/lib/connector/sabre/file.php
+++ b/apps/dav/lib/connector/sabre/file.php
@@ -450,10 +450,10 @@ class File extends Node implements IFile {
 					}
 				}
 
-				$this->fileView->changeLock($targetPath, ILockingProvider::LOCK_SHARED);
-
 				// since we skipped the view we need to scan and emit the hooks ourselves
 				$targetStorage->getUpdater()->update($targetInternalPath);
+
+				$this->fileView->changeLock($targetPath, ILockingProvider::LOCK_SHARED);
 
 				$this->emitPostHooks($exists, $targetPath);
 

--- a/apps/dav/lib/connector/sabre/file.php
+++ b/apps/dav/lib/connector/sabre/file.php
@@ -194,14 +194,14 @@ class File extends Node implements IFile {
 				}
 			}
 
+			// since we skipped the view we need to scan and emit the hooks ourselves
+			$storage->getUpdater()->update($internalPath);
+
 			try {
 				$this->changeLock(ILockingProvider::LOCK_SHARED);
 			} catch (LockedException $e) {
 				throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 			}
-
-			// since we skipped the view we need to scan and emit the hooks ourselves
-			$storage->getUpdater()->update($internalPath);
 
 			if ($view) {
 				$this->emitPostHooks($exists);


### PR DESCRIPTION
Currently there is a slight chance that a different process might trigger the scan before the upload process got the time do to it.

Note that we can do this within the exclusive lock only since the scan trigger from `Updater->update` explicitly does _not_ acquire another read lock

Should probably be backported to 8.2.x once properly tested

cc @PVince81 @schiesbn 
