### PR TITLE
Do not allow invisible link shares

### DIFF
--- a/lib/private/share20/defaultshareprovider.php
+++ b/lib/private/share20/defaultshareprovider.php
@@ -118,6 +118,10 @@ class DefaultShareProvider implements IShareProvider {
 			if ($share->getExpirationDate() !== null) {
 				$qb->setValue('expiration', $qb->createNamedParameter($share->getExpirationDate(), 'datetime'));
 			}
+
+			if (method_exists($share, 'getParent')) {
+				$qb->setValue('parent', $qb->createNamedParameter($share->getParent()));
+			}
 		} else {
 			throw new \Exception('invalid share type!');
 		}

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -415,6 +415,28 @@ class Manager implements IManager {
 	}
 
 	/**
+	 * To make sure we don't get invisible link shares we set the parent
+	 * of a link if it is a reshare. This is a quick word around
+	 * until we can properly display multiple link shares in the UI
+	 *
+	 * See: https://github.com/owncloud/core/issues/22295
+	 *
+	 * FIXME: Remove once multiple link shares can be properly displayed
+	 *
+	 * @param \OCP\Share\IShare $share
+	 */
+	protected function setLinkParent(\OCP\Share\IShare $share) {
+
+		// No sense in checking if the method is not there.
+		if (method_exists($share, 'setParent')) {
+			$storage = $share->getNode()->getStorage();
+			if ($storage->instanceOfStorage('\OCA\Files_Sharing\ISharedStorage')) {
+				$share->setParent($storage->getShareId());
+			}
+		};
+	}
+
+	/**
 	 * @param File|Folder $path
 	 */
 	protected function pathCreateChecks($path) {
@@ -470,6 +492,7 @@ class Manager implements IManager {
 			$this->groupCreateChecks($share);
 		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
 			$this->linkCreateChecks($share);
+			$this->setLinkParent($share);
 
 			/*
 			 * For now ignore a set token.

--- a/tests/lib/share20/managertest.php
+++ b/tests/lib/share20/managertest.php
@@ -1549,6 +1549,7 @@ class ManagerTest extends \Test\TestCase {
 				'pathCreateChecks',
 				'validateExpirationDate',
 				'verifyPassword',
+				'setLinkParent',
 			])
 			->getMock();
 
@@ -1589,6 +1590,9 @@ class ManagerTest extends \Test\TestCase {
 		$manager->expects($this->once())
 			->method('verifyPassword')
 			->with('password');
+		$manager->expects($this->once())
+			->method('setLinkParent')
+			->with($share);
 
 		$this->hasher->expects($this->once())
 			->method('hash')


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/22295

As described in https://github.com/owncloud/core/issues/22295#issuecomment-182531810

We set the parent for link shares (if there is any) to make sure that there won't be any leftover link shares possible.

This code will be removed again once we allow displaying multiple link shares in the UI.
