### PR TITLE
For now only allow 1 link share per file/folder

### DIFF
--- a/apps/files_sharing/api/share20ocs.php
+++ b/apps/files_sharing/api/share20ocs.php
@@ -303,6 +303,15 @@ class Share20OCS {
 				return new \OC_OCS_Result(null, 404, 'public link sharing is disabled by the administrator');
 			}
 
+			/*
+			 * For now we only allow 1 link share.
+			 * Return the existing link share if this is a duplicate
+			 */
+			$existingShares = $this->shareManager->getSharesBy($this->currentUser->getUID(), \OCP\Share::SHARE_TYPE_LINK, $path, false, 1, 0);
+			if (!empty($existingShares)) {
+				return new \OC_OCS_Result($this->formatShare($existingShares[0]));
+			}
+
 			$publicUpload = $this->request->getParam('publicUpload', null);
 			if ($publicUpload === 'true') {
 				// Check if public upload is allowed

--- a/build/integration/features/bootstrap/Sharing.php
+++ b/build/integration/features/bootstrap/Sharing.php
@@ -17,6 +17,9 @@ trait Sharing{
 	/** @var SimpleXMLElement */
 	private $lastShareData = null;
 
+	/** @var int */
+	private $savedShareId = null;
+
 	/**
 	 * @When /^creating a share with$/
 	 * @param \Behat\Gherkin\Node\TableNode|null $formData
@@ -414,5 +417,22 @@ trait Sharing{
 		}
 	}
 
+	/**
+	 * @When save last share id
+	 */
+	public function saveLastShareId()
+	{
+		$this->savedShareId = $this->lastShareData['data']['id'];
+	}
+
+	/**
+	 * @Then share ids should match
+	 */
+	public function shareIdsShouldMatch()
+	{
+		if ($this->savedShareId !== $this->lastShareData['data']['id']) {
+			throw new \Excetion('Expected the same link share to be returned');
+		}
+	}
 }
 

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -547,3 +547,15 @@ Feature: sharing
     When Updating last share with
       | permissions | 31 |
     Then the OCS status code should be "404"
+
+  Scenario: Only allow 1 link share per file/folder
+    Given user "user0" exists
+    And As an "user0"
+    And creating a share with
+      | path | welcome.txt |
+      | shareType | 3 |
+    When save last share id
+    And creating a share with
+      | path | welcome.txt |
+      | shareType | 3      |
+    Then share ids should match


### PR DESCRIPTION
Fixes #22692
This is a temp fix util we get #22327

We just block it in the OCS Share API since we have 1 endpoint now anyway.
