### PR TITLE
[stable9] Use CLOB for timezone

### DIFF
--- a/apps/dav/appinfo/database.xml
+++ b/apps/dav/appinfo/database.xml
@@ -283,7 +283,7 @@ CREATE TABLE calendarobjects (
 		description TEXT,
 		calendarorder INT(11) UNSIGNED NOT NULL DEFAULT '0',
 		calendarcolor VARBINARY(10),
-		timezone TEXT,
+		timezone CLOB,
 		components VARBINARY(20),
 		transparent TINYINT(1) NOT NULL DEFAULT '0',
 		UNIQUE(principaluri, uri)
@@ -337,7 +337,7 @@ CREATE TABLE calendarobjects (
 		</field>
 		<field>
 			<name>timezone</name>
-			<type>text</type>
+			<type>clob</type>
 		</field>
 		<field>
 			<name>components</name>

--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>ownCloud WebDAV endpoint</description>
 	<licence>AGPL</licence>
 	<author>owncloud.org</author>
-	<version>0.1.4</version>
+	<version>0.1.5</version>
 	<default_enable/>
 	<types>
 		<filesystem/>


### PR DESCRIPTION
TEXT defaults to a length of 255 which is going to fail in some cases as the timezone can be rather long.

This changes it back to a CLOB as it has been before as well: owncloudarchive/calendar@8d8bb68. I'm not super convinced that CLOB is the best choice here but at least it seems to work.

Fixes #22876

Backport of https://github.com/owncloud/core/pull/22878 to stable9 as per https://github.com/owncloud/core/pull/22878#issuecomment-192466713

cc @karlitschek @cmonteroluque @DeepDiver1975 @MorrisJobke 
