### PR TITLE
[stable8.2] Run cleanup of expired DB file locks to background job

### DIFF
--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -8,7 +8,7 @@
 	<shipped>true</shipped>
 	<standalone/>
 	<default_enable/>
-	<version>1.2.0</version>
+	<version>1.2.1</version>
 	<types>
 		<filesystem/>
 	</types>

--- a/apps/files/appinfo/install.php
+++ b/apps/files/appinfo/install.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @author Morris Jobke <hey@morrisjobke.de>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+\OC::$server->getJobList()->add('OCA\Files\BackgroundJob\CleanupFileLocks');

--- a/apps/files/appinfo/update.php
+++ b/apps/files/appinfo/update.php
@@ -104,3 +104,5 @@ if ($installedVersion === '1.1.9' && (
 if(defined('DEBUG') && DEBUG === true) {
 	\OC::$server->getConfig()->setSystemValue('debug', true);
 }
+
+\OC::$server->getJobList()->add('OCA\Files\BackgroundJob\CleanupFileLocks');

--- a/apps/files/lib/backgroundjob/cleanupfilelocks.php
+++ b/apps/files/lib/backgroundjob/cleanupfilelocks.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @author Morris Jobke <hey@morrisjobke.de>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files\BackgroundJob;
+
+use OC\BackgroundJob\TimedJob;
+use OC\Lock\DBLockingProvider;
+
+/**
+ * Clean up all file locks that are expired for the DB file locking provider
+ */
+class CleanupFileLocks extends TimedJob {
+
+	/**
+	 * Default interval in minutes
+	 *
+	 * @var int $defaultIntervalMin
+	 **/
+	protected $defaultIntervalMin = 5;
+
+	/**
+	 * sets the correct interval for this timed job
+	 */
+	public function __construct() {
+		$this->interval = $this->defaultIntervalMin * 60;
+	}
+
+	/**
+	 * Makes the background job do its work
+	 *
+	 * @param array $argument unused argument
+	 */
+	public function run($argument) {
+		$lockingProvider = \OC::$server->getLockingProvider();
+		if($lockingProvider instanceof DBLockingProvider) {
+			$lockingProvider->cleanExpiredLocks();
+		}
+	}
+}

--- a/lib/private/lock/dblockingprovider.php
+++ b/lib/private/lock/dblockingprovider.php
@@ -233,10 +233,17 @@ class DBLockingProvider extends AbstractLockingProvider {
 	 */
 	public function cleanExpiredLocks() {
 		$expire = $this->timeFactory->getTime();
-		$this->connection->executeUpdate(
-			'DELETE FROM `*PREFIX*file_locks` WHERE `ttl` < ?',
-			[$expire]
-		);
+		try {
+			$this->connection->executeUpdate(
+				'DELETE FROM `*PREFIX*file_locks` WHERE `ttl` < ?',
+				[$expire]
+			);
+		} catch (\Exception $e) {
+			// If the table is missing, the clean up was successful
+			if ($this->connection->tableExists('file_locks')) {
+				throw $e;
+			}
+		}
 	}
 
 	/**
@@ -252,17 +259,6 @@ class DBLockingProvider extends AbstractLockingProvider {
 					'UPDATE `*PREFIX*file_locks` SET `lock` = `lock` - 1 WHERE `key` = ? AND `lock` > 0',
 					[$path]
 				);
-			}
-		}
-	}
-
-	public function __destruct() {
-		try {
-			$this->cleanExpiredLocks();
-		} catch (\Exception $e) {
-			// If the table is missing, the clean up was successful
-			if ($this->connection->tableExists('file_locks')) {
-				throw $e;
 			}
 		}
 	}


### PR DESCRIPTION
- fixes #22819

The old way fired a DELETE statement on each destruction of the
DBLockingProvider. Which could cause a lot of queries. It's enough
to run this every 5 minutes in a background job, which in the end
could result in file locks that exists 5 minutes longer - in the
worst case and for not properly released locks.

This makes the DB based locking a lot more performant and could
result in a similar performance to the Redis based locking provider.

Backport of #22865 
General backport approval is in https://github.com/owncloud/core/pull/22865#issuecomment-192332936

@cmonteroluque @PVince81 @karlitschek I just put this into 8.2.4 for now. Feel free to merge this to 8.2.3 if this is fine for you and it is tested properly.

cc @LukasReschke @icewind1991 @DeepDiver1975 @rullzer
