### PR TITLE
Make sure that the return value is an array

### DIFF
--- a/lib/private/group/manager.php
+++ b/lib/private/group/manager.php
@@ -227,7 +227,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 */
 	public function getUserGroups($user) {
 		if (is_null($user)) {
-			return false;
+			return [];
 		}
 		return $this->getUserIdGroups($user->getUID());
 	}


### PR DESCRIPTION
Ref https://github.com/owncloud/enterprise/issues/1157

```
array_keys() expects parameter 1 to be array, boolean given at ...\/lib\/private\/group\/manager.php#283
```

As per docs: `@return \OC\Group\Group[]`

@blizzz @LukasReschke @MorrisJobke @PVince81 

Should backport to 9.0.x
