### PR TITLE
Share type 2 is private

### DIFF
--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -144,9 +144,7 @@ class ProviderFactory implements IProviderFactory {
 	public function getProviderForType($shareType) {
 		$provider = null;
 
-		//FIXME we should not report type 2
 		if ($shareType === \OCP\Share::SHARE_TYPE_USER  ||
-			$shareType === 2 ||
 			$shareType === \OCP\Share::SHARE_TYPE_GROUP ||
 			$shareType === \OCP\Share::SHARE_TYPE_LINK) {
 			$provider = $this->defaultShareProvider();


### PR DESCRIPTION
This was added to the factory for legacy reasons when converting from
old to new sharing code. It is not used anymore so can be deleted. Which
means we no longer expose internal types.

Easy one.

CC: @schiesbn @nickvergessen @MorrisJobke @LukasReschke
