### PR TITLE
Minor grammar in config.sample.php

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1110,7 +1110,7 @@ $CONFIG = array(
 'filesystem_check_changes' => 0,
 
 /**
- * On default ownCloud will store the part files created during upload in the
+ * By default ownCloud will store the part files created during upload in the
  * same storage as the upload target. Setting this to false will store the part
  * files in the root of the users folder which might be required to work with certain
  * external storage setups that have limited rename capabilities.


### PR DESCRIPTION
Fix this here in the source so it will propogate into the documentation.
Edit was already applied in https://github.com/owncloud/documentation/pull/2208 but needs to be done here at the source.
