### PR TITLE
Require CSRF token for non WebDAV authenticated requests

### DIFF
--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -30,6 +30,7 @@ use Sabre\CalDAV\CalendarRoot;
 $authBackend = new Auth(
 	\OC::$server->getSession(),
 	\OC::$server->getUserSession(),
+	\OC::$server->getRequest(),
 	'principals/'
 );
 $principalBackend = new Principal(

--- a/apps/dav/appinfo/v1/carddav.php
+++ b/apps/dav/appinfo/v1/carddav.php
@@ -32,6 +32,7 @@ use Sabre\CardDAV\Plugin;
 $authBackend = new Auth(
 	\OC::$server->getSession(),
 	\OC::$server->getUserSession(),
+	\OC::$server->getRequest(),
 	'principals/'
 );
 $principalBackend = new Principal(

--- a/apps/dav/appinfo/v1/webdav.php
+++ b/apps/dav/appinfo/v1/webdav.php
@@ -41,6 +41,7 @@ $serverFactory = new \OCA\DAV\Connector\Sabre\ServerFactory(
 $authBackend = new \OCA\DAV\Connector\Sabre\Auth(
 	\OC::$server->getSession(),
 	\OC::$server->getUserSession(),
+	\OC::$server->getRequest(),
 	'principals/'
 );
 $requestUri = \OC::$server->getRequest()->getRequestUri();

--- a/apps/dav/lib/dav/sharing/plugin.php
+++ b/apps/dav/lib/dav/sharing/plugin.php
@@ -129,9 +129,6 @@ class Plugin extends ServerPlugin {
 			return;
 		}
 
-		// CSRF protection
-		$this->protectAgainstCSRF();
-
 		$requestBody = $request->getBodyAsString();
 
 		// If this request handler could not deal with this POST request, it
@@ -200,19 +197,5 @@ class Plugin extends ServerPlugin {
 
 		}
 	}
-
-	private function protectAgainstCSRF() {
-		$user = $this->auth->getCurrentUser();
-		if ($this->auth->isDavAuthenticated($user)) {
-			return true;
-		}
-
-		if ($this->request->passesCSRFCheck()) {
-			return true;
-		}
-
-		throw new BadRequest();
-	}
-
 
 }

--- a/apps/dav/lib/server.php
+++ b/apps/dav/lib/server.php
@@ -53,7 +53,8 @@ class Server {
 		// Backends
 		$authBackend = new Auth(
 			\OC::$server->getSession(),
-			\OC::$server->getUserSession()
+			\OC::$server->getUserSession(),
+			\OC::$server->getRequest()
 		);
 
 		// Set URL explicitly due to reverse-proxy situations

--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -37,7 +37,10 @@
 		}
 
 		url += options.host + this._root;
-		this._defaultHeaders = options.defaultHeaders || {'X-Requested-With': 'XMLHttpRequest'};
+		this._defaultHeaders = options.defaultHeaders || {
+				'X-Requested-With': 'XMLHttpRequest',
+				'requesttoken': OC.requestToken
+			};
 		this._baseUrl = url;
 
 		var clientOptions = {

--- a/core/js/oc-backbone-webdav.js
+++ b/core/js/oc-backbone-webdav.js
@@ -240,7 +240,8 @@
 			return options.url;
 		};
 		var headers = _.extend({
-			'X-Requested-With': 'XMLHttpRequest'
+			'X-Requested-With': 'XMLHttpRequest',
+			'requesttoken': OC.requestToken
 		}, options.headers);
 		if (options.type === 'PROPFIND') {
 			return callPropFind(client, options, model, headers);


### PR DESCRIPTION
Requires fixing of https://github.com/evert/davclient.js/issues/14. Then we can also adjust the contacts and calendar rework to use this logic. I'll happily provide PRs to those projects once this is in to ensure that it works properly there.

Note that this only affects requests authenticated via the login form. If somebody authenticates via WebDAV no CSRF token is required at all.

@PVince81 Mind taking a look? At the davclient.js issue?

cc @DeepDiver1975 @PVince81 

Fixes https://github.com/owncloud/core/issues/22368
