### PR TITLE
Catch the AutoloadNotAllowedException also for legacy jobs

### DIFF
--- a/lib/private/backgroundjob/legacy/regularjob.php
+++ b/lib/private/backgroundjob/legacy/regularjob.php
@@ -22,10 +22,17 @@
 
 namespace OC\BackgroundJob\Legacy;
 
+use OCP\AutoloadNotAllowedException;
+
 class RegularJob extends \OC\BackgroundJob\Job {
 	public function run($argument) {
-		if (is_callable($argument)) {
-			call_user_func($argument);
+		try {
+			if (is_callable($argument)) {
+				call_user_func($argument);
+			}
+		} catch (AutoloadNotAllowedException $e) {
+			// job is from a disabled app, ignore
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
- same as #18839 for legacy jobs
- avoids spamming the log with useless entries

This was reported by @benediktg in https://github.com/owncloud/files_antivirus/issues/98#issuecomment-202405249

@karlitschek I would like to backport this to stable9, is this okay?
