### PR TITLE
improve log output when no LDAP user was found on login attempt

### DIFF
--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -34,6 +34,8 @@ use OC\ServerNotAvailableException;
  * magic properties (incomplete)
  * responsible for LDAP connections in context with the provided configuration
  *
+ * @property string ldapHost
+ * @property string ldapPort holds the port number
  * @property string ldapUserFilter
  * @property string ldapUserDisplayName
  * @property string ldapUserDisplayName2

--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -102,7 +102,8 @@ class USER_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 		$attrs = $this->access->userManager->getAttributes();
 		$users = $this->access->fetchUsersByLoginName($loginName, $attrs, 1);
 		if(count($users) < 1) {
-			throw new \Exception('No user available for the given login name.');
+			throw new \Exception('No user available for the given login name on ' .
+				$this->access->connection->ldapHost . ':' . $this->access->connection->ldapPort);
 		}
 		return $users[0];
 	}


### PR DESCRIPTION
Hopefully eases #21656 

To the exception message hostname and port  are appended, like this:

`No user available for the given login name on ldap://172.116.117.16:389`

@davitol @nickvergessen @MorrisJobke are you okay with this refinement?
