### PR TITLE
apply retry wrapper to make sure that we always read/write a complete block

### DIFF
--- a/apps/files_external/lib/ftp.php
+++ b/apps/files_external/lib/ftp.php
@@ -30,6 +30,8 @@
 
 namespace OC\Files\Storage;
 
+use Icewind\Streams\RetryWrapper;
+
 class FTP extends \OC\Files\Storage\StreamWrapper{
 	private $password;
 	private $user;
@@ -105,7 +107,8 @@ class FTP extends \OC\Files\Storage\StreamWrapper{
 			case 'ab':
 				//these are supported by the wrapper
 				$context = stream_context_create(array('ftp' => array('overwrite' => true)));
-				return fopen($this->constructUrl($path), $mode, false, $context);
+				$handle = fopen($this->constructUrl($path), $mode, false, $context);
+				return RetryWrapper::wrap($handle);
 			case 'r+':
 			case 'w+':
 			case 'wb+':


### PR DESCRIPTION
fix https://github.com/owncloud/core/issues/22286
- [x] need: https://github.com/owncloud/core/pull/23351 (merged :tada: )

@karlitschek we need to backport this in order to fix external ftp storage in combination with encryption

cc @icewind1991 @PVince81 @nickvergessen please review... thanks!
