### PR TITLE
[stable8.2] fix creation of versions of encrypted files on external storages

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -719,7 +719,8 @@ class OC {
 	}
 
 	private static function registerEncryptionWrapper() {
-		\OCP\Util::connectHook('OC_Filesystem', 'preSetup', 'OC\Encryption\Manager', 'setupStorage');
+		$manager = self::$server->getEncryptionManager();
+		\OCP\Util::connectHook('OC_Filesystem', 'preSetup', $manager, 'setupStorage');
 	}
 
 	private static function registerEncryptionHooks() {

--- a/lib/private/encryption/encryptionwrapper.php
+++ b/lib/private/encryption/encryptionwrapper.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OC\Encryption;
+
+
+use OC\Memcache\ArrayCache;
+use OC\Files\Filesystem;
+use OC\Files\Storage\Wrapper\Encryption;
+use OCP\Files\Mount\IMountPoint;
+use OC\Files\View;
+use OCP\Files\Storage;
+use OCP\ILogger;
+
+/**
+ * Class EncryptionWrapper
+ *
+ * applies the encryption storage wrapper
+ *
+ * @package OC\Encryption
+ */
+class EncryptionWrapper {
+
+	/** @var ArrayCache  */
+	private $arrayCache;
+
+	/** @var  Manager */
+	private $manager;
+
+	/** @var  ILogger */
+	private $logger;
+
+	/**
+	 * EncryptionWrapper constructor.
+	 *
+	 * @param ArrayCache $arrayCache
+	 * @param Manager $manager
+	 * @param ILogger $logger
+	 */
+	public function __construct(ArrayCache $arrayCache,
+								Manager $manager,
+								ILogger $logger
+	) {
+		$this->arrayCache = $arrayCache;
+		$this->manager = $manager;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Wraps the given storage when it is not a shared storage
+	 *
+	 * @param string $mountPoint
+	 * @param Storage $storage
+	 * @param IMountPoint $mount
+	 * @return Encryption|Storage
+	 */
+	public function wrapStorage($mountPoint, Storage $storage, IMountPoint $mount) {
+		$parameters = [
+			'storage' => $storage,
+			'mountPoint' => $mountPoint,
+			'mount' => $mount
+		];
+
+		if (!$storage->instanceOfStorage('OC\Files\Storage\Shared')
+			&& !$storage->instanceOfStorage('OCA\Files_Sharing\External\Storage')
+			&& !$storage->instanceOfStorage('OC\Files\Storage\OwnCloud')) {
+
+			$user = \OC::$server->getUserSession()->getUser();
+			$mountManager = Filesystem::getMountManager();
+			$uid = $user ? $user->getUID() : null;
+			$fileHelper = \OC::$server->getEncryptionFilesHelper();
+			$keyStorage = \OC::$server->getEncryptionKeyStorage();
+
+			$util = new Util(
+				new View(),
+				\OC::$server->getUserManager(),
+				\OC::$server->getGroupManager(),
+				\OC::$server->getConfig()
+			);
+			$update = new Update(
+				new View(),
+				$util,
+				Filesystem::getMountManager(),
+				$this->manager,
+				$fileHelper,
+				$uid
+			);
+			return new Encryption(
+				$parameters,
+				$this->manager,
+				$util,
+				$this->logger,
+				$fileHelper,
+				$uid,
+				$keyStorage,
+				$update,
+				$mountManager,
+				$this->arrayCache
+			);
+		} else {
+			return $storage;
+		}
+	}
+
+}

--- a/lib/private/encryption/util.php
+++ b/lib/private/encryption/util.php
@@ -28,10 +28,8 @@ use OC\Encryption\Exceptions\EncryptionHeaderKeyExistsException;
 use OC\Encryption\Exceptions\EncryptionHeaderToLargeException;
 use OC\Encryption\Exceptions\ModuleDoesNotExistsException;
 use OC\Files\Filesystem;
-use OC\Files\Storage\Wrapper\Encryption;
 use OC\Files\View;
 use OCP\Encryption\IEncryptionModule;
-use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage;
 use OCP\IConfig;
 
@@ -392,52 +390,4 @@ class Util {
 		return $this->config->getAppValue('core', 'encryption_key_storage_root', '');
 	}
 
-	/**
-	 * Wraps the given storage when it is not a shared storage
-	 *
-	 * @param string $mountPoint
-	 * @param Storage $storage
-	 * @param IMountPoint $mount
-	 * @return Encryption|Storage
-	 */
-	public function wrapStorage($mountPoint, Storage $storage, IMountPoint $mount) {
-		$parameters = [
-			'storage' => $storage,
-			'mountPoint' => $mountPoint,
-			'mount' => $mount];
-
-		if (!$storage->instanceOfStorage('OC\Files\Storage\Shared')
-			&& !$storage->instanceOfStorage('OCA\Files_Sharing\External\Storage')
-			&& !$storage->instanceOfStorage('OC\Files\Storage\OwnCloud')) {
-
-			$manager = \OC::$server->getEncryptionManager();
-			$user = \OC::$server->getUserSession()->getUser();
-			$logger = \OC::$server->getLogger();
-			$mountManager = Filesystem::getMountManager();
-			$uid = $user ? $user->getUID() : null;
-			$fileHelper = \OC::$server->getEncryptionFilesHelper();
-			$keyStorage = \OC::$server->getEncryptionKeyStorage();
-			$update = new Update(
-				new View(),
-				$this,
-				Filesystem::getMountManager(),
-				$manager,
-				$fileHelper,
-				$uid
-			);
-			return new Encryption(
-				$parameters,
-				$manager,
-				$this,
-				$logger,
-				$fileHelper,
-				$uid,
-				$keyStorage,
-				$update,
-				$mountManager
-			);
-		} else {
-			return $storage;
-		}
-	}
 }

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -55,6 +55,7 @@ use OC\Lock\DBLockingProvider;
 use OC\Lock\MemcacheLockingProvider;
 use OC\Lock\NoopLockingProvider;
 use OC\Mail\Mailer;
+use OC\Memcache\ArrayCache;
 use OC\Notification\Manager;
 use OC\Security\CertificateManager;
 use OC\Security\Crypto;
@@ -106,7 +107,8 @@ class Server extends SimpleContainer implements IServerContainer {
 				$c->getLogger(),
 				$c->getL10N('core'),
 				new View(),
-				$util
+				$util,
+				new ArrayCache()
 			);
 		});
 

