### PR TITLE
Update security headers in .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -11,12 +11,13 @@
 
   <IfModule mod_env.c>
     # Add security and privacy related headers
-    Header set X-Content-Type-Options "nosniff"
-    Header set X-XSS-Protection "1; mode=block"
-    Header set X-Robots-Tag "none"
-    Header set X-Frame-Options "SAMEORIGIN"
-    Header set X-Download-Options "noopen"
-    Header set X-Permitted-Cross-Domain-Policies "none"
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set X-XSS-Protection "1; mode=block"
+    Header always set X-Robots-Tag "none"
+    Header always set X-Frame-Options "SAMEORIGIN"
+    Header always set X-Download-Options "noopen"
+    Header always set X-Permitted-Cross-Domain-Policies "none"
+    Header always set Strict-Transport-Security "max-age=15768000; includeSubDomains; preload"
     SetEnv modHeadersAvailable true
   </IfModule>
 


### PR DESCRIPTION
I'd like to propose the following change to .htaccess:
- use `always` so they are set in even in shared environments where you don't have access to the apache host config.
- Add `Strict-Transport-Security` header as recommended in the docs: https://doc.owncloud.org/server/9.0/admin_manual/configuration_server/harden_server.html
