### PR TITLE
fix size propagation for new files

### DIFF
--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -198,7 +198,11 @@ class Scanner extends BasicEmitter implements IScanner {
 				if (!empty($newData)) {
 					$data['fileid'] = $this->addToCache($file, $newData, $fileId);
 				}
-				$data['oldSize'] = $cacheData['size'];
+				if (isset($cacheData['size'])) {
+					$data['oldSize'] = $cacheData['size'];
+				} else {
+					$data['oldSize'] = 0;
+				}
 
 				// post-emit only if it was a file. By that we avoid counting/treating folders as files
 				if ($data['mimetype'] !== 'httpd/unix-directory') {


### PR DESCRIPTION
Make sure we can get a correct size difference for new files.

For #18359

Missed this previously since blackfire on default runs everything 10 times, meaning that I was always overwriting files with my tests.

cc @PVince81 @MorrisJobke @DeepDiver1975 please review
