### PR TITLE
Fix email form on personal page

### DIFF
--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -72,7 +72,7 @@ if($_['displayNameChangeSupported']) {
 <?php
 } else {
 ?>
-<div class="section">
+<div id="displaynameform" class="section">
 	<h2><?php echo $l->t('Full name');?></h2>
 	<span><?php if(isset($_['displayName'][0])) { p($_['displayName']); } else { p($l->t('No display name set')); } ?></span>
 </div>
@@ -96,7 +96,7 @@ if($_['passwordChangeSupported']) {
 <?php
 } else {
 ?>
-<div class="section">
+<div id="lostpassword" class="section">
 	<h2><?php echo $l->t('Email'); ?></h2>
 	<span><?php if(isset($_['email'][0])) { p($_['email']); } else { p($l->t('No email address set')); }?></span>
 </div>

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -81,7 +81,7 @@ if($_['displayNameChangeSupported']) {
 ?>
 
 <?php
-if($_['passwordChangeSupported']) {
+if($_['displayNameChangeSupported']) {
 ?>
 <form id="lostpassword" class="section">
 	<h2>


### PR DESCRIPTION
- Fix indentation of username/email when not editable
- Correctly mark email not editable when API does not allow it.

@PVince81 @MorrisJobke 
