### PR TITLE
Remove double URL encoding

### DIFF
--- a/lib/private/streamer.php
+++ b/lib/private/streamer.php
@@ -51,10 +51,6 @@ class Streamer {
 	public function sendHeaders($name){
 		$extension = $this->streamerInstance instanceof ZipStreamer ? '.zip' : '.tar';
 		$fullName = $name . $extension;
-		// ZipStreamer does not escape name in Content-Disposition atm
-		if ($this->streamerInstance instanceof ZipStreamer) {
-			$fullName = rawurlencode($fullName);
-		}
 		$this->streamerInstance->sendHeaders($fullName);
 	}
 	


### PR DESCRIPTION
ZipStreamer as bundled with 9.0 will properly encode the filename already.

Fixes https://github.com/owncloud/core/issues/22836#issuecomment-193336245

@karlitschek I'd propose that we backport this also to 9.0.1

cc @oparoz @PVince81 Please test.
