### PR TITLE
Add question from where ownCloud was installed

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -29,7 +29,7 @@ Tell us what happens instead
 
 **Updated from an older ownCloud or fresh install:**
 
-**Where do you installed ownCloud from:**
+**Where did you install ownCloud from:**
 
 **Signing status (ownCloud 9.0 and above):**
 

--- a/issue_template.md
+++ b/issue_template.md
@@ -29,6 +29,8 @@ Tell us what happens instead
 
 **Updated from an older ownCloud or fresh install:**
 
+**Where do you installed ownCloud from:**
+
 **Signing status (ownCloud 9.0 and above):**
 
 ```


### PR DESCRIPTION
With regard to the following patch in Debian I'd recommend that we add to the issue template that we ask where users got their ownCloud from.

This is super dangerous stuff from Debian again. Can't call it otherwise. With 9.0 we can detect that since the question for the code integrity would return "Not enabled" instead of passed. But unluckily this is already 8.2.

(while skipping one version _might_ work it is completely untested and I smell already users reporting very hard to debug bugs to us => Waste of time)

https://sources.debian.net/src/owncloud/8.2.2~dfsg-1/debian/patches/0009-Don-t-stop-update-over-several-major-versions.patch/

@karlitschek @jospoortvliet @DeepDiver1975 Thoughts?
