### PR TITLE
getRootFolder should not setup the FS for any user

### DIFF
--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -237,9 +237,9 @@ class Filesystem {
 	 *
 	 * @return \OC\Files\Mount\Manager
 	 */
-	public static function getMountManager() {
+	public static function getMountManager($user = '') {
 		if (!self::$mounts) {
-			\OC_Util::setupFS();
+			\OC_Util::setupFS($user);
 		}
 		return self::$mounts;
 	}

--- a/lib/private/files/node/root.php
+++ b/lib/private/files/node/root.php
@@ -71,7 +71,7 @@ class Root extends Folder implements IRootFolder {
 	/**
 	 * @param \OC\Files\Mount\Manager $manager
 	 * @param \OC\Files\View $view
-	 * @param \OC\User\User $user
+	 * @param \OC\User\User|null $user
 	 */
 	public function __construct($manager, $view, $user) {
 		parent::__construct($this, $view, '');

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -165,14 +165,9 @@ class Server extends ServerContainer implements IServerContainer {
 			return $c->query('SystemTagManagerFactory')->getObjectMapper();
 		});
 		$this->registerService('RootFolder', function (Server $c) {
-			// TODO: get user and user manager from container as well
-			$user = \OC_User::getUser();
-			/** @var $c SimpleContainer */
-			$userManager = $c->query('UserManager');
-			$user = $userManager->get($user);
-			$manager = \OC\Files\Filesystem::getMountManager();
+			$manager = \OC\Files\Filesystem::getMountManager(null);
 			$view = new View();
-			$root = new Root($manager, $view, $user);
+			$root = new Root($manager, $view, null);
 			$connector = new HookConnector($root, $view);
 			$connector->viewToNode();
 			return $root;

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -40,7 +40,6 @@ namespace OC;
 use bantu\IniGetWrapper\IniGetWrapper;
 use OC\AppFramework\Http\Request;
 use OC\AppFramework\Db\Db;
-use OC\AppFramework\Utility\SimpleContainer;
 use OC\AppFramework\Utility\TimeFactory;
 use OC\Command\AsyncBus;
 use OC\Diagnostics\EventLogger;
@@ -164,7 +163,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('SystemTagObjectMapper', function (Server $c) {
 			return $c->query('SystemTagManagerFactory')->getObjectMapper();
 		});
-		$this->registerService('RootFolder', function (Server $c) {
+		$this->registerService('RootFolder', function () {
 			$manager = \OC\Files\Filesystem::getMountManager(null);
 			$view = new View();
 			$root = new Root($manager, $view, null);

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -128,7 +128,9 @@ class OC_Util {
 		\OC::$server->getEventLogger()->start('setup_fs', 'Setup filesystem');
 
 		// If we are not forced to load a specific user we load the one that is logged in
-		if ($user == "" && OC_User::isLoggedIn()) {
+		if ($user === null) {
+			$user = '';
+		} else if ($user == "" && OC_User::isLoggedIn()) {
 			$user = OC_User::getUser();
 		}
 


### PR DESCRIPTION
Fixes #22467

This can go wrong when an app (take the ldap app) DIs something that
needs the rootFolder. This break if we use cookie auth since then we
know the user at that point and thus try to setup the fs for that user.

However if there are then incomming shares from an ldap user they will
fails since the user manager can't find them yet.

Now getRootFolder does not setup the fs for any user.

@icewind1991 I plese have a look at this.
