### PR TITLE
Fix uploading to fed share when free space is unlimited

### DIFF
--- a/apps/files/ajax/upload.php
+++ b/apps/files/ajax/upload.php
@@ -138,7 +138,7 @@ $maxHumanFileSize = OCP\Util::humanFileSize($maxUploadFileSize);
 $totalSize = 0;
 $isReceivedShare = \OC::$server->getRequest()->getParam('isReceivedShare', false) === 'true';
 // defer quota check for received shares
-if (!$isReceivedShare) {
+if (!$isReceivedShare && $storageStats['freeSpace'] >= 0) {
 	foreach ($files['size'] as $size) {
 		$totalSize += $size;
 	}


### PR DESCRIPTION
A federated share can report unlimited quota as -3, so the
ajax/upload.php code needs to be adjusted to block uploads when the free
space is unlimited.

Fixes https://github.com/owncloud/core/issues/22882

Please review @icewind1991 @LukasReschke @tflidd @rullzer @MorrisJobke 

@karlitschek backport to stable9 ?
