### PR TITLE
Load all enabled apps in remote.php

### DIFF
--- a/remote.php
+++ b/remote.php
@@ -119,8 +119,7 @@ try {
 
 	// Load all required applications
 	\OC::$REQUESTEDAPP = $app;
-	OC_App::loadApps(array('authentication'));
-	OC_App::loadApps(array('filesystem', 'logging'));
+	\OC_App::loadApps();
 
 	switch ($app) {
 		case 'core':


### PR DESCRIPTION
Fixes #20564
Apps need to be able to listen to events triggered in Files (now that most operations use the DAV client) or remotely.

I think it's a regression since some of the events were probably caught by apps when Files was using its own ajax endpoints.

@DeepDiver1975 @PVince81 @MorrisJobke @LukasReschke @Xenopathic @stevenbuehner @athorel-asi @tombou
