### PR TITLE
Save the query when we get tags for no objects

### DIFF
--- a/lib/private/systemtag/systemtagobjectmapper.php
+++ b/lib/private/systemtag/systemtagobjectmapper.php
@@ -64,6 +64,8 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 	public function getTagIdsForObjects($objIds, $objectType) {
 		if (!is_array($objIds)) {
 			$objIds = [$objIds];
+		} else if (empty($objIds)) {
+			return [];
 		}
 
 		$query = $this->connection->getQueryBuilder();

--- a/tests/lib/systemtag/systemtagobjectmappertest.php
+++ b/tests/lib/systemtag/systemtagobjectmappertest.php
@@ -119,7 +119,7 @@ class SystemTagObjectMapperTest extends TestCase {
 		$query->delete(SystemTagManager::TAG_TABLE)->execute();
 	}
 
-	public function testGetTagsForObjects() {
+	public function testGetTagIdsForObjects() {
 		$tagIdMapping = $this->tagMapper->getTagIdsForObjects(
 			['1', '2', '3', '4'],
 			'testtype'
@@ -131,6 +131,15 @@ class SystemTagObjectMapperTest extends TestCase {
 			'3' => [],
 			'4' => [],
 		], $tagIdMapping);
+	}
+
+	public function testGetTagIdsForNoObjects() {
+		$tagIdMapping = $this->tagMapper->getTagIdsForObjects(
+			[],
+			'testtype'
+		);
+
+		$this->assertEquals([], $tagIdMapping);
 	}
 
 	public function testGetObjectsForTags() {


### PR DESCRIPTION
@rullzer @PVince81 

not worth backports, just for the future
