### PR TITLE
Add the uid on hover for sharing autocomplete

### DIFF
--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -16,12 +16,12 @@
 	var TEMPLATE =
 			'<ul id="shareWithList" class="shareWithList">' +
 			'{{#each sharees}}' +
-			'    <li data-share-id="{{shareId}}" data-share-type="{{shareType}}" data-share-with="{{shareWith}}" title="{{shareWith}}">' +
+			'    <li data-share-id="{{shareId}}" data-share-type="{{shareType}}" data-share-with="{{shareWith}}">' +
 			'        <a href="#" class="unshare"><span class="icon-loading-small hidden"></span><img class="svg" alt="{{unshareLabel}}" title="{{unshareLabel}}" src="{{unshareImage}}" /></a>' +
 			'        {{#if avatarEnabled}}' +
 			'        <div class="avatar {{#if modSeed}}imageplaceholderseed{{/if}}" data-username="{{shareWith}}" {{#if modSeed}}data-seed="{{shareWith}} {{shareType}}"{{/if}}></div>' +
 			'        {{/if}}' +
-			'        <span class="username">{{shareWithDisplayName}}</span>' +
+			'        <span class="has-tooltip username" title="{{shareWith}}">{{shareWithDisplayName}}</span>' +
 			'        {{#if mailNotificationEnabled}} {{#unless isRemoteShare}}' +
 			'        <input id="mail-{{cid}}-{{shareWith}}" type="checkbox" name="mailNotification" class="mailNotification checkbox" {{#if wasMailSent}}checked="checked"{{/if}} />' +
 			'        <label for="mail-{{cid}}-{{shareWith}}">{{notifyByMailLabel}}</label>' +
@@ -192,6 +192,10 @@
 					}
 				});
 			}
+
+			this.$el.find('.has-tooltip').tooltip({
+				placement: 'bottom'
+			});
 
 			this.delegateEvents();
 

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -221,7 +221,7 @@
 								.tooltip('hide')
 								.tooltip({
 									placement: 'bottom',
-									trigger: 'manual',
+									trigger: 'manual'
 								})
 								.tooltip('fixTitle')
 								.tooltip('show');
@@ -259,6 +259,7 @@
 				}
 			}
 			insert.text(text);
+			insert.attr('title', item.value.shareWith);
 			if(item.value.shareType === OC.Share.SHARE_TYPE_GROUP) {
 				insert = insert.wrapInner('<strong></strong>');
 			}

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -263,6 +263,10 @@
 			if(item.value.shareType === OC.Share.SHARE_TYPE_GROUP) {
 				insert = insert.wrapInner('<strong></strong>');
 			}
+			insert.tooltip({
+				placement: 'bottom',
+				container: 'body'
+			});
 			return $("<li>")
 				.addClass((item.value.shareType === OC.Share.SHARE_TYPE_GROUP) ? 'group' : 'user')
 				.append(insert)


### PR DESCRIPTION
### Steps
1. Add user1 with display name `user`
2. Add user2 with display name `user`
3. Try to share with user1
### Expected

Users are distinguishable in the share dropdown

This adds a title to the inputs, so you can hover them to see the uid. The same is already the case for the share rows, so that could potentially resolve https://github.com/owncloud/core/issues/20291

cc @PVince81 @MorrisJobke @rullzer 
