### PR TITLE
Do not copy skeleton on avatar access

### DIFF
--- a/lib/private/avatarmanager.php
+++ b/lib/private/avatarmanager.php
@@ -26,6 +26,7 @@
 
 namespace OC;
 
+use OCP\Files\Folder;
 use OCP\IAvatarManager;
 use OCP\IUserManager;
 use OCP\Files\IRootFolder;
@@ -45,6 +46,13 @@ class AvatarManager implements IAvatarManager {
 	/** @var IL10N */
 	private $l;
 
+	/**
+	 * AvatarManager constructor.
+	 *
+	 * @param IUserManager $userManager
+	 * @param IRootFolder $rootFolder
+	 * @param IL10N $l
+	 */
 	public function __construct(
 			IUserManager $userManager,
 			IRootFolder $rootFolder,
@@ -57,7 +65,7 @@ class AvatarManager implements IAvatarManager {
 	/**
 	 * return a user specific instance of \OCP\IAvatar
 	 * @see \OCP\IAvatar
-	 * @param string $user the ownCloud user id
+	 * @param string $userId the ownCloud user id
 	 * @return \OCP\IAvatar
 	 * @throws \Exception In case the username is potentially dangerous
 	 */
@@ -66,6 +74,16 @@ class AvatarManager implements IAvatarManager {
 		if (is_null($user)) {
 			throw new \Exception('user does not exist');
 		}
-		return new Avatar($this->rootFolder->getUserFolder($userId)->getParent(), $this->l, $user);
+
+		/*
+		 * Fix for #22119
+		 * Basically we do not want to copy the skeleton folder
+		 */
+		\OC\Files\Filesystem::initMountPoints($userId);
+		$dir = '/' . $userId;
+		/** @var Folder $folder */
+		$folder = $this->rootFolder->get($dir);
+
+		return new Avatar($folder, $this->l, $user);
 	}
 }


### PR DESCRIPTION
Fixes #22119

We do the step from the getUserFolder function here. So we make sure
that the user folder exists. But do not create the files folder (we
don't need it here) and do not copy the skeleton.

Note that this will still be triggered once the getUserFolder is called.

Moved the unit tests to more intergration tests with the traits we have..

@PVince81 @DeepDiver1975 as promised.
@DeepDiver1975 as far as I can tell this fixes the issue... but please verify on your setup.

CC: @MorrisJobke @nickvergessen 
