### PR TITLE
Bugfix removequota subadmins

### DIFF
--- a/settings/templates/users/part.setquota.php
+++ b/settings/templates/users/part.setquota.php
@@ -25,6 +25,11 @@
 		</select>
 	<?php endif; ?>
 	<?php if((bool) !$_['isAdmin']): ?>
-		: <?php p($_['default_quota']);?>
+		: 
+		<?php if( $_['default_quota']=="none"): ?>
+			<?php p($l->t('Unlimited'));?>
+		<?php else: ?>
+			<?php p($_['default_quota']);?>
+		<?php endif; ?>
 	<?php endif; ?>
 </div>

--- a/settings/templates/users/part.setquota.php
+++ b/settings/templates/users/part.setquota.php
@@ -1,6 +1,6 @@
 <div class="quota">
 	<!-- Default storage -->
-	<span><?php p($l->t('Default Quota'));?></span>
+	<span><?php p($l->t('Default quota'));?></span>
 	<?php if((bool) $_['isAdmin']): ?>
 		<select id='default_quota' data-inputtitle="<?php p($l->t('Please enter storage quota (ex: "512 MB" or "12 GB")')) ?>" data-tipsy-gravity="s">
 			<option <?php if($_['default_quota'] === 'none') print_unescaped('selected="selected"');?> value='none'>
@@ -25,10 +25,6 @@
 		</select>
 	<?php endif; ?>
 	<?php if((bool) !$_['isAdmin']): ?>
-		<select class='quota' disabled="disabled">
-			<option selected="selected">
-				<?php p($_['default_quota']);?>
-			</option>
-		</select>
+		: <?php p($_['default_quota']);?>
 	<?php endif; ?>
 </div>

--- a/settings/templates/users/part.setquota.php
+++ b/settings/templates/users/part.setquota.php
@@ -1,6 +1,6 @@
 <div class="quota">
 	<!-- Default storage -->
-	<span><?php p($l->t('Default quota'));?></span>
+	<span><?php p($l->t('Default Quota'));?></span>
 	<?php if((bool) $_['isAdmin']): ?>
 		<select id='default_quota' data-inputtitle="<?php p($l->t('Please enter storage quota (ex: "512 MB" or "12 GB")')) ?>" data-tipsy-gravity="s">
 			<option <?php if($_['default_quota'] === 'none') print_unescaped('selected="selected"');?> value='none'>
@@ -26,7 +26,7 @@
 	<?php endif; ?>
 	<?php if((bool) !$_['isAdmin']): ?>
 		: 
-		<?php if( $_['default_quota']=="none"): ?>
+		<?php if( $_['default_quota'] === 'none'): ?>
 			<?php p($l->t('Unlimited'));?>
 		<?php else: ?>
 			<?php p($_['default_quota']);?>


### PR DESCRIPTION
Fixes #20139

Documenting PR:

Generally I think there are 3 types of users
- Admin [1]
- SubAdmin (which are like admins of some group) [2]
- General Users [3]

Since the "User" interface is only visible for user type [1] & [2], I can just remove the default quota if the user is not of type [1].
