### PR TITLE
Always append the WebRoot

### DIFF
--- a/lib/private/urlgenerator.php
+++ b/lib/private/urlgenerator.php
@@ -204,13 +204,8 @@ class URLGenerator implements IURLGenerator {
 			return rtrim($this->config->getSystemValue('overwrite.cli.url'), '/') . '/' . ltrim($url, '/');
 		}
 
-		// The ownCloud web root can already be prepended.
-		$webRoot = substr($url, 0, strlen(\OC::$WEBROOT)) === \OC::$WEBROOT
-			? ''
-			: \OC::$WEBROOT;
-
 		$request = \OC::$server->getRequest();
-		return $request->getServerProtocol() . '://' . $request->getServerHost() . $webRoot . $separator . $url;
+		return $request->getServerProtocol() . '://' . $request->getServerHost() . \OC::$WEBROOT . $separator . $url;
 	}
 
 	/**


### PR DESCRIPTION
https://github.com/owncloud/core/commit/6292aa57af8900f38885e9bb08b748a80d86aec1 added a check to `\OCP\IURLGenerator::getAbsoluteURL($url)` whether `OC::$WEBROOT` is already prepended to `$url`. It does this kinda naively and is thus error prone.

So in case ownCloud is installed under `/oc`, `OC::$WEBROOT` will be `/oc`, then the URL generator checks `substr($url, 0, strlen(\OC::$WEBROOT)) === \OC::$WEBROOT`. Since `$url` is `/ocs/apps/notifications/` it will now compare `/oc` with `/oc` and won't append the webroot => :bomb:

Considering that this is rather a very error prone feature which is not used from a search over the core code I'd recommend to remove this logic.

Fixes https://github.com/owncloud/core/issues/22786
