### PR TITLE
WebUI feedback when sharing

### DIFF
--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -233,8 +233,18 @@
 
 		_onSelectRecipient: function(e, s) {
 			e.preventDefault();
-			$(e.target).val('');
-			this.model.addShare(s.item.value);
+			$(e.target).attr('disabled', true)
+				.val(s.item.label);
+			var $loading = this.$el.find('.shareWithLoading');
+			$loading.removeClass('hidden')
+				.addClass('inlineblock');
+
+			this.model.addShare(s.item.value, {success: function() {
+				$(e.target).val('')
+					.attr('disabled', false);
+				$loading.addClass('hidden')
+					.removeClass('inlineblock');
+			}});
 		},
 
 		_toggleLoading: function(state) {

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -183,11 +183,9 @@
 				data: attributes,
 				dataType: 'json'
 			}).done(function() {
-				self.fetch({
-					success: function() {
-						if (_.isFunction(options.success)) {
-							options.success(self);
-						}
+				self.fetch().done(function() {
+					if (_.isFunction(options.success)) {
+						options.success(self);
 					}
 				});
 			}).fail(function(xhr) {

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -956,9 +956,12 @@ describe('OC.Share.ShareDialogView', function() {
 
 		it('calls addShare after selection', function() {
 			dialog.render();
+
+			var shareWith = $('.shareWithField')[0];
+			var $shareWith = $(shareWith);
 			var addShareStub = sinon.stub(shareModel, 'addShare');
 			var autocompleteOptions = autocompleteStub.getCall(0).args[0];
-			autocompleteOptions.select(new $.Event('select'), {
+			autocompleteOptions.select(new $.Event('select', {target: shareWith}), {
 				item: {
 					label: 'User Two',
 					value: {
@@ -973,6 +976,17 @@ describe('OC.Share.ShareDialogView', function() {
 				shareType: OC.Share.SHARE_TYPE_USER,
 				shareWith: 'user2'
 			});
+
+			//Input is locked
+			expect($shareWith.val()).toEqual('User Two');
+			expect($shareWith.attr('disabled')).toEqual('disabled');
+
+			//Callback is called
+			addShareStub.firstCall.args[1].success();
+
+			//Input is unlocked
+			expect($shareWith.val()).toEqual('');
+			expect($shareWith.attr('disabled')).toEqual(undefined);
 
 			addShareStub.restore();
 		});


### PR DESCRIPTION
Fixes #22304

The input field is locked and the spinner is shown.
All is unlocked once it is shared.

CC: @owncloud/designers @owncloud/javascript @nickvergessen 
