### PR TITLE
[stable8.2] Read available l10n files also from theme folder

### DIFF
--- a/lib/private/l10n.php
+++ b/lib/private/l10n.php
@@ -190,15 +190,15 @@ class OC_L10N implements \OCP\IL10N {
 				)
 				&& file_exists($transFile)) {
 				// load the translations file
-				if($this->load($transFile)) {
-					//merge with translations from theme
-					$theme = \OC::$server->getConfig()->getSystemValue('theme');
-					if (!empty($theme)) {
-						$transFile = OC::$SERVERROOT.'/themes/'.$theme.substr($transFile, strlen(OC::$SERVERROOT));
-						if (file_exists($transFile)) {
-							$this->load($transFile, true);
-						}
-					}
+				$this->load($transFile);
+			}
+
+			//merge with translations from theme
+			$theme = \OC::$server->getConfig()->getSystemValue('theme');
+			if (!empty($theme)) {
+				$transFile = OC::$SERVERROOT.'/themes/'.$theme.substr($transFile, strlen(OC::$SERVERROOT));
+				if (file_exists($transFile)) {
+					$this->load($transFile, true);
 				}
 			}
 
@@ -476,6 +476,22 @@ class OC_L10N implements \OCP\IL10N {
 				if(substr($file, -5, 5) === '.json' && substr($file, 0, 4) !== 'l10n') {
 					$i = substr($file, 0, -5);
 					$available[] = $i;
+				}
+			}
+		}
+
+		$config = \OC::$server->getConfig();
+		// merge with translations from theme
+		$theme = $config->getSystemValue('theme');
+		if(!empty($theme)) {
+			$themeDir = \OC::$SERVERROOT . '/themes/' . $theme . substr($dir, strlen(\OC::$SERVERROOT));
+			if(is_dir($themeDir)) {
+				$files=scandir($dir);
+				foreach($files as $file) {
+					if(substr($file, -5, 5) === '.json' && substr($file, 0, 4) !== 'l10n') {
+						$i = substr($file, 0, -5);
+						$available[] = $i;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The old behaviour was that only languages could be used for an app
that are already present in the apps/$app/l10n folder. If there is
a themed l10n that is not present in the apps default l10n folder
the language could not be used and the texts are not translated.

With this change this is possible and also the l10n files are
loaded even if the default l10n doesn't contain the l10n file.

Stable8.2 version of #23362 

Approval in https://github.com/owncloud/core/pull/23362#issuecomment-200316254

I tested this and it works fine :) I need to remove the tests as this is the static code stuff that was refactored for 9.0
