### PR TITLE
don't hide server not available exception, fixes #20536

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -714,6 +714,9 @@ class OC {
 				try {
 					$cache = new \OC\Cache\File();
 					$cache->gc();
+				} catch (\OC\ServerNotAvailableException $e) {
+					// not a GC exception, pass it on
+					throw $e;
 				} catch (\Exception $e) {
 					// a GC exception should not prevent users from using OC,
 					// so log the exception


### PR DESCRIPTION
LDAP server is offline, but Local Luke has his sync client running. All the shared files from LDAP Lenny are purged, because the thrown ServerNotAvailable Exception was caught unintentionally on a very broad catch. Fixes #20536 

However,  I don't think it's the final solution. I'd prefer if we can specifically catch and sort out the GC Exception, instead of any. Otherwise we run into the same issue again.

@PVince81 @MorrisJobke 
