### PR TITLE
[stable8.1] Reindex array in GDrive after removing duplicates

### DIFF
--- a/apps/files_external/lib/google.php
+++ b/apps/files_external/lib/google.php
@@ -291,6 +291,8 @@ class Google extends \OC\Files\Storage\Common {
 				}
 				$pageToken = $children->getNextPageToken();
 			}
+			// reindex values to compensate for removed duplicates
+			$files = array_values($files);
 			\OC\Files\Stream\Dir::register('google'.$path, $files);
 			return opendir('fakedir://google'.$path);
 		} else {


### PR DESCRIPTION
Whenever duplicates are removed from the array, the indices are not in
sequence. This seems to cause trouble with opendir/the dir wrapper and
make it skip valid entries.

This fix reindexes the array to make it work.

Fixes https://github.com/owncloud/core/issues/16267

@karlitschek since we don't want to backport this big PR https://github.com/owncloud/core/pull/14779, the current PR is a 8.1-specific solution. Please let me know if this is acceptable and critical enough.
Note that this works fine in OC => 8.2 due to a better implementation of the directory iterator.

Please review @icewind1991 @Xenopathic @jmaciasportela 
