### PR TITLE
remove deprecated ldap_sort

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -1025,14 +1025,6 @@ class Access extends LDAPUtility implements user\IUserTools {
 				return array();
 			}
 
-			// Do the server-side sorting
-			foreach(array_reverse($attr) as $sortAttr){
-				foreach($sr as $searchResource) {
-					$this->ldap->sort($cr, $searchResource, $sortAttr);
-				}
-			}
-
-
 			foreach($sr as $res) {
 				$findings = array_merge($findings, $this->ldap->getEntries($cr	, $res ));
 			}

--- a/apps/user_ldap/lib/ildapwrapper.php
+++ b/apps/user_ldap/lib/ildapwrapper.php
@@ -179,14 +179,6 @@ interface ILDAPWrapper {
 	public function startTls($link);
 
 	/**
-	 * Sort the result of a LDAP search
-	 * @param resource $link LDAP link resource
-	 * @param resource $result LDAP result resource
-	 * @param string $sortFilter attribute to use a key in sort
-	 */
-	public function sort($link, $result, $sortFilter);
-
-	/**
 	 * Unbind from LDAP directory
 	 * @param resource $link LDAP link resource
 	 * @return bool true on success, false otherwise

--- a/apps/user_ldap/lib/ldap.php
+++ b/apps/user_ldap/lib/ldap.php
@@ -202,16 +202,6 @@ class LDAP implements ILDAPWrapper {
 
 	/**
 	 * @param LDAP $link
-	 * @param LDAP $result
-	 * @param string $sortFilter
-	 * @return mixed
-	 */
-	public function sort($link, $result, $sortFilter) {
-		return $this->invokeLDAPMethod('sort', $link, $result, $sortFilter);
-	}
-
-	/**
-	 * @param LDAP $link
 	 * @return mixed|true
 	 */
 	public function startTls($link) {
@@ -283,10 +273,7 @@ class LDAP implements ILDAPWrapper {
 			$errorCode = ldap_errno($this->curArgs[0]);
 			$errorMsg  = ldap_error($this->curArgs[0]);
 			if($errorCode !== 0) {
-				if($this->curFunc === 'ldap_sort' && $errorCode === -4) {
-					//You can safely ignore that decoding error.
-					//… says https://bugs.php.net/bug.php?id=18023
-				} else if($this->curFunc === 'ldap_get_entries'
+				if($this->curFunc === 'ldap_get_entries'
 						  && $errorCode === -4) {
 				} else if ($errorCode === 32) {
 					//for now


### PR DESCRIPTION
ldap_sort is deprecated since PHP 7.

Anyway it did not really do a server side sort, only in those already fetched results. Even if it would be on the server side, with paged results this would not work, as it is not supported by spec.

Since it does not provide any benefit at all, we can simply drop it.

Currently it throws E_DEPRECATED erros on PHP 7, thus it's a candidate for a backporting to 9.0. 

LDAP Integration tests ran successful.

cc @danimo 

please test and review @owncloud/ldap 
