### PR TITLE
adjust PrincipalUri as returned from Sabre to effective username

### DIFF
--- a/apps/dav/lib/connector/sabre/auth.php
+++ b/apps/dav/lib/connector/sabre/auth.php
@@ -169,6 +169,12 @@ class Auth extends AbstractBasic {
 			throw new \Sabre\DAV\Exception\NotAuthenticated('Cannot authenticate over ajax calls');
 		}
 
-		return parent::check($request, $response);
+		$data = parent::check($request, $response);
+		if($data[0] === true) {
+			$startPos = strrpos($data[1], '/') + 1;
+			$user = $this->userSession->getUser()->getUID();
+			$data[1] = substr_replace($data[1], $user, $startPos);
+		}
+		return $data;
 	}
 }

--- a/apps/dav/tests/unit/connector/sabre/auth.php
+++ b/apps/dav/tests/unit/connector/sabre/auth.php
@@ -407,15 +407,15 @@ class Auth extends TestCase {
 		$user = $this->getMockBuilder('\OCP\IUser')
 			->disableOriginalConstructor()
 			->getMock();
-		$user->expects($this->exactly(2))
+		$user->expects($this->exactly(3))
 			->method('getUID')
 			->will($this->returnValue('MyTestUser'));
 		$this->userSession
-			->expects($this->exactly(2))
+			->expects($this->exactly(3))
 			->method('getUser')
 			->will($this->returnValue($user));
 		$response = $this->auth->check($server->httpRequest, $server->httpResponse);
-		$this->assertEquals([true, 'principals/users/username'], $response);
+		$this->assertEquals([true, 'principals/users/MyTestUser'], $response);
 	}
 
 	public function testAuthenticateInvalidCredentials() {


### PR DESCRIPTION
We receive a PrincipalUri from Sabre which includes the login name. We missed to replace it with the username. 

How to test:
1. Have a local user joann
2. curl -u Joann -X PROPFIND http://zara.owncloud.bzoc/stable9/remote.php/caldav/calendars/joann (note to use a login name with a capital first letter)

Before the patch: Sabre\DAV\Exception\NotFound
Now: Directory listings

Helps extremely with LDAP users where login names and usernames often differ.

If not fixes, at least contributes to fixing #22988

@DeepDiver1975 you know the effective code best, love to read your opinion.
