### PR TITLE
Hardenings

### DIFF
--- a/lib/private/filechunking.php
+++ b/lib/private/filechunking.php
@@ -146,35 +146,6 @@ class OC_FileChunking {
 		$cache->remove($prefix.$index);
 	}
 
-	public function signature_split($orgfile, $input) {
-		$info = unpack('n', fread($input, 2));
-		$blocksize = $info[1];
-		$this->info['transferid'] = mt_rand();
-		$count = 0;
-		$needed = array();
-		$cache = $this->getCache();
-		$prefix = $this->getPrefix();
-		while (!feof($orgfile)) {
-			$new_md5 = fread($input, 16);
-			if (feof($input)) {
-				break;
-			}
-			$data = fread($orgfile, $blocksize);
-			$org_md5 = md5($data, true);
-			if ($org_md5 == $new_md5) {
-				$cache->set($prefix.$count, $data);
-			} else {
-				$needed[] = $count;
-			}
-			$count++;
-		}
-		return array(
-			'transferid' => $this->info['transferid'],
-			'needed' => $needed,
-			'count' => $count,
-		);
-	}
-
 	/**
 	 * Assembles the chunks into the file specified by the path.
 	 * Also triggers the relevant hooks and proxies.

--- a/lib/private/route/router.php
+++ b/lib/private/route/router.php
@@ -110,6 +110,10 @@ class Router implements IRouter {
 	 * @param null|string $app
 	 */
 	public function loadRoutes($app = null) {
+		if(is_string($app)) {
+			$app = \OC_App::cleanAppId($app);
+		}
+
 		$requestedApp = $app;
 		if ($this->loaded) {
 			return;


### PR DESCRIPTION
1. Escape AppID
   - While all callers do this as well this prevents a misuse of the API by mistake.
2. Remove unused code
   - This code is not used anymore.
