### PR TITLE
Add capability to show if group sharing is enabled

### DIFF
--- a/apps/files_sharing/lib/capabilities.php
+++ b/apps/files_sharing/lib/capabilities.php
@@ -74,6 +74,8 @@ class Capabilities implements ICapability {
 			$res['user']['send_mail'] = $this->config->getAppValue('core', 'shareapi_allow_mail_notification', 'no') === 'yes';
 
 			$res['resharing'] = $this->config->getAppValue('core', 'shareapi_allow_resharing', 'yes') === 'yes';
+
+			$res['group_sharing'] = $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes') === 'yes';
 		}
 
 		//Federated sharing

--- a/apps/files_sharing/tests/capabilities.php
+++ b/apps/files_sharing/tests/capabilities.php
@@ -243,6 +243,24 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 		$this->assertFalse($result['public']['upload']);
 	}
 
+	public function testNoGroupSharing() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_allow_group_sharing', 'yes', 'no'],
+		];
+		$result = $this->getResults($map);
+		$this->assertFalse($result['group_sharing']);
+	}
+
+	public function testGroupSharing() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_allow_group_sharing', 'yes', 'yes'],
+		];
+		$result = $this->getResults($map);
+		$this->assertTrue($result['group_sharing']);
+	}
+
 	public function testFederatedSharingIncomming() {
 		$map = [
 			['files_sharing', 'incoming_server2server_share_enabled', 'yes', 'yes'],

--- a/build/integration/capabilities_features/capabilities.feature
+++ b/build/integration/capabilities_features/capabilities.feature
@@ -16,6 +16,7 @@ Feature: capabilities
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | 1 |
+			| files_sharing | group_sharing         | 1 |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -35,6 +36,7 @@ Feature: capabilities
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | 1 |
+			| files_sharing | group_sharing         | 1 |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -73,6 +75,7 @@ Feature: capabilities
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | 1 |
+			| files_sharing | group_sharing         | 1 |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -92,6 +95,7 @@ Feature: capabilities
 			| files_sharing | resharing | EMPTY |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | 1 |
+			| files_sharing | group_sharing         | 1 |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -111,6 +115,7 @@ Feature: capabilities
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | EMPTY |
 			| files_sharing | federation@@@incoming | 1 |
+			| files_sharing | group_sharing         | 1 |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -130,6 +135,7 @@ Feature: capabilities
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | EMPTY |
+			| files_sharing | group_sharing         | 1 |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -150,6 +156,7 @@ Feature: capabilities
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | 1 |
+			| files_sharing | group_sharing         | 1 |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -170,6 +177,7 @@ Feature: capabilities
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | 1 |
+			| files_sharing | group_sharing         | 1 |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -190,6 +198,7 @@ Feature: capabilities
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | 1 |
+			| files_sharing | group_sharing         | 1 |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -212,6 +221,27 @@ Feature: capabilities
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | 1 |
+			| files_sharing | group_sharing         | 1 |
+			| files | bigfilechunking | 1 |
+			| files | undelete | 1 |
+			| files | versioning | 1 |
+
+	Scenario: Changing group sharing allowed
+		Given As an "admin"
+		And parameter "shareapi_allow_group_sharing" of app "core" is set to "no"
+		When sending "GET" to "/cloud/capabilities"
+		Then the HTTP status code should be "200"
+		And fields of capabilities match with
+			| capability | path_to_element | value |
+			| core | pollinterval | 60 |
+			| core | webdav-root | remote.php/webdav |
+			| files_sharing | api_enabled | 1 |
+			| files_sharing | public@@@enabled | 1 |
+			| files_sharing | public@@@upload | 1 |
+			| files_sharing | resharing | 1 |
+			| files_sharing | federation@@@outgoing | 1 |
+			| files_sharing | federation@@@incoming | 1 |
+			| files_sharing | group_sharing         | EMPTY |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |

--- a/build/integration/features/bootstrap/CapabilitiesContext.php
+++ b/build/integration/features/bootstrap/CapabilitiesContext.php
@@ -51,5 +51,6 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 		$this->modifyServerConfig('core', 'shareapi_allow_public_notification', 'no');
 		$this->modifyServerConfig('core', 'shareapi_default_expire_date', 'no');
 		$this->modifyServerConfig('core', 'shareapi_enforce_expire_date', 'no');
+		$this->modifyServerConfig('core', 'shareapi_allow_group_sharing', 'yes');
 	}
 }


### PR DESCRIPTION
fixes #23477

Now clients can correct wording to properly reflect who a user can share with.

CC: @MorrisJobke @PVince81 @nickvergessen
