### PR TITLE
Use the shipped cacerts.pem instead of the global one

### DIFF
--- a/apps/files_external/lib/google.php
+++ b/apps/files_external/lib/google.php
@@ -445,6 +445,7 @@ class Google extends \OC\Files\Storage\Common {
 							$client->get($downloadUrl, [
 								'headers' => $httpRequest->getRequestHeaders(),
 								'save_to' => $tmpFile,
+								'verify' => __DIR__ . '/../3rdparty/google-api-php-client/src/Google/IO/cacerts.pem',
 							]);
 						} catch (RequestException $e) {
 							if(!is_null($e->getResponse())) {


### PR DESCRIPTION
The one we ship may cause problems since Equifax is not included anymore (SHA-1 certs are deprecated). We should just be consistent here and also use the certificate file which is used by the other calls in the library.

cc @PVince81 Caused by the recent changes you have done here. Mind testing? Might also fix https://github.com/owncloud/core/pull/23518#issuecomment-203381720
