### PR TITLE
Make lock ttl configurable

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1194,6 +1194,15 @@ $CONFIG = array(
 'filelocking.enabled' => true,
 
 /**
+ * Set the time-to-live for locks in secconds.
+ *
+ * Any lock older than this will be automatically cleaned up.
+ *
+ * If not set this defaults to either 1 hour or the php max_execution_time, whichever is higher.
+ */
+'filelocking.ttl' => 3600,
+
+/**
  * Memory caching backend for file locking
  *
  * Because most memcache backends can clean values without warning using redis

--- a/lib/private/lock/abstractlockingprovider.php
+++ b/lib/private/lock/abstractlockingprovider.php
@@ -28,7 +28,7 @@ use OCP\Lock\ILockingProvider;
  * to release any left over locks at the end of the request
  */
 abstract class AbstractLockingProvider implements ILockingProvider {
-	const TTL = 3600; // how long until we clear stray locks in seconds
+	protected $ttl; // how long until we clear stray locks in seconds
 
 	protected $acquiredLocks = [
 		'shared' => [],

--- a/lib/private/lock/dblockingprovider.php
+++ b/lib/private/lock/dblockingprovider.php
@@ -93,11 +93,13 @@ class DBLockingProvider extends AbstractLockingProvider {
 	 * @param \OCP\IDBConnection $connection
 	 * @param \OCP\ILogger $logger
 	 * @param \OCP\AppFramework\Utility\ITimeFactory $timeFactory
+	 * @param int $ttl
 	 */
-	public function __construct(IDBConnection $connection, ILogger $logger, ITimeFactory $timeFactory) {
+	public function __construct(IDBConnection $connection, ILogger $logger, ITimeFactory $timeFactory, $ttl = 3600) {
 		$this->connection = $connection;
 		$this->logger = $logger;
 		$this->timeFactory = $timeFactory;
+		$this->ttl = $ttl;
 	}
 
 	/**
@@ -117,7 +119,7 @@ class DBLockingProvider extends AbstractLockingProvider {
 	 * @return int
 	 */
 	protected function getExpireTime() {
-		return $this->timeFactory->getTime() + self::TTL;
+		return $this->timeFactory->getTime() + $this->ttl;
 	}
 
 	/**

--- a/lib/private/lock/memcachelockingprovider.php
+++ b/lib/private/lock/memcachelockingprovider.php
@@ -33,14 +33,16 @@ class MemcacheLockingProvider extends AbstractLockingProvider {
 
 	/**
 	 * @param \OCP\IMemcache $memcache
+	 * @param int $ttl
 	 */
-	public function __construct(IMemcache $memcache) {
+	public function __construct(IMemcache $memcache, $ttl = 3600) {
 		$this->memcache = $memcache;
+		$this->ttl = $ttl;
 	}
 
 	private function setTTL($path) {
 		if ($this->memcache instanceof IMemcacheTTL) {
-			$this->memcache->setTTL($path, self::TTL);
+			$this->memcache->setTTL($path, $this->ttl);
 		}
 	}
 

--- a/tests/lib/lock/dblockingprovider.php
+++ b/tests/lib/lock/dblockingprovider.php
@@ -64,7 +64,7 @@ class DBLockingProvider extends LockingProvider {
 	 */
 	protected function getInstance() {
 		$this->connection = \OC::$server->getDatabaseConnection();
-		return new \OC\Lock\DBLockingProvider($this->connection, \OC::$server->getLogger(), $this->timeFactory);
+		return new \OC\Lock\DBLockingProvider($this->connection, \OC::$server->getLogger(), $this->timeFactory, 3600);
 	}
 
 	public function tearDown() {
@@ -81,7 +81,7 @@ class DBLockingProvider extends LockingProvider {
 		$this->instance->acquireLock('bar', ILockingProvider::LOCK_EXCLUSIVE);
 		$this->instance->changeLock('asd', ILockingProvider::LOCK_SHARED);
 
-		$this->currentTime = 150 + \OC\Lock\DBLockingProvider::TTL;
+		$this->currentTime = 150 + 3600;
 
 		$this->assertEquals(3, $this->getLockEntryCount());
 


### PR DESCRIPTION
Fixes #22591

Makes the lock ttl configurable in `config.php` and changes the default ttl to be either 1 hour or the php max_execution_time, whichever is higher.

By using max_execution_time as ttl we make sure we don't run into the issue of removing a lock of a process that's still running.

@Ma1kavian can you verify that this fixes the problem (undo the change to the ttl you made and apply this patch, you shouldn't need to configure the ttl manually since it takes the max_execution_time into account)

cc @PVince81
