### PR TITLE
Initialize submodules for Scrutinizer as well

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,3 +1,6 @@
+before_commands:
+  - 'git submodule update --init --recursive'
+
 filter:
     excluded_paths:
         - '3rdparty/*'


### PR DESCRIPTION
Scrutinizer otherwise complains about the fact that some classes are undefined etc.

Let's see whether that works :smile: 

(from https://github.com/scrutinizer-ci/scrutinizer/issues/296#issuecomment-70256137)
