### PR TITLE
getOwner is not available on FileHome

### DIFF
--- a/apps/dav/lib/connector/sabre/filesplugin.php
+++ b/apps/dav/lib/connector/sabre/filesplugin.php
@@ -235,6 +235,16 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 			$propFind->handle(self::GETETAG_PROPERTYNAME, function() use ($node) {
 				return $node->getEtag();
 			});
+
+			$propFind->handle(self::OWNER_ID_PROPERTYNAME, function() use ($node) {
+				$owner = $node->getOwner();
+				return $owner->getUID();
+			});
+			$propFind->handle(self::OWNER_DISPLAY_NAME_PROPERTYNAME, function() use ($node) {
+				$owner = $node->getOwner();
+				$displayName = $owner->getDisplayName();
+				return $displayName;
+			});
 		}
 
 		if ($node instanceof \OCA\DAV\Connector\Sabre\File) {
@@ -267,16 +277,6 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 				return $node->getSize();
 			});
 		}
-
-		$propFind->handle(self::OWNER_ID_PROPERTYNAME, function() use ($node) {
-			$owner = $node->getOwner();
-			return $owner->getUID();
-		});
-		$propFind->handle(self::OWNER_DISPLAY_NAME_PROPERTYNAME, function() use ($node) {
-			$owner = $node->getOwner();
-			$displayName = $owner->getDisplayName();
-			return $displayName;
-		});
 	}
 
 	/**

--- a/apps/dav/lib/files/fileshome.php
+++ b/apps/dav/lib/files/fileshome.php
@@ -29,6 +29,11 @@ use Sabre\HTTP\URLUtil;
 class FilesHome implements ICollection {
 
 	/**
+	 * @var array
+	 */
+	private $principalInfo;
+
+	/**
 	 * FilesHome constructor.
 	 *
 	 * @param array $principalInfo

--- a/apps/dav/tests/unit/connector/sabre/filesplugin.php
+++ b/apps/dav/tests/unit/connector/sabre/filesplugin.php
@@ -109,8 +109,6 @@ class FilesPlugin extends \Test\TestCase {
 		return $node;
 	}
 
-	/**
-	 */
 	public function testGetPropertiesForFile() {
 		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');
 
@@ -163,6 +161,56 @@ class FilesPlugin extends \Test\TestCase {
 		$this->assertEquals('foo', $propFind->get(self::OWNER_ID_PROPERTYNAME));
 		$this->assertEquals('M. Foo', $propFind->get(self::OWNER_DISPLAY_NAME_PROPERTYNAME));
 		$this->assertEquals(array(self::SIZE_PROPERTYNAME), $propFind->get404Properties());
+	}
+
+	public function testGetPropertiesForFileHome() {
+		$node = $this->createTestNode('\OCA\DAV\Files\FilesHome');
+
+		$propFind = new \Sabre\DAV\PropFind(
+			'/dummyPath',
+			array(
+				self::GETETAG_PROPERTYNAME,
+				self::FILEID_PROPERTYNAME,
+				self::INTERNAL_FILEID_PROPERTYNAME,
+				self::SIZE_PROPERTYNAME,
+				self::PERMISSIONS_PROPERTYNAME,
+				self::DOWNLOADURL_PROPERTYNAME,
+				self::OWNER_ID_PROPERTYNAME,
+				self::OWNER_DISPLAY_NAME_PROPERTYNAME
+			),
+			0
+		);
+
+		$user = $this->getMockBuilder('\OC\User\User')
+			->disableOriginalConstructor()->getMock();
+		$user->expects($this->never())->method('getUID');
+		$user->expects($this->never())->method('getDisplayName');
+		$node->expects($this->never())->method('getDirectDownload');
+		$node->expects($this->never())->method('getOwner');
+		$node->expects($this->never())->method('getSize');
+
+		$this->plugin->handleGetProperties(
+			$propFind,
+			$node
+		);
+
+		$this->assertEquals(null, $propFind->get(self::GETETAG_PROPERTYNAME));
+		$this->assertEquals(null, $propFind->get(self::FILEID_PROPERTYNAME));
+		$this->assertEquals(null, $propFind->get(self::INTERNAL_FILEID_PROPERTYNAME));
+		$this->assertEquals(null, $propFind->get(self::SIZE_PROPERTYNAME));
+		$this->assertEquals(null, $propFind->get(self::PERMISSIONS_PROPERTYNAME));
+		$this->assertEquals(null, $propFind->get(self::DOWNLOADURL_PROPERTYNAME));
+		$this->assertEquals(null, $propFind->get(self::OWNER_ID_PROPERTYNAME));
+		$this->assertEquals(null, $propFind->get(self::OWNER_DISPLAY_NAME_PROPERTYNAME));
+		$this->assertEquals(['{DAV:}getetag',
+					'{http://owncloud.org/ns}id',
+					'{http://owncloud.org/ns}fileid',
+					'{http://owncloud.org/ns}size',
+					'{http://owncloud.org/ns}permissions',
+					'{http://owncloud.org/ns}downloadURL',
+					'{http://owncloud.org/ns}owner-id',
+					'{http://owncloud.org/ns}owner-display-name'
+				], $propFind->get404Properties());
 	}
 
 	public function testGetPropertiesStorageNotAvailable() {


### PR DESCRIPTION
fixes #23116

@LukasReschke 

Explanation for the fix:
One could argue that getOwner() should be implemented on FileHome so that the owner is returned.
But this would require to implement the IACL interface which would drag in full acl support - what I don't want to do now right away.
