### PR TITLE
Revert for files app to use ajax download instead of Webdav

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -136,27 +136,13 @@
 
 		/**
 		 * Returns the download URL of the given file(s)
-		 * @param {string} filename string or array of file names to download
-		 * @param {string} [dir] optional directory in which the file name is, defaults to the current directory
-		 * @param {bool} [isDir=false] whether the given filename is a directory and might need a special URL
+		 * @param filename string or array of file names to download
+		 * @param dir optional directory in which the file name is, defaults to the current directory
 		 */
-		getDownloadUrl: function(filename, dir, isDir) {
-			if (!_.isArray(filename) && !isDir) {
-				var pathSections = dir.split('/');
-				pathSections.push(filename);
-				var encodedPath = '';
-				_.each(pathSections, function(section) {
-					if (section !== '') {
-						encodedPath += '/' + encodeURIComponent(section);
-					}
-				});
-				return OC.linkToRemoteBase('webdav') + encodedPath;
-			}
-
-			if (_.isArray(filename)) {
+		getDownloadUrl: function(filename, dir) {
+			if ($.isArray(filename)) {
 				filename = JSON.stringify(filename);
 			}
-
 			var params = {
 				dir: dir,
 				files: filename

--- a/apps/files/tests/js/favoritesfilelistspec.js
+++ b/apps/files/tests/js/favoritesfilelistspec.js
@@ -100,7 +100,8 @@ describe('OCA.Files.FavoritesFileList tests', function() {
 			expect($tr.attr('data-mtime')).toEqual('11111000');
 			expect($tr.find('a.name').attr('href')).toEqual(
 				OC.webroot +
-				'/remote.php/webdav/somedir/test.txt'
+				'/index.php/apps/files/ajax/download.php' +
+				'?dir=%2Fsomedir&files=test.txt'
 			);
 			expect($tr.find('.nametext').text().trim()).toEqual('test.txt');
 		});

--- a/apps/files/tests/js/fileactionsSpec.js
+++ b/apps/files/tests/js/fileactionsSpec.js
@@ -642,9 +642,8 @@ describe('OCA.Files.FileActions tests', function() {
 				expect(busyStub.calledOnce).toEqual(true);
 				expect(busyStub.calledWith('testName.txt', true)).toEqual(true);
 				expect(handleDownloadStub.calledOnce).toEqual(true);
-				expect(handleDownloadStub.getCall(0).args[0]).toEqual(
-					OC.webroot + '/remote.php/webdav/subdir/testName.txt'
-				);
+				expect(handleDownloadStub.getCall(0).args[0])
+					.toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files=testName.txt');
 				busyStub.reset();
 				handleDownloadStub.yield();
 

--- a/apps/files/tests/js/fileactionsmenuSpec.js
+++ b/apps/files/tests/js/fileactionsmenuSpec.js
@@ -253,8 +253,8 @@ describe('OCA.Files.FileActionsMenu tests', function() {
 			expect(redirectStub.calledOnce).toEqual(true);
 			expect(redirectStub.getCall(0).args[0]).toContain(
 				OC.webroot +
-				'/remote.php/webdav/subdir/testName.txt'
-			);
+				'/index.php/apps/files/ajax/download.php' +
+				'?dir=%2Fsubdir&files=testName.txt');
 			redirectStub.restore();
 		});
 		it('takes the file\'s path into account when clicking download', function() {
@@ -285,7 +285,8 @@ describe('OCA.Files.FileActionsMenu tests', function() {
 
 			expect(redirectStub.calledOnce).toEqual(true);
 			expect(redirectStub.getCall(0).args[0]).toContain(
-				OC.webroot + '/remote.php/webdav/anotherpath/there/testName.txt'
+				OC.webroot + '/index.php/apps/files/ajax/download.php' +
+				'?dir=%2Fanotherpath%2Fthere&files=testName.txt'
 			);
 			redirectStub.restore();
 		});

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -210,7 +210,7 @@ describe('OCA.Files.FileList tests', function() {
 			expect($tr.attr('data-mime')).toEqual('text/plain');
 			expect($tr.attr('data-mtime')).toEqual('123456');
 			expect($tr.find('a.name').attr('href'))
-				.toEqual(OC.webroot + '/remote.php/webdav/subdir/testName.txt');
+				.toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files=testName.txt');
 			expect($tr.find('.nametext').text().trim()).toEqual('testName.txt');
 
 			expect($tr.find('.filesize').text()).toEqual('1 KB');
@@ -623,7 +623,7 @@ describe('OCA.Files.FileList tests', function() {
 
 			$tr = fileList.findFileEl('Tu_after_three.txt');
 			expect($tr.find('a.name').attr('href'))
-				.toEqual(OC.webroot + '/remote.php/webdav/some/subdir/Tu_after_three.txt');
+				.toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fsome%2Fsubdir&files=Tu_after_three.txt');
 		});
 		it('Triggers "fileActionsReady" event after rename', function() {
 			var handler = sinon.stub();
@@ -1457,12 +1457,12 @@ describe('OCA.Files.FileList tests', function() {
 	describe('Download Url', function() {
 		it('returns correct download URL for single files', function() {
 			expect(fileList.getDownloadUrl('some file.txt'))
-				.toEqual(OC.webroot + '/remote.php/webdav/subdir/some%20file.txt');
+				.toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files=some%20file.txt');
 			expect(fileList.getDownloadUrl('some file.txt', '/anotherpath/abc'))
-				.toEqual(OC.webroot + '/remote.php/webdav/anotherpath/abc/some%20file.txt');
+				.toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fanotherpath%2Fabc&files=some%20file.txt');
 			$('#dir').val('/');
 			expect(fileList.getDownloadUrl('some file.txt'))
-				.toEqual(OC.webroot + '/remote.php/webdav/some%20file.txt');
+				.toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2F&files=some%20file.txt');
 		});
 		it('returns correct download URL for multiple files', function() {
 			expect(fileList.getDownloadUrl(['a b c.txt', 'd e f.txt']))

--- a/apps/files/tests/js/filesSpec.js
+++ b/apps/files/tests/js/filesSpec.js
@@ -76,11 +76,11 @@ describe('OCA.Files.Files tests', function() {
 	describe('getDownloadUrl', function() {
 		it('returns the ajax download URL when filename and dir specified', function() {
 			var url = Files.getDownloadUrl('test file.txt', '/subdir');
-			expect(url).toEqual(OC.webroot + '/remote.php/webdav/subdir/test%20file.txt');
+			expect(url).toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files=test%20file.txt');
 		});
-		it('returns the webdav download URL when filename and root dir specified', function() {
+		it('returns the ajax download URL when filename and root dir specific', function() {
 			var url = Files.getDownloadUrl('test file.txt', '/');
-			expect(url).toEqual(OC.webroot + '/remote.php/webdav/test%20file.txt');
+			expect(url).toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2F&files=test%20file.txt');
 		});
 		it('returns the ajax download URL when multiple files specified', function() {
 			var url = Files.getDownloadUrl(['test file.txt', 'abc.txt'], '/subdir');

--- a/apps/files_sharing/tests/js/sharedfilelistSpec.js
+++ b/apps/files_sharing/tests/js/sharedfilelistSpec.js
@@ -166,7 +166,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-share-id')).toEqual('7');
 			expect($tr.find('a.name').attr('href')).toEqual(
 				OC.webroot +
-				'/remote.php/webdav/local%20path/local%20name.txt'
+				'/index.php/apps/files/ajax/download.php' +
+				'?dir=%2Flocal%20path&files=local%20name.txt'
 			);
 			expect($tr.find('.nametext').text().trim()).toEqual('local name.txt');
 
@@ -184,7 +185,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-share-id')).toEqual('8');
 			expect($tr.find('a.name').attr('href')).toEqual(
 				OC.webroot +
-				'/remote.php/webdav/b.txt'
+				'/index.php/apps/files/ajax/download.php' +
+				'?dir=%2F&files=b.txt'
 			);
 			expect($tr.find('.nametext').text().trim()).toEqual('b.txt');
 		});
@@ -336,7 +338,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-share-id')).toEqual('7');
 			expect($tr.find('a.name').attr('href')).toEqual(
 				OC.webroot +
-				'/remote.php/webdav/local%20path/local%20name.txt'
+				'/index.php/apps/files/ajax/download.php' +
+				'?dir=%2Flocal%20path&files=local%20name.txt'
 			);
 			expect($tr.find('.nametext').text().trim()).toEqual('local name.txt');
 		});
@@ -426,8 +429,9 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-share-owner')).not.toBeDefined();
 			expect($tr.attr('data-share-id')).toEqual('7');
 			expect($tr.find('a.name').attr('href')).toEqual(
-				OC.webroot + '/remote.php/webdav/local%20path/local%20name.txt'
-			);
+					OC.webroot +
+					'/index.php/apps/files/ajax/download.php' +
+					'?dir=%2Flocal%20path&files=local%20name.txt');
 
 			expect($tr.find('.nametext').text().trim()).toEqual('local name.txt');
 		});
@@ -494,7 +498,9 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-share-owner')).not.toBeDefined();
 			expect($tr.attr('data-share-id')).toEqual('7,8,9');
 			expect($tr.find('a.name').attr('href')).toEqual(
-				OC.webroot + '/remote.php/webdav/local%20path/local%20name.txt'
+				OC.webroot +
+				'/index.php/apps/files/ajax/download.php' +
+				'?dir=%2Flocal%20path&files=local%20name.txt'
 			);
 			expect($tr.find('.nametext').text().trim()).toEqual('local name.txt');
 		});
@@ -586,8 +592,9 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-share-owner')).not.toBeDefined();
 			expect($tr.attr('data-share-id')).toEqual('7');
 			expect($tr.find('a.name').attr('href')).toEqual(
-				OC.webroot + '/remote.php/webdav/local%20path/local%20name.txt'
-			);
+					OC.webroot +
+					'/index.php/apps/files/ajax/download.php' +
+					'?dir=%2Flocal%20path&files=local%20name.txt');
 
 			expect($tr.find('.nametext').text().trim()).toEqual('local name.txt');
 		});
@@ -627,7 +634,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-share-id')).toEqual('7');
 			expect($tr.find('a.name').attr('href')).toEqual(
 					OC.webroot +
-					'/remote.php/webdav/local%20path/local%20name.txt');
+					'/index.php/apps/files/ajax/download.php' +
+					'?dir=%2Flocal%20path&files=local%20name.txt');
 
 			expect($tr.find('.nametext').text().trim()).toEqual('local name.txt');
 		});


### PR DESCRIPTION
This is required to be able to show a correct HTML error page in case
of error. Webdav only returns XML.

Fixes https://github.com/owncloud/core/issues/23500

@DeepDiver1975 @oparoz @SergioBertolinSG @icewind1991 @rullzer @nickvergessen
