### PR TITLE
Fix public page footer position in IE

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -3,6 +3,11 @@
 	min-height: calc(100vh - 120px);
 }
 
+/* force layout to make sure the content element's height matches its contents' height */
+.ie #content {
+	display: inline-block;
+}
+
 #preview {
 	background: #fff;
 	text-align: center;


### PR DESCRIPTION
The content element needs hasLayout, so triggering it with a display
attribute.

Without this, the #content element's height would be as high as the
window's height instead of adjusting itself to its contents' height.

Fixes https://github.com/owncloud/core/issues/22560

Please review @MorrisJobke @jancborchardt @Henni @LukasReschke @icewind1991 @karlitschek 

This shouldn't affect Edge but it would be good to confirm that Edge doesn't need this fix.

@karlitschek backport request
