### PR TITLE
Parallel backgroundjob execution

### DIFF
--- a/core/Command/Background/Run.php
+++ b/core/Command/Background/Run.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\Background;
+
+use OC\BackgroundJob\Executer;
+use OCP\BackgroundJob\IJobList;
+use OCP\IConfig;
+use OCP\Lock\ILockingProvider;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Run extends Command {
+	/** @var Executer */
+	private $executer;
+
+	/**
+	 * @param \OCP\IConfig $config
+	 * @param ILockingProvider $lockingProvider
+	 * @param IJobList $jobList
+	 */
+	public function __construct(IConfig $config, ILockingProvider $lockingProvider, IJobList $jobList) {
+		parent::__construct();
+		$this->executer = new Executer($lockingProvider, $jobList);
+	}
+
+	protected function configure() {
+		parent::configure();
+
+		$this
+			->setName('background:run')
+			->setDescription('Run a background job');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		// set non zero return value if no job is run
+		return ($this->executer->executeNextJob()) ? 0 : 1;
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -61,6 +61,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Background\Cron(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Background\WebCron(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Background\Ajax(\OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\Background\Run(\OC::$server->getConfig(), \OC::$server->getLockingProvider(), \OC::$server->getJobList()));
 
 	$application->add(new OC\Core\Command\Config\App\DeleteConfig(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Config\App\GetConfig(\OC::$server->getConfig()));

--- a/cron.php
+++ b/cron.php
@@ -106,32 +106,9 @@ try {
 			}
 		}
 
-		$instanceId = $config->getSystemValue('instanceid');
-		$lockFileName = 'owncloud-server-' . $instanceId . '-cron.lock';
-		$lockDirectory = $config->getSystemValue('cron.lockfile.location', sys_get_temp_dir());
-		$lockDirectory = rtrim($lockDirectory, '\\/');
-		$lockFile = $lockDirectory . '/' . $lockFileName;
-
-		if (!file_exists($lockFile)) {
-			touch($lockFile);
-		}
-
 		// We call ownCloud from the CLI (aka cron)
 		if ($appMode != 'cron') {
 			\OCP\BackgroundJob::setExecutionType('cron');
-		}
-
-		// open the file and try to lock it. If it is not locked, the background
-		// job can be executed, otherwise another instance is already running
-		$fp = fopen($lockFile, 'w');
-		$isLocked = flock($fp, LOCK_EX|LOCK_NB, $wouldBlock);
-
-		// check if backgroundjobs is still running. The wouldBlock check is
-		// needed on systems with advisory locking, see
-		// http://php.net/manual/en/function.flock.php#45464
-		if (!$isLocked || $wouldBlock) {
-			echo "Another instance of cron.php is still running!" . PHP_EOL;
-			exit(1);
 		}
 
 		// Work
@@ -148,10 +125,6 @@ try {
 			$executedJobs[$job->getId()] = true;
 			unset($job);
 		}
-
-		// unlock the file
-		flock($fp, LOCK_UN);
-		fclose($fp);
 
 	} else {
 		// We call cron.php from some website

--- a/lib/private/backgroundjob/executer.php
+++ b/lib/private/backgroundjob/executer.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\BackgroundJob;
+
+use OCP\BackgroundJob\IJob;
+use OCP\BackgroundJob\IJobList;
+use OCP\ILogger;
+use OCP\Lock\ILockingProvider;
+use OCP\Lock\LockedException;
+
+/**
+ * Concurrency aware job executer
+ */
+class Executer {
+	/** @var ILockingProvider */
+	private $lockingProvider;
+
+	/** @var IJobList */
+	private $jobList;
+
+	/** @var ILogger  */
+	private $logger;
+
+	/** how long until we give up trying to get the lock for getting a new job in seconds */
+	const LOCK_TIMEOUT = 5;
+
+	/** how long we sleep after each failed attempt to get exclusive access to the job list in seconds */
+	const LOCK_SLEEP_TIME = 0.015;
+
+	/**
+	 * @param ILockingProvider $lockingProvider
+	 * @param IJobList $jobList
+	 * @param ILogger $logger
+	 */
+	public function __construct(ILockingProvider $lockingProvider, IJobList $jobList, ILogger $logger = null) {
+		$this->lockingProvider = $lockingProvider;
+		$this->jobList = $jobList;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Get the next job from the joblist and execute it
+	 *
+	 * Locking is used to allow multiple processes using the method in parallel for parallel job execution
+	 *
+	 * @return bool returns whether or not a job has been executed
+	 */
+	public function executeNextJob() {
+		$job = $this->getNextJob();
+		if ($job) {
+			try {
+				$this->runJob($job);
+			} catch (LockedException $e) {
+				return false;
+			}
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	public function getNextJob() {
+		$timeWaited = 0;
+		while ($timeWaited < self::LOCK_TIMEOUT) {
+			try {
+				$this->lockingProvider->acquireLock('joblist', ILockingProvider::LOCK_EXCLUSIVE);
+
+				$job = $this->jobList->getNext();
+
+				if ($job) {
+					$this->jobList->setLastJob($job);
+				}
+
+				$this->lockingProvider->releaseLock('joblist', ILockingProvider::LOCK_EXCLUSIVE);
+				return $job;
+			} catch (LockedException $e) {
+				usleep(self::LOCK_SLEEP_TIME * 1000 * 1000);
+				$timeWaited += self::LOCK_SLEEP_TIME;
+			}
+		}
+
+		return null;
+	}
+
+	public function runJob(IJob $job) {
+		$this->lockingProvider->acquireLock('job/' . $job->getId(), ILockingProvider::LOCK_EXCLUSIVE);
+
+		$job->execute($this->jobList, $this->logger);
+
+		$this->lockingProvider->releaseLock('job/' . $job->getId(), ILockingProvider::LOCK_EXCLUSIVE);
+	}
+}

--- a/tests/lib/backgroundjob/executer.php
+++ b/tests/lib/backgroundjob/executer.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\BackgroundJob;
+
+use OC\Lock\MemcacheLockingProvider;
+use OC\Memcache\ArrayCache;
+use OCP\Lock\ILockingProvider;
+use Test\TestCase;
+
+class Executer extends TestCase {
+	public function testNoJob() {
+		$lockingProvider = new MemcacheLockingProvider(new ArrayCache());
+		$jobList = $this->getMock('\OCP\BackgroundJob\IJobList');
+		$jobList->expects($this->once())
+			->method('getNext')
+			->will($this->returnValue(null));
+
+		$jobList->expects($this->never())
+			->method('setLastJob');
+
+		$executer = new \OC\BackgroundJob\Executer($lockingProvider, $jobList);
+
+		$this->assertFalse($executer->executeNextJob());
+	}
+
+	public function testRunJob() {
+		$lockingProvider = new MemcacheLockingProvider(new ArrayCache());
+
+		$job = $this->getMock('\OCP\BackgroundJob\IJob');
+
+		$jobList = $this->getMock('\OCP\BackgroundJob\IJobList');
+		$jobList->expects($this->once())
+			->method('getNext')
+			->will($this->returnValue($job));
+
+		$jobList->expects($this->once())
+			->method('setLastJob')
+			->with($job);
+
+		$job->expects($this->once())
+			->method('execute')
+			->with($jobList);
+
+		$executer = new \OC\BackgroundJob\Executer($lockingProvider, $jobList);
+
+		$this->assertTrue($executer->executeNextJob());
+	}
+
+	public function testLocked() {
+		$lockingProvider = new MemcacheLockingProvider(new ArrayCache());
+
+		$jobList = $this->getMock('\OCP\BackgroundJob\IJobList');
+		$jobList->expects($this->never())
+			->method('getNext');
+
+		$jobList->expects($this->never())
+			->method('setLastJob');
+
+		$executer = new \OC\BackgroundJob\Executer($lockingProvider, $jobList);
+
+		$lockingProvider->acquireLock('joblist', ILockingProvider::LOCK_EXCLUSIVE);
+
+		$this->assertFalse($executer->executeNextJob());
+	}
+
+	public function testJobLocked() {
+		$lockingProvider = new MemcacheLockingProvider(new ArrayCache());
+
+		$job = $this->getMock('\OCP\BackgroundJob\IJob');
+		$job->method('getId')
+			->will($this->returnValue(1));
+
+		$jobList = $this->getMock('\OCP\BackgroundJob\IJobList');
+		$jobList->expects($this->once())
+			->method('getNext')
+			->will($this->returnValue($job));
+
+		$jobList->expects($this->once())
+			->method('setLastJob')
+			->with($job);
+
+		$job->expects($this->never())
+			->method('execute');
+
+		$lockingProvider->acquireLock('job/1', ILockingProvider::LOCK_EXCLUSIVE);
+
+		$executer = new \OC\BackgroundJob\Executer($lockingProvider, $jobList);
+
+		$this->assertFalse($executer->executeNextJob());
+	}
+}


### PR DESCRIPTION
Removes the global lock from cron.php and replaces it with a more fine grained locking system to allow concurrent job execution.
- A global lock for the joblist is acquired each time the job executor gets the next job from the list
  this ensures that multiple executors running at the same time will get different jobs to run
- A lock is acquired on a job when it's starts executing it to prevent multiple process from touching the same job in cases of long running jobs
- A 5 minute minimum delay is added before any job is considered for execution again after it's run, this prevents multiple executers running the same job after each other unnecessarily
- An occ command (`occ background:run`) has been added as an additional way to trigger the execution of background jobs, using this an admin can create more sophisticated system for running jobs.

I've done some tested (create artificial long running jobs, start cron.php a few time and look which cron.php instance runs which job) but ideally we'll figure out some way to get automated testing of parallel execution

cc @DeepDiver1975 @PVince81 @MorrisJobke 
