### PR TITLE
Properly trigger testRemote after getting a 404 from remote fed share

### DIFF
--- a/apps/files_sharing/lib/external/storage.php
+++ b/apps/files_sharing/lib/external/storage.php
@@ -252,6 +252,9 @@ class Storage extends DAV implements ISharedStorage {
 			if ($e->getCode() === 401 || $e->getCode() === 403) {
 				throw new ForbiddenException();
 			}
+			if ($e->getCode() === 404) {
+				throw new NotFoundException();
+			}
 			// throw this to be on the safe side: the share will still be visible
 			// in the UI in case the failure is intermittent, and the user will
 			// be able to decide whether to remove it if it's really gone


### PR DESCRIPTION
Whenever a remote fed share's shareinfo call returns a 404, don't
directly assume the storage is not available by throwing
StorageNotAvailableException. We need to properly throw
NotFoundException to trigger the later logic that calls testRemote()
that verifies that the 404 is not from a broken server but really from
an obsolete share.

When throwing this exception, the following code gets triggered properly: https://github.com/owncloud/core/blob/73d46afc3c5ef237cc8a5431aa1bef4686a7521b/apps/files_sharing/lib/external/storage.php#L187
As you can see, if the remote server properly exists, it will then proceed to remove the share.

I believe this bug was introduced when we moved to Guzzle, and exceptions needed to be thrown manually and that one was missing.

Fixes https://github.com/owncloud/core/issues/22483

Please review @rullzer @schiesbn @icewind1991 @nasli
