### PR TITLE
Properly check for legacy methods on IShare objects

### DIFF
--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -720,7 +720,7 @@ class Manager implements IManager {
 				'itemSource' => $share->getNodeId(),
 				'shareType'  => $shareType,
 				'shareWith'  => $sharedWith,
-				'itemparent' => $share->getParent(),
+				'itemparent' => method_exists($share, 'getParent') ? $share->getParent() : '',
 				'uidOwner'   => $share->getSharedBy(),
 				'fileSource' => $share->getNodeId(),
 				'fileTarget' => $share->getTarget()

--- a/lib/private/share20/share.php
+++ b/lib/private/share20/share.php
@@ -321,7 +321,11 @@ class Share implements \OCP\Share\IShare {
 	}
 
 	/**
-	 * @inheritdoc
+	 * Set the parent of this share
+	 *
+	 * @param int parent
+	 * @return \OCP\Share\IShare
+	 * @deprecated The new shares do not have parents. This is just here for legacy reasons.
 	 */
 	public function setParent($parent) {
 		$this->parent = $parent;
@@ -329,7 +333,10 @@ class Share implements \OCP\Share\IShare {
 	}
 
 	/**
-	 * @inheritdoc
+	 * Get the parent of this share.
+	 *
+	 * @return int
+	 * @deprecated The new shares do not have parents. This is just here for legacy reasons.
 	 */
 	public function getParent() {
 		return $this->parent;


### PR DESCRIPTION
The new shares are completely without parents eventually. But for some
current legacy reasons the methods are still around. But we should
properly check for them when using them.

Fixes #22311

CC: @nickvergessen @PVince81 @schiesbn @MorrisJobke 
