### PR TITLE
Calculate the share statuses in js from the OCS Response

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -122,6 +122,10 @@
 				}
 			});
 
+			fileList.$el.on('changeDirectory', function() {
+				OCA.Sharing.sharesLoaded = false;
+			});
+
 			fileActions.registerAction({
 				name: 'Share',
 				displayName: '',

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -50,12 +50,18 @@ OC.Share = _.extend(OC.Share || {}, {
 	 * @param callback function to call after the shares were loaded
 	 */
 	loadIcons:function(itemType, fileList, callback) {
+		var path = fileList.dirInfo.path;
+		if (path === '/') {
+			path = '';
+		}
+		path += '/' + fileList.dirInfo.name;
+
 		// Load all share icons
 		$.get(
 			OC.linkToOCS('apps/files_sharing/api/v1', 2) + 'shares',
 			{
 				subfiles: 'true',
-				path: fileList.dirInfo.path,
+				path: path,
 				format: 'json'
 			}, function(result) {
 				if (result && result.ocs.meta.statuscode === 200) {

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -52,15 +52,21 @@ OC.Share = _.extend(OC.Share || {}, {
 	loadIcons:function(itemType, fileList, callback) {
 		// Load all share icons
 		$.get(
-			OC.filePath('core', 'ajax', 'share.php'),
+			OC.linkToOCS('apps/files_sharing/api/v1', 2) + 'shares',
 			{
-				fetch: 'getItemsSharedStatuses',
-				itemType: itemType
+				subfiles: 'true',
+				path: fileList.dirInfo.path,
+				format: 'json'
 			}, function(result) {
-				if (result && result.status === 'success') {
+				if (result && result.ocs.meta.statuscode === 200) {
 					OC.Share.statuses = {};
-					$.each(result.data, function(item, data) {
-						OC.Share.statuses[item] = data;
+					$.each(result.ocs.data, function(it, share) {
+						if (!(share.item_source in OC.Share.statuses)) {
+							OC.Share.statuses[share.item_source] = {link: false};
+						}
+						if (share.share_type === OC.Share.SHARE_TYPE_LINK) {
+							OC.Share.statuses[share.item_source] = {link: true};
+						}
 					});
 					if (_.isFunction(callback)) {
 						callback(OC.Share.statuses);


### PR DESCRIPTION
Fixes #22298 

Right now this is only done on page load. We should do it on each directory traversal.

@PVince81 can you help out?
