### PR TITLE
Fix "AutoloadNotAllowedException" when files_sharing is disabled

### DIFF
--- a/lib/private/activitymanager.php
+++ b/lib/private/activitymanager.php
@@ -256,11 +256,11 @@ class ActivityManager implements IManager {
 		foreach ($this->getExtensions() as $c) {
 			$result = $c->getNotificationTypes($languageCode);
 			if (is_array($result)) {
-				if (class_exists('\OCA\Files\Activity') && $c instanceof \OCA\Files\Activity) {
+				if (class_exists('\OCA\Files\Activity', false) && $c instanceof \OCA\Files\Activity) {
 					$filesNotificationTypes = $result;
 					continue;
 				}
-				if (class_exists('\OCA\Files_Sharing\Activity') && $c instanceof \OCA\Files_Sharing\Activity) {
+				if (class_exists('\OCA\Files_Sharing\Activity', false) && $c instanceof \OCA\Files_Sharing\Activity) {
 					$sharingNotificationTypes = $result;
 					continue;
 				}


### PR DESCRIPTION
### Steps
1. Disable the files_sharing
2. Enable activity
3. Open activity page

Fix owncloud/activity#491

@rullzer @PVince81 @MorrisJobke 

@karlitschek should backport this easy fix
