### PR TITLE
[stable9] Use the shipped cacerts.pem instead of the global one

### DIFF
--- a/apps/files_external/lib/google.php
+++ b/apps/files_external/lib/google.php
@@ -445,6 +445,7 @@ class Google extends \OC\Files\Storage\Common {
 							$client->get($downloadUrl, [
 								'headers' => $httpRequest->getRequestHeaders(),
 								'save_to' => $tmpFile,
+								'verify' => __DIR__ . '/../3rdparty/google-api-php-client/src/Google/IO/cacerts.pem',
 							]);
 						} catch (RequestException $e) {
 							if(!is_null($e->getResponse())) {


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/23660
