### PR TITLE
Allow to migrate calendars of all users

### DIFF
--- a/apps/dav/command/migratecalendars.php
+++ b/apps/dav/command/migratecalendars.php
@@ -61,8 +61,8 @@ class MigrateCalendars extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$this->service->setup();
 
-		if ($input->hasArgument('user')) {
-			$user = $input->getArgument('user');
+		$user = $input->getArgument('user');
+		if (!is_null($user)) {
 			if (!$this->userManager->userExists($user)) {
 				throw new \InvalidArgumentException("User <$user> in unknown.");
 			}

--- a/apps/dav/command/syncbirthdaycalendar.php
+++ b/apps/dav/command/syncbirthdaycalendar.php
@@ -61,8 +61,8 @@ class SyncBirthdayCalendar extends Command {
 	 * @param OutputInterface $output
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		if ($input->getArgument('user') !== null) {
-			$user = $input->getArgument('user');
+		$user = $input->getArgument('user');
+		if (!is_null($user)) {
 			if (!$this->userManager->userExists($user)) {
 				throw new \InvalidArgumentException("User <$user> in unknown.");
 			}


### PR DESCRIPTION
Follow up to https://github.com/owncloud/core/pull/23035

@DeepDiver1975 `dav:migrate-calendars` suffers from the same issue.
So I fixed them all the same way now. Should backport to 9.0
