### PR TITLE
[stable9] Fix uploading to fed shares where free space is unlimited

### DIFF
--- a/apps/files/ajax/upload.php
+++ b/apps/files/ajax/upload.php
@@ -138,7 +138,7 @@ $maxHumanFileSize = OCP\Util::humanFileSize($maxUploadFileSize);
 $totalSize = 0;
 $isReceivedShare = \OC::$server->getRequest()->getParam('isReceivedShare', false) === 'true';
 // defer quota check for received shares
-if (!$isReceivedShare) {
+if (!$isReceivedShare && $storageStats['freeSpace'] >= 0) {
 	foreach ($files['size'] as $size) {
 		$totalSize += $size;
 	}


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/22898
- [x] Pending confirmation 

Need to evaluate for 9.0 since it breaks upload for fed shares, however it's limited to the web UI (Webdav is fine)

CC @karlitschek @cmonteroluque 
