### PR TITLE
Fix displaying owner before share icon in file list

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -111,8 +111,9 @@
 
 				_.each($files, function(file) {
 					var $tr = $(file);
-					var shareTypes = $tr.attr('data-share-types');
-					if (shareTypes) {
+					var shareTypes = $tr.attr('data-share-types') || '';
+					var shareOwner = $tr.attr('data-share-owner');
+					if (shareTypes || shareOwner) {
 						var hasLink = false;
 						var hasShares = false;
 						_.each(shareTypes.split(',') || [], function(shareType) {

--- a/apps/files_sharing/tests/js/shareSpec.js
+++ b/apps/files_sharing/tests/js/shareSpec.js
@@ -141,7 +141,7 @@ describe('OCA.Sharing.Util tests', function() {
 				permissions: OC.PERMISSION_ALL,
 				shareOwner: 'User One',
 				etag: 'abc',
-				shareTypes: [OC.Share.SHARE_TYPE_USER]
+				shareTypes: []
 			}]);
 			$tr = fileList.$el.find('tbody tr:first');
 			$action = $tr.find('.action-share');


### PR DESCRIPTION
Initial display of owner was missing

Fixes https://github.com/owncloud/core/issues/23645

@rullzer @schiesbn @icewind1991 @MorrisJobke @nickvergessen please review

@karlitschek backport for 9.0.1 to fix regression ?
