### PR TITLE
Add preupdate.php for apps

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -1141,7 +1141,7 @@ class OC_App {
 			return false;
 		}
 		if (file_exists($appPath . '/appinfo/preupdate.php')) {
-			if (!array_key_exists($appId, self::$loadedApps)) {
+			if (!in_array($appId, self::$loadedApps)) {
 				self::loadApp($appId, false);
 			}
 			include $appPath . '/appinfo/preupdate.php';
@@ -1153,7 +1153,7 @@ class OC_App {
 		unset(self::$appVersion[$appId]);
 		// run upgrade code
 		if (file_exists($appPath . '/appinfo/update.php')) {
-			if (!array_key_exists($appId, self::$loadedApps)) {
+			if (!in_array($appId, self::$loadedApps)) {
 				self::loadApp($appId, false);
 			}
 			include $appPath . '/appinfo/update.php';

--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -1140,13 +1140,22 @@ class OC_App {
 		if($appPath === false) {
 			return false;
 		}
+		if (file_exists($appPath . '/appinfo/preupdate.php')) {
+			if (!array_key_exists($appId, self::$loadedApps)) {
+				self::loadApp($appId, false);
+			}
+			include $appPath . '/appinfo/preupdate.php';
+		}
+
 		if (file_exists($appPath . '/appinfo/database.xml')) {
 			OC_DB::updateDbFromStructure($appPath . '/appinfo/database.xml');
 		}
 		unset(self::$appVersion[$appId]);
 		// run upgrade code
 		if (file_exists($appPath . '/appinfo/update.php')) {
-			self::loadApp($appId, false);
+			if (!array_key_exists($appId, self::$loadedApps)) {
+				self::loadApp($appId, false);
+			}
 			include $appPath . '/appinfo/update.php';
 		}
 


### PR DESCRIPTION
Ok, so I've tried to change a database column type from text to bigint in my database.xml which broke the app update on postgres with this:

```
Doctrine\DBAL\Exception\DriverException: An  exception occurred while executing 'ALTER TABLE 
oc_news_feeds ALTER  last_modified TYPE BIGINT':  SQLSTATE[42804]: 
Datatype mismatch: 7 ERROR:  column "last_modified"  cannot be cast automatically to
 type bigint HINT:  You might need to specify "USING last_modified::bigint".
```

So here's a preupdate.php hook (since in core only shipped apps can use it apparently) which would allow me to simply drop the column before the database migration.
