### PR TITLE
Don't calculate permissions twice

### DIFF
--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -648,7 +648,7 @@ abstract class Common implements Storage, ILockingStorage {
 		}
 		$data['etag'] = $this->getETag($path);
 		$data['storage_mtime'] = $data['mtime'];
-		$data['permissions'] = $this->getPermissions($path);
+		$data['permissions'] = $permissions;
 
 		return $data;
 	}


### PR DESCRIPTION
Found while converting the shared storage.

There is no need to calculate the permissions since we already did that ;)

CC: @icewind1991 @PVince81 @nickvergessen @MorrisJobke 