--- a/tests/lib/encryption/encryptionwrappertest.php
+++ b/tests/lib/encryption/encryptionwrappertest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace Test\Encryption;
+
+
+use OC\Encryption\EncryptionWrapper;
+use Test\TestCase;
+
+class EncryptionWrapperTest extends TestCase {
+
+	/** @var  EncryptionWrapper */
+	private $instance;
+
+	/** @var  \PHPUnit_Framework_MockObject_MockObject | \OCP\ILogger */
+	private $logger;
+
+	/** @var  \PHPUnit_Framework_MockObject_MockObject | \OC\Encryption\Manager */
+	private $manager;
+
+	/** @var  \PHPUnit_Framework_MockObject_MockObject | \OC\Memcache\ArrayCache */
+	private $arrayCache;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->arrayCache = $this->getMock('OC\Memcache\ArrayCache');
+		$this->manager = $this->getMockBuilder('OC\Encryption\Manager')
+			->disableOriginalConstructor()->getMock();
+		$this->logger = $this->getMock('OCP\ILogger');
+
+		$this->instance = new EncryptionWrapper($this->arrayCache, $this->manager, $this->logger);
+	}
+
+
+	/**
+	 * @dataProvider provideWrapStorage
+	 */
+	public function testWrapStorage($expectedWrapped, $wrappedStorages) {
+		$storage = $this->getMockBuilder('OC\Files\Storage\Storage')
+			->disableOriginalConstructor()
+			->getMock();
+
+		foreach ($wrappedStorages as $wrapper) {
+			$storage->expects($this->any())
+				->method('instanceOfStorage')
+				->willReturnMap([
+					[$wrapper, true],
+				]);
+		}
+
+		$mount = $this->getMockBuilder('OCP\Files\Mount\IMountPoint')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$returnedStorage = $this->instance->wrapStorage('mountPoint', $storage, $mount);
+
+		$this->assertEquals(
+			$expectedWrapped,
+			$returnedStorage->instanceOfStorage('OC\Files\Storage\Wrapper\Encryption'),
+			'Asserted that the storage is (not) wrapped with encryption'
+		);
+	}
+
+	public function provideWrapStorage() {
+		return [
+			// Wrap when not wrapped or not wrapped with storage
+			[true, []],
+			[true, ['OCA\Files_Trashbin\Storage']],
+
+			// Do not wrap shared storages
+			[false, ['OC\Files\Storage\Shared']],
+			[false, ['OCA\Files_Sharing\External\Storage']],
+			[false, ['OC\Files\Storage\OwnCloud']],
+			[false, ['OC\Files\Storage\Shared', 'OCA\Files_Sharing\External\Storage']],
+			[false, ['OC\Files\Storage\Shared', 'OC\Files\Storage\OwnCloud']],
+			[false, ['OCA\Files_Sharing\External\Storage', 'OC\Files\Storage\OwnCloud']],
+			[false, ['OC\Files\Storage\Shared', 'OCA\Files_Sharing\External\Storage', 'OC\Files\Storage\OwnCloud']],
+		];
+	}
+
+}

