### PR TITLE
Disable sharing by default for external storage mounts

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -23,7 +23,7 @@ var MOUNT_OPTIONS_DROPDOWN_TEMPLATE =
 	'		<label for="mountOptionsPreviews">{{t "files_external" "Enable previews"}}</label>' +
 	'	</div>' +
 	'	<div class="optionRow">' +
-	'		<input id="mountOptionsSharing" name="enable_sharing" type="checkbox" value="true" checked="checked"/>' +
+	'		<input id="mountOptionsSharing" name="enable_sharing" type="checkbox" value="true"/>' +
 	'		<label for="mountOptionsSharing">{{t "files_external" "Enable sharing"}}</label>' +
 	'	</div>' +
 	'	<div class="optionRow">' +
@@ -888,7 +888,7 @@ MountConfigListView.prototype = _.extend({
 			$tr.find('input.mountOptions').val(JSON.stringify({
 				'encrypt': true,
 				'previews': true,
-				'enable_sharing': true,
+				'enable_sharing': false,
 				'filesystem_check_changes': 1
 			}));
 		}

--- a/apps/files_external/lib/storageconfig.php
+++ b/apps/files_external/lib/storageconfig.php
@@ -126,6 +126,7 @@ class StorageConfig implements \JsonSerializable {
 	 */
 	public function __construct($id = null) {
 		$this->id = $id;
+		$this->mountOptions['enable_sharing'] = false;
 	}
 
 	/**

--- a/apps/files_external/migration/storagemigrator.php
+++ b/apps/files_external/migration/storagemigrator.php
@@ -100,6 +100,12 @@ class StorageMigrator {
 		$this->connection->beginTransaction();
 		try {
 			foreach ($existingStorage as $storage) {
+				$mountOptions = $storage->getMountOptions();
+				if (!empty($mountOptions) && !isset($mountOptions['enable_sharing'])) {
+					// existing mounts must have sharing enabled by default to avoid surprises
+					$mountOptions['enable_sharing'] = true;
+					$storage->setMountOptions($mountOptions);
+				}
 				$storageService->addStorage($storage);
 			}
 			$this->connection->commit();

--- a/apps/files_external/tests/js/settingsSpec.js
+++ b/apps/files_external/tests/js/settingsSpec.js
@@ -363,7 +363,7 @@ describe('OCA.External.Settings tests', function() {
 				expect(JSON.parse($tr.find('input.mountOptions').val())).toEqual({
 					encrypt: true,
 					previews: true,
-					enable_sharing: true,
+					enable_sharing: false,
 					filesystem_check_changes: 0
 				});
 			});


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/22460

This disabled the "enable_sharing" option by default for new mount points created over the web UI or CLI.
- [x] TEST: create storage over web UI, save: sharing is disabled
- [x] TEST: create storage over CLI: sharing is disabled
- [x] TEST: in 8.2.x create a storage, then migrate to this branch: sharing is still enabled for that storage

Will test the migration soon.
