### PR TITLE
Fix MKCOL for IE11 as well

### DIFF
--- a/core/js/files/iedavclient.js
+++ b/core/js/files/iedavclient.js
@@ -39,7 +39,12 @@
 			for(ii in headers) {
 				xhr.setRequestHeader(ii, headers[ii]);
 			}
-			xhr.send(body);
+
+			if (body === undefined) {
+				xhr.send();
+			} else {
+				xhr.send(body);
+			}
 
 			return new Promise(function(fulfill, reject) {
 


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/23067

Using https://github.com/owncloud/core/pull/22274 we have to patch the iedavclient.js as well.

It is the exact same work around. I did not even know we had a special IE davclient.

@ketolajuha please verify

CC: @PVince81 @MorrisJobke @nickvergessen 

@karlitschek we should backport this to stable9.
