### PR TITLE
Add XMLReader as requirement

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -726,7 +726,8 @@ class OC_Util {
 			'classes' => array(
 				'ZipArchive' => 'zip',
 				'DOMDocument' => 'dom',
-				'XMLWriter' => 'XMLWriter'
+				'XMLWriter' => 'XMLWriter',
+				'XMLReader' => 'XMLReader',
 			),
 			'functions' => [
 				'xml_parser_create' => 'libxml',


### PR DESCRIPTION
The SabreDAV release in 9.0 requires XMLReader, while this is usually compiled in by default some distributions like Gentoo don't.

Without this ownCloud gives a fatal 500 error instead of telling people to enable XMLReader.

Fixes https://github.com/owncloud/core/issues/23003

@karlitschek We should backport this into 9.0.1
