### PR TITLE
Check delete permission before attemping copy+delete

### DIFF
--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -613,6 +613,10 @@ abstract class Common implements Storage, ILockingStorage {
 			return $this->rename($sourceInternalPath, $targetInternalPath);
 		}
 
+		if (!$sourceStorage->isDeletable($sourceInternalPath)) {
+			return false;
+		}
+
 		$result = $this->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, true);
 		if ($result) {
 			if ($sourceStorage->is_dir($sourceInternalPath)) {

--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -459,6 +459,10 @@ class Encryption extends Wrapper {
 		// - copy the copyKeys() call from  $this->copyBetweenStorage to this method
 		// - remove $this->copyBetweenStorage
 
+		if (!$sourceStorage->isDeletable($sourceInternalPath)) {
+			return false;
+		}
+
 		$result = $this->copyBetweenStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime, true);
 		if ($result) {
 			if ($sourceStorage->is_dir($sourceInternalPath)) {


### PR DESCRIPTION
Some move operations when cross-storage will be replaced by copy and
delete. Before attempting this, first check whether the source storage
has delete permissions.

This also prevents renaming system-wide external storages.

Fixes https://github.com/owncloud/core/issues/21074

Please review @icewind1991 @schiesbn @MorrisJobke @nickvergessen @davitol 
