### PR TITLE
Add release channel selection back

### DIFF
--- a/apps/updatenotification/appinfo/app.php
+++ b/apps/updatenotification/appinfo/app.php
@@ -31,9 +31,11 @@ if(\OC::$server->getConfig()->getSystemValue('updatechecker', true) === true) {
 
 	$userObject = \OC::$server->getUserSession()->getUser();
 	if($userObject !== null) {
-		if(\OC::$server->getGroupManager()->isAdmin($userObject->getUID()) && $updateChecker->getUpdateState() !== []) {
-			\OCP\Util::addScript('updatenotification', 'notification');
-			OC_Hook::connect('\OCP\Config', 'js', $updateChecker, 'getJavaScript');
+		if(\OC::$server->getGroupManager()->isAdmin($userObject->getUID())) {
+			if($updateChecker->getUpdateState() !== []) {
+				\OCP\Util::addScript('updatenotification', 'notification');
+				OC_Hook::connect('\OCP\Config', 'js', $updateChecker, 'getJavaScript');
+			}
 			\OC_App::registerAdmin('updatenotification', 'admin');
 		}
 	}

--- a/apps/updatenotification/appinfo/application.php
+++ b/apps/updatenotification/appinfo/application.php
@@ -22,7 +22,9 @@
 namespace OCA\UpdateNotification\AppInfo;
 
 use OC\AppFramework\Utility\TimeFactory;
+use OC\Updater;
 use OCA\UpdateNotification\Controller\AdminController;
+use OCA\UpdateNotification\UpdateChecker;
 use OCP\AppFramework\App;
 use OCP\AppFramework\IAppContainer;
 
@@ -32,13 +34,21 @@ class Application extends App {
 		$container = $this->getContainer();
 
 		$container->registerService('AdminController', function(IAppContainer $c) {
+			$updater = new \OC\Updater(
+				\OC::$server->getHTTPHelper(),
+				\OC::$server->getConfig(),
+				\OC::$server->getIntegrityCodeChecker()
+			);
 			return new AdminController(
 				$c->query('AppName'),
 				$c->query('Request'),
 				$c->getServer()->getJobList(),
 				$c->getServer()->getSecureRandom(),
 				$c->getServer()->getConfig(),
-				new TimeFactory()
+				new TimeFactory(),
+				$c->getServer()->getL10N($c->query('AppName')),
+				new UpdateChecker($updater),
+				$c->getServer()->getDateTimeFormatter()
 			);
 		});
 	}

--- a/apps/updatenotification/appinfo/routes.php
+++ b/apps/updatenotification/appinfo/routes.php
@@ -24,4 +24,5 @@ namespace OCA\UpdateNotification\AppInfo;
 $application = new Application();
 $application->registerRoutes($this, ['routes' => [
 	['name' => 'Admin#createCredentials', 'url' => '/credentials', 'verb' => 'GET'],
+	['name' => 'Admin#setChannel', 'url' => '/channel', 'verb' => 'POST'],
 ]]);

--- a/apps/updatenotification/js/admin.js
+++ b/apps/updatenotification/js/admin.js
@@ -15,7 +15,7 @@
  */
 var loginToken = '';
 $(document).ready(function(){
-	$('#oca_updatenotification').click(function() {
+	$('#oca_updatenotification_button').click(function() {
 		// Load the new token
 		$.ajax({
 			url: OC.generateUrl('/apps/updatenotification/credentials')
@@ -38,5 +38,17 @@ $(document).ready(function(){
 				}
 			});
 		});
+	});
+	$('#release-channel').change(function() {
+		var newChannel = $('#release-channel').find(":selected").val();
+		$.post(
+			OC.generateUrl('/apps/updatenotification/channel'),
+			{
+				'channel': newChannel
+			},
+			function(data){
+				OC.msg.finishedAction('#channel_save_msg', data);
+			}
+		);
 	});
 });

--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -1,8 +1,42 @@
-<?php script('updatenotification', 'admin') ?>
-<form id="oca_updatenotification" class="section">
+<?php
+	script('updatenotification', 'admin');
+
+	/** @var array $_ */
+	/** @var bool $isNewVersionAvailable */
+	$isNewVersionAvailable = $_['isNewVersionAvailable'];
+	/** @var string $newVersionString */
+	$newVersionString = $_['newVersionString'];
+	/** @var string $lastCheckedDate */
+	$lastCheckedDate = $_['lastChecked'];
+	/** @var array $channels */
+	$channels = $_['channels'];
+	/** @var string $currentChannel */
+	$currentChannel = $_['currentChannel'];
+?>
+<form id="oca_updatenotification_section" class="section">
 	<h2><?php p($l->t('Updater')); ?></h2>
+
+	<?php if($isNewVersionAvailable === true): ?>
+		<strong><?php p($l->t('A new version is available: %s', [$newVersionString])); ?></strong>
+		<input type="button" id="oca_updatenotification_button" value="<?php p($l->t('Open updater')) ?>">
+	<?php else: ?>
+		<strong><?php print_unescaped($l->t('Your version is up to date.')); ?></strong>
+		<span class="icon-info svg" title="<?php p($l->t('Checked on %s', [$lastCheckedDate])) ?>"></span>
+	<?php endif; ?>
+
 	<p>
-		<?php p($l->t('For security reasons the built-in ownCloud updater is using additional credentials. To visit the updater page please click the following button.')) ?>
+		<label for="release-channel"><?php p($l->t('Update channel:')) ?></label>
+		<select id="release-channel">
+			<option value="<?php p($currentChannel); ?>"><?php p($currentChannel); ?></option>
+			<?php foreach ($channels as $channel => $channelTitle){ ?>
+				<option value="<?php p($channelTitle) ?>">
+					<?php p($channelTitle) ?>
+				</option>
+			<?php } ?>
+		</select>
+		<span id="channel_save_msg"></span>
 	</p>
-	<input type="button" id="oca_updatenotification" value="<?php p($l->t('Open updater')) ?>">
+	<p>
+		<em><?php p($l->t('You can always update to a newer version / experimental channel. But you can never downgrade to a more stable channel.')); ?></em>
+	</p>
 </form>


### PR DESCRIPTION
Allows to select the release channels again and also shows the last check date
Fixes https://github.com/owncloud/core/issues/22827

<hr/>

No update available:
![2016-03-04_13-56-39](https://cloud.githubusercontent.com/assets/878997/13527730/856aad28-e211-11e5-8c6f-ad6edf250fda.png)

Update available:
![2016-03-04_13-56-53](https://cloud.githubusercontent.com/assets/878997/13527723/786e7f0a-e211-11e5-805c-0c789ed679ef.png)
