### PR TITLE
Accumulate notifications instead of blinking

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -472,7 +472,11 @@ OC.Upload = {
 							OC.Upload.showUploadCancelMessage();
 						} else {
 							// HTTP connection problem
-							OC.Notification.showTemporary(data.errorThrown, {timeout: 10});
+							var message = t('files', 'Error uploading file "{fileName}": {message}', {
+								fileName: data.files[0].name,
+								message: data.errorThrown
+							});
+							OC.Notification.show(message, {timeout: 0, type: 'error'});
 							if (data.result) {
 								var result = JSON.parse(data.result);
 								if (result && result[0] && result[0].data && result[0].data.code === 'targetnotfound') {

--- a/apps/files/tests/js/fileactionsSpec.js
+++ b/apps/files/tests/js/fileactionsSpec.js
@@ -20,9 +20,10 @@
 */
 
 describe('OCA.Files.FileActions tests', function() {
-	var fileList, fileActions;
+	var fileList, fileActions, clock;
 
 	beforeEach(function() {
+		clock = sinon.useFakeTimers();
 		// init horrible parameters
 		var $body = $('#testArea');
 		$body.append('<input type="hidden" id="dir" value="/subdir"></input>');
@@ -63,6 +64,7 @@ describe('OCA.Files.FileActions tests', function() {
 		fileActions = null;
 		fileList.destroy();
 		fileList = undefined;
+		clock.restore();
 		$('#dir, #permissions, #filestable').remove();
 	});
 	it('calling clear() clears file actions', function() {

--- a/apps/systemtags/tests/js/systemtagsinfoviewSpec.js
+++ b/apps/systemtags/tests/js/systemtagsinfoviewSpec.js
@@ -22,14 +22,17 @@
 describe('OCA.SystemTags.SystemTagsInfoView tests', function() {
 	var isAdminStub;
 	var view;
+	var clock;
 
 	beforeEach(function() {
+		clock = sinon.useFakeTimers();
 		view = new OCA.SystemTags.SystemTagsInfoView();
 		$('#testArea').append(view.$el);
 		isAdminStub = sinon.stub(OC, 'isUserAdmin').returns(true);
 	});
 	afterEach(function() {
 		isAdminStub.restore();
+		clock.restore();
 		view.remove();
 		view = undefined;
 	});

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -669,6 +669,24 @@ td.avatar {
 	cursor: pointer;
 	margin-left: 1em;
 }
+#notification {
+	overflow-x: hidden;
+	overflow-y: auto;
+	max-height: 100px;
+}
+#notification .row {
+	position: relative;
+}
+#notification .row .close {
+	display: inline-block;
+	vertical-align: middle;
+	position: absolute;
+	right: 0;
+	top: 0;
+}
+#notification .row.closeable {
+	padding-right: 20px;
+}
 
 tr .action:not(.permanent),
 .selectedActions a {

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -650,7 +650,7 @@ td.avatar {
 	width: 100%;
 	text-align: center;
 }
-#notification, #update-notification {
+#notification {
 	margin: 0 auto;
 	max-width: 60%;
 	z-index: 8000;
@@ -665,7 +665,7 @@ td.avatar {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=90)";
 	opacity: .9;
 }
-#notification span, #update-notification span {
+#notification span {
 	cursor: pointer;
 	margin-left: 1em;
 }

--- a/core/js/tests/specs/systemtags/systemtagsinputfieldSpec.js
+++ b/core/js/tests/specs/systemtags/systemtagsinputfieldSpec.js
@@ -20,9 +20,10 @@
 */
 
 describe('OC.SystemTags.SystemTagsInputField tests', function() {
-	var view, select2Stub;
+	var view, select2Stub, clock;
 
 	beforeEach(function() {
+		clock = sinon.useFakeTimers();
 		var $container = $('<div class="testInputContainer"></div>');
 		select2Stub = sinon.stub($.fn, 'select2');
 		select2Stub.returnsThis();
@@ -31,6 +32,7 @@ describe('OC.SystemTags.SystemTagsInputField tests', function() {
 	afterEach(function() {
 		select2Stub.restore();
 		OC.SystemTags.collection.reset();
+		clock.restore();
 		view.remove();
 		view = undefined;
 	});


### PR DESCRIPTION
This makes it possible to display multiple notifications.
If the options.type is set to "error", it will also add a close button.

To test, edit "apps/files/ajax/upload.php" and add these lines to simulate failure:

```
    OCP\JSON::error(array('data' => ['message' => 'Connection timeout or other error message']));
    exit();
```

Then upload several files.

Another way is to call the API directly in the browser console:

```
OC.Notification.showHtml('<div>Oh hello</div><div>Second line</div>', {type: 'error'});
OC.Notification.show('test permanent notif without button');
OC.Notification.showTemporary('test temporary notif without button');
```

Some issues to discuss:
- [x] is the scrollbar acceptable when there are too many notifications ?
- [x] should upload errors time out ? (they used to, but it's convenient to be able to read it and close them afterwards)
- [x] missing "close all", how and where ?
- [x] should we always show the close button, even for non-errors ? (and force API consumers to pass "type: permanent" if they really want to make it unclosable ?)

Todos:
- [x] TODO: make sure the file name is included in all file-related error messages
- [x] TODO: write unit tests

Tests:
- [x] TEST: manual test (see example calls above)
- [x] TEST: upload with not enough space
- [x] TEST: users "undo" notification still works
- [x] TEST: update notification still works

@jancborchardt please try it out and see the items to discuss above

@MorrisJobke @rullzer @nickvergessen @schiesbn @icewind1991 

Fixes #19817
