### PR TITLE
[stable8.1] Fix broken scanner call in ajax/scan.php

### DIFF
--- a/apps/files/ajax/scan.php
+++ b/apps/files/ajax/scan.php
@@ -46,7 +46,7 @@ $listener = new ScanListener($eventSource);
 
 foreach ($users as $user) {
 	$eventSource->send('user', $user);
-	$scanner = new \OC\Files\Utils\Scanner($user, \OC::$server->getDatabaseConnection());
+	$scanner = new \OC\Files\Utils\Scanner($user, \OC::$server->getDatabaseConnection(), \OC::$server->getLogger());
 	$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function () use ($listener) {
 		$listener->file();
 	});


### PR DESCRIPTION
This fixes:

```
{"reqId":"...","remoteAddr":"10.128.15.50","app":"PHP","message":"Argument 3 passed to OC\\Files\\Utils\\Scanner::__construct() must implement interface OCP\\ILogger, none given, called in apps\/files\/ajax\/scan.php on line 49 and defined at lib\/private\/files\/utils\/scanner.php#71","level":3,"time":"2016-03-10T18:19:19+09:00"} 
{"reqId":"...","remoteAddr":"...","app":"PHP","message":"Undefined variable: logger at lib\/private\/files\/utils\/scanner.php#72","level":3,"time":"2016-03-10T18:19:19+09:00"} 
```

This somehow slipped through during the backport of #20789 in #21314

cc @PVince81 @icewind1991 

cc @karlitschek for this stable8.1 only fix
