### PR TITLE
Fix race condition when switching filter mode. Fixes #22278

### DIFF
--- a/apps/user_ldap/js/wizard/wizardTabGeneric.js
+++ b/apps/user_ldap/js/wizard/wizardTabGeneric.js
@@ -28,6 +28,12 @@ OCA = OCA || {};
 		 */
 		bjQuiButtonClass: 'ui-button',
 
+		/**
+		 * @property {bool} - indicates whether a filter mode toggle operation
+		 * is still in progress
+		 */
+		isToggling: false,
+
 		/** @inheritdoc */
 		init: function(tabIndex, tabID) {
 			this.tabIndex = tabIndex;
@@ -408,6 +414,20 @@ OCA = OCA || {};
 		},
 
 		/**
+		 * sets the filter mode initially and resets the "isToggling" marker.
+		 * This method is called after a save operation against the mode key.
+		 *
+		 * @param mode
+		 */
+		setFilterModeOnce: function(mode) {
+			this.isToggling = false;
+			if(!this.filterModeInitialized) {
+				this.filterModeInitialized = true;
+				this.setFilterMode(mode);
+			}
+		},
+
+		/**
 		 * sets the filter mode according to the provided configuration value
 		 *
 		 * @param {string} mode
@@ -568,8 +588,15 @@ OCA = OCA || {};
 			this.filterModeDisableableElements = filterModeDisableableElements;
 			this.filterModeStateElement = filterModeStateElement;
 			this.filterModeKey = filterModeKey;
-			$switcher.click(this._toggleRawFilterMode);
-		}
+			var view = this;
+			$switcher.click(function() {
+				if(view.isToggling) {
+					return;
+				}
+				view.isToggling = true;
+				view._toggleRawFilterMode();
+			});
+		},
 
 	});
 

--- a/apps/user_ldap/js/wizard/wizardTabGroupFilter.js
+++ b/apps/user_ldap/js/wizard/wizardTabGroupFilter.js
@@ -26,7 +26,7 @@ OCA = OCA || {};
 					featureName: 'GroupObjectClasses'
 				},
 				ldap_group_filter_mode: {
-					setMethod: 'setFilterMode'
+					setMethod: 'setFilterModeOnce'
 				},
 				ldap_groupfilter_groups: {
 					$element: $('#ldap_groupfilter_groups'),

--- a/apps/user_ldap/js/wizard/wizardTabLoginFilter.js
+++ b/apps/user_ldap/js/wizard/wizardTabLoginFilter.js
@@ -32,7 +32,7 @@ OCA = OCA || {};
 					setMethod: 'setLoginAttributeEmail'
 				},
 				ldap_login_filter_mode: {
-					setMethod: 'setFilterMode'
+					setMethod: 'setFilterModeOnce'
 				},
 				ldap_loginfilter_attributes: {
 					$element: $('#ldap_loginfilter_attributes'),

--- a/apps/user_ldap/js/wizard/wizardTabUserFilter.js
+++ b/apps/user_ldap/js/wizard/wizardTabUserFilter.js
@@ -26,7 +26,7 @@ OCA = OCA || {};
 					featureName: 'UserObjectClasses'
 				},
 				ldap_user_filter_mode: {
-					setMethod: 'setFilterMode'
+					setMethod: 'setFilterModeOnce'
 				},
 				ldap_userfilter_groups: {
 					$element: $('#ldap_userfilter_groups'),


### PR DESCRIPTION
How to test:
1. Have LDAP configured.
2. Go to Groups (or Users, or even  Login) tab
3. Click on "↓ Edit LDAP Query" to switch the filter mode as if there is no tomorrow

Expected:
1. When ending up in Assistant Mode, the objectclass  dropdown is enabled, and the group down is enabled when it is supposed to be
2. The filter Mode setting (ldapGroupFilterMode, ldapUserFilterMode or ldapLoginFilterMode) is correctly set: 0 for assited mode, 1 for manual LDAP filter entry (e.g. grep /occ ldap:show-config output for it).

Please test and review @ejouvin @owncloud/ldap @PVince81 
