### PR TITLE
only enable encryption wrapper is encryption is enabled

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -722,7 +722,8 @@ class OC {
 	}
 
 	private static function registerEncryptionWrapper() {
-		\OCP\Util::connectHook('OC_Filesystem', 'preSetup', 'OC\Encryption\Manager', 'setupStorage');
+		$encryptionManager = \OC::$server->getEncryptionManager();
+		\OCP\Util::connectHook('OC_Filesystem', 'preSetup', $encryptionManager, 'setupStorage');
 	}
 
 	private static function registerEncryptionHooks() {

--- a/lib/private/encryption/manager.php
+++ b/lib/private/encryption/manager.php
@@ -227,14 +227,16 @@ class Manager implements IManager {
 	/**
 	 * Add storage wrapper
 	 */
-	public static function setupStorage() {
+	public function setupStorage() {
 		$util = new Util(
 			new View(),
 			\OC::$server->getUserManager(),
 			\OC::$server->getGroupManager(),
 			\OC::$server->getConfig()
 		);
-		Filesystem::addStorageWrapper('oc_encryption', array($util, 'wrapStorage'), 2);
+		if ($this->isEnabled()) {
+			Filesystem::addStorageWrapper('oc_encryption', array($util, 'wrapStorage'), 2);
+		}
 	}
 
 


### PR DESCRIPTION
the encryption wrapper adds an overhead to pretty much every operation even if no encryption is used.

[propfind comparison](https://blackfire.io/profiles/compare/15b73386-3306-462b-8b1a-766494b7cc5f/graph)

cc @PVince81 @schiesbn
