### PR TITLE
Don't resize trash when no user

### DIFF
--- a/apps/files_trashbin/lib/hooks.php
+++ b/apps/files_trashbin/lib/hooks.php
@@ -40,10 +40,13 @@ class Hooks {
 		if( \OCP\App::isEnabled('files_trashbin') ) {
 			$uid = $params['uid'];
 			Trashbin::deleteUser($uid);
-			}
+		}
 	}
 
 	public static function post_write_hook($params) {
-		Trashbin::resizeTrash(\OCP\User::getUser());
+		$user = \OCP\User::getUser();
+		if (!empty($user)) {
+			Trashbin::resizeTrash($user);
+		}
 	}
 }


### PR DESCRIPTION
Happens when overwriting files on federated shares.

Fixes https://github.com/owncloud/core/issues/22433

Please review @schiesbn @rullzer @nickvergessen @LukasReschke @icewind1991
