### PR TITLE
Fix conditional check in MySQL setup

### DIFF
--- a/lib/private/setup/mysql.php
+++ b/lib/private/setup/mysql.php
@@ -43,7 +43,7 @@ class MySQL extends AbstractDatabase {
 		$query='select count(*) from information_schema.tables where table_schema=? AND table_name = ?';
 		$result = $connection->executeQuery($query, [$this->dbName, $this->tablePrefix.'users']);
 		$row = $result->fetch();
-		if(!$result or $row[0]==0) {
+		if (!$row or $row['count(*)'] === '0') {
 			\OC_DB::createDbFromStructure($this->dbDefinitionFile);
 		}
 	}


### PR DESCRIPTION
The original check didn't make sense - `$result` is always an object, and always evaluates to true. I believe the intention of the check was if there is any rows in the result, so `$row` needs to be checked.

Might affect #23637 cc @enoch85
