### PR TITLE
remove remote address book if access was revoked

### DIFF
--- a/apps/dav/appinfo/app.php
+++ b/apps/dav/appinfo/app.php
@@ -20,6 +20,7 @@
  */
 
 use OCA\Dav\AppInfo\Application;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 $app = new Application();
 $app->registerHooks();
@@ -31,12 +32,14 @@ $app->registerHooks();
 $eventDispatcher = \OC::$server->getEventDispatcher();
 
 $eventDispatcher->addListener('OCP\Federation\TrustedServerEvent::remove',
-	function(\Symfony\Component\EventDispatcher\GenericEvent $event) use ($app) {
+	function(GenericEvent $event) use ($app) {
 		/** @var \OCA\DAV\CardDAV\CardDavBackend $cardDavBackend */
 		$cardDavBackend = $app->getContainer()->query('CardDavBackend');
 		$addressBookUri = $event->getSubject();
 		$addressBook = $cardDavBackend->getAddressBooksByUri('principals/system/system', $addressBookUri);
-		$cardDavBackend->deleteAddressBook($addressBook['id']);
+		if (!is_null($addressBook)) {
+			$cardDavBackend->deleteAddressBook($addressBook['id']);
+		}
 	}
 );
 

--- a/apps/dav/appinfo/app.php
+++ b/apps/dav/appinfo/app.php
@@ -28,6 +28,18 @@ $app->registerHooks();
 	return $app->getSyncService();
 });
 
