### PR TITLE
Set proper public webdav permissions when public upload disabled

### DIFF
--- a/apps/dav/lib/connector/publicauth.php
+++ b/apps/dav/lib/connector/publicauth.php
@@ -61,6 +61,11 @@ class PublicAuth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
 			return false;
 		}
 
+		if ((int)$linkItem['share_type'] === \OCP\Share::SHARE_TYPE_LINK &&
+			$this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes') !== 'yes') {
+			$this->share['permissions'] &= ~(\OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE);
+		}
+
 		// check if the share is password protected
 		if (isset($linkItem['share_with'])) {
 			if ($linkItem['share_type'] == \OCP\Share::SHARE_TYPE_LINK) {


### PR DESCRIPTION
Fixes #23325

It can happen that a user shares a folder with public upload. And some time later the admin disables public upload on the server.

To make sure this is handled correctly we need to check the config value and reduce the permissions.

This subtile case was missed when we ported the public link stuff to webdav.

@jesmrec please verify

Please review: @PVince81 @schiesbn @LukasReschke @nickvergessen @MorrisJobke 

@karlitschek we should backport this
