### PR TITLE
Fix archive file name when downloading public share

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -158,9 +158,11 @@ OCA.Sharing.PublicApp = {
 					filename = JSON.stringify(filename);
 				}
 				var params = {
-					path: path,
-					files: filename
+					path: path
 				};
+				if (filename) {
+					params.files = filename;
+				}
 				return OC.generateUrl('/s/' + token + '/download') + '?' + OC.buildQueryString(params);
 			};
 

--- a/apps/files_sharing/lib/controllers/sharecontroller.php
+++ b/apps/files_sharing/lib/controllers/sharecontroller.php
@@ -479,7 +479,7 @@ class ShareController extends Controller {
 		$this->emitAccessShareHook($share);
 
 		// download selected files
-		if (!is_null($files)) {
+		if (!is_null($files) && $files !== '') {
 			// FIXME: The exit is required here because otherwise the AppFramework is trying to add headers as well
 			// after dispatching the request which results in a "Cannot modify header information" notice.
 			OC_Files::get($originalSharePath, $files_list, $_SERVER['REQUEST_METHOD'] == 'HEAD');


### PR DESCRIPTION
When download a public link share folder using the button on the top
right, it doesn't provide a list of files.

This fix makes sure to trigger the correct logic when no file list was
given.

Fixes https://github.com/owncloud/core/issues/22836

Please review @oparoz @MorrisJobke @schiesbn @rullzer
