### PR TITLE
Allow defining a limit and offset for getObjectIdsForTags

### DIFF
--- a/apps/dav/tests/unit/connector/sabre/filesreportplugin.php
+++ b/apps/dav/tests/unit/connector/sabre/filesreportplugin.php
@@ -19,7 +19,7 @@
  *
  */
 
-namespace OCA\DAV\Tests\Unit\Sabre\Connector;
+namespace OCA\DAV\Tests\Unit\Connector\Sabre;
 
 use OCA\DAV\Connector\Sabre\FilesReportPlugin as FilesReportPluginImplementation;
 use Sabre\DAV\Exception\NotFound;
@@ -369,7 +369,7 @@ class FilesReportPlugin extends \Test\TestCase {
 				['123', 'files']
 			)
 			->willReturnMap([
-				['123', 'files', ['111', '222']],
+				['123', 'files', 0, '', ['111', '222']],
 			]);
 
 		$rules = [
@@ -391,8 +391,8 @@ class FilesReportPlugin extends \Test\TestCase {
 				['456', 'files']
 			)
 			->willReturnMap([
-				['123', 'files', ['111', '222']],
-				['456', 'files', ['222', '333']],
+				['123', 'files', 0, '', ['111', '222']],
+				['456', 'files', 0, '', ['222', '333']],
 			]);
 
 		$rules = [
@@ -415,8 +415,8 @@ class FilesReportPlugin extends \Test\TestCase {
 				['456', 'files']
 			)
 			->willReturnMap([
-				['123', 'files', ['111', '222']],
-				['456', 'files', []],
+				['123', 'files', 0, '', ['111', '222']],
+				['456', 'files', 0, '', []],
 			]);
 
 		$rules = [
@@ -439,8 +439,8 @@ class FilesReportPlugin extends \Test\TestCase {
 				['456', 'files']
 			)
 			->willReturnMap([
-				['123', 'files', []],
-				['456', 'files', ['111', '222']],
+				['123', 'files', 0, '', []],
+				['456', 'files', 0, '', ['111', '222']],
 			]);
 
 		$rules = [
@@ -464,9 +464,9 @@ class FilesReportPlugin extends \Test\TestCase {
 				['789', 'files']
 			)
 			->willReturnMap([
-				['123', 'files', ['111', '222']],
-				['456', 'files', ['333']],
-				['789', 'files', ['111', '222']],
+				['123', 'files', 0, '', ['111', '222']],
+				['456', 'files', 0, '', ['333']],
+				['789', 'files', 0, '', ['111', '222']],
 			]);
 
 		$rules = [

--- a/lib/public/systemtag/isystemtagobjectmapper.php
+++ b/lib/public/systemtag/isystemtagobjectmapper.php
@@ -57,15 +57,19 @@ interface ISystemTagObjectMapper {
 	 *
 	 * @param string|array $tagIds Tag id or array of tag ids.
 	 * @param string $objectType object type
+	 * @param int $limit Count of object ids you want to get
+	 * @param string $offset The last object id you already received
 	 *
 	 * @return string[] array of object ids or empty array if none found
 	 *
 	 * @throws \OCP\SystemTag\TagNotFoundException if at least one of the
 	 * given tags does not exist
+	 * @throws \InvalidArgumentException When a limit is specified together with
+	 * multiple tag ids
 	 *
 	 * @since 9.0.0
 	 */
-	public function getObjectIdsForTags($tagIds, $objectType);
+	public function getObjectIdsForTags($tagIds, $objectType, $limit = 0, $offset = '');
 
 	/**
 	 * Assign the given tags to the given object.

--- a/tests/lib/systemtag/systemtagobjectmappertest.php
+++ b/tests/lib/systemtag/systemtagobjectmappertest.php
@@ -145,6 +145,42 @@ class SystemTagObjectMapperTest extends TestCase {
 		], $objectIds);
 	}
 
+	public function testGetObjectsForTagsLimit() {
+		$objectIds = $this->tagMapper->getObjectIdsForTags(
+			[$this->tag1->getId()],
+			'testtype',
+			1
+		);
+
+		$this->assertEquals([
+			1,
+		], $objectIds);
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testGetObjectsForTagsLimitWithMultipleTags() {
+		$this->tagMapper->getObjectIdsForTags(
+			[$this->tag1->getId(), $this->tag2->getId(), $this->tag3->getId()],
+			'testtype',
+			1
+		);
+	}
+
+	public function testGetObjectsForTagsLimitOffset() {
+		$objectIds = $this->tagMapper->getObjectIdsForTags(
+			[$this->tag1->getId()],
+			'testtype',
+			1,
+			'1'
+		);
+
+		$this->assertEquals([
+			2,
+		], $objectIds);
+	}
+
 	/**
 	 * @expectedException \OCP\SystemTag\TagNotFoundException
 	 */


### PR DESCRIPTION
Fix #22566 

@PVince81 @LukasReschke 
