### PR TITLE
Suppress warnings from DAV migration if there's nothing to do

### DIFF
--- a/apps/dav/appinfo/application.php
+++ b/apps/dav/appinfo/application.php
@@ -32,6 +32,7 @@ use OCA\Dav\Migration\AddressBookAdapter;
 use OCA\Dav\Migration\CalendarAdapter;
 use OCA\Dav\Migration\MigrateAddressbooks;
 use OCA\Dav\Migration\MigrateCalendars;
+use OCA\Dav\Migration\NothingToDoException;
 use \OCP\AppFramework\App;
 use OCP\AppFramework\IAppContainer;
 use OCP\Contacts\IManager;
@@ -190,6 +191,8 @@ class Application extends App {
 				/** @var IUser $user */
 				$migration->migrateForUser($user->getUID());
 			});
+		} catch (NothingToDoException $ex) {
+			// nothing to do, yay!
 		} catch (\Exception $ex) {
 			$this->getContainer()->getServer()->getLogger()->logException($ex);
 		}
@@ -206,6 +209,8 @@ class Application extends App {
 				/** @var IUser $user */
 				$migration->migrateForUser($user->getUID());
 			});
+		} catch (NothingToDoException $ex) {
+			// nothing to do, yay!
 		} catch (\Exception $ex) {
 			$this->getContainer()->getServer()->getLogger()->logException($ex);
 		}

--- a/apps/dav/lib/migration/addressbookadapter.php
+++ b/apps/dav/lib/migration/addressbookadapter.php
@@ -69,7 +69,7 @@ class AddressBookAdapter {
 
 	public function setup() {
 		if (!$this->dbConnection->tableExists($this->sourceBookTable)) {
-			throw new \DomainException('Contacts tables are missing. Nothing to do.');
+			throw new NothingToDoException('Contacts tables are missing');
 		}
 	}
 

--- a/apps/dav/lib/migration/calendaradapter.php
+++ b/apps/dav/lib/migration/calendaradapter.php
@@ -65,7 +65,7 @@ class CalendarAdapter {
 
 	public function setup() {
 		if (!$this->dbConnection->tableExists($this->sourceCalendarTable)) {
-			throw new \DomainException('Calendar tables are missing. Nothing to do.');
+			throw new NothingToDoException('Calendar tables are missing');
 		}
 	}
 

--- a/apps/dav/lib/migration/nothingtodoexception.php
+++ b/apps/dav/lib/migration/nothingtodoexception.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @author Robin McCorkell <robin@mccorkell.me.uk>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Dav\Migration;
+
+/**
+ * Exception if no migration needs to be done
+ */
+class NothingToDoException extends \DomainException {}


### PR DESCRIPTION
Errors should not be printed to the log if there's nothing to do (that's a good thing!)

Fixes #23747, fixes #23637 

cc @enoch85 @DeepDiver1975 @LukasReschke
