### PR TITLE
Remove notification on unshare and on errors

### DIFF
--- a/apps/files_sharing/api/remote.php
+++ b/apps/files_sharing/api/remote.php
@@ -67,6 +67,9 @@ class Remote {
 			return new \OC_OCS_Result();
 		}
 
+		// Make sure the user has no notification for something that does not exist anymore.
+		$externalManager->processNotification((int) $params['id']);
+
 		return new \OC_OCS_Result(null, 404, "wrong share ID, share doesn't exist.");
 	}
 
@@ -90,12 +93,15 @@ class Remote {
 			return new \OC_OCS_Result();
 		}
 
+		// Make sure the user has no notification for something that does not exist anymore.
+		$externalManager->processNotification((int) $params['id']);
+
 		return new \OC_OCS_Result(null, 404, "wrong share ID, share doesn't exist.");
 	}
 
 	/**
 	 * @param array $share Share with info from the share_external table
-	 * @return enriched share info with data from the filecache
+	 * @return array enriched share info with data from the filecache
 	 */
 	private static function extendShareInfo($share) {
 		$view = new \OC\Files\View('/' . \OC_User::getUser() . '/files/');

--- a/apps/files_sharing/api/server2server.php
+++ b/apps/files_sharing/api/server2server.php
@@ -225,6 +225,13 @@ class Server2Server {
 				$path = trim($share['name'], '/');
 			}
 
+			$notificationManager = \OC::$server->getNotificationManager();
+			$notification = $notificationManager->createNotification();
+			$notification->setApp('files_sharing')
+				->setUser($share['user'])
+				->setObject('remote_share', (int) $share['id']);
+			$notificationManager->markProcessed($notification);
+
 			\OC::$server->getActivityManager()->publishActivity(
 				Activity::FILES_SHARING_APP, Activity::SUBJECT_REMOTE_SHARE_UNSHARED, array($owner, $path), '', array(),
 				'', '', $user, Activity::TYPE_REMOTE_SHARE, Activity::PRIORITY_MEDIUM);

--- a/apps/files_sharing/lib/external/manager.php
+++ b/apps/files_sharing/lib/external/manager.php
@@ -194,7 +194,7 @@ class Manager {
 
 			\OC_Hook::emit('OCP\Share', 'federated_share_added', ['server' => $share['remote']]);
 
-			$this->scrapNotification($id);
+			$this->processNotification($id);
 			return true;
 		}
 
@@ -217,7 +217,7 @@ class Manager {
 			$removeShare->execute(array($id, $this->uid));
 			$this->sendFeedbackToRemote($share['remote'], $share['share_token'], $share['remote_id'], 'decline');
 
-			$this->scrapNotification($id);
+			$this->processNotification($id);
 			return true;
 		}
 
@@ -227,7 +227,7 @@ class Manager {
 	/**
 	 * @param int $remoteShare
 	 */
-	protected function scrapNotification($remoteShare) {
+	public function processNotification($remoteShare) {
 		$filter = $this->notificationManager->createNotification();
 		$filter->setApp('files_sharing')
 			->setUser($this->uid)


### PR DESCRIPTION
### Steps
1. Remote share a file to user test
2. Unshare the remote
3. As test check notifications
### Expected

Nothing
### Actual

Remote share notification for unexisting share

Now try to press any action-button, the notification is dismissed, but comes back with the next polling (30secs). This is fixed with the first commit.
Second commit removes the notification on unshare, so the user doesn't even have to press any button.

@PVince81 @MorrisJobke @rullzer 
