### PR TITLE
Avoids scanning the root storage

### DIFF
--- a/lib/private/files/utils/scanner.php
+++ b/lib/private/files/utils/scanner.php
@@ -119,6 +119,10 @@ class Scanner extends PublicEmitter {
 			if (is_null($mount->getStorage())) {
 				continue;
 			}
+			// don't scan the root storage
+			if ($mount->getStorage()->instanceOfStorage('\OC\Files\Storage\Local') && $mount->getMountPoint() === '/') {
+				continue;
+			}
 			$scanner = $mount->getStorage()->getScanner();
 			$this->attachListener($mount);
 			$scanner->backgroundScan();


### PR DESCRIPTION
This check will skip the background scan for the root storage
because there is nothing in the root storage that isn't already
in another (mostly user-) storage.

An `instanceof` check could not be done because the storage
is wrapped multiple times and needs to be unwrapped to be
properly checked.

Fixes #22501 

cc @PVince81 @icewind1991 

I tested this also with other local storages that are created with the files_external app. Those are scanned.
