### PR TITLE
Migrate post_groupDelete hook to share manager

### DIFF
--- a/apps/federatedfilesharing/lib/federatedshareprovider.php
+++ b/apps/federatedfilesharing/lib/federatedshareprovider.php
@@ -580,4 +580,14 @@ class FederatedShareProvider implements IShareProvider {
 			->andWhere($qb->expr()->eq('uid_owner', $qb->createNamedParameter($uid)))
 			->execute();
 	}
+
+	/**
+	 * This provider does not handle groups
+	 *
+	 * @param string $gid
+	 */
+	public function groupDeleted($gid) {
+		// We don't handle groups here
+		return;
+	}
 }

--- a/lib/base.php
+++ b/lib/base.php
@@ -781,7 +781,7 @@ class OC {
 			OC_Hook::connect('OC_User', 'post_addToGroup', 'OC\Share\Hooks', 'post_addToGroup');
 			OC_Hook::connect('OC_Group', 'pre_addToGroup', 'OC\Share\Hooks', 'pre_addToGroup');
 			OC_Hook::connect('OC_User', 'post_removeFromGroup', 'OC\Share\Hooks', 'post_removeFromGroup');
-			OC_Hook::connect('OC_User', 'post_deleteGroup', 'OC\Share\Hooks', 'post_deleteGroup');
+			OC_Hook::connect('OC_User', 'post_deleteGroup', 'OC\Share20\Hooks', 'post_deleteGroup');
 		}
 	}
 

--- a/lib/private/Share20/Hooks.php
+++ b/lib/private/Share20/Hooks.php
@@ -24,4 +24,8 @@ class Hooks {
 	public static function post_deleteUser($arguments) {
 		\OC::$server->getShareManager()->userDeleted($arguments['uid']);
 	}
+
+	public static function post_deleteGroup($arguments) {
+		\OC::$server->getShareManager()->groupDeleted($arguments['gid']);
+	}
 }

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1049,6 +1049,14 @@ class Manager implements IManager {
 	}
 
 	/**
+	 * @inheritdoc
+	 */
+	public function groupDeleted($gid) {
+		$provider = $this->factory->getProviderForType(\OCP\Share::SHARE_TYPE_GROUP);
+		$provider->groupDeleted($gid);
+	}
+
+	/**
 	 * Get access list to a path. This means
 	 * all the users and groups that can access a given path.
 	 *

--- a/lib/private/share/hooks.php
+++ b/lib/private/share/hooks.php
@@ -161,17 +161,4 @@ class Hooks extends \OC\Share\Constants {
 			}
 		}
 	}
-
-	/**
-	 * Function that is called after a group is removed. Cleans up the shares to that group.
-	 * @param array $arguments
-	 */
-	public static function post_deleteGroup($arguments) {
-		$sql = 'SELECT `id` FROM `*PREFIX*share` WHERE `share_type` = ? AND `share_with` = ?';
-		$result = \OC_DB::executeAudited($sql, array(self::SHARE_TYPE_GROUP, $arguments['gid']));
-		while ($item = $result->fetchRow()) {
-			Helper::delete($item['id']);
-		}
-	}
-
 }

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -161,6 +161,15 @@ interface IManager {
 	public function userDeleted($uid);
 
 	/**
+	 * The group with $gid is deleted
+	 * We need to clear up all shares to this group
+	 *
+	 * @param $gid
+	 * @since 9.1.0
+	 */
+	public function groupDeleted($gid);
+
+	/**
 	 * Instantiates a new share object. This is to be passed to
 	 * createShare.
 	 *

--- a/lib/public/Share/IShareProvider.php
+++ b/lib/public/Share/IShareProvider.php
@@ -156,4 +156,14 @@ interface IShareProvider {
 	 * @since 9.1.0
 	 */
 	public function userDeleted($uid, $shareType);
+
+	/**
+	 * A group is deleted from the system.
+	 * We have to clean up all shares to this group.
+	 * Providers not handling group shares should just return
+	 *
+	 * @param string $gid
+	 * @since 9.1.0
+	 */
+	public function groupDeleted($gid);
 }


### PR DESCRIPTION
For #22209

The hook now calls the share manager that will call the responsible
shareProvider to do the proper cleanup.
- Unit tests added

Again nothing should change it is just to cleanup old code

CC: @schiesbn @nickvergessen @PVince81 @MorrisJobke @DeepDiver1975
