### PR TITLE
Touching a link share url should select the whole field

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -81,6 +81,7 @@
 			'keyup input.linkPassText': 'onPasswordKeyUp',
 			'click .linkCheckbox': 'onLinkCheckBoxChange',
 			'click .linkText': 'onLinkTextClick',
+			'touchstart .linkText': 'onLinkTextClick',
 			'change .publicUploadCheckbox': 'onAllowPublicUploadChange',
 			'click .showPasswordCheckbox': 'onShowPasswordClick'
 		},

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -150,9 +150,9 @@
 		},
 
 		onLinkTextClick: function() {
-			var $el = this.$el.find('.linkText');
+			var $el = this.$el.find('.linkText')[0];
 			$el.focus();
-			$el.select();
+			$el.setSelectionRange(0, $el.value.length);
 		},
 
 		onShowPasswordClick: function() {

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -207,19 +207,22 @@ describe('OC.Share.ShareDialogView', function() {
 			$('#allowShareWithLink').val('yes');
 
 			dialog.model.set('linkShare', {
-				isLinkShare: true
+				isLinkShare: true,
+				link: 'https://server.com/s/token'
 			});
 			dialog.render();
 
-			var focusStub = sinon.stub($.fn, 'focus');
-			var selectStub = sinon.stub($.fn, 'select');
-			dialog.$el.find('.linkText').click();
+			var linkText = dialog.$el.find('.linkText')[0];
+			var focusStub = sinon.stub(linkText, 'focus');
+			var setSelectionRangeStub = sinon.stub(linkText, 'setSelectionRange');
+			linkText.click();
 
 			expect(focusStub.calledOnce).toEqual(true);
-			expect(selectStub.calledOnce).toEqual(true);
+			expect(setSelectionRangeStub.calledOnce).toEqual(true);
+			expect(setSelectionRangeStub.args[0]).toEqual([0, 26]);
 
 			focusStub.restore();
-			selectStub.restore();
+			setSelectionRangeStub.restore();
 		});
 		describe('password', function() {
 			var slideToggleStub;


### PR DESCRIPTION
Fixes #22336

We did not have a touchstart event anymore. Added back now.
Tested on Android and that event is emitted.

@oparoz please verify it works on IOS as well.
