### PR TITLE
make scrollbar less obnoxious: tad narrower, rounded corners

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -73,13 +73,14 @@ body {
 
 /* SCROLLING */
 ::-webkit-scrollbar {
-	width: 8px;
+	width: 5px;
 }
 ::-webkit-scrollbar-track-piece {
 	background-color: transparent;
 }
 ::-webkit-scrollbar-thumb {
 	background: #ddd;
+	border-radius: 3px;
 }
 
 /* Searchbox */


### PR DESCRIPTION
Please review @owncloud/designers @PVince81 @MorrisJobke 

Otherwise it overpowers other elements on the page. Especially when used in the app-navigation and the content list used in Mail and the new Contacts app.
