### PR TITLE
Catch Files\NotFoundException when copying skeleton

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -311,7 +311,13 @@ class OC_Util {
 				'copying skeleton for '.$userId.' from '.$skeletonDirectory.' to '.$userDirectory->getFullPath('/'),
 				\OCP\Util::DEBUG
 			);
-			self::copyr($skeletonDirectory, $userDirectory);
+			try {
+				self::copyr($skeletonDirectory, $userDirectory);
+			} catch (\OCP\Files\NotFoundException $e) {
+				\OC::$server->getLogger()->logException($e, [
+					'app' => 'files_skeleton',
+				]);
+			}
 			// update the file cache
 			$userDirectory->getStorage()->getScanner()->scan('', \OC\Files\Cache\Scanner::SCAN_RECURSIVE);
 		}


### PR DESCRIPTION
Fix #22603

Logging the exception and still continuing the installation process is better then fatal.

@DeepDiver1975 @PVince81 @MorrisJobke 

I think it is okay, to catch the exception, although we should also fix our docker setup to wait for everything before running. Alternative approach would be to do things different in rcopy, but that is public API and we shouldn't change that behaviour so close to a release.
