### PR TITLE
Use more generic node instead of File/Folder

### DIFF
--- a/lib/private/share20/defaultshareprovider.php
+++ b/lib/private/share20/defaultshareprovider.php
@@ -454,15 +454,7 @@ class DefaultShareProvider implements IShareProvider {
 	}
 
 	/**
-	 * Get all shares by the given user. Sharetype and path can be used to filter.
-	 *
-	 * @param string $userId
-	 * @param int $shareType
-	 * @param \OCP\Files\File|\OCP\Files\Folder $node
-	 * @param bool $reshares Also get the shares where $user is the owner instead of just the shares where $user is the initiator
-	 * @param int $limit The maximum number of shares to be returned, -1 for all shares
-	 * @param int $offset
-	 * @return Share[]
+	 * @inheritdoc
 	 */
 	public function getSharesBy($userId, $shareType, $node, $reshares, $limit, $offset) {
 		$qb = $this->dbConn->getQueryBuilder();

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -834,15 +834,7 @@ class Manager implements IManager {
 	}
 
 	/**
-	 * Get shares shared by (initiated) by the provided user.
-	 *
-	 * @param string $userId
-	 * @param int $shareType
-	 * @param \OCP\Files\File|\OCP\Files\Folder $path
-	 * @param bool $reshares
-	 * @param int $limit The maximum number of returned results, -1 for all results
-	 * @param int $offset
-	 * @return \OCP\Share\IShare[]
+	 * @inheritdoc
 	 */
 	public function getSharesBy($userId, $shareType, $path = null, $reshares = false, $limit = 50, $offset = 0) {
 		if ($path !== null &&

--- a/lib/public/share/imanager.php
+++ b/lib/public/share/imanager.php
@@ -21,6 +21,7 @@
 
 namespace OCP\Share;
 
+use OCP\Files\Node;
 use OCP\IUser;
 
 use OCP\Share\Exceptions\ShareNotFound;
@@ -91,7 +92,7 @@ interface IManager {
 	 *
 	 * @param string $userId
 	 * @param int $shareType
-	 * @param \OCP\Files\File|\OCP\Files\Folder $path
+	 * @param Node|null $path
 	 * @param bool $reshares
 	 * @param int $limit The maximum number of returned results, -1 for all results
 	 * @param int $offset
@@ -106,7 +107,7 @@ interface IManager {
 	 *
 	 * @param string $userId
 	 * @param int $shareType
-	 * @param \OCP\Files\File|\OCP\Files\Folder|null $node
+	 * @param Node|null $node
 	 * @param int $limit The maximum number of shares returned, -1 for all
 	 * @param int $offset
 	 * @return IShare[]

--- a/lib/public/share/ishareprovider.php
+++ b/lib/public/share/ishareprovider.php
@@ -21,10 +21,8 @@
 
 namespace OCP\Share;
 
-use OC\Share20\Exception\ShareNotFound;
-use OC\Share20\Exception\BackendError;
+use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Files\Node;
-use OCP\IUser;
 
 /**
  * Interface IShareProvider
@@ -97,7 +95,7 @@ interface IShareProvider {
 	 *
 	 * @param string $userId
 	 * @param int $shareType
-	 * @param \OCP\Files\File|\OCP\Files\Folder $node
+	 * @param Node|null $node
 	 * @param bool $reshares Also get the shares where $user is the owner instead of just the shares where $user is the initiator
 	 * @param int $limit The maximum number of shares to be returned, -1 for all shares
 	 * @param int $offset
@@ -120,11 +118,11 @@ interface IShareProvider {
 	/**
 	 * Get shares for a given path
 	 *
-	 * @param \OCP\Files\Node $path
+	 * @param Node $path
 	 * @return \OCP\Share\IShare[]
 	 * @since 9.0.0
 	 */
-	public function getSharesByPath(\OCP\Files\Node $path);
+	public function getSharesByPath(Node $path);
 
 	/**
 	 * Get shared with the given user


### PR DESCRIPTION
The phpdoc for the sharing functions was very restrictive. As a
consequence passing node object (for example from the OCS Share API
where we don't really care if it is a file or folder), would actually
be invalid.

With this loser restriction the interfaces become more generic.

@nickvergessen as discussed

CC: @PVince81 @MorrisJobke
