### PR TITLE
Add blacklisted_files to capabilities

### DIFF
--- a/apps/files/lib/capabilities.php
+++ b/apps/files/lib/capabilities.php
@@ -24,6 +24,7 @@
 namespace OCA\Files;
 
 use OCP\Capabilities\ICapability;
+use OCP\IConfig;
 
 /**
  * Class Capabilities
@@ -31,6 +32,17 @@ use OCP\Capabilities\ICapability;
  * @package OCA\Files
  */
 class Capabilities implements ICapability {
+	/** @var IConfig */
+	protected $config;
+
+	/**
+	 * Capabilities constructor.
+	 *
+	 * @param IConfig $config
+	 */
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
 
 	/**
 	 * Return this classes capabilities
@@ -41,6 +53,7 @@ class Capabilities implements ICapability {
 		return [
 			'files' => [
 				'bigfilechunking' => true,
+				'blacklisted_files' => $this->config->getSystemValue('blacklisted_files', ['.htaccess']),
 			],
 		];
 	}


### PR DESCRIPTION
Working towards https://github.com/owncloud/client/issues/434

``` xml
<ocs>
 ...
 <data>
  ...
  <capabilities>
   ...
   <files>
    ...
    <blacklisted_files>
     <element>.htaccess</element>
    </blacklisted_files>
    ...
   </files>
   ...
  </capabilities>
 </data>
</ocs>
```

if we populate our blacklist to the client, the client could read it, and e.g. allow `.htaccess` when the admin removed them from the blacklist, because he is using nginx.

cc @DeepDiver1975 @LukasReschke @PVince81 @ogoffart
