### PR TITLE
Do not abort with an exception when a default app can not be enabled

### DIFF
--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -333,7 +333,12 @@ class Updater extends BasicEmitter {
 
 			// install new shipped apps on upgrade
 			OC_App::loadApps('authentication');
-			OC_Installer::installShippedApps();
+			$errors = OC_Installer::installShippedApps(true);
+			foreach ($errors as $appId => $exception) {
+				/** @var \Exception $exception */
+				$this->log->logException($exception, ['app' => $appId]);
+				$this->emit('\OC\Updater', 'failure', [$appId . ': ' . $exception->getMessage()]);
+			}
 
 			// post-upgrade repairs
 			$repair = new Repair(Repair::getRepairSteps());


### PR DESCRIPTION
### Steps to error
1. Install activity app
2. Remove values from appconfig, without deleting the activitiy table itself
3. Trigger an update of owncloud (change config.php version to a lower version)
### Expected

Update prints an error, but ownCloud is usable after the update
### Actual

Update breaks and the update is tried for each refresh.

Fix #22993 

@PVince81 @MorrisJobke @DeepDiver1975
