### PR TITLE
Unlock sharee input field when sharing fails

### DIFF
--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -281,6 +281,12 @@
 					.attr('disabled', false);
 				$loading.addClass('hidden')
 					.removeClass('inlineblock');
+			}, error: function(obj, msg) {
+				OC.Notification.showTemporary(msg);
+				$(e.target).val('')
+					.attr('disabled', false);
+				$loading.addClass('hidden')
+					.removeClass('inlineblock');
 			}});
 		},
 

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -283,8 +283,8 @@
 					.removeClass('inlineblock');
 			}, error: function(obj, msg) {
 				OC.Notification.showTemporary(msg);
-				$(e.target).val('')
-					.attr('disabled', false);
+				$(e.target).attr('disabled', false)
+					.autocomplete('search', $(e.target).val());
 				$loading.addClass('hidden')
 					.removeClass('inlineblock');
 			}});

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -990,6 +990,43 @@ describe('OC.Share.ShareDialogView', function() {
 
 			addShareStub.restore();
 		});
+
+		it('calls addShare after selection and fail to share', function() {
+			dialog.render();
+
+			var shareWith = $('.shareWithField')[0];
+			var $shareWith = $(shareWith);
+			var addShareStub = sinon.stub(shareModel, 'addShare');
+			var autocompleteOptions = autocompleteStub.getCall(0).args[0];
+			autocompleteOptions.select(new $.Event('select', {target: shareWith}), {
+				item: {
+					label: 'User Two',
+					value: {
+						shareType: OC.Share.SHARE_TYPE_USER,
+						shareWith: 'user2'
+					}
+				}
+			});
+
+			expect(addShareStub.calledOnce).toEqual(true);
+			expect(addShareStub.firstCall.args[0]).toEqual({
+				shareType: OC.Share.SHARE_TYPE_USER,
+				shareWith: 'user2'
+			});
+
+			//Input is locked
+			expect($shareWith.val()).toEqual('User Two');
+			expect($shareWith.attr('disabled')).toEqual('disabled');
+
+			//Callback is called
+			addShareStub.firstCall.args[1].error();
+
+			//Input is unlocked
+			expect($shareWith.val()).toEqual('User Two');
+			expect($shareWith.attr('disabled')).toEqual(undefined);
+
+			addShareStub.restore();
+		});
 	});
 	describe('reshare permissions', function() {
 		it('does not show sharing options when sharing not allowed', function() {


### PR DESCRIPTION
Fixes #22441

When addShares fails (for whatever reason) we should unlock the sharee input field so the user does not have to reload the page.

@Dianafg76 please verify

CC: @PVince81 @nickvergessen @MorrisJobke 
