### PR TITLE
Return false on 401 in file list + trash file list

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1436,6 +1436,10 @@
 			delete this._reloadCall;
 			this.hideMask();
 
+			if (status === 401) {
+				return false;
+			}
+
 			// Firewall Blocked request?
 			if (status === 403) {
 				// Go home

--- a/apps/files_trashbin/js/filelist.js
+++ b/apps/files_trashbin/js/filelist.js
@@ -325,6 +325,10 @@
 				return false;
 			}
 
+			if (result.status === 401) {
+				return false;
+			}
+
 			// Firewall Blocked request?
 			if (result.status === 403) {
 				// Go home


### PR DESCRIPTION
This gives a chance to the global ajax error handler to do its work if
the session expired.

The reason it didn't work is because we specify an explicit error callback, so that one is run first. If that callback doesn't return false, it means that we already processed the error. This fix makes it return false to make sure the next handler, the global one, gets executed.
Ideally this code needs to be rewritten to only check if there is a correct response, else return false.

Fixes https://github.com/owncloud/core/issues/21140

Please review @MorrisJobke @rullzer @Blizzz @icewind1991
