### PR TITLE
[stable8.1] Use "json_encode" and "json_decode" instead of unserialize

### DIFF
--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -206,7 +206,7 @@ class Connection extends LDAPUtility {
 		}
 		$key = $this->getCacheKey($key);
 
-		return json_decode(base64_decode($this->cache->get($key)));
+		return json_decode(base64_decode($this->cache->get($key)), true);
 	}
 
 	/**

--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -206,7 +206,7 @@ class Connection extends LDAPUtility {
 		}
 		$key = $this->getCacheKey($key);
 
-		return unserialize(base64_decode($this->cache->get($key)));
+		return json_decode(base64_decode($this->cache->get($key)));
 	}
 
 	/**
@@ -240,7 +240,7 @@ class Connection extends LDAPUtility {
 			return null;
 		}
 		$key   = $this->getCacheKey($key);
-		$value = base64_encode(serialize($value));
+		$value = base64_encode(json_encode($value));
 		$this->cache->set($key, $value, $this->configuration->ldapCacheTTL);
 	}
 

--- a/apps/user_ldap/lib/proxy.php
+++ b/apps/user_ldap/lib/proxy.php
@@ -161,7 +161,7 @@ abstract class Proxy {
 		}
 		$key = $this->getCacheKey($key);
 
-		return unserialize(base64_decode($this->cache->get($key)));
+		return json_decode(base64_decode($this->cache->get($key)));
 	}
 
 	/**
@@ -185,7 +185,7 @@ abstract class Proxy {
 			return;
 		}
 		$key   = $this->getCacheKey($key);
-		$value = base64_encode(serialize($value));
+		$value = base64_encode(json_encode($value));
 		$this->cache->set($key, $value, '2592000');
 	}
 


### PR DESCRIPTION
Backport of #18762 and #21999
- [x] approval by @karlitschek needed
- fixes issue that was noticed in owncloud/enterprise#1094

cc @LukasReschke @blizzz @owncloud/ldap Please review
