### PR TITLE
do not expand sidebar to full width on mobile, but up the min-width

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -445,7 +445,7 @@
 	left: auto;
 	bottom: 0;
 	width: 27%;
-	min-width: 250px;
+	min-width: 300px;
 	display: block;
 	background: #fff;
 	border-left: 1px solid #eee;

--- a/core/css/mobile.css
+++ b/core/css/mobile.css
@@ -73,10 +73,6 @@
 	z-index: 1000;
 }
 
-#app-sidebar{
-	width: 100% !important;
-}
-
 /* allow horizontal scrollbar in settings
 	otherwise user management is not usable on mobile */
 #body-settings #app-content {


### PR DESCRIPTION
Fix #19915, please review @PVince81 @Blizzz @MorrisJobke @owncloud/designers – very important because otherwise the sidebar takes all space on mobile and ownCloud basically is unusable on a tablet.

It also takes care of a few other issues, most namely the tendency of the share list entries to jump to a second line, as well as the tab bar to do the same. Also gives more breathing space to the content in the sidebar.
