### PR TITLE
Fix public link selection on iOS

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -151,7 +151,8 @@
 		onLinkTextClick: function() {
 			var $el = this.$el.find('.linkText');
 			$el.focus();
-			$el.select();
+			// select() isn't supported in iOS
+			$el.get(0).setSelectionRange(0, 9999);
 		},
 
 		onShowPasswordClick: function() {


### PR DESCRIPTION
fixes #22336

iOS seems to not support `.select()` so I replaced it with `setSelectionRange(0, 9999)` as suggested at http://stackoverflow.com/a/6302507

I wasn't able to test it on iOS, but it still works on Chrome desktop.

@oparoz @PVince81 @rullzer @jancborchardt 
