### PR TITLE
Add base rewrite rule only when RewriteBase is defined

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -65,7 +65,6 @@
   RewriteCond %{REQUEST_FILENAME} !/updater/
   RewriteCond %{REQUEST_FILENAME} !/ocs-provider/
   RewriteCond %{REQUEST_URI} !^/.well-known/acme-challenge/.*
-  RewriteRule .* index.php [PT,E=PATH_INFO:$1]
 </IfModule>
 <IfModule mod_mime.c>
   AddType image/svg+xml svg svgz

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -422,8 +422,9 @@ class Setup {
 
 		// Add rewrite base
 		$webRoot = !empty(\OC::$WEBROOT) ? \OC::$WEBROOT : '/';
-		$content.="\n<IfModule mod_rewrite.c>";
-		$content.="\n  RewriteBase ".$webRoot;
+		$content .= "\n<IfModule mod_rewrite.c>";
+		$content .= "\n  RewriteRule .* index.php [PT,E=PATH_INFO:$1]";
+		$content .= "\n  RewriteBase ".$webRoot;
 		$content .= "\n  <IfModule mod_env.c>";
 		$content .= "\n    SetEnv front_controller_active true";
 		$content .= "\n    <IfModule mod_dir.c>";


### PR DESCRIPTION
In case Apache is configured with an `Alias` such as with the ownCloud packages the rewrite rules will fail when no valid RewriteBase is configured.

Potentially fixes https://github.com/owncloud/core/issues/22970
