### PR TITLE
Open menus on hover

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -95,6 +95,7 @@ var OC={
 	coreApps:['', 'admin','log','core/search','settings','core','3rdparty'],
 	requestToken: oc_requesttoken,
 	menuSpeed: 50,
+	menuHoverTimeout: 250,
 
 	/**
 	 * Get an absolute url to a file in an app
@@ -628,7 +629,7 @@ var OC={
 	registerMenu: function($toggle, $menuEl) {
 		var self = this;
 		$menuEl.addClass('menu');
-		$toggle.on('click.menu', function(event) {
+		var toggleHandler = function(event) {
 			// prevent the link event (append anchor to URL)
 			event.preventDefault();
 
@@ -641,9 +642,25 @@ var OC={
 				// close it
 				self.hideMenus();
 			}
+
 			$menuEl.slideToggle(OC.menuSpeed);
 			OC._currentMenu = $menuEl;
-			OC._currentMenuToggle = $toggle;
+		};
+		var debouncedToggleHandler = _.debounce(toggleHandler, 400, true);
+		$toggle.on('click.menu', debouncedToggleHandler);
+		$toggle.on('hover.menu', function(event) {
+			// has it been opened already?
+			if ($menuEl.is(OC._currentMenu)) {
+				// don't close on hover
+				return;
+			}
+			setTimeout(function() {
+				if ($toggle.is(':hover')) {
+					// The element is still hovered -> open
+					// the menu
+					debouncedToggleHandler(event);
+				}
+			}, OC.menuHoverTimeout);
 		});
 	},
 
@@ -676,7 +693,6 @@ var OC={
 			});
 		}
 		OC._currentMenu = null;
-		OC._currentMenuToggle = null;
 	},
 
 	/**
@@ -692,7 +708,6 @@ var OC={
 		}
 		this.hideMenus();
 		OC._currentMenu = $menuEl;
-		OC._currentMenuToggle = $toggle;
 		$menuEl.trigger(new $.Event('beforeShow'));
 		$menuEl.show();
 		$menuEl.trigger(new $.Event('afterShow'));


### PR DESCRIPTION
fixes #23683

Menus:
- [x] App menu in the top left
- [x] User menu in the top right
- [ ] Action menu in the files list for every row
- [ ] Action menu when it’s used anywhere else, like in the app-navigation

TODO:
- [x] define hover timeout as constant
- [ ] don't ignore subsequent clicks forever
- [ ] close menus that were opened by hovering when moving the mouse out of the element
