### PR TITLE
fix writing to cache when fallback server should be used immediately

### DIFF
--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -180,6 +180,16 @@ class Connection extends LDAPUtility {
 	}
 
 	/**
+	 * resets the connection resource
+	 */
+	public function resetConnectionResource() {
+		if(!is_null($this->ldapConnectionRes)) {
+			@$this->ldap->unbind($this->ldapConnectionRes);
+			$this->ldapConnectionRes = null;
+		}
+	}
+
+	/**
 	 * @param string|null $key
 	 * @return string
 	 */
@@ -530,7 +540,7 @@ class Connection extends LDAPUtility {
 			}
 
 			$bindStatus = false;
-			$error = null;
+			$error = -1;
 			try {
 				if (!$this->configuration->ldapOverrideMainServer
 					&& !$this->getFromCache('overrideMainServer')
@@ -558,7 +568,7 @@ class Connection extends LDAPUtility {
 				$this->doConnect($this->configuration->ldapBackupHost,
 								 $this->configuration->ldapBackupPort);
 				$bindStatus = $this->bind();
-				if($bindStatus && $error === -1) {
+				if($bindStatus && $error === -1 && !$this->getFromCache('overrideMainServer')) {
 					//when bind to backup server succeeded and failed to main server,
 					//skip contacting him until next cache refresh
 					$this->writeToCache('overrideMainServer', true);


### PR DESCRIPTION
To reproduce:
1. Have a memory cache enabled
2. Have an LDAP server configured including a backup server
3. Turn off main LDAP server
4. Attempt login twice

First attempted may take a while (depending on the network e.g.), but the second attempt should be done normally. If you monitor your network, the main ldap server should be contacted only once (!), and the fallback twice.

Comes with unit test.

Fixes https://github.com/owncloud/enterprise/issues/988

Please test and review @owncloud/ldap @owncloud/qa @MorrisJobke 

@karlitschek request to backport down to 8.1
