### PR TITLE
Fix verifyExpirationDate passwordSet argument

### DIFF
--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -280,7 +280,7 @@ class Manager implements IManager {
 			'expirationDate' => &$expirationDate,
 			'accepted' => &$accepted,
 			'message' => &$message,
-			'passwordSet' => $share->getPassword() === null,
+			'passwordSet' => $share->getPassword() !== null,
 		]);
 
 		if (!$accepted) {

--- a/tests/lib/share20/managertest.php
+++ b/tests/lib/share20/managertest.php
@@ -787,7 +787,7 @@ class ManagerTest extends \Test\TestCase {
 		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
 		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListner, 'listener');
 		$hookListner->expects($this->once())->method('listener')->with($this->callback(function ($data) use ($expected) {
-			return $data['expirationDate'] == $expected;
+			return $data['expirationDate'] == $expected && $data['passwordSet'] === false;
 		}));
 
 		$res = $this->invokePrivate($this->manager, 'validateExpirationDate', [$share]);
@@ -799,10 +799,11 @@ class ManagerTest extends \Test\TestCase {
 		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
 		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListner, 'listener');
 		$hookListner->expects($this->once())->method('listener')->with($this->callback(function ($data) {
-			return $data['expirationDate'] === null;
+			return $data['expirationDate'] === null && $data['passwordSet'] === true;
 		}));
 
 		$share = $this->manager->newShare();
+		$share->setPassword('password');
 
 		$date = $this->invokePrivate($this->manager, 'validateExpirationDate', [$share]);
 


### PR DESCRIPTION
Password set should be false if the password is null.

Also updated the unit tests to tests this now.

Easy one: @MorrisJobke @PVince81 @nickvergessen @LukasReschke 
