### PR TITLE
Write .htaccess update only if not already written

### DIFF
--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -411,32 +411,32 @@ class Setup {
 
 		$htaccessContent = file_get_contents($setupHelper->pathToHtaccess());
 		$content = "#### DO NOT CHANGE ANYTHING ABOVE THIS LINE ####\n";
-		if (strpos($htaccessContent, 'ErrorDocument 403') === false) {
+		if(strpos($htaccessContent, $content) === false) {
 			//custom 403 error page
 			$content.= "\nErrorDocument 403 ".\OC::$WEBROOT."/core/templates/403.php";
-		}
-		if (strpos($htaccessContent, 'ErrorDocument 404') === false) {
+
 			//custom 404 error page
 			$content.= "\nErrorDocument 404 ".\OC::$WEBROOT."/core/templates/404.php";
+
+			// Add rewrite base
+			$webRoot = !empty(\OC::$WEBROOT) ? \OC::$WEBROOT : '/';
+			$content .= "\n<IfModule mod_rewrite.c>";
+			$content .= "\n  RewriteRule . index.php [PT,E=PATH_INFO:$1]";
+			$content .= "\n  RewriteBase ".$webRoot;
+			$content .= "\n  <IfModule mod_env.c>";
+			$content .= "\n    SetEnv front_controller_active true";
+			$content .= "\n    <IfModule mod_dir.c>";
+			$content .= "\n      DirectorySlash off";
+			$content .= "\n    </IfModule>";
+			$content.="\n  </IfModule>";
+			$content.="\n</IfModule>";
+
+			if ($content !== '') {
+				//suppress errors in case we don't have permissions for it
+				@file_put_contents($setupHelper->pathToHtaccess(), $content . "\n", FILE_APPEND);
+			}
 		}
 
-		// Add rewrite base
-		$webRoot = !empty(\OC::$WEBROOT) ? \OC::$WEBROOT : '/';
-		$content .= "\n<IfModule mod_rewrite.c>";
-		$content .= "\n  RewriteRule . index.php [PT,E=PATH_INFO:$1]";
-		$content .= "\n  RewriteBase ".$webRoot;
-		$content .= "\n  <IfModule mod_env.c>";
-		$content .= "\n    SetEnv front_controller_active true";
-		$content .= "\n    <IfModule mod_dir.c>";
-		$content .= "\n      DirectorySlash off";
-		$content .= "\n    </IfModule>";
-		$content.="\n  </IfModule>";
-		$content.="\n</IfModule>";
-
-		if ($content !== '') {
-			//suppress errors in case we don't have permissions for it
-			@file_put_contents($setupHelper->pathToHtaccess(), $content . "\n", FILE_APPEND);
-		}
 	}
 
 	public static function protectDataDirectory() {


### PR DESCRIPTION
The ownCloud update routine also runs the "updateHtaccess" code in case only an application gets updated. This leads to having entries multiple time in the .htaccess file leading to unpredictable behaviour.

With 9.0 we added the "#### DO NOT CHANGE ANYTHING ABOVE THIS LINE ####" entry to the .htaccess file, this change uses it to ensure that only to the .htaccess gets written if the file has not been modified already. Since the .htaccess modifications are optional this is not a big deal.

Without this change updates of applications can break the rewrite rules (ending in endless redirects) as well as breaking the code integrity checker.

@karlitschek I'd propose a backport to 9.0.1. Agreed?
