### PR TITLE
Move `-an` after the input arg because it is an output option

### DIFF
--- a/lib/private/preview/movie.php
+++ b/lib/private/preview/movie.php
@@ -83,9 +83,9 @@ class Movie extends Provider {
 		$tmpPath = \OC::$server->getTempManager()->getTemporaryFile();
 
 		if (self::$avconvBinary) {
-			$cmd = self::$avconvBinary . ' -an -y -ss ' . escapeshellarg($second) .
+			$cmd = self::$avconvBinary . ' -y -ss ' . escapeshellarg($second) .
 				' -i ' . escapeshellarg($absPath) .
-				' -f mjpeg -vframes 1 -vsync 1 ' . escapeshellarg($tmpPath) .
+				' -an -f mjpeg -vframes 1 -vsync 1 ' . escapeshellarg($tmpPath) .
 				' > /dev/null 2>&1';
 		} else {
 			$cmd = self::$ffmpegBinary . ' -y -ss ' . escapeshellarg($second) .


### PR DESCRIPTION
As per http://manpages.ubuntu.com/manpages/precise/man1/avconv.1.html
`-an` is an output file option, therefore has to occur after the file input arg (`-i`)
This worked in the past, but throws an error in newer versions of avconv

@MorrisJobke @LukasReschke 
