### PR TITLE
Fix concurrency issues for insertIfNotExists

### DIFF
--- a/lib/private/db/adapter.php
+++ b/lib/private/db/adapter.php
@@ -88,7 +88,7 @@ class Adapter {
 			}
 		}
 		$query = substr($query, 0, strlen($query) - 5);
-		$query .= ' HAVING COUNT(*) = 0';
+		$query .= ' HAVING COUNT(*) = 0 FOR UPDATE';
 
 		return $this->conn->executeUpdate($query, $inserts);
 	}

--- a/lib/private/db/adaptersqlsrv.php
+++ b/lib/private/db/adaptersqlsrv.php
@@ -34,4 +34,40 @@ class AdapterSQLSrv extends Adapter {
 		$statement = str_ireplace( 'UNIX_TIMESTAMP()', 'DATEDIFF(second,{d \'1970-01-01\'},GETDATE())', $statement );
 		return $statement;
 	}
+
+	/**
+	 * Insert a row if the matching row does not exists.
+	 *
+	 * @param string $table The table name (will replace *PREFIX* with the actual prefix)
+	 * @param array $input data that should be inserted into the table  (column name => value)
+	 * @param array|null $compare List of values that should be checked for "if not exists"
+	 *				If this is null or an empty array, all keys of $input will be compared
+	 *				Please note: text fields (clob) must not be used in the compare array
+	 * @return int number of inserted rows
+	 * @throws \Doctrine\DBAL\DBALException
+	 */
+	public function insertIfNotExist($table, $input, array $compare = null) {
+		if (empty($compare)) {
+			$compare = array_keys($input);
+		}
+		$query = 'INSERT INTO `' .$table . '` (`'
+			. implode('`,`', array_keys($input)) . '`) SELECT '
+			. str_repeat('?,', count($input)-1).'? ' // Is there a prettier alternative?
+			. 'FROM `' . $table . '` WITH (UPDLOCK, ROWLOCK) WHERE ';
+
+		$inserts = array_values($input);
+		foreach($compare as $key) {
+			$query .= '`' . $key . '`';
+			if (is_null($input[$key])) {
+				$query .= ' IS NULL AND ';
+			} else {
+				$inserts[] = $input[$key];
+				$query .= ' = ? AND ';
+			}
+		}
+		$query = substr($query, 0, strlen($query) - 5);
+		$query .= ' HAVING COUNT(*) = 0 FOR UPDATE';
+
+		return $this->conn->executeUpdate($query, $inserts);
+	}
 }


### PR DESCRIPTION
similar to the code in drupal: https://api.drupal.org/api/drupal/vendor!symfony!http-foundation!Session!Storage!Handler!PdoSessionHandler.php/function/PdoSessionHandler%3A%3AgetSelectSql/8

SQLite already locks the file.
Mysql Support: http://dev.mysql.com/doc/refman/5.7/en/innodb-locking-reads.html
Postgres support: http://www.postgresql.org/docs/9.0/static/sql-select.html
Oracle Support: https://docs.oracle.com/cd/B28359_01/server.111/b28286/statements_10002.htm#SQLRF55266
MSSQL uses WITH (UPDLOCK, ROWLOCK)
