### PR TITLE
Do not show hash if parent is shared by link

### DIFF
--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -115,10 +115,23 @@
 			}
 			var displayName = this.model.getShareWithDisplayName(shareIndex);
 			if(!_.isUndefined(this._collections[id])) {
-				this._collections[id].text = this._collections[id].text + ", " + displayName;
+				if (this.model.getShareType(shareIndex) === OC.Share.SHARE_TYPE_LINK) {
+					this._collections[id].text = this._collections[id].text + ", " + t('core', 'by link');
+				} else {
+					this._collections[id].text = this._collections[id].text + ", " + displayName;
+				}
 			} else {
 				this._collections[id] = {};
-				this._collections[id].text = t('core', 'Shared in {item} with {user}', {'item': id, user: displayName});
+				if (this.model.getShareType(shareIndex) === OC.Share.SHARE_TYPE_LINK) {
+					this._collections[id].text = t('core', 'Shared in {item} by link', {
+						'item': id
+					});
+				} else {
+					this._collections[id].text = t('core', 'Shared in {item} with {user}', {
+						'item': id,
+						user: displayName
+					});
+				}
 				this._collections[id].id = id;
 				this._collections[id].isCollection = true;
 			}


### PR DESCRIPTION
fixes #22128

We print a nice message like `Shared in {item} with {user}` but we need to make sure this is not a link share. Else `{user}` can be the hash of the password. Wich looks very weird.

CC: @PVince81 @nickvergessen
