### PR TITLE
Dont double load class

### DIFF
--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -164,6 +164,10 @@ class Autoloader {
 			$pathsToRequire = $this->memoryCache->get($class);
 		}
 
+		if(class_exists($class, false)) {
+			return false;
+		}
+
 		if (!is_array($pathsToRequire)) {
 			// No cache or cache miss
 			$pathsToRequire = array();


### PR DESCRIPTION
If the class already exists we should not load it twice. Since the composer autoloader is also used in core this could otherwise load a file twice. OS X can be fun :see_no_evil: 

@rullzer THX.
