### PR TITLE
Fixed dynamic group ldap access

### DIFF
--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -529,12 +529,21 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 			$uid = $userDN;
 		}
 
-		if($primaryGroup !== false) {
-			$groups[] = $primaryGroup;
-		}
+                if(isset($this->cachedGroupsByMember[$uid])) {
+                        $groups[] = $this->cachedGroupsByMember[$uid];
+                } else {
+                        $groupsByMember = array_values($this->getGroupsByMember($uid));
+                        $groupsByMember = $this->access->ownCloudGroupNames($groupsByMember);
+                        $this->cachedGroupsByMember[$uid] = $groupsByMember;
+                        $groups = array_merge($groups, $groupsByMember);
+                }
 
-		$groups = array_unique($groups, SORT_LOCALE_STRING);
-		$this->access->connection->writeToCache($cacheKey, $groups);
+                if($primaryGroup !== false) {
+                        $groups[] = $primaryGroup;
+                }
+
+                $groups = array_unique($groups, SORT_LOCALE_STRING);
+                $this->access->connection->writeToCache($cacheKey, $groups);
 
 		return $groups;
 	}

--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -479,7 +479,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 							// be sure to never return false if the dn could not be
 							// resolved to a name, for whatever reason.
 							$groups[] = $groupName;
-                                                }
+						}
 					}
 				} else {
 					\OCP\Util::writeLog('user_ldap', 'No search filter found on member url '.

--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -468,17 +468,18 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 					// apply filter via ldap search to see if this user is in this
 					// dynamic group
 					$userMatch = $this->access->readAttribute(
-						$uid,
+						$userDN,
 						$this->access->connection->ldapUserDisplayName,
 						$memberUrlFilter
 					);
 					if ($userMatch !== false) {
 						// match found so this user is in this group
-						$pos = strpos($dynamicGroup['dn'][0], ',');
-						if ($pos !== false) {
-							$membershipGroup = substr($dynamicGroup['dn'][0],3,$pos-3);
-							$groups[] = $membershipGroup;
-						}
+						$groupName = $this->access->dn2groupname($dynamicGroup['dn'][0]);
+                                                if(is_string($groupName)) {
+                                                        // be sure to never return false if the dn could not be
+                                                        // resolved to a name, for whatever reason.
+                                                        $groups[] = $groupName;
+                                                }
 					}
 				} else {
 					\OCP\Util::writeLog('user_ldap', 'No search filter found on member url '.
@@ -526,14 +527,6 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 		} else {
 			// just in case
 			$uid = $userDN;
-		}
-
-		if(isset($this->cachedGroupsByMember[$uid])) {
-			$groups = $this->cachedGroupsByMember[$uid];
-		} else {
-			$groups = array_values($this->getGroupsByMember($uid));
-			$groups = $this->access->ownCloudGroupNames($groups);
-			$this->cachedGroupsByMember[$uid] = $groups;
 		}
 
 		if($primaryGroup !== false) {

--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -475,10 +475,10 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 					if ($userMatch !== false) {
 						// match found so this user is in this group
 						$groupName = $this->access->dn2groupname($dynamicGroup['dn'][0]);
-                                                if(is_string($groupName)) {
-                                                        // be sure to never return false if the dn could not be
-                                                        // resolved to a name, for whatever reason.
-                                                        $groups[] = $groupName;
+						if(is_string($groupName)) {
+							// be sure to never return false if the dn could not be
+							// resolved to a name, for whatever reason.
+							$groups[] = $groupName;
                                                 }
 					}
 				} else {
@@ -529,9 +529,9 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 			$uid = $userDN;
 		}
 
-                if(isset($this->cachedGroupsByMember[$uid])) {
+		if(isset($this->cachedGroupsByMember[$uid])) {
 			$groups[] = $this->cachedGroupsByMember[$uid];
-                } else {
+		} else {
 			$groupsByMember = array_values($this->getGroupsByMember($uid));
 			$groupsByMember = $this->access->ownCloudGroupNames($groupsByMember);
 			$this->cachedGroupsByMember[$uid] = $groupsByMember;

--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -530,20 +530,20 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 		}
 
                 if(isset($this->cachedGroupsByMember[$uid])) {
-                        $groups[] = $this->cachedGroupsByMember[$uid];
+			$groups[] = $this->cachedGroupsByMember[$uid];
                 } else {
-                        $groupsByMember = array_values($this->getGroupsByMember($uid));
-                        $groupsByMember = $this->access->ownCloudGroupNames($groupsByMember);
-                        $this->cachedGroupsByMember[$uid] = $groupsByMember;
-                        $groups = array_merge($groups, $groupsByMember);
-                }
+			$groupsByMember = array_values($this->getGroupsByMember($uid));
+			$groupsByMember = $this->access->ownCloudGroupNames($groupsByMember);
+			$this->cachedGroupsByMember[$uid] = $groupsByMember;
+			$groups = array_merge($groups, $groupsByMember);
+		}
 
-                if($primaryGroup !== false) {
-                        $groups[] = $primaryGroup;
-                }
+		if($primaryGroup !== false) {
+			$groups[] = $primaryGroup;
+		}
 
-                $groups = array_unique($groups, SORT_LOCALE_STRING);
-                $this->access->connection->writeToCache($cacheKey, $groups);
+		$groups = array_unique($groups, SORT_LOCALE_STRING);
+		$this->access->connection->writeToCache($cacheKey, $groups);
 
 		return $groups;
 	}


### PR DESCRIPTION
getUserGroups:
Using $userDN instead of $uid to query LDAP
Converting groupDN to group name using API instead of substring
Removing cache processing at the end of the method
