### PR TITLE
show remote server on federated share auto-complete

### DIFF
--- a/apps/files_sharing/api/sharees.php
+++ b/apps/files_sharing/api/sharees.php
@@ -279,6 +279,7 @@ class Sharees {
 					$cloudIds = [$cloudIds];
 				}
 				foreach ($cloudIds as $cloudId) {
+					list(, $serverUrl) = $this->splitUserRemote($cloudId);
 					if (strtolower($contact['FN']) === $search || strtolower($cloudId) === $search) {
 						if (strtolower($cloudId) === $search) {
 							$foundRemoteById = true;
@@ -288,6 +289,7 @@ class Sharees {
 							'value' => [
 								'shareType' => Share::SHARE_TYPE_REMOTE,
 								'shareWith' => $cloudId,
+								'server' => $serverUrl,
 							],
 						];
 					} else {
@@ -296,6 +298,7 @@ class Sharees {
 							'value' => [
 								'shareType' => Share::SHARE_TYPE_REMOTE,
 								'shareWith' => $cloudId,
+								'server' => $serverUrl,
 							],
 						];
 					}
@@ -318,6 +321,74 @@ class Sharees {
 		}
 
 		$this->reachedEndFor[] = 'remotes';
+	}
+
+	/**
+	 * split user and remote from federated cloud id
+	 *
+	 * @param string $address federated share address
+	 * @return array [user, remoteURL]
+	 * @throws \Exception
+	 */
+	public function splitUserRemote($address) {
+		if (strpos($address, '@') === false) {
+			throw new \Exception('Invalid Federated Cloud ID');
+		}
+
+		// Find the first character that is not allowed in user names
+		$id = str_replace('\\', '/', $address);
+		$posSlash = strpos($id, '/');
+		$posColon = strpos($id, ':');
+
+		if ($posSlash === false && $posColon === false) {
+			$invalidPos = strlen($id);
+		} else if ($posSlash === false) {
+			$invalidPos = $posColon;
+		} else if ($posColon === false) {
+			$invalidPos = $posSlash;
+		} else {
+			$invalidPos = min($posSlash, $posColon);
+		}
+
+		// Find the last @ before $invalidPos
+		$pos = $lastAtPos = 0;
+		while ($lastAtPos !== false && $lastAtPos <= $invalidPos) {
+			$pos = $lastAtPos;
+			$lastAtPos = strpos($id, '@', $pos + 1);
+		}
+
+		if ($pos !== false) {
+			$user = substr($id, 0, $pos);
+			$remote = substr($id, $pos + 1);
+			$remote = $this->fixRemoteURL($remote);
+			if (!empty($user) && !empty($remote)) {
+				return array($user, $remote);
+			}
+		}
+
+		throw new \Exception('Invalid Federated Cloud ID');
+	}
+
+	/**
+	 * Strips away a potential file names and trailing slashes:
+	 * - http://localhost
+	 * - http://localhost/
+	 * - http://localhost/index.php
+	 * - http://localhost/index.php/s/{shareToken}
+	 *
+	 * all return: http://localhost
+	 *
+	 * @param string $remote
+	 * @return string
+	 */
+	protected function fixRemoteURL($remote) {
+		$remote = str_replace('\\', '/', $remote);
+		if ($fileNamePosition = strpos($remote, '/index.php')) {
+			$remote = substr($remote, 0, $fileNamePosition);
+		}
+		$remote = rtrim($remote, '/');
+
+		return $remote;
 	}
 
 	/**

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -219,7 +219,11 @@
 			if (item.value.shareType === OC.Share.SHARE_TYPE_GROUP) {
 				text = text +  ' ('+t('core', 'group')+')';
 			} else if (item.value.shareType === OC.Share.SHARE_TYPE_REMOTE) {
-				text = text +  ' ('+t('core', 'remote')+')';
+				if (item.value.server) {
+					text = text + ' (' + t('core', 'at') + ' ' + item.value.server + ')';
+				} else {
+					text = text + ' (' + t('core', 'remote') + ')';
+				}
 			}
 			insert.text(text);
 			if(item.value.shareType === OC.Share.SHARE_TYPE_GROUP) {


### PR DESCRIPTION
fix https://github.com/owncloud/core/issues/22277

To distinguish different users with the same user name on different server I changed the auto-complete output from `John Doe (remote)` to `John Doe (at <server>)`

@blizzz maybe you can review it, afaik you wrote the new share dialog. So please check if I did everything the right way :wink:  Thanks!
