### PR TITLE
Fallback for crappy ancient distributions

### DIFF
--- a/apps/encryption/lib/crypto/crypt.php
+++ b/apps/encryption/lib/crypto/crypt.php
@@ -266,6 +266,13 @@ class Crypt {
 			$cipher = self::DEFAULT_CIPHER;
 		}
 
+		// Workaround for OpenSSL 0.9.8. Fallback to an old cipher that should work.
+		if(OPENSSL_VERSION_NUMBER < 0x1000101f) {
+			if($cipher === 'AES-256-CTR' || $cipher === 'AES-128-CTR') {
+				$cipher = self::LEGACY_CIPHER;
+			}
+		}
+
 		return $cipher;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/23181

Totally untested. Installing a such old OpenSSL version in combination with a compatible PHP and libxml2 version of ownCloud takes multiple hours. Whoever wants to have that fun can do that. I won't :see_no_evil: 

It's quite a miracle to see custom maintained distributions having such an horrible mixup of broken old with somewhat decent new. Not that I'm keen about this. So whoever in the future will hate me for this should read https://github.com/owncloud/core/issues/23181#issuecomment-195806012 :wink: 

@lorddoumer Please test.
@karlitschek Ref https://github.com/owncloud/core/issues/23181#issuecomment-195815260
