### PR TITLE
properly use smb permissions

### DIFF
--- a/apps/files_external/lib/smb.php
+++ b/apps/files_external/lib/smb.php
@@ -349,6 +349,28 @@ class SMB extends Common {
 		}
 	}
 
+	public function isReadable($path) {
+		try {
+			$info = $this->getFileInfo($path);
+			return !$info->isHidden();
+		} catch (NotFoundException $e) {
+			return false;
+		} catch (ForbiddenException $e) {
+			return false;
+		}
+	}
+
+	public function isUpdatable($path) {
+		try {
+			$info = $this->getFileInfo($path);
+			return !$info->isHidden() && !$info->isReadOnly();
+		} catch (NotFoundException $e) {
+			return false;
+		} catch (ForbiddenException $e) {
+			return false;
+		}
+	}
+
 	/**
 	 * check if smbclient is installed
 	 */


### PR DESCRIPTION
implement`isUpdatable` and `isReadable` for smb external storage

@karlitschek should be backported to 9.0.1

cc @PVince81 @Xenopathic @jmaciasportela