--- a/tests/lib/encryption/managertest.php
+++ b/tests/lib/encryption/managertest.php
@@ -24,6 +24,9 @@ class ManagerTest extends TestCase {
 
 	/** @var \PHPUnit_Framework_MockObject_MockObject */
 	private $util;
+	
+	/** @var  \PHPUnit_Framework_MockObject_MockObject | \OC\Memcache\ArrayCache */
+	private $arrayCache;
 
 	public function setUp() {
 		parent::setUp();
@@ -32,7 +35,8 @@ class ManagerTest extends TestCase {
 		$this->l10n = $this->getMock('\OCP\Il10n');
 		$this->view = $this->getMock('\OC\Files\View');
 		$this->util = $this->getMockBuilder('\OC\Encryption\Util')->disableOriginalConstructor()->getMock();
-		$this->manager = new Manager($this->config, $this->logger, $this->l10n, $this->view, $this->util);
+		$this->arrayCache = $this->getMock('OC\Memcache\ArrayCache');
+		$this->manager = new Manager($this->config, $this->logger, $this->l10n, $this->view, $this->util, $this->arrayCache);
 	}
 
 	public function testManagerIsDisabled() {

--- a/tests/lib/encryption/utiltest.php
+++ b/tests/lib/encryption/utiltest.php
@@ -188,49 +188,4 @@ class UtilTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider provideWrapStorage
-	 */
-	public function testWrapStorage($expectedWrapped, $wrappedStorages) {
-		$storage = $this->getMockBuilder('OC\Files\Storage\Storage')
-			->disableOriginalConstructor()
-			->getMock();
-
-		foreach ($wrappedStorages as $wrapper) {
-			$storage->expects($this->any())
-				->method('instanceOfStorage')
-				->willReturnMap([
-					[$wrapper, true],
-				]);
-		}
-
-		$mount = $this->getMockBuilder('OCP\Files\Mount\IMountPoint')
-			->disableOriginalConstructor()
-			->getMock();
-
-		$returnedStorage = $this->util->wrapStorage('mountPoint', $storage, $mount);
-
-		$this->assertEquals(
-			$expectedWrapped,
-			$returnedStorage->instanceOfStorage('OC\Files\Storage\Wrapper\Encryption'),
-			'Asserted that the storage is (not) wrapped with encryption'
-		);
-	}
-
-	public function provideWrapStorage() {
-		return [
-			// Wrap when not wrapped or not wrapped with storage
-			[true, []],
-			[true, ['OCA\Files_Trashbin\Storage']],
-
-			// Do not wrap shared storages
-			[false, ['OC\Files\Storage\Shared']],
-			[false, ['OCA\Files_Sharing\External\Storage']],
-			[false, ['OC\Files\Storage\OwnCloud']],
-			[false, ['OC\Files\Storage\Shared', 'OCA\Files_Sharing\External\Storage']],
-			[false, ['OC\Files\Storage\Shared', 'OC\Files\Storage\OwnCloud']],
-			[false, ['OCA\Files_Sharing\External\Storage', 'OC\Files\Storage\OwnCloud']],
-			[false, ['OC\Files\Storage\Shared', 'OCA\Files_Sharing\External\Storage', 'OC\Files\Storage\OwnCloud']],
-		];
-	}
 }

--- a/tests/lib/files/storage/wrapper/encryption.php
+++ b/tests/lib/files/storage/wrapper/encryption.php
@@ -87,6 +87,9 @@ class Encryption extends Storage {
 	 */
 	private $config;
 
+	/** @var  \OC\Memcache\ArrayCache | \PHPUnit_Framework_MockObject_MockObject */
+	private $arrayCache;
+
 
 	/** @var  integer dummy unencrypted size */
 	private $dummySize = -1;
@@ -104,6 +107,7 @@ class Encryption extends Storage {
 			->method('getEncryptionModule')
 			->willReturn($mockModule);
 
+		$this->arrayCache = $this->getMock('OC\Memcache\ArrayCache');
 		$this->config = $this->getMockBuilder('\OCP\IConfig')
 			->disableOriginalConstructor()
 			->getMock();
@@ -111,9 +115,10 @@ class Encryption extends Storage {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->util = $this->getMock('\OC\Encryption\Util',
+		$this->util = $this->getMock(
+			'\OC\Encryption\Util',
 			['getUidAndFilename', 'isFile', 'isExcluded'],
-			[new View(), new \OC\User\Manager(), $this->groupManager, $this->config]);
+			[new View(), new \OC\User\Manager(), $this->groupManager, $this->config, $this->arrayCache]);
 		$this->util->expects($this->any())
 			->method('getUidAndFilename')
 			->willReturnCallback(function ($path) {
@@ -168,7 +173,7 @@ class Encryption extends Storage {
 						'mountPoint' => '/',
 						'mount' => $this->mount
 					],
-					$this->encryptionManager, $this->util, $this->logger, $this->file, null, $this->keyStore, $this->update, $this->mountManager
+					$this->encryptionManager, $this->util, $this->logger, $this->file, null, $this->keyStore, $this->update, $this->mountManager, $this->arrayCache
 				]
 			)
 			->setMethods(['getMetaData', 'getCache', 'getEncryptionModule'])
@@ -245,7 +250,7 @@ class Encryption extends Storage {
 						'mountPoint' => '/',
 						'mount' => $this->mount
 					],
-					$this->encryptionManager, $this->util, $this->logger, $this->file, null, $this->keyStore, $this->update, $this->mountManager
+					$this->encryptionManager, $this->util, $this->logger, $this->file, null, $this->keyStore, $this->update, $this->mountManager, $this->arrayCache
 				]
 			)
 			->setMethods(['getCache', 'verifyUnencryptedSize'])
@@ -293,7 +298,7 @@ class Encryption extends Storage {
 						'mountPoint' => '/',
 						'mount' => $this->mount
 					],
-					$this->encryptionManager, $this->util, $this->logger, $this->file, null, $this->keyStore, $this->update, $this->mountManager
+					$this->encryptionManager, $this->util, $this->logger, $this->file, null, $this->keyStore, $this->update, $this->mountManager, $this->arrayCache
 				]
 			)
 			->setMethods(['getCache', 'verifyUnencryptedSize'])
@@ -331,7 +336,7 @@ class Encryption extends Storage {
 						'mountPoint' => '/',
 						'mount' => $this->mount
 					],
-					$this->encryptionManager, $this->util, $this->logger, $this->file, null, $this->keyStore, $this->update, $this->mountManager
+					$this->encryptionManager, $this->util, $this->logger, $this->file, null, $this->keyStore, $this->update, $this->mountManager, $this->arrayCache
 				]
 			)
 			->setMethods(['fixUnencryptedSize'])
