### PR TITLE
Don't show PCNTL warning if --no-warnings is passed

### DIFF
--- a/console.php
+++ b/console.php
@@ -77,7 +77,7 @@ try {
 		exit(1);
 	}
 
-	if (!function_exists('pcntl_signal')) {
+	if (!function_exists('pcntl_signal') && !in_array('--no-warnings', $argv)) {
 		echo "The process control (PCNTL) extensions are required in case you want to interrupt long running commands - see http://php.net/manual/en/book.pcntl.php" . PHP_EOL;
 	}
 


### PR DESCRIPTION
- fixes owncloud/updater#252

cc @LukasReschke @VicDeo @DeepDiver1975 

@karlitschek @cmonteroluque I put this in the 9.0 milestone because it fixes a updater issue. And I would rate this low risk.
