### PR TITLE
Return the correct group casing in sharee api

### DIFF
--- a/apps/files_sharing/api/sharees.php
+++ b/apps/files_sharing/api/sharees.php
@@ -223,10 +223,10 @@ class Sharees {
 		foreach ($groups as $gid) {
 			if (strtolower($gid) === $search) {
 				$this->result['exact']['groups'][] = [
-					'label' => $search,
+					'label' => $gid,
 					'value' => [
 						'shareType' => Share::SHARE_TYPE_GROUP,
-						'shareWith' => $search,
+						'shareWith' => $gid,
 					],
 				];
 			} else {

--- a/apps/files_sharing/api/sharees.php
+++ b/apps/files_sharing/api/sharees.php
@@ -147,8 +147,8 @@ class Sharees {
 
 		$foundUserById = false;
 		foreach ($users as $uid => $userDisplayName) {
-			if (strtolower($uid) === $search || strtolower($userDisplayName) === $search) {
-				if (strtolower($uid) === $search) {
+			if (strtolower($uid) === strtolower($search) || strtolower($userDisplayName) === strtolower($search)) {
+				if (strtolower($uid) === strtolower($search)) {
 					$foundUserById = true;
 				}
 				$this->result['exact']['users'][] = [
@@ -221,7 +221,7 @@ class Sharees {
 		}
 
 		foreach ($groups as $gid) {
-			if (strtolower($gid) === $search) {
+			if (strtolower($gid) === strtolower($search)) {
 				$this->result['exact']['groups'][] = [
 					'label' => $gid,
 					'value' => [
@@ -282,8 +282,8 @@ class Sharees {
 				}
 				foreach ($cloudIds as $cloudId) {
 					list(, $serverUrl) = $this->splitUserRemote($cloudId);
-					if (strtolower($contact['FN']) === $search || strtolower($cloudId) === $search) {
-						if (strtolower($cloudId) === $search) {
+					if (strtolower($contact['FN']) === strtolower($search) || strtolower($cloudId) === strtolower($search)) {
+						if (strtolower($cloudId) === strtolower($search)) {
 							$foundRemoteById = true;
 						}
 						$this->result['exact']['remotes'][] = [

--- a/build/integration/features/bootstrap/Sharing.php
+++ b/build/integration/features/bootstrap/Sharing.php
@@ -442,5 +442,56 @@ trait Sharing{
 			throw new \Excetion('Expected the same link share to be returned');
 		}
 	}
+
+	/**
+	 * @When /^getting sharees for$/
+	 * @param \Behat\Gherkin\Node\TableNode $body
+	 */
+	public function whenGettingShareesFor($body) {
+		$url = '/apps/files_sharing/api/v1/sharees';
+		if ($body instanceof \Behat\Gherkin\Node\TableNode) {
+			$parameters = [];
+			foreach ($body->getRowsHash() as $key => $value) {
+				$parameters[] = $key . '=' . $value;
+			}
+			if (!empty($parameters)) {
+				$url .= '?' . implode('&', $parameters);
+			}
+		}
+
+		$this->sendingTo('GET', $url);
+	}
+
+	/**
+	 * @Then /^"([^"]*)" sharees returned (are|is empty)$/
+	 * @param string $shareeType
+	 * @param string $isEmpty
+	 * @param \Behat\Gherkin\Node\TableNode|null $shareesList
+	 */
+	public function thenListOfSharees($shareeType, $isEmpty, $shareesList = null) {
+		if ($isEmpty !== 'is empty') {
+			$sharees = $shareesList->getRows();
+			$respondedArray = $this->getArrayOfShareesResponded($this->response, $shareeType);
+			PHPUnit_Framework_Assert::assertEquals($sharees, $respondedArray);
+		} else {
+			$respondedArray = $this->getArrayOfShareesResponded($this->response, $shareeType);
+			PHPUnit_Framework_Assert::assertEmpty($respondedArray);
+		}
+	}
+
+	public function getArrayOfShareesResponded(ResponseInterface $response, $shareeType) {
+		$elements = $response->xml()->data;
+		$elements = json_decode(json_encode($elements), 1);
+		if (strpos($shareeType, 'exact ') === 0) {
+			$elements = $elements['exact'];
+			$shareeType = substr($shareeType, 6);
+		}
+
+		$sharees = [];
+		foreach ($elements[$shareeType] as $element) {
+			$sharees[] = [$element['label'], $element['value']['shareType'], $element['value']['shareWith']];
+		}
+		return $sharees;
+	}
 }
 

--- a/build/integration/features/sharees.feature
+++ b/build/integration/features/sharees.feature
@@ -1,0 +1,148 @@
+Feature: sharees
+  Background:
+    Given using api version "1"
+
+  Scenario: Search without exact match
+    Given user "test" exists
+    And user "Sharee1" exists
+    And group "ShareeGroup" exists
+    And As an "test"
+    When getting sharees for
+      | search | Sharee |
+      | itemType | file |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And "exact users" sharees returned is empty
+    And "users" sharees returned are
+      | Sharee1 | 0 | Sharee1 |
+    And "exact groups" sharees returned is empty
+    And "groups" sharees returned are
+      | ShareeGroup | 1 | ShareeGroup |
+    And "exact remotes" sharees returned is empty
+    And "remotes" sharees returned is empty
+
+  Scenario: Search without exact match not-exact casing
+    Given user "test" exists
+    And user "Sharee1" exists
+    And group "ShareeGroup" exists
+    And As an "test"
+    When getting sharees for
+      | search | sharee |
+      | itemType | file |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And "exact users" sharees returned is empty
+    And "users" sharees returned are
+      | Sharee1 | 0 | Sharee1 |
+    And "exact groups" sharees returned is empty
+    And "groups" sharees returned are
+      | ShareeGroup | 1 | ShareeGroup |
+    And "exact remotes" sharees returned is empty
+    And "remotes" sharees returned is empty
+
+  Scenario: Search with exact match
+    Given user "test" exists
+    And user "Sharee1" exists
+    And group "ShareeGroup" exists
+    And As an "test"
+    When getting sharees for
+      | search | Sharee1 |
+      | itemType | file |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    Then "exact users" sharees returned are
+      | Sharee1 | 0 | Sharee1 |
+    Then "users" sharees returned is empty
+    Then "exact groups" sharees returned is empty
+    Then "groups" sharees returned is empty
+    Then "exact remotes" sharees returned is empty
+    Then "remotes" sharees returned is empty
+
+  Scenario: Search with exact match not-exact casing
+    Given user "test" exists
+    And user "Sharee1" exists
+    And group "ShareeGroup" exists
+    And As an "test"
+    When getting sharees for
+      | search | sharee1 |
+      | itemType | file |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    Then "exact users" sharees returned are
+      | Sharee1 | 0 | Sharee1 |
+    Then "users" sharees returned is empty
+    Then "exact groups" sharees returned is empty
+    Then "groups" sharees returned is empty
+    Then "exact remotes" sharees returned is empty
+    Then "remotes" sharees returned is empty
+
+  Scenario: Search with exact match not-exact casing group
+    Given user "test" exists
+    And user "Sharee1" exists
+    And group "ShareeGroup" exists
+    And As an "test"
+    When getting sharees for
+      | search | shareegroup |
+      | itemType | file |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    Then "exact users" sharees returned is empty
+    Then "users" sharees returned is empty
+    Then "exact groups" sharees returned are
+      | ShareeGroup | 1 | ShareeGroup |
+    Then "groups" sharees returned is empty
+    Then "exact remotes" sharees returned is empty
+    Then "remotes" sharees returned is empty
+
+  Scenario: Search with "self"
+    Given user "test" exists
+    And user "Sharee1" exists
+    And group "ShareeGroup" exists
+    And As an "Sharee1"
+    When getting sharees for
+      | search | Sharee1 |
+      | itemType | file |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    Then "exact users" sharees returned are
+      | Sharee1 | 0 | Sharee1 |
+    Then "users" sharees returned is empty
+    Then "exact groups" sharees returned is empty
+    Then "groups" sharees returned is empty
+    Then "exact remotes" sharees returned is empty
+    Then "remotes" sharees returned is empty
+
+  Scenario: Remote sharee for files
+    Given user "test" exists
+    And user "Sharee1" exists
+    And group "ShareeGroup" exists
+    And As an "test"
+    When getting sharees for
+      | search | test@localhost |
+      | itemType | file |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    Then "exact users" sharees returned is empty
+    Then "users" sharees returned is empty
+    Then "exact groups" sharees returned is empty
+    Then "groups" sharees returned is empty
+    Then "exact remotes" sharees returned are
+      | test@localhost | 6 | test@localhost |
+    Then "remotes" sharees returned is empty
+
+  Scenario: Remote sharee for calendars not allowed
+    Given user "test" exists
+    And user "Sharee1" exists
+    And group "ShareeGroup" exists
+    And As an "test"
+    When getting sharees for
+      | search | test@localhost |
+      | itemType | calendar |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    Then "exact users" sharees returned is empty
+    Then "users" sharees returned is empty
+    Then "exact groups" sharees returned is empty
+    Then "groups" sharees returned is empty
+    Then "exact remotes" sharees returned is empty
+    Then "remotes" sharees returned is empty

--- a/build/integration/features/sharees.feature
+++ b/build/integration/features/sharees.feature
@@ -40,6 +40,60 @@ Feature: sharees
     And "exact remotes" sharees returned is empty
     And "remotes" sharees returned is empty
 
+# TODO need to move the appconfig setting from Capabilities to Basic/Provisioning
+#  Scenario: Search without exact match no iteration allowed
+#    Given user "test" exists
+#    And user "Sharee1" exists
+#    And group "ShareeGroup" exists
+#    And As an "test"
+#    When getting sharees for
+#      | search | Sharee |
+#      | itemType | file |
+#    Then the OCS status code should be "100"
+#    And the HTTP status code should be "200"
+#    And "exact users" sharees returned is empty
+#    And "users" sharees returned is empty
+#    And "exact groups" sharees returned is empty
+#    And "groups" sharees returned is empty
+#    And "exact remotes" sharees returned is empty
+#    And "remotes" sharees returned is empty
+#
+#  Scenario: Search with exact match no iteration allowed
+#    Given user "test" exists
+#    And user "Sharee1" exists
+#    And group "ShareeGroup" exists
+#    And As an "test"
+#    When getting sharees for
+#      | search | Sharee1 |
+#      | itemType | file |
+#    Then the OCS status code should be "100"
+#    And the HTTP status code should be "200"
+#    And "exact users" sharees returned are
+#      | Sharee1 | 0 | Sharee1 |
+#    And "users" sharees returned is empty
+#    And "exact groups" sharees returned is empty
+#    And "groups" sharees returned is empty
+#    And "exact remotes" sharees returned is empty
+#    And "remotes" sharees returned is empty
+#
+#  Scenario: Search with exact match group no iteration allowed
+#    Given user "test" exists
+#    And user "Sharee1" exists
+#    And group "ShareeGroup" exists
+#    And As an "test"
+#    When getting sharees for
+#      | search | ShareeGroup |
+#      | itemType | file |
+#    Then the OCS status code should be "100"
+#    And the HTTP status code should be "200"
+#    And "exact users" sharees returned is empty
+#    And "users" sharees returned is empty
+#    And "exact groups" sharees returned are
+#      | ShareeGroup | 1 | ShareeGroup |
+#    And "groups" sharees returned is empty
+#    And "exact remotes" sharees returned is empty
+#    And "remotes" sharees returned is empty
+
   Scenario: Search with exact match
     Given user "test" exists
     And user "Sharee1" exists


### PR DESCRIPTION
Fix #23085
### Steps
1. Create group "Foobar"
2. Type "foobar" into the sharing sidebar
3. Try to select the group
### Expected

You can share
### Actual

You receive an error `please specify a valid group`

review @rullzer @SergioBertolinSG a test case for the QA list

@karlitschek should backport till 8.2.4

Fix https://github.com/owncloud/QA/issues/171
