### PR TITLE
xcache.var_size with 64M should evaluate to isAvailable

### DIFF
--- a/lib/private/memcache/xcache.php
+++ b/lib/private/memcache/xcache.php
@@ -125,7 +125,7 @@ class XCache extends Cache implements IMemcache {
 			// AND administration functions are password-protected.
 			return false;
 		}
-		$var_size = \OC::$server->getIniWrapper()->getNumeric('xcache.var_size');
+		$var_size = \OC::$server->getIniWrapper()->getBytes('xcache.var_size');
 		if (!$var_size) {
 			return false;
 		}


### PR DESCRIPTION
Fix #23653 

@karlitschek should backport to 9.0

@LukasReschke @PVince81 @icewind1991
