### PR TITLE
Fix call to disk_free_space when a file is provided

### DIFF
--- a/lib/private/files/storage/local.php
+++ b/lib/private/files/storage/local.php
@@ -252,7 +252,15 @@ class Local extends \OC\Files\Storage\Common {
 	}
 
 	public function free_space($path) {
-		$space = @disk_free_space($this->getSourcePath($path));
+		$sourcePath = $this->getSourcePath($path);
+		// using !is_dir because $sourcePath might be a part file or
+		// non-existing file, so we'd still want to use the parent dir
+		// in such cases
+		if (!is_dir($sourcePath)) {
+			// disk_free_space doesn't work on files
+			$sourcePath = dirname($sourcePath);
+		}
+		$space = @disk_free_space($sourcePath);
 		if ($space === false || is_null($space)) {
 			return \OCP\Files\FileInfo::SPACE_UNKNOWN;
 		}


### PR DESCRIPTION
In the case of shared files, we have to call free_space() on the file
name. This has the side-effect that when uploading to a local storage
without quota set, it will call disk_free_space with the file name,
which fails.

This fix uses the parent folder in case the given path is a file.

Please review @icewind1991 @MorrisJobke @rullzer @nickvergessen 

@karlitschek backport to 9.0.1 ?
