### PR TITLE
Use raw PATH_INFO

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -62,8 +62,8 @@
 
   # Rewrite rules for `front_controller_active`
   Options -MultiViews
-  RewriteRule ^core/js/oc.js$ index.php/core/js/oc.js [PT,E=PATH_INFO:$1]
-  RewriteRule ^core/preview.png$ index.php/core/preview.png [PT,E=PATH_INFO:$1]
+  RewriteRule ^core/js/oc.js$ index.php [PT,E=PATH_INFO:$1]
+  RewriteRule ^core/preview.png$ index.php [PT,E=PATH_INFO:$1]
   RewriteCond %{REQUEST_FILENAME} !\.(css|js|svg|gif|png|html|ttf|woff|ico|jpg|jpeg)$
   RewriteCond %{REQUEST_FILENAME} !core/img/favicon.ico$
   RewriteCond %{REQUEST_FILENAME} !/remote.php

--- a/lib/base.php
+++ b/lib/base.php
@@ -823,7 +823,7 @@ class OC {
 		}
 
 		$request = \OC::$server->getRequest();
-		$requestPath = $request->getPathInfo();
+		$requestPath = $request->getRawPathInfo();
 		if (substr($requestPath, -3) !== '.js') { // we need these files during the upgrade
 			self::checkMaintenanceMode();
 			self::checkUpgrade();


### PR DESCRIPTION
PATH_INFO will be empty at this point and thus the logic in base.php did not catch this. Changing this to "getRawPathInfo" will ensure that the path info is properly read.

Fixes https://github.com/owncloud/core/issues/23199

@perohen @olimination Mind testing? Thanks a lot :rocket:
