### PR TITLE
Remove updater switch documentation

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -460,12 +460,6 @@ $CONFIG = array(
 'appcodechecker' => true,
 
 /**
- * Check if ownCloud is up-to-date and shows a notification if a new version is
- * available.
- */
-'updatechecker' => true,
-
-/**
  * Is ownCloud connected to the Internet or running in a closed network?
  */
 'has_internet_connection' => true,


### PR DESCRIPTION
This can now be achieved by just disabling the `updatenotification` application. While it still respects this configuration flag we should in my opinion not advertise it anymore.

@karlitschek @DeepDiver1975 Thoughts?
