### PR TITLE
Handles null as return code and uses proper UserFolder in trashbin

### DIFF
--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -730,7 +730,7 @@ class Server extends ServerContainer implements IServerContainer {
 	 * Returns a view to ownCloud's files folder
 	 *
 	 * @param string $userId user ID
-	 * @return \OCP\Files\Folder
+	 * @return \OCP\Files\Folder|null
 	 */
 	public function getUserFolder($userId = null) {
 		if ($userId === null) {


### PR DESCRIPTION
Otherwise LDAP home folder naming rules will not get applied - just noticed this while debugging another issue that was related to the home folder naming rule.

cc @LukasReschke @nickvergessen @PVince81 @blizzz 

@rullzer I guess this could also has the same drawbacks as the avatars, but I think this is not that critical here because we call this on expire of the trashbin.
