### PR TITLE
Revert back to non-webdav download link for public URLs

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -154,9 +154,6 @@ OCA.Sharing.PublicApp = {
 			// TODO: move this to a separate PublicFileList class that extends OCA.Files.FileList (+ unit tests)
 			this.fileList.getDownloadUrl = function (filename, dir, isDir) {
 				var path = dir || this.getCurrentDirectory();
-				if (filename && !_.isArray(filename) && !isDir) {
-					return OC.getProtocol() + '://' + token + '@' + OC.getHost() + OC.getRootPath() + '/public.php/webdav' + OC.joinPaths(path, filename);
-				}
 				if (_.isArray(filename)) {
 					filename = JSON.stringify(filename);
 				}

--- a/apps/files_sharing/tests/js/publicAppSpec.js
+++ b/apps/files_sharing/tests/js/publicAppSpec.js
@@ -102,12 +102,12 @@ describe('OCA.Sharing.PublicApp tests', function() {
 
 			it('returns correct download URL for single files', function() {
 				expect(fileList.getDownloadUrl('some file.txt'))
-					.toEqual('https://sh4tok@example.com:9876/owncloud/public.php/webdav/subdir/some file.txt');
-				expect(fileList.getDownloadUrl('some file.txt', '/another path/abc'))
-					.toEqual('https://sh4tok@example.com:9876/owncloud/public.php/webdav/another path/abc/some file.txt');
+					.toEqual(OC.webroot + '/index.php/s/sh4tok/download?path=%2Fsubdir&files=some%20file.txt');
+				expect(fileList.getDownloadUrl('some file.txt', '/anotherpath/abc'))
+					.toEqual(OC.webroot + '/index.php/s/sh4tok/download?path=%2Fanotherpath%2Fabc&files=some%20file.txt');
 				fileList.changeDirectory('/');
 				expect(fileList.getDownloadUrl('some file.txt'))
-					.toEqual('https://sh4tok@example.com:9876/owncloud/public.php/webdav/some file.txt');
+					.toEqual(OC.webroot + '/index.php/s/sh4tok/download?path=%2F&files=some%20file.txt');
 			});
 			it('returns correct download URL for multiple files', function() {
 				expect(fileList.getDownloadUrl(['a b c.txt', 'd e f.txt']))


### PR DESCRIPTION
Fixes issues with browsers not happy with the token.
Fixes activities which were not sent.

@nickvergessen @oparoz @MorrisJobke @DeepDiver1975 @icewind1991 @schiesbn @rullzer 

Ref https://github.com/owncloud/core/issues/21787#issuecomment-182507143
Should hopefully fix https://github.com/owncloud/core/issues/22296 @oparoz 
