### PR TITLE
Allow to overwrite a single language string via the theme folder

### DIFF
--- a/core/js/l10n.js
+++ b/core/js/l10n.js
@@ -78,9 +78,7 @@ OC.L10N = {
 			}
 		} else {
 			// Theme overwriting the default language
-			_.each(bundle, function(translation, key) {
-				self._bundles[appName][key] = translation
-			});
+			_.extend(self._bundles[appName], bundle);
 		}
 	},
 

--- a/core/js/l10n.js
+++ b/core/js/l10n.js
@@ -66,13 +66,21 @@ OC.L10N = {
 	 * @param {Function|String} [pluralForm] optional plural function or plural string
 	 */
 	register: function(appName, bundle, pluralForm) {
-		this._bundles[appName] = bundle || {};
+		var self = this;
+		if (_.isUndefined(this._bundles[appName])) {
+			this._bundles[appName] = bundle || {};
 
-		if (_.isFunction(pluralForm)) {
-			this._pluralFunctions[appName] = pluralForm;
+			if (_.isFunction(pluralForm)) {
+				this._pluralFunctions[appName] = pluralForm;
+			} else {
+				// generate plural function based on form
+				this._pluralFunctions[appName] = this._generatePluralFunction(pluralForm);
+			}
 		} else {
-			// generate plural function based on form
-			this._pluralFunctions[appName] = this._generatePluralFunction(pluralForm);
+			// Theme overwriting the default language
+			_.each(bundle, function(translation, key) {
+				self._bundles[appName][key] = translation
+			});
 		}
 	},
 

--- a/core/js/tests/specs/l10nSpec.js
+++ b/core/js/tests/specs/l10nSpec.js
@@ -52,6 +52,14 @@ describe('OC.L10N tests', function() {
 				t(TEST_APP, 'Hello {name}', {name: '<strong>Steve</strong>'}, null, {escape: false})
 			).toEqual('Hello <strong>Steve</strong>');
 		});
+		it('keeps old texts when registering existing bundle', function() {
+			OC.L10N.register(TEST_APP, {
+				'sunny': 'sonnig',
+				'new': 'neu'
+			});
+			expect(t(TEST_APP, 'sunny')).toEqual('sonnig');
+			expect(t(TEST_APP, 'new')).toEqual('neu');
+		});
 	});
 	describe('plurals', function() {
 		function checkPlurals() {

--- a/lib/private/template/jsresourcelocator.php
+++ b/lib/private/template/jsresourcelocator.php
@@ -31,8 +31,24 @@ class JSResourceLocator extends ResourceLocator {
 	public function doFind($script) {
 		$theme_dir = 'themes/'.$this->theme.'/';
 		if (strpos($script, '3rdparty') === 0
-			&& $this->appendIfExist($this->thirdpartyroot, $script.'.js')
-			|| $this->appendIfExist($this->serverroot, $theme_dir.'apps/'.$script.'.js')
+			&& $this->appendIfExist($this->thirdpartyroot, $script.'.js')) {
+			return;
+		}
+
+		if (strpos($script, '/l10n/') !== false) {
+			// For language files we try to load them all, so themes can overwrite
+			// single l10n strings without having to translate all of them.
+			$found = 0;
+			$found += $this->appendIfExist($this->serverroot, 'core/'.$script.'.js');
+			$found += $this->appendIfExist($this->serverroot, $theme_dir.'core/'.$script.'.js');
+			$found += $this->appendIfExist($this->serverroot, $script.'.js');
+			$found += $this->appendIfExist($this->serverroot, $theme_dir.$script.'.js');
+			$found += $this->appendIfExist($this->serverroot, $theme_dir.'apps/'.$script.'.js');
+
+			if ($found) {
+				return;
+			}
+		} else if ($this->appendIfExist($this->serverroot, $theme_dir.'apps/'.$script.'.js')
 			|| $this->appendIfExist($this->serverroot, $theme_dir.$script.'.js')
 			|| $this->appendIfExist($this->serverroot, $script.'.js')
 			|| $this->appendIfExist($this->serverroot, $theme_dir.'core/'.$script.'.js')
@@ -40,6 +56,7 @@ class JSResourceLocator extends ResourceLocator {
 		) {
 			return;
 		}
+
 		$app = substr($script, 0, strpos($script, '/'));
 		$script = substr($script, strpos($script, '/')+1);
 		$app_path = \OC_App::getAppPath($app);


### PR DESCRIPTION
Anti whitespace: https://github.com/owncloud/core/pull/22677/files?w=1
### Steps
1. Use a theme
2. Switch the language to "Deutsch (Persönlich)"
3. Put the file `core/l10n/de.js` with the following content into your theme:

``` js
OC.L10N.register(
  "core",
  {
    "Share link" : "Niemand sollte diese Checkbox auswählen"
  },
  "nplurals=2; plural=(n != 1);"
);
```
1. Open the sharing sidebar
### Expected

German page with "Niemand sollte diese Checkbox auswählen" checkbox
### Actual

Everything is reset to english, apart from the "Niemand sollte diese Checkbox auswählen" checkbox

The problem is we only loaded one l10n resource, so when we found the one in the theme we didn't load the core version with the remaining translations anymore.
Now we load all languages (first core, then theme) and overwrite core strings with the theme.

Fixes https://github.com/owncloud/enterprise/issues/1109

cc @MorrisJobke @DeepDiver1975 @PVince81 
