### PR TITLE
Check correct permissions when resharing

### DIFF
--- a/apps/files_sharing/api/share20ocs.php
+++ b/apps/files_sharing/api/share20ocs.php
@@ -594,6 +594,22 @@ class Share20OCS {
 			}
 		}
 
+		if ($permissions !== null) {
+			/* Check if this is an incomming share */
+			$incomingShares = $this->shareManager->getSharedWith($this->currentUser->getUID(), \OCP\Share::SHARE_TYPE_USER, $share->getNode(), -1, 0);
+			$incomingShares = array_merge($incomingShares, $this->shareManager->getSharedWith($this->currentUser->getUID(), \OCP\Share::SHARE_TYPE_GROUP, $share->getNode(), -1, 0));
+
+			if (!empty($incomingShares)) {
+				$maxPermissions = 0;
+				foreach ($incomingShares as $incomingShare) {
+					$maxPermissions |= $incomingShare->getPermissions();
+				}
+
+				if ($share->getPermissions() & ~$maxPermissions) {
+					return new \OC_OCS_Result(null, 404, 'Cannot increase permissions');
+				}
+			}
+		}
 
 
 		try {

--- a/apps/files_sharing/tests/api/share20ocstest.php
+++ b/apps/files_sharing/tests/api/share20ocstest.php
@@ -1433,6 +1433,8 @@ class Share20OCSTest extends \Test\TestCase {
 			})
 		)->will($this->returnArgument(0));
 
+		$this->shareManager->method('getSharedWith')->willReturn([]);
+
 		$expected = new \OC_OCS_Result(null);
 		$result = $ocs->updateShare(42);
 
@@ -1497,6 +1499,8 @@ class Share20OCSTest extends \Test\TestCase {
 				return $share->getPermissions() === \OCP\Constants::PERMISSION_ALL;
 			})
 		)->will($this->returnArgument(0));
+
+		$this->shareManager->method('getSharedWith')->willReturn([]);
 
 		$expected = new \OC_OCS_Result(null);
 		$result = $ocs->updateShare(42);

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -526,3 +526,24 @@ Feature: sharing
     When Updating last share with
       | permissions | 1 |
     Then the OCS status code should be "100"
+
+  Scenario: Do not allow reshare to exceed permissions
+    Given user "user0" exists
+    And user "user1" exists
+    And user "user2" exists
+    And user "user0" created a folder "/TMP"
+    And As an "user0"
+    And creating a share with
+      | path | /TMP |
+      | shareType | 0 |
+      | shareWith | user1 |
+      | permissions | 21 |
+    And As an "user1"
+    And creating a share with
+      | path | /TMP |
+      | shareType | 0 |
+      | shareWith | user2 |
+      | permissions | 21 |
+    When Updating last share with
+      | permissions | 31 |
+    Then the OCS status code should be "404"


### PR DESCRIPTION
Fixes #22675

Since we only get a share id we do not know the path for the sharer.
Now if we edit a share we start searching for shares for that user of
that node. And deduce the permissions that way.
- Intergration test added

@PVince81 @cmonteroluque I really hate to do this but getting this into 9.0 is kind of curcial from my POV

@nasli please verify

The intergration test check the test case. But please try yourself ;)

CC: @schiesbn  @MorrisJobke @nickvergessen @PVince81 @LukasReschke @DeepDiver1975 
