### PR TITLE
Use RetryWrapper for SFTP storage

### DIFF
--- a/apps/files_external/lib/sftp.php
+++ b/apps/files_external/lib/sftp.php
@@ -32,6 +32,7 @@
 namespace OC\Files\Storage;
 use Icewind\Streams\IteratorDirectory;
 
+use Icewind\Streams\RetryWrapper;
 use phpseclib\Net\SFTP\Stream;
 
 /**
@@ -374,7 +375,8 @@ class SFTP extends \OC\Files\Storage\Common {
 				case 'c':
 				case 'c+':
 					$context = stream_context_create(array('sftp' => array('session' => $this->getConnection())));
-					return fopen($this->constructUrl($path), $mode, false, $context);
+					$handle = fopen($this->constructUrl($path), $mode, false, $context);
+					return RetryWrapper::wrap($handle);
 			}
 		} catch (\Exception $e) {
 		}


### PR DESCRIPTION
Equivalent to https://github.com/owncloud/core/pull/23442

Required for making encryption work with external storage reliable. Part of https://github.com/owncloud/core/issues/23657

cc @karlitschek Backport to 9.0.1? It's the same what @schiesbn did to the FTP wrapper already. 
cc @owncloud/qa Please test as well. THX.
