### PR TITLE
Return 401 DummyBasicAuth in case of ajax call in public link page

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -32,7 +32,7 @@ OC_App::loadApps($RUNTIME_APPTYPES);
 OC_Util::obEnd();
 
 // Backends
-$authBackend = new OCA\DAV\Connector\PublicAuth(\OC::$server->getConfig());
+$authBackend = new OCA\DAV\Connector\PublicAuth(\OC::$server->getConfig(), \OC::$server->getRequest());
 
 $serverFactory = new OCA\DAV\Connector\Sabre\ServerFactory(
 	\OC::$server->getConfig(),

--- a/apps/dav/lib/connector/publicauth.php
+++ b/apps/dav/lib/connector/publicauth.php
@@ -26,6 +26,7 @@
 
 namespace OCA\DAV\Connector;
 
+use OCP\IConfig;
 use OCP\IRequest;
 
 class PublicAuth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
@@ -46,7 +47,8 @@ class PublicAuth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
 	 * @param \OCP\IConfig $config
 	 * @param IRequest $request
 	 */
-	public function __construct($config, $request) {
+	public function __construct(IConfig $config,
+								IRequest $request) {
 		$this->config = $config;
 		$this->request = $request;
 	}
@@ -61,6 +63,7 @@ class PublicAuth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
 	 * @param string $password
 	 *
 	 * @return bool
+	 * @throws \Sabre\DAV\Exception\NotAuthenticated
 	 */
 	protected function validateUserPass($username, $password) {
 		$linkItem = \OCP\Share::getShareByToken($username, false);
@@ -103,7 +106,7 @@ class PublicAuth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
 				} else {
 					if (in_array('XMLHttpRequest', explode(',', $this->request->getHeader('X-Requested-With')))) {
 						// do not re-authenticate over ajax, use dummy auth name to prevent browser popup
-						header('Status: 401');
+						http_response_code(401);
 						header('WWW-Authenticate', 'DummyBasic real="ownCloud"');
 						throw new \Sabre\DAV\Exception\NotAuthenticated('Cannot authenticate over ajax calls');
 					}


### PR DESCRIPTION
Very crude due to `header`. Need to take more time to look into how to use Sabre's request/response, or might need a bit of refactoring / moving around code to make it look like https://github.com/owncloud/core/blob/v9.0.0/apps/dav/lib/connector/sabre/auth.php#L165 which happens in the `auth` method, but `PublicAuth` doesn't have it...

@LukasReschke what do you think ?

When using the steps from https://github.com/owncloud/core/issues/23066#issuecomment-200871655, instead of showing the browser's basic auth dialog it will refresh the page, and correctly show the password field page again.
