### PR TITLE
Correctly return an empty string for empty files

### DIFF
--- a/lib/private/files/storage/local.php
+++ b/lib/private/files/storage/local.php
@@ -177,9 +177,15 @@ class Local extends \OC\Files\Storage\Common {
 
 	public function file_get_contents($path) {
 		// file_get_contents() has a memory leak: https://bugs.php.net/bug.php?id=61961
-		$filename = $this->getSourcePath($path);
-		$handle = fopen($filename,'rb');
-		$content = fread($handle, filesize($filename));
+		$fileName = $this->getSourcePath($path);
+
+		$fileSize = filesize($fileName);
+		if ($fileSize === 0) {
+			return '';
+		}
+
+		$handle = fopen($fileName,'rb');
+		$content = fread($handle, $fileSize);
 		fclose($handle);
 		return $content;
 	}


### PR DESCRIPTION
### Steps
1. Create an empty text file in the UI
2. Try to open it with the text editor app
### Expected

You can edit the file
### Actually

> An error occurred!
> Cannot read the file.
### Problem

php returns `false` for `fread(..., 0)` which is the case for empty files. `file_get_contents` returns an empty string, so we have to adjust that and still return an empty string

Follow up for https://github.com/owncloud/core/pull/23304/files#r59019143

cc @icewind1991 @MorrisJobke @LukasReschke 

@karlitschek should also backport
