### PR TITLE
Use CLOB for timezone

### DIFF
--- a/apps/dav/appinfo/database.xml
+++ b/apps/dav/appinfo/database.xml
@@ -283,7 +283,7 @@ CREATE TABLE calendarobjects (
 		description TEXT,
 		calendarorder INT(11) UNSIGNED NOT NULL DEFAULT '0',
 		calendarcolor VARBINARY(10),
-		timezone TEXT,
+		timezone CLOB,
 		components VARBINARY(20),
 		transparent TINYINT(1) NOT NULL DEFAULT '0',
 		UNIQUE(principaluri, uri)
@@ -337,7 +337,7 @@ CREATE TABLE calendarobjects (
 		</field>
 		<field>
 			<name>timezone</name>
-			<type>text</type>
+			<type>clob</type>
 		</field>
 		<field>
 			<name>components</name>

--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>ownCloud WebDAV endpoint</description>
 	<licence>AGPL</licence>
 	<author>owncloud.org</author>
-	<version>0.2.0</version>
+	<version>0.2.1</version>
 	<default_enable/>
 	<types>
 		<filesystem/>


### PR DESCRIPTION
TEXT defaults to a length of 255 which is going to fail in some cases as the timezone can be rather long.

This changes it back to a CLOB as it has been before as well: https://github.com/owncloudarchive/calendar/commit/8d8bb68b010fc2c42a258dee43516404a95ab861. I'm not super convinced that CLOB is the best choice here but at least it seems to work.

Fixes https://github.com/owncloud/core/issues/22876

cc @DeepDiver1975 @blizzz Mind reviewing? THX
