### PR TITLE
Add integration test for CSRF protection on DAV

### DIFF
--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -62,7 +62,7 @@ Feature: sharing
 			|X-XSS-Protection|1; mode=block|
 		And Downloaded content should start with "Welcome to your ownCloud account!"
 
-	Scenario: Doing a GET with a web login should work without CSRF token on the nwe backend
+	Scenario: Doing a GET with a web login should work without CSRF token on the new backend
 		Given Logging in using web as "admin"
 		When Sending a "GET" to "/remote.php/dav/files/admin/welcome.txt" without requesttoken
 		Then Downloaded content should start with "Welcome to your ownCloud account!"

--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -62,9 +62,46 @@ Feature: sharing
 			|X-XSS-Protection|1; mode=block|
 		And Downloaded content should start with "Welcome to your ownCloud account!"
 
+	Scenario: Doing a GET with a web login should work without CSRF token on the nwe backend
+		Given Logging in using web as "admin"
+		When Sending a "GET" to "/remote.php/dav/files/admin/welcome.txt" without requesttoken
+		Then Downloaded content should start with "Welcome to your ownCloud account!"
+		Then the HTTP status code should be "200"
 
+	Scenario: Doing a GET with a web login should work with CSRF token on the new backend
+		Given Logging in using web as "admin"
+		When Sending a "GET" to "/remote.php/dav/files/admin/welcome.txt" with requesttoken
+		Then Downloaded content should start with "Welcome to your ownCloud account!"
+		Then the HTTP status code should be "200"
 
+	Scenario: Doing a PROPFIND with a web login should not work without CSRF token on the new backend
+		Given Logging in using web as "admin"
+		When Sending a "PROPFIND" to "/remote.php/dav/files/admin/welcome.txt" without requesttoken
+		Then the HTTP status code should be "401"
 
+	Scenario: Doing a PROPFIND with a web login should work with CSRF token on the new backend
+		Given Logging in using web as "admin"
+		When Sending a "PROPFIND" to "/remote.php/dav/files/admin/welcome.txt" with requesttoken
+		Then the HTTP status code should be "207"
 
+	Scenario: Doing a GET with a web login should work without CSRF token on the old backend
+		Given Logging in using web as "admin"
+		When Sending a "GET" to "/remote.php/webdav/welcome.txt" without requesttoken
+		Then Downloaded content should start with "Welcome to your ownCloud account!"
+		Then the HTTP status code should be "200"
 
+	Scenario: Doing a GET with a web login should work with CSRF token on the old backend
+		Given Logging in using web as "admin"
+		When Sending a "GET" to "/remote.php/webdav/welcome.txt" with requesttoken
+		Then Downloaded content should start with "Welcome to your ownCloud account!"
+		Then the HTTP status code should be "200"
 
+	Scenario: Doing a PROPFIND with a web login should not work without CSRF token on the old backend
+		Given Logging in using web as "admin"
+		When Sending a "PROPFIND" to "/remote.php/webdav/welcome.txt" without requesttoken
+		Then the HTTP status code should be "401"
+
+	Scenario: Doing a PROPFIND with a web login should work with CSRF token on the old backend
+		Given Logging in using web as "admin"
+		When Sending a "PROPFIND" to "/remote.php/webdav/welcome.txt" with requesttoken
+		Then the HTTP status code should be "207"


### PR DESCRIPTION
This adds the integration tests for the CSRF protection on the DAV backend introduced with 9.0. Also adds the whole web login logic so that we can also add tests for other parts of core that are behind the regular session login :smile: 

Fixes https://github.com/owncloud/core/issues/22598
