### PR TITLE
added VALARM to birthday event

### DIFF
--- a/apps/dav/lib/caldav/birthdayservice.php
+++ b/apps/dav/lib/caldav/birthdayservice.php
@@ -153,6 +153,11 @@ class BirthdayService {
 		$vEvent->{'RRULE'} = 'FREQ=YEARLY';
 		$vEvent->{'SUMMARY'} = $title . ' (*' . $date->format('Y') . ')';
 		$vEvent->{'TRANSP'} = 'TRANSPARENT';
+		$alarm = $vCal->createComponent('VALARM');
+		$alarm->add($vCal->createProperty('TRIGGER', '-PT0M', ['VALUE' => 'DURATION']));
+		$alarm->add($vCal->createProperty('ACTION', 'DISPLAY'));
+		$alarm->add($vCal->createProperty('DESCRIPTION', $title . ' (' . $date->format('Y') . ')'));
+		$vEvent->add($alarm);
 		$vCal->add($vEvent);
 		return $vCal;
 	}


### PR DESCRIPTION
This was discussed for the contacts app in the past but had a bit of trouble getting in. Now the code has been moved to core, so I'll try here again.

One result of the past discussion (can't find it anymore) was to set ACTION=DISPLAY, so it _should_ only display a notification and not make a sound.

It might be preferable to make this configurable. But I don't know how to achieve this, right now. 

Anyway, I put this up for discussion, again and would be happy to see it getting merged. Otherwise I'll have to live with the integrity warning, for now.
