### PR TITLE
Sanitize more data in config report

### DIFF
--- a/lib/private/systemconfig.php
+++ b/lib/private/systemconfig.php
@@ -44,7 +44,19 @@ class SystemConfig {
 		'secret' => true,
 		'updater.secret' => true,
 		'ldap_agent_password' => true,
-		'objectstore' => ['arguments' => ['password' => true]],
+		'proxyuserpwd' => true,
+		'log.condition' => [
+			'shared_secret' => true,
+		],
+		'license-key' => true,
+		'redis' => [
+			'password' => true,
+		],
+		'objectstore' => [
+			'arguments' => [
+				'password' => true,
+			],
+		],
 	];
 
 	/** @var Config */


### PR DESCRIPTION
This sanitizes the following keys as well:
- `proxyuserpwd`
- `shared_secret` of `log.condition`
- `license-key`
- `password` of `redis`

cc @MorrisJobke @nickvergessen Mind reviewing?
