### PR TITLE
Scrutinizer should not check generated composer files

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -20,7 +20,7 @@ filter:
         - 'settings/l10n/*'
         - 'tests/*'
         - 'build/*'
-
+        - 'lib/composer/*'
 
 imports:
     - javascript


### PR DESCRIPTION
@DeepDiver1975 
