### PR TITLE
Migrate post_userDelete hook to share manager

### DIFF
--- a/apps/federatedfilesharing/lib/federatedshareprovider.php
+++ b/apps/federatedfilesharing/lib/federatedshareprovider.php
@@ -563,4 +563,21 @@ class FederatedShareProvider implements IShareProvider {
 		return $nodes[0];
 	}
 
+	/**
+	 * A user is deleted from the system
+	 * So clean up the relevant shares.
+	 *
+	 * @param string $uid
+	 * @param int $shareType
+	 */
+	public function userDeleted($uid, $shareType) {
+		//TODO: probabaly a good idea to send unshare info to remote servers
+
+		$qb = $this->dbConnection->getQueryBuilder();
+
+		$qb->delete('share')
+			->where($qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_REMOTE)))
+			->andWhere($qb->expr()->eq('uid_owner', $qb->createNamedParameter($uid)))
+			->execute();
+	}
 }

--- a/lib/base.php
+++ b/lib/base.php
@@ -776,7 +776,7 @@ class OC {
 	 */
 	public static function registerShareHooks() {
 		if (\OC::$server->getSystemConfig()->getValue('installed')) {
-			OC_Hook::connect('OC_User', 'post_deleteUser', 'OC\Share\Hooks', 'post_deleteUser');
+			OC_Hook::connect('OC_User', 'post_deleteUser', 'OC\Share20\Hooks', 'post_deleteUser');
 			OC_Hook::connect('OC_User', 'post_addToGroup', 'OC\Share\Hooks', 'post_addToGroup');
 			OC_Hook::connect('OC_Group', 'pre_addToGroup', 'OC\Share\Hooks', 'pre_addToGroup');
 			OC_Hook::connect('OC_User', 'post_removeFromGroup', 'OC\Share\Hooks', 'post_removeFromGroup');

--- a/lib/private/Share20/Hooks.php
+++ b/lib/private/Share20/Hooks.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Share20;
+
+class Hooks {
+	public static function post_deleteUser($arguments) {
+		\OC::$server->getShareManager()->userDeleted($arguments['uid']);
+	}
+}

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1019,6 +1019,18 @@ class Manager implements IManager {
 	}
 
 	/**
+	 * @inheritdoc
+	 */
+	public function userDeleted($uid) {
+		$types = [\OCP\Share::SHARE_TYPE_USER, \OCP\Share::SHARE_TYPE_GROUP, \OCP\Share::SHARE_TYPE_LINK, \OCP\Share::SHARE_TYPE_REMOTE];
+
+		foreach ($types as $type) {
+			$provider = $this->factory->getProviderForType($type);
+			$provider->userDeleted($uid, $type);
+		}
+	}
+
+	/**
 	 * Get access list to a path. This means
 	 * all the users and groups that can access a given path.
 	 *

--- a/lib/private/share/hooks.php
+++ b/lib/private/share/hooks.php
@@ -33,24 +33,6 @@ class Hooks extends \OC\Share\Constants {
 	private static $updateTargets = array();
 
 	/**
-	 * Function that is called after a user is deleted. Cleans up the shares of that user.
-	 * @param array $arguments
-	 */
-	public static function post_deleteUser($arguments) {
-		// Delete any items shared with the deleted user
-		$query = \OC_DB::prepare('DELETE FROM `*PREFIX*share`'
-			.' WHERE `share_with` = ? AND (`share_type` = ? OR `share_type` = ?)');
-		$query->execute(array($arguments['uid'], self::SHARE_TYPE_USER, self::$shareTypeGroupUserUnique));
-		// Delete any items the deleted user shared
-		$query = \OC_DB::prepare('SELECT `id` FROM `*PREFIX*share` WHERE `uid_owner` = ?');
-		$result = $query->execute(array($arguments['uid']));
-		while ($item = $result->fetchRow()) {
-			Helper::delete($item['id']);
-		}
-	}
-
-
-	/**
 	 * Function that is called before a user is added to a group.
 	 * check if we need to create a unique target for the user
 	 * @param array $arguments

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -150,6 +150,17 @@ interface IManager {
 	public function checkPassword(IShare $share, $password);
 
 	/**
+	 * The user with UID is deleted.
+	 * All share providers have to cleanup the shares with this user as well
+	 * as shares owned by this user.
+	 * Shares only initiated by this user are fine.
+	 *
+	 * @param string $uid
+	 * @since 9.1.0
+	 */
+	public function userDeleted($uid);
+
+	/**
 	 * Instantiates a new share object. This is to be passed to
 	 * createShare.
 	 *

--- a/lib/public/Share/IShareProvider.php
+++ b/lib/public/Share/IShareProvider.php
@@ -146,4 +146,14 @@ interface IShareProvider {
 	 * @since 9.0.0
 	 */
 	public function getShareByToken($token);
+
+	/**
+	 * A user is deleted from the system
+	 * So clean up the relevant shares.
+	 *
+	 * @param string $uid
+	 * @param int $shareType
+	 * @since 9.1.0
+	 */
+	public function userDeleted($uid, $shareType);
 }


### PR DESCRIPTION
For #22209

This makes the post_userDelete hook call the sharemanager. This will
cleanup to and from this user.
- All shares owned by this user
- All shares with this user (user)
- All custom group shares
- All link share initiated by this user (to avoid invisible link shares)

Unit tests are added for the defaultshare provider as well as the
federated share provider

CC: @schiesbn @nickvergessen @PVince81 @MorrisJobke @DeepDiver1975
