### PR TITLE
[stable8.2] Avoids scanning the root storage

### DIFF
--- a/lib/private/files/utils/scanner.php
+++ b/lib/private/files/utils/scanner.php
@@ -135,6 +135,10 @@ class Scanner extends PublicEmitter {
 			if (is_null($mount->getStorage())) {
 				continue;
 			}
+			// don't scan the root storage
+			if ($mount->getStorage()->instanceOfStorage('\OC\Files\Storage\Local') && $mount->getMountPoint() === '/') {
+				continue;
+			}
 			$scanner = $mount->getStorage()->getScanner();
 			$this->attachListener($mount);
 			$scanner->backgroundScan();


### PR DESCRIPTION
This check will skip the background scan for the root storage
because there is nothing in the root storage that isn't already
in another (mostly user-) storage.

Fixes #22501

Backport of #22565 
Approval in https://github.com/owncloud/core/pull/22565#issuecomment-187822333

Please review @icewind1991 @PVince81 @butonic @LukasReschke 
