### PR TITLE
[stable9] Show version to update to properly

### DIFF
--- a/apps/updatenotification/controller/admincontroller.php
+++ b/apps/updatenotification/controller/admincontroller.php
@@ -99,12 +99,13 @@ class AdminController extends Controller {
 		if(($key = array_search($currentChannel, $channels)) !== false) {
 			unset($channels[$key]);
 		}
-
+		$updateState = $this->updateChecker->getUpdateState();
 		$params = [
-			'isNewVersionAvailable' => ($this->updateChecker->getUpdateState() === []) ? false : true,
+			'isNewVersionAvailable' => ($updateState === []) ? false : true,
 			'lastChecked' => $lastUpdateCheck,
 			'currentChannel' => $currentChannel,
 			'channels' => $channels,
+			'newVersionString' => ($updateState === []) ? '' : $updateState['updateVersion'],
 		];
 
 		return new TemplateResponse($this->appName, 'admin', $params, '');

--- a/apps/updatenotification/tests/controller/AdminControllerTest.php
+++ b/apps/updatenotification/tests/controller/AdminControllerTest.php
@@ -107,13 +107,14 @@ class AdminControllerTest extends TestCase {
 		$this->updateChecker
 			->expects($this->once())
 			->method('getUpdateState')
-			->willReturn(['foo' => 'bar']);
+			->willReturn(['updateVersion' => '8.1.2']);
 
 		$params = [
 			'isNewVersionAvailable' => true,
 			'lastChecked' => 'LastCheckedReturnValue',
 			'currentChannel' => \OCP\Util::getChannel(),
 			'channels' => $channels,
+			'newVersionString' => '8.1.2',
 		];
 
 		$expected = new TemplateResponse('updatenotification', 'admin', $params, '');
@@ -154,6 +155,7 @@ class AdminControllerTest extends TestCase {
 			'lastChecked' => 'LastCheckedReturnValue',
 			'currentChannel' => \OCP\Util::getChannel(),
 			'channels' => $channels,
+			'newVersionString' => '',
 		];
 
 		$expected = new TemplateResponse('updatenotification', 'admin', $params, '');


### PR DESCRIPTION
Properly shows the version that will be updated to.

cc @karlitschek 9.0.1 from my PoV. Backport of https://github.com/owncloud/core/pull/22885

Also fixes https://github.com/owncloud/core/issues/22917
