### PR TITLE
Fix dropbox storage to not store the whole file in memory

### DIFF
--- a/apps/files_external/3rdparty/Dropbox/OAuth/Curl.php
+++ b/apps/files_external/3rdparty/Dropbox/OAuth/Curl.php
@@ -196,7 +196,7 @@ class Dropbox_OAuth_Curl extends Dropbox_OAuth {
      * @return array Array for request's headers section like
      * array('Authorization' => 'OAuth ...');
      */
-    private function getOAuthHeader($uri, $params, $method = 'GET', $oAuthParams = null) {
+    public function getOAuthHeader($uri, $params, $method = 'GET', $oAuthParams = null) {
         $oAuthParams = $oAuthParams ? $oAuthParams : $this->getOAuthBaseParams();
 
         // create baseString to encode for the sent parameters


### PR DESCRIPTION
Since the library can only store the full response in memory on
download, we use an alternate client lib and set the correct headers to
be able to stream the content to a temp file.

Note: I had to patch the library and also note that the library is unmaintained and that we should really find some time to update to a better library... https://github.com/owncloud/core/issues/13841

Similar approach like for GDrive.

Fixes https://github.com/owncloud/core/issues/4040

Please review @LukasReschke @icewind1991 @Xenopathic
