### PR TITLE
improved encrypt-all script

### DIFF
--- a/apps/encryption/appinfo/application.php
+++ b/apps/encryption/appinfo/application.php
@@ -242,6 +242,7 @@ class Application extends \OCP\AppFramework\App {
 					$c->getServer()->getUserManager(),
 					new View(),
 					$c->query('KeyManager'),
+					$c->query('Util'),
 					$server->getConfig(),
 					$server->getMailer(),
 					$server->getL10N('encryption'),

--- a/apps/encryption/lib/keymanager.php
+++ b/apps/encryption/lib/keymanager.php
@@ -394,17 +394,20 @@ class KeyManager {
 	public function getFileKey($path, $uid) {
 		$encryptedFileKey = $this->keyStorage->getFileKey($path, $this->fileKeyId, Encryption::ID);
 
+		if (empty($encryptedFileKey)) {
+			return '';
+		}
+
+		if ($this->util->isMasterKeyEnabled()) {
+			$uid = $this->getMasterKeyId();
+		}
+
 		if (is_null($uid)) {
 			$uid = $this->getPublicShareKeyId();
 			$shareKey = $this->getShareKey($path, $uid);
 			$privateKey = $this->keyStorage->getSystemUserKey($this->publicShareKeyId . '.privateKey', Encryption::ID);
 			$privateKey = $this->crypt->decryptPrivateKey($privateKey);
 		} else {
-
-			if ($this->util->isMasterKeyEnabled()) {
-				$uid = $this->getMasterKeyId();
-			}
-
 			$shareKey = $this->getShareKey($path, $uid);
 			$privateKey = $this->session->getPrivateKey();
 		}

--- a/apps/encryption/tests/lib/crypto/encryptalltest.php
+++ b/apps/encryption/tests/lib/crypto/encryptalltest.php
@@ -153,6 +153,36 @@ class EncryptAllTest extends TestCase {
 
 	}
 
+	public function testEncryptAllWithMasterKey() {
+		/** @var EncryptAll  | \PHPUnit_Framework_MockObject_MockObject  $encryptAll */
+		$encryptAll = $this->getMockBuilder('OCA\Encryption\Crypto\EncryptAll')
+			->setConstructorArgs(
+				[
+					$this->setupUser,
+					$this->userManager,
+					$this->view,
+					$this->keyManager,
+					$this->util,
+					$this->config,
+					$this->mailer,
+					$this->l,
+					$this->questionHelper,
+					$this->secureRandom
+				]
+			)
+			->setMethods(['createKeyPairs', 'encryptAllUsersFiles', 'outputPasswords'])
+			->getMock();
+
+		$this->util->expects($this->any())->method('isMasterKeyEnabled')->willReturn(true);
+		$encryptAll->expects($this->never())->method('createKeyPairs');
+		$this->keyManager->expects($this->once())->method('validateMasterKey');
+		$encryptAll->expects($this->at(0))->method('encryptAllUsersFiles')->with();
+		$encryptAll->expects($this->never())->method('outputPasswords');
+
+		$encryptAll->encryptAll($this->inputInterface, $this->outputInterface);
+
+	}
+
 	public function testCreateKeyPairs() {
 		/** @var EncryptAll  | \PHPUnit_Framework_MockObject_MockObject  $encryptAll */
 		$encryptAll = $this->getMockBuilder('OCA\Encryption\Crypto\EncryptAll')

--- a/apps/encryption/tests/lib/crypto/encryptalltest.php
+++ b/apps/encryption/tests/lib/crypto/encryptalltest.php
@@ -31,6 +31,9 @@ class EncryptAllTest extends TestCase {
 	/** @var  \PHPUnit_Framework_MockObject_MockObject | \OCA\Encryption\KeyManager */
 	protected $keyManager;
 
+	/** @var  \PHPUnit_Framework_MockObject_MockObject | \OCA\Encryption\Util */
+	protected $util;
+
 	/** @var  \PHPUnit_Framework_MockObject_MockObject | \OCP\IUserManager */
 	protected $userManager;
 
@@ -73,6 +76,8 @@ class EncryptAllTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->keyManager = $this->getMockBuilder('OCA\Encryption\KeyManager')
 			->disableOriginalConstructor()->getMock();
+		$this->util = $this->getMockBuilder('OCA\Encryption\Util')
+			->disableOriginalConstructor()->getMock();
 		$this->userManager = $this->getMockBuilder('OCP\IUserManager')
 			->disableOriginalConstructor()->getMock();
 		$this->view = $this->getMockBuilder('OC\Files\View')
@@ -110,6 +115,7 @@ class EncryptAllTest extends TestCase {
 			$this->userManager,
 			$this->view,
 			$this->keyManager,
+			$this->util,
 			$this->config,
 			$this->mailer,
 			$this->l,
@@ -127,6 +133,7 @@ class EncryptAllTest extends TestCase {
 					$this->userManager,
 					$this->view,
 					$this->keyManager,
+					$this->util,
 					$this->config,
 					$this->mailer,
 					$this->l,
@@ -137,6 +144,7 @@ class EncryptAllTest extends TestCase {
 			->setMethods(['createKeyPairs', 'encryptAllUsersFiles', 'outputPasswords'])
 			->getMock();
 
+		$this->util->expects($this->any())->method('isMasterKeyEnabled')->willReturn(false);
 		$encryptAll->expects($this->at(0))->method('createKeyPairs')->with();
 		$encryptAll->expects($this->at(1))->method('encryptAllUsersFiles')->with();
 		$encryptAll->expects($this->at(2))->method('outputPasswords')->with();
@@ -154,6 +162,7 @@ class EncryptAllTest extends TestCase {
 					$this->userManager,
 					$this->view,
 					$this->keyManager,
+					$this->util,
 					$this->config,
 					$this->mailer,
 					$this->l,
@@ -202,6 +211,7 @@ class EncryptAllTest extends TestCase {
 					$this->userManager,
 					$this->view,
 					$this->keyManager,
+					$this->util,
 					$this->config,
 					$this->mailer,
 					$this->l,
@@ -211,6 +221,8 @@ class EncryptAllTest extends TestCase {
 			)
 			->setMethods(['encryptUsersFiles'])
 			->getMock();
+
+		$this->util->expects($this->any())->method('isMasterKeyEnabled')->willReturn(false);
 
 		// set protected property $output
 		$this->invokePrivate($encryptAll, 'output', [$this->outputInterface]);
@@ -232,6 +244,7 @@ class EncryptAllTest extends TestCase {
 					$this->userManager,
 					$this->view,
 					$this->keyManager,
+					$this->util,
 					$this->config,
 					$this->mailer,
 					$this->l,
@@ -239,9 +252,10 @@ class EncryptAllTest extends TestCase {
 					$this->secureRandom
 				]
 			)
-			->setMethods(['encryptFile'])
+			->setMethods(['encryptFile', 'setupUserFS'])
 			->getMock();
 
+		$this->util->expects($this->any())->method('isMasterKeyEnabled')->willReturn(false);
 
 		$this->view->expects($this->at(0))->method('getDirectoryContent')
 			->with('/user1/files')->willReturn(
@@ -268,8 +282,8 @@ class EncryptAllTest extends TestCase {
 				}
 			);
 
-		$encryptAll->expects($this->at(0))->method('encryptFile')->with('/user1/files/bar');
-		$encryptAll->expects($this->at(1))->method('encryptFile')->with('/user1/files/foo/subfile');
+		$encryptAll->expects($this->at(1))->method('encryptFile')->with('/user1/files/bar');
+		$encryptAll->expects($this->at(2))->method('encryptFile')->with('/user1/files/foo/subfile');
 
 		$progressBar = $this->getMockBuilder('Symfony\Component\Console\Helper\ProgressBar')
 			->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
If the master key is enabled we don't need to create a private-/public-key for each user. This improves the performance of encrypt-all a lot if a master key is in use.

Steps to test:
- enable default encryption module
- enable server-side encryption
- enable master key: ./occ encryption:enable-master-key
- run encrypt-all: ./occ encryption:encrypt-all
- [x] unit tests