+$eventDispatcher = \OC::$server->getEventDispatcher();
+
+$eventDispatcher->addListener('OCP\Federation\TrustedServerEvent::remove',
+	function(\Symfony\Component\EventDispatcher\GenericEvent $event) use ($app) {
+		/** @var \OCA\DAV\CardDAV\CardDavBackend $cardDavBackend */
+		$cardDavBackend = $app->getContainer()->query('CardDavBackend');
+		$addressBookUri = $event->getSubject();
+		$addressBook = $cardDavBackend->getAddressBooksByUri('principals/system/system', $addressBookUri);
+		$cardDavBackend->deleteAddressBook($addressBook['id']);
+	}
+);
+
 $cm = \OC::$server->getContactsManager();
 $cm->register(function() use ($cm, $app) {
 	$userId = \OC::$server->getUserSession()->getUser()->getUID();

--- a/apps/dav/appinfo/application.php
+++ b/apps/dav/appinfo/application.php
@@ -69,7 +69,8 @@ class Application extends App {
 			/** @var IAppContainer $c */
 			return new SyncService(
 				$c->query('CardDavBackend'),
-				$c->getServer()->getUserManager()
+				$c->getServer()->getUserManager(),
+				$c->getServer()->getLogger()
 			);
 		});
 

--- a/apps/dav/tests/unit/carddav/syncservicetest.php
+++ b/apps/dav/tests/unit/carddav/syncservicetest.php
@@ -68,13 +68,15 @@ class SyncServiceTest extends TestCase {
 
 		/** @var IUserManager $userManager */
 		$userManager = $this->getMockBuilder('OCP\IUserManager')->disableOriginalConstructor()->getMock();
-		$ss = new SyncService($backend, $userManager);
+		$logger = $this->getMockBuilder('OCP\ILogger')->disableOriginalConstructor()->getMock();
+		$ss = new SyncService($backend, $userManager, $logger);
 		$book = $ss->ensureSystemAddressBookExists('principals/users/adam', 'contacts', []);
 	}
 
 	public function testUpdateAndDeleteUser() {
 		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $backend */
 		$backend = $this->getMockBuilder('OCA\DAV\CardDAV\CardDAVBackend')->disableOriginalConstructor()->getMock();
+		$logger = $this->getMockBuilder('OCP\ILogger')->disableOriginalConstructor()->getMock();
 
 		$backend->expects($this->once())->method('createCard');
 		$backend->expects($this->once())->method('updateCard');
@@ -92,7 +94,7 @@ class SyncServiceTest extends TestCase {
 		$user->method('getBackendClassName')->willReturn('unittest');
 		$user->method('getUID')->willReturn('test-user');
 
-		$ss = new SyncService($backend, $userManager);
+		$ss = new SyncService($backend, $userManager, $logger);
 		$ss->updateUser($user);
 
 		$user->method('getDisplayName')->willReturn('A test user for unit testing');
@@ -123,8 +125,9 @@ class SyncServiceTest extends TestCase {
 	 */
 	private function getSyncServiceMock($backend, $response) {
 		$userManager = $this->getMockBuilder('OCP\IUserManager')->disableOriginalConstructor()->getMock();
+		$logger = $this->getMockBuilder('OCP\ILogger')->disableOriginalConstructor()->getMock();
 		/** @var SyncService | \PHPUnit_Framework_MockObject_MockObject $ss */
-		$ss = $this->getMock('OCA\DAV\CardDAV\SyncService', ['ensureSystemAddressBookExists', 'requestSyncReport', 'download'], [$backend, $userManager]);
+		$ss = $this->getMock('OCA\DAV\CardDAV\SyncService', ['ensureSystemAddressBookExists', 'requestSyncReport', 'download'], [$backend, $userManager, $logger]);
 		$ss->method('requestSyncReport')->withAnyParameters()->willReturn(['response' => $response, 'token' => 'sync-token-1']);
 		$ss->method('ensureSystemAddressBookExists')->willReturn(['id' => 1]);
 		$ss->method('download')->willReturn([

--- a/apps/federation/appinfo/application.php
+++ b/apps/federation/appinfo/application.php
@@ -75,13 +75,15 @@ class Application extends \OCP\AppFramework\App {
 		});
 
 		$container->registerService('TrustedServers', function(IAppContainer $c) {
+			$server = $c->getServer();
 			return new TrustedServers(
 				$c->query('DbHandler'),
-				\OC::$server->getHTTPClientService(),
-				\OC::$server->getLogger(),
-				\OC::$server->getJobList(),
-				\OC::$server->getSecureRandom(),
-				\OC::$server->getConfig()
+				$server->getHTTPClientService(),
+				$server->getLogger(),
+				$server->getJobList(),
+				$server->getSecureRandom(),
+				$server->getConfig(),
+				$server->getEventDispatcher()
 			);
 		});
 
@@ -94,6 +96,7 @@ class Application extends \OCP\AppFramework\App {
 				$c->query('TrustedServers')
 			);
 		});
+
 	}
 
 	private function registerMiddleware() {

--- a/apps/federation/appinfo/database.xml
+++ b/apps/federation/appinfo/database.xml
@@ -27,8 +27,7 @@
 				<type>text</type>
 				<default></default>
 				<notnull>true</notnull>
-				<length>32</length>
-				<comments>md5 hash of the url without the protocol</comments>
+				<comments>sha1 hash of the url without the protocol</comments>
 			</field>
 			<field>
 				<name>token</name>

--- a/apps/federation/appinfo/info.xml
+++ b/apps/federation/appinfo/info.xml
@@ -5,7 +5,7 @@
     <description>ownCloud Federation allows you to connect with other trusted ownClouds to exchange the user directory. For example this will be used to auto-complete external users for federated sharing.</description>
     <licence>AGPL</licence>
     <author>Bjoern Schiessle</author>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
     <namespace>Federation</namespace>
     <category>other</category>
 	<dependencies>

--- a/apps/federation/backgroundjob/getsharedsecret.php
+++ b/apps/federation/backgroundjob/getsharedsecret.php
@@ -91,12 +91,13 @@ class GetSharedSecret extends QueuedJob{
 			$this->trustedServers = $trustedServers;
 		} else {
 			$this->trustedServers = new TrustedServers(
-					$this->dbHandler,
-					\OC::$server->getHTTPClientService(),
-					$this->logger,
-					$this->jobList,
-					\OC::$server->getSecureRandom(),
-					\OC::$server->getConfig()
+				$this->dbHandler,
+				\OC::$server->getHTTPClientService(),
+				$this->logger,
+				$this->jobList,
+				\OC::$server->getSecureRandom(),
+				\OC::$server->getConfig(),
+				\OC::$server->getEventDispatcher()
 			);
 		}
 	}

--- a/apps/federation/backgroundjob/requestsharedsecret.php
+++ b/apps/federation/backgroundjob/requestsharedsecret.php
@@ -95,7 +95,8 @@ class RequestSharedSecret extends QueuedJob {
 				$this->logger,
 				$this->jobList,
 				\OC::$server->getSecureRandom(),
-				\OC::$server->getConfig()
+				\OC::$server->getConfig(),
+				\OC::$server->getEventDispatcher()
 			);
 		}
 	}

--- a/apps/federation/command/syncfederationaddressbooks.php
+++ b/apps/federation/command/syncfederationaddressbooks.php
@@ -40,6 +40,7 @@ class SyncFederationAddressBooks extends Command {
 		$this->syncService->syncThemAll(function($url, $ex) use ($progress, $output) {
 			if ($ex instanceof \Exception) {
 				$output->writeln("Error while syncing $url : " . $ex->getMessage());
+
 			} else {
 				$progress->advance();
 			}

--- a/apps/federation/lib/dbhandler.php
+++ b/apps/federation/lib/dbhandler.php
@@ -106,6 +106,28 @@ class DbHandler {
 	}
 
 	/**
+	 * get trusted server with given ID
+	 *
+	 * @param int $id
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function getServerById($id) {
+		$query = $this->connection->getQueryBuilder();
+		$query->select('*')->from($this->dbTable)
+			->where($query->expr()->eq('id', $query->createParameter('id')))
+			->setParameter('id', $id);
+		$query->execute();
+		$result = $query->execute()->fetchAll();
+
+		if (empty($result)) {
+			throw new \Exception('No Server found with ID: ' . $id);
+		}
+
+		return $result[0];
+	}
+
+	/**
 	 * get all trusted servers
 	 *
 	 * @return array

--- a/apps/federation/lib/dbhandler.php
+++ b/apps/federation/lib/dbhandler.php
@@ -112,7 +112,7 @@ class DbHandler {
 	 */
 	public function getAllServer() {
 		$query = $this->connection->getQueryBuilder();
-		$query->select(['url', 'id', 'status', 'shared_secret', 'sync_token'])->from($this->dbTable);
+		$query->select(['url', 'url_hash', 'id', 'status', 'shared_secret', 'sync_token'])->from($this->dbTable);
 		$result = $query->execute()->fetchAll();
 		return $result;
 	}
@@ -252,11 +252,11 @@ class DbHandler {
 	 */
 	protected function hash($url) {
 		$normalized = $this->normalizeUrl($url);
-		return md5($normalized);
+		return sha1($normalized);
 	}
 
 	/**
-	 * normalize URL, used to create the md5 hash
+	 * normalize URL, used to create the sha1 hash
 	 *
 	 * @param string $url
 	 * @return string

--- a/apps/federation/lib/syncfederationaddressbooks.php
+++ b/apps/federation/lib/syncfederationaddressbooks.php
@@ -40,7 +40,7 @@ class SyncFederationAddressBooks {
 			if (is_null($sharedSecret)) {
 				continue;
 			}
-			$targetBookId = sha1($url);
+			$targetBookId = $trustedServer['url_hash'];
 			$targetPrincipal = "principals/system/system";
 			$targetBookProperties = [
 					'{DAV:}displayname' => $url

--- a/apps/federation/lib/syncfederationaddressbooks.php
+++ b/apps/federation/lib/syncfederationaddressbooks.php
@@ -3,6 +3,7 @@
 namespace OCA\Federation;
 
 use OCA\DAV\CardDAV\SyncService;
+use OCP\AppFramework\Http;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -51,6 +52,9 @@ class SyncFederationAddressBooks {
 					$this->dbHandler->setServerStatus($url, TrustedServers::STATUS_OK, $newToken);
 				}
 			} catch (\Exception $ex) {
+				if ($ex->getCode() === Http::STATUS_UNAUTHORIZED) {
+					$this->dbHandler->setServerStatus($url, TrustedServers::STATUS_ACCESS_REVOKED);
+				}
 				$callback($url, $ex);
 			}
 		}

--- a/apps/federation/lib/trustedservers.php
+++ b/apps/federation/lib/trustedservers.php
@@ -235,6 +235,7 @@ class TrustedServers {
 	 *
 	 * @param $status
 	 * @return bool
+	 * @throws HintException
 	 */
 	protected function checkOwnCloudVersion($status) {
 		$decoded = json_decode($status, true);

--- a/apps/federation/lib/trustedservers.php
+++ b/apps/federation/lib/trustedservers.php
@@ -41,6 +41,8 @@ class TrustedServers {
 	const STATUS_PENDING = 2;
 	/** something went wrong, misconfigured server, software bug,... user interaction needed */
 	const STATUS_FAILURE = 3;
+	/** remote server revoked access */
+	const STATUS_ACCESS_REVOKED = 4;
 
 	/** @var  dbHandler */
 	private $dbHandler;

--- a/apps/federation/settings/settings-admin.php
+++ b/apps/federation/settings/settings-admin.php
@@ -34,7 +34,8 @@ $trustedServers = new \OCA\Federation\TrustedServers(
 	\OC::$server->getLogger(),
 	\OC::$server->getJobList(),
 	\OC::$server->getSecureRandom(),
-	\OC::$server->getConfig()
+	\OC::$server->getConfig(),
+	\OC::$server->getEventDispatcher()
 );
 
 $template->assign('trustedServers', $trustedServers->getServers());

--- a/apps/federation/templates/settings-admin.php
+++ b/apps/federation/templates/settings-admin.php
@@ -26,7 +26,11 @@ style('federation', 'settings-admin')
 			<li id="<?php p($trustedServer['id']); ?>" class="icon-delete">
 				<?php if((int)$trustedServer['status'] === TrustedServers::STATUS_OK) { ?>
 					<span class="status success"></span>
-				<?php } elseif((int)$trustedServer['status'] === TrustedServers::STATUS_PENDING) { ?>
+				<?php
+				} elseif(
+					(int)$trustedServer['status'] === TrustedServers::STATUS_PENDING ||
+					(int)$trustedServer['status'] === TrustedServers::STATUS_ACCESS_REVOKED
+				) { ?>
 					<span class="status indeterminate"></span>
 				<?php } else {?>
 					<span class="status error"></span>

--- a/apps/federation/tests/lib/dbhandlertest.php
+++ b/apps/federation/tests/lib/dbhandlertest.php
@@ -89,9 +89,9 @@ class DbHandlerTest extends TestCase {
 
 	public function dataTestAddServer() {
 		return [
-				['http://owncloud.org', 'http://owncloud.org', md5('owncloud.org')],
-				['https://owncloud.org', 'https://owncloud.org', md5('owncloud.org')],
-				['http://owncloud.org/', 'http://owncloud.org', md5('owncloud.org')],
+				['http://owncloud.org', 'http://owncloud.org', sha1('owncloud.org')],
+				['https://owncloud.org', 'https://owncloud.org', sha1('owncloud.org')],
+				['http://owncloud.org/', 'http://owncloud.org', sha1('owncloud.org')],
 		];
 	}
 
@@ -233,10 +233,10 @@ class DbHandlerTest extends TestCase {
 
 	public function dataTestHash() {
 		return [
-			['server1', md5('server1')],
-			['http://server1', md5('server1')],
-			['https://server1', md5('server1')],
-			['http://server1/', md5('server1')],
+			['server1', sha1('server1')],
+			['http://server1', sha1('server1')],
+			['https://server1', sha1('server1')],
+			['http://server1/', sha1('server1')],
 		];
 	}
 

--- a/apps/federation/tests/lib/dbhandlertest.php
+++ b/apps/federation/tests/lib/dbhandlertest.php
@@ -115,6 +115,15 @@ class DbHandlerTest extends TestCase {
 		$this->assertSame($id1, (int)$result[0]['id']);
 	}
 
+
+	public function testGetServerById() {
+		$this->dbHandler->addServer('server1');
+		$id = $this->dbHandler->addServer('server2');
+
+		$result = $this->dbHandler->getServerById($id);
+		$this->assertSame('server2', $result['url']);
+	}
+
 	public function testGetAll() {
 		$id1 = $this->dbHandler->addServer('server1');
 		$id2 = $this->dbHandler->addServer('server2');

--- a/apps/federation/tests/lib/syncfederationaddressbookstest.php
+++ b/apps/federation/tests/lib/syncfederationaddressbookstest.php
@@ -19,6 +19,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 			willReturn([
 			[
 				'url' => 'https://cloud.drop.box',
+				'url_hash' => 'sha1',
 				'shared_secret' => 'iloveowncloud',
 				'sync_token' => '0'
 			]
@@ -47,6 +48,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 		willReturn([
 			[
 				'url' => 'https://cloud.drop.box',
+				'url_hash' => 'sha1',
 				'shared_secret' => 'iloveowncloud',
 				'sync_token' => '0'
 			]


### PR DESCRIPTION
Following scenario:
1. server1 adds server2 as trusted server
2. server2 adds server1 as trusted server
3. both exchange their system address books
4. admin of server2 removes server1 from the list of trusted servers

Current behavior:

both will still have the latest version of the synced address books and use it for auto-complete

Behavior with this PR:

both server will remove the synced address books. The status indicator on server1 will go back to yellow.

cc @DeepDiver1975 please have a look. Thanks!
