### PR TITLE
Fix activity emails always using the short translation

### DIFF
--- a/lib/private/activitymanager.php
+++ b/lib/private/activitymanager.php
@@ -49,6 +49,9 @@ class ActivityManager implements IManager {
 	/** @var int */
 	protected $formattingObjectId;
 
+	/** @var string */
+	protected $currentUserId;
+
 	/**
 	 * constructor of the controller
 	 *
@@ -476,6 +479,19 @@ class ActivityManager implements IManager {
 	}
 
 	/**
+	 * Set the user we need to use
+	 *
+	 * @param string|null $currentUserId
+	 * @throws \UnexpectedValueException If the user is invalid
+	 */
+	public function setCurrentUserId($currentUserId) {
+		if (!is_string($currentUserId) && $currentUserId !== null) {
+			throw new \UnexpectedValueException('The given current user is invalid');
+		}
+		$this->currentUserId = $currentUserId;
+	}
+
+	/**
 	 * Get the user we need to use
 	 *
 	 * Either the user is logged in, or we try to get it from the token
@@ -484,7 +500,9 @@ class ActivityManager implements IManager {
 	 * @throws \UnexpectedValueException If the token is invalid, does not exist or is not unique
 	 */
 	public function getCurrentUserId() {
-		if (!$this->session->isLoggedIn()) {
+		if ($this->currentUserId !== null) {
+			return $this->currentUserId;
+		} else if (!$this->session->isLoggedIn()) {
 			return $this->getUserFromToken();
 		} else {
 			return $this->session->getUser()->getUID();

--- a/lib/private/activitymanager.php
+++ b/lib/private/activitymanager.php
@@ -321,7 +321,8 @@ class ActivityManager implements IManager {
 	 * @return bool
 	 */
 	public function isFormattingFilteredObject() {
-		return $this->formattingObjectType === $this->request->getParam('object_type')
+		return $this->formattingObjectType !== null && $this->formattingObjectId !== null
+			&& $this->formattingObjectType === $this->request->getParam('object_type')
 			&& $this->formattingObjectId === $this->request->getParam('object_id');
 	}
 

--- a/lib/public/activity/imanager.php
+++ b/lib/public/activity/imanager.php
@@ -204,6 +204,16 @@ interface IManager {
 	 */
 	public function getQueryForFilter($filter);
 
+
+	/**
+	 * Set the user we need to use
+	 *
+	 * @param string|null $currentUserId
+	 * @throws \UnexpectedValueException If the user is invalid
+	 * @since 9.0.1
+	 */
+	public function setCurrentUserId($currentUserId);
+
 	/**
 	 * Get the user we need to use
 	 *


### PR DESCRIPTION
Fix #23503 

@karlitschek should backport, otherwise the activity emails render useless for most cases, since the file names on which the actions have been done are stripped away
