### PR TITLE
Remove any stray socket files before creating new ones

### DIFF
--- a/apps/files_external/tests/env/start-amazons3-ceph.sh
+++ b/apps/files_external/tests/env/start-amazons3-ceph.sh
@@ -33,6 +33,7 @@ fi;
 
 # create readiness notification socket
 notify_sock=$(readlink -f "$thisFolder"/dockerContainerCeph.$EXECUTOR_NUMBER.amazons3.sock)
+rm -f "$notify_sock" # in case an unfinished test left one behind
 mkfifo "$notify_sock"
 
 user=test

--- a/apps/files_external/tests/env/start-swift-ceph.sh
+++ b/apps/files_external/tests/env/start-swift-ceph.sh
@@ -33,6 +33,7 @@ fi;
 
 # create readiness notification socket
 notify_sock=$(readlink -f "$thisFolder"/dockerContainerCeph.$EXECUTOR_NUMBER.swift.sock)
+rm -f "$notify_sock" # in case an unfinished test left one behind
 mkfifo "$notify_sock"
 
 port=5001


### PR DESCRIPTION
Fixes the Swift (and Amazon S3?) test failures on Jenkins that are due to the socket file already existing. No idea why they sometimes get left behind, I can only assume the tests are sometimes terminated forcefully and the cleanup script doesn't get run.

@DeepDiver1975 From some of the test run logs, I see that sometimes the socket 'file' is actually a directory? This PR won't remove directories (intentionally, to limit damages in case something goes strange), so please remove all directories on CI in the env folder that look like 'dockerContainerCeph.n.swift.sock' or 'dockerContainerCeph.n.amazons3.sock'
