### PR TITLE
Fix paths returned by \OC\Files\Storage\Shared hooks

### DIFF
--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -321,7 +321,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		$source = $this->getSourcePath($path);
 		if ($source) {
 			$info = array(
-				'target' => $this->getMountPoint() . $path,
+				'target' => $this->getMountPoint() . '/' . $path,
 				'source' => $source,
 			);
 			\OCP\Util::emitHook('\OC\Files\Storage\Shared', 'file_get_contents', $info);
@@ -460,7 +460,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 					}
 			}
 			$info = array(
-				'target' => $this->getMountPoint() . $path,
+				'target' => $this->getMountPoint() . '/' . $path,
 				'source' => $source,
 				'mode' => $mode,
 			);


### PR DESCRIPTION
Fixes #23620

All targets in hooks should look like this:

'target' => $this->getMountPoint() . '/' . $path
- [ ] Add a test since this was missed...

@rullzer @PVince81
