### PR TITLE
chunk the cleaning up of shared locks

### DIFF
--- a/lib/private/Lock/DBLockingProvider.php
+++ b/lib/private/Lock/DBLockingProvider.php
@@ -24,6 +24,7 @@
 
 namespace OC\Lock;
 
+use OC\DB\QueryBuilder\Literal;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IDBConnection;
 use OCP\ILogger;
@@ -257,13 +258,25 @@ class DBLockingProvider extends AbstractLockingProvider {
 		parent::releaseAll();
 
 		// since we keep shared locks we need to manually clean those
-		foreach ($this->sharedLocks as $path => $lock) {
-			if ($lock) {
-				$this->connection->executeUpdate(
-					'UPDATE `*PREFIX*file_locks` SET `lock` = `lock` - 1 WHERE `key` = ? AND `lock` > 0',
-					[$path]
-				);
-			}
+		$lockedPaths = array_keys($this->sharedLocks);
+		$lockedPaths = array_filter($lockedPaths, function ($path) {
+			return $this->sharedLocks[$path];
+		});
+
+		$chunkedPaths = array_chunk($lockedPaths, 100);
+
+		foreach ($chunkedPaths as $chunk) {
+			$builder = $this->connection->getQueryBuilder();
+			$params = array_map(function ($path) use ($builder) {
+				return $builder->createNamedParameter($path);
+			}, $chunk);
+
+			$query = $builder->update('file_locks')
+				->set('lock', $builder->createFunction('`lock` -1'))
+				->where($builder->expr()->in('key', $params))
+				->andWhere($builder->expr()->gt('lock', new Literal(0)));
+
+			$query->execute();
 		}
 	}
 }

--- a/lib/private/Lock/DBLockingProvider.php
+++ b/lib/private/Lock/DBLockingProvider.php
@@ -26,6 +26,7 @@ namespace OC\Lock;
 
 use OC\DB\QueryBuilder\Literal;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\ILogger;
 use OCP\Lock\ILockingProvider;
@@ -267,13 +268,10 @@ class DBLockingProvider extends AbstractLockingProvider {
 
 		foreach ($chunkedPaths as $chunk) {
 			$builder = $this->connection->getQueryBuilder();
-			$params = array_map(function ($path) use ($builder) {
-				return $builder->createNamedParameter($path);
-			}, $chunk);
 
 			$query = $builder->update('file_locks')
 				->set('lock', $builder->createFunction('`lock` -1'))
-				->where($builder->expr()->in('key', $params))
+				->where($builder->expr()->in('key', $builder->createNamedParameter($chunk, IQueryBuilder::PARAM_STR_ARRAY)))
 				->andWhere($builder->expr()->gt('lock', new Literal(0)));
 
 			$query->execute();


### PR DESCRIPTION
Large performance improvement if a request acquires a large number of locks (very obvious when using `occ files:scan` with the db locking provider)

[comparison](https://blackfire.io/profiles/compare/5beccfa2-1e7c-46c5-882a-2088f575cc5c/graph)

cc @MorrisJobke @DeepDiver1975 @LukasReschke please review
