### PR TITLE
Redis Cluster support

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -876,12 +876,13 @@ $CONFIG = array(
  *
  * Available cache backends:
  *
- * * ``\OC\Memcache\APC``        Alternative PHP Cache backend
- * * ``\OC\Memcache\APCu``       APC user backend
- * * ``\OC\Memcache\ArrayCache`` In-memory array-based backend (not recommended)
- * * ``\OC\Memcache\Memcached``  Memcached backend
- * * ``\OC\Memcache\Redis``      Redis backend
- * * ``\OC\Memcache\XCache``     XCache backend
+ * * ``\OC\Memcache\APC``          Alternative PHP Cache backend
+ * * ``\OC\Memcache\APCu``         APC user backend
+ * * ``\OC\Memcache\ArrayCache``   In-memory array-based backend (not recommended)
+ * * ``\OC\Memcache\Memcached``    Memcached backend
+ * * ``\OC\Memcache\Redis``        Redis backend, single-server mode
+ * * ``\OC\Memcache\RedisCluster`` Redis Cluster backend
+ * * ``\OC\Memcache\XCache``       XCache backend
  *
  * Advice on choosing between the various backends:
  *

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -907,19 +907,41 @@ $CONFIG = array(
 'memcache.distributed' => '\OC\Memcache\Memcached',
 
 /**
- * Connection details for redis to use for memory caching.
+ * Connection details for redis to use for memory caching in a single server configuration.
  *
  * For enhanced security it is recommended to configure Redis
  * to require a password. See http://redis.io/topics/security
  * for more information.
  */
-'redis' => array(
+'redis' => [
 	'host' => 'localhost', // can also be a unix domain socket: '/tmp/redis.sock'
 	'port' => 6379,
 	'timeout' => 0.0,
 	'password' => '', // Optional, if not defined no password will be used.
 	'dbindex' => 0, // Optional, if undefined SELECT will not run and will use Redis Server's default DB Index.
-),
+],
+
+/**
+ * Connection details for a Redis Cluster
+ *
+ * Only for use with Redis Clustering, for Sentinel-based setups use the single
+ * server configuration above, and perform HA on the hostname.
+ *
+ * Available failover modes:
+ *  - \RedisCluster::FAILOVER_NONE - only send commands to master nodes (default)
+ *  - \RedisCluster::FAILOVER_ERROR - failover to slaves for read commands if master is unavailable
+ *  - \RedisCluster::FAILOVER_DISTRIBUTE - randomly distribute read commands across master and slaves
+ */
+'redis.cluster' => [
+	'seeds' => [ // provide some/all of the cluster servers to bootstrap discovery, port required
+		'localhost:7000',
+		'localhost:7001'
+	],
+	'timeout' => 0.0,
+	'read_timeout' => 0.0,
+	'failover_mode' => \RedisCluster::FAILOVER_DISTRIBUTE
+],
+
 
 /**
  * Server details for one or more memcached servers to use for memory caching.

--- a/lib/private/memcache/rediscluster.php
+++ b/lib/private/memcache/rediscluster.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @author Robin McCorkell <robin@mccorkell.me.uk>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Memcache;
+
+class RedisCluster extends Redis {
+
+	public function __construct($prefix = '') {
+		if (is_null(self::$cache)) {
+			$systemConfig = \OC::$server->getSystemConfig();
+
+			if ($config = $systemConfig->getValue('redis.cluster', [])) {
+				$timeout = isset($config['timeout']) ? $config['timeout'] : null;
+				$readTimeout = isset($config['read_timeout']) ? $config['read_timeout'] : null;
+				self::$cache = new \RedisCluster(null, $config['seeds'], $timeout, $readTimeout);
+
+				if (isset($config['failover_mode'])) {
+					self::$cache->setOption(\RedisCluster::OPT_SLAVE_FAILOVER, $config['failover_mode']);
+				}
+			} else {
+				throw new \OC\HintException(
+					'No Redis cluster definitions found',
+					'Configure Redis Cluster in config.php, or use the single-server Redis memcache'
+				);
+			}
+		}
+
+		parent::__construct($prefix);
+	}
+
+}
+

--- a/lib/private/memcache/rediscluster.php
+++ b/lib/private/memcache/rediscluster.php
@@ -46,5 +46,13 @@ class RedisCluster extends Redis {
 		parent::__construct($prefix);
 	}
 
+	// TODO: phpredis with cluster support not currently available
+	// Assume it will be available in 2.2.8?
+	static public function isAvailable() {
+		//return extension_loaded('redis')
+		//&& version_compare(phpversion('redis'), '2.2.8', '>=');
+		return parent::isAvailable();
+	}
+
 }
 

--- a/tests/lib/memcache/rediscluster.php
+++ b/tests/lib/memcache/rediscluster.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Copyright (c) 2016 Robin McCorkell <robin@mccorkell.me.uk>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Memcache;
+
+class RedisCluster extends Cache {
+	static public function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		if (!\OC\Memcache\RedisCluster::isAvailable()) {
+			self::markTestSkipped('The redis extension is not available.');
+		}
+
+		set_error_handler(
+			function($errno, $errstr) {
+				restore_error_handler();
+				self::markTestSkipped($errstr);
+			},
+			E_WARNING
+		);
+		try {
+			$instance = new \OC\Memcache\RedisCluster(self::getUniqueID());
+		} catch (\OC\HintException $e) {
+			self::markTestSkipped('Cluster definition not available in config.php');
+		}
+		restore_error_handler();
+
+		if ($instance->set(self::getUniqueID(), self::getUniqueID()) === false) {
+			self::markTestSkipped('redis server seems to be down.');
+		}
+	}
+
+	protected function setUp() {
+		parent::setUp();
+		$this->instance = new \OC\Memcache\RedisCluster($this->getUniqueID());
+	}
+}


### PR DESCRIPTION
This adds the ability to specify a Redis Cluster, rather than a single Redis server, with the new `redis.cluster` config.php key. There are no unit tests for this since we would need a way to run Docker containers for multiple Redis servers, with the whole kill-a-master-everything-should-work thing.

Note that this does NOT bring support for Redis Sentinel-based configurations, or manual master-slave configurations, that is a different architecture.

Also, there seems to be no way to do authentication or DB index selection with a cluster, for those features you'll want the single server mode

Fixes #21448 

cc @pako81 @cdamken @MorrisJobke @MTRichards 
