### PR TITLE
do propagation in a single query

### DIFF
--- a/apps/files_sharing/lib/sharedpropagator.php
+++ b/apps/files_sharing/lib/sharedpropagator.php
@@ -33,7 +33,6 @@ class SharedPropagator extends Propagator {
 	 * @param string $internalPath
 	 * @param int $time
 	 * @param int $sizeDifference
-	 * @return \array[] all propagated entries
 	 */
 	public function propagateChange($internalPath, $time, $sizeDifference = 0) {
 		/** @var \OC\Files\Storage\Storage $storage */

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -332,7 +332,7 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 		if (!$storage) {
 			$storage = $this;
 		}
-		return new \OCA\Files_Sharing\SharedPropagator($storage);
+		return new \OCA\Files_Sharing\SharedPropagator($storage, \OC::$server->getDatabaseConnection());
 	}
 
 	public function getOwner($path) {

--- a/lib/private/DB/AdapterSqlite.php
+++ b/lib/private/DB/AdapterSqlite.php
@@ -32,6 +32,7 @@ class AdapterSqlite extends Adapter {
 		$statement = preg_replace('/`(\w+)` ILIKE \?/', 'LOWER($1) LIKE LOWER(?)', $statement);
 		$statement = str_replace( '`', '"', $statement );
 		$statement = str_ireplace( 'NOW()', 'datetime(\'now\')', $statement );
+		$statement = str_ireplace('GREATEST(', 'MAX(', $statement);
 		$statement = str_ireplace( 'UNIX_TIMESTAMP()', 'strftime(\'%s\',\'now\')', $statement );
 		return $statement;
 	}

--- a/lib/private/Files/Cache/HomePropagator.php
+++ b/lib/private/Files/Cache/HomePropagator.php
@@ -21,14 +21,16 @@
 
 namespace OC\Files\Cache;
 
+use OCP\IDBConnection;
+
 class HomePropagator extends Propagator {
 	private $ignoredBaseFolders;
 
 	/**
 	 * @param \OC\Files\Storage\Storage $storage
 	 */
-	public function __construct(\OC\Files\Storage\Storage $storage) {
-		parent::__construct($storage);
+	public function __construct(\OC\Files\Storage\Storage $storage, IDBConnection $connection) {
+		parent::__construct($storage, $connection);
 		$this->ignoredBaseFolders = ['files_encryption'];
 	}
 
@@ -37,14 +39,13 @@ class HomePropagator extends Propagator {
 	 * @param string $internalPath
 	 * @param int $time
 	 * @param int $sizeDifference number of bytes the file has grown
-	 * @return array[] all propagated entries
 	 */
 	public function propagateChange($internalPath, $time, $sizeDifference = 0) {
 		list($baseFolder) = explode('/', $internalPath, 2);
 		if (in_array($baseFolder, $this->ignoredBaseFolders)) {
 			return [];
 		} else {
-			return parent::propagateChange($internalPath, $time, $sizeDifference);
+			parent::propagateChange($internalPath, $time, $sizeDifference);
 		}
 	}
 }

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -352,7 +352,7 @@ abstract class Common implements Storage, ILockingStorage {
 			$storage = $this;
 		}
 		if (!isset($storage->propagator)) {
-			$storage->propagator = new Propagator($storage);
+			$storage->propagator = new Propagator($storage, \OC::$server->getDatabaseConnection());
 		}
 		return $storage->propagator;
 	}

--- a/lib/private/Files/Storage/Home.php
+++ b/lib/private/Files/Storage/Home.php
@@ -88,7 +88,7 @@ class Home extends Local implements \OCP\Files\IHomeStorage {
 			$storage = $this;
 		}
 		if (!isset($this->propagator)) {
-			$this->propagator = new HomePropagator($storage);
+			$this->propagator = new HomePropagator($storage, \OC::$server->getDatabaseConnection());
 		}
 		return $this->propagator;
 	}

--- a/lib/public/files/cache/ipropagator.php
+++ b/lib/public/files/cache/ipropagator.php
@@ -30,7 +30,6 @@ interface IPropagator {
 	/**
 	 * @param string $internalPath
 	 * @param int $time
-	 * @return array[] all propagated cache entries
 	 * @since 9.0.0
 	 */
 	public function propagateChange($internalPath, $time);


### PR DESCRIPTION
(actually two queries but don't tell anyone that)

tricks in use
- use sql `GREATEST` to only increate folder mtimes in case of a `touch`
- use `path_hash` instead of `fileid` to prevent having to traverse up the filetree to get all parent ids
- give each folder the same etag during propagation so we can do it all in one query
- limit the size propagation with a `WHERE size>-1` to prevent having to do the check for each entry

Improves upload performance anywhere from ~14% ([comparison](https://blackfire.io/profiles/compare/cdb172a8-c227-40b8-8389-1ca6ce3d74bf/graph)) for uploading to the root folder to over ~35% ([comparison](https://blackfire.io/profiles/compare/9a26a89c-ce9b-4064-8741-1c618f1c0751/graph)) when uploading to a deeper nested folder

cc @PVince81 
