### PR TITLE
Exclude only known failing third-party files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 
 
 script:
-  - sh -c "if [ '$TC' = 'syntax' ]; then composer install && lib/composer/bin/parallel-lint --exclude lib/composer/jakub-onderka/ --exclude 3rdparty .; fi"
+  - sh -c "if [ '$TC' = 'syntax' ]; then composer install && lib/composer/bin/parallel-lint --exclude lib/composer/jakub-onderka/ --exclude 3rdparty/symfony/polyfill-php70/Resources/stubs/ --exclude 3rdparty/patchwork/utf8/src/Patchwork/Utf8/Bootup/ --exclude 3rdparty/paragonie/random_compat/lib/ .; fi"
   - sh -c "if [ '$TEST_DAV' != '1' ]; then echo \"Not testing DAV\"; fi"
   - sh -c "if [ '$TEST_DAV' = '1' ]; then echo \"Testing DAV\"; fi"
 


### PR DESCRIPTION
This way we can also scan the third-party folder for incompatibilities with a used PHP version. Since there are some polyfills that would otherwise fail I had to exclude them manually here.
