### PR TITLE
[stable8.2] Update error text for link passwords

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -192,6 +192,8 @@
 			this.model.setPassword(password);
 			this.model.saveLinkShare({}, {
 				error: function(model, msg) {
+					// destroy old tooltips
+					$input.tooltip('destroy');
 					$loading.removeClass('inlineblock').addClass('hidden');
 					$input.addClass('error');
 					$input.attr('title', msg);


### PR DESCRIPTION
- this removes the old tooltip first before showing
  the new one to update the text - otherwise the old
  text will be shown

Backport of #22872
Approval https://github.com/owncloud/core/pull/22872#issuecomment-193310141

cc @PVince81 @rullzer @owncloud/javascript

I tested it and it works fine here.
