### PR TITLE
Ensure that stored version is at least 1 for cross-storage copy

### DIFF
--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -634,7 +634,18 @@ class Encryption extends Wrapper {
 			'encrypted' => (bool)$isEncrypted,
 		];
 		if($isEncrypted === 1) {
-			$cacheInformation['encryptedVersion'] = $sourceStorage->getCache()->get($sourceInternalPath)['encryptedVersion'];
+			$encryptedVersion = $sourceStorage->getCache()->get($sourceInternalPath)['encryptedVersion'];
+
+			// In case of a move operation from an unencrypted to an encrypted
+			// storage the old encrypted version would stay with "0" while the
+			// correct value would be "1". Thus we manually set the value to "1"
+			// for those cases.
+			// See also https://github.com/owncloud/core/issues/23078
+			if($encryptedVersion === 0) {
+				$encryptedVersion = 1;
+			}
+
+			$cacheInformation['encryptedVersion'] = $encryptedVersion;
 		}
 
 		// in case of a rename we need to manipulate the source cache because


### PR DESCRIPTION
In case of a move operation from an unencrypted to an encrypted
storage the old encrypted version would stay with "0" while the
correct value would be "1". Thus we manually set the value to "1"
for those cases.

**Tested locally:**
- [x] Using ./occ encryption:encrypt-all works for unencrypted files
- [x] Migrating an encrypted 8.2.x instance to a branch with this patch applied works
- [x] Renaming and moving files on the same local storage works
- [x] Renaming and moving files to an not encrypted external storage works in both directions
- [x] Renaming and moving files to a encrypted external storage works in both directions

**Pending tests:**
- [x] Execute Smashbox with encryption enabled against this 

Fixes https://github.com/owncloud/core/issues/23078

cc @schiesbn Mind taking a look? Thanks a lot!
cc @nickvergessen Oh! Great Master of Smashbox testing! May I beg for your help on running Smashbox on this one with encryption enabled? It should at least not fail more as before :see_no_evil: 
cc @mmaedler It would be utmost appreciated if you could try to reproduce the steps with this patch applied :)
