### PR TITLE
Make app updates better visible (part1)

### DIFF
--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -124,6 +124,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 				$('.app-level .experimental').tipsy({fallback: t('settings', 'This app is not checked for security issues and is new or known to be unstable. Install at your own risk.')});
 			},
 			complete: function() {
+				var availableUpdates = 0;
 				$('#apps-list').removeClass('icon-loading');
 				$.ajax(OC.generateUrl('settings/apps/list?category={categoryId}&includeUpdateInfo=1', {
 					categoryId: categoryId
@@ -135,8 +136,14 @@ OC.Settings.Apps = OC.Settings.Apps || {
 								var $update = $('#app-' + app.id + ' .update');
 								$update.removeClass('hidden');
 								$update.val(t('settings', 'Update to %s').replace(/%s/g, app.update));
+								availableUpdates++;
+								OC.Settings.Apps.State.apps[app.id].update = true;
 							}
-						})
+						});
+
+						if (availableUpdates > 0) {
+							OC.Notification.show(n('settings', 'You have %n app update pending', 'You have %n app updates pending', availableUpdates));
+						}
 					}
 				});
 			}

--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -97,6 +97,10 @@ script(
 	<div class="app-description-toggle-show"><?php p($l->t("Show description …"));?></div>
 	<div class="app-description-toggle-hide hidden"><?php p($l->t("Hide description …"));?></div>
 
+	<div class="app-dependencies update hidden">
+		<p><?php p($l->t('This app has an update available.')); ?></p>
+	</div>
+
 	{{#if missingMinOwnCloudVersion}}
 		<div class="app-dependencies">
 			<p><?php p($l->t('This app has no minimum ownCloud version assigned. This will be an error in ownCloud 11 and later.')); ?></p>


### PR DESCRIPTION
1. Show a temp notification when there are app updates available
2. Show a red message on apps that have an update available for better visibility
3. Add an option to filter for apps with updates.

![bildschirmfoto vom 2016-02-16 12 55 34](https://cloud.githubusercontent.com/assets/213943/13075694/71a4112e-d4ad-11e5-9568-643d4e638cb7.png)

Fix #17230 

@PVince81 @jancborchardt @LukasReschke @MorrisJobke 
