### PR TITLE
Execute travis on stable9 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 branches:
   only:
     - master
-#    - /^stable\d+(\.\d+)?$/
+    - /^stable\d+(\.\d+)?$/
 
 addons:
   apt:


### PR DESCRIPTION
Backport of #23100 to stable9

cc @LukasReschke @DeepDiver1975 @nickvergessen 

stable8, 8.1 and 8.2 receive this through #23310, #23311, #23312
