### PR TITLE
Fake LOCK statement for Windows 7, 8 and 10 network mounts

### DIFF
--- a/apps/dav/lib/connector/sabre/serverfactory.php
+++ b/apps/dav/lib/connector/sabre/serverfactory.php
@@ -110,6 +110,7 @@ class ServerFactory {
 		if($this->request->isUserAgent([
 				'/WebDAVFS/',
 				'/Microsoft Office OneNote 2013/',
+				'/Microsoft-WebDAV-MiniRedir/',
 		])) {
 			$server->addPlugin(new \OCA\DAV\Connector\Sabre\FakeLockerPlugin());
 		}


### PR DESCRIPTION
- fixes #22596 

cc @LukasReschke @gig13 

@karlitschek I would like to backport this to stable8.2 and stable9
