### PR TITLE
Add DAV authenticated also to other scopes

### DIFF
--- a/lib/private/api.php
+++ b/lib/private/api.php
@@ -364,6 +364,18 @@ class OC_API {
 				\OC_Util::setUpFS(\OC_User::getUser());
 				self::$isLoggedIn = true;
 
+				/**
+				 * Add DAV authenticated. This should in an ideal world not be
+				 * necessary but the iOS App reads cookies from anywhere instead
+				 * only the DAV endpoint.
+				 * This makes sure that the cookies will be valid for the whole scope
+				 * @see https://github.com/owncloud/core/issues/22893
+				 */
+				\OC::$server->getSession()->set(
+					\OCA\DAV\Connector\Sabre\Auth::DAV_AUTHENTICATED,
+					\OC::$server->getUserSession()->getUser()->getUID()
+				);
+
 				return \OC_User::getUser();
 			}
 		}

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -281,7 +281,20 @@ class OC_User {
 	 */
 	public static function tryBasicAuthLogin() {
 		if (!empty($_SERVER['PHP_AUTH_USER']) && !empty($_SERVER['PHP_AUTH_PW'])) {
-			\OC_User::login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
+			$result = \OC_User::login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
+			if($result === true) {
+				/**
+				 * Add DAV authenticated. This should in an ideal world not be
+				 * necessary but the iOS App reads cookies from anywhere instead
+				 * only the DAV endpoint.
+				 * This makes sure that the cookies will be valid for the whole scope
+				 * @see https://github.com/owncloud/core/issues/22893
+				 */
+				\OC::$server->getSession()->set(
+					\OCA\DAV\Connector\Sabre\Auth::DAV_AUTHENTICATED,
+					\OC::$server->getUserSession()->getUser()->getUID()
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/22893

@javiergonzper Please test. My local testing here did work properly, though I fired the requests manually.
~~@karlitschek We might want to have this in 9.0.0 already. This was not earlier discovered due to the iOS app not working with 9.0 anyways and the patched version (that "works" with 9.0 but experiences now this issue) has just reached the Apple Store 2 days ago using new API endpoints.~~
Edit: https://github.com/owncloud/core/pull/22901#issuecomment-193212988

My risk assessment here here would be rather low. The session anyways has to be open at this point and this is just an additional write into the user session.
