### PR TITLE
allow group shares, even if not all public keys are available

### DIFF
--- a/apps/encryption/lib/crypto/encryption.php
+++ b/apps/encryption/lib/crypto/encryption.php
@@ -390,7 +390,11 @@ class Encryption implements IEncryptionModule {
 				$publicKeys[$this->keyManager->getMasterKeyId()] = $this->keyManager->getPublicMasterKey();
 			} else {
 				foreach ($accessList['users'] as $user) {
-					$publicKeys[$user] = $this->keyManager->getPublicKey($user);
+					try {
+						$publicKeys[$user] = $this->keyManager->getPublicKey($user);
+					} catch (PublicKeyMissingException $e) {
+						$this->logger->warning('Could not encrypt file for ' . $user . ': ' . $e->getMessage());
+					}
 				}
 			}
 

--- a/apps/encryption/tests/lib/crypto/encryptionTest.php
+++ b/apps/encryption/tests/lib/crypto/encryptionTest.php
@@ -304,7 +304,6 @@ class EncryptionTest extends TestCase {
 		$this->assertSame($expected,
 			$this->instance->update('path', 'user1', ['users' => ['user1']])
 		);
-
 	}
 
 	public function dataTestUpdate() {
@@ -328,6 +327,43 @@ class EncryptionTest extends TestCase {
 				$this->assertTrue($view instanceof \OC\Files\View);
 			});
 		$this->instance->update('path', 'user1', []);
+	}
+
+	/**
+	 * Test case if the public key is missing. ownCloud should still encrypt
+	 * the file for the remaining users
+	 */
+	public function testUpdateMissingPublicKey() {
+		$this->keyManagerMock->expects($this->once())
+			->method('getFileKey')->willReturn('fileKey');
+
+		$this->keyManagerMock->expects($this->any())
+			->method('getPublicKey')->willReturnCallback(
+				function($user) {
+					throw new PublicKeyMissingException($user);
+				}
+			);
+
+		$this->keyManagerMock->expects($this->any())
+			->method('addSystemKeys')
+			->willReturnCallback(function($accessList, $publicKeys) {
+				return $publicKeys;
+			});
+
+		$this->cryptMock->expects($this->once())->method('multiKeyEncrypt')
+			->willReturnCallback(
+				function($fileKey, $publicKeys) {
+					$this->assertEmpty($publicKeys);
+					$this->assertSame('fileKey', $fileKey);
+				}
+			);
+
+		$this->keyManagerMock->expects($this->never())->method('getVersion');
+		$this->keyManagerMock->expects($this->never())->method('setVersion');
+
+		$this->assertTrue(
+			$this->instance->update('path', 'user1', ['users' => ['user1']])
+		);
 	}
 
 	/**


### PR DESCRIPTION
fix https://github.com/owncloud/core/issues/22907

Steps to test:
1. Start with a fresh ownCloud 9.0 or master installation
2. Create a user `user1` and add it to the group `users`
3. enable encryption
4. re-login as admin
5. upload a file
6. try to share the file with the group `users`

With the PR the share operation should work. If user1 tries to access the file he will get a error message that ownCloud can't read a file, probably because it is a shared file which was shared before his public key existed and that he should ask the owner to re-share the file.
