### PR TITLE
get the actual user instead of a federated cloud id

### DIFF
--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -29,7 +29,9 @@
 namespace OCA\Files_Sharing;
 
 use OC\Files\Filesystem;
+use OC\Files\View;
 use OCP\Files\NotFoundException;
+use OCP\User;
 
 class Helper {
 
@@ -78,7 +80,7 @@ class Helper {
 		}
 
 		try {
-			$path = \OC\Files\Filesystem::getPath($linkItem['file_source']);
+			$path = Filesystem::getPath($linkItem['file_source']);
 		} catch (NotFoundException $e) {
 			\OCP\Util::writeLog('share', 'could not resolve linkItem', \OCP\Util::DEBUG);
 			\OC_Response::setStatus(404);
@@ -103,8 +105,8 @@ class Helper {
 
 		$basePath = $path;
 
-		if ($relativePath !== null && \OC\Files\Filesystem::isReadable($basePath . $relativePath)) {
-			$path .= \OC\Files\Filesystem::normalizePath($relativePath);
+		if ($relativePath !== null && Filesystem::isReadable($basePath . $relativePath)) {
+			$path .= Filesystem::normalizePath($relativePath);
 		}
 
 		return array(
@@ -168,11 +170,11 @@ class Helper {
 
 	public static function getSharesFromItem($target) {
 		$result = array();
-		$owner = \OC\Files\Filesystem::getOwner($target);
-		\OC\Files\Filesystem::initMountPoints($owner);
-		$info = \OC\Files\Filesystem::getFileInfo($target);
-		$ownerView = new \OC\Files\View('/'.$owner.'/files');
-		if ( $owner != \OCP\User::getUser() ) {
+		$owner = Filesystem::getOwner($target);
+		Filesystem::initMountPoints($owner);
+		$info = Filesystem::getFileInfo($target);
+		$ownerView = new View('/'.$owner.'/files');
+		if ( $owner != User::getUser() ) {
 			$path = $ownerView->getPath($info['fileid']);
 		} else {
 			$path = $target;
@@ -205,8 +207,34 @@ class Helper {
 		return $result;
 	}
 
+	/**
+	 * get the UID of the owner of the file and the path to the file relative to
+	 * owners files folder
+	 *
+	 * @param $filename
+	 * @return array
+	 * @throws \OC\User\NoUserException
+	 */
 	public static function getUidAndFilename($filename) {
-		return Filesystem::getView()->getUidAndFilename($filename);
+		$uid = Filesystem::getOwner($filename);
+		$userManager = \OC::$server->getUserManager();
+		// if the user with the UID doesn't exists, e.g. because the UID points
+		// to a remote user with a federated cloud ID we use the current logged-in
+		// user. We need a valid local user to create the share
+		if (!$userManager->userExists($uid)) {
+			$uid = User::getUser();
+		}
+		Filesystem::initMountPoints($uid);
+		if ( $uid != User::getUser() ) {
+			$info = Filesystem::getFileInfo($filename);
+			$ownerView = new View('/'.$uid.'/files');
+			try {
+				$filename = $ownerView->getPath($info['fileid']);
+			} catch (NotFoundException $e) {
+				$filename = null;
+			}
+		}
+		return [$uid, $filename];
 	}
 
 	/**
@@ -234,7 +262,7 @@ class Helper {
 	 *
 	 * @param string $path
 	 * @param array $excludeList
-	 * @param \OC\Files\View $view
+	 * @param View $view
 	 * @return string $path
 	 */
 	public static function generateUniqueTarget($path, $excludeList, $view) {
@@ -244,7 +272,7 @@ class Helper {
 		$dir = $pathinfo['dirname'];
 		$i = 2;
 		while ($view->file_exists($path) || in_array($path, $excludeList)) {
-			$path = \OC\Files\Filesystem::normalizePath($dir . '/' . $name . ' ('.$i.')' . $ext);
+			$path = Filesystem::normalizePath($dir . '/' . $name . ' ('.$i.')' . $ext);
 			$i++;
 		}
 
@@ -278,15 +306,15 @@ class Helper {
 	 */
 	public static function getShareFolder() {
 		$shareFolder = \OC::$server->getConfig()->getSystemValue('share_folder', '/');
-		$shareFolder = \OC\Files\Filesystem::normalizePath($shareFolder);
+		$shareFolder = Filesystem::normalizePath($shareFolder);
 
-		if (!\OC\Files\Filesystem::file_exists($shareFolder)) {
+		if (!Filesystem::file_exists($shareFolder)) {
 			$dir = '';
 			$subdirs = explode('/', $shareFolder);
 			foreach ($subdirs as $subdir) {
 				$dir = $dir . '/' . $subdir;
-				if (!\OC\Files\Filesystem::is_dir($dir)) {
-					\OC\Files\Filesystem::mkdir($dir);
+				if (!Filesystem::is_dir($dir)) {
+					Filesystem::mkdir($dir);
 				}
 			}
 		}


### PR DESCRIPTION
`$view->getUidAndFilename($filename);` returns the federated cloud id in case of a federated share. But in the case of versioning and trashbin we need the local user who "owns" the file which is the current logged in user in case of a federated share.

This reverts changes introduced here by @icewind1991: https://github.com/owncloud/core/commit/300eb54c871cfe48165ee32ecdc5067226aa0b7b 

While in most cases in makes sense to return the federated cloud id of the owner of the file. In this cases it breaks the trashbin and versions.

Steps to test:
- set up two ownClouds
- ownCloud1 shares a folder which contains a file to ownCloud2
- try to delete the file on ownCloud2

Expected: 

File gets deleted and added to the trashbin of owner@ownCloud1 and to the user at ownCloud2

Actual Result: 

delete fails with this exception:

```
{"reqId":"h3FJVmACIo8+mISwiP+g","remoteAddr":"::1","app":"files","message":" Backends provided no user object for schiesbn@localhost\/federation\/","level":3,"time":"2016-02-16T16:08:39+00:00"}
{"reqId":"h3FJVmACIo8+mISwiP+g","remoteAddr":"::1","app":"no app in context","message":"Exception: {\"Exception\":\"OC\\\\User\\\\NoUserException\",\"Message\":\"Backends provided no user object for schiesbn@localhost\\\/federation\\\/\",\"Code\":0,\"Trace\":\"#0 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/apps\\\/files_trashbin\\\/lib\\\/trashbin.php(80): OC\\\\Files\\\\Filesystem::initMountPoints('schiesbn@localh...')\\n#1 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/apps\\\/files_trashbin\\\/lib\\\/trashbin.php(67): OCA\\\\Files_Trashbin\\\\Trashbin::getUidAndFilename('\\\/New folder\\\/wel...')\\n#2 [internal function]: OCA\\\\Files_Trashbin\\\\Trashbin::ensureFileScannedHook(Array)\\n#3 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/lib\\\/private\\\/hook.php(104): call_user_func(Array, Array)\\n#4 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/lib\\\/private\\\/files\\\/view.php(1172): OC_Hook::emit('OC_Filesystem', 'delete', Array)\\n#5 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/lib\\\/private\\\/files\\\/view.php(1048): OC\\\\Files\\\\View->runHooks(Array, '\\\/New folder\\\/wel...')\\n#6 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/lib\\\/private\\\/files\\\/view.php(641): OC\\\\Files\\\\View->basicOperation('unlink', '\\\/New folder\\\/wel...', Array)\\n#7 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/apps\\\/dav\\\/lib\\\/connector\\\/sabre\\\/file.php(320): OC\\\\Files\\\\View->unlink('\\\/New folder\\\/wel...')\\n#8 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/3rdparty\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Tree.php(179): OCA\\\\DAV\\\\Connector\\\\Sabre\\\\File->delete()\\n#9 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/3rdparty\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/CorePlugin.php(287): Sabre\\\\DAV\\\\Tree->delete('New folder\\\/welc...')\\n#10 [internal function]: Sabre\\\\DAV\\\\CorePlugin->httpDelete(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response))\\n#11 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/3rdparty\\\/sabre\\\/event\\\/lib\\\/EventEmitterTrait.php(105): call_user_func_array(Array, Array)\\n#12 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/3rdparty\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(459): Sabre\\\\Event\\\\EventEmitter->emit('method:DELETE', Array)\\n#13 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/3rdparty\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(248): Sabre\\\\DAV\\\\Server->invokeMethod(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response))\\n#14 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/apps\\\/dav\\\/appinfo\\\/v1\\\/webdav.php(54): Sabre\\\\DAV\\\\Server->exec()\\n#15 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/remote.php(137): require_once('\\\/home\\\/src\\\/owncl...')\\n#16 {main}\",\"File\":\"\\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/lib\\\/private\\\/files\\\/filesystem.php\",\"Line\":387}","level":3,"time":"2016-02-16T16:08:39+00:00"}
{"reqId":"h3FJVmACIo8+mISwiP+g","remoteAddr":"::1","app":"no app in context","message":"Exception: {\"Exception\":\"OCP\\\\Files\\\\NotFoundException\",\"Message\":\"File with id \\\"11\\\" has not been found.\",\"Code\":0,\"Trace\":\"#0 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/apps\\\/files_versions\\\/lib\\\/storage.php(98): OC\\\\Files\\\\View->getPath(11)\\n#1 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/apps\\\/files_versions\\\/lib\\\/storage.php(198): OCA\\\\Files_Versions\\\\Storage::getUidAndFilename('\\\/New folder\\\/wel...')\\n#2 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/apps\\\/files_versions\\\/lib\\\/hooks.php(90): OCA\\\\Files_Versions\\\\Storage::markDeletedFile('\\\/New folder\\\/wel...')\\n#3 [internal function]: OCA\\\\Files_Versions\\\\Hooks::pre_remove_hook(Array)\\n#4 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/lib\\\/private\\\/hook.php(104): call_user_func(Array, Array)\\n#5 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/lib\\\/private\\\/files\\\/view.php(1172): OC_Hook::emit('OC_Filesystem', 'delete', Array)\\n#6 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/lib\\\/private\\\/files\\\/view.php(1048): OC\\\\Files\\\\View->runHooks(Array, '\\\/New folder\\\/wel...')\\n#7 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/lib\\\/private\\\/files\\\/view.php(641): OC\\\\Files\\\\View->basicOperation('unlink', '\\\/New folder\\\/wel...', Array)\\n#8 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/apps\\\/dav\\\/lib\\\/connector\\\/sabre\\\/file.php(320): OC\\\\Files\\\\View->unlink('\\\/New folder\\\/wel...')\\n#9 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/3rdparty\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Tree.php(179): OCA\\\\DAV\\\\Connector\\\\Sabre\\\\File->delete()\\n#10 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/3rdparty\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/CorePlugin.php(287): Sabre\\\\DAV\\\\Tree->delete('New folder\\\/welc...')\\n#11 [internal function]: Sabre\\\\DAV\\\\CorePlugin->httpDelete(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response))\\n#12 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/3rdparty\\\/sabre\\\/event\\\/lib\\\/EventEmitterTrait.php(105): call_user_func_array(Array, Array)\\n#13 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/3rdparty\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(459): Sabre\\\\Event\\\\EventEmitter->emit('method:DELETE', Array)\\n#14 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/3rdparty\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(248): Sabre\\\\DAV\\\\Server->invokeMethod(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response))\\n#15 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/apps\\\/dav\\\/appinfo\\\/v1\\\/webdav.php(54): Sabre\\\\DAV\\\\Server->exec()\\n#16 \\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/remote.php(137): require_once('\\\/home\\\/src\\\/owncl...')\\n#17 {main}\",\"File\":\"\\\/home\\\/src\\\/owncloud\\\/server\\\/master\\\/lib\\\/private\\\/files\\\/view.php\",\"Line\":1639}","level":3,"time":"2016-02-16T16:08:42+00:00"}
{"reqId":"h3FJVmACIo8+mISwiP+g","remoteAddr":"::1","app":"PHP","message":"Undefined index: \/New folder\/welcome.txt at \/home\/src\/owncloud\/server\/master\/apps\/files_versions\/lib\/storage.php#226","level":3,"time":"2016-02-16T16:08:45+00:00"}
```

@icewind1991 @PVince81 please have a look. I think that's the smallest possible change to fix it for 9.0. Not sure if we can do something else for 9.1 in order to use `$view->getUidAndFilename($filename);` again.

@rullzer I didn't revert the changes for apps/files_sharing/lib/helper.php yet: https://github.com/owncloud/core/commit/300eb54c871cfe48165ee32ecdc5067226aa0b7b#diff-407e98495650a16757767c1f2b423ddbR209
Do you think we should revert this too? Is it still used for sharing 2.0 and do you think it can create problems if the federated cloud ID is returned here instead of a local user?

fix https://github.com/owncloud/core/issues/22504
