### PR TITLE
Use IQueryBuilder::PARAM_* instead of \PDO::PARAM_*

### DIFF
--- a/apps/dav/lib/caldav/caldavbackend.php
+++ b/apps/dav/lib/caldav/caldavbackend.php
@@ -607,7 +607,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->values([
 				'calendarid' => $query->createNamedParameter($calendarId),
 				'uri' => $query->createNamedParameter($objectUri),
-				'calendardata' => $query->createNamedParameter($calendarData, \PDO::PARAM_LOB),
+				'calendardata' => $query->createNamedParameter($calendarData, IQueryBuilder::PARAM_LOB),
 				'lastmodified' => $query->createNamedParameter(time()),
 				'etag' => $query->createNamedParameter($extraData['etag']),
 				'size' => $query->createNamedParameter($extraData['size']),
@@ -646,7 +646,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 		$query = $this->db->getQueryBuilder();
 		$query->update('calendarobjects')
-				->set('calendardata', $query->createNamedParameter($calendarData, \PDO::PARAM_LOB))
+				->set('calendardata', $query->createNamedParameter($calendarData, IQueryBuilder::PARAM_LOB))
 				->set('lastmodified', $query->createNamedParameter(time()))
 				->set('etag', $query->createNamedParameter($extraData['etag']))
 				->set('size', $query->createNamedParameter($extraData['size']))

--- a/apps/dav/lib/carddav/carddavbackend.php
+++ b/apps/dav/lib/carddav/carddavbackend.php
@@ -489,7 +489,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		$query = $this->db->getQueryBuilder();
 		$query->insert('cards')
 			->values([
-				'carddata' => $query->createNamedParameter($cardData, \PDO::PARAM_LOB),
+				'carddata' => $query->createNamedParameter($cardData, IQueryBuilder::PARAM_LOB),
 				'uri' => $query->createNamedParameter($cardUri),
 				'lastmodified' => $query->createNamedParameter(time()),
 				'addressbookid' => $query->createNamedParameter($addressBookId),
@@ -542,7 +542,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		$etag = md5($cardData);
 		$query = $this->db->getQueryBuilder();
 		$query->update('cards')
-			->set('carddata', $query->createNamedParameter($cardData, \PDO::PARAM_LOB))
+			->set('carddata', $query->createNamedParameter($cardData, IQueryBuilder::PARAM_LOB))
 			->set('lastmodified', $query->createNamedParameter(time()))
 			->set('size', $query->createNamedParameter(strlen($cardData)))
 			->set('etag', $query->createNamedParameter($etag))

--- a/apps/dav/tests/unit/carddav/carddavbackendtest.php
+++ b/apps/dav/tests/unit/carddav/carddavbackendtest.php
@@ -26,6 +26,7 @@ use InvalidArgumentException;
 use OCA\DAV\CardDAV\AddressBook;
 use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\Connector\Sabre\Principal;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use Sabre\DAV\PropPatch;
 use Sabre\VObject\Component\VCard;
@@ -480,7 +481,7 @@ class CardDavBackendTest extends TestCase {
 					->values(
 							[
 									'addressbookid' => $query->createNamedParameter(0),
-									'carddata' => $query->createNamedParameter($vCards[$i]->serialize(), \PDO::PARAM_LOB),
+									'carddata' => $query->createNamedParameter($vCards[$i]->serialize(), IQueryBuilder::PARAM_LOB),
 									'uri' => $query->createNamedParameter('uri' . $i),
 									'lastmodified' => $query->createNamedParameter(time()),
 									'etag' => $query->createNamedParameter('etag' . $i),
@@ -558,7 +559,7 @@ class CardDavBackendTest extends TestCase {
 				->values(
 						[
 								'addressbookid' => $query->createNamedParameter(1),
-								'carddata' => $query->createNamedParameter('carddata', \PDO::PARAM_LOB),
+								'carddata' => $query->createNamedParameter('carddata', IQueryBuilder::PARAM_LOB),
 								'uri' => $query->createNamedParameter('uri'),
 								'lastmodified' => $query->createNamedParameter(5489543),
 								'etag' => $query->createNamedParameter('etag'),
@@ -586,7 +587,7 @@ class CardDavBackendTest extends TestCase {
 					->values(
 							[
 									'addressbookid' => $query->createNamedParameter($i),
-									'carddata' => $query->createNamedParameter('carddata' . $i, \PDO::PARAM_LOB),
+									'carddata' => $query->createNamedParameter('carddata' . $i, IQueryBuilder::PARAM_LOB),
 									'uri' => $query->createNamedParameter('uri' . $i),
 									'lastmodified' => $query->createNamedParameter(5489543),
 									'etag' => $query->createNamedParameter('etag' . $i),

--- a/apps/files_external/service/dbconfigservice.php
+++ b/apps/files_external/service/dbconfigservice.php
@@ -65,7 +65,7 @@ class DBConfigService {
 		$builder = $this->connection->getQueryBuilder();
 		$query = $builder->select(['mount_id', 'mount_point', 'storage_backend', 'auth_backend', 'priority', 'type'])
 			->from('external_mounts', 'm')
-			->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, \PDO::PARAM_INT)));
+			->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, IQueryBuilder::PARAM_INT)));
 		$mounts = $this->getMountsFromQuery($query);
 		if (count($mounts) > 0) {
 			return $mounts[0];
@@ -83,7 +83,7 @@ class DBConfigService {
 		$builder = $this->connection->getQueryBuilder();
 		$query = $builder->select(['mount_id', 'mount_point', 'storage_backend', 'auth_backend', 'priority', 'type'])
 			->from('external_mounts')
-			->where($builder->expr()->eq('type', $builder->expr()->literal(self::MOUNT_TYPE_ADMIN, \PDO::PARAM_INT)));
+			->where($builder->expr()->eq('type', $builder->expr()->literal(self::MOUNT_TYPE_ADMIN, IQueryBuilder::PARAM_INT)));
 		return $this->getMountsFromQuery($query);
 	}
 
@@ -91,7 +91,7 @@ class DBConfigService {
 		$query = $builder->select(['m.mount_id', 'mount_point', 'storage_backend', 'auth_backend', 'priority', 'm.type'])
 			->from('external_mounts', 'm')
 			->innerJoin('m', 'external_applicable', 'a', 'm.mount_id = a.mount_id')
-			->where($builder->expr()->eq('a.type', $builder->createNamedParameter($type, \PDO::PARAM_INT)));
+			->where($builder->expr()->eq('a.type', $builder->createNamedParameter($type, IQueryBuilder::PARAM_INT)));
 
 		if (is_null($value)) {
 			$query = $query->andWhere($builder->expr()->isNull('a.value'));
@@ -126,7 +126,7 @@ class DBConfigService {
 	public function getAdminMountsFor($type, $value) {
 		$builder = $this->connection->getQueryBuilder();
 		$query = $this->getForQuery($builder, $type, $value);
-		$query->andWhere($builder->expr()->eq('m.type', $builder->expr()->literal(self::MOUNT_TYPE_ADMIN, \PDO::PARAM_INT)));
+		$query->andWhere($builder->expr()->eq('m.type', $builder->expr()->literal(self::MOUNT_TYPE_ADMIN, IQueryBuilder::PARAM_INT)));
 
 		return $this->getMountsFromQuery($query);
 	}
@@ -141,15 +141,15 @@ class DBConfigService {
 	public function getAdminMountsForMultiple($type, array $values) {
 		$builder = $this->connection->getQueryBuilder();
 		$params = array_map(function ($value) use ($builder) {
-			return $builder->createNamedParameter($value, \PDO::PARAM_STR);
+			return $builder->createNamedParameter($value, IQueryBuilder::PARAM_STR);
 		}, $values);
 
 		$query = $builder->select(['m.mount_id', 'mount_point', 'storage_backend', 'auth_backend', 'priority', 'm.type'])
 			->from('external_mounts', 'm')
 			->innerJoin('m', 'external_applicable', 'a', 'm.mount_id = a.mount_id')
-			->where($builder->expr()->eq('a.type', $builder->createNamedParameter($type, \PDO::PARAM_INT)))
+			->where($builder->expr()->eq('a.type', $builder->createNamedParameter($type, IQueryBuilder::PARAM_INT)))
 			->andWhere($builder->expr()->in('a.value', $params));
-		$query->andWhere($builder->expr()->eq('m.type', $builder->expr()->literal(self::MOUNT_TYPE_ADMIN, \PDO::PARAM_INT)));
+		$query->andWhere($builder->expr()->eq('m.type', $builder->expr()->literal(self::MOUNT_TYPE_ADMIN, IQueryBuilder::PARAM_INT)));
 
 		return $this->getMountsFromQuery($query);
 	}
@@ -164,7 +164,7 @@ class DBConfigService {
 	public function getUserMountsFor($type, $value) {
 		$builder = $this->connection->getQueryBuilder();
 		$query = $this->getForQuery($builder, $type, $value);
-		$query->andWhere($builder->expr()->eq('m.type', $builder->expr()->literal(self::MOUNT_TYPE_PERSONAl, \PDO::PARAM_INT)));
+		$query->andWhere($builder->expr()->eq('m.type', $builder->expr()->literal(self::MOUNT_TYPE_PERSONAl, IQueryBuilder::PARAM_INT)));
 
 		return $this->getMountsFromQuery($query);
 	}
@@ -186,11 +186,11 @@ class DBConfigService {
 		$builder = $this->connection->getQueryBuilder();
 		$query = $builder->insert('external_mounts')
 			->values([
-				'mount_point' => $builder->createNamedParameter($mountPoint, \PDO::PARAM_STR),
-				'storage_backend' => $builder->createNamedParameter($storageBackend, \PDO::PARAM_STR),
-				'auth_backend' => $builder->createNamedParameter($authBackend, \PDO::PARAM_STR),
-				'priority' => $builder->createNamedParameter($priority, \PDO::PARAM_INT),
-				'type' => $builder->createNamedParameter($type, \PDO::PARAM_INT)
+				'mount_point' => $builder->createNamedParameter($mountPoint, IQueryBuilder::PARAM_STR),
+				'storage_backend' => $builder->createNamedParameter($storageBackend, IQueryBuilder::PARAM_STR),
+				'auth_backend' => $builder->createNamedParameter($authBackend, IQueryBuilder::PARAM_STR),
+				'priority' => $builder->createNamedParameter($priority, IQueryBuilder::PARAM_INT),
+				'type' => $builder->createNamedParameter($type, IQueryBuilder::PARAM_INT)
 			]);
 		$query->execute();
 		return (int)$this->connection->lastInsertId('external_mounts');
@@ -204,19 +204,19 @@ class DBConfigService {
 	public function removeMount($mountId) {
 		$builder = $this->connection->getQueryBuilder();
 		$query = $builder->delete('external_mounts')
-			->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, \PDO::PARAM_INT)));
+			->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, IQueryBuilder::PARAM_INT)));
 		$query->execute();
 
 		$query = $builder->delete('external_applicable')
-			->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, \PDO::PARAM_INT)));
+			->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, IQueryBuilder::PARAM_INT)));
 		$query->execute();
 
 		$query = $builder->delete('external_config')
-			->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, \PDO::PARAM_INT)));
+			->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, IQueryBuilder::PARAM_INT)));
 		$query->execute();
 
 		$query = $builder->delete('external_options')
