### PR TITLE
Add header for attachment disposition only once

### DIFF
--- a/apps/dav/lib/server.php
+++ b/apps/dav/lib/server.php
@@ -114,19 +114,6 @@ class Server {
 			$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\FakeLockerPlugin());
 		}
 
-		// Serve all files with an Content-Disposition of type "attachment"
-		$this->server->on('beforeMethod', function (RequestInterface $requestInterface, ResponseInterface $responseInterface) {
-			if ($requestInterface->getMethod() === 'GET') {
-				$path = $requestInterface->getPath();
-				if ($this->server->tree->nodeExists($path)) {
-					$node = $this->server->tree->getNodeForPath($path);
-					if (($node instanceof IFile)) {
-						$responseInterface->addHeader('Content-Disposition', 'attachment');
-					}
-				}
-			}
-		});
-
 		// wait with registering these until auth is handled and the filesystem is setup
 		$this->server->on('beforeMethod', function () {
 			// custom properties plugin must be the last one

--- a/apps/dav/lib/server.php
+++ b/apps/dav/lib/server.php
@@ -31,10 +31,6 @@ use OCA\DAV\Files\CustomPropertiesBackend;
 use OCP\IRequest;
 use OCP\SabrePluginEvent;
 use Sabre\DAV\Auth\Plugin;
-use Sabre\DAV\IFile;
-use Sabre\HTTP\RequestInterface;
-use Sabre\HTTP\ResponseInterface;
-use Sabre\HTTP\Util;
 
 class Server {
 

--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -15,7 +15,6 @@ Feature: sharing
 		When Downloading file "/welcome.txt" with range "bytes=51-77"
 		Then Downloaded content should be "example file for developers"
 
-
 	Scenario: Upload forbidden if quota is 0
 		Given using dav path "remote.php/webdav"
 		And As an "admin"
@@ -33,9 +32,35 @@ Feature: sharing
 		And Downloading last public shared file with range "bytes=51-77"
 		Then Downloaded content should be "example file for developers"
 
+	Scenario: Downloading a file on the old endpoint should serve security headers
+		Given using dav path "remote.php/webdav"
+		And As an "admin"
+		When Downloading file "/welcome.txt"
+		Then The following headers should be set
+			|Content-Disposition|attachment|
+			|Content-Security-Policy|default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; frame-src *; img-src * data: blob:; font-src 'self' data:; media-src *; connect-src *|
+			|X-Content-Type-Options |nosniff|
+			|X-Download-Options|noopen|
+			|X-Frame-Options|Sameorigin|
+			|X-Permitted-Cross-Domain-Policies|none|
+			|X-Robots-Tag|none|
+			|X-XSS-Protection|1; mode=block|
+		And Downloaded content should start with "Welcome to your ownCloud account!"
 
-
-
+	Scenario: Downloading a file on the new endpoint should serve security headers
+		Given using dav path "remote.php/dav/files/admin/"
+		And As an "admin"
+		When Downloading file "/welcome.txt"
+		Then The following headers should be set
+			|Content-Disposition|attachment|
+			|Content-Security-Policy|default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; frame-src *; img-src * data: blob:; font-src 'self' data:; media-src *; connect-src *|
+			|X-Content-Type-Options |nosniff|
+			|X-Download-Options|noopen|
+			|X-Frame-Options|Sameorigin|
+			|X-Permitted-Cross-Domain-Policies|none|
+			|X-Robots-Tag|none|
+			|X-XSS-Protection|1; mode=block|
+		And Downloaded content should start with "Welcome to your ownCloud account!"
 
 
 


### PR DESCRIPTION
Recent refactorings have resulted in the header being added twice, this makes browsers ignore the header which removes any security gains.

This changeset adds the header only once and adds integration tests ensuring the correct header in future.

https://github.com/owncloud/core/issues/22577
