### PR TITLE
Filter closures when writing config

### DIFF
--- a/lib/private/config.php
+++ b/lib/private/config.php
@@ -219,10 +219,21 @@ class Config {
 	 * @throws \Exception If no file lock can be acquired
 	 */
 	private function writeData() {
+
+		// filter config
+		$config = [];
+		foreach ($this->cache as $key => $value) {
+			if ($value instanceof \Closure) {
+				$config[$key] = 'Closure from separate config file';
+			} else {
+				$config[$key] = $value;
+			}
+		}
+
 		// Create a php file ...
 		$content = "<?php\n";
 		$content .= '$CONFIG = ';
-		$content .= var_export($this->cache, true);
+		$content .= var_export($config, true);
 		$content .= ";\n";
 
 		touch ($this->configFilePath);

--- a/tests/lib/configtests.php
+++ b/tests/lib/configtests.php
@@ -73,6 +73,21 @@ class ConfigTests extends TestCase {
 		$this->assertEquals($expected, $content);
 	}
 
+	public function testFilterClosure() {
+
+		$func = function($foo){ return $foo; };
+
+		$this->config->setValue('closure', $func);
+		$this->assertSame($func, $this->config->getValue('closure'));
+
+		$content = file_get_contents($this->configFile);
+
+		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'bur',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
+			"  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n" .
+			"  'closure' => 'Closure from separate config file',\n);\n";
+		$this->assertEquals($expected, $content);
+	}
+
 	public function testSetValues() {
 		$content = file_get_contents($this->configFile);
 		$this->assertEquals(self::TESTCONTENT, $content);


### PR DESCRIPTION
We would like to give administrators the power to customize the behavior of apps. This PR allows creating a `config/myapp.config.php` like:

``` php
<?php
$CONFIG = array (
  'myapp.uid_mapping' => function($uid) {
    return $uid.'@foo.tld';
  },
);
```

Without this PR writing the config file, eg when changing the loglevel in the web ui will result in a broken and unusable owncloud instance:

```
Fatal error: Call to undefined method Closure::__set_state() in /var/www/owncloud/config/config.php on line 30
```

which looks like:

``` php
  'myapp.uid_mapping' => 
  Closure::__set_state(array(
  )),
```

With this PR the closure is replaced with a hint `Closure from separate config file` so it is clear the actual closure comes from another config file.

cc @felixboehm
