### PR TITLE
take the first result of that array, if present. Fixes 2nd display na…

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -546,8 +546,8 @@ class Access extends LDAPUtility implements user\IUserTools {
 					if(is_null($nameByLDAP)) {
 						continue;
 					}
-					$sndName = isset($ldapObject[$sndAttribute])
-						? $ldapObject[$sndAttribute] : '';
+					$sndName = isset($ldapObject[$sndAttribute][0])
+						? $ldapObject[$sndAttribute][0] : '';
 					$this->cacheUserDisplayName($ocName, $nameByLDAP, $sndName);
 				}
 			}


### PR DESCRIPTION
…me to be 'Array', if cache is configured and  enabled.

How to test:
1. Have an memcache enabled (e.g. APCu)
2. Have LDAP configured (inlcuding 2nd display name attribute)
3. Open the share dialog and look for an LDAP user
Before: Array appears in brackets, e.g. "Joan Doe (Array)"
Fixed: The second attribute is shown correctly (e.g. "Joan Doe (joan.doe@example.com)")

Fixes https://github.com/owncloud/enterprise/issues/1088

@karlitschek request to backport to 8.2. Easy fix.

Please test and review @owncloud/ldap @owncloud/qa @MorrisJobke 
