### PR TITLE
Issue 14127 allow change email without displayname

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -176,6 +176,15 @@ $CONFIG = array(
 'allow_user_to_change_display_name' => true,
 
 /**
+ * ``true`` allows users to change their email addresses (on their Personal
+ * pages), and ``false`` prevents them from changing their email addresses.
+ *
+ * If this value is not set, it falls back to
+ * ``allow_user_to_change_display_name``
+ */
+'allow_user_to_change_email' => true,
+
+/**
  * Lifetime of the remember login cookie, which is set when the user clicks the
  * ``remember`` checkbox on the login screen. The default is 15 days, expressed
  * in seconds.

--- a/lib/private/user/user.php
+++ b/lib/private/user/user.php
@@ -305,6 +305,19 @@ class User implements IUser {
 	}
 
 	/**
+	 * check if the email can be changed
+	 *
+	 * @return bool
+	 */
+	public function canChangeEmail() {
+		if ($this->config->getSystemValue('allow_user_to_change_email', null) !== null) {
+			return $this->config->getSystemValue('allow_user_to_change_email', null) !== false;
+		}
+
+		return $this->config->getSystemValue('allow_user_to_change_display_name') !== false;
+	}
+
+	/**
 	 * check if the user is enabled
 	 *
 	 * @return bool

--- a/lib/public/iuser.php
+++ b/lib/public/iuser.php
@@ -130,6 +130,14 @@ interface IUser {
 	public function canChangeDisplayName();
 
 	/**
+	 * check if the backend supports changing display names
+	 *
+	 * @return bool
+	 * @since 9.0.0
+	 */
+	public function canChangeEmail();
+
+	/**
 	 * check if the user is enabled
 	 *
 	 * @return bool

--- a/settings/controller/userscontroller.php
+++ b/settings/controller/userscontroller.php
@@ -534,9 +534,7 @@ class UsersController extends Controller {
 			);
 		}
 
-		// this is the only permission a backend provides and is also used
-		// for the permission of setting a email address
-		if(!$user->canChangeDisplayName()){
+		if(!$user->canChangeEmail()){
 			return new DataResponse(
 				array(
 					'status' => 'error',

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -135,6 +135,7 @@ if ($externalStorageEnabled) {
 	$enableCertImport = $backendService->isUserMountingAllowed();
 }
 
+$user = \OC::$server->getUserManager()->get(OC_User::getUser());
 
 // Return template
 $tmpl = new OC_Template( 'settings', 'personal', 'user');
@@ -146,18 +147,19 @@ $tmpl->assign('email', $email);
 $tmpl->assign('languages', $languages);
 $tmpl->assign('commonlanguages', $commonLanguages);
 $tmpl->assign('activelanguage', $userLang);
-$tmpl->assign('passwordChangeSupported', OC_User::canUserChangePassword(OC_User::getUser()));
-$tmpl->assign('displayNameChangeSupported', OC_User::canUserChangeDisplayName(OC_User::getUser()));
-$tmpl->assign('displayName', OC_User::getDisplayName());
+$tmpl->assign('passwordChangeSupported', $user->canChangePassword());
+$tmpl->assign('displayNameChangeSupported', $user->canChangeDisplayName());
+$tmpl->assign('emailChangeSupported', $user->canChangeEmail());
+$tmpl->assign('displayName', $user->getDisplayName());
 $tmpl->assign('enableAvatars', $config->getSystemValue('enable_avatars', true) === true);
-$tmpl->assign('avatarChangeSupported', OC_User::canUserChangeAvatar(OC_User::getUser()));
+$tmpl->assign('avatarChangeSupported', $user->canChangeAvatar());
 $tmpl->assign('certs', $certificateManager->listCertificates());
 $tmpl->assign('showCertificates', $enableCertImport);
 $tmpl->assign('urlGenerator', $urlGenerator);
 
 // Get array of group ids for this user
 $groups = \OC::$server->getGroupManager()->getUserIdGroups(OC_User::getUser());
-$groups2 = array_map(function($group) { return $group->getGID(); }, $groups);
+$groups2 = array_map(function(\OCP\IGroup $group) { return $group->getGID(); }, $groups);
 sort($groups2);
 $tmpl->assign('groups', $groups2);
 

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -72,7 +72,7 @@ if($_['displayNameChangeSupported']) {
 <?php
 } else {
 ?>
-<div class="section">
+<div id="displaynameform" class="section">
 	<h2><?php echo $l->t('Full name');?></h2>
 	<span><?php if(isset($_['displayName'][0])) { p($_['displayName']); } else { p($l->t('No display name set')); } ?></span>
 </div>
@@ -96,7 +96,7 @@ if($_['emailChangeSupported']) {
 <?php
 } else {
 ?>
-<div class="section">
+<div id="lostpassword" class="section">
 	<h2><?php echo $l->t('Email'); ?></h2>
 	<span><?php if(isset($_['email'][0])) { p($_['email']); } else { p($l->t('No email address set')); }?></span>
 </div>

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -81,7 +81,7 @@ if($_['displayNameChangeSupported']) {
 ?>
 
 <?php
-if($_['passwordChangeSupported']) {
+if($_['emailChangeSupported']) {
 ?>
 <form id="lostpassword" class="section">
 	<h2>


### PR DESCRIPTION
- Introduced a new config `allow_user_to_change_email`
- When the config is not set to either true or false, it falls back to `allow_user_to_change_display_name` so the behaviour of existing installations is unchanged.

Fix #14127

@DeepDiver1975 for API change :speak_no_evil: 

@PVince81 @MorrisJobke 
