### PR TITLE
small performance improvement: no need to calculate the header size

### DIFF
--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -841,7 +841,7 @@ class Encryption extends Wrapper {
 		$firstBlock = $this->readFirstBlock($path);
 
 		if (substr($firstBlock, 0, strlen(Util::HEADER_START)) === Util::HEADER_START) {
-			$headerSize = strlen($firstBlock);
+			$headerSize = $this->util->getHeaderSize();
 		}
 
 		return $headerSize;


### PR DESCRIPTION
no need to calculate the header size, if the first block contain a header we already know the size
