### PR TITLE
Copy into local file

### DIFF
--- a/apps/files_external/lib/google.php
+++ b/apps/files_external/lib/google.php
@@ -33,6 +33,7 @@
 
 namespace OC\Files\Storage;
 
+use GuzzleHttp\Exception\RequestException;
 use Icewind\Streams\IteratorDirectory;
 
 set_include_path(get_include_path().PATH_SEPARATOR.
@@ -439,9 +440,10 @@ class Google extends \OC\Files\Storage\Common {
 						// the library's service doesn't support streaming, so we use Guzzle instead
 						$client = \OC::$server->getHTTPClientService()->newClient();
 						try {
-							$response = $client->get($downloadUrl, [
+							$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
+							$client->get($downloadUrl, [
 								'headers' => $httpRequest->getRequestHeaders(),
-								'stream' => true
+								'save_to' => $tmpFile,
 							]);
 						} catch (RequestException $e) {
 							if ($e->getResponse()->getStatusCode() === 404) {
@@ -451,7 +453,7 @@ class Google extends \OC\Files\Storage\Common {
 							}
 						}
 
-						return $response->getBody();
+						return fopen($tmpFile, 'r');
 					}
 				}
 				return false;

--- a/apps/files_external/lib/google.php
+++ b/apps/files_external/lib/google.php
@@ -446,8 +446,12 @@ class Google extends \OC\Files\Storage\Common {
 								'save_to' => $tmpFile,
 							]);
 						} catch (RequestException $e) {
-							if ($e->getResponse()->getStatusCode() === 404) {
-								return false;
+							if(!is_null($e->getResponse())) {
+								if ($e->getResponse()->getStatusCode() === 404) {
+									return false;
+								} else {
+									throw $e;
+								}
 							} else {
 								throw $e;
 							}


### PR DESCRIPTION
Using the Guzzle stream directly here will only return 1739 characters for `fread` instead of all data. This leads to the problem that the stream is read incorrectly and thus the data cannot be properly decrypted => :bomb:
(see https://github.com/owncloud/core/issues/22590#issuecomment-187773063 for more context)

This approach copies the data into a local temporary file, as done before in all stable releases as well as other storage connectors.

While this approach will load the whole file into memory, this is already was has happened before in any stable release as well. See https://github.com/owncloud/core/commit/d608c37c90c308d0518d854de908ec4be5f462dc for the breaking change. I believe for 9.0 we should keep it like that.

To test this enable Google Drive as external storage and upload some files with encryption enabled. Reading the file should fail now.

Fixes https://github.com/owncloud/core/issues/22590

<hr/>

@PVince81 please test.
@icewind1991 Other ideas?
