### PR TITLE
Make sure that the encrypted version is set

### DIFF
--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -104,7 +104,7 @@ class Encryption extends Wrapper {
 			Update $update = null,
 			Manager $mountManager = null
 		) {
-		
+
 		$this->mountPoint = $parameters['mountPoint'];
 		$this->mount = $parameters['mount'];
 		$this->encryptionManager = $encryptionManager;
@@ -167,20 +167,25 @@ class Encryption extends Wrapper {
 			return null;
 		}
 		$fullPath = $this->getFullPath($path);
+		$info = $this->getCache()->get($path);
 
 		if (isset($this->unencryptedSize[$fullPath])) {
 			$data['encrypted'] = true;
 			$data['size'] = $this->unencryptedSize[$fullPath];
 		} else {
-			$info = $this->getCache()->get($path);
 			if (isset($info['fileid']) && $info['encrypted']) {
 				$data['size'] = $this->verifyUnencryptedSize($path, $info['size']);
 				$data['encrypted'] = true;
 			}
 		}
 
+		if (isset($info['encryptedVersion']) && $info['encryptedVersion'] > 1) {
+			$data['encryptedVersion'] = $info['encryptedVersion'];
+		}
+
 		return $data;
 	}
+
 	/**
 	 * see http://php.net/manual/en/function.file_get_contents.php
 	 *

--- a/tests/lib/files/storage/wrapper/encryption.php
+++ b/tests/lib/files/storage/wrapper/encryption.php
@@ -255,25 +255,39 @@ class Encryption extends Storage {
 			$this->invokePrivate($this->instance, 'unencryptedSize', [[$path => $storedUnencryptedSize]]);
 		}
 
-
+		$fileEntry = $this->getMockBuilder('\OC\Files\Cache\Cache')
+			->disableOriginalConstructor()->getMock();
 		$sourceStorage->expects($this->once())->method('getMetaData')->with($path)
 			->willReturn($metaData);
+		$sourceStorage->expects($this->any())
+			->method('getCache')
+			->with($path)
+			->willReturn($fileEntry);
+		$fileEntry->expects($this->any())
+			->method('get')
+			->with($metaData['fileid']);
 
 		$this->instance->expects($this->any())->method('getCache')->willReturn($cache);
 		$this->instance->expects($this->any())->method('verifyUnencryptedSize')
 			->with($path, 0)->willReturn($expected['size']);
 
 		$result = $this->instance->getMetaData($path);
-		$this->assertSame($expected['encrypted'], $result['encrypted']);
+		if(isset($expected['encrypted'])) {
+			$this->assertSame($expected['encrypted'], (bool)$result['encrypted']);
+
+			if(isset($expected['encryptedVersion'])) {
+				$this->assertSame($expected['encryptedVersion'], $result['encryptedVersion']);
+			}
+		}
 		$this->assertSame($expected['size'], $result['size']);
 	}
 
 	public function dataTestGetMetaData() {
 		return [
-			['/test.txt', ['size' => 42, 'encrypted' => false], true, true, 12, ['size' => 12, 'encrypted' => true]],
+			['/test.txt', ['size' => 42, 'encrypted' => 2, 'encryptedVersion' => 2, 'fileid' => 1], true, true, 12, ['size' => 12, 'encrypted' => true, 'encryptedVersion' => 2]],
 			['/test.txt', null, true, true, 12, null],
-			['/test.txt', ['size' => 42, 'encrypted' => false], false, false, 12, ['size' => 42, 'encrypted' => false]],
-			['/test.txt', ['size' => 42, 'encrypted' => false], true, false, 12, ['size' => 12, 'encrypted' => true]]
+			['/test.txt', ['size' => 42, 'encrypted' => 0, 'fileid' => 1], false, false, 12, ['size' => 42, 'encrypted' => false]],
+			['/test.txt', ['size' => 42, 'encrypted' => false, 'fileid' => 1], true, false, 12, ['size' => 12, 'encrypted' => true]]
 		];
 	}
 


### PR DESCRIPTION
The code path called when using external storage with WebDAV is using `\OC\Files\Storage\Wrapper\Encryption::getMetaData` which did not contain the actual encrypted version inside the cache entry version. This lead to the following:
1. User uploaded a file
2. File is created and `\OC\Files\Storage\Wrapper\Encryption::getMetaData` is called. It has an empty `encryptedVersion` but sets `encrypted` to either `true` or `false`.
3. The call when updating the file cache will use the old version.

<hr/>

Makes some encryption cases work properly again together with  https://github.com/owncloud/core/pull/23675

cc @schiesbn @PVince81 Please test.
