### PR TITLE
Move public webdav auth to share manager

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -32,7 +32,11 @@ OC_App::loadApps($RUNTIME_APPTYPES);
 OC_Util::obEnd();
 
 // Backends
-$authBackend = new OCA\DAV\Connector\PublicAuth(\OC::$server->getConfig(), \OC::$server->getRequest());
+$authBackend = new OCA\DAV\Connector\PublicAuth(
+	\OC::$server->getRequest(),
+	\OC::$server->getShareManager(),
+	\OC::$server->getSession()
+);
 
 $serverFactory = new OCA\DAV\Connector\Sabre\ServerFactory(
 	\OC::$server->getConfig(),
@@ -56,10 +60,9 @@ $server = $serverFactory->createServer($baseuri, $requestUri, $authBackend, func
 	}
 
 	$share = $authBackend->getShare();
-	$rootShare = \OCP\Share::resolveReShare($share);
-	$owner = $rootShare['uid_owner'];
-	$isWritable = $share['permissions'] & (\OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE);
-	$fileId = $share['file_source'];
+	$owner = $share->getShareOwner();
+	$isWritable = $share->getPermissions() & (\OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE);
+	$fileId = $share->getNodeId();
 
 	if (!$isWritable) {
 		\OC\Files\Filesystem::addStorageWrapper('readonly', function ($mountPoint, $storage) {

--- a/apps/dav/tests/unit/connector/publicauth.php
+++ b/apps/dav/tests/unit/connector/publicauth.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace OCA\DAV\Tests\Unit\Connector;
+
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\IManager;
+
+class PublicAuth extends \Test\TestCase {
+
+	/** @var ISession|\PHPUnit_Framework_MockObject_MockObject */
+	private $session;
+	/** @var IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	private $request;
+	/** @var IManager|\PHPUnit_Framework_MockObject_MockObject */
+	private $shareManager;
+	/** @var \OCA\DAV\Connector\PublicAuth */
+	private $auth;
+
+	/** @var string */
+	private $oldUser;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->session = $this->getMock('\OCP\ISession');
+		$this->request = $this->getMock('\OCP\IRequest');
+		$this->shareManager = $this->getMock('\OCP\Share\IManager');
+
+		$this->auth = new \OCA\DAV\Connector\PublicAuth(
+			$this->request,
+			$this->shareManager,
+			$this->session
+		);
+
+		// Store current user
+		$this->oldUser = \OC_User::getUser();
+	}
+
+	protected function tearDown() {
+		\OC_User::setIncognitoMode(false);
+
+		// Set old user
+		\OC_User::setUserId($this->oldUser);
+		\OC_Util::setupFS($this->oldUser);
+
+		parent::tearDown();
+	}
+
+	public function testNoShare() {
+		$this->shareManager->expects($this->once())
+			->method('getShareByToken')
+			->willThrowException(new ShareNotFound());
+
+		$result = $this->invokePrivate($this->auth, 'validateUserPass', ['username', 'password']);
+
+		$this->assertFalse($result);
+	}
+
+	public function testShareNoPassword() {
+		$share = $this->getMock('OCP\Share\IShare');
+		$share->method('getPassword')->willReturn(null);
+
+		$this->shareManager->expects($this->once())
+			->method('getShareByToken')
+			->willReturn($share);
+
+		$result = $this->invokePrivate($this->auth, 'validateUserPass', ['username', 'password']);
+
+		$this->assertTrue($result);
+	}
+
+	public function testSharePasswordFancyShareType() {
+		$share = $this->getMock('OCP\Share\IShare');
+		$share->method('getPassword')->willReturn('password');
+		$share->method('getShareType')->willReturn(42);
+
+		$this->shareManager->expects($this->once())
+			->method('getShareByToken')
+			->willReturn($share);
+
+		$result = $this->invokePrivate($this->auth, 'validateUserPass', ['username', 'password']);
+
+		$this->assertFalse($result);
+	}
+
+
+	public function testSharePasswordRemote() {
+		$share = $this->getMock('OCP\Share\IShare');
+		$share->method('getPassword')->willReturn('password');
+		$share->method('getShareType')->willReturn(\OCP\Share::SHARE_TYPE_REMOTE);
+
+		$this->shareManager->expects($this->once())
+			->method('getShareByToken')
+			->willReturn($share);
+
+		$result = $this->invokePrivate($this->auth, 'validateUserPass', ['username', 'password']);
+
+		$this->assertTrue($result);
+	}
+
+	public function testSharePasswordLinkValidPassword() {
+		$share = $this->getMock('OCP\Share\IShare');
+		$share->method('getPassword')->willReturn('password');
+		$share->method('getShareType')->willReturn(\OCP\Share::SHARE_TYPE_LINK);
+
+		$this->shareManager->expects($this->once())
+			->method('getShareByToken')
+			->willReturn($share);
+
+		$this->shareManager->expects($this->once())
+			->method('checkPassword')->with(
+			$this->equalTo($share),
+			$this->equalTo('password')
+		)->willReturn(true);
+
+		$result = $this->invokePrivate($this->auth, 'validateUserPass', ['username', 'password']);
+
+		$this->assertTrue($result);
+	}
+
+	public function testSharePasswordLinkValidSession() {
+		$share = $this->getMock('OCP\Share\IShare');
+		$share->method('getPassword')->willReturn('password');
+		$share->method('getShareType')->willReturn(\OCP\Share::SHARE_TYPE_LINK);
+		$share->method('getId')->willReturn('42');
+
+		$this->shareManager->expects($this->once())
+			->method('getShareByToken')
+			->willReturn($share);
+
+		$this->shareManager->method('checkPassword')
+			->with(
+				$this->equalTo($share),
+				$this->equalTo('password')
+			)->willReturn(false);
+
+		$this->session->method('exists')->with('public_link_authenticated')->willReturn(true);
+		$this->session->method('get')->with('public_link_authenticated')->willReturn('42');
+
+		$result = $this->invokePrivate($this->auth, 'validateUserPass', ['username', 'password']);
+
+		$this->assertTrue($result);
+	}
+
+	public function testSharePasswordLinkInvalidSession() {
+		$share = $this->getMock('OCP\Share\IShare');
+		$share->method('getPassword')->willReturn('password');
+		$share->method('getShareType')->willReturn(\OCP\Share::SHARE_TYPE_LINK);
+		$share->method('getId')->willReturn('42');
+
+		$this->shareManager->expects($this->once())
+			->method('getShareByToken')
+			->willReturn($share);
+
+		$this->shareManager->method('checkPassword')
+			->with(
+				$this->equalTo($share),
+				$this->equalTo('password')
+			)->willReturn(false);
+
+		$this->session->method('exists')->with('public_link_authenticated')->willReturn(true);
+		$this->session->method('get')->with('public_link_authenticated')->willReturn('43');
+
+		$result = $this->invokePrivate($this->auth, 'validateUserPass', ['username', 'password']);
+
+		$this->assertFalse($result);
+	}
+}

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -976,12 +976,30 @@ class Manager implements IManager {
 	public function getShareByToken($token) {
 		$provider = $this->factory->getProviderForType(\OCP\Share::SHARE_TYPE_LINK);
 
-		$share = $provider->getShareByToken($token);
+		try {
+			$share = $provider->getShareByToken($token);
+		} catch (ShareNotFound $e) {
+			//Ignore
+		}
+
+		// If it is not a link share try to fetch a federated share by token
+		if ($share === null) {
+			$provider = $this->factory->getProviderForType(\OCP\Share::SHARE_TYPE_REMOTE);
+			$share = $provider->getShareByToken($token);
+		}
 
 		if ($share->getExpirationDate() !== null &&
 			$share->getExpirationDate() <= new \DateTime()) {
 			$this->deleteShare($share);
 			throw new ShareNotFound();
+		}
+
+		/*
+		 * Reduce the permissions for link shares if public upload is not enabled
+		 */
+		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK &&
+			!$this->shareApiLinkAllowPublicUpload()) {
+			$share->setPermissions($share->getPermissions() & ~(\OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE));
 		}
 
 		return $share;

--- a/tests/lib/share20/managertest.php
+++ b/tests/lib/share20/managertest.php
@@ -2084,6 +2084,25 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertSame($share, $res);
 	}
 
+	public function testGetShareByTokenPublicSharingDisabled() {
+		$share = $this->manager->newShare();
+		$share->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setPermissions(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE);
+
+		$this->config->method('getAppValue')->will($this->returnValueMap([
+			['core', 'shareapi_allow_public_upload', 'yes', 'no'],
+		]));
+
+		$this->defaultProvider->expects($this->once())
+			->method('getShareByToken')
+			->willReturn('validToken')
+			->willReturn($share);
+
+		$res = $this->manager->getShareByToken('validToken');
+
+		$this->assertSame(\OCP\Constants::PERMISSION_READ, $res->getPermissions());
+	}
+
 	public function testCheckPasswordNoLinkShare() {
 		$share = $this->getMock('\OCP\Share\IShare');
 		$share->method('getShareType')->willReturn(\OCP\Share::SHARE_TYPE_USER);


### PR DESCRIPTION
For https://github.com/owncloud/core/issues/22209

This moves over the webdav public auth to the sharemanager.
As a bonus we now finally have (at least some) unit tests for the webdav public auth!

CC: @PVince81 @schiesbn @DeepDiver1975 @nickvergessen
