### PR TITLE
fetchall appconfig entries

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -273,7 +273,9 @@ class AppConfig implements IAppConfig {
 			->from('appconfig');
 		$result = $sql->execute();
 
-		while ($row = $result->fetch()) {
+		// we are going to store the result in memory anyway
+		$rows = $result->fetchAll();
+		foreach ($rows as $row) {
 			if (!isset($this->cache[$row['appid']])) {
 				$this->cache[$row['appid']] = [];
 			}


### PR DESCRIPTION
While Oracle connections are expensive this PR improves the appconfig loading by fetchall ing the results. We are going to store the result set in memory anyway.

Before and after for the status.php
![callstack](https://cloud.githubusercontent.com/assets/956847/14348466/ee1887e4-fcbc-11e5-966f-9d4d23a6e2b0.png)

I know that oracle prefetches 100 results so it does not have to make a trip to the db for every new row and I know that that number can be tweaked. In the appconfig case I think it still makes sense to fetchall and the cachgrind profiling agrees.
