### PR TITLE
[stable9] Fix PHP memory leak in file_get_contents()

### DIFF
--- a/lib/private/filechunking.php
+++ b/lib/private/filechunking.php
@@ -90,7 +90,7 @@ class OC_FileChunking {
 	 * Assembles the chunks into the file specified by the path.
 	 * Chunks are deleted afterwards.
 	 *
-	 * @param string $f target path
+	 * @param resource $f target path
 	 *
 	 * @return integer assembled file size
 	 *
@@ -106,6 +106,8 @@ class OC_FileChunking {
 			// remove after reading to directly save space
 			$cache->remove($prefix.$i);
 			$count += fwrite($f, $chunk);
+			// let php release the memory to work around memory exhausted error with php 5.6
+			$chunk = null;
 		}
 
 		return $count;

--- a/lib/private/files/storage/local.php
+++ b/lib/private/files/storage/local.php
@@ -177,9 +177,15 @@ class Local extends \OC\Files\Storage\Common {
 
 	public function file_get_contents($path) {
 		// file_get_contents() has a memory leak: https://bugs.php.net/bug.php?id=61961
-		$filename = $this->getSourcePath($path);
-		$handle = fopen($filename,'rb');
-		$content = fread($handle, filesize($filename));
+		$fileName = $this->getSourcePath($path);
+
+		$fileSize = filesize($fileName);
+		if ($fileSize === 0) {
+			return '';
+		}
+
+		$handle = fopen($fileName,'rb');
+		$content = fread($handle, $fileSize);
 		fclose($handle);
 		return $content;
 	}

--- a/lib/private/files/storage/local.php
+++ b/lib/private/files/storage/local.php
@@ -176,7 +176,12 @@ class Local extends \OC\Files\Storage\Common {
 	}
 
 	public function file_get_contents($path) {
-		return file_get_contents($this->getSourcePath($path));
+		// file_get_contents() has a memory leak: https://bugs.php.net/bug.php?id=61961
+		$filename = $this->getSourcePath($path);
+		$handle = fopen($filename,'rb');
+		$content = fread($handle, filesize($filename));
+		fclose($handle);
+		return $content;
 	}
 
 	public function file_put_contents($path, $data) {


### PR DESCRIPTION
- ref https://bugs.php.net/bug.php?id=61961
- ref https://github.com/owncloud/core/issues/20261#issuecomment-180000256
- code is based on the proposal of @chriseqipe
- fixes #20261 
- backport of #23304 
- approval in https://github.com/owncloud/core/pull/23304#issuecomment-205338565

@LukasReschke @nickvergessen @icewind1991 @rullzer @PVince81 Please review
