### PR TITLE
Fix typo in PHPDoc

### DIFF
--- a/lib/private/notification/manager.php
+++ b/lib/private/notification/manager.php
@@ -28,7 +28,7 @@ use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
 
 class Manager implements IManager {
-	/** @var IApp */
+	/** @var IApp[] */
 	protected $apps;
 
 	/** @var INotifier */

--- a/lib/private/user/manager.php
+++ b/lib/private/user/manager.php
@@ -50,7 +50,7 @@ use OCP\IConfig;
  */
 class Manager extends PublicEmitter implements IUserManager {
 	/**
-	 * @var \OCP\UserInterface [] $backends
+	 * @var \OCP\UserInterface[] $backends
 	 */
 	private $backends = array();
 


### PR DESCRIPTION
cc @rullzer @DeepDiver1975 @LukasReschke @nickvergessen 

This will make scrutinizer and PHPStorm a lot happier.
