### PR TITLE
Speedup schema cloning for MySQL

### DIFF
--- a/lib/private/DB/MySQLMigrator.php
+++ b/lib/private/DB/MySQLMigrator.php
@@ -24,6 +24,7 @@
 namespace OC\DB;
 
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 
 class MySQLMigrator extends Migrator {
 	/**
@@ -48,4 +49,26 @@ class MySQLMigrator extends Migrator {
 
 		return $schemaDiff;
 	}
+	
+        /**
+         * Speed up migration test by disabling autocommit and unique indexes check
+         *
+         * @param \Doctrine\DBAL\Schema\Table $table
+         * @throws \OC\DB\MigrationException
+         */
+        protected function checkTableMigrate(Table $table) {
+                $this->connection->exec('SET autocommit=0');
+                $this->connection->exec('SET unique_checks=0');
+
+                try {
+                        parent::checkTableMigrate($table);
+                } catch (\Exception $e) {
+                        $this->connection->exec('SET unique_checks=1');
+                        $this->connection->exec('SET autocommit=1');
+                        throw new MigrationException($table->getName(), $e->getMessage());
+                }
+                $this->connection->exec('SET unique_checks=1');
+                $this->connection->exec('SET autocommit=1');
+        }
+
 }


### PR DESCRIPTION
test results on the same container (Schema change was nothing but adding/droping `checksum` column to `filecache` table with 300 000 entries in it):
Time of `occ upgrade` completion (including schema check) in seconds

| operation | 8.2.3 | 8.2.3 + #23395 |
| --- | --- | --- |
| add column | 1417 | 1131 |
| drop column | 1360 | 1085 |
