### PR TITLE
Detect user navigating away, don't interpret as ajax error

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1448,10 +1448,10 @@ function initCore() {
 		$('html').addClass('edge');
 	}
 
-	$(window).on('unload', function() {
+	$(window).on('unload.main', function() {
 		OC._unloadCalled = true;
 	});
-	$(window).on('beforeunload', function() {
+	$(window).on('beforeunload.main', function() {
 		// super-trick thanks to http://stackoverflow.com/a/4651049
 		// in case another handler displays a confirmation dialog (ex: navigating away
 		// during an upload), there are two possible outcomes: user clicked "ok" or

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -747,7 +747,7 @@ var OC={
 			return;
 		}
 
-		if (_.contains([0, 302, 307, 401], xhr.status)) {
+		if (_.contains([0, 302, 303, 307, 401], xhr.status)) {
 			OC.reload();
 		}
 	},

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -740,15 +740,23 @@ var OC={
 	 * if an error/auth error status was returned.
 	 */
 	_processAjaxError: function(xhr) {
+		var self = this;
 		// purposefully aborted request ?
 		// this._userIsNavigatingAway needed to distinguish ajax calls cancelled by navigating away
 		// from calls cancelled by failed cross-domain ajax due to SSO redirect
-		if (xhr.status === 0 && (xhr.statusText === 'abort' || xhr.statusText === 'timeout' || this._userIsNavigatingAway)) {
+		if (xhr.status === 0 && (xhr.statusText === 'abort' || xhr.statusText === 'timeout' || self._reloadCalled)) {
 			return;
 		}
 
 		if (_.contains([0, 302, 303, 307, 401], xhr.status)) {
-			OC.reload();
+			// sometimes "beforeunload" happens later, so need to defer the reload a bit
+			setTimeout(function() {
+				if (!self._userIsNavigatingAway && !self._reloadCalled) {
+					OC.reload();
+					// only call reload once
+					self._reloadCalled = true;
+				}
+			}, 100);
 		}
 	},
 


### PR DESCRIPTION
Whenever a user navigates away, all ajax calls will fail with the same result like a cross-domain redirect (SSO). To distinguish these cases, we need to detect whether the error is a result of the user navigating away. For this, we introduce a new flag that will be set in "beforeunload".

Additional handling was required for false positives in case "beforeunload" is used (ex: cancelled upload) and the user cancelled the navigation.

Please review @oparoz @nickvergessen @rullzer @blizzz @DeepDiver1975 

Fixes https://github.com/owncloud/core/issues/23482

@karlitschek backport for 9.0.1 ?
