### PR TITLE
Pass checked host as "domain" variable to "untrustedDomain" template.

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -692,7 +692,7 @@ class OC {
 			);
 
 			$tmpl = new OCP\Template('core', 'untrustedDomain', 'guest');
-			$tmpl->assign('domain', $request->server['SERVER_NAME']);
+			$tmpl->assign('domain', $host);
 			$tmpl->printPage();
 
 			exit();


### PR DESCRIPTION
Currently the "SERVER_NAME" is passed to the template, which in some cases doesn't match the host returned by "getInsecureServerHost" (or is empty).
