### PR TITLE
Fix syncing of all birthday calendars in one go

### DIFF
--- a/apps/dav/command/syncbirthdaycalendar.php
+++ b/apps/dav/command/syncbirthdaycalendar.php
@@ -61,7 +61,7 @@ class SyncBirthdayCalendar extends Command {
 	 * @param OutputInterface $output
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		if ($input->hasArgument('user')) {
+		if ($input->getArgument('user') !== null) {
 			$user = $input->getArgument('user');
 			if (!$this->userManager->userExists($user)) {
 				throw new \InvalidArgumentException("User <$user> in unknown.");


### PR DESCRIPTION
```
./occ dav:sync-birthday-calendar

  [InvalidArgumentException]  
  User <> in unknown.         

dav:sync-birthday-calendar [<user>]
```

The problem is unlike `hasOption`, `hasArgument` is always true (even when the argument is not set)
A bit awkward, but checking for `getArgument !== null` fixes the issue. Null is the default value.

@LukasReschke @DeepDiver1975 @MorrisJobke 

@karlitschek backport to 9.0.1 would be cool
