### PR TITLE
Log more information by default

### DIFF
--- a/lib/private/log/owncloud.php
+++ b/lib/private/log/owncloud.php
@@ -88,14 +88,21 @@ class OC_Log_Owncloud {
 		$remoteAddr = $request->getRemoteAddress();
 		// remove username/passwords from URLs before writing the to the log file
 		$time = $time->format($format);
-		$minLevel=min($config->getValue( "loglevel", \OCP\Util::WARN ), \OCP\Util::ERROR);
-		if($minLevel == \OCP\Util::DEBUG) {
-			$url = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '--';
-			$method = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : '--';
-			$entry = compact('reqId', 'remoteAddr', 'app', 'message', 'level', 'time', 'method', 'url');
-		} else {
-			$entry = compact('reqId', 'remoteAddr', 'app', 'message', 'level', 'time');
-		}
+		$url = ($request->getRequestUri() !== '') ? $request->getRequestUri() : '--';
+		$method = is_string($request->getMethod()) ? $request->getMethod() : '--';
+		$userObj = \OC::$server->getUserSession()->getUser();
+		$user = !is_null($userObj) ? $userObj->getUID() : '--';
+		$entry = compact(
+			'reqId',
+			'remoteAddr',
+			'app',
+			'message',
+			'level',
+			'time',
+			'method',
+			'url',
+			'user'
+		);
 		$entry = json_encode($entry);
 		$handle = @fopen(self::$logFile, 'a');
 		@chmod(self::$logFile, 0640);


### PR DESCRIPTION
This modifies the logger to add the following logging information by default:
- Request Method
- Request URL
- Current user

While, except the currently logged-in user, they were already logged in debug mode this was not sufficient for a proper debugging of some encountered real life issues.

For example we're facing this problem when debugging https://github.com/owncloud/enterprise/issues/1199 since the productive instance that this issue has been encountered on obviously did not run in debug mode. As requested by @MorrisJobke in https://github.com/owncloud/enterprise/issues/1199#issuecomment-199202377.

So it probably makes sense to log these information always as otherwise debugging gets a ton harder.

@karlitschek @DeepDiver1975 Thoughts?
