### PR TITLE
Avatar must be saved after login is done and external storages set up…

### DIFF
--- a/apps/user_ldap/tests/user/user.php
+++ b/apps/user_ldap/tests/user/user.php
@@ -798,6 +798,7 @@ class Test_User_User extends \Test\TestCase {
 		}
 
 		$userMock->processAttributes($record);
+		\OC_Hook::emit('OC_User', 'post_login', array('uid' => $uid));
 	}
 
 	public function emptyHomeFolderAttributeValueProvider() {


### PR DESCRIPTION
… properly, fixes #21555
1. Have files_external configured using "ownCloud session credentials" for authentication
2. Have LDAP configured and a user with an avatar image
3. Use Android app to browse files

Before: the mounts do not appear

Now: they hopefully do :) :four_leaf_clover: 

That's a solution with least impact/code changes. I am not entirely fond of it, but hope that works. Please test and review @dbenz04 @rullzer @rperezb @davivel
