### PR TITLE
SharedStorage to new sharing code + cleanup

### DIFF
--- a/apps/dav/lib/connector/sabre/node.php
+++ b/apps/dav/lib/connector/sabre/node.php
@@ -224,7 +224,7 @@ abstract class Node implements \Sabre\DAV\INode {
 
 		if ($storage->instanceOfStorage('\OC\Files\Storage\Shared')) {
 			/** @var \OC\Files\Storage\Shared $storage */
-			$permissions = (int)$storage->getShare()['permissions'];
+			$permissions = (int)$storage->getShare()->getPermissions();
 		} else {
 			$permissions = $storage->getPermissions($path);
 		}

--- a/apps/files_sharing/appinfo/application.php
+++ b/apps/files_sharing/appinfo/application.php
@@ -111,7 +111,8 @@ class Application extends App {
 			/** @var \OCP\IServerContainer $server */
 			$server = $c->query('ServerContainer');
 			return new MountProvider(
-				$server->getConfig()
+				$server->getConfig(),
+				$server->getShareManager()
 			);
 		});
 

--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -102,4 +102,8 @@ class Shared_Cache extends CacheJail {
 	public function clear() {
 		// Not a valid action for Shared Cache
 	}
+
+	public function moveFromCache(\OCP\Files\Cache\ICache $sourceCache, $sourcePath, $targetPath) {
+		parent::moveFromCache($sourceCache, $sourcePath, $this->storage->getSourcePath($targetPath));
+	}
 }

--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -102,8 +102,4 @@ class Shared_Cache extends CacheJail {
 	public function clear() {
 		// Not a valid action for Shared Cache
 	}
-
-	public function moveFromCache(\OCP\Files\Cache\ICache $sourceCache, $sourcePath, $targetPath) {
-		parent::moveFromCache($sourceCache, $sourcePath, $this->storage->getSourcePath($targetPath));
-	}
 }

--- a/apps/files_sharing/lib/scanner.php
+++ b/apps/files_sharing/lib/scanner.php
@@ -42,7 +42,10 @@ class SharedScanner extends Scanner {
 	 */
 	public function getData($path) {
 		$data = parent::getData($path);
-		$sourcePath = $this->storage->getSourcePath($path);
+		if ($data === null) {
+			return null;
+		}
+		$sourcePath = '/' . $this->storage->getOwner($path) . '/' . $this->storage->getSourcePath($path);
 		list($sourceStorage, $internalPath) = \OC\Files\Filesystem::resolvePath($sourcePath);
 		$data['permissions'] = $sourceStorage->getPermissions($internalPath);
 		return $data;

--- a/apps/files_sharing/lib/scanner.php
+++ b/apps/files_sharing/lib/scanner.php
@@ -45,8 +45,7 @@ class SharedScanner extends Scanner {
 		if ($data === null) {
 			return null;
 		}
-		$sourcePath = '/' . $this->storage->getOwner($path) . '/' . $this->storage->getSourcePath($path);
-		list($sourceStorage, $internalPath) = \OC\Files\Filesystem::resolvePath($sourcePath);
+		list($sourceStorage, $internalPath) = $this->storage->resolvePath($path);
 		$data['permissions'] = $sourceStorage->getPermissions($internalPath);
 		return $data;
 	}

--- a/apps/files_sharing/lib/sharedmount.php
+++ b/apps/files_sharing/lib/sharedmount.php
@@ -49,6 +49,9 @@ class SharedMount extends MountPoint implements MoveableMount {
 	 */
 	private $user;
 
+	/** @var \OCP\Share\IShare */
+	private $share;
+
 	/**
 	 * @param string $storage
 	 * @param SharedMount[] $mountpoints
@@ -58,11 +61,10 @@ class SharedMount extends MountPoint implements MoveableMount {
 	public function __construct($storage, array $mountpoints, $arguments = null, $loader = null) {
 		$this->user = $arguments['user'];
 		$this->recipientView = new View('/' . $this->user . '/files');
-		/** @var \OCP\Share\IShare $share */
-		$share = $arguments['newShare'];
-		$newMountPoint = $this->verifyMountPoint($share, $mountpoints);
+		$this->share = $arguments['newShare'];
+		$newMountPoint = $this->verifyMountPoint($this->share, $mountpoints);
 		$absMountPoint = '/' . $this->user . '/files' . $newMountPoint;
-		$arguments['ownerView'] = new View('/' . $share->getShareOwner() . '/files');
+		$arguments['ownerView'] = new View('/' . $this->share->getShareOwner() . '/files');
 		parent::__construct($storage, $absMountPoint, $arguments, $loader);
 	}
 
@@ -210,8 +212,15 @@ class SharedMount extends MountPoint implements MoveableMount {
 	 * @return \OCP\Share\IShare
 	 */
 	public function getShare() {
-		/** @var $storage \OC\Files\Storage\Shared */
-		$storage = $this->getStorage();
-		return $storage->getShare();
+		return $this->share;
+	}
+
+	/**
+	 * Get the file id of the root of the storage
+	 *
+	 * @return int
+	 */
+	public function getStorageRootId() {
+		return $this->share->getNodeId();
 	}
 }

--- a/apps/files_sharing/lib/sharedpropagator.php
+++ b/apps/files_sharing/lib/sharedpropagator.php
@@ -36,9 +36,8 @@ class SharedPropagator extends Propagator {
 	 * @return \array[] all propagated entries
 	 */
 	public function propagateChange($internalPath, $time, $sizeDifference = 0) {
-		$source = $this->storage->getSourcePath($internalPath);
 		/** @var \OC\Files\Storage\Storage $storage */
-		list($storage, $sourceInternalPath) = \OC\Files\Filesystem::resolvePath($source);
+		list($storage, $sourceInternalPath) = $this->storage->resolvePath($internalPath);
 		return $storage->getPropagator()->propagateChange($sourceInternalPath, $time, $sizeDifference);
 	}
 }

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -41,20 +41,17 @@ use OCP\Lock\ILockingProvider;
 /**
  * Convert target path to source path and pass the function call to the correct storage provider
  */
-class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
+class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 
 	private $share;   // the shared resource
-	private $files = array();
+
+	/** @var \OCP\Share\IShare */
+	private $newShare;
 
 	/**
 	 * @var \OC\Files\View
 	 */
 	private $ownerView;
-
-	/**
-	 * @var string
-	 */
-	private $user;
 
 	private $initialized = false;
 
@@ -68,16 +65,28 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 	 */
 	private $sourceStorage;
 
+	/** @var string */
+	private $user;
+
 	/**
 	 * @var \OCP\ILogger
 	 */
 	private $logger;
 
 	public function __construct($arguments) {
-		$this->share = $arguments['share'];
 		$this->ownerView = $arguments['ownerView'];
-		$this->user = $arguments['user'];
 		$this->logger = \OC::$server->getLogger();
+		$this->newShare = $arguments['newShare'];
+		$this->user = $arguments['user'];
+
+		Filesystem::initMountPoints($this->newShare->getShareOwner());
+		$sourcePath = $this->ownerView->getPath($this->newShare->getNodeId());
+		list($storage, $internalPath) = $this->ownerView->resolvePath($sourcePath);
+
+		parent::__construct([
+			'storage' => $storage,
+			'root' => $internalPath,
+		]);
 	}
 
 	private function init() {
@@ -86,8 +95,8 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		}
 		$this->initialized = true;
 		try {
-			Filesystem::initMountPoints($this->share['uid_owner']);
-			$sourcePath = $this->ownerView->getPath($this->share['file_source']);
+			Filesystem::initMountPoints($this->newShare->getShareOwner());
+			$sourcePath = $this->ownerView->getPath($this->newShare->getNodeId());
 			list($this->sourceStorage, $sourceInternalPath) = $this->ownerView->resolvePath($sourcePath);
 			$this->sourceRootInfo = $this->sourceStorage->getCache()->get($sourceInternalPath);
 		} catch (\Exception $e) {
@@ -115,59 +124,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 	 * @return int
 	 */
 	public function getSourceId() {
-		return (int)$this->share['file_source'];
-	}
-
-	/**
-	 * Get the source file path, permissions, and owner for a shared file
-	 *
-	 * @param string $target Shared target file path
-	 * @return array Returns array with the keys path, permissions, and owner or false if not found
-	 */
-	public function getFile($target) {
-		$this->init();
-		if (!isset($this->files[$target])) {
-			// Check for partial files
-			if (pathinfo($target, PATHINFO_EXTENSION) === 'part') {
-				$source = \OC_Share_Backend_File::getSource(substr($target, 0, -5), $this->getShare());
-				if ($source) {
-					$source['path'] .= '.part';
-					// All partial files have delete permission
-					$source['permissions'] |= \OCP\Constants::PERMISSION_DELETE;
-				}
-			} else {
-				$source = \OC_Share_Backend_File::getSource($target, $this->getShare());
-			}
-			$this->files[$target] = $source;
-		}
-		return $this->files[$target];
-	}
-
-	/**
-	 * Get the source file path for a shared file
-	 *
-	 * @param string $target Shared target file path
-	 * @return string|false source file path or false if not found
-	 */
-	public function getSourcePath($target) {
-		if (!$this->isValid()){
-			return false;
-		}
-		$source = $this->getFile($target);
-		if ($source) {
-			if (!isset($source['fullPath'])) {
-				\OC\Files\Filesystem::initMountPoints($source['fileOwner']);
-				$mount = \OC\Files\Filesystem::getMountByNumericId($source['storage']);
-				if (is_array($mount) && !empty($mount)) {
-					$this->files[$target]['fullPath'] = $mount[key($mount)]->getMountPoint() . $source['path'];
-				} else {
-					$this->files[$target]['fullPath'] = false;
-					\OCP\Util::writeLog('files_sharing', "Unable to get mount for shared storage '" . $source['storage'] . "' user '" . $source['fileOwner'] . "'", \OCP\Util::ERROR);
-				}
-			}
-			return $this->files[$target]['fullPath'];
-		}
-		return false;
+		return $this->newShare->getNodeId();
 	}
 
 	/**
@@ -180,7 +137,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		if (!$this->isValid()) {
 			return 0;
 		}
-		$permissions = $this->share['permissions'];
+		$permissions = $this->newShare->getPermissions();
 		// part files and the mount point always have delete permissions
 		if ($target === '' || pathinfo($target, PATHINFO_EXTENSION) === 'part') {
 			$permissions |= \OCP\Constants::PERMISSION_DELETE;
@@ -191,84 +148,6 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		}
 
 		return $permissions;
-	}
-
-	public function mkdir($path) {
-		if ($path == '' || $path == '/' || !$this->isCreatable(dirname($path))) {
-			return false;
-		} else if ($source = $this->getSourcePath($path)) {
-			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-			return $storage->mkdir($internalPath);
-		}
-		return false;
-	}
-
-	/**
-	 * Delete the directory if DELETE permission is granted
-	 *
-	 * @param string $path
-	 * @return boolean
-	 */
-	public function rmdir($path) {
-
-		// never delete a share mount point
-		if (empty($path)) {
-			return false;
-		}
-
-		if (($source = $this->getSourcePath($path)) && $this->isDeletable($path)) {
-			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-			return $storage->rmdir($internalPath);
-		}
-		return false;
-	}
-
-	public function opendir($path) {
-		$source = $this->getSourcePath($path);
-		list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-		return $storage->opendir($internalPath);
-	}
-
-	public function is_dir($path) {
-		$source = $this->getSourcePath($path);
-		list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-		return $storage->is_dir($internalPath);
-	}
-
-	public function is_file($path) {
-		if ($source = $this->getSourcePath($path)) {
-			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-			return $storage->is_file($internalPath);
-		}
-		return false;
-	}
-
-	public function stat($path) {
-		if ($path == '' || $path == '/') {
-			$stat['size'] = $this->filesize($path);
-			$stat['mtime'] = $this->filemtime($path);
-			return $stat;
-		} else if ($source = $this->getSourcePath($path)) {
-			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-			return $storage->stat($internalPath);
-		}
-		return false;
-	}
-
-	public function filetype($path) {
-		if ($path == '' || $path == '/') {
-			return 'dir';
-		} else if ($source = $this->getSourcePath($path)) {
-			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-			return $storage->filetype($internalPath);
-		}
-		return false;
-	}
-
-	public function filesize($path) {
-		$source = $this->getSourcePath($path);
-		list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-		return $storage->filesize($internalPath);
 	}
 
 	public function isCreatable($path) {
@@ -299,127 +178,6 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 			return false;
 		}
 		return ($this->getPermissions($path) & \OCP\Constants::PERMISSION_SHARE);
-	}
-
-	public function file_exists($path) {
-		if ($path == '' || $path == '/') {
-			return true;
-		} else if ($source = $this->getSourcePath($path)) {
-			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-			return $storage->file_exists($internalPath);
-		}
-		return false;
-	}
-
-	public function filemtime($path) {
-		$source = $this->getSourcePath($path);
-		list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-		return $storage->filemtime($internalPath);
-	}
-
-	public function file_get_contents($path) {
-		$source = $this->getSourcePath($path);
-		if ($source) {
-			$info = array(
-				'target' => $this->getMountPoint() . $path,
-				'source' => $source,
-			);
-			\OCP\Util::emitHook('\OC\Files\Storage\Shared', 'file_get_contents', $info);
-			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-			return $storage->file_get_contents($internalPath);
-		}
-	}
-
-	public function file_put_contents($path, $data) {
-		if ($source = $this->getSourcePath($path)) {
-			// Check if permission is granted
-			if (($this->file_exists($path) && !$this->isUpdatable($path))
-				|| ($this->is_dir($path) && !$this->isCreatable($path))
-			) {
-				return false;
-			}
-			$info = array(
-				'target' => $this->getMountPoint() . '/' . $path,
-				'source' => $source,
-			);
-			\OCP\Util::emitHook('\OC\Files\Storage\Shared', 'file_put_contents', $info);
-			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-			$result = $storage->file_put_contents($internalPath, $data);
-			return $result;
-		}
-		return false;
-	}
-
-	/**
-	 * Delete the file if DELETE permission is granted
-	 *
-	 * @param string $path
-	 * @return boolean
-	 */
-	public function unlink($path) {
-
-		// never delete a share mount point
-		if (empty($path)) {
-			return false;
-		}
-		if ($source = $this->getSourcePath($path)) {
-			if ($this->isDeletable($path)) {
-				list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-				return $storage->unlink($internalPath);
-			}
-		}
-		return false;
-	}
-
-	public function rename($path1, $path2) {
-		$this->init();
-		// we need the paths relative to data/user/files
-		$relPath1 = $this->getMountPoint() . '/' . $path1;
-		$relPath2 = $this->getMountPoint() . '/' . $path2;
-		$pathinfo = pathinfo($relPath1);
-
-		$isPartFile = (isset($pathinfo['extension']) && $pathinfo['extension'] === 'part');
-		$targetExists = $this->file_exists($path2);
-		$sameFolder = (dirname($relPath1) === dirname($relPath2));
-		if ($targetExists || ($sameFolder && !$isPartFile)) {
-			// note that renaming a share mount point is always allowed
-			if (!$this->isUpdatable('')) {
-				return false;
-			}
-		} else {
-			if (!$this->isCreatable('')) {
-				return false;
-			}
-		}
-
-
-		/**
-		 * @var \OC\Files\Storage\Storage $sourceStorage
-		 */
-		list($sourceStorage, $sourceInternalPath) = $this->resolvePath($path1);
-		/**
-		 * @var \OC\Files\Storage\Storage $targetStorage
-		 */
-		list($targetStorage, $targetInternalPath) = $this->resolvePath($path2);
-
-		return $targetStorage->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
-	}
-
-	public function copy($path1, $path2) {
-		// Copy the file if CREATE permission is granted
-		if ($this->isCreatable(dirname($path2))) {
-			/**
-			 * @var \OC\Files\Storage\Storage $sourceStorage
-			 */
-			list($sourceStorage, $sourceInternalPath) = $this->resolvePath($path1);
-			/**
-			 * @var \OC\Files\Storage\Storage $targetStorage
-			 */
-			list($targetStorage, $targetInternalPath) = $this->resolvePath($path2);
-
-			return $targetStorage->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
-		}
-		return false;
 	}
 
 	public function fopen($path, $mode) {
@@ -465,43 +223,34 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 				'mode' => $mode,
 			);
 			\OCP\Util::emitHook('\OC\Files\Storage\Shared', 'fopen', $info);
-			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-			return $storage->fopen($internalPath, $mode);
+			return parent::fopen($path, $mode);
 		}
 		return false;
 	}
 
