### PR TITLE
Fix the translations of the User menu

### DIFF
--- a/lib/private/l10n/factory.php
+++ b/lib/private/l10n/factory.php
@@ -89,20 +89,18 @@ class Factory implements IFactory {
 		if ($lang !== null) {
 			$lang = str_replace(array('\0', '/', '\\', '..'), '', (string) $lang);
 		}
-		$key = $lang;
-		if ($key === null || !$this->languageExists($app, $lang)) {
-			$key = 'null';
+		if ($lang === null || !$this->languageExists($app, $lang)) {
 			$lang = $this->findLanguage($app);
 		}
 
-		if (!isset($this->instances[$key][$app])) {
-			$this->instances[$key][$app] = new L10N(
+		if (!isset($this->instances[$lang][$app])) {
+			$this->instances[$lang][$app] = new L10N(
 				$this, $app, $lang,
 				$this->getL10nFilesForApp($app, $lang)
 			);
 		}
 
-		return $this->instances[$key][$app];
+		return $this->instances[$lang][$app];
 	}
 
 	/**


### PR DESCRIPTION
The problem is, something calls `get('lib', null)` before anything is loaded. In that case `findLanguage()` can not fallback to the user value (preferences) nor the accept header. So it falls back to the default language or english.
Now when the stuff is set up, and we call `get('lib', null)` for the menu, the english instance is returned, since it's saved in the cache. So we need to store the cache stuff with the language it actually is, instead of `null` for the fallback.

Fix #22695 

@karlitschek I suggest a backport to 9.0

cc @MorrisJobke @PVince81
