### PR TITLE
On mount make sure multiple shares with same target map to unique ones

### DIFF
--- a/apps/files_sharing/lib/mountprovider.php
+++ b/apps/files_sharing/lib/mountprovider.php
@@ -55,19 +55,20 @@ class MountProvider implements IMountProvider {
 		$shares = array_filter($shares, function ($share) {
 			return $share['permissions'] > 0;
 		});
-		$shares = array_map(function ($share) use ($user, $storageFactory) {
-
-			return new SharedMount(
+		$mounts = [];
+		foreach ($shares as $share) {
+			$mounts[] = new SharedMount(
 				'\OC\Files\Storage\Shared',
-				'/' . $user->getUID() . '/' . $share['file_target'],
-				array(
+				$mounts,
+				[
 					'share' => $share,
 					'user' => $user->getUID()
-				),
+				],
 				$storageFactory
 			);
-		}, $shares);
+		}
+
 		// array_filter removes the null values from the array
-		return array_filter($shares);
+		return array_filter($mounts);
 	}
 }

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -670,3 +670,15 @@ Feature: sharing
     When as "user1" gets properties of folder "/tmp" with
       |{http://owncloud.org/ns}share-permissions|
     Then the single response should contain a property "{http://owncloud.org/ns}share-permissions" with value "15"
+
+  Scenario: unique target names for incomming shares
+    Given user "user0" exists
+    And user "user1" exists
+    And user "user2" exists
+    And user "user0" created a folder "/foo"
+    And user "user1" created a folder "/foo"
+    When file "/foo" of user "user0" is shared with user "user2"
+    And file "/foo" of user "user1" is shared with user "user2"
+    Then user "user2" should see following elements
+      | /foo/       |
+      | /foo%20(2)/ |


### PR DESCRIPTION
I found this while migrating the sharedStorage.
I think this is the result of recent moving around of stuff. But we did not notice because there was no testing for it. (not with 2 incomming shares). Works fine in 9.0 as far as I can tell.

Scenario:
- user0 shares a folder 'foo' with user2
- user1 shares a folder 'foo' with user2
- user2 logs in

Before: show only the 'foo' from user1

After: show both.
- Added intergration tests

CC: @schiesbn @icewind1991 @nickvergessen @MorrisJobke 
