### PR TITLE
Return remote shares in oc:share-types Webdav property

### DIFF
--- a/apps/dav/lib/connector/sabre/sharesplugin.php
+++ b/apps/dav/lib/connector/sabre/sharesplugin.php
@@ -116,7 +116,8 @@ class SharesPlugin extends \Sabre\DAV\ServerPlugin {
 		$requestedShareTypes = [
 			\OCP\Share::SHARE_TYPE_USER,
 			\OCP\Share::SHARE_TYPE_GROUP,
-			\OCP\Share::SHARE_TYPE_LINK
+			\OCP\Share::SHARE_TYPE_LINK,
+			\OCP\Share::SHARE_TYPE_REMOTE
 		];
 		foreach ($requestedShareTypes as $requestedShareType) {
 			// one of each type is enough to find out about the types

--- a/apps/dav/tests/unit/connector/sabre/sharesplugin.php
+++ b/apps/dav/tests/unit/connector/sabre/sharesplugin.php
@@ -248,10 +248,12 @@ class SharesPlugin extends \Test\TestCase {
 			[[\OCP\Share::SHARE_TYPE_USER]],
 			[[\OCP\Share::SHARE_TYPE_GROUP]],
 			[[\OCP\Share::SHARE_TYPE_LINK]],
+			[[\OCP\Share::SHARE_TYPE_REMOTE]],
 			[[\OCP\Share::SHARE_TYPE_USER, \OCP\Share::SHARE_TYPE_GROUP]],
 			[[\OCP\Share::SHARE_TYPE_USER, \OCP\Share::SHARE_TYPE_GROUP, \OCP\Share::SHARE_TYPE_LINK]],
 			[[\OCP\Share::SHARE_TYPE_USER, \OCP\Share::SHARE_TYPE_LINK]],
 			[[\OCP\Share::SHARE_TYPE_GROUP, \OCP\Share::SHARE_TYPE_LINK]],
+			[[\OCP\Share::SHARE_TYPE_USER, \OCP\Share::SHARE_TYPE_REMOTE]],
 		];
 	}
 }

--- a/apps/files/controller/apicontroller.php
+++ b/apps/files/controller/apicontroller.php
@@ -177,7 +177,8 @@ class ApiController extends Controller {
 		$requestedShareTypes = [
 			\OCP\Share::SHARE_TYPE_USER,
 			\OCP\Share::SHARE_TYPE_GROUP,
-			\OCP\Share::SHARE_TYPE_LINK
+			\OCP\Share::SHARE_TYPE_LINK,
+			\OCP\Share::SHARE_TYPE_REMOTE
 		];
 		foreach ($requestedShareTypes as $requestedShareType) {
 			// one of each type is enough to find out about the types

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -123,6 +123,8 @@
 								hasShares = true;
 							} else if (shareType === OC.Share.SHARE_TYPE_GROUP) {
 								hasShares = true;
+							} else if (shareType === OC.Share.SHARE_TYPE_REMOTE) {
+								hasShares = true;
 							}
 						});
 						OCA.Sharing.Util._updateFileActionIcon($tr, hasShares, hasLink);


### PR DESCRIPTION
Fixes web UI to properly display the share status icon when an outgoing
remote share exists

To test:
1. Create a folder "test"
2. Favorite "test"
3. Share "test" with a remote user (fed share)
4. Refresh the page
5. Check folder icon
6. Go to "Favorites" section
7. Check folder icon

Before this fix: icon resets to regular icon in both pages
After this fix: icon properly shows shared status in both pages

Please review @icewind1991 @rullzer @MorrisJobke @nickvergessen @blizzz @DeepDiver1975 @LukasReschke 

@karlitschek backport this omission to stable9 ?
