### PR TITLE
Prevent rmdir of the mount point of ext storages

### DIFF
--- a/apps/files_external/lib/dropbox.php
+++ b/apps/files_external/lib/dropbox.php
@@ -205,6 +205,10 @@ class Dropbox extends \OC\Files\Storage\Common {
 	}
 
 	public function unlink($path) {
+		if (empty($path) || $path === '/') {
+			return false;
+		}
+
 		try {
 			$this->dropbox->delete($this->root.$path);
 			$this->deleteMetaData($path);

--- a/apps/files_external/lib/sftp.php
+++ b/apps/files_external/lib/sftp.php
@@ -276,6 +276,9 @@ class SFTP extends \OC\Files\Storage\Common {
 	 */
 	public function rmdir($path) {
 		try {
+			if (empty($path) || $path === '/') {
+				return false;
+			}
 			$result = $this->getConnection()->delete($this->absPath($path), true);
 			// workaround: stray stat cache entry when deleting empty folders
 			// see https://github.com/phpseclib/phpseclib/issues/706

--- a/apps/files_external/lib/smb.php
+++ b/apps/files_external/lib/smb.php
@@ -248,6 +248,10 @@ class SMB extends Common {
 	}
 
 	public function rmdir($path) {
+		if (empty($path) || $path === '/') {
+			return false;
+		}
+
 		try {
 			$this->statCache = array();
 			$content = $this->share->dir($this->buildPath($path));

--- a/apps/files_trashbin/lib/storage.php
+++ b/apps/files_trashbin/lib/storage.php
@@ -114,6 +114,10 @@ class Storage extends Wrapper {
 	 * @return bool
 	 */
 	protected function shouldMoveToTrash($path){
+		// don't move mount point roots to trash
+		if (empty($path) || $path === '/') {
+			return false;
+		}
 		$normalized = Filesystem::normalizePath($this->mountPoint . '/' . $path);
 		$parts = explode('/', $normalized);
 		if (count($parts) < 4) {

--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -181,6 +181,9 @@ class DAV extends Common {
 	public function rmdir($path) {
 		$this->init();
 		$path = $this->cleanPath($path);
+		if (empty($path) || $path === '/') {
+			return false;
+		}
 		// FIXME: some WebDAV impl return 403 when trying to DELETE
 		// a non-empty folder
 		$result = $this->simpleResponse('DELETE', $path . '/', null, 204);


### PR DESCRIPTION
Not all ext storages' `rmdir` call checks whether the folder is deletable.
In the ones that don't, I added a check whether we are trying to delete the mount point itself, which is wrong.
This would protect against code paths that call `rmdir` directly on the storages.

However, I'm not 100% sure whether some piece of code expect that doing `$storage->rmdir('')` is supposed to delete the contents ?
I think in general `unlink('')` and `rmdir('')` should be invalid.

So there is a slight risk of regression in this PR.

@icewind1991 can you clarify ?

Note, this is only hardening for https://github.com/owncloud/core/issues/21074.
The actual fix is here https://github.com/owncloud/core/pull/22518
