### PR TITLE
Employ a stricter Content Security Policy on remote.php

### DIFF
--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -74,7 +74,7 @@ Feature: webdav-related
 		When Downloading file "/welcome.txt"
 		Then The following headers should be set
 			|Content-Disposition|attachment|
-			|Content-Security-Policy|default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; frame-src *; img-src * data: blob:; font-src 'self' data:; media-src *; connect-src *|
+			|Content-Security-Policy|default-src 'none';|
 			|X-Content-Type-Options |nosniff|
 			|X-Download-Options|noopen|
 			|X-Frame-Options|Sameorigin|
@@ -89,7 +89,7 @@ Feature: webdav-related
 		When Downloading file "/welcome.txt"
 		Then The following headers should be set
 			|Content-Disposition|attachment|
-			|Content-Security-Policy|default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; frame-src *; img-src * data: blob:; font-src 'self' data:; media-src *; connect-src *|
+			|Content-Security-Policy|default-src 'none';|
 			|X-Content-Type-Options |nosniff|
 			|X-Download-Options|noopen|
 			|X-Frame-Options|Sameorigin|

--- a/remote.php
+++ b/remote.php
@@ -108,6 +108,11 @@ function resolveService($service) {
 try {
 	require_once 'lib/base.php';
 
+	// All resources served via the DAV endpoint should have the strictest possible
+	// policy. Exempted from this is the SabreDAV browser plugin which overwrites
+	// this policy with a softer one if debug mode is enabled.
+	header("Content-Security-Policy: default-src 'none';");
+
 	if (\OCP\Util::needUpgrade()) {
 		// since the behavior of apps or remotes are unpredictable during
 		// an upgrade, return a 503 directly


### PR DESCRIPTION
Items sent by remote.php have not to be interpreted by browsers in any way.
