### PR TITLE
remove comments count because it is not that relevant to show directly

### DIFF
--- a/apps/comments/css/comments.css
+++ b/apps/comments/css/comments.css
@@ -128,6 +128,6 @@
 	box-shadow: 0 0 6px #f8b9b7;
 }
 
-.app-files .action-comment>img {
-	margin-right: 5px;
+.app-files .action-comment {
+	padding: 16px 14px;
 }

--- a/apps/comments/js/filesplugin.js
+++ b/apps/comments/js/filesplugin.js
@@ -14,9 +14,8 @@
 	var TEMPLATE_COMMENTS_UNREAD =
 		'<a class="action action-comment permanent" title="{{countMessage}}" href="#">' +
 		'<img class="svg" src="{{iconUrl}}"/>' +
-		'{{count}}' +
 		'</a>';
-	
+
 	OCA.Comments = _.extend({}, OCA.Comments);
 	if (!OCA.Comments) {
 		/**
@@ -122,4 +121,3 @@
 })();
 
 OC.Plugins.register('OCA.Files.FileList', OCA.Comments.FilesPlugin);
-


### PR DESCRIPTION
Please review @PVince81 @owncloud/designers 

It’s not needed directly in the filelist:
- takes mental space
- takes actual space
- it’s not relevant how many new comments there exactly are

And I’d like to fix that for 9.0 since otherwise ppl will complain when we remove it in 9.1 ;)
