### PR TITLE
Limit scope of scrutinizer to actual application code

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,6 +6,7 @@ filter:
         - 'l10n/*'
         - 'core/l10n/*'
         - 'apps/*/l10n/*'
+        - 'apps/*/tests/*'
         - 'lib/l10n/*'
         - 'core/vendor/*'
         - 'core/js/tests/lib/*.js'
@@ -13,6 +14,9 @@ filter:
         - 'core/js/jquery-showpassword.js'
         - 'core/js/jquery-tipsy.js'
         - 'core/js/placeholders.js'
+        - 'settings/l10n/*'
+        - 'tests/*'
+        - 'build/*'
 
 
 imports:


### PR DESCRIPTION
I think this makes scrutinizer more useful. cc @LukasReschke @DeepDiver1975 
