### PR TITLE
[stable8.2] Gracefull handle link shares rename hook

### DIFF
--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -73,6 +73,12 @@ class Shared_Updater {
 	 */
 	static private function moveShareToShare($path) {
 		$userFolder = \OC::$server->getUserFolder();
+
+		// If the user folder can't be constructed (e.g. link share) just return.
+		if ($userFolder === null) {
+			return;
+		}
+
 		$src = $userFolder->get($path);
 
 		$type = $src instanceof \OCP\Files\File ? 'file' : 'folder';


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/22159 to stable8.2

Steps https://github.com/owncloud/core/issues/23057#issuecomment-196376065

Make sure the outgoing share is from this branch or 8.2.

Please review @oparoz @rullzer @MorrisJobke @nickvergessen @SergioBertolinSG
