### PR TITLE
Add option to hide hidden files

### DIFF
--- a/apps/files/appinfo/routes.php
+++ b/apps/files/appinfo/routes.php
@@ -54,6 +54,11 @@ $application->registerRoutes(
 				'url' => '/api/v1/sorting',
 				'verb' => 'POST'
 			),
+			array(
+				'name' => 'API#showHiddenFiles',
+				'url' => '/api/v1/showhidden',
+				'verb' => 'POST'
+			),
 			[
 				'name' => 'view#index',
 				'url' => '/',

--- a/apps/files/controller/apicontroller.php
+++ b/apps/files/controller/apicontroller.php
@@ -224,4 +224,16 @@ class ApiController extends Controller {
 		return new Response();
 	}
 
+	/**
+	 * Toggle default for showing/hiding hidden files
+	 *
+	 * @NoAdminRequired
+	 *
+	 * @param bool $show
+	 */
+	public function showHiddenFiles($show) {
+		$this->config->setUserValue($this->userSession->getUser()->getUID(), 'files', 'show_hidden', (int) $show);
+		return new Response();
+	}
+
 }

--- a/apps/files/controller/viewcontroller.php
+++ b/apps/files/controller/viewcontroller.php
@@ -67,6 +67,7 @@ class ViewController extends Controller {
 	 * @param IL10N $l10n
 	 * @param IConfig $config
 	 * @param EventDispatcherInterface $eventDispatcherInterface
+	 * @param IUserSession $userSession
 	 */
 	public function __construct($appName,
 								IRequest $request,
@@ -222,6 +223,8 @@ class ViewController extends Controller {
 		$user = $this->userSession->getUser()->getUID();
 		$params['defaultFileSorting'] = $this->config->getUserValue($user, 'files', 'file_sorting', 'name');
 		$params['defaultFileSortingDirection'] = $this->config->getUserValue($user, 'files', 'file_sorting_direction', 'asc');
+		$showHidden = (bool) $this->config->getUserValue($this->userSession->getUser()->getUID(), 'files', 'show_hidden', false);
+		$params['showHiddenFiles'] = $showHidden ? 1 : 0;
 		$params['appNavigation'] = $nav;
 		$params['appContents'] = $contentItems;
 		$this->navigationManager->setActiveEntry('files_index');

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -2,6 +2,11 @@
  This file is licensed under the Affero General Public License version 3 or later.
  See the COPYING-README file. */
 
+/* SETTINGS */
+#files-setting-showhidden {
+	padding-bottom: 8px;
+}
+
 /* FILE MENU */
 .actions { padding:5px; height:32px; display: inline-block; float: left; }
 .actions input, .actions button, .actions .button { margin:0; float:left; }

--- a/apps/files/templates/appnavigation.php
+++ b/apps/files/templates/appnavigation.php
@@ -16,9 +16,13 @@
 			</button>
 		</div>
 		<div id="app-settings-content">
-				<label for="webdavurl"><?php p($l->t('WebDAV'));?></label>
-				<input id="webdavurl" type="text" readonly="readonly" value="<?php p(\OCP\Util::linkToRemote('webdav')); ?>" />
-				<em><?php print_unescaped($l->t('Use this address to <a href="%s" target="_blank" rel="noreferrer">access your Files via WebDAV</a>', array(link_to_docs('user-webdav'))));?></em>
+			<div id="files-setting-showhidden">
+				<input class="checkbox" id="showhiddenfilesToggle" checked="checked" type="checkbox">
+				<label for="showhiddenfilesToggle"><?php p($l->t('Show hidden files')); ?></label>
+			</div>
+			<label for="webdavurl"><?php p($l->t('WebDAV'));?></label>
+			<input id="webdavurl" type="text" readonly="readonly" value="<?php p(\OCP\Util::linkToRemote('webdav')); ?>" />
+			<em><?php print_unescaped($l->t('Use this address to <a href="%s" target="_blank" rel="noreferrer">access your Files via WebDAV</a>', array(link_to_docs('user-webdav'))));?></em>
 		</div>
 	</div>
 </div>

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -20,4 +20,5 @@
 <input type="hidden" name="allowShareWithLink" id="allowShareWithLink" value="<?php p($_['allowShareWithLink']) ?>" />
 <input type="hidden" name="defaultFileSorting" id="defaultFileSorting" value="<?php p($_['defaultFileSorting']) ?>" />
 <input type="hidden" name="defaultFileSortingDirection" id="defaultFileSortingDirection" value="<?php p($_['defaultFileSortingDirection']) ?>" />
+<input type="hidden" name="showHiddenFiles" id="showHiddenFiles" value="<?php p($_['showHiddenFiles']); ?>" />
 <?php endif;

--- a/apps/files/tests/controller/ViewControllerTest.php
+++ b/apps/files/tests/controller/ViewControllerTest.php
@@ -155,11 +155,12 @@ class ViewControllerTest extends TestCase {
 				'owner' => 'MyName',
 				'ownerDisplayName' => 'MyDisplayName',
 			]));
