### PR TITLE
set correct http status code in redirect response

### DIFF
--- a/lib/public/appframework/http/redirectresponse.php
+++ b/lib/public/appframework/http/redirectresponse.php
@@ -44,7 +44,7 @@ class RedirectResponse extends Response {
 	 */
 	public function __construct($redirectURL) {
 		$this->redirectURL = $redirectURL;
-		$this->setStatus(Http::STATUS_TEMPORARY_REDIRECT);
+		$this->setStatus(Http::STATUS_SEE_OTHER);
 		$this->addHeader('Location', $redirectURL);
 	}
 

--- a/tests/lib/appframework/http/RedirectResponseTest.php
+++ b/tests/lib/appframework/http/RedirectResponseTest.php
@@ -43,7 +43,7 @@ class RedirectResponseTest extends \Test\TestCase {
 	public function testHeaders() {
 		$headers = $this->response->getHeaders();
 		$this->assertEquals('/url', $headers['Location']);
-		$this->assertEquals(Http::STATUS_TEMPORARY_REDIRECT, 
+		$this->assertEquals(Http::STATUS_SEE_OTHER, 
 			$this->response->getStatus());
 	}
 


### PR DESCRIPTION
Was intended to respond with a 303 (See other) status code instead of 307 (Temporary Redirect).

cc @BernhardPosselt (btw: thanks for the fix! ;))
