### PR TITLE
Fix errors in memcached implementation

### DIFF
--- a/lib/private/memcache/memcached.php
+++ b/lib/private/memcache/memcached.php
@@ -88,7 +88,9 @@ class Memcached extends Cache implements IMemcache {
 
 	public function remove($key) {
 		$result= self::$cache->delete($this->getNamespace() . $key);
-		$this->verifyReturnCode();
+		if (self::$cache->getResultCode() !== \Memcached::RES_NOTFOUND) {
+			$this->verifyReturnCode();
+		}
 		return $result;
 	}
 
@@ -124,10 +126,13 @@ class Memcached extends Cache implements IMemcache {
 	 * @param mixed $value
 	 * @param int $ttl Time To Live in seconds. Defaults to 60*60*24
 	 * @return bool
+	 * @throws \Exception
 	 */
 	public function add($key, $value, $ttl = 0) {
 		$result = self::$cache->add($this->getPrefix() . $key, $value, $ttl);
-		$this->verifyReturnCode();
+		if (self::$cache->getResultCode() !== \Memcached::RES_NOTSTORED) {
+			$this->verifyReturnCode();
+		}
 		return $result;
 	}
 
@@ -141,7 +146,11 @@ class Memcached extends Cache implements IMemcache {
 	public function inc($key, $step = 1) {
 		$this->add($key, 0);
 		$result = self::$cache->increment($this->getPrefix() . $key, $step);
-		$this->verifyReturnCode();
+
+		if (self::$cache->getResultCode() !== \Memcached::RES_SUCCESS) {
+			return false;
+		}
+
 		return $result;
 	}
 
@@ -154,7 +163,11 @@ class Memcached extends Cache implements IMemcache {
 	 */
 	public function dec($key, $step = 1) {
 		$result = self::$cache->decrement($this->getPrefix() . $key, $step);
-		$this->verifyReturnCode();
+
+		if (self::$cache->getResultCode() !== \Memcached::RES_SUCCESS) {
+			return false;
+		}
+
 		return $result;
 	}
 

--- a/tests/lib/memcache/cache.php
+++ b/tests/lib/memcache/cache.php
@@ -39,6 +39,11 @@ abstract class Cache extends \Test_Cache {
 		$this->assertFalse($this->instance->hasKey('foo'));
 	}
 
+	public function testRemoveNonExisting() {
+		$this->instance->remove('foo');
+		$this->assertFalse($this->instance->hasKey('foo'));
+	}
+
 	public function testArrayAccessSet() {
 		$this->instance['foo'] = 'bar';
 		$this->assertEquals('bar', $this->instance->get('foo'));
@@ -72,7 +77,9 @@ abstract class Cache extends \Test_Cache {
 		$this->assertEquals(1, $this->instance->inc('foo'));
 		$this->assertEquals(1, $this->instance->get('foo'));
 		$this->assertEquals(2, $this->instance->inc('foo'));
+		$this->assertEquals(2, $this->instance->get('foo'));
 		$this->assertEquals(12, $this->instance->inc('foo', 10));
+		$this->assertEquals(12, $this->instance->get('foo'));
 
 		$this->instance->set('foo', 'bar');
 		$this->assertFalse($this->instance->inc('foo'));
@@ -80,7 +87,7 @@ abstract class Cache extends \Test_Cache {
 	}
 
 	public function testDec() {
-		$this->assertEquals(false, $this->instance->dec('foo'));
+		$this->assertFalse($this->instance->dec('foo'));
 		$this->instance->set('foo', 20);
 		$this->assertEquals(19, $this->instance->dec('foo'));
 		$this->assertEquals(19, $this->instance->get('foo'));


### PR DESCRIPTION
Unit tests before:

```
./autotest.sh sqlite tests/lib/memcache/memcached.php 
...
Runtime:    PHP 5.5.33-1+deb.sury.org~trusty+1 with Xdebug 2.3.3
Configuration:  /home/nickv/ownCloud/master/core/tests/phpunit-autotest.xml

.....E....EEE.....

Time: 381 ms, Memory: 20.00Mb

There were 4 errors:

1) Test\Memcache\Memcached::testRemoveNonExisting
Exception: Error 16 interacting with memcached : NOT FOUND

/home/nickv/ownCloud/master/core/lib/private/memcache/memcached.php:199
/home/nickv/ownCloud/master/core/lib/private/memcache/memcached.php:91
/home/nickv/ownCloud/master/core/tests/lib/memcache/cache.php:43

2) Test\Memcache\Memcached::testAdd
Exception: Error 14 interacting with memcached : NOT STORED

/home/nickv/ownCloud/master/core/lib/private/memcache/memcached.php:199
/home/nickv/ownCloud/master/core/lib/private/memcache/memcached.php:138
/home/nickv/ownCloud/master/core/tests/lib/memcache/cache.php:72

3) Test\Memcache\Memcached::testInc
Exception: Error 14 interacting with memcached : NOT STORED

/home/nickv/ownCloud/master/core/lib/private/memcache/memcached.php:199
/home/nickv/ownCloud/master/core/lib/private/memcache/memcached.php:138
/home/nickv/ownCloud/master/core/lib/private/memcache/memcached.php:157
/home/nickv/ownCloud/master/core/tests/lib/memcache/cache.php:79

4) Test\Memcache\Memcached::testDec
Exception: Error 16 interacting with memcached : NOT FOUND

/home/nickv/ownCloud/master/core/lib/private/memcache/memcached.php:199
/home/nickv/ownCloud/master/core/lib/private/memcache/memcached.php:177
/home/nickv/ownCloud/master/core/tests/lib/memcache/cache.php:90

FAILURES!
Tests: 18, Assertions: 63, Errors: 4.
```

Fix #23132

@DeepDiver1975 can we add CI for all cache implementations?

cc @MorrisJobke @LukasReschke @PVince81 

cc @karlitschek should backport to 9.0 to fix updating from 8.2 to 9.0 with memcached enabled.
