### PR TITLE
[backport] [stable8.2] take the first result of that array, if present. Fixes 2nd display na…

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -543,8 +543,8 @@ class Access extends LDAPUtility implements user\IUserTools {
 					if(is_null($nameByLDAP)) {
 						continue;
 					}
-					$sndName = isset($ldapObject[$sndAttribute])
-						? $ldapObject[$sndAttribute] : '';
+					$sndName = isset($ldapObject[$sndAttribute][0])
+						? $ldapObject[$sndAttribute][0] : '';
 					$this->cacheUserDisplayName($ocName, $nameByLDAP, $sndName);
 				}
 			}


### PR DESCRIPTION
…me to be 'Array', if cache is configured and  enabled.

Backport of https://github.com/owncloud/core/pull/22599

@owncloud/ldap @MorrisJobke @PVince81 
