### PR TITLE
Properly check path validity before deleting to trash

### DIFF
--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -204,7 +204,7 @@ class Trashbin {
 
 		$ownerView = new View('/' . $owner);
 		// file has been deleted in between
-		if (!$ownerView->file_exists('/files/' . $ownerPath)) {
+		if (is_null($ownerPath) || $ownerPath === '' || !$ownerView->file_exists('/files/' . $ownerPath)) {
 			return true;
 		}
 


### PR DESCRIPTION
This prevents deleting the whole "files" folder of the user whenever
$ownerPath is empty. This can happen in concurrency situations.

Please review @icewind1991 @schiesbn @blizzz @LukasReschke @MorrisJobke 

@karlitschek backport to 8.2.2 and further ? (I need to check which versions are affected too)

Fixes https://github.com/owncloud/core/issues/22824
(nasty data loss in concurrency case)