-	public function getMimeType($path) {
-		if ($source = $this->getSourcePath($path)) {
-			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-			return $storage->getMimeType($internalPath);
-		}
-		return false;
-	}
+	/**
+	 * see http://php.net/manual/en/function.rename.php
+	 *
+	 * @param string $path1
+	 * @param string $path2
+	 * @return bool
+	 */
+	public function rename($path1, $path2) {
+		$isPartFile = pathinfo($path1, PATHINFO_EXTENSION) === 'part';
+		$targetExists = $this->file_exists($path2);
+		$sameFodler = dirname($path1) === dirname($path2);
 
-	public function free_space($path) {
-		$source = $this->getSourcePath($path);
-		if ($source) {
-			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-			return $storage->free_space($internalPath);
+		if ($targetExists || ($sameFodler && !$isPartFile)) {
+			if (!$this->isUpdatable('')) {
+				return false;
+			}
+		} else {
+			if (!$this->isCreatable('')) {
+				return false;
+			}
 		}
-		return \OCP\Files\FileInfo::SPACE_UNKNOWN;
-	}
 
-	public function getLocalFile($path) {
-		if ($source = $this->getSourcePath($path)) {
-			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-			return $storage->getLocalFile($internalPath);
-		}
-		return false;
-	}
-
-	public function touch($path, $mtime = null) {
-		if ($source = $this->getSourcePath($path)) {
-			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-			return $storage->touch($internalPath, $mtime);
-		}
-		return false;
+		return parent::rename($path1, $path2);
 	}
 
 	/**
@@ -510,33 +259,21 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 	 * @return string
 	 */
 	public function getMountPoint() {
-		return $this->share['file_target'];
+		return $this->newShare->getTarget();
 	}
 
+	/**
+	 * @param string $path
+	 */
 	public function setMountPoint($path) {
-		$this->share['file_target'] = $path;
+		$this->newShare->setTarget($path);
 	}
 
+	/**
+	 * @return int
+	 */
 	public function getShareType() {
-		return $this->share['share_type'];
-	}
-
-	/**
-	 * does the group share already has a user specific unique name
-	 *
-	 * @return bool
-	 */
-	public function uniqueNameSet() {
-		return (isset($this->share['unique_name']) && $this->share['unique_name']);
-	}
-
-	/**
-	 * the share now uses a unique name of this user
-	 *
-	 * @brief the share now uses a unique name of this user
-	 */
-	public function setUniqueName() {
-		$this->share['unique_name'] = true;
+		return $this->newShare->getShareType();
 	}
 
 	/**
@@ -545,7 +282,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 	 * @return integer unique share ID
 	 */
 	public function getShareId() {
-		return $this->share['id'];
+		return $this->newShare->getId();
 	}
 
 	/**
@@ -554,14 +291,14 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 	 * @return string
 	 */
 	public function getSharedFrom() {
-		return $this->share['uid_owner'];
+		return $this->newShare->getShareOwner();
 	}
 
 	/**
-	 * @return array
+	 * @return \OCP\Share\IShare
 	 */
 	public function getShare() {
-		return $this->share;
+		return $this->newShare;
 	}
 
 	/**
@@ -570,11 +307,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 	 * @return string
 	 */
 	public function getItemType() {
-		return $this->share['item_type'];
-	}
-
-	public function hasUpdated($path, $time) {
-		return $this->filemtime($path) > $time;
+		return $this->newShare->getNodeType();
 	}
 
 	public function getCache($path = '', $storage = null) {
@@ -603,22 +336,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 	}
 
 	public function getOwner($path) {
-		if ($path == '') {
-			$path = $this->getMountPoint();
-		}
-		$source = $this->getFile($path);
-		if ($source) {
-			return $source['fileOwner'];
-		}
-		return false;
-	}
-
-	public function getETag($path) {
-		if ($source = $this->getSourcePath($path)) {
-			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-			return $storage->getETag($internalPath);
-		}
-		return null;
+		return $this->newShare->getShareOwner();
 	}
 
 	/**
@@ -627,15 +345,8 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 	 * @return bool
 	 */
 	public function unshareStorage() {
-		$result = true;
-		if (!empty($this->share['grouped'])) {
-			foreach ($this->share['grouped'] as $share) {
-				$result = $result && \OCP\Share::unshareFromSelf($share['item_type'], $share['file_target']);
-			}
-		}
-		$result = $result && \OCP\Share::unshareFromSelf($this->getItemType(), $this->getMountPoint());
-
-		return $result;
+		\OC::$server->getShareManager()->deleteFromSelf($this->newShare, $this->user);
+		return true;
 	}
 
 	/**
@@ -645,32 +356,8 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 	 * @return array
 	 */
 	public function resolvePath($path) {
-		$source = $this->getSourcePath($path);
+		$source = '/' . $this->newShare->getShareOwner() . '/' . $this->getSourcePath($path);
 		return \OC\Files\Filesystem::resolvePath($source);
-	}
-
-	/**
-	 * @param \OCP\Files\Storage $sourceStorage
-	 * @param string $sourceInternalPath
-	 * @param string $targetInternalPath
-	 * @return bool
-	 */
-	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
-		/** @var \OCP\Files\Storage $targetStorage */
-		list($targetStorage, $targetInternalPath) = $this->resolvePath($targetInternalPath);
-		return $targetStorage->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
-	}
-
-	/**
-	 * @param \OCP\Files\Storage $sourceStorage
-	 * @param string $sourceInternalPath
-	 * @param string $targetInternalPath
-	 * @return bool
-	 */
-	public function moveFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
-		/** @var \OCP\Files\Storage $targetStorage */
-		list($targetStorage, $targetInternalPath) = $this->resolvePath($targetInternalPath);
-		return $targetStorage->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}
 
 	/**
@@ -685,7 +372,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		$targetStorage->acquireLock($targetInternalPath, $type, $provider);
 		// lock the parent folders of the owner when locking the share as recipient
 		if ($path === '') {
-			$sourcePath = $this->ownerView->getPath($this->share['file_source']);
+			$sourcePath = $this->ownerView->getPath($this->newShare->getNodeId());
 			$this->ownerView->lockFile(dirname($sourcePath), ILockingProvider::LOCK_SHARED, true);
 		}
 	}
@@ -701,7 +388,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		$targetStorage->releaseLock($targetInternalPath, $type, $provider);
 		// unlock the parent folders of the owner when unlocking the share as recipient
 		if ($path === '') {
-			$sourcePath = $this->ownerView->getPath($this->share['file_source']);
+			$sourcePath = $this->ownerView->getPath($this->newShare->getNodeId());
 			$this->ownerView->unlockFile(dirname($sourcePath), ILockingProvider::LOCK_SHARED, true);
 		}
 	}
@@ -735,14 +422,28 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		// shares do not participate in availability logic
 	}
 
-	public function isLocal() {
-		$this->init();
-		$ownerPath = $this->ownerView->getPath($this->share['item_source']);
-		list($targetStorage) = $this->ownerView->resolvePath($ownerPath);
-		return $targetStorage->isLocal();
-	}
-
 	public function getSourceStorage() {
 		return $this->sourceStorage;
 	}
+
+	/**
+	 * @param \OCP\Files\Storage $sourceStorage
+	 * @param string $sourceInternalPath
+	 * @param string $targetInternalPath
+	 * @return bool
+	 */
+	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+		return parent::copyFromStorage($sourceStorage, $sourceInternalPath, $this->getSourcePath($targetInternalPath));
+	}
+
+	/**
+	 * @param \OCP\Files\Storage $sourceStorage
+	 * @param string $sourceInternalPath
+	 * @param string $targetInternalPath
+	 * @return bool
+	 */
+	public function moveFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+		return parent::moveFromStorage($sourceStorage, $sourceInternalPath, $this->getSourcePath($targetInternalPath));
+	}
+
 }

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -350,17 +350,6 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 	}
 
 	/**
-	 * Resolve the path for the source of the share
-	 *
-	 * @param string $path
-	 * @return array
-	 */
-	public function resolvePath($path) {
-		$source = '/' . $this->newShare->getShareOwner() . '/' . $this->getSourcePath($path);
-		return \OC\Files\Filesystem::resolvePath($source);
-	}
-
-	/**
 	 * @param string $path
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
 	 * @param \OCP\Lock\ILockingProvider $provider

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -415,24 +415,4 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 		return $this->sourceStorage;
 	}
 
-	/**
-	 * @param \OCP\Files\Storage $sourceStorage
-	 * @param string $sourceInternalPath
-	 * @param string $targetInternalPath
-	 * @return bool
-	 */
-	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
-		return parent::copyFromStorage($sourceStorage, $sourceInternalPath, $this->getSourcePath($targetInternalPath));
-	}
-
-	/**
-	 * @param \OCP\Files\Storage $sourceStorage
-	 * @param string $sourceInternalPath
-	 * @param string $targetInternalPath
-	 * @return bool
-	 */
-	public function moveFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
-		return parent::moveFromStorage($sourceStorage, $sourceInternalPath, $this->getSourcePath($targetInternalPath));
-	}
-
 }

