### PR TITLE
Close session for publicwebdav

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -30,6 +30,7 @@ $RUNTIME_APPTYPES = ['filesystem', 'authentication', 'logging'];
 OC_App::loadApps($RUNTIME_APPTYPES);
 
 OC_Util::obEnd();
+\OC::$server->getSession()->close();
 
 // Backends
 $authBackend = new OCA\DAV\Connector\PublicAuth(\OC::$server->getConfig());


### PR DESCRIPTION
We need to close the session otherwise downloading files will lead to a blocked ownCloud. Quite a performance killer.

Found while debugging https://github.com/owncloud/files_videoplayer/issues/41#issuecomment-196890721

@icewind1991 @DeepDiver1975 Objections?
