### PR TITLE
Do not getShare in deleteShare, it's already there when deleting

### DIFF
--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -695,9 +695,9 @@ class Manager implements IManager {
 	 * @throws \InvalidArgumentException
 	 */
 	public function deleteShare(\OCP\Share\IShare $share) {
-		// Just to make sure we have all the info
+
 		try {
-			$share = $this->getShareById($share->getFullId());
+			$share->getFullId();
 		} catch (\UnexpectedValueException $e) {
 			throw new \InvalidArgumentException('Share does not have a full id');
 		}

--- a/tests/lib/share20/managertest.php
+++ b/tests/lib/share20/managertest.php
@@ -132,16 +132,10 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException \OCP\Share\Exceptions\ShareNotFound
+	 * @expectedException \InvalidArgumentException
 	 */
 	public function testDeleteNoShareId() {
-		$share = $this->getMock('\OCP\Share\IShare');
-
-		$share
-			->expects($this->once())
-			->method('getFullId')
-			->with()
-			->willReturn(null);
+		$share = $this->manager->newShare();
 
 		$this->manager->deleteShare($share);
 	}
@@ -181,7 +175,6 @@ class ManagerTest extends \Test\TestCase {
 			->setNode($path)
 			->setTarget('myTarget');
 
-		$manager->expects($this->once())->method('getShareById')->with('prov:42')->willReturn($share);
 		$manager->expects($this->once())->method('deleteChildren')->with($share);
 
 		$this->defaultProvider
@@ -261,7 +254,6 @@ class ManagerTest extends \Test\TestCase {
 
 		$this->rootFolder->expects($this->never())->method($this->anything());
 
-		$manager->expects($this->once())->method('getShareById')->with('prov:42')->willReturn($share);
 		$manager->expects($this->once())->method('deleteChildren')->with($share);
 
 		$this->defaultProvider
@@ -358,8 +350,6 @@ class ManagerTest extends \Test\TestCase {
 			->setNode($path)
 			->setTarget('myTarget3')
 			->setParent(43);
-
-		$manager->expects($this->once())->method('getShareById')->with('prov:42')->willReturn($share1);
 
 		$this->defaultProvider
 			->method('getChildren')


### PR DESCRIPTION
### Steps
1. Create a link share
2. Set Expire date
3. Manipulate DB to set the expire date to the past
4. Access share
### Expected

Message that share is expired
### Actual

500 - Server error
Problem: infinite recursion:

```
->getShare()
->deleteShare()
->getShare()
->deleteShare()
....
```

@rullzer said the get inside delete was for the transition phase and is not needed anymore

@PVince81 review
