### PR TITLE
Exclude the assets folder from integrity check

### DIFF
--- a/lib/private/integritycheck/iterator/excludefoldersbypathfilteriterator.php
+++ b/lib/private/integritycheck/iterator/excludefoldersbypathfilteriterator.php
@@ -35,8 +35,9 @@ class ExcludeFoldersByPathFilterIterator extends \RecursiveFilterIterator {
 		$excludedFolders = [
 			rtrim($root . '/data', '/'),
 			rtrim($root .'/themes', '/'),
-			rtrim($root.'/config', '/'),
-			rtrim($root.'/apps', '/'),
+			rtrim($root . '/config', '/'),
+			rtrim($root . '/apps', '/'),
+			rtrim($root . '/assets', '/'),
 		];
 		$customDataDir = \OC::$server->getConfig()->getSystemValue('datadirectory', '');
 		if($customDataDir !== '') {


### PR DESCRIPTION
We should not scan the assets folder as this can contain user specific content. Partially addresses https://github.com/owncloud/core/issues/22803

cc @PVince81 
