### PR TITLE
Add verbose flag to occ commands of autotest*

### DIFF
--- a/autotest-external.sh
+++ b/autotest-external.sh
@@ -148,7 +148,7 @@ EOF
 
 	# trigger installation
 	echo "Installing ...."
-	./occ maintenance:install --database=$1 --database-name=$DATABASENAME --database-host=localhost --database-user=$DATABASEUSER --database-pass=owncloud --database-table-prefix=oc_ --admin-user=$ADMINLOGIN --admin-pass=admin --data-dir=$DATADIR
+	./occ maintenance:install -vvv --database=$1 --database-name=$DATABASENAME --database-host=localhost --database-user=$DATABASEUSER --database-pass=owncloud --database-table-prefix=oc_ --admin-user=$ADMINLOGIN --admin-pass=admin --data-dir=$DATADIR
 
 	#test execution
 	echo "Testing with $1 ..."
@@ -161,7 +161,7 @@ EOF
 	rm -rf "coverage-external-html-$1"
 	mkdir "coverage-external-html-$1"
 	# just enable files_external
-	php ../occ app:enable files_external
+	php ../occ app:enable -vvv files_external
 	if [[ "$_XDEBUG_CONFIG" ]]; then
 		export XDEBUG_CONFIG=$_XDEBUG_CONFIG
 	fi

--- a/autotest.sh
+++ b/autotest.sh
@@ -251,7 +251,7 @@ function execute_tests {
 
 	# trigger installation
 	echo "Installing ...."
-	"$PHP" ./occ maintenance:install --database="$_DB" --database-name="$DATABASENAME" --database-host="$DATABASEHOST" --database-user="$DATABASEUSER" --database-pass=owncloud --database-table-prefix=oc_ --admin-user="$ADMINLOGIN" --admin-pass=admin --data-dir="$DATADIR"
+	"$PHP" ./occ maintenance:install -vvv --database="$_DB" --database-name="$DATABASENAME" --database-host="$DATABASEHOST" --database-user="$DATABASEUSER" --database-pass=owncloud --database-table-prefix=oc_ --admin-user="$ADMINLOGIN" --admin-pass=admin --data-dir="$DATADIR"
 
 	#test execution
 	echo "Testing with $DB ..."


### PR DESCRIPTION
Let's see if we can get the stacktrace of that core-ci-linux-swift-primary-storage/database=mysql,label=SLAVE` failure CI is seeing from time to time
