### PR TITLE
[stable9] Use custom header

### DIFF
--- a/apps/updatenotification/js/admin.js
+++ b/apps/updatenotification/js/admin.js
@@ -24,7 +24,7 @@ $(document).ready(function(){
 			$.ajax({
 				url: OC.webroot+'/updater/',
 				headers: {
-					'Authorization': loginToken
+					'X-Updater-Auth': loginToken
 				},
 				method: 'POST',
 				success: function(data){


### PR DESCRIPTION
PHP in CGI mode eats the Authorization header => :bomb:

Backport of https://github.com/owncloud/core/pull/22888
Requires https://github.com/owncloud/updater/pull/266
@karlitschek I recommend that we merge this for 9.0.0. Otherwise the updater app will not work for people that use PHP in CGI mode.
