### PR TITLE
only remove avatars from the folder we store them in

### DIFF
--- a/lib/private/avatar.php
+++ b/lib/private/avatar.php
@@ -134,7 +134,7 @@ class Avatar implements IAvatar {
 	*/
 	public function remove () {
 		$regex = '/^avatar\.([0-9]+\.)?(jpg|png)$/';
-		$avatars = $this->folder->search('avatar');
+		$avatars = $this->folder->getDirectoryListing();
 
 		foreach ($avatars as $avatar) {
 			if (preg_match($regex, $avatar->getName())) {

--- a/tests/lib/avatartest.php
+++ b/tests/lib/avatartest.php
@@ -148,8 +148,7 @@ class AvatarTest extends \Test\TestCase {
 			->willReturn('avatarX');
 		$nonAvatarFile->expects($this->never())->method('delete');
 
-		$this->folder->method('search')
-			->with('avatar')
+		$this->folder->method('getDirectoryListing')
 			->willReturn([$avatarFileJPG, $avatarFilePNG, $resizedAvatarFile, $nonAvatarFile]);
 
 		$newFile = $this->getMock('\OCP\Files\File');


### PR DESCRIPTION
Currently it removes **all** files named `avatar.png`/`avatar.jpg` stored in the users filesystem which can lead to data loss

@PVince81 @cmonteroluque might be high priority, fixes a (very specific) data loss issue

To test:
- upload a file called `avatar.png`/`avatar.jpg` somewhere in ownCloud
- change or remove your avatar
- verify that the upload image still exists.

cc @rullzer @MorrisJobke
