### PR TITLE
[stable9] Use static method

### DIFF
--- a/lib/private/log/owncloud.php
+++ b/lib/private/log/owncloud.php
@@ -91,11 +91,10 @@ class OC_Log_Owncloud {
 		$url = ($request->getRequestUri() !== '') ? $request->getRequestUri() : '--';
 		$method = is_string($request->getMethod()) ? $request->getMethod() : '--';
 		if(\OC::$server->getConfig()->getSystemValue('installed', false)) {
-			$userObj = \OC::$server->getUserSession()->getUser();
+			$user = (\OC_User::getUser()) ? \OC_User::getUser() : '--';
 		} else {
-			$userObj = null;
+			$user = '--';
 		}
-		$user = !is_null($userObj) ? $userObj->getUID() : '--';
 		$entry = compact(
 			'reqId',
 			'remoteAddr',


### PR DESCRIPTION
This is ugly as hell. But if we directly access `\OCP\IUserSession::getUser` here PHP throws a segfault on some servers:

```
gdb /usr/sbin/apache2 --batch --quiet -ex "run -f /etc/apache2/apache2.conf -DNO_DETACH -DONE_PROCESS -DDEBUG $defines" -ex "quit"
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using 172.17.0.6. Set the 'ServerName' directive globally to suppress this message
warning: the debug information found in "/usr/lib/debug//usr/lib/php5/20121212/mysql.so" does not match "/usr/lib/php5/20121212/mysql.so" (CRC mismatch).

warning: the debug information found in "/usr/lib/debug/usr/lib/php5/20121212/mysql.so" does not match "/usr/lib/php5/20121212/mysql.so" (CRC mismatch).

warning: the debug information found in "/usr/lib/debug//usr/lib/php5/20121212/mysqli.so" does not match "/usr/lib/php5/20121212/mysqli.so" (CRC mismatch).

warning: the debug information found in "/usr/lib/debug/usr/lib/php5/20121212/mysqli.so" does not match "/usr/lib/php5/20121212/mysqli.so" (CRC mismatch).

warning: the debug information found in "/usr/lib/debug//usr/lib/php5/20121212/pdo_mysql.so" does not match "/usr/lib/php5/20121212/pdo_mysql.so" (CRC mismatch).

warning: the debug information found in "/usr/lib/debug/usr/lib/php5/20121212/pdo_mysql.so" does not match "/usr/lib/php5/20121212/pdo_mysql.so" (CRC mismatch).

[New Thread 0x7fffdd206700 (LWP 28386)]
[Thread 0x7fffdd206700 (LWP 28386) exited]
[New Thread 0x7fffdd206700 (LWP 28387)]
[New Thread 0x7fffdc975700 (LWP 28388)]

Program received signal SIGSEGV, Segmentation fault.
zend_parse_parameters (num_args=2, type_spec=type_spec@entry=0x7ffff3f85227 "s|s") at /build/php5-pO28mL/php5-5.5.9+dfsg/Zend/zend_API.c:923
923 /build/php5-pO28mL/php5-5.5.9+dfsg/Zend/zend_API.c: No such file or directory.
A debugging session is active.

    Inferior 1 [process 28382] will be killed.

Quit anyway? (y or n) [answered Y; input not from terminal]
```

I'm still struggling to get a minimal example of this (also considering that it doesn't happen on every system :tada: ). Anyways, it's a functional workaround until I determined the exact bug… (also given the fact that patches may never be backported to distributions :see_no_evil:

Fixes https://github.com/owncloud/user_shibboleth/issues/128

cc @karlitschek @cmonteroluque @blizzz @davitol @rperezb
