### PR TITLE
Removed unnecessary check 'installed' system value' call.

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -612,7 +612,7 @@ class OC_Util {
 		$errors = array();
 		$CONFIG_DATADIRECTORY = $config->getSystemValue('datadirectory', OC::$SERVERROOT . '/data');
 
-		if (!self::needUpgrade($config) && $config->getSystemValue('installed', false)) {
+		if (!self::needUpgrade($config)) {
 			// this check needs to be done every time
 			$errors = self::checkDataDirectoryValidity($CONFIG_DATADIRECTORY);
 		}


### PR DESCRIPTION
OC_Utils::checkServer makes an unnecessary call to $config->getSystemValue('installed', false), which replicates the call made immediately before it during the call to needUpgrade.
