### PR TITLE
On backend hickups don't crash OCS output

### DIFF
--- a/apps/files_sharing/api/share20ocs.php
+++ b/apps/files_sharing/api/share20ocs.php
@@ -98,7 +98,7 @@ class Share20OCS {
 			'expiration' => null,
 			'token' => null,
 			'uid_file_owner' => $share->getShareOwner(),
-			'displayname_file_owner' => $shareOwner->getDisplayName(),
+			'displayname_file_owner' => $shareOwner !== null ? $shareOwner->getDisplayName() : $share->getShareOwner(),
 		];
 
 		$node = $share->getNode();
@@ -117,8 +117,8 @@ class Share20OCS {
 
 		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER) {
 			$sharedWith = $this->userManager->get($share->getSharedWith());
-			$result['share_with'] = $sharedWith->getUID();
-			$result['share_with_displayname'] = $sharedWith->getDisplayName();
+			$result['share_with'] = $share->getSharedWith();
+			$result['share_with_displayname'] = $sharedWith !== null ? $sharedWith->getDisplayName() : $share->getSharedWith();
 		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
 			$result['share_with'] = $share->getSharedWith();
 			$result['share_with_displayname'] = $share->getSharedWith();

--- a/apps/files_sharing/api/share20ocs.php
+++ b/apps/files_sharing/api/share20ocs.php
@@ -91,7 +91,7 @@ class Share20OCS {
 			'id' => $share->getId(),
 			'share_type' => $share->getShareType(),
 			'uid_owner' => $share->getSharedBy(),
-			'displayname_owner' => $sharedBy->getDisplayName(),
+			'displayname_owner' => $sharedBy !== null ? $sharedBy->getDisplayName() : $share->getSharedBy(),
 			'permissions' => $share->getPermissions(),
 			'stime' => $share->getShareTime()->getTimestamp(),
 			'parent' => null,


### PR DESCRIPTION
It can happen that the share initiator is deleted. Because of the new
resharing behaviour this share then still exists. We just can fetch the
displayname properly.

Example:
1. user1 shares foo with user2
2. user2 shares foo with user3
3. user2 is deleted from the system.

The share at 2 still existst (since we have flat shares). However fetching this from the OCS Share API used to give an error. Now it does not.

CC: @PVince81 @schiesbn @nickvergessen @MorrisJobke @LukasReschke 
