### PR TITLE
ensure comments-href returns a value also when propfind is done again…

### DIFF
--- a/apps/dav/lib/Connector/Sabre/CommentPropertiesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/CommentPropertiesPlugin.php
@@ -99,13 +99,13 @@ class CommentPropertiesPlugin extends ServerPlugin {
 	 */
 	public function getCommentsLink(Node $node) {
 		$href =  $this->server->getBaseUri();
-		$entryPoint = strrpos($href, '/webdav/');
+		$entryPoint = strpos($href, '/remote.php/');
 		if($entryPoint === false) {
 			// in case we end up somewhere else, unexpectedly.
 			return null;
 		}
-		$href = substr_replace($href, '/dav/', $entryPoint);
-		$href .= 'comments/files/' . rawurldecode($node->getId());
+		$commentsPart = 'dav/comments/files/' . rawurldecode($node->getId());
+		$href = substr_replace($href, $commentsPart, $entryPoint + strlen('/remote.php/'));
 		return $href;
 	}
 

--- a/apps/dav/tests/unit/connector/sabre/commentpropertiesplugin.php
+++ b/apps/dav/tests/unit/connector/sabre/commentpropertiesplugin.php
@@ -84,7 +84,8 @@ class CommentsPropertiesPlugin extends \Test\TestCase {
 	public function baseUriProvider() {
 		return [
 			['owncloud/remote.php/webdav/', '4567', 'owncloud/remote.php/dav/comments/files/4567'],
-			['owncloud/remote.php/wicked/', '4567', null]
+			['owncloud/remote.php/files/', '4567', 'owncloud/remote.php/dav/comments/files/4567'],
+			['owncloud/wicked.php/files/', '4567', null]
 		];
 	}
 


### PR DESCRIPTION
…st remote.php/files

Previously, this worked only with remote.php/webdav/.

To test, following curl commands should return a value for oc:comments-href:

``` xml
curl -u USER:PWD -X PROPFIND --data-binary "@propfind.files.xml" -H "Content-Type: text/xml" http://192.168.56.101/remote.php/files/test.txt
<?xml version="1.0"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">
 <d:response>
  <d:href>/remote.php/files/test.txt</d:href>
  <d:propstat>
   <d:prop>
    <d:getetag>&quot;f3857038edba39035c5294ffedf14583&quot;</d:getetag>
    <oc:comments-count>0</oc:comments-count>
    <oc:comments-href>/remote.php/dav/comments/files/780</oc:comments-href>
    <oc:comments-unread>0</oc:comments-unread>
   </d:prop>
   <d:status>HTTP/1.1 200 OK</d:status>
  </d:propstat>
 </d:response>
</d:multistatus>
```

``` xml
curl -u USER:PWD -X PROPFIND --data-binary "@propfind.files.xml" -H "Content-Type: text/xml" http://192.168.56.101/remote.php/webdav/test.txt
<?xml version="1.0"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">
 <d:response>
  <d:href>/remote.php/webdav/test.txt</d:href>
  <d:propstat>
   <d:prop>
    <d:getetag>&quot;f3857038edba39035c5294ffedf14583&quot;</d:getetag>
    <oc:comments-count>0</oc:comments-count>
    <oc:comments-href>/remote.php/dav/comments/files/780</oc:comments-href>
    <oc:comments-unread>0</oc:comments-unread>
   </d:prop>
   <d:status>HTTP/1.1 200 OK</d:status>
  </d:propstat>
 </d:response>
</d:multistatus>
```

content of propfind.files.xml is:

``` xml
<?xml version="1.0" encoding="utf-8" ?>
<D:propfind xmlns:D="DAV:" xmlns:oc="http://owncloud.org/ns" >
  <D:prop>
    <D:getetag/>
    <oc:comments-count/>
    <oc:comments-href/>
    <oc:comments-unread/>
  </D:prop>
</D:propfind>
```

Please test+review @DeepDiver1975 @nickvergessen @PVince81 (unsure about severity, thus did not set label and milestone).
