### PR TITLE
avconv command line syntax compat

### DIFF
--- a/lib/private/preview/movie.php
+++ b/lib/private/preview/movie.php
@@ -83,9 +83,9 @@ class Movie extends Provider {
 		$tmpPath = \OC::$server->getTempManager()->getTemporaryFile();
 
 		if (self::$avconvBinary) {
-			$cmd = self::$avconvBinary . ' -an -y -ss ' . escapeshellarg($second) .
+			$cmd = self::$avconvBinary . ' -y -ss ' . escapeshellarg($second) .
 				' -i ' . escapeshellarg($absPath) .
-				' -f mjpeg -vframes 1 -vsync 1 ' . escapeshellarg($tmpPath) .
+				' -an -f mjpeg -vframes 1 -vsync 1 ' . escapeshellarg($tmpPath) .
 				' > /dev/null 2>&1';
 		} else {
 			$cmd = self::$ffmpegBinary . ' -y -ss ' . escapeshellarg($second) .


### PR DESCRIPTION
Manually testing this line I hit a failure:

$ avconv  -an -y -ss 5 -i vid.3gp -f mjpeg -vframes 1 -vsync 1 tmpfile.jpg

```
Built on Jun  4 2015 19:39:02 with gcc 4.9.2 (Debian 4.9.2-10)
Option an (disable audio) cannot be applied to input file vid.3gp -- you are trying to apply an input option to an output file or vice versa. Move this option before the file it belongs to.
Error parsing options for input file vid.3gp.
```

$ avconv -y -ss 5 -i vid.3gp -an -f mjpeg -vframes 1 -vsync 1 tmpfile.jpg
`# ok`

Moving the `-an` option after the `-i <input file>` does the job.

[using libavconv56 6:11.4-1~deb8u1 on Debian Jessie]
