### PR TITLE
[Stable 8.1] Rename and move permissions are set when a file is updatable

### DIFF
--- a/lib/private/connector/sabre/node.php
+++ b/lib/private/connector/sabre/node.php
@@ -225,7 +225,7 @@ abstract class Node implements \Sabre\DAV\INode {
 		if ($this->info->isDeletable()) {
 			$p .= 'D';
 		}
-		if ($this->info->isDeletable()) {
+		if ($this->info->isUpdateable()) {
 			$p .= 'NV'; // Renameable, Moveable
 		}
 		if ($this->info->getType() === \OCP\Files\FileInfo::TYPE_FILE) {

--- a/tests/lib/connector/sabre/node.php
+++ b/tests/lib/connector/sabre/node.php
@@ -17,8 +17,8 @@ class Node extends \Test\TestCase {
 			array(\OCP\Constants::PERMISSION_ALL, 'file', true, false, 'SRDNVW'),
 			array(\OCP\Constants::PERMISSION_ALL, 'file', true, true, 'SRMDNVW'),
 			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_SHARE, 'file', true, false, 'SDNVW'),
-			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_UPDATE, 'file', false, false, 'RDNV'),
-			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_DELETE, 'file', false, false, 'RW'),
+			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_UPDATE, 'file', false, false, 'RD'),
+			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_DELETE, 'file', false, false, 'RNVW'),
 			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_CREATE, 'file', false, false, 'RDNVW'),
 			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_CREATE, 'dir', false, false, 'RDNV'),
 		);


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/22830
Permissions in https://github.com/owncloud/core/pull/22830#issuecomment-191990355

CC: @karlitschek @MorrisJobke @PVince81 @nickvergessen @DeepDiver1975 
