### PR TITLE
We should check for exceptions when trying to get the avatar

### DIFF
--- a/lib/private/avatarmanager.php
+++ b/lib/private/avatarmanager.php
@@ -27,6 +27,7 @@
 namespace OC;
 
 use OCP\Files\Folder;
+use OCP\Files\NotFoundException;
 use OCP\IAvatarManager;
 use OCP\IUserManager;
 use OCP\Files\IRootFolder;
@@ -68,6 +69,7 @@ class AvatarManager implements IAvatarManager {
 	 * @param string $userId the ownCloud user id
 	 * @return \OCP\IAvatar
 	 * @throws \Exception In case the username is potentially dangerous
+	 * @throws NotFoundException In case there is no user folder yet
 	 */
 	public function getAvatar($userId) {
 		$user = $this->userManager->get($userId);

--- a/lib/public/iavatarmanager.php
+++ b/lib/public/iavatarmanager.php
@@ -36,6 +36,8 @@ interface IAvatarManager {
 	 * @see \OCP\IAvatar
 	 * @param string $user the ownCloud user id
 	 * @return \OCP\IAvatar
+	 * @throws \Exception In case the username is potentially dangerous
+	 * @throws \OCP\Files\NotFoundException In case there is no user folder yet
 	 * @since 6.0.0
 	 */
 	public function getAvatar($user);

--- a/settings/controller/userscontroller.php
+++ b/settings/controller/userscontroller.php
@@ -176,7 +176,11 @@ class UsersController extends Controller {
 
 		$avatarAvailable = false;
 		if ($this->config->getSystemValue('enable_avatars', true) === true) {
-			$avatarAvailable = $this->avatarManager->getAvatar($user->getUID())->exists();
+			try {
+				$avatarAvailable = $this->avatarManager->getAvatar($user->getUID())->exists();
+			} catch (\Exception $e) {
+				//No avatar yet
+			}
 		}
 
 		return [

--- a/tests/settings/controller/userscontrollertest.php
+++ b/tests/settings/controller/userscontrollertest.php
@@ -1696,6 +1696,32 @@ class UsersControllerTest extends \Test\TestCase {
 		$this->assertEquals($expectedResult, $result);
 	}
 
+	public function testNoAvatar() {
+		$this->container['IsAdmin'] = true;
+
+		list($user, $expectedResult) = $this->mockUser();
+
+		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+			->disableOriginalConstructor()
+			->getMock();
+		$subadmin->expects($this->once())
+			->method('getSubAdminsGroups')
+			->with($user)
+			->will($this->returnValue([]));
+		$this->container['GroupManager']
+			->expects($this->any())
+			->method('getSubAdmin')
+			->will($this->returnValue($subadmin));
+
+		$this->container['OCP\\IAvatarManager']
+			->method('getAvatar')
+			->will($this->throwException(new \OCP\Files\NotFoundException()));
+		$expectedResult['isAvatarAvailable'] = false;
+
+		$result = self::invokePrivate($this->container['UsersController'], 'formatUserForIndex', [$user]);
+		$this->assertEquals($expectedResult, $result);
+	}
+
 	/**
 	 * @return array
 	 */


### PR DESCRIPTION
Fixes #22550

Basically we did not check for the exception. Which we should. (even before there was the possibility of the exception being thrown).

@LukasReschke as promised
