### PR TITLE
Remove background job if the server accepted to ask for the shared secret

### DIFF
--- a/apps/federation/backgroundjob/getsharedsecret.php
+++ b/apps/federation/backgroundjob/getsharedsecret.php
@@ -150,10 +150,14 @@ class GetSharedSecret extends QueuedJob{
 
 		} catch (ClientException $e) {
 			$status = $e->getCode();
-			$this->logger->logException($e);
+			if ($status === Http::STATUS_FORBIDDEN) {
+				$this->logger->info($target . ' refused to exchange a shared secret with you.', ['app' => 'federation']);
+			} else {
+				$this->logger->logException($e, ['app' => 'federation']);
+			}
 		} catch (\Exception $e) {
 			$status = HTTP::STATUS_INTERNAL_SERVER_ERROR;
-			$this->logger->logException($e);
+			$this->logger->logException($e, ['app' => 'federation']);
 		}
 
 		// if we received a unexpected response we try again later

--- a/apps/federation/backgroundjob/requestsharedsecret.php
+++ b/apps/federation/backgroundjob/requestsharedsecret.php
@@ -148,10 +148,14 @@ class RequestSharedSecret extends QueuedJob {
 
 		} catch (ClientException $e) {
 			$status = $e->getCode();
-			$this->logger->logException($e);
+			if ($status === Http::STATUS_FORBIDDEN) {
+				$this->logger->info($target . ' refused to ask for a shared secret.', ['app' => 'federation']);
+			} else {
+				$this->logger->logException($e, ['app' => 'federation']);
+			}
 		} catch (\Exception $e) {
 			$status = HTTP::STATUS_INTERNAL_SERVER_ERROR;
-			$this->logger->logException($e);
+			$this->logger->logException($e, ['app' => 'federation']);
 		}
 
 		// if we received a unexpected response we try again later

--- a/apps/federation/lib/dbhandler.php
+++ b/apps/federation/lib/dbhandler.php
@@ -156,6 +156,7 @@ class DbHandler {
 	 *
 	 * @param string $url
 	 * @return string
+	 * @throws \Exception
 	 */
 	public function getToken($url) {
 		$hash = $this->hash($url);
@@ -165,6 +166,11 @@ class DbHandler {
 			->setParameter('url_hash', $hash);
 
 		$result = $query->execute()->fetch();
+
+		if (!isset($result['token'])) {
+			throw new \Exception('No token found for: ' . $url);
+		}
+
 		return $result['token'];
 	}
 

--- a/apps/federation/tests/api/ocsauthapitest.php
+++ b/apps/federation/tests/api/ocsauthapitest.php
@@ -105,8 +105,11 @@ class OCSAuthAPITest extends TestCase {
 		if ($expected === Http::STATUS_OK) {
 			$this->jobList->expects($this->once())->method('add')
 				->with('OCA\Federation\BackgroundJob\GetSharedSecret', ['url' => $url, 'token' => $token]);
+			$this->jobList->expects($this->once())->method('remove')
+				->with('OCA\Federation\BackgroundJob\RequestSharedSecret', ['url' => $url, 'token' => $localToken]);
 		} else {
 			$this->jobList->expects($this->never())->method('add');
+			$this->jobList->expects($this->never())->method('remove');
 		}
 
 		$result = $this->ocsAuthApi->requestSharedSecret();


### PR DESCRIPTION
If we don't remove it the server will later ask the remote server to ask for the shared secret which will result in a error log message on the remote server and in some circumstances maybe even to a failure.

cc @MorrisJobke please test if this changes anything with respect to https://github.com/owncloud/core/issues/21929. Even if it still fails please check the error message if something changed there.
