### PR TITLE
Add note if integrity check is disabled

### DIFF
--- a/lib/private/integritycheck/checker.php
+++ b/lib/private/integritycheck/checker.php
@@ -87,8 +87,6 @@ class Checker {
 	 * @return bool
 	 */
 	public function isCodeCheckEnforced() {
-		// FIXME: Once the signing server is instructed to sign daily, beta and
-		// RCs as well these need to be included also.
 		$signedChannels = [
 			'daily',
 			'testing',

--- a/settings/controller/checksetupcontroller.php
+++ b/settings/controller/checksetupcontroller.php
@@ -271,6 +271,10 @@ class CheckSetupController extends Controller {
 	 * @return DataResponse
 	 */
 	public function getFailedIntegrityCheckFiles() {
+		if(!$this->checker->isCodeCheckEnforced()) {
+			return new DataDisplayResponse('Integrity checker has been disabled. Integrity cannot be verified.');
+		}
+
 		$completeResults = $this->checker->getResults();
 
 		if(!empty($completeResults)) {

--- a/tests/settings/controller/CheckSetupControllerTest.php
+++ b/tests/settings/controller/CheckSetupControllerTest.php
@@ -618,7 +618,22 @@ class CheckSetupControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->checkSetupController->rescanFailedIntegrityCheck());
 	}
 
+	public function testGetFailedIntegrityCheckDisabled() {
+		$this->checker
+			->expects($this->once())
+			->method('isCodeCheckEnforced')
+			->willReturn(false);
+
+		$expected = new DataDisplayResponse('Integrity checker has been disabled. Integrity cannot be verified.');
+		$this->assertEquals($expected, $this->checkSetupController->getFailedIntegrityCheckFiles());
+	}
+
+
 	public function testGetFailedIntegrityCheckFilesWithNoErrorsFound() {
+		$this->checker
+			->expects($this->once())
+			->method('isCodeCheckEnforced')
+			->willReturn(true);
 		$this->checker
 			->expects($this->once())
 			->method('getResults')
@@ -635,6 +650,10 @@ class CheckSetupControllerTest extends TestCase {
 	}
 
 	public function testGetFailedIntegrityCheckFilesWithSomeErrorsFound() {
+		$this->checker
+			->expects($this->once())
+			->method('isCodeCheckEnforced')
+			->willReturn(true);
 		$this->checker
 				->expects($this->once())
 				->method('getResults')


### PR DESCRIPTION
Our issue template states that users should post the output of `/index.php/settings/integrity/failed`, at the moment it displays that all passes have been passed if the integrity checker has been disabled.

This is however a wrong approach considering that some distributions are gonna package Frankenstein releases and makes it harder for us to detect such issues. Thus if the integrity code checker is disabled (using the config switch)  it displays now: `Appcode checker has been disabled. Integrity cannot be verified.`

This is not displayed anywhere else in the UI except these URL used for us for debugging purposes.

This is in reaction to https://github.com/owncloud/core/issues/22313#issuecomment-183259328. I very much expect distributions to disable the integrity code checker. We should at least have it _VERY_ easy for us to detect such cases.

@karlitschek @DeepDiver1975 THX
