### PR TITLE
Fixed Issue 23594 - Invalid 'Help translate' link

### DIFF
--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -160,7 +160,7 @@ if($_['passwordChangeSupported']) {
 		<?php endforeach;?>
 	</select>
 	<?php if (OC_Util::getEditionString() === ''): ?>
-	<a href="https://www.transifex.com/projects/p/owncloud/team/<?php p($_['activelanguage']['code']);?>/"
+	<a href="https://www.transifex.com/projects/p/owncloud/"
 		target="_blank" rel="noreferrer">
 		<em><?php p($l->t('Help translate'));?></em>
 	</a>


### PR DESCRIPTION
Changed the for 'Help Translate' to the correct one because the previous one gave a 403 Forbidden access error. This fixes the issue #23594.
