### PR TITLE
LDAP Wizard: reset connection status indicator when switching LDAP co…

### DIFF
--- a/apps/user_ldap/js/wizard/view.js
+++ b/apps/user_ldap/js/wizard/view.js
@@ -24,6 +24,8 @@ OCA = OCA || {};
 		STATUS_INCOMPLETE: 1,
 		/** @constant {number} */
 		STATUS_SUCCESS: 2,
+		/** @constant {number} */
+		STATUS_UNTESTED: 3,
 
 		/**
 		 * initializes the instance. Always call it after creating the instance.
@@ -210,6 +212,7 @@ OCA = OCA || {};
 		 * @listens ConfigModel#configLoaded
 		 */
 		onConfigLoaded: function(view) {
+			view._updateStatusIndicator(view.STATUS_UNTESTED);
 			view.basicStatusCheck(view);
 			view.functionalityCheck();
 		},
@@ -370,6 +373,14 @@ OCA = OCA || {};
 			var $indicatorLight = $('.ldap_config_state_indicator_sign');
 
 			switch(state) {
+				case this.STATUS_UNTESTED:
+					$indicator.text(t('user_ldap',
+						'Testing configuration…'
+					));
+					$indicator.addClass('ldap_grey');
+					$indicatorLight.removeClass('error');
+					$indicatorLight.removeClass('success');
+					break;
 				case this.STATUS_ERROR:
 					$indicator.text(t('user_ldap',
 						'Configuration incorrect'


### PR DESCRIPTION
…nfig

Currently, when switching an LDAP configuration the connection status indicator is not reset. This can be confusing, when an unexpected red (or green) is shown. This PR resets the indicator on config switch, like this:

![change4](https://cloud.githubusercontent.com/assets/2184312/14204250/3c766b0e-f803-11e5-8666-94eb6043cfdd.gif)

Few JS changes. Please test and review @owncloud/ldap  @MorrisJobke  @PVince81
