### PR TITLE
Update imagePath to prefer theme, then app, then core images

### DIFF
--- a/lib/private/urlgenerator.php
+++ b/lib/private/urlgenerator.php
@@ -158,28 +158,31 @@ class URLGenerator implements IURLGenerator {
 		} elseif (!file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$basename.svg")
 			&& file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$basename.png")) {
 			$path =  \OC::$WEBROOT . "/themes/$theme/apps/$app/img/$basename.png";
-		} elseif ($appPath && file_exists($appPath . "/img/$image")) {
-			$path =  \OC_App::getAppWebPath($app) . "/img/$image";
-		} elseif ($appPath && !file_exists($appPath . "/img/$basename.svg")
-			&& file_exists($appPath . "/img/$basename.png")) {
-			$path =  \OC_App::getAppWebPath($app) . "/img/$basename.png";
 		} elseif (!empty($app) and file_exists(\OC::$SERVERROOT . "/themes/$theme/$app/img/$image")) {
 			$path =  \OC::$WEBROOT . "/themes/$theme/$app/img/$image";
 		} elseif (!empty($app) and (!file_exists(\OC::$SERVERROOT . "/themes/$theme/$app/img/$basename.svg")
 			&& file_exists(\OC::$SERVERROOT . "/themes/$theme/$app/img/$basename.png"))) {
 			$path =  \OC::$WEBROOT . "/themes/$theme/$app/img/$basename.png";
-		} elseif (!empty($app) and file_exists(\OC::$SERVERROOT . "/$app/img/$image")) {
-			$path =  \OC::$WEBROOT . "/$app/img/$image";
-		} elseif (!empty($app) and (!file_exists(\OC::$SERVERROOT . "/$app/img/$basename.svg")
-			&& file_exists(\OC::$SERVERROOT . "/$app/img/$basename.png"))) {
-			$path =  \OC::$WEBROOT . "/$app/img/$basename.png";
 		} elseif (file_exists(\OC::$SERVERROOT . "/themes/$theme/core/img/$image")) {
 			$path =  \OC::$WEBROOT . "/themes/$theme/core/img/$image";
 		} elseif (!file_exists(\OC::$SERVERROOT . "/themes/$theme/core/img/$basename.svg")
 			&& file_exists(\OC::$SERVERROOT . "/themes/$theme/core/img/$basename.png")) {
 			$path =  \OC::$WEBROOT . "/themes/$theme/core/img/$basename.png";
+		} elseif ($appPath && file_exists($appPath . "/img/$image")) {
+			$path =  \OC_App::getAppWebPath($app) . "/img/$image";
+		} elseif ($appPath && !file_exists($appPath . "/img/$basename.svg")
+			&& file_exists($appPath . "/img/$basename.png")) {
+			$path =  \OC_App::getAppWebPath($app) . "/img/$basename.png";
+		} elseif (!empty($app) and file_exists(\OC::$SERVERROOT . "/$app/img/$image")) {
+			$path =  \OC::$WEBROOT . "/$app/img/$image";
+		} elseif (!empty($app) and (!file_exists(\OC::$SERVERROOT . "/$app/img/$basename.svg")
+			&& file_exists(\OC::$SERVERROOT . "/$app/img/$basename.png"))) {
+			$path =  \OC::$WEBROOT . "/$app/img/$basename.png";
 		} elseif (file_exists(\OC::$SERVERROOT . "/core/img/$image")) {
 			$path =  \OC::$WEBROOT . "/core/img/$image";
+		} elseif (!file_exists(\OC::$SERVERROOT . "/core/img/$basename.svg")
+			&& file_exists(\OC::$SERVERROOT . "/core/img/$basename.png")) {
+			$path =  \OC::$WEBROOT . "/themes/$theme/core/img/$basename.png";
 		}
 
 		if($path !== '') {


### PR DESCRIPTION
Fix https://github.com/owncloud/core/issues/23758

imagePath updated so that image searches follow this priority:

1) /themes/$theme/apps/$app/img
2) /themes/$theme/$app/img
3) /themes/$theme/core/img
4) $appPath/img
5) /$app/img
6) /core/img

For each folder:
- if the specified file exists, use it.
- otherwise, if $basename.svg does NOT exist, try $basename.png
  (This might better be "if filename was an svg, try the png"...)
