### PR TITLE
Add displayNamesInGroups function to fix Provisioning API subadmin user listing

### DIFF
--- a/apps/provisioning_api/tests/UsersTest.php
+++ b/apps/provisioning_api/tests/UsersTest.php
@@ -164,10 +164,16 @@ class UsersTest extends OriginalTest {
 			->expects($this->once())
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
+
+		$user1 = $this->getMock('\OCP\IUser');
+		$user1->method('getUID')->willReturn('AnotherUserInTheFirstGroup');
+		$user2 = $this->getMock('\OCP\IUser');
+		$user2->method('getUID')->willReturn('UserInTheSecondGroup');
+
 		$this->groupManager
 			->expects($this->any())
-			->method('displayNamesInGroup')
-			->will($this->onConsecutiveCalls(['AnotherUserInTheFirstGroup' => []], ['UserInTheSecondGroup' => []]));
+			->method('displayNamesInGroups')
+			->willReturn([$user1, $user2]);
 
 		$expected = new \OC_OCS_Result([
 			'users' => [

--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -170,6 +170,46 @@ Feature: provisioning
 		And the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
+	Scenario: get users using a subadmin complex
+		Given As an "admin"
+		And user "brand-new-user" exists
+		And group "new-group" exists
+		And group "new-group2" exists
+		And group "new-group3" exists
+		And user "brand-new-user" belongs to group "new-group"
+		And sending "POST" to "/cloud/users/brand-new-user/subadmins" with
+			| groupid | new-group |
+		And user "brand-new-user" is subadmin of group "new-group"
+		And sending "POST" to "/cloud/users/brand-new-user/subadmins" with
+			| groupid | new-group2 |
+		And user "brand-new-user" is subadmin of group "new-group2"
+		And user "user1" exists
+		And user "user1" belongs to group "new-group"
+		And user "user1" belongs to group "new-group2"
+		And user "user1" belongs to group "new-group3"
+		And user "user2" exists
+		And user "user2" belongs to group "new-group"
+		And user "user2" belongs to group "new-group2"
+		And user "user3" exists
+		And user "user3" belongs to group "new-group2"
+		And user "user3" belongs to group "new-group3"
+		And user "user4" exists
+		And user "user4" belongs to group "new-group"
+		And user "user4" belongs to group "new-group3"
+		And user "user5" exists
+		And user "user5" belongs to group "new-group3"
+		And user "user6" exists
+		And As an "brand-new-user"
+		When sending "GET" to "/cloud/users"
+		Then users returned are
+			| brand-new-user |
+			| user1          |
+			| user2          |
+			| user3          |
+			| user4          |
+		And the OCS status code should be "100"
+		And the HTTP status code should be "200"
+
 	Scenario: removing a user from a group which doesn't exists
 		Given As an "admin"
 		And user "brand-new-user" exists

--- a/lib/public/IGroupManager.php
+++ b/lib/public/IGroupManager.php
@@ -121,6 +121,19 @@ interface IGroupManager {
 	public function displayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0);
 
 	/**
+	 * Get a list of all display names in groups
+	 *
+	 * @param array $gids The group ids of the groups to search in
+	 * @param string $search Part of the displayname to search for
+	 * @param int $limit The max number of returned Users
+	 * @param int $offset Skip the first $offset results
+	 *
+	 * @return \OCP\IUser[]
+	 * @since 9.0.0
+	 */
+	public function displayNamesInGroups(array $gids, $search = '', $limit = -1, $offset = 0);
+
+	/**
 	 * Checks if a userId is in the admin group
 	 * @param string $userId
 	 * @return bool if admin

--- a/tests/lib/Group/ManagerTest.php
+++ b/tests/lib/Group/ManagerTest.php
@@ -779,6 +779,82 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertTrue(isset($users['user33']));
 	}
 
+	public function testDisplayNamesInGroupsOneBackendNoSearchNoLimitNoOffset() {
+		$groupBackend = new \OC_Group_Dummy();
+
+		$userBackend = new \Test\Util\User\Dummy();
+
+		$userManager = new \OC\User\Manager();
+		$userManager->registerBackend($userBackend);
+
+		$groupManager = new \OC\Group\Manager($userManager);
+		$groupManager->addBackend($groupBackend);
+
+		$user1 = $userManager->createUser('user1', 'user');
+		$user2 = $userManager->createUser('user2', 'user');
+		$user3 = $userManager->createUser('user3', 'user');
+		$user4 = $userManager->createUser('user4', 'user');
+
+		$group1 = $groupManager->createGroup('group1');
+		$group2 = $groupManager->createGroup('group2');
+
+		$group1->addUser($user1);
+		$group1->addUser($user2);
+		$group2->addUser($user2);
+		$group2->addUser($user3);
+
+		$result = $groupManager->displayNamesInGroups(['group1', 'group2']);
+
+		$this->assertCount(3, $result);
+		$this->assertContains($user1, $result);
+		$this->assertContains($user2, $result);
+		$this->assertContains($user3, $result);
+		$this->assertNotContains($user4, $result);
+	}
+
+	public function testDisplayNamesInGroupsOneBackendSearchLimitOffset() {
+		$groupBackend = new \OC_Group_Dummy();
+
+		$userBackend = new \Test\Util\User\Dummy();
+
+		$userManager = new \OC\User\Manager();
+		$userManager->registerBackend($userBackend);
+
+		$groupManager = new \OC\Group\Manager($userManager);
+		$groupManager->addBackend($groupBackend);
+
+		$user1 = $userManager->createUser('u1', 'user');
+		$user2 = $userManager->createUser('user2', 'user');
+		$user3 = $userManager->createUser('u3', 'user');
+		$user4 = $userManager->createUser('user4', 'user');
+		$user5 = $userManager->createUser('u5', 'user');
+		$user6 = $userManager->createUser('user6', 'user');
+		$user7 = $userManager->createUser('user7', 'user');
+		$user8 = $userManager->createUser('user8', 'user');
+
+
+		$group1 = $groupManager->createGroup('group1');
+		$group2 = $groupManager->createGroup('group2');
+		$group3 = $groupManager->createGroup('group3');
+
+		$group1->addUser($user1);
+		$group1->addUser($user2);
+		$group1->addUser($user4);
+		$group2->addUser($user2);
+		$group2->addUser($user3);
+		$group2->addUser($user4);
+		$group2->addUser($user5);
+		$group2->addUser($user6);
+		$group3->addUser($user4);
+		$group3->addUser($user7);
+		$group3->addUser($user8);
+
+		$result = $groupManager->displayNamesInGroups(['group2', 'group1'], 'user', 2, 2);
+
+		$this->assertCount(1, $result);
+		$this->assertContains($user6, $result);
+	}
+
 	public function testGetUserGroupsWithAddUser() {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend

--- a/tests/lib/Util/User/Dummy.php
+++ b/tests/lib/Util/User/Dummy.php
@@ -118,14 +118,25 @@ class Dummy extends Backend implements \OCP\IUserBackend {
 	 */
 	public function getUsers($search = '', $limit = null, $offset = null) {
 		if (empty($search)) {
-			return array_keys($this->users);
-		}
-		$result = array();
-		foreach (array_keys($this->users) as $user) {
-			if (stripos($user, $search) !== false) {
-				$result[] = $user;
+			$result = array_keys($this->users);
+		} else {
+			$result = array();
+			foreach (array_keys($this->users) as $user) {
+				if (stripos($user, $search) !== false) {
+					$result[] = $user;
+				}
 			}
 		}
+
+		if ($offset === null) {
+			$offset = 0;
+		}
+		if ($limit === null) {
+			$result = array_splice($result, $offset);
+		} else {
+			$result = array_splice($result, $offset, $limit);
+		}
+
 		return $result;
 	}
 


### PR DESCRIPTION
Fixes #18418
Fixes #19964

The first commit adds a function displayNamesInGroups to the group manager. This will search in a provided list of groups.

The second commit adds unit tests for this new function.

The third commit updates the provisioning API to use this

And the fourth commit adds intergration tests for this API (and thus indirect the function).

I did it all in 1 PR since this way it is tested in a bit more depth. And the changes to the provisioning API are minimal.

CC: @tomneedham @PVince81 @nickvergessen @LukasReschke h
