### PR TITLE
When (re-)sharing an incomming federated share set the corrent owner

### DIFF
--- a/apps/files_versions/lib/storage.php
+++ b/apps/files_versions/lib/storage.php
@@ -104,6 +104,9 @@ class Storage {
 			$ownerView = new View('/'.$uid.'/files');
 			try {
 				$filename = $ownerView->getPath($info['fileid']);
+				// make sure that the file name doesn't end with a trailing slash
+				// can for example happen single files shared across servers
+				$filename = rtrim($filename, '/');
 			} catch (NotFoundException $e) {
 				$filename = null;
 			}

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -517,8 +517,20 @@ class Manager implements IManager {
 		// Verify if there are any issues with the path
 		$this->pathCreateChecks($share->getNode());
 
-		// On creation of a share the owner is always the owner of the path
-		$share->setShareOwner($share->getNode()->getOwner()->getUID());
+		/*
+		 * On creation of a share the owner is always the owner of the path
+		 * Except for mounted federated shares.
+		 */
+		$storage = $share->getNode()->getStorage();
+		if ($storage->instanceOfStorage('OCA\Files_Sharing\External\Storage')) {
+			$parent = $share->getNode()->getParent();
+			while($parent->getStorage()->instanceOfStorage('OCA\Files_Sharing\External\Storage')) {
+				$parent = $parent->getParent();
+			}
+			$share->setShareOwner($parent->getOwner()->getUID());
+		} else {
+			$share->setShareOwner($share->getNode()->getOwner()->getUID());
+		}
 
 		// Cannot share with the owner
 		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER &&


### PR DESCRIPTION
Incomming federated shares are a special kind. We mount them as normal
webdav shares but we do supply owner info with the federated cloud id of
the share owner.

Since we do not yet have the new resharing behaviour on federated shares
we need to set the correct owner. Which will allow sharing and proper
mounting for other users.

fixes #22500 

@rperezb please verify

CC: @schiesbn @nickvergessen @DeepDiver1975 @PVince81 
