### PR TITLE
ldap group membership background job should also throw pre_addToGroup…

### DIFF
--- a/apps/user_ldap/lib/jobs.php
+++ b/apps/user_ldap/lib/jobs.php
@@ -98,6 +98,7 @@ class Jobs extends \OC\BackgroundJob\TimedJob {
 				$hasChanged = true;
 			}
 			foreach(array_diff($actualUsers, $knownUsers) as $addedUser) {
+				\OCP\Util::emitHook('OC_Group', 'pre_addToGroup', array('uid' => $addedUser, 'gid' => $group));
 				\OCP\Util::emitHook('OC_User', 'post_addToGroup', array('uid' => $addedUser, 'gid' => $group));
 				\OCP\Util::writeLog('user_ldap',
 				'bgJ "updateGroups" – "'.$addedUser.'" added to "'.$group.'".',


### PR DESCRIPTION
…, because sharing listens to it. Fixes #21986.

Reason for this PR is https://github.com/owncloud/core/pull/21854#issuecomment-174198467, however looking at the code, this hook should have been fired before. Nevertheless, sharing worked. Now I wonder whether this is really needed, but I still guess so.

As brief excursion: At some time in the past sharing listened to addToGroup and RemoveFromGroup hooks for updating the shares. Because with LDAP we do not when a member is added or removed from a group, we have a background job that updates the members and throws hooks, if necessary.

@schiesbn @MorrisJobke @rullzer what do you think?
