### PR TITLE
allow configuration of memcached options

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -922,6 +922,30 @@ $CONFIG = array(
 	//array('other.host.local', 11211),
 ),
 
+/**
+ * Connection options for memcached, see http://apprize.info/php/scaling/15.html
+ */
+'memcached_options' => array(
+	// Set timeouts to 50ms
+	array(\Memcached::OPT_CONNECT_TIMEOUT, 50),
+	array(\Memcached::OPT_RETRY_TIMEOUT,   50),
+	array(\Memcached::OPT_SEND_TIMEOUT,    50),
+	array(\Memcached::OPT_RECV_TIMEOUT,    50),
+	array(\Memcached::OPT_POLL_TIMEOUT,    50),
+
+	// Enable compression
+	array(\Memcached::OPT_COMPRESSION,          true),
+
+	// Turn on consistent hashing
+	array(\Memcached::OPT_LIBKETAMA_COMPATIBLE, true),
+
+	// Enable Binary Protocol
+	array(\Memcached::OPT_BINARY_PROTOCOL,      true),
+
+	// Enabling igbinary requires igbinary PECL module
+	//array(\Memcached::OPT_SERIALIZER, \Memcached::SERIALIZER_IGBINARY),
+),
+
 
 /**
  * Location of the cache folder, defaults to ``data/$user/cache`` where

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -927,23 +927,23 @@ $CONFIG = array(
  */
 'memcached_options' => array(
 	// Set timeouts to 50ms
-	array(\Memcached::OPT_CONNECT_TIMEOUT, 50),
-	array(\Memcached::OPT_RETRY_TIMEOUT,   50),
-	array(\Memcached::OPT_SEND_TIMEOUT,    50),
-	array(\Memcached::OPT_RECV_TIMEOUT,    50),
-	array(\Memcached::OPT_POLL_TIMEOUT,    50),
+	\Memcached::OPT_CONNECT_TIMEOUT => 50,
+	\Memcached::OPT_RETRY_TIMEOUT =>   50,
+	\Memcached::OPT_SEND_TIMEOUT =>    50,
+	\Memcached::OPT_RECV_TIMEOUT =>    50,
+	\Memcached::OPT_POLL_TIMEOUT =>    50,
 
 	// Enable compression
-	array(\Memcached::OPT_COMPRESSION,          true),
+	\Memcached::OPT_COMPRESSION =>          true,
 
 	// Turn on consistent hashing
-	array(\Memcached::OPT_LIBKETAMA_COMPATIBLE, true),
+	\Memcached::OPT_LIBKETAMA_COMPATIBLE => true,
 
 	// Enable Binary Protocol
-	array(\Memcached::OPT_BINARY_PROTOCOL,      true),
+	\Memcached::OPT_BINARY_PROTOCOL =>      true,
 
-	// Enabling igbinary requires igbinary PECL module
-	//array(\Memcached::OPT_SERIALIZER, \Memcached::SERIALIZER_IGBINARY),
+	// Binary serializer vill be enabled if the igbinary PECL module is available
+	//\Memcached::OPT_SERIALIZER => \Memcached::SERIALIZER_IGBINARY,
 ),
 
 

--- a/lib/private/Memcache/Memcached.php
+++ b/lib/private/Memcache/Memcached.php
@@ -52,6 +52,35 @@ class Memcached extends Cache implements IMemcache {
 				}
 			}
 			self::$cache->addServers($servers);
+
+			$options = \OC::$server->getConfig()->getSystemValue('memcached_options');
+			if ($options) {
+				$options = array($options);
+			} else {
+				// set production options
+				$options = array(
+					// Set timeouts to 50ms
+					array(\Memcached::OPT_CONNECT_TIMEOUT, 50),
+					array(\Memcached::OPT_RETRY_TIMEOUT,   50),
+					array(\Memcached::OPT_SEND_TIMEOUT,    50),
+					array(\Memcached::OPT_RECV_TIMEOUT,    50),
+					array(\Memcached::OPT_POLL_TIMEOUT,    50),
+					
+					// Enable compression
+					array(\Memcached::OPT_COMPRESSION,          true),
+					
+					// Turn on consistent hashing
+					array(\Memcached::OPT_LIBKETAMA_COMPATIBLE, true),
+					
+					// Enable Binary Protocol
+					array(\Memcached::OPT_BINARY_PROTOCOL,      true),
+				);
+				//Enable igbinary serializer if available
+				if (\Memcached::HAVE_IGBINARY) {
+					$options[] = array(\Memcached::OPT_SERIALIZER, \Memcached::SERIALIZER_IGBINARY);
+				}
+			}
+			self::$cache->setOptions($options);
 		}
 	}
 

--- a/lib/private/Memcache/Memcached.php
+++ b/lib/private/Memcache/Memcached.php
@@ -80,7 +80,7 @@ class Memcached extends Cache implements IMemcache {
 				$options = $options + $defaultOptions;
 				self::$cache->setOptions($options);
 			} else {
-				throw new HintException("Expectod 'memcached_options' config to be an array, got $options");
+				throw new HintException("Expected 'memcached_options' config to be an array, got $options");
 			}
 		}
 	}


### PR DESCRIPTION
The current implementiation uses ascii based serialization. This PR should reduce traffic to the memcached server by use production values for memcached as explained in http://apprize.info/php/scaling/15.html

cc @MorrisJobke  @felixboehm
