### PR TITLE
Call private cache methods only for `OC\Files\Cache\Cache`

### DIFF
--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -469,7 +469,7 @@ class Scanner extends BasicEmitter implements IScanner {
 		try {
 			$callback();
 			\OC_Hook::emit('Scanner', 'correctFolderSize', array('path' => $path));
-			if ($this->cacheActive) {
+			if ($this->cacheActive && $this->cache instanceof Cache) {
 				$this->cache->correctFolderSize($path);
 			}
 		} catch (\OCP\Files\StorageInvalidException $e) {

--- a/lib/private/files/cache/updater.php
+++ b/lib/private/files/cache/updater.php
@@ -123,7 +123,9 @@ class Updater implements IUpdater {
 		} else {
 			// scanner didn't provide size info, fallback to full size calculation
 			$sizeDifference = 0;
-			$this->cache->correctFolderSize($path, $data);
+			if ($this->cache instanceof Cache) {
+				$this->cache->correctFolderSize($path, $data);
+			}
 		}
 		$this->correctParentStorageMtime($path);
 		$this->propagator->propagateChange($path, $time, $sizeDifference);
@@ -145,7 +147,9 @@ class Updater implements IUpdater {
 		}
 
 		$this->cache->remove($path);
-		$this->cache->correctFolderSize($parent);
+		if ($this->cache instanceof Cache) {
+			$this->cache->correctFolderSize($parent);
+		}
 		$this->correctParentStorageMtime($path);
 		$this->propagator->propagateChange($path, time());
 	}
@@ -187,8 +191,12 @@ class Updater implements IUpdater {
 			$this->cache->update($fileId, ['mimetype' => $mimeType]);
 		}
 
-		$sourceCache->correctFolderSize($source);
-		$this->cache->correctFolderSize($target);
+		if ($sourceCache instanceof Cache) {
+			$sourceCache->correctFolderSize($source);
+		}
+		if ($this->cache instanceof Cache) {
+			$this->cache->correctFolderSize($target);
+		}
 		if ($sourceUpdater instanceof Updater) {
 			$sourceUpdater->correctParentStorageMtime($source);
 		}

--- a/lib/private/files/cache/watcher.php
+++ b/lib/private/files/cache/watcher.php
@@ -106,7 +106,9 @@ class Watcher implements IWatcher {
 		if ($cachedData['mimetype'] === 'httpd/unix-directory') {
 			$this->cleanFolder($path);
 		}
-		$this->cache->correctFolderSize($path);
+		if ($this->cache instanceof Cache) {
+			$this->cache->correctFolderSize($path);
+		}
 	}
 
 	/**

--- a/lib/private/files/cache/wrapper/cachejail.php
+++ b/lib/private/files/cache/wrapper/cachejail.php
@@ -23,6 +23,7 @@
  */
 
 namespace OC\Files\Cache\Wrapper;
+use OC\Files\Cache\Cache;
 
 /**
  * Jail to a subdirectory of the wrapped cache
@@ -233,7 +234,9 @@ class CacheJail extends CacheWrapper {
 	 * @param array $data (optional) meta data of the folder
 	 */
 	public function correctFolderSize($path, $data = null) {
-		$this->cache->correctFolderSize($this->getSourcePath($path), $data);
+		if ($this->cache instanceof Cache) {
+			$this->cache->correctFolderSize($this->getSourcePath($path), $data);
+		}
 	}
 
 	/**
@@ -244,7 +247,12 @@ class CacheJail extends CacheWrapper {
 	 * @return int
 	 */
 	public function calculateFolderSize($path, $entry = null) {
-		return $this->cache->calculateFolderSize($this->getSourcePath($path), $entry);
+		if ($this->cache instanceof Cache) {
+			return $this->cache->calculateFolderSize($this->getSourcePath($path), $entry);
+		} else {
+			return 0;
+		}
+
 	}
 
 	/**

--- a/lib/private/files/cache/wrapper/cachewrapper.php
+++ b/lib/private/files/cache/wrapper/cachewrapper.php
@@ -240,7 +240,9 @@ class CacheWrapper extends Cache {
 	 * @param array $data (optional) meta data of the folder
 	 */
 	public function correctFolderSize($path, $data = null) {
-		$this->cache->correctFolderSize($path, $data);
+		if ($this->cache instanceof Cache) {
+			$this->cache->correctFolderSize($path, $data);
+		}
 	}
 
 	/**
@@ -251,7 +253,11 @@ class CacheWrapper extends Cache {
 	 * @return int
 	 */
 	public function calculateFolderSize($path, $entry = null) {
-		return $this->cache->calculateFolderSize($path, $entry);
+		if ($this->cache instanceof Cache) {
+			return $this->cache->calculateFolderSize($path, $entry);
+		} else {
+			return 0;
+		}
 	}
 
 	/**


### PR DESCRIPTION
The two methods `correctFolderSize` and `calculateFolderSize` should be
part of the interface since they are used  throughout the code when
an instance of this interface is expected. The implementation
`OC\Files\Cache\FailedCache` was missing this methods.

This fixes #23534
