### PR TITLE
Shorter cache key for URL entries

### DIFF
--- a/lib/private/route/cachingrouter.php
+++ b/lib/private/route/cachingrouter.php
@@ -49,7 +49,7 @@ class CachingRouter extends Router {
 	 */
 	public function generate($name, $parameters = array(), $absolute = false) {
 		asort($parameters);
-		$key = $this->context->getHost() . '#' . $this->context->getBaseUrl() . $name . json_encode($parameters) . intval($absolute);
+		$key = $this->context->getHost() . '#' . $this->context->getBaseUrl() . $name . sha1(json_encode($parameters)) . intval($absolute);
 		if ($this->cache->hasKey($key)) {
 			return $this->cache->get($key);
 		} else {


### PR DESCRIPTION
### Steps
1. Set up `memcached` WITH d :exclamation: 
2. Create a file-path that is longer then 250 characters
3. Trigger an activity for that file
4. Try to open the activity app

Fix #23076 

@beedaddy @blizzz @LukasReschke @DeepDiver1975 
