### PR TITLE
Moved set -e option to enable executable checks again

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -13,8 +13,6 @@
 # @copyright 2012-2015 Thomas Müller thomas.mueller@tmit.eu
 #
 
-set -e
-
 #$EXECUTOR_NUMBER is set by Jenkins and allows us to run autotest in parallel
 DATABASENAME=oc_autotest$EXECUTOR_NUMBER
 DATABASEUSER=oc_autotest$EXECUTOR_NUMBER
@@ -33,6 +31,8 @@ if [ -z "$PHP_EXE" ]; then
 fi
 PHP=$(which "$PHP_EXE")
 PHPUNIT=$(which phpunit)
+
+set -e
 
 _XDEBUG_CONFIG=$XDEBUG_CONFIG
 unset XDEBUG_CONFIG


### PR DESCRIPTION
While trying to reproduce issue #19983 we stumbled over a non working autotest.sh (we had no phpunit in our path). After a closer look into autotest.sh we found a "-set e" above the executable checks. After moving it below those tests everything works fine again and we got the expected warning that phpunit was missing.
