### PR TITLE
Correctly escape join statements and use selectAlias

### DIFF
--- a/apps/dav/lib/caldav/caldavbackend.php
+++ b/apps/dav/lib/caldav/caldavbackend.php
@@ -815,9 +815,9 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	function getCalendarObjectByUID($principalUri, $uid) {
 
 		$query = $this->db->getQueryBuilder();
-		$query->select([$query->createFunction('c.`uri` AS `calendaruri`'), $query->createFunction('co.`uri` AS `objecturi`')])
+		$query->selectAlias('c.uri', 'calendaruri')->selectAlias('co.uri', 'objecturi')
 			->from('calendarobjects', 'co')
-			->leftJoin('co', 'calendars', 'c', 'co.`calendarid` = c.`id`')
+			->leftJoin('co', 'calendars', 'c', $query->expr()->eq('co.calendarid', 'c.id'))
 			->where($query->expr()->eq('c.principaluri', $query->createNamedParameter($principalUri)))
 			->andWhere($query->expr()->eq('co.uid', $query->createNamedParameter($uid)));
 

--- a/apps/files_external/service/dbconfigservice.php
+++ b/apps/files_external/service/dbconfigservice.php
@@ -92,7 +92,7 @@ class DBConfigService {
 	protected function getForQuery(IQueryBuilder $builder, $type, $value) {
 		$query = $builder->select(['m.mount_id', 'mount_point', 'storage_backend', 'auth_backend', 'priority', 'm.type'])
 			->from('external_mounts', 'm')
-			->innerJoin('m', 'external_applicable', 'a', 'm.mount_id = a.mount_id')
+			->innerJoin('m', 'external_applicable', 'a', $builder->expr()->eq('m.mount_id', 'a.mount_id'))
 			->where($builder->expr()->eq('a.type', $builder->createNamedParameter($type, IQueryBuilder::PARAM_INT)));
 
 		if (is_null($value)) {
@@ -148,7 +148,7 @@ class DBConfigService {
 
 		$query = $builder->select(['m.mount_id', 'mount_point', 'storage_backend', 'auth_backend', 'priority', 'm.type'])
 			->from('external_mounts', 'm')
-			->innerJoin('m', 'external_applicable', 'a', 'm.mount_id = a.mount_id')
+			->innerJoin('m', 'external_applicable', 'a', $builder->expr()->eq('m.mount_id', 'a.mount_id'))
 			->where($builder->expr()->eq('a.type', $builder->createNamedParameter($type, IQueryBuilder::PARAM_INT)))
 			->andWhere($builder->expr()->in('a.value', $params));
 		$query->andWhere($builder->expr()->eq('m.type', $builder->expr()->literal(self::MOUNT_TYPE_ADMIN, IQueryBuilder::PARAM_INT)));

--- a/lib/private/repair/oldgroupmembershipshares.php
+++ b/lib/private/repair/oldgroupmembershipshares.php
@@ -69,7 +69,7 @@ class OldGroupMembershipShares extends BasicEmitter implements RepairStep {
 		$deletedEntries = 0;
 
 		$query = $this->connection->getQueryBuilder();
-		$query->select(['s1.id', $query->createFunction('s1.`share_with` AS `user`'), $query->createFunction('s2.`share_with` AS `group`')])
+		$query->select('s1.id')->selectAlias('s1.share_with', 'user')->selectAlias('s2.share_with', 'group')
 			->from('share', 's1')
 			->where($query->expr()->isNotNull('s1.parent'))
 				// \OC\Share\Constant::$shareTypeGroupUserUnique === 2


### PR DESCRIPTION
Fix #22835 

@DeepDiver1975 @PVince81 @icewind1991 

@karlitschek should backport, so ext. storage works on oracle :speak_no_evil: 
