### PR TITLE
Fix BMP support

### DIFF
--- a/lib/private/image.php
+++ b/lib/private/image.php
@@ -257,6 +257,7 @@ class OC_Image implements \OCP\IImage {
 					$imageType = IMAGETYPE_XBM;
 					break;
 				case 'image/bmp':
+				case 'image/x-ms-bmp':
 					$imageType = IMAGETYPE_BMP;
 					break;
 				default:


### PR DESCRIPTION
- fixes #16461

Before following was in the logs and BMP previews didn't worked:

```
{"reqId":"AuMsiCh2IzCSSDuaFIjm","remoteAddr":"::1","app":"index","message":"Exception: {\"Exception\":\"Exception\",\"Message\":\"\\\\OC_Image::_output(): \\\"image\\\/x-ms-bmp\\\" is not supported when forcing a specific output format\",\"Code\":0,\"Trace\":\"#0 \\\/Users\\\/morrisjobke\\\/Projects\\\/owncloud\\\/master\\\/lib\\\/private\\\/image.php(196): OC_Image->_output(NULL, 'image\\\/x-ms-bmp')\\n#1 \\\/Users\\\/morrisjobke\\\/Projects\\\/owncloud\\\/master\\\/lib\\\/private\\\/preview.php(804): OC_Image->show(NULL)\\n#2 \\\/Users\\\/morrisjobke\\\/Projects\\\/owncloud\\\/master\\\/core\\\/ajax\\\/preview.php(63): OC\\\\Preview->showPreview()\\n#3 \\\/Users\\\/morrisjobke\\\/Projects\\\/owncloud\\\/master\\\/lib\\\/private\\\/route\\\/route.php(154) : runtime-created function(1): require_once('\\\/Users\\\/morrisjo...')\\n#4 [internal function]: __lambda_func(Array)\\n#5 \\\/Users\\\/morrisjobke\\\/Projects\\\/owncloud\\\/master\\\/lib\\\/private\\\/route\\\/router.php(273): call_user_func('\\\\x00lambda_1786', Array)\\n#6 \\\/Users\\\/morrisjobke\\\/Projects\\\/owncloud\\\/master\\\/lib\\\/base.php(856): OC\\\\Route\\\\Router->match('\\\/core\\\/preview.p...')\\n#7 \\\/Users\\\/morrisjobke\\\/Projects\\\/owncloud\\\/master\\\/index.php(39): OC::handleRequest()\\n#8 {main}\",\"File\":\"\\\/Users\\\/morrisjobke\\\/Projects\\\/owncloud\\\/master\\\/lib\\\/private\\\/image.php\",\"Line\":263}","level":3,"time":"2016-02-13T20:52:44+00:00"}
```

Afterwards the BMP is previewed just fine.

cc @oparoz @LukasReschke @nickvergessen @PVince81 
