### PR TITLE
[stable8.2] Fixes a possible infinite change-dir-loop

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1371,7 +1371,8 @@
 				// if the error is not related to folder we're trying to load, reload the page to handle logout etc
 				if (result.data.error === 'authentication_error' ||
 					result.data.error === 'token_expired' ||
-					result.data.error === 'application_not_enabled'
+					result.data.error === 'application_not_enabled' ||
+					result.data.exception === '\\OCP\\Files\\StorageNotAvailableException'
 				) {
 					OC.redirect(OC.generateUrl('apps/files'));
 				}


### PR DESCRIPTION
Those can occur when browsing in a mount that got unavailable
1. Have an external mount with some directory levels
2. Browse it
3. Make the external mount unavailable, so it throws \OCP\Files\StorageNotAvailableException
4. Click on a folder (can be in breadcrumb to) that exists on the mount

Without the fix the files app will infinitely attempt to switch between the clicked and the old folder.

Now, it redirects to /.

:warning: there is no PR against master yet, my need is 8.2 currently

What ya think @icewind1991 @MorrisJobke @rullzer ?

rel https://github.com/owncloud/windows_network_drive/pull/372