--- a/apps/files_sharing/tests/cache.php
+++ b/apps/files_sharing/tests/cache.php
@@ -26,27 +26,6 @@
  */
 use OCA\Files_sharing\Tests\TestCase;
 
-/**
- * ownCloud
- *
- * @author Vincent Petry, Bjoern Schiessle
- * @copyright 2014 Vincent Petry <pvince81@owncloud.com>
- *            2014 Bjoern Schiessle <schiessle@owncloud.com>
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
- *
- * You should have received a copy of the GNU Affero General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
 
 /**
  * Class Test_Files_Sharing_Cache
@@ -72,8 +51,13 @@ class Test_Files_Sharing_Cache extends TestCase {
 	/** @var \OC\Files\Storage\Storage */
 	protected $sharedStorage;
 
+	/** @var \OCP\Share\IManager */
+	protected $shareManager;
+
 	protected function setUp() {
 		parent::setUp();
+
+		$this->shareManager = \OC::$server->getShareManager();
 
 		\OC_User::setDisplayName(self::TEST_FILES_SHARING_API_USER1, 'User One');
 		\OC_User::setDisplayName(self::TEST_FILES_SHARING_API_USER2, 'User Two');
@@ -101,13 +85,25 @@ class Test_Files_Sharing_Cache extends TestCase {
 		$this->ownerStorage->getScanner()->scan('');
 
 		// share "shareddir" with user2
-		$fileinfo = $this->view->getFileInfo('container/shareddir');
-		\OCP\Share::shareItem('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
-			self::TEST_FILES_SHARING_API_USER2, 31);
+		$rootFolder = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER1);
 
-		$fileinfo = $this->view->getFileInfo('container/shared single file.txt');
-		\OCP\Share::shareItem('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
-			self::TEST_FILES_SHARING_API_USER2, 31);
+		$node = $rootFolder->get('container/shareddir');
+		$share = $this->shareManager->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
+			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		$this->shareManager->createShare($share);
+
+		$node = $rootFolder->get('container/shared single file.txt');
+		$share = $this->shareManager->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
+			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL & ~(\OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_DELETE));
+		$this->shareManager->createShare($share);
 
 		// login as user2
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
@@ -125,13 +121,10 @@ class Test_Files_Sharing_Cache extends TestCase {
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
-		$fileinfo = $this->view->getFileInfo('container/shareddir');
-		\OCP\Share::unshare('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
-			self::TEST_FILES_SHARING_API_USER2);
-
-		$fileinfo = $this->view->getFileInfo('container/shared single file.txt');
-		\OCP\Share::unshare('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
-			self::TEST_FILES_SHARING_API_USER2);
+		$shares = $this->shareManager->getSharesBy(self::TEST_FILES_SHARING_API_USER1, \OCP\Share::SHARE_TYPE_USER);
+		foreach ($shares as $share) {
+			$this->shareManager->deleteShare($share);
+		}
 
 		$this->view->deleteAll('container');
 
@@ -392,9 +385,15 @@ class Test_Files_Sharing_Cache extends TestCase {
 	function testGetFolderContentsWhenSubSubdirShared() {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
-		$fileinfo = $this->view->getFileInfo('container/shareddir/subdir');
-		\OCP\Share::shareItem('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
-			self::TEST_FILES_SHARING_API_USER3, 31);
+		$rootFolder = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER1);
+		$node = $rootFolder->get('container/shareddir/subdir');
+		$share = $this->shareManager->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith(self::TEST_FILES_SHARING_API_USER3)
+			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		$share = $this->shareManager->createShare($share);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER3);
 
@@ -430,8 +429,7 @@ class Test_Files_Sharing_Cache extends TestCase {
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
-		\OCP\Share::unshare('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
-			self::TEST_FILES_SHARING_API_USER3);
+		$this->shareManager->deleteShare($share);
 	}
 
 	/**
@@ -470,7 +468,17 @@ class Test_Files_Sharing_Cache extends TestCase {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 		\OC\Files\Filesystem::file_put_contents('test.txt', 'foo');
 		$info = \OC\Files\Filesystem::getFileInfo('test.txt');
-		\OCP\Share::shareItem('file', $info->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, \OCP\Constants::PERMISSION_ALL);
+
+		$rootFolder = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER1);
+		$node = $rootFolder->get('test.txt');
+		$share = $this->shareManager->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
+			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
+			->setPermissions(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE);
+		$this->shareManager->createShare($share);
+
 		\OC_Util::tearDownFS();
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
@@ -491,7 +499,16 @@ class Test_Files_Sharing_Cache extends TestCase {
 		\OC\Files\Filesystem::touch('foo/bar/test.txt');
 		$folderInfo = \OC\Files\Filesystem::getFileInfo('foo');
 		$fileInfo = \OC\Files\Filesystem::getFileInfo('foo/bar/test.txt');
-		\OCP\Share::shareItem('folder', $folderInfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, \OCP\Constants::PERMISSION_ALL);
+
+		$rootFolder = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER1);
+		$node = $rootFolder->get('foo');
+		$share = $this->shareManager->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
+			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		$this->shareManager->createShare($share);
 		\OC_Util::tearDownFS();
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);

--- a/apps/files_sharing/tests/etagpropagation.php
+++ b/apps/files_sharing/tests/etagpropagation.php
@@ -50,12 +50,14 @@ class EtagPropagation extends PropagationTestCase {
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER3] = [];
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER4] = [];
 
+		$rootFolder = \OC::$server->getRootFolder();
+		$shareManager = \OC::$server->getShareManager();
+
 		$this->rootView = new View('');
 		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER1);
 		$view1 = new View('/' . self::TEST_FILES_SHARING_API_USER1 . '/files');
 		$view1->mkdir('/sub1/sub2/folder/inside');
 		$view1->mkdir('/directReshare');
-		$view1->mkdir('/sub1/sub2/folder/other');
 		$view1->mkdir('/sub1/sub2/folder/other');
 		$view1->file_put_contents('/foo.txt', 'foobar');
 		$view1->file_put_contents('/sub1/sub2/folder/file.txt', 'foobar');
@@ -64,30 +66,90 @@ class EtagPropagation extends PropagationTestCase {
 		$this->assertInstanceOf('\OC\Files\FileInfo', $folderInfo);
 		$fileInfo = $view1->getFileInfo('/foo.txt');
 		$this->assertInstanceOf('\OC\Files\FileInfo', $fileInfo);
-		\OCP\Share::shareItem('file', $fileInfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, 31);
-		\OCP\Share::shareItem('folder', $folderInfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, 31);
-		\OCP\Share::shareItem('folder', $folderInfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER3, 31);
+
+		$node = $rootFolder->getUserFolder(self::TEST_FILES_SHARING_API_USER1)
+			->get('/foo.txt');
+		$share = $shareManager->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
+			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
+			->setPermissions(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE);
+		$shareManager->createShare($share);
+		$node = $rootFolder->getUserFolder(self::TEST_FILES_SHARING_API_USER1)
+			->get('/sub1/sub2/folder');
+		$share = $shareManager->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
+			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		$shareManager->createShare($share);
+		$share = $shareManager->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith(self::TEST_FILES_SHARING_API_USER3)
+			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		$shareManager->createShare($share);
+
 		$folderInfo = $view1->getFileInfo('/directReshare');
 		$this->assertInstanceOf('\OC\Files\FileInfo', $folderInfo);
-		\OCP\Share::shareItem('folder', $folderInfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, 31);
+
+		$node = $rootFolder->getUserFolder(self::TEST_FILES_SHARING_API_USER1)
+			->get('/directReshare');
+		$share = $shareManager->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
+			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		$shareManager->createShare($share);
+
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER1][''] = $view1->getFileInfo('')->getId();
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER1]['sub1'] = $view1->getFileInfo('sub1')->getId();
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER1]['sub1/sub2'] = $view1->getFileInfo('sub1/sub2')->getId();
 
+		/*
+		 * User 2
+		 */
 		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER2);
 		$view2 = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 		$view2->mkdir('/sub1/sub2');
 		$view2->rename('/folder', '/sub1/sub2/folder');
 		$insideInfo = $view2->getFileInfo('/sub1/sub2/folder/inside');
 		$this->assertInstanceOf('\OC\Files\FileInfo', $insideInfo);