@@ -521,8 +526,15 @@ class Encryption extends Storage {
 			->disableOriginalConstructor()->getMock();
 
 		$util = $this->getMockBuilder('\OC\Encryption\Util')
-			->setConstructorArgs([new View(), new \OC\User\Manager(), $this->groupManager, $this->config])
-			->getMock();
+			->setConstructorArgs(
+				[
+					new View(),
+					new \OC\User\Manager(),
+					$this->groupManager,
+					$this->config,
+					$this->arrayCache
+				]
+			)->getMock();
 
 		$instance = $this->getMockBuilder('\OC\Files\Storage\Wrapper\Encryption')
 			->setConstructorArgs(
@@ -533,7 +545,7 @@ class Encryption extends Storage {
 						'mountPoint' => '/',
 						'mount' => $this->mount
 					],
-					$this->encryptionManager, $util, $this->logger, $this->file, null, $this->keyStore, $this->update, $this->mountManager
+					$this->encryptionManager, $util, $this->logger, $this->file, null, $this->keyStore, $this->update, $this->mountManager, $this->arrayCache
 				]
 			)
 			->setMethods(['readFirstBlock', 'parseRawHeader'])
@@ -582,7 +594,7 @@ class Encryption extends Storage {
 			->disableOriginalConstructor()->getMock();
 
 		$util = $this->getMockBuilder('\OC\Encryption\Util')
-			->setConstructorArgs([new View(), new \OC\User\Manager(), $this->groupManager, $this->config])
+			->setConstructorArgs([new View(), new \OC\User\Manager(), $this->groupManager, $this->config, $this->arrayCache])
 			->getMock();
 
 		$cache = $this->getMockBuilder('\OC\Files\Cache\Cache')
@@ -600,7 +612,7 @@ class Encryption extends Storage {
 						'mountPoint' => '/',
 						'mount' => $this->mount
 					],
-					$this->encryptionManager, $util, $this->logger, $this->file, null, $this->keyStore, $this->update, $this->mountManager
+					$this->encryptionManager, $util, $this->logger, $this->file, null, $this->keyStore, $this->update, $this->mountManager, $this->arrayCache
 				]
 			)
 			->setMethods(['readFirstBlock', 'parseRawHeader', 'getCache'])