-			->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, \PDO::PARAM_INT)));
+			->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, IQueryBuilder::PARAM_INT)));
 		$query->execute();
 	}
 
@@ -229,7 +229,7 @@ class DBConfigService {
 
 		$query = $builder->update('external_mounts')
 			->set('mount_point', $builder->createNamedParameter($newMountPoint))
-			->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, \PDO::PARAM_INT)));
+			->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, IQueryBuilder::PARAM_INT)));
 
 		$query->execute();
 	}
@@ -243,7 +243,7 @@ class DBConfigService {
 
 		$query = $builder->update('external_mounts')
 			->set('auth_backend', $builder->createNamedParameter($newAuthBackend))
-			->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, \PDO::PARAM_INT)));
+			->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, IQueryBuilder::PARAM_INT)));
 
 		$query->execute();
 	}
@@ -265,9 +265,9 @@ class DBConfigService {
 		if ($count === 0) {
 			$builder = $this->connection->getQueryBuilder();
 			$query = $builder->update('external_config')
-				->set('value', $builder->createNamedParameter($value, \PDO::PARAM_STR))
-				->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, \PDO::PARAM_INT)))
-				->andWhere($builder->expr()->eq('key', $builder->createNamedParameter($key, \PDO::PARAM_STR)));
+				->set('value', $builder->createNamedParameter($value, IQueryBuilder::PARAM_STR))
+				->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, IQueryBuilder::PARAM_INT)))
+				->andWhere($builder->expr()->eq('key', $builder->createNamedParameter($key, IQueryBuilder::PARAM_STR)));
 			$query->execute();
 		}
 	}