-		\OCP\Share::shareItem('folder', $insideInfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER4, 31);
+
+		$node = $rootFolder->getUserFolder(self::TEST_FILES_SHARING_API_USER2)
+			->get('/sub1/sub2/folder/inside');
+		$share = $shareManager->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith(self::TEST_FILES_SHARING_API_USER4)
+			->setSharedBy(self::TEST_FILES_SHARING_API_USER2)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		$shareManager->createShare($share);
+
 		$folderInfo = $view2->getFileInfo('/directReshare');
 		$this->assertInstanceOf('\OC\Files\FileInfo', $folderInfo);
-		\OCP\Share::shareItem('folder', $folderInfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER4, 31);
+
+		$node = $rootFolder->getUserFolder(self::TEST_FILES_SHARING_API_USER2)
+			->get('/directReshare');
+		$share = $shareManager->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith(self::TEST_FILES_SHARING_API_USER4)
+			->setSharedBy(self::TEST_FILES_SHARING_API_USER2)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		$shareManager->createShare($share);
+
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER2][''] = $view2->getFileInfo('')->getId();
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER2]['sub1'] = $view2->getFileInfo('sub1')->getId();
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER2]['sub1/sub2'] = $view2->getFileInfo('sub1/sub2')->getId();
 
+		/*
+		 * User 3
+		 */
 		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER3);
 		$view3 = new View('/' . self::TEST_FILES_SHARING_API_USER3 . '/files');
 		$view3->mkdir('/sub1/sub2');
@@ -96,6 +158,9 @@ class EtagPropagation extends PropagationTestCase {
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER3]['sub1'] = $view3->getFileInfo('sub1')->getId();
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER3]['sub1/sub2'] = $view3->getFileInfo('sub1/sub2')->getId();
 
+		/*
+		 * User 4
+		 */
 		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER4);
 		$view4 = new View('/' . self::TEST_FILES_SHARING_API_USER4 . '/files');
 		$view4->mkdir('/sub1/sub2');
@@ -108,6 +173,7 @@ class EtagPropagation extends PropagationTestCase {
 			$this->loginAsUser($user);
 			foreach ($ids as $id) {
 				$path = $this->rootView->getPath($id);
+				$ls = $this->rootView->getDirectoryContent($path);
 				$this->fileEtags[$id] = $this->rootView->getFileInfo($path)->getEtag();
 			}
 		}
@@ -202,19 +268,40 @@ class EtagPropagation extends PropagationTestCase {
 		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER1);
 		$folderInfo = $this->rootView->getFileInfo('/' . self::TEST_FILES_SHARING_API_USER1 . '/files/sub1/sub2/folder');
 		$this->assertInstanceOf('\OC\Files\FileInfo', $folderInfo);
-		$folderId = $folderInfo->getId();
-		$this->assertTrue(
-			\OCP\Share::unshare(
-				'folder',
-				$folderId,
-				\OCP\Share::SHARE_TYPE_USER,
-				self::TEST_FILES_SHARING_API_USER2
-			)
-		);
+
+		$node = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER1)->get('/sub1/sub2/folder');
+		$shareManager = \OC::$server->getShareManager();
+		$shares = $shareManager->getSharesBy(self::TEST_FILES_SHARING_API_USER1, \OCP\Share::SHARE_TYPE_USER, $node, true);
+
+		foreach ($shares as $share) {
+			if ($share->getSharedWith() === self::TEST_FILES_SHARING_API_USER2) {
+				$shareManager->deleteShare($share);
+			}
+		}
+
 		$this->assertEtagsForFoldersChanged([
 			// direct recipient affected
 			self::TEST_FILES_SHARING_API_USER2,
-			// reshare recipient affected
+		]);
+
+		$this->assertAllUnchanged();
+	}
+
+	public function testOwnerUnsharesFlatReshares() {
+		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER1);
+		$folderInfo = $this->rootView->getFileInfo('/' . self::TEST_FILES_SHARING_API_USER1 . '/files/sub1/sub2/folder/inside');
+		$this->assertInstanceOf('\OC\Files\FileInfo', $folderInfo);
+
+		$node = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER1)->get('/sub1/sub2/folder/inside');
+		$shareManager = \OC::$server->getShareManager();
+		$shares = $shareManager->getSharesBy(self::TEST_FILES_SHARING_API_USER1, \OCP\Share::SHARE_TYPE_USER, $node, true);
+
+		foreach ($shares as $share) {
+			$shareManager->deleteShare($share);
+		}
+
+		$this->assertEtagsForFoldersChanged([
+			// direct recipient affected
 			self::TEST_FILES_SHARING_API_USER4,
 		]);
 
@@ -223,14 +310,13 @@ class EtagPropagation extends PropagationTestCase {
 
 	public function testRecipientUnsharesFromSelf() {
 		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER2);
+		$ls = $this->rootView->getDirectoryContent('/' . self::TEST_FILES_SHARING_API_USER2 . '/files/sub1/sub2/');
 		$this->assertTrue(
 			$this->rootView->unlink('/' . self::TEST_FILES_SHARING_API_USER2 . '/files/sub1/sub2/folder')
 		);
 		$this->assertEtagsForFoldersChanged([
 			// direct recipient affected
 			self::TEST_FILES_SHARING_API_USER2,
-			// reshare recipient affected
-			self::TEST_FILES_SHARING_API_USER4,
 		]);
 
 		$this->assertAllUnchanged();
@@ -240,8 +326,11 @@ class EtagPropagation extends PropagationTestCase {
 		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER2);
 		Filesystem::file_put_contents('/sub1/sub2/folder/asd.txt', 'bar');
 		$this->assertEtagsNotChanged([self::TEST_FILES_SHARING_API_USER4]);
-		$this->assertEtagsForFoldersChanged([self::TEST_FILES_SHARING_API_USER1, self::TEST_FILES_SHARING_API_USER2,
-			self::TEST_FILES_SHARING_API_USER3]);
+		$this->assertEtagsForFoldersChanged([
+			self::TEST_FILES_SHARING_API_USER1,
+			self::TEST_FILES_SHARING_API_USER2,
+			self::TEST_FILES_SHARING_API_USER3
+		]);
 
 		$this->assertAllUnchanged();
 	}
