### PR TITLE
map oracle driver options to params

### DIFF
--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -104,6 +104,10 @@ class ConnectionFactory {
 				break;
 			case 'oci':
 				$eventManager->addEventSubscriber(new OracleSessionInit);
+				// the driverOptions are unused in dbal and need to be mapped to the parameters
+				if (isset($additionalConnectionParams['driverOptions'])) {
+					$additionalConnectionParams = array_merge($additionalConnectionParams, $additionalConnectionParams['driverOptions']);
+				}
 				break;
 			case 'sqlite3':
 				$journalMode = $additionalConnectionParams['sqlite.journal_mode'];


### PR DESCRIPTION
Supersedes https://github.com/owncloud/core/pull/16266 by reusing the dbdriveroptions and feeding them to oracle as driver options.

Allows using oracle wallet and connection pooling in oracle.

As the driver options are [ignored by the doctrine oracle driver](https://github.com/owncloud/3rdparty/blob/master/doctrine/dbal/lib/Doctrine/DBAL/Driver/OCI8/Driver.php#L36) we need to remap them to parameters so that something like pooling and external credentials can be configured.
