### PR TITLE
Exclude ocs-provider from rewrite rule

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -63,6 +63,7 @@
   RewriteCond %{REQUEST_FILENAME} !/ocs/v1.php
   RewriteCond %{REQUEST_FILENAME} !/ocs/v2.php
   RewriteCond %{REQUEST_FILENAME} !/updater/
+  RewriteCond %{REQUEST_FILENAME} !/ocs-provider/
   RewriteCond %{REQUEST_URI} !^/.well-known/acme-challenge/.*
   RewriteRule .* index.php [PT,E=PATH_INFO:$1]
 </IfModule>


### PR DESCRIPTION
Otherwise `localhost/ocs-provider/` cannot be accessed if mod_rewrite is install
ed. Only affects master.

Quick one. @MorrisJobke @schiesbn @PVince81 
