### PR TITLE
Fix unit tests warnings

### DIFF
--- a/apps/dav/tests/unit/comments/commentsplugin.php
+++ b/apps/dav/tests/unit/comments/commentsplugin.php
@@ -449,16 +449,6 @@ class CommentsPlugin extends \Test\TestCase {
 			->with('users', 'alice', 'files', '42')
 			->will($this->returnValue($comment));
 
-		$this->commentsManager->expects($this->any())
-			->method('setMessage')
-			->with('')
-			->will($this->throwException(new \InvalidArgumentException()));
-
-		$this->commentsManager->expects($this->any())
-			->method('setVerb')
-			->with('')
-			->will($this->throwException(new \InvalidArgumentException()));
-
 		$this->userSession->expects($this->once())
 			->method('getUser')
 			->will($this->returnValue($user));

--- a/apps/dav/tests/unit/connector/sabre/filesplugin.php
+++ b/apps/dav/tests/unit/connector/sabre/filesplugin.php
@@ -84,6 +84,7 @@ class FilesPlugin extends \Test\TestCase {
 		$node = $this->getMockBuilder($class)
 			->disableOriginalConstructor()
 			->getMock();
+
 		$node->expects($this->any())
 			->method('getId')
 			->will($this->returnValue(123));
@@ -164,7 +165,9 @@ class FilesPlugin extends \Test\TestCase {
 	}
 
 	public function testGetPropertiesForFileHome() {
-		$node = $this->createTestNode('\OCA\DAV\Files\FilesHome');
+		$node = $this->getMockBuilder('\OCA\DAV\Files\FilesHome')
+			->disableOriginalConstructor()
+			->getMock();
 
 		$propFind = new \Sabre\DAV\PropFind(
 			'/dummyPath',
@@ -185,9 +188,6 @@ class FilesPlugin extends \Test\TestCase {
 			->disableOriginalConstructor()->getMock();
 		$user->expects($this->never())->method('getUID');
 		$user->expects($this->never())->method('getDisplayName');
-		$node->expects($this->never())->method('getDirectDownload');
-		$node->expects($this->never())->method('getOwner');
-		$node->expects($this->never())->method('getSize');
 
 		$this->plugin->handleGetProperties(
 			$propFind,
@@ -276,8 +276,6 @@ class FilesPlugin extends \Test\TestCase {
 			0
 		);
 
-		$node->expects($this->never())
-			->method('getDirectDownload');
 		$node->expects($this->once())
 			->method('getSize')
 			->will($this->returnValue(1025));

--- a/apps/encryption/tests/lib/MigrationTest.php
+++ b/apps/encryption/tests/lib/MigrationTest.php
@@ -512,13 +512,9 @@ class MigrationTest extends \Test\TestCase {
 	 */
 	public function testGetTargetDir($user, $keyPath, $filename, $trash, $systemMounts, $expected) {
 
-		$updater = $this->getMockBuilder('\OC\Files\Cache\Updater')
-			->disableOriginalConstructor()->getMock();
 		$view = $this->getMockBuilder('\OC\Files\View')
 			->disableOriginalConstructor()->getMock();
 		$view->expects($this->any())->method('file_exists')->willReturn(true);
-		$view->expects($this->any())->method('getUpdater')->willReturn($updater);
-
 
 		$m = $this->getMockBuilder('OCA\Encryption\Migration')
 			->setConstructorArgs(

--- a/apps/encryption/tests/lib/crypto/encryptionTest.php
+++ b/apps/encryption/tests/lib/crypto/encryptionTest.php
@@ -142,9 +142,6 @@ class EncryptionTest extends TestCase {
 		$this->cryptMock->expects($this->any())
 			->method('multiKeyEncrypt')
 			->willReturn(true);
-		$this->cryptMock->expects($this->any())
-			->method('setAllFileKeys')
-			->willReturn(true);
 
 		$this->instance->end('/foo/bar');
 	}

--- a/apps/files_sharing/tests/api/share20ocstest.php
+++ b/apps/files_sharing/tests/api/share20ocstest.php
@@ -661,10 +661,9 @@ class Share20OCSTest extends \Test\TestCase {
 				->with('valid-path')
 				->willReturn($path);
 
-		$user = $this->getMock('\OCP\IUser');
 		$this->userManager->method('userExists')->with('validUser')->willReturn(true);
 
-		$share->method('setPath')->with($path);
+		$share->method('setNode')->with($path);
 		$share->method('setPermissions')
 			->with(
 				\OCP\Constants::PERMISSION_ALL &
@@ -769,7 +768,7 @@ class Share20OCSTest extends \Test\TestCase {
 			->method('allowGroupSharing')
 			->willReturn(true);
 
-		$share->method('setPath')->with($path);
+		$share->method('setNode')->with($path);
 		$share->method('setPermissions')->with(\OCP\Constants::PERMISSION_ALL);
 		$share->method('setShareType')->with(\OCP\Share::SHARE_TYPE_GROUP);
 		$share->method('setSharedWith')->with('validGroup');
@@ -818,7 +817,7 @@ class Share20OCSTest extends \Test\TestCase {
 			->method('allowGroupSharing')
 			->willReturn(false);
 
-		$share->method('setPath')->with($path);
+		$share->method('setNode')->with($path);
 
 		$expected = new \OC_OCS_Result(null, 404, 'group sharing is disabled by the administrator');
 		$result = $this->ocs->createShare();

--- a/tests/core/controller/avatarcontrollertest.php
+++ b/tests/core/controller/avatarcontrollertest.php
@@ -93,7 +93,7 @@ class AvatarControllerTest extends \Test\TestCase {
 		$this->container['UserSession']->method('getUser')->willReturn($this->userMock);
 
 		$this->avatarFile = $this->getMock('OCP\Files\File');
-		$this->avatarFile->method('getContnet')->willReturn('image data');
+		$this->avatarFile->method('getContent')->willReturn('image data');
 		$this->avatarFile->method('getMimeType')->willReturn('image type');
 		$this->avatarFile->method('getEtag')->willReturn('my etag');
 	}

--- a/tests/lib/appframework/db/mappertest.php
+++ b/tests/lib/appframework/db/mappertest.php
@@ -22,10 +22,11 @@
  */
 
 
-namespace OCP\AppFramework\Db;
+namespace Test\AppFramework\Db;
 
 use \OCP\IDBConnection;
-use Test\AppFramework\Db\MapperTestUtility;
+use \OCP\AppFramework\Db\Entity;
+use \OCP\AppFramework\Db\Mapper;
 
 /**
  * @method integer getId()
@@ -236,7 +237,7 @@ class MapperTest extends MapperTestUtility {
 		$entity->resetUpdatedFields();
 
 		$this->db->expects($this->never())
-			->method('prepareQuery');
+			->method('prepare');
 
 		$this->mapper->update($entity);
 	}

--- a/tests/lib/notification/notificationtest.php
+++ b/tests/lib/notification/notificationtest.php
@@ -517,6 +517,7 @@ class NotificationTest extends TestCase {
 			->setMethods([
 				'isValidCommon',
 				'getSubject',
+				'getParsedSubject',
 			])
 			->getMock();
 
@@ -548,6 +549,7 @@ class NotificationTest extends TestCase {
 			->setMethods([
 				'isValidCommon',
 				'getParsedSubject',
+				'getSubject',
 			])
 			->getMock();
 

--- a/tests/lib/share20/managertest.php
+++ b/tests/lib/share20/managertest.php
@@ -579,7 +579,7 @@ class ManagerTest extends \Test\TestCase {
 		$share->method('getShareType')->willReturn($type);
 		$share->method('getSharedWith')->willReturn($sharedWith);
 		$share->method('getSharedBy')->willReturn($sharedBy);
-		$share->method('getSharedOwner')->willReturn($shareOwner);
+		$share->method('getShareOwner')->willReturn($shareOwner);
 		$share->method('getNode')->willReturn($path);
 		$share->method('getPermissions')->willReturn($permissions);
 		$share->method('getExpirationDate')->willReturn($expireDate);


### PR DESCRIPTION
The new phpunit throws exceptions (and prints a warning) if on a mock a method is unkown etc.
In other words this PR cleans up our unit tests a bit.

CC: @nickvergessen @DeepDiver1975 @blizzz @PVince81 @MorrisJobke
