### PR TITLE
dont die when we cant save the resized avatar, log instead

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -312,7 +312,8 @@ class Server extends ServerContainer implements IServerContainer {
 			return new AvatarManager(
 				$c->getUserManager(),
 				$c->getRootFolder(),
-				$c->getL10N('lib')
+				$c->getL10N('lib'),
+				$c->getLogger()
 			);
 		});
 		$this->registerService('Logger', function (Server $c) {

--- a/lib/private/avatarmanager.php
+++ b/lib/private/avatarmanager.php
@@ -28,6 +28,7 @@ namespace OC;
 use OCP\Files\Folder;
 use OCP\Files\NotFoundException;
 use OCP\IAvatarManager;
+use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\Files\IRootFolder;
 use OCP\IL10N;
@@ -46,20 +47,26 @@ class AvatarManager implements IAvatarManager {
 	/** @var IL10N */
 	private $l;
 
+	/** @var ILogger  */
+	private $logger;
+
 	/**
 	 * AvatarManager constructor.
 	 *
 	 * @param IUserManager $userManager
 	 * @param IRootFolder $rootFolder
 	 * @param IL10N $l
+	 * @param ILogger $logger
 	 */
 	public function __construct(
 			IUserManager $userManager,
 			IRootFolder $rootFolder,
-			IL10N $l) {
+			IL10N $l,
+			ILogger $logger) {
 		$this->userManager = $userManager;
 		$this->rootFolder = $rootFolder;
 		$this->l = $l;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -85,6 +92,6 @@ class AvatarManager implements IAvatarManager {
 		/** @var Folder $folder */
 		$folder = $this->rootFolder->get($dir);
 
-		return new Avatar($folder, $this->l, $user);
+		return new Avatar($folder, $this->l, $user, $this->logger);
 	}
 }

--- a/tests/lib/avatartest.php
+++ b/tests/lib/avatartest.php
@@ -27,7 +27,7 @@ class AvatarTest extends \Test\TestCase {
 		$l = $this->getMock('\OCP\IL10N');
 		$l->method('t')->will($this->returnArgument(0));
 		$this->user = $this->getMockBuilder('\OC\User\User')->disableOriginalConstructor()->getMock();
-		$this->avatar = new \OC\Avatar($this->folder, $l, $this->user);
+		$this->avatar = new \OC\Avatar($this->folder, $l, $this->user, $this->getMock('\OCP\ILogger'));
 	}
 
 	public function testGetNoAvatar() {


### PR DESCRIPTION
This way the avatar will still be shown

Tested by manually setting the permissions for my users storage to remove create permissions

cc @rullzer @blizzz @PVince81
