### PR TITLE
Display external storage GUI even if user mounting disabled

### DIFF
--- a/apps/files_external/appinfo/application.php
+++ b/apps/files_external/appinfo/application.php
@@ -59,9 +59,7 @@ class Application extends App {
 		$backendService = $container->query('OCA\\Files_External\\Service\\BackendService');
 
 		\OCP\App::registerAdmin('files_external', 'settings');
-		if ($backendService->isUserMountingAllowed()) {
-			\OCP\App::registerPersonal('files_external', 'personal');
-		}
+		\OCP\App::registerPersonal('files_external', 'personal');
 	}
 
 	/**

--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -813,6 +813,7 @@ MountConfigListView.prototype = _.extend({
 		this.$el.find('tbody').append($tr.clone());
 
 		$tr.data('storageConfig', storageConfig);
+		$tr.show();
 		$tr.find('td').last().attr('class', 'remove');
 		$tr.find('td.mountOptionsToggle').removeClass('hidden');
 		$tr.find('td').last().removeAttr('style');

--- a/apps/files_external/personal.php
+++ b/apps/files_external/personal.php
@@ -38,4 +38,5 @@ $tmpl->assign('storages', $userStoragesService->getStorages());
 $tmpl->assign('dependencies', OC_Mount_Config::dependencyMessage($backendService->getBackends()));
 $tmpl->assign('backends', $backendService->getAvailableBackends());
 $tmpl->assign('authMechanisms', $backendService->getAuthMechanisms());
+$tmpl->assign('allowUserMounting', $backendService->isUserMountingAllowed());
 return $tmpl->fetchPage();

--- a/apps/files_external/settings.php
+++ b/apps/files_external/settings.php
@@ -44,5 +44,4 @@ $tmpl->assign('backends', $backendService->getAvailableBackends());
 $tmpl->assign('authMechanisms', $backendService->getAuthMechanisms());
 $tmpl->assign('dependencies', OC_Mount_Config::dependencyMessage($backendService->getBackends()));
 $tmpl->assign('allowUserMounting', $backendService->isUserMountingAllowed());
-$tmpl->assign('allowUserMounting', $backendService->isUserMountingAllowed());
 return $tmpl->fetchPage();

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -85,7 +85,11 @@
 			</tr>
 		</thead>
 		<tbody>
-			<tr id="addMountPoint">
+			<tr id="addMountPoint"
+			<?php if ($_['visibilityType'] === BackendService::VISIBILITY_PERSONAL && $_['allowUserMounting'] === false): ?>
+				style="display: none;"
+			<?php endif; ?>
+			>
 				<td class="status">
 					<span></span>
 				</td>

--- a/apps/files_external/tests/js/settingsSpec.js
+++ b/apps/files_external/tests/js/settingsSpec.js
@@ -179,6 +179,12 @@ describe('OCA.External.Settings tests', function() {
 
 				// TODO: check "remove" button visibility
 			});
+			it('shows row even if selection row is hidden', function() {
+				view.$el.find('tr#addMountPoint').hide();
+				selectBackend('\\OC\\TestBackend');
+				expect(view.$el.find('tr:first').is(':visible')).toBe(true);
+				expect(view.$el.find('tr#addMountPoint').is(':visible')).toBe(false);
+			});
 			// TODO: test with personal mounts (no applicable fields)
 			// TODO: test suggested mount point logic
 		});


### PR DESCRIPTION
Personal settings with user mounting now look like this:

![screenshot_2016-03-16_21-18-49](https://cloud.githubusercontent.com/assets/2016878/13830272/8fb016b8-ebc3-11e5-8320-26efa372346a.png)

Fixes #23294 

Issue marked as 9.0.1 severity high, @karlitschek backport?

cc @PVince81 @icewind1991 @jvillafanez
