### PR TITLE
Improved rewrite rule

### DIFF
--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -423,7 +423,7 @@ class Setup {
 		// Add rewrite base
 		$webRoot = !empty(\OC::$WEBROOT) ? \OC::$WEBROOT : '/';
 		$content .= "\n<IfModule mod_rewrite.c>";
-		$content .= "\n  RewriteRule .* index.php [PT,E=PATH_INFO:$1]";
+		$content .= "\n  RewriteRule . index.php [PT,E=PATH_INFO:$1]";
 		$content .= "\n  RewriteBase ".$webRoot;
 		$content .= "\n  <IfModule mod_env.c>";
 		$content .= "\n    SetEnv front_controller_active true";


### PR DESCRIPTION
As per https://github.com/owncloud/core/issues/23098 and https://github.com/owncloud/core/issues/23117

Also per [Apache documentation](https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewriterule):

> In any case, remember that regular expressions are substring matches. That is, you don't need the regex to describe the entire string, just the part that you wish to match. Thus, using a regex of . is often sufficient rather than .*, and the regex abc is not the same as ^abc$.
