### PR TITLE
Only show the ... menu in the filelist if there are multiple dropdown items

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -531,6 +531,7 @@
 				fileList: fileList
 			};
 
+			var numDropDown = 0;
 			$.each(actions, function (name, actionSpec) {
 				if (actionSpec.type === FileActions.TYPE_INLINE) {
 					self._renderInlineAction(
@@ -538,10 +539,24 @@
 						defaultAction && actionSpec.name === defaultAction.name,
 						context
 					);
+				} else {
+					numDropDown++;
 				}
 			});
 
-			this._renderMenuTrigger($tr, context);
+			if (numDropDown === 1) {
+				$.each(actions, function (name, actionSpec) {
+					if (actionSpec.type === FileActions.TYPE_DROPDOWN) {
+						self._renderInlineAction(
+							actionSpec,
+							defaultAction && actionSpec.name === defaultAction.name,
+							context
+						);
+					}
+				});
+			} else if (numDropDown > 1) {
+				this._renderMenuTrigger($tr, context);
+			}
 
 			if (triggerEvent){
 				fileList.$fileList.trigger(jQuery.Event("fileActionsReady", {fileList: fileList, $files: $tr}));

--- a/apps/files/tests/js/fileactionsSpec.js
+++ b/apps/files/tests/js/fileactionsSpec.js
@@ -207,6 +207,27 @@ describe('OCA.Files.FileActions tests', function() {
 			expect($tr.find('.action.action-iconnoalttext').find('img').length).toEqual(1);
 			expect($tr.find('.action.action-iconnoalttext').find('img').eq(0).attr('alt')).toEqual('');
 		});
+		it('display dropdown action inline if there is only 1', function() {
+			fileActions.clear();
+			fileActions.registerAction({
+				name: 'Inline',
+				displayName: 'Inline',
+				type: OCA.Files.FileActions.TYPE_INLINE,
+				mime: 'text/plain',
+				permissions: OC.PERMISSION_READ
+			});
+			fileActions.registerAction({
+				name: 'DropDown',
+				displayName: 'DropDown',
+				type: OCA.Files.FileActions.TYPE_DROPDOWN,
+				mime: 'text/plain',
+				permissions: OC.PERMISSION_READ
+			});
+
+			fileActions.display($tr.find('td.filename'), true, fileList);
+			expect($tr.find('.action.action-inline').length).toEqual(1);
+			expect($tr.find('.action.action-dropdown').length).toEqual(1);
+		});
 	});
 	describe('action handler', function() {
 		var actionStub, $tr, clock;


### PR DESCRIPTION
Fixes #21143

Having a dropdown with only 1 items makes no sense and looks weird.
- Added unit test

To test:
1. share a folder read only (with content) by link
2. open the link

Before:
The menu with 3 dots that only contains Download

After:
Download is an inline item

CC: @owncloud/designers @PVince81 @MorrisJobke @nickvergessen
