### PR TITLE
Add LazyRootFolder

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -48,6 +48,7 @@ use OC\Diagnostics\QueryLogger;
 use OC\Files\Config\UserMountCache;
 use OC\Files\Config\UserMountCacheListener;
 use OC\Files\Node\HookConnector;
+use OC\Files\Node\LazyRoot;
 use OC\Files\Node\Root;
 use OC\Files\View;
 use OC\Http\Client\ClientService;
@@ -171,6 +172,11 @@ class Server extends ServerContainer implements IServerContainer {
 			$connector = new HookConnector($root, $view);
 			$connector->viewToNode();
 			return $root;
+		});
+		$this->registerService('LazyRootFolder', function(Server $c) {
+			return new LazyRoot(function() use ($c) {
+				return $c->getRootFolder();
+			});
 		});
 		$this->registerService('UserManager', function (Server $c) {
 			$config = $c->getConfig();
@@ -621,7 +627,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getL10N('core'),
 				$factory,
 				$c->getUserManager(),
-				$c->getRootFolder()
+				$c->getLazyRootFolder()
 			);
 
 			return $manager;
@@ -725,6 +731,17 @@ class Server extends ServerContainer implements IServerContainer {
 	 */
 	public function getRootFolder() {
 		return $this->query('RootFolder');
+	}
+
+	/**
+	 * Returns the root folder of ownCloud's data directory
+	 * This is the lazy variant so this gets only initialized once it
+	 * is actually used.
+	 *
+	 * @return \OCP\Files\IRootFolder
+	 */
+	public function getLazyRootFolder() {
+		return $this->query('LazyRootFolder');
 	}
 
 	/**

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -63,7 +63,7 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->getDatabaseConnection(),
 				$this->serverContainer->getUserManager(),
 				$this->serverContainer->getGroupManager(),
-				$this->serverContainer->getRootFolder()
+				$this->serverContainer->getLazyRootFolder()
 			);
 		}
 
@@ -114,7 +114,7 @@ class ProviderFactory implements IProviderFactory {
 				$tokenHandler,
 				$l,
 				$this->serverContainer->getLogger(),
-				$this->serverContainer->getRootFolder()
+				$this->serverContainer->getLazyRootFolder()
 			);
 		}
 

--- a/lib/private/files/node/lazyroot.php
+++ b/lib/private/files/node/lazyroot.php
@@ -1,0 +1,474 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Files\Node;
+
+use OC\Files\Mount\MountPoint;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotPermittedException;
+
+/**
+ * Class LazyRoot
+ *
+ * This is a lazy wrapper around the root. So only
+ * once it is needed this will get initialized.
+ *
+ * @package OC\Files\Node
+ */
+class LazyRoot implements IRootFolder {
+	/** @var \Closure */
+	private $rootFolderClosure;
+
+	/** @var IRootFolder */
+	private $rootFolder;
+
+	/**
+	 * LazyRoot constructor.
+	 *
+	 * @param \Closure $rootFolderClosure
+	 */
+	public function __construct(\Closure $rootFolderClosure) {
+		$this->rootFolderClosure = $rootFolderClosure;
+	}
+
+	/**
+	 * Magic method to first get the real rootFolder and then
+	 * call $method with $args on it
+	 *
+	 * @param $method
+	 * @param $args
+	 * @return mixed
+	 */
+	public function __call($method, $args) {
+		if ($this->rootFolder === null) {
+			$this->rootFolder = call_user_func($this->rootFolderClosure);
+		}
+
+		return call_user_func_array([$this->rootFolder, $method], $args);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getUser() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function listen($scope, $method, callable $callback) {
+		$this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function removeListener($scope = null, $method = null, callable $callback = null) {
+		$this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function emit($scope, $method, $arguments = array()) {
+		$this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function mount($storage, $mountPoint, $arguments = array()) {
+		$this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getMount($mountPoint) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getMountsIn($mountPoint) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getMountByStorageId($storageId) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getMountByNumericStorageId($numericId) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function unMount($mount) {
+		$this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get($path) {
+		$this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function rename($targetPath) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function delete() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function copy($targetPath) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function touch($mtime = null) {
+		$this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getStorage() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getPath() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getInternalPath() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getId() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function stat() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getMTime() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getSize() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getEtag() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getPermissions() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function isReadable() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function isUpdateable() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function isDeletable() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function isShareable() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getParent() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getName() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getUserFolder($userId) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getMimetype() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getMimePart() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function isEncrypted() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getType() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function isShared() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function isMounted() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getMountPoint() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getOwner() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getChecksum() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getFullPath($path) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getRelativePath($path) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function isSubNode($node) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getDirectoryListing() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function nodeExists($path) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function newFolder($path) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function newFile($path) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function search($query) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function searchByMime($mimetype) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function searchByTag($tag, $userId) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getById($id) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getFreeSpace() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function isCreatable() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getNonExistingName($name) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function move($targetPath) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function lock($type) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function changeLock($targetType) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function unlock($type) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+
+}


### PR DESCRIPTION
To make https://github.com/owncloud/core/pull/23919 a bit smaller.

This adds a LazyRootFolder. That will only initialize the moment a function is called. This allows the share Manager/Providers/Shares to be a lot more lazy.

This lazyness is required if we want to use the shareManager also in the sharedMount. Else we get cyclic dependencies.

CC: @icewind1991 @DeepDiver1975 @nickvergessen @PVince81 @MorrisJobke @LukasReschke 
