### PR TITLE
Do not allow sharing of the users root folder

### DIFF
--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -506,3 +506,11 @@ Feature: sharing
     And file "myfile.txt" of user "user0" is shared with user "user1"
     When User "user1" uploads file "data/textfile.txt" to "/myfile.txt"
     Then the HTTP status code should be "204"
+
+  Scenario: Don't allow sharing of the root
+    Given user "user0" exists
+    And As an "user0"
+    When creating a share with
+      | path | / |
+      | shareType | 3 |
+    Then the OCS status code should be "403"

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -197,6 +197,11 @@ class Manager implements IManager {
 			throw new \InvalidArgumentException('Path should be either a file or a folder');
 		}
 
+		// And you can't share your rootfolder
+		if ($this->rootFolder->getUserFolder($share->getSharedBy())->isSubNode($share->getNode()) === false) {
+			throw new \InvalidArgumentException('You can\'t share your root folder');
+		}
+
 		// Check if we actually have share permissions
 		if (!$share->getNode()->isShareable()) {
 			$message_t = $this->l->t('You are not allowed to share %s', [$share->getNode()->getPath()]);

--- a/tests/lib/share20/managertest.php
+++ b/tests/lib/share20/managertest.php
@@ -677,6 +677,9 @@ class ManagerTest extends \Test\TestCase {
 			['group0', true],
 		]));
 
+		$userFolder = $this->getMock('\OCP\Files\Folder');
+		$this->rootFolder->method('getUserFolder')->willReturn($userFolder);
+
 		try {
 			$this->invokePrivate($this->manager, 'generalCreateChecks', [$share]);
 			$thrown = false;
@@ -689,6 +692,32 @@ class ManagerTest extends \Test\TestCase {
 		}
 
 		$this->assertSame($exception, $thrown);
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 * @expectedExceptionMessage You can't share your root folder
+	 */
+	public function testGeneralCheckShareRoot() {
+		$thrown = null;
+
+		$this->userManager->method('userExists')->will($this->returnValueMap([
+			['user0', true],
+			['user1', true],
+		]));
+
+		$userFolder = $this->getMock('\OCP\Files\Folder');
+		$userFolder->method('isSubNode')->with($userFolder)->willReturn(false);
+		$this->rootFolder->method('getUserFolder')->willReturn($userFolder);
+
+		$share = $this->manager->newShare();
+
+		$share->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith('user0')
+			->setSharedBy('user1')
+			->setNode($userFolder);
+
+		$this->invokePrivate($this->manager, 'generalCreateChecks', [$share]);
 	}
 
 	/**


### PR DESCRIPTION
Sharing of the users root folder should not be allowed as it is very
weird UX. Also many of our clients have no proper way of displaying
this.

Also added intergration tests to make sure we won't allow it in the
future.

Fixes #22656
