### PR TITLE
Make sure that we don't throw InvalidArgumentException when locking fails

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1850,9 +1850,14 @@ class View {
 					);
 				}
 			} catch (\OCP\Lock\LockedException $e) {
+				try {
+					$lockedPath = $this->getPathRelativeToFiles($absolutePath);
+				} catch (\InvalidArgumentException $e) {
+					$lockedPath = $absolutePath;
+				}
 				// rethrow with the a human-readable path
 				throw new \OCP\Lock\LockedException(
-					$this->getPathRelativeToFiles($absolutePath),
+					$lockedPath,
 					$e
 				);
 			}
@@ -1891,9 +1896,14 @@ class View {
 					);
 				}
 			} catch (\OCP\Lock\LockedException $e) {
+				try {
+					$lockedPath = $this->getPathRelativeToFiles($absolutePath);
+				} catch (\InvalidArgumentException $e) {
+					$lockedPath = $absolutePath;
+				}
 				// rethrow with the a human-readable path
 				throw new \OCP\Lock\LockedException(
-					$this->getPathRelativeToFiles($absolutePath),
+					$lockedPath,
 					$e
 				);
 			}


### PR DESCRIPTION
Ref: https://github.com/owncloud/enterprise/issues/1157

Unsure how it comes to this situation at all, because `shouldLockFile` only allows locking for `/<user>/files/<path>` so this should always be the case.

but it failed on S3:

``` json
{...,"app":"core","message":"$absolutePath must be relative to \"files\"","level":3,...,"method":"PROPFIND","url":"\/owncloud\/remote.php\/webdav\/"}
```

@icewind1991 any idea?
