### PR TITLE
fix getNodeForPath for non existing part files

### DIFF
--- a/apps/dav/lib/connector/sabre/objecttree.php
+++ b/apps/dav/lib/connector/sabre/objecttree.php
@@ -136,7 +136,7 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			$mount = $this->fileView->getMount($path);
 			$storage = $mount->getStorage();
 			$internalPath = $mount->getInternalPath($absPath);
-			if ($storage) {
+			if ($storage && $storage->file_exists($internalPath)) {
 				/**
 				 * @var \OC\Files\Storage\Storage $storage
 				 */

--- a/tests/lib/files/storage/storage.php
+++ b/tests/lib/files/storage/storage.php
@@ -608,4 +608,10 @@ abstract class Storage extends \Test\TestCase {
 		$stat = $this->instance->stat('foo.txt');
 		$this->assertEquals(6, $stat['size']);
 	}
+
+	public function testPartFile() {
+		$this->instance->file_put_contents('bar.txt.part', 'bar');
+		$this->instance->rename('bar.txt.part', 'bar.txt');
+		$this->assertEquals('bar', $this->instance->file_get_contents('bar.txt'));
+	}
 }


### PR DESCRIPTION
Returning a "valid" node for a non existing file messed with the locking logic which broke uploading .part files to an oc webdav server.

Fixes #21927

cc @PVince81 @davitol 
