### PR TITLE
Fix GDrive mime type detection with encryption

### DIFF
--- a/apps/files_external/lib/google.php
+++ b/apps/files_external/lib/google.php
@@ -520,7 +520,8 @@ class Google extends \OC\Files\Storage\Common {
 				// Download as .odp is not available
 				return 'application/pdf';
 			} else {
-				return $mimetype;
+				// use extension-based detection, could be an encrypted file
+				return parent::getMimeType($path);
 			}
 		} else {
 			return false;


### PR DESCRIPTION
When encryption is enabled, GDrive would think that all files are text
files. This fix falls back to the extension based detection when a
non-special mime type is returned

Fixes https://github.com/owncloud/core/issues/21271

Please review @icewind1991 @nickvergessen @DeepDiver1975 @MorrisJobke 
