### PR TITLE
Explicitly check for port

### DIFF
--- a/lib/private/security/trusteddomainhelper.php
+++ b/lib/private/security/trusteddomainhelper.php
@@ -78,6 +78,12 @@ class TrustedDomainHelper {
 		if (preg_match(Request::REGEX_LOCALHOST, $domain) === 1) {
 			return true;
 		}
+
+		// Compare with port appended
+		if(in_array($domainWithPort, $trustedList, true)) {
+			return true;
+		}
+
 		return in_array($domain, $trustedList, true);
 	}
 

--- a/tests/lib/security/trusteddomainhelper.php
+++ b/tests/lib/security/trusteddomainhelper.php
@@ -42,7 +42,12 @@ class TrustedDomainHelperTest extends \Test\TestCase {
 	 * @return array
 	 */
 	public function trustedDomainDataProvider() {
-		$trustedHostTestList = ['host.one.test', 'host.two.test', '[1fff:0:a88:85a3::ac1f]'];
+		$trustedHostTestList = [
+			'host.one.test',
+			'host.two.test',
+			'[1fff:0:a88:85a3::ac1f]',
+			'host.three.test:443',
+		];
 		return [
 			// empty defaults to false with 8.1
 			[null, 'host.one.test:8080', false],
@@ -56,6 +61,9 @@ class TrustedDomainHelperTest extends \Test\TestCase {
 			[$trustedHostTestList, '[1fff:0:a88:85a3::ac1f]', true],
 			[$trustedHostTestList, '[1fff:0:a88:85a3::ac1f]:801', true],
 			[$trustedHostTestList, '[1fff:0:a88:85a3::ac1f]:801:34', false],
+			[$trustedHostTestList, 'host.three.test:443', true],
+			[$trustedHostTestList, 'host.three.test:80', false],
+			[$trustedHostTestList, 'host.three.test', false],
 			// trust localhost regardless of trust list
 			[$trustedHostTestList, 'localhost', true],
 			[$trustedHostTestList, 'localhost:8080', true],


### PR DESCRIPTION
The setup uses `\OCP\IRequest::getInsecureServerHost` which in some cases can also include a port. This makes the trusted domain check fail thus.

I've decided to add this here that way because adjusting the setup would require parsing the host properly. This is not something that can be done very good in PHP. Check the following example for why `parse_url` is not our friend: https://3v4l.org/k501Z

@karlitschek I'd like to propose to backport this to 9.0. This has been reported multiple times by users in our 9.0 forum. (older releases do not need this)
