### PR TITLE
Update error text for link passwords

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -193,6 +193,8 @@
 				password: password
 			}, {
 				error: function(model, msg) {
+					// destroy old tooltips
+					$input.tooltip('destroy');
 					$loading.removeClass('inlineblock').addClass('hidden');
 					$input.addClass('error');
 					$input.attr('title', msg);


### PR DESCRIPTION
- this removes the old tooltip first before showing
  the new one to update the text - otherwise the old
  text will be shown

cc @PVince81 @rullzer @owncloud/javascript 