-		$this->config->expects($this->exactly(2))
+		$this->config->expects($this->exactly(3))
 			->method('getUserValue')
 			->will($this->returnValueMap([
 				[$this->user->getUID(), 'files', 'file_sorting', 'name', 'name'],
-				[$this->user->getUID(), 'files', 'file_sorting_direction', 'asc', 'asc']
+				[$this->user->getUID(), 'files', 'file_sorting_direction', 'asc', 'asc'],
+				[$this->user->getUID(), 'files', 'show_hidden', false, false],
 			]));
 
 		$this->config
@@ -244,6 +245,7 @@ class ViewControllerTest extends TestCase {
 				'isPublic' => false,
 				'defaultFileSorting' => 'name',
 				'defaultFileSortingDirection' => 'asc',
+				'showHiddenFiles' => false,
 				'mailNotificationEnabled' => 'no',
 				'mailPublicNotificationEnabled' => 'no',
 				'allowShareWithLink' => 'yes',

--- a/apps/files/tests/controller/apicontrollertest.php
+++ b/apps/files/tests/controller/apicontrollertest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  * @author Lukas Reschke <lukas@owncloud.com>
@@ -380,6 +381,19 @@ class ApiControllerTest extends TestCase {
 		$result = $this->apiController->updateFileSorting($mode, $direction);
 
 		$this->assertEquals($expected, $result);
+	}
+
+	public function testShowHiddenFiles() {
+		$show = false;
+
+		$this->config->expects($this->once())
+			->method('setUserValue')
+			->with($this->user->getUID(), 'files', 'show_hidden', $show);
+
+		$expected = new Http\Response();
+		$actual = $this->apiController->showHiddenFiles($show);
+
+		$this->assertEquals($expected, $actual);
 	}
 
 }

--- a/apps/files_sharing/js/app.js
+++ b/apps/files_sharing/js/app.js
@@ -33,7 +33,8 @@ OCA.Sharing.App = {
 				id: 'shares.self',
 				scrollContainer: $('#app-content'),
 				sharedWithUser: true,
-				fileActions: this._createFileActions()
+				fileActions: this._createFileActions(),
+				config: OCA.Files.App.getFilesConfig()
 			}
 		);
 
@@ -55,7 +56,8 @@ OCA.Sharing.App = {
 				id: 'shares.others',
 				scrollContainer: $('#app-content'),
 				sharedWithUser: false,
-				fileActions: this._createFileActions()
+				fileActions: this._createFileActions(),
+				config: OCA.Files.App.getFilesConfig()
 			}
 		);
 
@@ -77,7 +79,8 @@ OCA.Sharing.App = {
 				id: 'shares.link',
 				scrollContainer: $('#app-content'),
 				linksOnly: true,
-				fileActions: this._createFileActions()
+				fileActions: this._createFileActions(),
+				config: OCA.Files.App.getFilesConfig()
 			}
 		);
 

--- a/apps/files_trashbin/js/app.js
+++ b/apps/files_trashbin/js/app.js
@@ -29,7 +29,8 @@ OCA.Trashbin.App = {
 				scrollContainer: $('#app-content'),
 				fileActions: this._createFileActions(),
 				detailsViewEnabled: false,
-				scrollTo: urlParams.scrollto
+				scrollTo: urlParams.scrollto,
+				config: OCA.Files.App.getFilesConfig()
 			}
 		);
 	},

--- a/apps/systemtags/js/app.js
+++ b/apps/systemtags/js/app.js
@@ -28,7 +28,8 @@
 				{
 					id: 'systemtags',
 					scrollContainer: $('#app-content'),
-					fileActions: this._createFileActions()
+					fileActions: this._createFileActions(),
+					config: OCA.Files.App.getFilesConfig()
 				}
 			);
 


### PR DESCRIPTION
fixes https://github.com/owncloud/core/issues/2589

TODO:
- [x] hide hidden files/folders on the we interface
- [x] add checkbox to the settings menu
- [x] persist user settings
- [x] fix html/css
- [x] hide hidden files by default
- [x] fix/adjust unit tests
- [x] TEST: collision detection when creating a new file/folder
- [x] TEST: collision detection when renaming a file/folder
- [x] TEST: favorites folder respects setting
- [x] DOC: documentation
## Questions
- Is it sufficient that files are hidden while rending the view or should hidden files be excluded server-side?
- Should new, but hidden files be shown right after creating?

cc @jancborchardt @MTRichards 