@@ -287,9 +287,9 @@ class DBConfigService {
 		if ($count === 0) {
 			$builder = $this->connection->getQueryBuilder();
 			$query = $builder->update('external_options')
-				->set('value', $builder->createNamedParameter(json_encode($value), \PDO::PARAM_STR))
-				->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, \PDO::PARAM_INT)))
-				->andWhere($builder->expr()->eq('key', $builder->createNamedParameter($key, \PDO::PARAM_STR)));
+				->set('value', $builder->createNamedParameter(json_encode($value), IQueryBuilder::PARAM_STR))
+				->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, IQueryBuilder::PARAM_INT)))
+				->andWhere($builder->expr()->eq('key', $builder->createNamedParameter($key, IQueryBuilder::PARAM_STR)));
 			$query->execute();
 		}
 	}
@@ -305,13 +305,13 @@ class DBConfigService {
 	public function removeApplicable($mountId, $type, $value) {
 		$builder = $this->connection->getQueryBuilder();
 		$query = $builder->delete('external_applicable')
-			->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, \PDO::PARAM_INT)))
-			->andWhere($builder->expr()->eq('type', $builder->createNamedParameter($type, \PDO::PARAM_INT)));
+			->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, IQueryBuilder::PARAM_INT)))
+			->andWhere($builder->expr()->eq('type', $builder->createNamedParameter($type, IQueryBuilder::PARAM_INT)));
 
 		if (is_null($value)) {
 			$query = $query->andWhere($builder->expr()->isNull('value'));
 		} else {
-			$query = $query->andWhere($builder->expr()->eq('value', $builder->createNamedParameter($value, \PDO::PARAM_STR)));
+			$query = $query->andWhere($builder->expr()->eq('value', $builder->createNamedParameter($value, IQueryBuilder::PARAM_STR)));
 		}
 
 		$query->execute();