@@ -350,14 +439,21 @@ class EtagPropagation extends PropagationTestCase {
 	}
 
 	public function testEtagChangeOnPermissionsChange() {
-		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER1);
+		$userFolder = $this->rootFolder->getUserFolder(self::TEST_FILES_SHARING_API_USER1);
+		$node = $userFolder->get('/sub1/sub2/folder');
 
-		$view = new View('/' . self::TEST_FILES_SHARING_API_USER1 . '/files');
-		$folderInfo = $view->getFileInfo('/sub1/sub2/folder');
+		$shares = $this->shareManager->getSharesBy(self::TEST_FILES_SHARING_API_USER1, \OCP\Share::SHARE_TYPE_USER, $node);
+		/** @var \OCP\Share\IShare[] $shares */
+		$shares = array_filter($shares, function(\OCP\Share\IShare $share) {
+			return $share->getSharedWith() === self::TEST_FILES_SHARING_API_USER2;
+		});
+		$this->assertCount(1, $shares);
 
-		\OCP\Share::setPermissions('folder', $folderInfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, 17);
+		$share = $shares[0];
+		$share->setPermissions(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE);
+		$this->shareManager->updateShare($share);
 
-		$this->assertEtagsForFoldersChanged([self::TEST_FILES_SHARING_API_USER2, self::TEST_FILES_SHARING_API_USER4]);
+		$this->assertEtagsForFoldersChanged([self::TEST_FILES_SHARING_API_USER2]);
 
 		$this->assertAllUnchanged();
 	}

--- a/apps/files_sharing/tests/groupetagpropagation.php
+++ b/apps/files_sharing/tests/groupetagpropagation.php
@@ -46,18 +46,36 @@ class GroupEtagPropagation extends PropagationTestCase {
 		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER1);
 		$view1 = new View('/' . self::TEST_FILES_SHARING_API_USER1 . '/files');
 		$view1->mkdir('/test/sub');
-		$folderInfo = $view1->getFileInfo('/test');
-		\OCP\Share::shareItem('folder', $folderInfo->getId(), \OCP\Share::SHARE_TYPE_GROUP, 'group1', 31);
+
+		$this->share(
+			\OCP\Share::SHARE_TYPE_GROUP,
+			'/test',
+			self::TEST_FILES_SHARING_API_USER1,
+			'group1',
+			\OCP\Constants::PERMISSION_ALL
+		);
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER1][''] = $view1->getFileInfo('')->getId();
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER1]['test'] = $view1->getFileInfo('test')->getId();
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER1]['test/sub'] = $view1->getFileInfo('test/sub')->getId();
 
 		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER2);
 		$view2 = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
-		$folderInfo = $view2->getFileInfo('/test');
-		$subFolderInfo = $view2->getFileInfo('/test/sub');
-		\OCP\Share::shareItem('folder', $folderInfo->getId(), \OCP\Share::SHARE_TYPE_GROUP, 'group2', 31);
-		\OCP\Share::shareItem('folder', $subFolderInfo->getId(), \OCP\Share::SHARE_TYPE_GROUP, 'group3', 31);
+
+		$this->share(
+			\OCP\Share::SHARE_TYPE_GROUP,
+			'/test',
+			self::TEST_FILES_SHARING_API_USER2,
+			'group2',
+			\OCP\Constants::PERMISSION_ALL
+		);
+		$this->share(
+			\OCP\Share::SHARE_TYPE_GROUP,
+			'/test/sub',
+			self::TEST_FILES_SHARING_API_USER2,
+			'group3',
+			\OCP\Constants::PERMISSION_ALL
+		);
+
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER2][''] = $view2->getFileInfo('')->getId();
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER2]['test'] = $view2->getFileInfo('test')->getId();
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER2]['test/sub'] = $view2->getFileInfo('test/sub')->getId();

