### PR TITLE
Only add checksum headers for 'real' files

### DIFF
--- a/apps/dav/lib/connector/sabre/filesplugin.php
+++ b/apps/dav/lib/connector/sabre/filesplugin.php
@@ -193,11 +193,13 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 		// adds a 'Content-Disposition: attachment' header
 		$response->addHeader('Content-Disposition', 'attachment');
 
-		//Add OC-Checksum header
-		/** @var $node File */
-		$checksum = $node->getChecksum();
-		if ($checksum !== null) {
-			$response->addHeader('OC-Checksum', $checksum);
+		if ($node instanceof \OCA\DAV\Connector\Sabre\File) {
+			//Add OC-Checksum header
+			/** @var $node File */
+			$checksum = $node->getChecksum();
+			if ($checksum !== null) {
+				$response->addHeader('OC-Checksum', $checksum);
+			}
 		}
 	}
 


### PR DESCRIPTION
Found while debugging the error in travis of #22509

We should only add checksum headers if we are handling a 'real' file (so we have a fileinfo object etc). Caldav and Carddav entries are also files. But don't have a fileinfo so we have no stored checksum.

Easy one.

CC: @PVince81 @DeepDiver1975 @nickvergessen @MorrisJobke 
