### PR TITLE
[stable9] Fix for themes with .jpg backgrounds

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -64,7 +64,7 @@
   Options -MultiViews
   RewriteRule ^core/js/oc.js$ index.php [PT,E=PATH_INFO:$1]
   RewriteRule ^core/preview.png$ index.php [PT,E=PATH_INFO:$1]
-  RewriteCond %{REQUEST_FILENAME} !\.(css|js|svg|gif|png|html|ttf|woff|ico)$
+  RewriteCond %{REQUEST_FILENAME} !\.(css|js|svg|gif|png|html|ttf|woff|ico|jpg|jpeg)$
   RewriteCond %{REQUEST_FILENAME} !core/img/favicon.ico$
   RewriteCond %{REQUEST_FILENAME} !/remote.php
   RewriteCond %{REQUEST_FILENAME} !/public.php


### PR DESCRIPTION
Without this all themes with .jpg or .jpeg are broken.

Fix for #23239
