### PR TITLE
Verify the getResponse returns a ResponseInterface

### DIFF
--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -34,6 +34,7 @@ namespace OC\Files\Storage;
 
 use Exception;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Message\ResponseInterface;
 use OC\Files\Filesystem;
 use OC\Files\Stream\Close;
 use Icewind\Streams\IteratorDirectory;
@@ -351,7 +352,8 @@ class DAV extends Common {
 									'stream' => true
 							]);
 				} catch (RequestException $e) {
-					if ($e->getResponse()->getStatusCode() === 404) {
+					if ($e->getResponse() instanceof ResponseInterface
+						&& $e->getResponse()->getStatusCode() === 404) {
 						return false;
 					} else {
 						throw $e;


### PR DESCRIPTION
Can also return `null` as per PHPDoc. Regression added by https://github.com/owncloud/core/commit/97f5c095f4018119e15d7c612a685da1dc91a340 to stable9

Fixes https://github.com/owncloud/core/issues/23145

@thejabok Mind testing? Thanks a lot!
@karlitschek Breaks DAV external storage for some scenarios. I'd vote for a backport to 9.0.1
@icewind1991 Objections?
