### PR TITLE
untangle different user manager instances, fixes #22770

### DIFF
--- a/apps/user_ldap/lib/proxy.php
+++ b/apps/user_ldap/lib/proxy.php
@@ -61,7 +61,7 @@ abstract class Proxy {
 		static $userMap;
 		static $groupMap;
 		static $db;
-		static $userManager;
+		static $coreUserManager;
 		if(is_null($fs)) {
 			$ocConfig = \OC::$server->getConfig();
 			$fs       = new FilesystemHelper();
@@ -70,10 +70,10 @@ abstract class Proxy {
 			$db       = \OC::$server->getDatabaseConnection();
 			$userMap  = new UserMapping($db);
 			$groupMap = new GroupMapping($db);
-			$userManager = \OC::$server->getUserManager();
+			$coreUserManager = \OC::$server->getUserManager();
 		}
 		$userManager =
-			new user\Manager($ocConfig, $fs, $log, $avatarM, new \OCP\Image(), $db, $userManager);
+			new user\Manager($ocConfig, $fs, $log, $avatarM, new \OCP\Image(), $db, $coreUserManager);
 		$connector = new Connection($this->ldap, $configPrefix);
 		$access = new Access($connector, $this->ldap, $userManager);
 		$access->setUserMapper($userMap);


### PR DESCRIPTION
Only reproducible with 2 active LDAP configurations. Easiest thing if you have just one: clone it.

please test and review @DeepDiver1975 @davitol @MorrisJobke @owncloud/ldap 

@karlitschek we need to backport to 9.0.1, granted?

fixes #22770
