### PR TITLE
Relax rootfolder check

### DIFF
--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -514,3 +514,15 @@ Feature: sharing
       | path | / |
       | shareType | 3 |
     Then the OCS status code should be "403"
+
+  Scenario: Allow modification of reshare
+    Given user "user0" exists
+    And user "user1" exists
+    And user "user2" exists
+    And user "user0" created a folder "/TMP"
+    And file "TMP" of user "user0" is shared with user "user1"
+    And file "TMP" of user "user1" is shared with user "user2"
+    And As an "user1"
+    When Updating last share with
+      | permissions | 1 |
+    Then the OCS status code should be "100"

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -198,7 +198,7 @@ class Manager implements IManager {
 		}
 
 		// And you can't share your rootfolder
-		if ($this->rootFolder->getUserFolder($share->getSharedBy())->isSubNode($share->getNode()) === false) {
+		if ($this->rootFolder->getUserFolder($share->getSharedBy())->getPath() === $share->getNode()->getPath()) {
 			throw new \InvalidArgumentException('You can\'t share your root folder');
 		}
 

--- a/tests/lib/share20/managertest.php
+++ b/tests/lib/share20/managertest.php
@@ -644,6 +644,15 @@ class ManagerTest extends \Test\TestCase {
 		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $limitedPermssions, $group0, $user0, $user0, 17, null, null), 'Cannot increase permissions of path', true];
 		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK,  $limitedPermssions, null, $user0, $user0, 3, null, null), 'Cannot increase permissions of path', true];
 
+		$rootFolder = $this->getMock('\OCP\Files\Folder');
+		$rootFolder->method('isShareable')->willReturn(true);
+		$rootFolder->method('getPermissions')->willReturn(\OCP\Constants::PERMISSION_ALL);
+		$rootFolder->method('getPath')->willReturn('myrootfolder');
+
+		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_USER,  $rootFolder, $user2, $user0, $user0, 30, null, null), 'You can\'t share your root folder', true];
+		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $rootFolder, $group0, $user0, $user0, 2, null, null), 'You can\'t share your root folder', true];
+		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK,  $rootFolder, null, $user0, $user0, 16, null, null), 'You can\'t share your root folder', true];
+
 		$allPermssions = $this->getMock('\OCP\Files\Folder');
 		$allPermssions->method('isShareable')->willReturn(true);
 		$allPermssions->method('getPermissions')->willReturn(\OCP\Constants::PERMISSION_ALL);
@@ -678,7 +687,9 @@ class ManagerTest extends \Test\TestCase {
 		]));
 
 		$userFolder = $this->getMock('\OCP\Files\Folder');
+		$userFolder->method('getPath')->willReturn('myrootfolder');
 		$this->rootFolder->method('getUserFolder')->willReturn($userFolder);
+
 
 		try {
 			$this->invokePrivate($this->manager, 'generalCreateChecks', [$share]);


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/22682
- Updated unit tests
- Added intergration test

The original test was comparing the wrong object when modifying reshares.
Now there is an intergration test to ensure this will continue to work.

CC: @MorrisJobke @nickvergessen @PVince81 @schiesbn 
