### PR TITLE
Read available l10n files also from theme folder

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -261,7 +261,8 @@ class Server extends ServerContainer implements IServerContainer {
 			return new \OC\L10N\Factory(
 				$c->getConfig(),
 				$c->getRequest(),
-				$c->getUserSession()
+				$c->getUserSession(),
+				\OC::$SERVERROOT
 			);
 		});
 		$this->registerService('URLGenerator', function (Server $c) {

--- a/lib/private/l10n/factory.php
+++ b/lib/private/l10n/factory.php
@@ -64,17 +64,23 @@ class Factory implements IFactory {
 	/** @var IUserSession */
 	protected $userSession;
 
+	/** @var string */
+	protected $serverRoot;
+
 	/**
 	 * @param IConfig $config
 	 * @param IRequest $request
 	 * @param IUserSession $userSession
+	 * @param string $serverRoot
 	 */
 	public function __construct(IConfig $config,
 								IRequest $request,
-								IUserSession $userSession) {
+								IUserSession $userSession,
+								$serverRoot) {
 		$this->config = $config;
 		$this->request = $request;
 		$this->userSession = $userSession;
+		$this->serverRoot = $serverRoot;
 	}
 
 	/**
@@ -189,7 +195,7 @@ class Factory implements IFactory {
 		// merge with translations from theme
 		$theme = $this->config->getSystemValue('theme');
 		if (!empty($theme)) {
-			$themeDir = \OC::$SERVERROOT . '/themes/' . $theme . substr($dir, strlen(\OC::$SERVERROOT));
+			$themeDir = $this->serverRoot . '/themes/' . $theme . substr($dir, strlen($this->serverRoot));
 
 			if (is_dir($themeDir)) {
 				$files = scandir($themeDir);
@@ -280,9 +286,9 @@ class Factory implements IFactory {
 		$i18nDir = $this->findL10nDir($app);
 		$transFile = strip_tags($i18nDir) . strip_tags($lang) . '.json';
 
-		if ((\OC_Helper::isSubDirectory($transFile, \OC::$SERVERROOT . '/core/l10n/')
-				|| \OC_Helper::isSubDirectory($transFile, \OC::$SERVERROOT . '/lib/l10n/')
-				|| \OC_Helper::isSubDirectory($transFile, \OC::$SERVERROOT . '/settings/l10n/')
+		if ((\OC_Helper::isSubDirectory($transFile, $this->serverRoot . '/core/l10n/')
+				|| \OC_Helper::isSubDirectory($transFile, $this->serverRoot . '/lib/l10n/')
+				|| \OC_Helper::isSubDirectory($transFile, $this->serverRoot . '/settings/l10n/')
 				|| \OC_Helper::isSubDirectory($transFile, \OC_App::getAppPath($app) . '/l10n/')
 			)
 			&& file_exists($transFile)) {
@@ -293,7 +299,7 @@ class Factory implements IFactory {
 		// merge with translations from theme
 		$theme = $this->config->getSystemValue('theme');
 		if (!empty($theme)) {
-			$transFile = \OC::$SERVERROOT . '/themes/' . $theme . substr($transFile, strlen(\OC::$SERVERROOT));
+			$transFile = $this->serverRoot . '/themes/' . $theme . substr($transFile, strlen($this->serverRoot));
 			if (file_exists($transFile)) {
 				$languageFiles[] = $transFile;
 			}
@@ -310,14 +316,14 @@ class Factory implements IFactory {
 	 */
 	protected function findL10nDir($app = null) {
 		if (in_array($app, ['core', 'lib', 'settings'])) {
-			if (file_exists(\OC::$SERVERROOT . '/' . $app . '/l10n/')) {
-				return \OC::$SERVERROOT . '/' . $app . '/l10n/';
+			if (file_exists($this->serverRoot . '/' . $app . '/l10n/')) {
+				return $this->serverRoot . '/' . $app . '/l10n/';
 			}
 		} else if ($app && \OC_App::getAppPath($app) !== false) {
 			// Check if the app is in the app folder
 			return \OC_App::getAppPath($app) . '/l10n/';
 		}
-		return \OC::$SERVERROOT . '/core/l10n/';
+		return $this->serverRoot . '/core/l10n/';
 	}
 
 

--- a/lib/private/l10n/factory.php
+++ b/lib/private/l10n/factory.php
@@ -186,6 +186,23 @@ class Factory implements IFactory {
 			}
 		}
 
+		// merge with translations from theme
+		$theme = $this->config->getSystemValue('theme');
+		if (!empty($theme)) {
+			$themeDir = \OC::$SERVERROOT . '/themes/' . $theme . substr($dir, strlen(\OC::$SERVERROOT));
+
+			if (is_dir($themeDir)) {
+				$files = scandir($themeDir);
+				if ($files !== false) {
+					foreach ($files as $file) {
+						if (substr($file, -5) === '.json' && substr($file, 0, 4) !== 'l10n') {
+							$available[] = substr($file, 0, -5);
+						}
+					}
+				}
+			}
+		}
+
 		$this->availableLanguages[$key] = $available;
 		return $available;
 	}
@@ -271,14 +288,14 @@ class Factory implements IFactory {
 			&& file_exists($transFile)) {
 			// load the translations file
 			$languageFiles[] = $transFile;
+		}
 
-			// merge with translations from theme
-			$theme = $this->config->getSystemValue('theme');
-			if (!empty($theme)) {
-				$transFile = \OC::$SERVERROOT . '/themes/' . $theme . substr($transFile, strlen(\OC::$SERVERROOT));
-				if (file_exists($transFile)) {
-					$languageFiles[] = $transFile;
-				}
+		// merge with translations from theme
+		$theme = $this->config->getSystemValue('theme');
+		if (!empty($theme)) {
+			$transFile = \OC::$SERVERROOT . '/themes/' . $theme . substr($transFile, strlen(\OC::$SERVERROOT));
+			if (file_exists($transFile)) {
+				$languageFiles[] = $transFile;
 			}
 		}
 

--- a/tests/lib/l10n/factorytest.php
+++ b/tests/lib/l10n/factorytest.php
@@ -287,6 +287,31 @@ class FactoryTest extends TestCase {
 		];
 	}
 
+	public function testFindAvailableLanguagesWithThemes() {
+		$serverRoot = \OC::$SERVERROOT;
+		\OC::$SERVERROOT = \OC::$SERVERROOT . '/tests/data';
+		$app = 'files';
+
+		$factory = $this->getFactory(['findL10nDir']);
+		$factory->expects($this->once())
+			->method('findL10nDir')
+			->with($app)
+			->willReturn(\OC::$SERVERROOT . '/apps/files/l10n/');
+		$this->config
+			->expects($this->once())
+			->method('getSystemValue')
+			->with('theme')
+			->willReturn('abc');
+
+		try {
+			$this->assertEquals(['en', 'zz'], $factory->findAvailableLanguages($app), '', 0.0, 10, true);
+		} catch (\Exception $e) {
+			\OC::$SERVERROOT = $serverRoot;
+			throw $e;
+		}
+		\OC::$SERVERROOT = $serverRoot;
+	}
+
 	/**
 	 * @dataProvider dataLanguageExists
 	 *

--- a/tests/lib/l10n/l10nlegacytest.php
+++ b/tests/lib/l10n/l10nlegacytest.php
@@ -124,7 +124,7 @@ class L10nLegacyTest extends \Test\TestCase {
 	}
 
 	public function testFactoryGetLanguageCode() {
-		$factory = new \OC\L10N\Factory($this->getMock('OCP\IConfig'), $this->getMock('OCP\IRequest'), $this->getMock('OCP\IUserSession'));
+		$factory = new \OC\L10N\Factory($this->getMock('OCP\IConfig'), $this->getMock('OCP\IRequest'), $this->getMock('OCP\IUserSession'), \OC::$SERVERROOT);
 		$l = $factory->get('lib', 'de');
 		$this->assertEquals('de', $l->getLanguageCode());
 	}

--- a/tests/lib/l10n/l10ntest.php
+++ b/tests/lib/l10n/l10ntest.php
@@ -31,7 +31,7 @@ class L10nTest extends TestCase {
 		$request = $this->getMock('OCP\IRequest');
 		/** @var IUserSession $userSession */
 		$userSession = $this->getMock('OCP\IUserSession');
-		return new Factory($config, $request, $userSession);
+		return new Factory($config, $request, $userSession, \OC::$SERVERROOT);
 	}
 
 	public function testGermanPluralTranslations() {


### PR DESCRIPTION
The old behaviour was that only languages could be used for an app
that are already present in the apps/$app/l10n folder. If there is
a themed l10n that is not present in the apps default l10n folder
the language could not be used and the texts are not translated.

With this change this is possible and also the l10n files are
loaded even if the default l10n doesn't contain the l10n file.

Bonus: This contains unit tests for these scenarios :)

cc @nickvergessen @LukasReschke
