### PR TITLE
Correctly default to null and add type hint

### DIFF
--- a/apps/dav/lib/carddav/carddavbackend.php
+++ b/apps/dav/lib/carddav/carddavbackend.php
@@ -78,7 +78,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	 */
 	public function __construct(IDBConnection $db,
 								Principal $principalBackend,
-								$dispatcher ) {
+								EventDispatcherInterface $dispatcher = null) {
 		$this->db = $db;
 		$this->principalBackend = $principalBackend;
 		$this->dispatcher = $dispatcher;


### PR DESCRIPTION
@MorrisJobke @LukasReschke @DeepDiver1975 

Should fix the problem from morris:

> Missing argument 3 for OCA\DAV\CardDAV\CardDavBackend::__construct(), called in \/usr\/share\/webapps\/owncloud\/apps\/dav\/appinfo\/v1\/carddav.php on line 45 and defined at \/usr\/share\/webapps\/owncloud\/apps\/dav\/lib\/carddav\/carddavbackend.php#79

Ref https://github.com/owncloud/core/pull/22198/files#r53437948
