### PR TITLE
Use "hasKey" instead of checking the value

### DIFF
--- a/apps/files_sharing/lib/external/storage.php
+++ b/apps/files_sharing/lib/external/storage.php
@@ -253,8 +253,8 @@ class Storage extends DAV implements ISharedStorage {
 	 */
 	private function testRemoteUrl($url) {
 		$cache = $this->memcacheFactory->create('files_sharing_remote_url');
-		if($result = $cache->get($url)) {
-			return (bool)$result;
+		if($cache->hasKey($url)) {
+			return (bool)$cache->get($url);
 		}
 
 		$result = file_get_contents($url);


### PR DESCRIPTION
If the check is negative it would depending on the used cache store the value as an empty string. When reading the value this check would thus return "false" even if a value exists. This makes the check fail and thus ownClouds kinda slow.

Step 1 on "getting @danimo's server running with ownCloud 9.0"

cc @icewind1991 
cc @karlitschek I'd advocate for 9.0.1 on this 

Partially fixes https://github.com/owncloud/core/issues/22987
