### PR TITLE
[stable9] Remove double URL encoding

### DIFF
--- a/lib/private/streamer.php
+++ b/lib/private/streamer.php
@@ -51,10 +51,6 @@ class Streamer {
 	public function sendHeaders($name){
 		$extension = $this->streamerInstance instanceof ZipStreamer ? '.zip' : '.tar';
 		$fullName = $name . $extension;
-		// ZipStreamer does not escape name in Content-Disposition atm
-		if ($this->streamerInstance instanceof ZipStreamer) {
-			$fullName = rawurlencode($fullName);
-		}
 		$this->streamerInstance->sendHeaders($fullName);
 	}
 	


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/22918 as per https://github.com/owncloud/core/pull/22918#issuecomment-193384975
