### PR TITLE
Expiration date can only be enforced if default is enabled

### DIFF
--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -1079,7 +1079,8 @@ class Manager implements IManager {
 	 * @return bool
 	 */
 	public function shareApiLinkDefaultExpireDateEnforced() {
-		return $this->config->getAppValue('core', 'shareapi_enforce_expire_date', 'no') === 'yes';
+		return $this->shareApiLinkDefaultExpireDate() &&
+			$this->config->getAppValue('core', 'shareapi_enforce_expire_date', 'no') === 'yes';
 	}
 
 	/**

--- a/tests/lib/share20/managertest.php
+++ b/tests/lib/share20/managertest.php
@@ -746,10 +746,25 @@ class ManagerTest extends \Test\TestCase {
 
 		$this->config->method('getAppValue')
 			->will($this->returnValueMap([
+				['core', 'shareapi_default_expire_date', 'no', 'yes'],
 				['core', 'shareapi_enforce_expire_date', 'no', 'yes'],
 			]));
 
 		$this->invokePrivate($this->manager, 'validateExpirationDate', [$share]);
+	}
+
+	public function testvalidateExpirationDateEnforceButNotEnabledAndNotSet() {
+		$share = $this->manager->newShare();
+		$share->setProviderId('foo')->setId('bar');
+
+		$this->config->method('getAppValue')
+			->will($this->returnValueMap([
+				['core', 'shareapi_enforce_expire_date', 'no', 'yes'],
+			]));
+
+		$this->invokePrivate($this->manager, 'validateExpirationDate', [$share]);
+
+		$this->assertNull($share->getExpirationDate());
 	}
 
 	public function testvalidateExpirationDateEnforceButNotSetNewShare() {


### PR DESCRIPTION
If the default expiration date is not enebaled it can not be enforced.
- Added unit tests

Steps to test:
1. Go to the admin settings
2. Enable the default expiration date
3. Enforce the default expiration date
3. Disabled the default expiration date
4. Try to share by link

Before: Error since the expiration date was still enforced
After: All is well.

Fixes https://github.com/owncloud/core/issues/22642#issuecomment-189188171

CC: @PVince81 @nickvergessen @MorrisJobke 