--- a/apps/files_sharing/tests/locking.php
+++ b/apps/files_sharing/tests/locking.php
@@ -59,7 +59,13 @@ class Locking extends TestCase {
 		Filesystem::file_put_contents('/foo/bar.txt', 'asd');
 		$fileId = Filesystem::getFileInfo('/foo/bar.txt')->getId();
 
-		\OCP\Share::shareItem('file', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->recipientUid, 31);
+		$this->share(
+			\OCP\Share::SHARE_TYPE_USER,
+			'/foo/bar.txt',
+			$this->ownerUid,
+			$this->recipientUid,
+			\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE
+		);
 
 		$this->loginAsUser($this->recipientUid);
 		$this->assertTrue(Filesystem::file_exists('bar.txt'));

--- a/apps/files_sharing/tests/permissions.php
+++ b/apps/files_sharing/tests/permissions.php
@@ -33,39 +33,25 @@ use OC\Files\View;
  */
 class Test_Files_Sharing_Permissions extends OCA\Files_sharing\Tests\TestCase {
 
-	/**
-	 * @var Storage
-	 */
+	/** @var Storage */
 	private $sharedStorageRestrictedShare;
 
-	/**
-	 * @var Storage
-	 */
+	/** @var Storage */
 	private $sharedCacheRestrictedShare;
 
-	/**
-	 * @var View
-	 */
+	/** @var View */
 	private $secondView;
 
-	/**
-	 * @var Storage
-	 */
+	/** @var Storage */
 	private $ownerStorage;
 
-	/**
-	 * @var Storage
-	 */
+	/** @var Storage */
 	private $sharedStorage;
 
-	/**
-	 * @var Cache
-	 */
+	/** @var Cache */
 	private $sharedCache;
 
-	/**
-	 * @var Cache
-	 */
+	/** @var Cache */
 	private $ownerCache;
 
 	protected function setUp() {
@@ -88,12 +74,25 @@ class Test_Files_Sharing_Permissions extends OCA\Files_sharing\Tests\TestCase {
 		$this->ownerStorage->getScanner()->scan('');
 
 		// share "shareddir" with user2
-		$fileinfo = $this->view->getFileInfo('container/shareddir');
-		\OCP\Share::shareItem('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
-			self::TEST_FILES_SHARING_API_USER2, 31);
-		$fileinfo2 = $this->view->getFileInfo('container/shareddirrestricted');
-		\OCP\Share::shareItem('folder', $fileinfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
-			self::TEST_FILES_SHARING_API_USER2, 7);
+		$rootFolder = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER1);
+
+		$node = $rootFolder->get('container/shareddir');
+		$share = $this->shareManager->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
+			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		$this->shareManager->createShare($share);
+
+		$node = $rootFolder->get('container/shareddirrestricted');
+		$share = $this->shareManager->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
+			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
+			->setPermissions(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE);
+		$this->shareManager->createShare($share);
 
 		// login as user2
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
@@ -113,12 +112,10 @@ class Test_Files_Sharing_Permissions extends OCA\Files_sharing\Tests\TestCase {
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
-		$fileinfo = $this->view->getFileInfo('container/shareddir');
-		\OCP\Share::unshare('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
-			self::TEST_FILES_SHARING_API_USER2);
-		$fileinfo2 = $this->view->getFileInfo('container/shareddirrestricted');
-		\OCP\Share::unshare('folder', $fileinfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
-			self::TEST_FILES_SHARING_API_USER2);
+		$shares = $this->shareManager->getSharesBy(self::TEST_FILES_SHARING_API_USER1, \OCP\Share::SHARE_TYPE_USER);
+		foreach ($shares as $share) {
+			$this->shareManager->deleteShare($share);
+		}
 
 		$this->view->deleteAll('container');
 

--- a/apps/files_sharing/tests/sizepropagation.php
+++ b/apps/files_sharing/tests/sizepropagation.php
@@ -43,9 +43,13 @@ class SizePropagation extends TestCase {
 		$ownerView->mkdir('/sharedfolder/subfolder');
 		$ownerView->file_put_contents('/sharedfolder/subfolder/foo.txt', 'bar');
 
-		$sharedFolderInfo = $ownerView->getFileInfo('/sharedfolder', false);
-		$this->assertInstanceOf('\OC\Files\FileInfo', $sharedFolderInfo);
-		\OCP\Share::shareItem('folder', $sharedFolderInfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER1, 31);
+		$this->share(
+			\OCP\Share::SHARE_TYPE_USER,
+			'/sharedfolder',
+			self::TEST_FILES_SHARING_API_USER2,
+			self::TEST_FILES_SHARING_API_USER1,
+			\OCP\Constants::PERMISSION_ALL
+		);
 		$ownerRootInfo = $ownerView->getFileInfo('', false);
 
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER1);
@@ -76,9 +80,13 @@ class SizePropagation extends TestCase {
 		$ownerView->mkdir('/sharedfolder/subfolder');
 		$ownerView->file_put_contents('/sharedfolder/subfolder/foo.txt', 'bar');
 
-		$sharedFolderInfo = $ownerView->getFileInfo('/sharedfolder', false);
-		$this->assertInstanceOf('\OC\Files\FileInfo', $sharedFolderInfo);
-		\OCP\Share::shareItem('folder', $sharedFolderInfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER1, 31);
+		$this->share(
+			\OCP\Share::SHARE_TYPE_USER,
+			'/sharedfolder',
+			self::TEST_FILES_SHARING_API_USER2,
+			self::TEST_FILES_SHARING_API_USER1,
+			\OCP\Constants::PERMISSION_ALL
+		);
 		$ownerRootInfo = $ownerView->getFileInfo('', false);
 
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER1);

--- a/apps/files_sharing/tests/testcase.php
+++ b/apps/files_sharing/tests/testcase.php
@@ -59,6 +59,11 @@ abstract class TestCase extends \Test\TestCase {
 	public $folder;
 	public $subfolder;
 
+	/** @var \OCP\Share\IManager */
+	protected $shareManager;
+	/** @var \OCP\Files\IRootFolder */
+	protected $rootFolder;
+
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
@@ -96,7 +101,6 @@ abstract class TestCase extends \Test\TestCase {
 		$groupBackend->addToGroup(self::TEST_FILES_SHARING_API_USER4, 'group3');
 		$groupBackend->addToGroup(self::TEST_FILES_SHARING_API_USER2, self::TEST_FILES_SHARING_API_GROUP1);
 		\OC_Group::useBackend($groupBackend);
-
 	}
 
 	protected function setUp() {
@@ -107,6 +111,9 @@ abstract class TestCase extends \Test\TestCase {
 
 		$this->data = 'foobar';
 		$this->view = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER1 . '/files');
+
+		$this->shareManager = \OC::$server->getShareManager();
+		$this->rootFolder = \OC::$server->getRootFolder();
 	}
 
 	protected function tearDown() {
@@ -201,4 +208,26 @@ abstract class TestCase extends \Test\TestCase {
 
 	}
 
+	/**
+	 * @param int $type The share type
+	 * @param string $path The path to share relative to $initiators root
+	 * @param string $initiator
+	 * @param string $recipient
+	 * @param int $permissions
+	 * @return \OCP\Share\IShare
+	 */
+	protected function share($type, $path, $initiator, $recipient, $permissions) {
+		$userFolder = $this->rootFolder->getUserFolder($initiator);
+		$node = $userFolder->get($path);
+
+		$share = $this->shareManager->newShare();
+		$share->setShareType($type)
+			->setSharedWith($recipient)
+			->setSharedBy($initiator)
+			->setNode($node)
+			->setPermissions($permissions);
+		$share = $this->shareManager->createShare($share);
+
+		return $share;
+	}
 }

--- a/apps/files_sharing/tests/unsharechildren.php
+++ b/apps/files_sharing/tests/unsharechildren.php
@@ -78,14 +78,19 @@ class UnshareChildren extends TestCase {
 
 		$fileInfo2 = \OC\Files\Filesystem::getFileInfo($this->folder);
 
-		$result = \OCP\Share::shareItem('folder', $fileInfo2->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, 31);
-		$this->assertTrue($result);
+		$this->share(
+			\OCP\Share::SHARE_TYPE_USER,
+			$this->folder,
+			self::TEST_FILES_SHARING_API_USER1,
+			self::TEST_FILES_SHARING_API_USER2,
+			\OCP\Constants::PERMISSION_ALL
+		);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
 		// one folder should be shared with the user
-		$sharedFolders = \OCP\Share::getItemsSharedWith('folder');
-		$this->assertSame(1, count($sharedFolders));
+		$shares = $this->shareManager->getSharedWith(self::TEST_FILES_SHARING_API_USER2, \OCP\Share::SHARE_TYPE_USER);
+		$this->assertCount(1, $shares);
 
 		// move shared folder to 'localDir'
 		\OC\Files\Filesystem::mkdir('localDir');
@@ -97,8 +102,8 @@ class UnshareChildren extends TestCase {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
 		// after the parent directory was deleted the share should be unshared
-		$sharedFolders = \OCP\Share::getItemsSharedWith('folder');
-		$this->assertTrue(empty($sharedFolders));
+		$shares = $this->shareManager->getSharedWith(self::TEST_FILES_SHARING_API_USER2, \OCP\Share::SHARE_TYPE_USER);
+		$this->assertEmpty($shares);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 

--- a/apps/files_sharing/tests/updater.php
+++ b/apps/files_sharing/tests/updater.php
@@ -75,7 +75,13 @@ class Test_Files_Sharing_Updater extends OCA\Files_Sharing\Tests\TestCase {
 		$fileinfo = \OC\Files\Filesystem::getFileInfo($this->folder);
 		$this->assertTrue($fileinfo instanceof \OC\Files\FileInfo);
 
-		\OCP\Share::shareItem('folder', $fileinfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, 31);
+		$this->share(
+			\OCP\Share::SHARE_TYPE_USER,
+			$this->folder,
+			self::TEST_FILES_SHARING_API_USER1,
+			self::TEST_FILES_SHARING_API_USER2,
+			\OCP\Constants::PERMISSION_ALL
+		);
 
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
 		$view = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
@@ -152,9 +158,14 @@ class Test_Files_Sharing_Updater extends OCA\Files_Sharing\Tests\TestCase {
 		$etagBeforeShareDir = $beforeShareDir->getEtag();
 
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER1);
-		$fileinfo = \OC\Files\Filesystem::getFileInfo($this->folder);
-		$result = \OCP\Share::shareItem('folder', $fileinfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, 31);
-		$this->assertTrue($result);
+
+		$share = $this->share(
+			\OCP\Share::SHARE_TYPE_USER,
+			$this->folder,
+			self::TEST_FILES_SHARING_API_USER1,
+			self::TEST_FILES_SHARING_API_USER2,
+			\OCP\Constants::PERMISSION_ALL
+		);
 
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
@@ -173,8 +184,7 @@ class Test_Files_Sharing_Updater extends OCA\Files_Sharing\Tests\TestCase {
 
 		// cleanup
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER1);
-		$result = \OCP\Share::unshare('folder', $fileinfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
-		$this->assertTrue($result);
+		$this->shareManager->deleteShare($share);
 
 		$config->setSystemValue('share_folder', $oldShareFolder);
 	}
@@ -185,8 +195,14 @@ class Test_Files_Sharing_Updater extends OCA\Files_Sharing\Tests\TestCase {
 	function testRename() {
 
 		$fileinfo = \OC\Files\Filesystem::getFileInfo($this->folder);
-		$result = \OCP\Share::shareItem('folder', $fileinfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, 31);
-		$this->assertTrue($result);
+
+		$share = $this->share(
+			\OCP\Share::SHARE_TYPE_USER,
+			$this->folder,
+			self::TEST_FILES_SHARING_API_USER1,
+			self::TEST_FILES_SHARING_API_USER2,
+			\OCP\Constants::PERMISSION_ALL
+		);
 
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
@@ -210,9 +226,7 @@ class Test_Files_Sharing_Updater extends OCA\Files_Sharing\Tests\TestCase {
 		$this->assertTrue(\OC\Files\Filesystem::file_exists('/newTarget/oldTarget/subfolder/' . $this->folder));
 
 		// cleanup
-		$this->loginHelper(self::TEST_FILES_SHARING_API_USER1);
-		$result = \OCP\Share::unshare('folder', $fileinfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
-		$this->assertTrue($result);
+		$this->shareManager->deleteShare($share);
 	}
 
 }

--- a/apps/files_sharing/tests/watcher.php
+++ b/apps/files_sharing/tests/watcher.php
@@ -32,25 +32,20 @@
  */
 class Test_Files_Sharing_Watcher extends OCA\Files_sharing\Tests\TestCase {
 
-	/**
-	 * @var \OC\Files\Storage\Storage
-	 */
+	/** @var \OC\Files\Storage\Storage */
 	private $ownerStorage;
 
-	/**
-	 * @var \OC\Files\Cache\Cache
-	 */
+	/** @var \OC\Files\Cache\Cache */
 	private $ownerCache;
 
-	/**
-	 * @var \OC\Files\Storage\Storage
-	 */
+	/** @var \OC\Files\Storage\Storage */
 	private $sharedStorage;
 
-	/**
-	 * @var \OC\Files\Cache\Cache
-	 */
+	/** @var \OC\Files\Cache\Cache */
 	private $sharedCache;
+
+	/** @var \OCP\Share\IShare */
+	private $_share;
 
 	protected function setUp() {
 		parent::setUp();
@@ -58,7 +53,6 @@ class Test_Files_Sharing_Watcher extends OCA\Files_sharing\Tests\TestCase {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
 		// prepare user1's dir structure
-		$textData = "dummy file data\n";
 		$this->view->mkdir('container');
 		$this->view->mkdir('container/shareddir');
 		$this->view->mkdir('container/shareddir/subdir');
@@ -68,9 +62,13 @@ class Test_Files_Sharing_Watcher extends OCA\Files_sharing\Tests\TestCase {
 		$this->ownerStorage->getScanner()->scan('');
 
 		// share "shareddir" with user2
-		$fileinfo = $this->view->getFileInfo('container/shareddir');
-		\OCP\Share::shareItem('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
-			self::TEST_FILES_SHARING_API_USER2, 31);
+		$this->_share = $this->share(
+			\OCP\Share::SHARE_TYPE_USER,
+			'container/shareddir',
+			self::TEST_FILES_SHARING_API_USER1,
+			self::TEST_FILES_SHARING_API_USER2,
+			\OCP\Constants::PERMISSION_ALL
+		);
 
 		// login as user2
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
@@ -89,9 +87,7 @@ class Test_Files_Sharing_Watcher extends OCA\Files_sharing\Tests\TestCase {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
 		if ($this->view) {
-			$fileinfo = $this->view->getFileInfo('container/shareddir');
-			\OCP\Share::unshare('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
-					self::TEST_FILES_SHARING_API_USER2);
+			$this->shareManager->deleteShare($this->_share);
 
 			$this->view->deleteAll('container');
 

--- a/apps/files_trashbin/tests/storage.php
+++ b/apps/files_trashbin/tests/storage.php
@@ -261,9 +261,14 @@ class Storage extends \Test\TestCase {
 		$recipientUser = $this->getUniqueId('recipient_');
 		\OC::$server->getUserManager()->createUser($recipientUser, $recipientUser);
 
-		$fileinfo = $this->userView->getFileInfo('share');
-		$this->assertTrue(\OCP\Share::shareItem('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
-				$recipientUser, 31));
+		$node = \OC::$server->getUserFolder($this->user)->get('share');
+		$share = \OC::$server->getShareManager()->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedBy($this->user)
+			->setSharedWith($recipientUser)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		\OC::$server->getShareManager()->createShare($share);
 
 		$this->loginAsUser($recipientUser);
 
@@ -309,9 +314,14 @@ class Storage extends \Test\TestCase {
 		$recipientUser = $this->getUniqueId('recipient_');
 		\OC::$server->getUserManager()->createUser($recipientUser, $recipientUser);
 
-		$fileinfo = $this->userView->getFileInfo('share');
-		$this->assertTrue(\OCP\Share::shareItem('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
-				$recipientUser, 31));
+		$node = \OC::$server->getUserFolder($this->user)->get('share');
+		$share = \OC::$server->getShareManager()->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedBy($this->user)
+			->setSharedWith($recipientUser)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		\OC::$server->getShareManager()->createShare($share);
 
 		$this->loginAsUser($recipientUser);
 

--- a/apps/files_trashbin/tests/trashbin.php
+++ b/apps/files_trashbin/tests/trashbin.php
@@ -211,9 +211,14 @@ class Test_Trashbin extends \Test\TestCase {
 		\OC\Files\Filesystem::file_put_contents($folder . 'user1-4.txt', 'file4');
 
 		//share user1-4.txt with user2
-		$fileInfo = \OC\Files\Filesystem::getFileInfo($folder);
-		$result = \OCP\Share::shareItem('folder', $fileInfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_TRASHBIN_USER2, 31);
-		$this->assertTrue($result);
+		$node = \OC::$server->getUserFolder(self::TEST_TRASHBIN_USER1)->get($folder);
+		$share = \OC::$server->getShareManager()->newShare();
+		$share->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setNode($node)
+			->setSharedBy(self::TEST_TRASHBIN_USER1)
+			->setSharedWith(self::TEST_TRASHBIN_USER2)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		\OC::$server->getShareManager()->createShare($share);
 
 		// delete them so that they end up in the trash bin
 		\OC\Files\Filesystem::unlink($folder . 'user1-1.txt');

--- a/apps/files_versions/tests/versions.php
+++ b/apps/files_versions/tests/versions.php
@@ -297,8 +297,6 @@ class Test_Files_Versioning extends \Test\TestCase {
 		\OC\Files\Filesystem::mkdir('folder1/folder2');
 		\OC\Files\Filesystem::file_put_contents("folder1/test.txt", "test file");
 
-		$fileInfo = \OC\Files\Filesystem::getFileInfo('folder1');
-
 		$t1 = time();
 		// second version is two weeks older, this way we make sure that no
 		// version will be expired
@@ -314,7 +312,14 @@ class Test_Files_Versioning extends \Test\TestCase {
 		$this->rootView->file_put_contents($v1, 'version1');
 		$this->rootView->file_put_contents($v2, 'version2');
 
-		\OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, self::TEST_VERSIONS_USER2, \OCP\Constants::PERMISSION_ALL);
+		$node = \OC::$server->getUserFolder(self::TEST_VERSIONS_USER)->get('folder1');
+		$share = \OC::$server->getShareManager()->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedBy(self::TEST_VERSIONS_USER)
+			->setSharedWith(self::TEST_VERSIONS_USER2)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		$share = \OC::$server->getShareManager()->createShare($share);
 
 		self::loginHelper(self::TEST_VERSIONS_USER2);
 
@@ -332,6 +337,8 @@ class Test_Files_Versioning extends \Test\TestCase {
 
 		$this->assertTrue($this->rootView->file_exists($v1Renamed));
 		$this->assertTrue($this->rootView->file_exists($v2Renamed));
+
+		\OC::$server->getShareManager()->deleteShare($share);
 	}
 
 	public function testMoveFolder() {
@@ -373,13 +380,14 @@ class Test_Files_Versioning extends \Test\TestCase {
 		\OC\Files\Filesystem::mkdir('folder1');
 		$fileInfo = \OC\Files\Filesystem::getFileInfo('folder1');
 
-		\OCP\Share::shareItem(
-			'folder',
-			$fileInfo['fileid'],
-			\OCP\Share::SHARE_TYPE_USER,
-			self::TEST_VERSIONS_USER2,
-			\OCP\Constants::PERMISSION_ALL
-		);
+		$node = \OC::$server->getUserFolder(self::TEST_VERSIONS_USER)->get('folder1');
+		$share = \OC::$server->getShareManager()->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedBy(self::TEST_VERSIONS_USER)
+			->setSharedWith(self::TEST_VERSIONS_USER2)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		$share = \OC::$server->getShareManager()->createShare($share);
 
 		self::loginHelper(self::TEST_VERSIONS_USER2);
 		$versionsFolder2 = '/' . self::TEST_VERSIONS_USER2 . '/files_versions';
@@ -413,20 +421,22 @@ class Test_Files_Versioning extends \Test\TestCase {
 
 		$this->assertTrue($this->rootView->file_exists($v1Renamed));
 		$this->assertTrue($this->rootView->file_exists($v2Renamed));
+
+		\OC::$server->getShareManager()->deleteShare($share);
 	}
 
 	public function testMoveFolderIntoSharedFolderAsRecipient() {
 
 		\OC\Files\Filesystem::mkdir('folder1');
-		$fileInfo = \OC\Files\Filesystem::getFileInfo('folder1');
 
-		\OCP\Share::shareItem(
-			'folder',
-			$fileInfo['fileid'],
-			\OCP\Share::SHARE_TYPE_USER,
-			self::TEST_VERSIONS_USER2,
-			\OCP\Constants::PERMISSION_ALL
-		);
+		$node = \OC::$server->getUserFolder(self::TEST_VERSIONS_USER)->get('folder1');
+		$share = \OC::$server->getShareManager()->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedBy(self::TEST_VERSIONS_USER)
+			->setSharedWith(self::TEST_VERSIONS_USER2)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		$share = \OC::$server->getShareManager()->createShare($share);
 
 		self::loginHelper(self::TEST_VERSIONS_USER2);
 		$versionsFolder2 = '/' . self::TEST_VERSIONS_USER2 . '/files_versions';
@@ -462,13 +472,13 @@ class Test_Files_Versioning extends \Test\TestCase {
 
 		$this->assertTrue($this->rootView->file_exists($v1Renamed));
 		$this->assertTrue($this->rootView->file_exists($v2Renamed));
+
+		\OC::$server->getShareManager()->deleteShare($share);
 	}
 
 	public function testRenameSharedFile() {
 
 		\OC\Files\Filesystem::file_put_contents("test.txt", "test file");
-
-		$fileInfo = \OC\Files\Filesystem::getFileInfo('test.txt');
 
 		$t1 = time();
 		// second version is two weeks older, this way we make sure that no
@@ -486,7 +496,14 @@ class Test_Files_Versioning extends \Test\TestCase {
 		$this->rootView->file_put_contents($v1, 'version1');
 		$this->rootView->file_put_contents($v2, 'version2');
 
-		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, self::TEST_VERSIONS_USER2, \OCP\Constants::PERMISSION_ALL);
+		$node = \OC::$server->getUserFolder(self::TEST_VERSIONS_USER)->get('test.txt');
+		$share = \OC::$server->getShareManager()->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedBy(self::TEST_VERSIONS_USER)
+			->setSharedWith(self::TEST_VERSIONS_USER2)
+			->setPermissions(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE);
+		$share = \OC::$server->getShareManager()->createShare($share);
 
 		self::loginHelper(self::TEST_VERSIONS_USER2);
 
@@ -504,6 +521,8 @@ class Test_Files_Versioning extends \Test\TestCase {
 
 		$this->assertFalse($this->rootView->file_exists($v1Renamed));
 		$this->assertFalse($this->rootView->file_exists($v2Renamed));
+
+		\OC::$server->getShareManager()->deleteShare($share);
 	}
 
 	public function testCopy() {
@@ -744,15 +763,15 @@ class Test_Files_Versioning extends \Test\TestCase {
 
 		\OC\Files\Filesystem::mkdir('folder');
 		\OC\Files\Filesystem::file_put_contents('folder/test.txt', 'test file');
-		$fileInfo = \OC\Files\Filesystem::getFileInfo('folder');
 
-		\OCP\Share::shareItem(
-			'folder',
-			$fileInfo['fileid'],
-			\OCP\Share::SHARE_TYPE_USER,
-			self::TEST_VERSIONS_USER2,
-			\OCP\Constants::PERMISSION_ALL
-		);
+		$node = \OC::$server->getUserFolder(self::TEST_VERSIONS_USER)->get('folder');
+		$share = \OC::$server->getShareManager()->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedBy(self::TEST_VERSIONS_USER)
+			->setSharedWith(self::TEST_VERSIONS_USER2)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		$share = \OC::$server->getShareManager()->createShare($share);
 
 		$this->loginAsUser(self::TEST_VERSIONS_USER2);
 
@@ -760,6 +779,8 @@ class Test_Files_Versioning extends \Test\TestCase {
 			\OC\Files\Filesystem::getView(),
 			'folder/test.txt'
 		);
+
+		\OC::$server->getShareManager()->deleteShare($share);
 	}
 
 	/**

--- a/lib/private/files/cache/wrapper/cachejail.php
+++ b/lib/private/files/cache/wrapper/cachejail.php
@@ -281,4 +281,20 @@ class CacheJail extends CacheWrapper {
 		$path = $this->cache->getPathById($id);
 		return $this->getJailedPath($path);
 	}
+
+	/**
+	 * Move a file or folder in the cache
+	 *
+	 * Note that this should make sure the entries are removed from the source cache
+	 *
+	 * @param \OCP\Files\Cache\ICache $sourceCache
+	 * @param string $sourcePath
+	 * @param string $targetPath
+	 */
+	public function moveFromCache(\OCP\Files\Cache\ICache $sourceCache, $sourcePath, $targetPath) {
+		if ($sourceCache === $this) {
+			return $this->move($sourcePath, $targetPath);
+		}
+		return $this->cache->moveFromCache($sourceCache, $sourcePath, $targetPath);
+	}
 }

--- a/lib/private/files/config/usermountcache.php
+++ b/lib/private/files/config/usermountcache.php
@@ -80,18 +80,11 @@ class UserMountCache implements IUserMountCache {
 		});
 		/** @var ICachedMountInfo[] $newMounts */
 		$newMounts = array_map(function (IMountPoint $mount) use ($user) {
-			$storage = $mount->getStorage();
-			if ($storage->instanceOfStorage('\OC\Files\Storage\Shared')) {
-				$rootId = (int)$storage->getShare()->getNodeId();
-			} else {
-				$rootId = (int)$storage->getCache()->getId('');
-			}
-			$storageId = (int)$storage->getStorageCache()->getNumericId();
 			// filter out any storages which aren't scanned yet since we aren't interested in files from those storages (yet)
-			if ($rootId === -1) {
+			if ($mount->getStorageRootId() === -1) {
 				return null;
 			} else {
-				return new CachedMountInfo($user, $storageId, $rootId, $mount->getMountPoint());
+				return new LazyStorageMountInfo($user, $mount);
 			}
 		}, $mounts);
 		$newMounts = array_values(array_filter($newMounts));

--- a/lib/private/files/config/usermountcache.php
+++ b/lib/private/files/config/usermountcache.php
@@ -82,7 +82,7 @@ class UserMountCache implements IUserMountCache {
 		$newMounts = array_map(function (IMountPoint $mount) use ($user) {
 			$storage = $mount->getStorage();
 			if ($storage->instanceOfStorage('\OC\Files\Storage\Shared')) {
-				$rootId = (int)$storage->getShare()['file_source'];
+				$rootId = (int)$storage->getShare()->getNodeId();
 			} else {
 				$rootId = (int)$storage->getCache()->getId('');
 			}

--- a/lib/private/files/mount/mountpoint.php
+++ b/lib/private/files/mount/mountpoint.php
@@ -239,4 +239,13 @@ class MountPoint implements IMountPoint {
 	public function getOptions() {
 		return $this->mountOptions;
 	}
+
+	/**
+	 * Get the file id of the root of the storage
+	 *
+	 * @return int
+	 */
+	public function getStorageRootId() {
+		return (int)$this->getStorage()->getCache()->getId('');
+	}
 }

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -313,20 +313,20 @@ abstract class Common implements Storage, ILockingStorage {
 		if (!$storage) {
 			$storage = $this;
 		}
-		if (!isset($this->cache)) {
-			$this->cache = new Cache($storage);
+		if (!isset($storage->cache)) {
+			$storage->cache = new Cache($storage);
 		}
-		return $this->cache;
+		return $storage->cache;
 	}
 
 	public function getScanner($path = '', $storage = null) {
 		if (!$storage) {
 			$storage = $this;
 		}
-		if (!isset($this->scanner)) {
-			$this->scanner = new Scanner($storage);
+		if (!isset($storage->scanner)) {
+			$storage->scanner = new Scanner($storage);
 		}
-		return $this->scanner;
+		return $storage->scanner;
 	}
 
 	public function getWatcher($path = '', $storage = null) {
@@ -351,20 +351,20 @@ abstract class Common implements Storage, ILockingStorage {
 		if (!$storage) {
 			$storage = $this;
 		}
-		if (!isset($this->propagator)) {
-			$this->propagator = new Propagator($storage);
+		if (!isset($storage->propagator)) {
+			$storage->propagator = new Propagator($storage);
 		}
-		return $this->propagator;
+		return $storage->propagator;
 	}
 
 	public function getUpdater($storage = null) {
 		if (!$storage) {
 			$storage = $this;
 		}
-		if (!isset($this->updater)) {
-			$this->updater = new Updater($storage);
+		if (!isset($storage->updater)) {
+			$storage->updater = new Updater($storage);
 		}
-		return $this->updater;
+		return $storage->updater;
 	}
 
 	public function getStorageCache($storage = null) {

--- a/lib/private/files/storage/wrapper/jail.php
+++ b/lib/private/files/storage/wrapper/jail.php
@@ -460,4 +460,30 @@ class Jail extends Wrapper {
 	public function resolvePath($path) {
 		return [$this->storage, $this->getSourcePath($path)];
 	}
+
+	/**
+	 * @param \OCP\Files\Storage $sourceStorage
+	 * @param string $sourceInternalPath
+	 * @param string $targetInternalPath
+	 * @return bool
+	 */
+	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+		if ($sourceStorage === $this) {
+			return $this->copy($sourceInternalPath, $targetInternalPath);
+		}
+		return $this->storage->copyFromStorage($sourceStorage, $sourceInternalPath, $this->getSourcePath($targetInternalPath));
+	}
+
+	/**
+	 * @param \OCP\Files\Storage $sourceStorage
+	 * @param string $sourceInternalPath
+	 * @param string $targetInternalPath
+	 * @return bool
+	 */
+	public function moveFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+		if ($sourceStorage === $this) {
+			return $this->rename($sourceInternalPath, $targetInternalPath);
+		}
+		return $this->storage->moveFromStorage($sourceStorage, $sourceInternalPath, $this->getSourcePath($targetInternalPath));
+	}
 }

--- a/lib/private/files/storage/wrapper/jail.php
+++ b/lib/private/files/storage/wrapper/jail.php
@@ -47,7 +47,7 @@ class Jail extends Wrapper {
 		$this->rootPath = $arguments['root'];
 	}
 
-	protected function getSourcePath($path) {
+	public function getSourcePath($path) {
 		if ($path === '') {
 			return $this->rootPath;
 		} else {
@@ -417,6 +417,14 @@ class Jail extends Wrapper {
 
 	/**
 	 * @param string $path
+	 * @return array
+	 */
+	public function getMetaData($path) {
+		return $this->storage->getMetaData($this->getSourcePath($path));
+	}
+
+	/**
+	 * @param string $path
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
 	 * @param \OCP\Lock\ILockingProvider $provider
 	 * @throws \OCP\Lock\LockedException
@@ -441,5 +449,10 @@ class Jail extends Wrapper {
 	 */
 	public function changeLock($path, $type, ILockingProvider $provider) {
 		$this->storage->changeLock($this->getSourcePath($path), $type, $provider);
+	}
+
+	public function resolvePath($path) {
+		$path = $this->getSourcePath($path);
+		return \OC\Files\Filesystem::resolvePath($path);
 	}
 }

--- a/lib/private/files/storage/wrapper/jail.php
+++ b/lib/private/files/storage/wrapper/jail.php
@@ -451,8 +451,13 @@ class Jail extends Wrapper {
 		$this->storage->changeLock($this->getSourcePath($path), $type, $provider);
 	}
 
+	/**
+	 * Resolve the path for the source of the share
+	 *
+	 * @param string $path
+	 * @return array
+	 */
 	public function resolvePath($path) {
-		$path = $this->getSourcePath($path);
-		return \OC\Files\Filesystem::resolvePath($path);
+		return [$this->storage, $this->getSourcePath($path)];
 	}
 }

--- a/lib/private/files/storage/wrapper/wrapper.php
+++ b/lib/private/files/storage/wrapper/wrapper.php
@@ -35,6 +35,12 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 */
 	protected $storage;
 
+	public $cache;
+	public $scanner;
+	public $watcher;
+	public $propagator;
+	public $updater;
+
 	/**
 	 * @param array $parameters
 	 */

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -628,7 +628,7 @@ class OC_Helper {
 			/** @var \OC\Files\Storage\Wrapper\Quota $storage */
 			$quota = $sourceStorage->getQuota();
 		}
-		$free = $storage->free_space('');
+		$free = $sourceStorage->free_space('');
 		if ($free >= 0) {
 			$total = $free + $used;
 		} else {

--- a/lib/public/files/mount/imountpoint.php
+++ b/lib/public/files/mount/imountpoint.php
@@ -94,4 +94,12 @@ interface IMountPoint {
 	 * @since 8.1.0
 	 */
 	public function getOptions();
+
+	/**
+	 * Get the file id of the root of the storage
+	 *
+	 * @return int
+	 * @since 9.1.0
+	 */
+	public function getStorageRootId();
 }

--- a/tests/lib/share20/managertest.php
+++ b/tests/lib/share20/managertest.php
@@ -647,7 +647,7 @@ class ManagerTest extends \Test\TestCase {
 		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $limitedPermssions, $group0, $user0, $user0, 17, null, null), 'Cannot increase permissions of path', true];
 		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK,  $limitedPermssions, null, $user0, $user0, 3, null, null), 'Cannot increase permissions of path', true];
 
-		$nonMoveableMountPermssions = $this->getMock('\OCP\Files\File');
+		$nonMoveableMountPermssions = $this->getMock('\OCP\Files\Folder');
 		$nonMoveableMountPermssions->method('isShareable')->willReturn(true);
 		$nonMoveableMountPermssions->method('getPermissions')->willReturn(\OCP\Constants::PERMISSION_READ);
 		$nonMoveableMountPermssions->method('getPath')->willReturn('path');
@@ -2477,7 +2477,9 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testMoveShareUser() {
 		$share = $this->manager->newShare();
-		$share->setShareType(\OCP\Share::SHARE_TYPE_USER);
+		$share->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setId('42')
+			->setProviderId('foo');
 
 		$share->setSharedWith('recipient');
 
@@ -2508,7 +2510,9 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testMoveShareGroup() {
 		$share = $this->manager->newShare();
-		$share->setShareType(\OCP\Share::SHARE_TYPE_GROUP);
+		$share->setShareType(\OCP\Share::SHARE_TYPE_GROUP)
+			->setId('42')
+			->setProviderId('foo');
 
 		$group = $this->getMock('\OCP\IGroup');
 		$share->setSharedWith('group');


### PR DESCRIPTION
For https://github.com/owncloud/core/issues/22209

This (big) PR will move the sharedstorage over to the share manager. Since this is not a 1 on 1 transformation this will cleanup the shared storage (and simplify it!) as well.

TODO:
- [x] Get rid of the old share
- [x] Get rid of functions that are covered in the jail
- [x] Get rid of all node API usage
- [x] Squash

CC: @icewind1991 