@@ -354,7 +354,7 @@ class DBConfigService {
 		$builder = $this->connection->getQueryBuilder();
 		$fields[] = 'mount_id';
 		$placeHolders = array_map(function ($id) use ($builder) {
-			return $builder->createPositionalParameter($id, \PDO::PARAM_INT);
+			return $builder->createPositionalParameter($id, IQueryBuilder::PARAM_INT);
 		}, $mountIds);
 		$query = $builder->select($fields)
 			->from($table)

--- a/lib/private/appframework/db/db.php
+++ b/lib/private/appframework/db/db.php
@@ -25,6 +25,7 @@
 
 namespace OC\AppFramework\Db;
 
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDb;
 use OCP\IDBConnection;
 
@@ -240,7 +241,7 @@ class Db implements IDb {
 	 * @param int $type Type of the parameter.
 	 * @return string The quoted parameter.
 	 */
-	public function quote($input, $type = \PDO::PARAM_STR) {
+	public function quote($input, $type = IQueryBuilder::PARAM_STR) {
 		return $this->connection->quote($input, $type);
 	}
 

--- a/lib/private/backgroundjob/joblist.php
+++ b/lib/private/backgroundjob/joblist.php
@@ -28,6 +28,7 @@ use OCP\AppFramework\QueryException;
 use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\IJobList;
 use OCP\AutoloadNotAllowedException;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 
 class JobList implements IJobList {
 	/** @var \OCP\IDBConnection */
@@ -69,7 +70,7 @@ class JobList implements IJobList {
 				->values([
 					'class' => $query->createNamedParameter($class),
 					'argument' => $query->createNamedParameter($argument),
-					'last_run' => $query->createNamedParameter(0, \PDO::PARAM_INT),
+					'last_run' => $query->createNamedParameter(0, IQueryBuilder::PARAM_INT),
 				]);
 			$query->execute();
 		}
@@ -102,7 +103,7 @@ class JobList implements IJobList {
 	protected function removeById($id) {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete('jobs')
-			->where($query->expr()->eq('id', $query->createNamedParameter($id, \PDO::PARAM_INT)));
+			->where($query->expr()->eq('id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
 		$query->execute();
 	}
 
@@ -171,7 +172,7 @@ class JobList implements IJobList {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')
 			->from('jobs')
-			->where($query->expr()->gt('id', $query->createNamedParameter($lastId, \PDO::PARAM_INT)))
+			->where($query->expr()->gt('id', $query->createNamedParameter($lastId, IQueryBuilder::PARAM_INT)))
 			->orderBy('id', 'ASC')
 			->setMaxResults(1);
 		$result = $query->execute();
@@ -216,7 +217,7 @@ class JobList implements IJobList {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')
 			->from('jobs')
-			->where($query->expr()->eq('id', $query->createNamedParameter($id, \PDO::PARAM_INT)));
+			->where($query->expr()->eq('id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
 		$result = $query->execute();
 		$row = $result->fetch();
 		$result->closeCursor();
@@ -286,8 +287,8 @@ class JobList implements IJobList {
 	public function setLastRun($job) {
 		$query = $this->connection->getQueryBuilder();
 		$query->update('jobs')
-			->set('last_run', $query->createNamedParameter(time(), \PDO::PARAM_INT))
-			->where($query->expr()->eq('id', $query->createNamedParameter($job->getId(), \PDO::PARAM_INT)));
+			->set('last_run', $query->createNamedParameter(time(), IQueryBuilder::PARAM_INT))
+			->where($query->expr()->eq('id', $query->createNamedParameter($job->getId(), IQueryBuilder::PARAM_INT)));
 		$query->execute();
 	}
 }

--- a/lib/private/comments/manager.php
+++ b/lib/private/comments/manager.php
@@ -25,6 +25,7 @@ use OCP\Comments\CommentsEvent;
 use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\IConfig;
 use OCP\ILogger;
@@ -233,7 +234,7 @@ class Manager implements ICommentsManager {
 		$resultStatement = $qb->select('*')
 			->from('comments')
 			->where($qb->expr()->eq('id', $qb->createParameter('id')))
-			->setParameter('id', $id, \PDO::PARAM_INT)
+			->setParameter('id', $id, IQueryBuilder::PARAM_INT)
 			->execute();
 
 		$data = $resultStatement->fetch();
@@ -675,9 +676,9 @@ class Manager implements ICommentsManager {
 			->where($qb->expr()->eq('user_id', $qb->createParameter('user_id')))
 			->andWhere($qb->expr()->eq('object_type', $qb->createParameter('object_type')))
 			->andWhere($qb->expr()->eq('object_id', $qb->createParameter('object_id')))
-			->setParameter('user_id', $user->getUID(), \PDO::PARAM_STR)
-			->setParameter('object_type', $objectType, \PDO::PARAM_STR)
-			->setParameter('object_id', $objectId, \PDO::PARAM_STR)
+			->setParameter('user_id', $user->getUID(), IQueryBuilder::PARAM_STR)
+			->setParameter('object_type', $objectType, IQueryBuilder::PARAM_STR)
+			->setParameter('object_id', $objectId, IQueryBuilder::PARAM_STR)
 			->execute();
 
 		if ($affectedRows > 0) {
@@ -707,9 +708,9 @@ class Manager implements ICommentsManager {
 			->where($qb->expr()->eq('user_id', $qb->createParameter('user_id')))
 			->andWhere($qb->expr()->eq('object_type', $qb->createParameter('object_type')))
 			->andWhere($qb->expr()->eq('object_id', $qb->createParameter('object_id')))
-			->setParameter('user_id', $user->getUID(), \PDO::PARAM_STR)
-			->setParameter('object_type', $objectType, \PDO::PARAM_STR)
-			->setParameter('object_id', $objectId, \PDO::PARAM_STR)
+			->setParameter('user_id', $user->getUID(), IQueryBuilder::PARAM_STR)
+			->setParameter('object_type', $objectType, IQueryBuilder::PARAM_STR)
+			->setParameter('object_id', $objectId, IQueryBuilder::PARAM_STR)
 			->execute();
 
 		$data = $resultStatement->fetch();

--- a/lib/private/db/querybuilder/querybuilder.php
+++ b/lib/private/db/querybuilder/querybuilder.php
@@ -168,7 +168,7 @@ class QueryBuilder implements IQueryBuilder {
 	 *
 	 * @param string|integer $key The parameter position or name.
 	 * @param mixed $value The parameter value.
-	 * @param string|null $type One of the PDO::PARAM_* constants.
+	 * @param string|null $type One of the IQueryBuilder::PARAM_* constants.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 */
@@ -988,7 +988,7 @@ class QueryBuilder implements IQueryBuilder {
 	 *
 	 * @return IParameter the placeholder name used.
 	 */
-	public function createNamedParameter($value, $type = \PDO::PARAM_STR, $placeHolder = null) {
+	public function createNamedParameter($value, $type = IQueryBuilder::PARAM_STR, $placeHolder = null) {
 		return new Parameter($this->queryBuilder->createNamedParameter($value, $type, $placeHolder));
 	}
 
@@ -1005,8 +1005,8 @@ class QueryBuilder implements IQueryBuilder {
 	 *  $qb = $conn->getQueryBuilder();
 	 *  $qb->select('u.*')
 	 *     ->from('users', 'u')
-	 *     ->where('u.username = ' . $qb->createPositionalParameter('Foo', PDO::PARAM_STR))
-	 *     ->orWhere('u.username = ' . $qb->createPositionalParameter('Bar', PDO::PARAM_STR))
+	 *     ->where('u.username = ' . $qb->createPositionalParameter('Foo', IQueryBuilder::PARAM_STR))
+	 *     ->orWhere('u.username = ' . $qb->createPositionalParameter('Bar', IQueryBuilder::PARAM_STR))
 	 * </code>
 	 *
 	 * @param mixed $value
@@ -1014,7 +1014,7 @@ class QueryBuilder implements IQueryBuilder {
 	 *
 	 * @return IParameter
 	 */
-	public function createPositionalParameter($value, $type = \PDO::PARAM_STR) {
+	public function createPositionalParameter($value, $type = IQueryBuilder::PARAM_STR) {
 		return new Parameter($this->queryBuilder->createPositionalParameter($value, $type));
 	}
 
@@ -1027,7 +1027,7 @@ class QueryBuilder implements IQueryBuilder {
 	 *  $qb->select('u.*')
 	 *     ->from('users', 'u')
 	 *     ->where('u.username = ' . $qb->createParameter('name'))
-	 *     ->setParameter('name', 'Bar', PDO::PARAM_STR))
+	 *     ->setParameter('name', 'Bar', IQueryBuilder::PARAM_STR))
 	 * </code>
 	 *
 	 * @param string $name

--- a/lib/public/appframework/db/mapper.php
+++ b/lib/public/appframework/db/mapper.php
@@ -202,7 +202,7 @@ abstract class Mapper {
 	/**
 	 * Returns the correct PDO constant based on the value type
 	 * @param $value
-	 * @return PDO constant
+	 * @return int PDO constant
 	 * @since 8.1.0
 	 */
 	private function getPDOType($value) {

--- a/lib/public/db/querybuilder/iquerybuilder.php
+++ b/lib/public/db/querybuilder/iquerybuilder.php
@@ -156,7 +156,7 @@ interface IQueryBuilder {
 	 *
 	 * @param string|integer $key The parameter position or name.
 	 * @param mixed $value The parameter value.
-	 * @param string|null $type One of the PDO::PARAM_* constants.
+	 * @param string|null $type One of the IQueryBuilder::PARAM_* constants.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 * @since 8.2.0
@@ -780,7 +780,7 @@ interface IQueryBuilder {
 	 * @return IParameter
 	 * @since 8.2.0
 	 */
-	public function createNamedParameter($value, $type = \PDO::PARAM_STR, $placeHolder = null);
+	public function createNamedParameter($value, $type = self::PARAM_STR, $placeHolder = null);
 
 	/**
 	 * Creates a new positional parameter and bind the given value to it.
@@ -795,8 +795,8 @@ interface IQueryBuilder {
 	 *  $qb = $conn->getQueryBuilder();
 	 *  $qb->select('u.*')
 	 *     ->from('users', 'u')
-	 *     ->where('u.username = ' . $qb->createPositionalParameter('Foo', PDO::PARAM_STR))
-	 *     ->orWhere('u.username = ' . $qb->createPositionalParameter('Bar', PDO::PARAM_STR))
+	 *     ->where('u.username = ' . $qb->createPositionalParameter('Foo', IQueryBuilder::PARAM_STR))
+	 *     ->orWhere('u.username = ' . $qb->createPositionalParameter('Bar', IQueryBuilder::PARAM_STR))
 	 * </code>
 	 *
 	 * @param mixed $value
@@ -805,7 +805,7 @@ interface IQueryBuilder {
 	 * @return IParameter
 	 * @since 8.2.0
 	 */
-	public function createPositionalParameter($value, $type = \PDO::PARAM_STR);
+	public function createPositionalParameter($value, $type = self::PARAM_STR);
 
 	/**
 	 * Creates a new parameter
@@ -816,7 +816,7 @@ interface IQueryBuilder {
 	 *  $qb->select('u.*')
 	 *     ->from('users', 'u')
 	 *     ->where('u.username = ' . $qb->createParameter('name'))
-	 *     ->setParameter('name', 'Bar', PDO::PARAM_STR))
+	 *     ->setParameter('name', 'Bar', IQueryBuilder::PARAM_STR))
 	 * </code>
 	 *
 	 * @param string $name

--- a/lib/public/idbconnection.php
+++ b/lib/public/idbconnection.php
@@ -32,6 +32,7 @@
 // use OCP namespace for all classes that are considered public.
 // This means that they should be used by apps instead of the internal ownCloud classes
 namespace OCP;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 
 /**
  * Interface IDBConnection
@@ -193,7 +194,7 @@ interface IDBConnection {
 	 * @return string The quoted parameter.
 	 * @since 8.0.0
 	 */
-	public function quote($input, $type = \PDO::PARAM_STR);
+	public function quote($input, $type = IQueryBuilder::PARAM_STR);
 
 	/**
 	 * Gets the DatabasePlatform instance that provides all the metadata about

--- a/tests/lib/appframework/db/mappertestutility.php
+++ b/tests/lib/appframework/db/mappertestutility.php
@@ -68,7 +68,7 @@ abstract class MapperTestUtility extends \Test\TestCase {
 	/**
 	 * Returns the correct PDO constant based on the value type
 	 * @param $value
-	 * @return PDO constant
+	 * @return int PDO constant
 	 */
 	private function getPDOType($value) {
 		switch (gettype($value)) {

--- a/tests/lib/db/connection.php
+++ b/tests/lib/db/connection.php
@@ -11,6 +11,7 @@ namespace Test\DB;
 
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use OC\DB\MDB2SchemaManager;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 
 /**
  * Class Connection
@@ -94,7 +95,7 @@ class Connection extends \Test\TestCase {
 		$builder = $this->connection->getQueryBuilder();
 		$query = $builder->select('textfield')
 			->from('table')
-			->where($builder->expr()->eq('integerfield', $builder->createNamedParameter($integerField, \PDO::PARAM_INT)));
+			->where($builder->expr()->eq('integerfield', $builder->createNamedParameter($integerField, IQueryBuilder::PARAM_INT)));
 
 		$result = $query->execute();
 		return $result->fetchColumn();

--- a/tests/lib/db/querybuilder/expressionbuildertest.php
+++ b/tests/lib/db/querybuilder/expressionbuildertest.php
@@ -327,7 +327,7 @@ class ExpressionBuilderTest extends TestCase {
 			[1, null],
 			[1, 'string'],
 			[1, 'integer'],
-			[1, \PDO::PARAM_INT],
+			[1, IQueryBuilder::PARAM_INT],
 		];
 	}
 

--- a/tests/lib/repair/cleantags.php
+++ b/tests/lib/repair/cleantags.php
@@ -7,6 +7,7 @@
  */
 
 namespace Test\Repair;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 
 /**
  * Tests for the cleaning the tags tables
@@ -123,8 +124,8 @@ class CleanTags extends \Test\TestCase {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->insert('vcategory_to_object')
 			->values([
-				'objid'			=> $qb->createNamedParameter($objectId, \PDO::PARAM_INT),
-				'categoryid'	=> $qb->createNamedParameter($category, \PDO::PARAM_INT),
+				'objid'			=> $qb->createNamedParameter($objectId, IQueryBuilder::PARAM_INT),
+				'categoryid'	=> $qb->createNamedParameter($category, IQueryBuilder::PARAM_INT),
 				'type'			=> $qb->createNamedParameter($type),
 			])
 			->execute();


### PR DESCRIPTION
They are the same by definition, but they are our public api,
so not urgent, just to be a good example:
https://github.com/owncloud/core/blob/2a0cda74d41ece6bee48024dd485bf08087054ad/lib/public/db/querybuilder/iquerybuilder.php#L33-L65

@LukasReschke @DeepDiver1975 
