### PR TITLE
[stable8.2] Workaround to be able to recognize unlimited quota in fed shares

### DIFF
--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -413,7 +413,14 @@ class DAV extends Common {
 			// TODO: cacheable ?
 			$response = $this->client->propfind($this->encodePath($path), array('{DAV:}quota-available-bytes'));
 			if (isset($response['{DAV:}quota-available-bytes'])) {
-				return (int)$response['{DAV:}quota-available-bytes'];
+				$freeSpace = (int)$response['{DAV:}quota-available-bytes'];
+				if ($freeSpace === FileInfo::SPACE_UNLIMITED) {
+					// most of the code cannot cope with unlimited storage,
+					// so as a workaround convert to SPACE_UNKNOWN which is a
+					// value recognized in many places
+					return FileInfo::SPACE_UNKNOWN;
+				}
+				return $freeSpace;
 			} else {
 				return FileInfo::SPACE_UNKNOWN;
 			}


### PR DESCRIPTION
Fixes issues where a user cannot upload to a fed share on OC >= 9.0
where the sharer has unlimited quota (-3)

Fixes https://github.com/owncloud/core/issues/23547

9.0 itself already works correctly, this PR is for 8.2 and previous.

Please review @icewind1991 @DeepDiver1975 @MorrisJobke @nickvergessen @LukasReschke @rullzer 

@karlitschek backport down to 8.0 ?
This is due to the decision of returning -3 here https://github.com/owncloud/core/issues/19988 when a user has unlimited quota in 9.0.