@@ -636,7 +648,7 @@ class Encryption extends Storage {
 						'mountPoint' => '/',
 						'mount' => $this->mount
 					],
-					$this->encryptionManager, $this->util, $this->logger, $this->file, null, $this->keyStore, $this->update, $this->mountManager
+					$this->encryptionManager, $this->util, $this->logger, $this->file, null, $this->keyStore, $this->update, $this->mountManager, $this->arrayCache
 
 			);
 
@@ -706,6 +718,15 @@ class Encryption extends Storage {
 		global $mockedMountPointEncryptionEnabled;
 		$mockedMountPointEncryptionEnabled = $mountPointEncryptionEnabled;
 
+		$expectedCachePut = [
+			'encrypted' => $expectedEncrypted,
+		];
+		if($expectedEncrypted === true) {
+			$expectedCachePut['encryptedVersion'] = 12345;
+		}
+
+		$this->arrayCache->expects($this->never())->method('set');
+
 		$this->cache->expects($this->once())
 			->method('put')
 			->with($sourceInternalPath, ['encrypted' => $expectedEncrypted]);
@@ -755,7 +776,8 @@ class Encryption extends Storage {
 					null,
 					$this->keyStore,
 					$this->update,
-					$this->mountManager
+					$this->mountManager,
+					$this->arrayCache
 				]
 			)
 			->setMethods(['updateUnencryptedSize', 'getCache'])
