### PR TITLE
Disable pastezone for jquery.fileupload

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -274,6 +274,7 @@ OC.Upload = {
 		if ( $('#file_upload_start').exists() ) {
 			var file_upload_param = {
 				dropZone: $('#content'), // restrict dropZone to content div
+				pasteZone: null, 
 				autoUpload: false,
 				sequentialUploads: true,
 				//singleFileUploads is on by default, so the data.files array will always have length 1

--- a/settings/js/certificates.js
+++ b/settings/js/certificates.js
@@ -16,6 +16,7 @@ $(document).ready(function () {
 	$('#sslCertificate tr > td').tipsy({gravity: 'n', live: true});
 
 	$('#rootcert_import').fileupload({
+		pasteZone: null,
 		submit: function (e, data) {
 			data.formData = _.extend(data.formData || {}, {
 				requesttoken: OC.requestToken

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -244,6 +244,7 @@ $(document).ready(function () {
 	});
 
 	var uploadparms = {
+		pasteZone: null,
 		done: function (e, data) {
 			var response = data;
 			if (typeof data.result === 'string') {


### PR DESCRIPTION
jquery.fileupload offers the [`pastezone`](https://github.com/blueimp/jQuery-File-Upload/wiki/Options#pastezone) functionality. This functionality is enabled by default and if somebody copy-pastes something into Chrome it will automatically trigger an upload of the content to any configured jquery.fileupload element embedded in the JS.

This implementation triggers some problems:
1. The pastezone is defined globally by default (:see_no_evil:). So if there are multiple fileupload's on a page (such as in the personal settings) then stuff is going to be uploaded to all embedded uploads.
2. Our server code is not able to parse the data. For example for uploads in the files app we expect a file name which is not specified => Just an error is thrown. You can reproduce this by taking a file into your clipboard and in Chrome then pressing <kbd>CTRL + V</kbd>.
3. When copy-pasting some string from MS Office on the personal page a temporary avatar with said content is created. (a little bit of an annoyance if the clipboard contains sensitive data like the password that the user wants to set)

Considering that this is anyways was never working at all and causes bugs I've set the `pastezone` to `null`. This mens that upload via copy and paste will be disabled.

Lesson learned: Third-party JS libraries can have some weird defaults.

<hr/>

@PVince81 Thoughts?
