### PR TITLE
Only use the user session if ownCloud is already installed

### DIFF
--- a/lib/private/log/owncloud.php
+++ b/lib/private/log/owncloud.php
@@ -90,7 +90,11 @@ class OC_Log_Owncloud {
 		$time = $time->format($format);
 		$url = ($request->getRequestUri() !== '') ? $request->getRequestUri() : '--';
 		$method = is_string($request->getMethod()) ? $request->getMethod() : '--';
-		$userObj = \OC::$server->getUserSession()->getUser();
+		if(\OC::$server->getConfig()->getSystemValue('installed', false)) {
+			$userObj = \OC::$server->getUserSession()->getUser();
+		} else {
+			$userObj = null;
+		}
 		$user = !is_null($userObj) ? $userObj->getUID() : '--';
 		$entry = compact(
 			'reqId',


### PR DESCRIPTION
When installing ownCloud with autotest and MySQL some log entries may be created which will invoke the logging class. IUserSession has a dependency on the database which will make the installation fail => :bomb:

cc @DeepDiver1975 @MorrisJobke