@@ -764,6 +786,12 @@ class Encryption extends Storage {
 		$targetStorage->expects($this->once())->method('copyFromStorage')
 			->with($sourceStorage, $sourceInternalPath, $targetInternalPath)
 			->willReturn($copyResult);
+
+		$instance->expects($this->any())->method('getCache')
+			->willReturn($cache);
+
+		$this->arrayCache->expects($this->once())->method('set')
+			->with('encryption_copy_version_' . $sourceInternalPath, true);
 
 		if ($copyResult) {
 			$instance->expects($this->once())->method('getCache')

--- a/tests/lib/files/stream/encryption.php
+++ b/tests/lib/files/stream/encryption.php
@@ -31,6 +31,7 @@ class Encryption extends \Test\TestCase {
 		$config = $this->getMockBuilder('\OCP\IConfig')
 			->disableOriginalConstructor()
 			->getMock();
+		$arrayCache = $this->getMock('OC\Memcache\ArrayCache');
 		$groupManager = $this->getMockBuilder('\OC\Group\Manager')
 			->disableOriginalConstructor()
 			->getMock();
@@ -39,7 +40,11 @@ class Encryption extends \Test\TestCase {
 			->setMethods(['getAccessList'])
 			->getMock();
 		$file->expects($this->any())->method('getAccessList')->willReturn([]);
-		$util = $this->getMock('\OC\Encryption\Util', ['getUidAndFilename'], [new View(), new \OC\User\Manager(), $groupManager, $config]);
+		$util = $this->getMock(
+			'\OC\Encryption\Util',
+			['getUidAndFilename'],
+			[new View(), new \OC\User\Manager(), $groupManager, $config, $arrayCache]
+		);
 		$util->expects($this->any())
 			->method('getUidAndFilename')
 			->willReturn(['user1', $internalPath]);

--- a/tests/lib/traits/encryptiontrait.php
+++ b/tests/lib/traits/encryptiontrait.php
@@ -8,8 +8,8 @@
 
 namespace Test\Traits;
 
-use OC\Encryption\Util;
-use OC\Files\View;
+use OC\Encryption\EncryptionWrapper;
+use OC\Memcache\ArrayCache;
 use OCA\Encryption\AppInfo\Application;
 use OCA\Encryption\KeyManager;
 use OCA\Encryption\Users\Setup;
@@ -68,13 +68,13 @@ trait EncryptionTrait {
 	}
 
 	protected function postLogin() {
-		$util = new Util(
-			new View(),
-			\OC::$server->getUserManager(),
-			\OC::$server->getGroupManager(),
-			\OC::$server->getConfig()
+		$encryptionWrapper = new EncryptionWrapper(
+			new ArrayCache(),
+			\OC::$server->getEncryptionManager(),
+			\OC::$server->getLogger()
 		);
-		$this->registerStorageWrapper('oc_encryption', array($util, 'wrapStorage'));
+
+		$this->registerStorageWrapper('oc_encryption', array($encryptionWrapper, 'wrapStorage'));
 	}
 
 	protected function setUpEncryptionTrait() {


### PR DESCRIPTION
approved backport of #23675

in order to create a 1:1 copy of a file if a version gets created
we need to store this information on copyBetweenStorage(). This
allows us to by-pass the encryption wrapper if we read the source file.

cc @LukasReschke @PVince81
