### PR TITLE
Allow jpg files to be statically served

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -53,7 +53,7 @@
   Options -MultiViews
   RewriteRule ^core/js/oc.js$ index.php/core/js/oc.js [PT,E=PATH_INFO:$1]
   RewriteRule ^core/preview.png$ index.php/core/preview.png [PT,E=PATH_INFO:$1]
-  RewriteCond %{REQUEST_FILENAME} !\.(css|js|svg|gif|png|html|ttf|woff|ico)$
+  RewriteCond %{REQUEST_FILENAME} !\.(css|js|svg|gif|png|html|ttf|woff|ico|jpg|jpeg)$
   RewriteCond %{REQUEST_FILENAME} !core/img/favicon.ico$
   RewriteCond %{REQUEST_FILENAME} !/remote.php
   RewriteCond %{REQUEST_FILENAME} !/public.php


### PR DESCRIPTION
When using an background image in themes of type JPG, the current setting of owncloud's htaccess file does not allow to deliver these kinds of images as static content. Adding the file extensions as done in this commit, it works flawlessly.
