### PR TITLE
Use proper URLs for search results

### DIFF
--- a/lib/private/search/result/file.php
+++ b/lib/private/search/result/file.php
@@ -79,10 +79,12 @@ class File extends \OCP\Search\Result {
 		$info = pathinfo($path);
 		$this->id = $data->getId();
 		$this->name = $info['basename'];
-		$this->link = \OCP\Util::linkTo(
-			'files',
-			'index.php',
-			array('dir' => $info['dirname'], 'scrollto' => $info['basename'])
+		$this->link = \OC::$server->getURLGenerator()->linkToRoute(
+			'files.view.index',
+			[
+				'dir' => $info['dirname'],
+				'scrollto' => $info['basename'],
+			]
 		);
 		$this->permissions = $data->getPermissions();
 		$this->path = $path;


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/23136

**Steps to reproduce:**
1. Move file into subfolder
2. Search for it
3. Click search result => Not working without this patch

@karlitschek Backport to 9.0.1?
@apg1980 Mind testing? Thanks a lot :smile: 
