### PR TITLE
Fix HTTPS support on external storages

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -859,6 +859,9 @@ MountConfigListView.prototype = _.extend({
 				var input = $(this);
 				var val = storageConfig.backendOptions[input.data('parameter')];
 				if (val !== undefined) {
+					if(input.is('input:checkbox')) {
+						input.prop('checked', val);
+					}
 					input.val(storageConfig.backendOptions[input.data('parameter')]);
 					highlightInput(input);
 				}

--- a/apps/files_external/lib/storageconfig.php
+++ b/apps/files_external/lib/storageconfig.php
@@ -210,6 +210,20 @@ class StorageConfig implements \JsonSerializable {
 	 * @param array $backendOptions backend options
 	 */
 	public function setBackendOptions($backendOptions) {
+		if($this->getBackend() instanceof  Backend) {
+			$parameters = $this->getBackend()->getParameters();
+			foreach($backendOptions as $key => $value) {
+				if(isset($parameters[$key])) {
+					switch ($parameters[$key]->getType()) {
+						case \OCA\Files_External\Lib\DefinitionParameter::VALUE_BOOLEAN:
+							$value = (bool)$value;
+							break;
+					}
+					$backendOptions[$key] = $value;
+				}
+			}
+		}
+
 		$this->backendOptions = $backendOptions;
 	}
 

--- a/apps/files_external/tests/storageconfigtest.php
+++ b/apps/files_external/tests/storageconfigtest.php
@@ -30,6 +30,17 @@ class StorageConfigTest extends \Test\TestCase {
 		$backend = $this->getMockBuilder('\OCA\Files_External\Lib\Backend\Backend')
 			->disableOriginalConstructor()
 			->getMock();
+		$parameter = $this->getMockBuilder('\OCA\Files_External\Lib\DefinitionParameter')
+			->disableOriginalConstructor()
+			->getMock();
+		$parameter
+			->expects($this->once())
+			->method('getType')
+			->willReturn(1);
+		$backend
+			->expects($this->once())
+			->method('getParameters')
+			->willReturn(['secure' => $parameter]);
 		$backend->method('getIdentifier')
 			->willReturn('storage::identifier');
 
@@ -43,7 +54,7 @@ class StorageConfigTest extends \Test\TestCase {
 		$storageConfig->setMountPoint('test');
 		$storageConfig->setBackend($backend);
 		$storageConfig->setAuthMechanism($authMech);
-		$storageConfig->setBackendOptions(['user' => 'test', 'password' => 'password123']);
+		$storageConfig->setBackendOptions(['user' => 'test', 'password' => 'password123', 'secure' => '1']);
 		$storageConfig->setPriority(128);
 		$storageConfig->setApplicableUsers(['user1', 'user2']);
 		$storageConfig->setApplicableGroups(['group1', 'group2']);
@@ -51,16 +62,17 @@ class StorageConfigTest extends \Test\TestCase {
 
 		$json = $storageConfig->jsonSerialize();
 
-		$this->assertEquals(1, $json['id']);
-		$this->assertEquals('/test', $json['mountPoint']);
-		$this->assertEquals('storage::identifier', $json['backend']);
-		$this->assertEquals('auth::identifier', $json['authMechanism']);
-		$this->assertEquals('test', $json['backendOptions']['user']);
-		$this->assertEquals('password123', $json['backendOptions']['password']);
-		$this->assertEquals(128, $json['priority']);
-		$this->assertEquals(['user1', 'user2'], $json['applicableUsers']);
-		$this->assertEquals(['group1', 'group2'], $json['applicableGroups']);
-		$this->assertEquals(['preview' => false], $json['mountOptions']);
+		$this->assertSame(1, $json['id']);
+		$this->assertSame('/test', $json['mountPoint']);
+		$this->assertSame('storage::identifier', $json['backend']);
+		$this->assertSame('auth::identifier', $json['authMechanism']);
+		$this->assertSame('test', $json['backendOptions']['user']);
+		$this->assertSame('password123', $json['backendOptions']['password']);
+		$this->assertSame(true, $json['backendOptions']['secure']);
+		$this->assertSame(128, $json['priority']);
+		$this->assertSame(['user1', 'user2'], $json['applicableUsers']);
+		$this->assertSame(['group1', 'group2'], $json['applicableGroups']);
+		$this->assertSame(['preview' => false], $json['mountOptions']);
 	}
 
 }

--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -136,9 +136,13 @@ class DAV extends Common {
 			'password' => $this->password,
 		);
 
+		$proxy = \OC::$server->getConfig()->getSystemValue('proxy', '');
+		if($proxy !== '') {
+			$settings['proxy'] = $proxy;
+		}
+
 		$this->client = new Client($settings);
 		$this->client->setThrowExceptions(true);
-
 		if ($this->secure === true && $this->certPath) {
 			$this->client->addCurlSetting(CURLOPT_CAINFO, $this->certPath);
 		}


### PR DESCRIPTION
The current logic is checking whether:
1. The returned value is a boolen
2. The returned value is a string and then matches for "true"

Since the config is now written to the database the data is now a string with the value "1" if HTTPS is set to true. Effectively this option was thus always disabled at the moment, falling back to plain HTTP.

This change casts the data to a boolean if it is defined as boolean.

Fixes #22605
Fixes #22016

<hr/>

@SergioBertolinSG Please test
@PVince81 @icewind1991 Mind taking a look?
