### PR TITLE
Fix namespaces for files_external

### DIFF
--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -27,7 +27,6 @@
  */
 
 OC::$CLASSPATH['OC_Mount_Config'] = 'files_external/lib/config.php';
-OC::$CLASSPATH['OCA\Files\External\Api'] = 'files_external/lib/api.php';
 
 require_once __DIR__ . '/../3rdparty/autoload.php';
 

--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -26,15 +26,6 @@
  *
  */
 
-OC::$CLASSPATH['OC\Files\Storage\StreamWrapper'] = 'files_external/lib/streamwrapper.php';
-OC::$CLASSPATH['OC\Files\Storage\FTP'] = 'files_external/lib/ftp.php';
-OC::$CLASSPATH['OC\Files\Storage\OwnCloud'] = 'files_external/lib/owncloud.php';
-OC::$CLASSPATH['OC\Files\Storage\Google'] = 'files_external/lib/google.php';
-OC::$CLASSPATH['OC\Files\Storage\Swift'] = 'files_external/lib/swift.php';
-OC::$CLASSPATH['OC\Files\Storage\SMB'] = 'files_external/lib/smb.php';
-OC::$CLASSPATH['OC\Files\Storage\AmazonS3'] = 'files_external/lib/amazons3.php';
-OC::$CLASSPATH['OC\Files\Storage\Dropbox'] = 'files_external/lib/dropbox.php';
-OC::$CLASSPATH['OC\Files\Storage\SFTP'] = 'files_external/lib/sftp.php';
 OC::$CLASSPATH['OC_Mount_Config'] = 'files_external/lib/config.php';
 OC::$CLASSPATH['OCA\Files\External\Api'] = 'files_external/lib/api.php';
 

--- a/apps/files_external/appinfo/routes.php
+++ b/apps/files_external/appinfo/routes.php
@@ -61,6 +61,6 @@ $this->create('files_external_list_applicable', '/applicable')
 
 \OCP\API::register('get',
 		'/apps/files_external/api/v1/mounts',
-		array('\OCA\Files\External\Api', 'getUserMounts'),
+		array('\OCA\Files_External\Lib\Api', 'getUserMounts'),
 		'files_external');
 

--- a/apps/files_external/lib/api.php
+++ b/apps/files_external/lib/api.php
@@ -23,7 +23,7 @@
  *
  */
 
-namespace OCA\Files\External;
+namespace OCA\Files_External\Lib;
 
 class Api {
 

--- a/apps/files_external/lib/backend/amazons3.php
+++ b/apps/files_external/lib/backend/amazons3.php
@@ -38,7 +38,7 @@ class AmazonS3 extends Backend {
 		$this
 			->setIdentifier('amazons3')
 			->addIdentifierAlias('\OC\Files\Storage\AmazonS3') // legacy compat
-			->setStorageClass('\OC\Files\Storage\AmazonS3')
+			->setStorageClass('\OCA\Files_External\Lib\Storage\AmazonS3')
 			->setText($l->t('Amazon S3'))
 			->addParameters([
 				(new DefinitionParameter('bucket', $l->t('Bucket'))),

--- a/apps/files_external/lib/backend/dropbox.php
+++ b/apps/files_external/lib/backend/dropbox.php
@@ -38,7 +38,7 @@ class Dropbox extends Backend {
 		$this
 			->setIdentifier('dropbox')
 			->addIdentifierAlias('\OC\Files\Storage\Dropbox') // legacy compat
-			->setStorageClass('\OC\Files\Storage\Dropbox')
+			->setStorageClass('\OCA\Files_External\Lib\Storage\Dropbox')
 			->setText($l->t('Dropbox'))
 			->addParameters([
 				// all parameters handled in OAuth1 mechanism

--- a/apps/files_external/lib/backend/ftp.php
+++ b/apps/files_external/lib/backend/ftp.php
@@ -38,7 +38,7 @@ class FTP extends Backend {
 		$this
 			->setIdentifier('ftp')
 			->addIdentifierAlias('\OC\Files\Storage\FTP') // legacy compat
-			->setStorageClass('\OC\Files\Storage\FTP')
+			->setStorageClass('\OCA\Files_External\Lib\Storage\FTP')
 			->setText($l->t('FTP'))
 			->addParameters([
 				(new DefinitionParameter('host', $l->t('Host'))),

--- a/apps/files_external/lib/backend/google.php
+++ b/apps/files_external/lib/backend/google.php
@@ -38,7 +38,7 @@ class Google extends Backend {
 		$this
 			->setIdentifier('googledrive')
 			->addIdentifierAlias('\OC\Files\Storage\Google') // legacy compat
-			->setStorageClass('\OC\Files\Storage\Google')
+			->setStorageClass('\OCA\Files_External\Lib\Storage\Google')
 			->setText($l->t('Google Drive'))
 			->addParameters([
 				// all parameters handled in OAuth2 mechanism

--- a/apps/files_external/lib/backend/owncloud.php
+++ b/apps/files_external/lib/backend/owncloud.php
@@ -35,7 +35,7 @@ class OwnCloud extends Backend {
 		$this
 			->setIdentifier('owncloud')
 			->addIdentifierAlias('\OC\Files\Storage\OwnCloud') // legacy compat
-			->setStorageClass('\OC\Files\Storage\OwnCloud')
+			->setStorageClass('\OCA\Files_External\Lib\Storage\OwnCloud')
 			->setText($l->t('ownCloud'))
 			->addParameters([
 				(new DefinitionParameter('host', $l->t('URL'))),

--- a/apps/files_external/lib/backend/sftp.php
+++ b/apps/files_external/lib/backend/sftp.php
@@ -35,7 +35,7 @@ class SFTP extends Backend {
 		$this
 			->setIdentifier('sftp')
 			->addIdentifierAlias('\OC\Files\Storage\SFTP') // legacy compat
-			->setStorageClass('\OC\Files\Storage\SFTP')
+			->setStorageClass('\OCA\Files_External\Lib\Storage\SFTP')
 			->setText($l->t('SFTP'))
 			->addParameters([
 				(new DefinitionParameter('host', $l->t('Host'))),

--- a/apps/files_external/lib/backend/sftp_key.php
+++ b/apps/files_external/lib/backend/sftp_key.php
@@ -34,7 +34,7 @@ class SFTP_Key extends Backend {
 	public function __construct(IL10N $l, RSA $legacyAuth, SFTP $sftpBackend) {
 		$this
 			->setIdentifier('\OC\Files\Storage\SFTP_Key')
-			->setStorageClass('\OC\Files\Storage\SFTP')
+			->setStorageClass('\OCA\Files_External\Lib\Storage\SFTP')
 			->setText($l->t('SFTP with secret key login'))
 			->addParameters([
 				(new DefinitionParameter('host', $l->t('Host'))),

--- a/apps/files_external/lib/backend/smb.php
+++ b/apps/files_external/lib/backend/smb.php
@@ -40,7 +40,7 @@ class SMB extends Backend {
 		$this
 			->setIdentifier('smb')
 			->addIdentifierAlias('\OC\Files\Storage\SMB') // legacy compat
-			->setStorageClass('\OC\Files\Storage\SMB')
+			->setStorageClass('\OCA\Files_External\Lib\Storage\SMB')
 			->setText($l->t('SMB / CIFS'))
 			->addParameters([
 				(new DefinitionParameter('host', $l->t('Host'))),

--- a/apps/files_external/lib/backend/smb_oc.php
+++ b/apps/files_external/lib/backend/smb_oc.php
@@ -42,7 +42,7 @@ class SMB_OC extends Backend {
 	public function __construct(IL10N $l, SessionCredentials $legacyAuth, SMB $smbBackend) {
 		$this
 			->setIdentifier('\OC\Files\Storage\SMB_OC')
-			->setStorageClass('\OC\Files\Storage\SMB')
+			->setStorageClass('\OCA\Files_External\Lib\Storage\SMB')
 			->setText($l->t('SMB / CIFS using OC login'))
 			->addParameters([
 				(new DefinitionParameter('host', $l->t('Host'))),

--- a/apps/files_external/lib/backend/swift.php
+++ b/apps/files_external/lib/backend/swift.php
@@ -38,7 +38,7 @@ class Swift extends Backend {
 		$this
 			->setIdentifier('swift')
 			->addIdentifierAlias('\OC\Files\Storage\Swift') // legacy compat
-			->setStorageClass('\OC\Files\Storage\Swift')
+			->setStorageClass('\OCA\Files_External\Lib\Storage\Swift')
 			->setText($l->t('OpenStack Object Storage'))
 			->addParameters([
 				(new DefinitionParameter('service_name', $l->t('Service name')))

--- a/apps/files_external/lib/storage/amazons3.php
+++ b/apps/files_external/lib/storage/amazons3.php
@@ -33,7 +33,7 @@
  *
  */
 
-namespace OC\Files\Storage;
+namespace OCA\Files_External\Lib\Storage;
 
 set_include_path(get_include_path() . PATH_SEPARATOR .
 	\OC_App::getAppPath('files_external') . '/3rdparty/aws-sdk-php');

--- a/apps/files_external/lib/storage/dropbox.php
+++ b/apps/files_external/lib/storage/dropbox.php
@@ -27,7 +27,7 @@
  *
  */
 
-namespace OC\Files\Storage;
+namespace OCA\Files_External\Lib\Storage;
 
 use GuzzleHttp\Exception\RequestException;
 use Icewind\Streams\IteratorDirectory;
@@ -59,7 +59,7 @@ class Dropbox extends \OC\Files\Storage\Common {
 			// note: Dropbox_API connection is lazy
 			$this->dropbox = new \Dropbox_API($this->oauth, 'auto');
 		} else {
-			throw new \Exception('Creating \OC\Files\Storage\Dropbox storage failed');
+			throw new \Exception('Creating Dropbox storage failed');
 		}
 	}
 

--- a/apps/files_external/lib/storage/ftp.php
+++ b/apps/files_external/lib/storage/ftp.php
@@ -28,11 +28,11 @@
  *
  */
 
-namespace OC\Files\Storage;
+namespace OCA\Files_External\Lib\Storage;
 
 use Icewind\Streams\RetryWrapper;
 
-class FTP extends \OC\Files\Storage\StreamWrapper{
+class FTP extends StreamWrapper{
 	private $password;
 	private $user;
 	private $host;
@@ -59,7 +59,7 @@ class FTP extends \OC\Files\Storage\StreamWrapper{
 				$this->root .= '/';
 			}
 		} else {
-			throw new \Exception('Creating \OC\Files\Storage\FTP storage failed');
+			throw new \Exception('Creating FTP storage failed');
 		}
 		
 	}

--- a/apps/files_external/lib/storage/google.php
+++ b/apps/files_external/lib/storage/google.php
@@ -31,7 +31,7 @@
  *
  */
 
-namespace OC\Files\Storage;
+namespace OCA\Files_External\Lib\Storage;
 
 use GuzzleHttp\Exception\RequestException;
 use Icewind\Streams\IteratorDirectory;
@@ -79,7 +79,7 @@ class Google extends \OC\Files\Storage\Common {
 			$token = json_decode($params['token'], true);
 			$this->id = 'google::'.substr($params['client_id'], 0, 30).$token['created'];
 		} else {
-			throw new \Exception('Creating \OC\Files\Storage\Google storage failed');
+			throw new \Exception('Creating Google storage failed');
 		}
 	}
 

--- a/apps/files_external/lib/storage/owncloud.php
+++ b/apps/files_external/lib/storage/owncloud.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace OC\Files\Storage;
+namespace OCA\Files_External\Lib\Storage;
 
 /**
  * ownCloud backend for external storage based on DAV backend.

--- a/apps/files_external/lib/storage/sftp.php
+++ b/apps/files_external/lib/storage/sftp.php
@@ -29,7 +29,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-namespace OC\Files\Storage;
+namespace OCA\Files_External\Lib\Storage;
 use Icewind\Streams\IteratorDirectory;
 
 use Icewind\Streams\RetryWrapper;

--- a/apps/files_external/lib/storage/smb.php
+++ b/apps/files_external/lib/storage/smb.php
@@ -28,7 +28,7 @@
  *
  */
 
-namespace OC\Files\Storage;
+namespace OCA\Files_External\Lib\Storage;
 
 use Icewind\SMB\Exception\ConnectException;
 use Icewind\SMB\Exception\Exception;
@@ -42,7 +42,7 @@ use OC\Cache\CappedMemoryCache;
 use OC\Files\Filesystem;
 use OCP\Files\StorageNotAvailableException;
 
-class SMB extends Common {
+class SMB extends \OC\Files\Storage\Common {
 	/**
 	 * @var \Icewind\SMB\Server
 	 */

--- a/apps/files_external/lib/storage/streamwrapper.php
+++ b/apps/files_external/lib/storage/streamwrapper.php
@@ -24,9 +24,9 @@
  *
  */
 
-namespace OC\Files\Storage;
+namespace OCA\Files_External\Lib\Storage;
 
-abstract class StreamWrapper extends Common {
+abstract class StreamWrapper extends \OC\Files\Storage\Common {
 
 	/**
 	 * @param string $path

--- a/apps/files_external/lib/storage/swift.php
+++ b/apps/files_external/lib/storage/swift.php
@@ -32,7 +32,7 @@
  *
  */
 
-namespace OC\Files\Storage;
+namespace OCA\Files_External\Lib\Storage;
 
 use Guzzle\Http\Url;
 use Guzzle\Http\Exception\ClientErrorResponseException;

--- a/apps/files_external/tests/amazons3migration.php
+++ b/apps/files_external/tests/amazons3migration.php
@@ -24,14 +24,16 @@
  */
 
 
-namespace Test\Files\Storage;
+namespace OCA\Files_External\Tests;
+
+use OCA\Files_External\Lib\Storage\AmazonS3;
 
 /**
  * Class AmazonS3Migration
  *
  * @group DB
  *
- * @package Test\Files\Storage
+ * @package OCA\Files_External\Tests
  */
 class AmazonS3Migration extends \Test\TestCase {
 
@@ -77,7 +79,7 @@ class AmazonS3Migration extends \Test\TestCase {
 		$fileId = $oldCache->put('foobar', array('size' => 0, 'mtime' => time(), 'mimetype' => 'httpd/directory'));
 
 		try {
-			$this->instance = new \OC\Files\Storage\AmazonS3($this->params);
+			$this->instance = new AmazonS3($this->params);
 		} catch (\Exception $e) {
 			//ignore
 		}
@@ -103,7 +105,7 @@ class AmazonS3Migration extends \Test\TestCase {
 		$fileId = $oldCache->put('/', array('size' => 0, 'mtime' => time(), 'mimetype' => 'httpd/directory'));
 
 		try {
-			$this->instance = new \OC\Files\Storage\AmazonS3($this->params);
+			$this->instance = new AmazonS3($this->params);
 		} catch (\Exception $e) {
 			//ignore
 		}

--- a/apps/files_external/tests/controller/storagescontrollertest.php
+++ b/apps/files_external/tests/controller/storagescontrollertest.php
@@ -51,7 +51,7 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 	/**
 	 * @return \OCA\Files_External\Lib\Backend\Backend
 	 */
-	protected function getBackendMock($class = '\OCA\Files_External\Lib\Backend\SMB', $storageClass = '\OC\Files\Storage\SMB') {
+	protected function getBackendMock($class = '\OCA\Files_External\Lib\Backend\SMB', $storageClass = '\OCA\Files_External\Lib\Storage\SMB') {
 		$backend = $this->getMockBuilder('\OCA\Files_External\Lib\Backend\Backend')
 			->disableOriginalConstructor()
 			->getMock();
@@ -104,7 +104,7 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 
 		$response = $this->controller->create(
 			'mount',
-			'\OC\Files\Storage\SMB',
+			'\OCA\Files_External\Lib\Storage\SMB',
 			'\OCA\Files_External\Lib\Auth\NullMechanism',
 			array(),
 			[],
@@ -146,7 +146,7 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 		$response = $this->controller->update(
 			1,
 			'mount',
-			'\OC\Files\Storage\SMB',
+			'\OCA\Files_External\Lib\Storage\SMB',
 			'\OCA\Files_External\Lib\Auth\NullMechanism',
 			array(),
 			[],
@@ -188,7 +188,7 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 
 		$response = $this->controller->create(
 			$mountPoint,
-			'\OC\Files\Storage\SMB',
+			'\OCA\Files_External\Lib\Storage\SMB',
 			'\OCA\Files_External\Lib\Auth\NullMechanism',
 			array(),
 			[],
@@ -202,7 +202,7 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 		$response = $this->controller->update(
 			1,
 			$mountPoint,
-			'\OC\Files\Storage\SMB',
+			'\OCA\Files_External\Lib\Storage\SMB',
 			'\OCA\Files_External\Lib\Auth\NullMechanism',
 			array(),
 			[],
@@ -279,7 +279,7 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 		$response = $this->controller->update(
 			255,
 			'mount',
-			'\OC\Files\Storage\SMB',
+			'\OCA\Files_External\Lib\Storage\SMB',
 			'\OCA\Files_External\Lib\Auth\NullMechanism',
 			array(),
 			[],
@@ -375,7 +375,7 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 
 		$response = $this->controller->create(
 			'mount',
-			'\OC\Files\Storage\SMB',
+			'\OCA\Files_External\Lib\Storage\SMB',
 			'\OCA\Files_External\Lib\Auth\NullMechanism',
 			array(),
 			[],

--- a/apps/files_external/tests/controller/userstoragescontrollertest.php
+++ b/apps/files_external/tests/controller/userstoragescontrollertest.php
@@ -78,7 +78,7 @@ class UserStoragesControllerTest extends StoragesControllerTest {
 
 		$response = $this->controller->create(
 			'mount',
-			'\OC\Files\Storage\SMB',
+			'\OCA\Files_External\Lib\Storage\SMB',
 			'\Auth\Mechanism',
 			array(),
 			[],
@@ -92,7 +92,7 @@ class UserStoragesControllerTest extends StoragesControllerTest {
 		$response = $this->controller->update(
 			1,
 			'mount',
-			'\OC\Files\Storage\SMB',
+			'\OCA\Files_External\Lib\Storage\SMB',
 			'\Auth\Mechanism',
 			array(),
 			[],

--- a/apps/files_external/tests/owncloudfunctions.php
+++ b/apps/files_external/tests/owncloudfunctions.php
@@ -23,14 +23,14 @@
  *
  */
 
-namespace Test\Files\Storage;
+namespace OCA\Files_External\Tests;
 
 /**
  * Class OwnCloudFunctions
  *
  * @group DB
  *
- * @package Test\Files\Storage
+ * @package OCA\Files_External\Tests
  */
 class OwnCloudFunctions extends \Test\TestCase {
 
@@ -109,7 +109,7 @@ class OwnCloudFunctions extends \Test\TestCase {
 	public function testConfig($config, $expectedUri) {
 		$config['user'] = 'someuser';
 		$config['password'] = 'somepassword';
-		$instance = new \OC\Files\Storage\OwnCloud($config);
+		$instance = new \OCA\Files_External\Lib\Storage\OwnCloud($config);
 		$this->assertEquals($expectedUri, $instance->createBaseUri());
 	}
 }

--- a/apps/files_external/tests/service/storagesservicetest.php
+++ b/apps/files_external/tests/service/storagesservicetest.php
@@ -121,9 +121,9 @@ abstract class StoragesServiceTest extends \Test\TestCase {
 		$this->backendService->method('getAuthMechanisms')
 			->will($this->returnValue($authMechanisms));
 
-		$sftpBackend = $this->getBackendMock('\OCA\Files_External\Lib\Backend\SFTP', '\OC\Files\Storage\SFTP');
+		$sftpBackend = $this->getBackendMock('\OCA\Files_External\Lib\Backend\SFTP', '\OCA\Files_External\Lib\Storage\SFTP');
 		$backends = [
-			'identifier:\OCA\Files_External\Lib\Backend\SMB' => $this->getBackendMock('\OCA\Files_External\Lib\Backend\SMB', '\OC\Files\Storage\SMB'),
+			'identifier:\OCA\Files_External\Lib\Backend\SMB' => $this->getBackendMock('\OCA\Files_External\Lib\Backend\SMB', '\OCA\Files_External\Lib\Storage\SMB'),
 			'identifier:\OCA\Files_External\Lib\Backend\SFTP' => $sftpBackend,
 			'identifier:sftp_alias' => $sftpBackend,
 		];
@@ -171,7 +171,7 @@ abstract class StoragesServiceTest extends \Test\TestCase {
 		}
 	}
 
-	protected function getBackendMock($class = '\OCA\Files_External\Lib\Backend\SMB', $storageClass = '\OC\Files\Storage\SMB') {
+	protected function getBackendMock($class = '\OCA\Files_External\Lib\Backend\SMB', $storageClass = '\OCA\Files_External\Lib\Storage\SMB') {
 		$backend = $this->getMockBuilder('\OCA\Files_External\Lib\Backend\Backend')
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/files_external/tests/storage/amazons3test.php
+++ b/apps/files_external/tests/storage/amazons3test.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * @author Christian Berendt <berendt@b1-systems.de>
  * @author Joas Schilling <nickvergessen@owncloud.com>
+ * @author Michael Gapczynski <GapczynskiM@gmail.com>
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Robin Appelman <icewind@owncloud.com>
  * @author Robin McCorkell <robin@mccorkell.me.uk>
@@ -24,51 +24,40 @@
  *
  */
 
-namespace Test\Files\Storage;
+namespace OCA\Files_External\Tests\Storage;
+
+use \OCA\Files_External\Lib\Storage\AmazonS3;
 
 /**
- * Class Swift
+ * Class AmazonS3Test
  *
  * @group DB
  *
- * @package Test\Files\Storage
+ * @package OCA\Files_External\Tests\Storage
  */
-class Swift extends Storage {
+class AmazonS3Test extends \Test\Files\Storage\Storage {
 
 	private $config;
 
 	protected function setUp() {
 		parent::setUp();
 
-		$this->config = include('files_external/tests/config.swift.php');
-		if (!is_array($this->config) or !$this->config['run']) {
-			$this->markTestSkipped('OpenStack Object Storage backend not configured');
+		$this->config = include('files_external/tests/config.amazons3.php');
+		if ( ! is_array($this->config) or ! $this->config['run']) {
+			$this->markTestSkipped('AmazonS3 backend not configured');
 		}
-		$this->instance = new \OC\Files\Storage\Swift($this->config);
+		$this->instance = new AmazonS3($this->config);
 	}
 
 	protected function tearDown() {
 		if ($this->instance) {
-			try {
-				$connection = $this->instance->getConnection();
-				$container = $connection->getContainer($this->config['bucket']);
-
-				$objects = $container->objectList();
-				while($object = $objects->next()) {
-					$object->setName(str_replace('#','%23',$object->getName()));
-					$object->delete();
-				}
-
-				$container->delete();
-			} catch (\Guzzle\Http\Exception\ClientErrorResponseException $e) {
-				// container didn't exist, so we don't need to delete it
-			}
+			$this->instance->rmdir('');
 		}
 
 		parent::tearDown();
 	}
 
 	public function testStat() {
-		$this->markTestSkipped('Swift doesn\'t update the parents folder mtime');
+		$this->markTestSkipped('S3 doesn\'t update the parents folder mtime');
 	}
 }

--- a/apps/files_external/tests/storage/ftptest.php
+++ b/apps/files_external/tests/storage/ftptest.php
@@ -24,16 +24,18 @@
  *
  */
 
-namespace Test\Files\Storage;
+namespace OCA\Files_External\Tests\Storage;
+
+use \OCA\Files_External\Lib\Storage\FTP;
 
 /**
- * Class FTP
+ * Class FTPTest
  *
  * @group DB
  *
- * @package Test\Files\Storage
+ * @package OCA\Files_External\Tests\Storage
  */
-class FTP extends Storage {
+class FTPTest extends \Test\Files\Storage\Storage {
 	private $config;
 
 	protected function setUp() {
@@ -45,7 +47,7 @@ class FTP extends Storage {
 			$this->markTestSkipped('FTP backend not configured');
 		}
 		$this->config['root'] .= '/' . $id; //make sure we have an new empty folder to work in
-		$this->instance = new \OC\Files\Storage\FTP($this->config);
+		$this->instance = new FTP($this->config);
 		$this->instance->mkdir('/');
 	}
 
@@ -63,31 +65,31 @@ class FTP extends Storage {
 						  'password' => 'ftp',
 						  'root' => '/',
 						  'secure' => false );
-		$instance = new \OC\Files\Storage\FTP($config);
+		$instance = new FTP($config);
 		$this->assertEquals('ftp://ftp:ftp@localhost/', $instance->constructUrl(''));
 
 		$config['secure'] = true;
-		$instance = new \OC\Files\Storage\FTP($config);
+		$instance = new FTP($config);
 		$this->assertEquals('ftps://ftp:ftp@localhost/', $instance->constructUrl(''));
 
 		$config['secure'] = 'false';
-		$instance = new \OC\Files\Storage\FTP($config);
+		$instance = new FTP($config);
 		$this->assertEquals('ftp://ftp:ftp@localhost/', $instance->constructUrl(''));
 
 		$config['secure'] = 'true';
-		$instance = new \OC\Files\Storage\FTP($config);
+		$instance = new FTP($config);
 		$this->assertEquals('ftps://ftp:ftp@localhost/', $instance->constructUrl(''));
 
 		$config['root'] = '';
-		$instance = new \OC\Files\Storage\FTP($config);
+		$instance = new FTP($config);
 		$this->assertEquals('ftps://ftp:ftp@localhost/somefile.txt', $instance->constructUrl('somefile.txt'));
 
 		$config['root'] = '/abc';
-		$instance = new \OC\Files\Storage\FTP($config);
+		$instance = new FTP($config);
 		$this->assertEquals('ftps://ftp:ftp@localhost/abc/somefile.txt', $instance->constructUrl('somefile.txt'));
 
 		$config['root'] = '/abc/';
-		$instance = new \OC\Files\Storage\FTP($config);
+		$instance = new FTP($config);
 		$this->assertEquals('ftps://ftp:ftp@localhost/abc/somefile.txt', $instance->constructUrl('somefile.txt'));
 	}
 }

--- a/apps/files_external/tests/storage/googletest.php
+++ b/apps/files_external/tests/storage/googletest.php
@@ -1,11 +1,12 @@
 <?php
 /**
+ * @author Bart Visscher <bartv@thisnet.nl>
+ * @author Christopher Schäpers <kondou@ts.unde.re>
  * @author Joas Schilling <nickvergessen@owncloud.com>
- * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ * @author Michael Gapczynski <GapczynskiM@gmail.com>
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Robin Appelman <icewind@owncloud.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
- * @author Vincent Petry <pvince81@owncloud.com>
  *
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  * @license AGPL-3.0
@@ -24,51 +25,38 @@
  *
  */
 
-namespace Test\Files\Storage;
+namespace OCA\Files_External\Tests\Storage;
+
+use \OCA\Files_External\Lib\Storage\Google;
 
 /**
- * Class Dropbox
+ * Class GoogleTest
  *
  * @group DB
  *
- * @package Test\Files\Storage
+ * @package OCA\Files_External\Tests\Storage
  */
-class Dropbox extends Storage {
+class GoogleTest extends \Test\Files\Storage\Storage {
+
 	private $config;
 
 	protected function setUp() {
 		parent::setUp();
 
-		$id = $this->getUniqueID();
 		$this->config = include('files_external/tests/config.php');
-		if ( ! is_array($this->config) or ! isset($this->config['dropbox']) or ! $this->config['dropbox']['run']) {
-			$this->markTestSkipped('Dropbox backend not configured');
+		if (!is_array($this->config) || !isset($this->config['google'])
+			|| !$this->config['google']['run']
+		) {
+			$this->markTestSkipped('Google Drive backend not configured');
 		}
-		$this->config['dropbox']['root'] .= '/' . $id; //make sure we have an new empty folder to work in
-		$this->instance = new \OC\Files\Storage\Dropbox($this->config['dropbox']);
+		$this->instance = new Google($this->config['google']);
 	}
 
 	protected function tearDown() {
 		if ($this->instance) {
-			$this->instance->unlink('/');
+			$this->instance->rmdir('/');
 		}
 
 		parent::tearDown();
-	}
-
-	public function directoryProvider() {
-		// doesn't support leading/trailing spaces
-		return array(array('folder'));
-	}
-
-	public function testDropboxTouchReturnValue() {
-		$this->assertFalse($this->instance->file_exists('foo'));
-
-		// true because succeeded
-		$this->assertTrue($this->instance->touch('foo'));
-		$this->assertTrue($this->instance->file_exists('foo'));
-
-		// false because not supported
-		$this->assertFalse($this->instance->touch('foo'));
 	}
 }

--- a/apps/files_external/tests/storage/owncloudtest.php
+++ b/apps/files_external/tests/storage/owncloudtest.php
@@ -1,12 +1,9 @@
 <?php
 /**
- * @author Bart Visscher <bartv@thisnet.nl>
- * @author Christopher Schäpers <kondou@ts.unde.re>
  * @author Joas Schilling <nickvergessen@owncloud.com>
- * @author Michael Gapczynski <GapczynskiM@gmail.com>
  * @author Morris Jobke <hey@morrisjobke.de>
- * @author Robin Appelman <icewind@owncloud.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Vincent Petry <pvince81@owncloud.com>
  *
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  * @license AGPL-3.0
@@ -25,31 +22,32 @@
  *
  */
 
-namespace Test\Files\Storage;
+namespace OCA\Files_External\Tests\Storage;
 
-require_once 'files_external/lib/google.php';
+use \OCA\Files_External\Lib\Storage\OwnCloud;
 
 /**
- * Class Google
+ * Class OwnCloudTest
  *
  * @group DB
  *
- * @package Test\Files\Storage
+ * @package OCA\Files_External\Tests\Storage
  */
-class Google extends Storage {
+class OwnCloudTest extends \Test\Files\Storage\Storage {
 
 	private $config;
 
 	protected function setUp() {
 		parent::setUp();
 
+		$id = $this->getUniqueID();
 		$this->config = include('files_external/tests/config.php');
-		if (!is_array($this->config) || !isset($this->config['google'])
-			|| !$this->config['google']['run']
-		) {
-			$this->markTestSkipped('Google Drive backend not configured');
+		if ( ! is_array($this->config) or ! isset($this->config['owncloud']) or ! $this->config['owncloud']['run']) {
+			$this->markTestSkipped('ownCloud backend not configured');
 		}
-		$this->instance = new \OC\Files\Storage\Google($this->config['google']);
+		$this->config['owncloud']['root'] .= '/' . $id; //make sure we have an new empty folder to work in
+		$this->instance = new OwnCloud($this->config['owncloud']);
+		$this->instance->mkdir('/');
 	}
 
 	protected function tearDown() {

--- a/apps/files_external/tests/storage/sftp_keytest.php
+++ b/apps/files_external/tests/storage/sftp_keytest.php
@@ -22,16 +22,18 @@
  *
  */
 
-namespace Test\Files\Storage;
+namespace OCA\Files_External\Tests\Storage;
+
+use \OCA\Files_External\Lib\Storage\SFTP_Key;
 
 /**
- * Class SFTP_Key
+ * Class SFTP_KeyTest
  *
  * @group DB
  *
- * @package Test\Files\Storage
+ * @package OCA\Files_External\Tests\Storage
  */
-class SFTP_Key extends Storage {
+class SFTP_KeyTest extends \Test\Files\Storage\Storage {
 	private $config;
 
 	protected function setUp() {
@@ -44,7 +46,7 @@ class SFTP_Key extends Storage {
 		}
 		// Make sure we have an new empty folder to work in
 		$this->config['sftp_key']['root'] .= '/' . $id;
-		$this->instance = new \OC\Files\Storage\SFTP_Key($this->config['sftp_key']);
+		$this->instance = new SFTP_Key($this->config['sftp_key']);
 		$this->instance->mkdir('/');
 	}
 

--- a/apps/files_external/tests/storage/sftptest.php
+++ b/apps/files_external/tests/storage/sftptest.php
@@ -24,18 +24,20 @@
  *
  */
 
-namespace Test\Files\Storage;
+namespace OCA\Files_External\Tests\Storage;
+
+use \OCA\Files_External\Lib\Storage\SFTP;
 
 /**
- * Class SFTP
+ * Class SFTPTest
  *
  * @group DB
  *
- * @package Test\Files\Storage
+ * @package OCA\Files_External\Tests\Storage
  */
-class SFTP extends Storage {
+class SFTPTest extends \Test\Files\Storage\Storage {
 	/**
-	 * @var \OC\Files\Storage\SFTP instance
+	 * @var SFTP instance
 	 */
 	protected $instance;
 
@@ -50,7 +52,7 @@ class SFTP extends Storage {
 			$this->markTestSkipped('SFTP backend not configured');
 		}
 		$this->config['root'] .= '/' . $id; //make sure we have an new empty folder to work in
-		$this->instance = new \OC\Files\Storage\SFTP($this->config);
+		$this->instance = new SFTP($this->config);
 		$this->instance->mkdir('/');
 	}
 
@@ -66,7 +68,7 @@ class SFTP extends Storage {
 	 * @dataProvider configProvider
 	 */
 	public function testStorageId($config, $expectedStorageId) {
-		$instance = new \OC\Files\Storage\SFTP($config);
+		$instance = new SFTP($config);
 		$this->assertEquals($expectedStorageId, $instance->getId());
 	}
 

--- a/apps/files_external/tests/storage/smbtest.php
+++ b/apps/files_external/tests/storage/smbtest.php
@@ -23,16 +23,18 @@
  *
  */
 
-namespace Test\Files\Storage;
+namespace OCA\Files_External\Tests\Storage;
+
+use \OCA\Files_External\Lib\Storage\SMB;
 
 /**
- * Class SMB
+ * Class SMBTest
  *
  * @group DB
  *
- * @package Test\Files\Storage
+ * @package OCA\Files_External\Tests\Storage
  */
-class SMB extends Storage {
+class SMBTest extends \Test\Files\Storage\Storage {
 
 	protected function setUp() {
 		parent::setUp();
@@ -46,7 +48,7 @@ class SMB extends Storage {
 			$config['root'] .= '/';
 		}
 		$config['root'] .= $id; //make sure we have an new empty folder to work in
-		$this->instance = new \OC\Files\Storage\SMB($config);
+		$this->instance = new SMB($config);
 		$this->instance->mkdir('/');
 	}
 
@@ -71,7 +73,7 @@ class SMB extends Storage {
 	}
 
 	public function testStorageId() {
-		$this->instance = new \OC\Files\Storage\SMB([
+		$this->instance = new SMB([
 			'host' => 'testhost',
 			'user' => 'testuser',
 			'password' => 'somepass',

--- a/apps/files_external/tests/storage/swifttest.php
+++ b/apps/files_external/tests/storage/swifttest.php
@@ -1,7 +1,7 @@
 <?php
 /**
+ * @author Christian Berendt <berendt@b1-systems.de>
  * @author Joas Schilling <nickvergessen@owncloud.com>
- * @author Michael Gapczynski <GapczynskiM@gmail.com>
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Robin Appelman <icewind@owncloud.com>
  * @author Robin McCorkell <robin@mccorkell.me.uk>
@@ -24,38 +24,53 @@
  *
  */
 
-namespace Test\Files\Storage;
+namespace OCA\Files_External\Tests\Storage;
+
+use \OCA\Files_External\Lib\Storage\Swift;
 
 /**
- * Class AmazonS3
+ * Class SwiftTest
  *
  * @group DB
  *
- * @package Test\Files\Storage
+ * @package OCA\Files_External\Tests\Storage
  */
-class AmazonS3 extends Storage {
+class SwiftTest extends \Test\Files\Storage\Storage {
 
 	private $config;
 
 	protected function setUp() {
 		parent::setUp();
 
-		$this->config = include('files_external/tests/config.amazons3.php');
-		if ( ! is_array($this->config) or ! $this->config['run']) {
-			$this->markTestSkipped('AmazonS3 backend not configured');
+		$this->config = include('files_external/tests/config.swift.php');
+		if (!is_array($this->config) or !$this->config['run']) {
+			$this->markTestSkipped('OpenStack Object Storage backend not configured');
 		}
-		$this->instance = new \OC\Files\Storage\AmazonS3($this->config);
+		$this->instance = new Swift($this->config);
 	}
 
 	protected function tearDown() {
 		if ($this->instance) {
-			$this->instance->rmdir('');
+			try {
+				$connection = $this->instance->getConnection();
+				$container = $connection->getContainer($this->config['bucket']);
+
+				$objects = $container->objectList();
+				while($object = $objects->next()) {
+					$object->setName(str_replace('#','%23',$object->getName()));
+					$object->delete();
+				}
+
+				$container->delete();
+			} catch (\Guzzle\Http\Exception\ClientErrorResponseException $e) {
+				// container didn't exist, so we don't need to delete it
+			}
 		}
 
 		parent::tearDown();
 	}
 
 	public function testStat() {
-		$this->markTestSkipped('S3 doesn\'t update the parents folder mtime');
+		$this->markTestSkipped('Swift doesn\'t update the parents folder mtime');
 	}
 }

--- a/apps/files_external/tests/storage/webdavtest.php
+++ b/apps/files_external/tests/storage/webdavtest.php
@@ -23,16 +23,18 @@
  *
  */
 
-namespace Test\Files\Storage;
+namespace OCA\Files_External\Tests\Storage;
+
+use \OC\Files\Storage\DAV;
 
 /**
- * Class DAV
+ * Class WebDAVTest
  *
  * @group DB
  *
- * @package Test\Files\Storage
+ * @package OCA\Files_External\Tests\Storage
  */
-class DAV extends Storage {
+class WebDAVTest extends \Test\Files\Storage\Storage {
 
 	protected function setUp() {
 		parent::setUp();
@@ -46,7 +48,7 @@ class DAV extends Storage {
 			$this->waitDelay = $config['wait'];
 		}
 		$config['root'] .= '/' . $id; //make sure we have an new empty folder to work in
-		$this->instance = new \OC\Files\Storage\DAV($config);
+		$this->instance = new DAV($config);
 		$this->instance->mkdir('/');
 	}
 

--- a/autotest-external.sh
+++ b/autotest-external.sh
@@ -178,7 +178,7 @@ EOF
 		return;
 	fi
 
-	FILES_EXTERNAL_BACKEND_PATH=../apps/files_external/tests/backends
+	FILES_EXTERNAL_BACKEND_PATH=../apps/files_external/tests/storage
 	FILES_EXTERNAL_BACKEND_ENV_PATH=../apps/files_external/tests/env
 
 	for startFile in `ls -1 $FILES_EXTERNAL_BACKEND_ENV_PATH | grep start`; do
@@ -198,16 +198,17 @@ EOF
 			# getting backend to test from filename
 			# it's the part between the dots startSomething.TestToRun.sh
 			testToRun=`echo $startFile | cut -d '-' -f 2`
+			testToRun="${testToRun}test.php"
 
 			# run the specific test
 			if [ -z "$NOCOVERAGE" ]; then
 				rm -rf "coverage-external-html-$1-$name"
 				mkdir "coverage-external-html-$1-$name"
-				"$PHPUNIT" --configuration phpunit-autotest-external.xml --log-junit "autotest-external-results-$1-$name.xml" --coverage-clover "autotest-external-clover-$1-$name.xml" --coverage-html "coverage-external-html-$1-$name" "$FILES_EXTERNAL_BACKEND_PATH/$testToRun.php"
+				"$PHPUNIT" --configuration phpunit-autotest-external.xml --log-junit "autotest-external-results-$1-$name.xml" --coverage-clover "autotest-external-clover-$1-$name.xml" --coverage-html "coverage-external-html-$1-$name" "$FILES_EXTERNAL_BACKEND_PATH/$testToRun"
 				RESULT=$?
 			else
 				echo "No coverage"
-				"$PHPUNIT" --configuration phpunit-autotest-external.xml --log-junit "autotest-external-results-$1-$name.xml" "$FILES_EXTERNAL_BACKEND_PATH/$testToRun.php"
+				"$PHPUNIT" --configuration phpunit-autotest-external.xml --log-junit "autotest-external-results-$1-$name.xml" "$FILES_EXTERNAL_BACKEND_PATH/$testToRun"
 				RESULT=$?
 			fi
 		else

--- a/tests/phpunit-autotest-external.xml
+++ b/tests/phpunit-autotest-external.xml
@@ -8,7 +8,7 @@
 	<testsuite name='ownCloud files external'>
 		<directory suffix=".php">../apps/files_external/tests</directory>
 		<!-- exclude backends as they are called separately -->
-		<exclude>../apps/files_external/tests/backends/</exclude>
+		<exclude>../apps/files_external/tests/storage/</exclude>
 	</testsuite>
 	<!-- filters for code coverage -->
 	<filter>


### PR DESCRIPTION
We had a bunch of CLASSPATH entries, for storage classes (and the Api connector, for some reason). I've moved all the storage classes to a subdirectory of lib/ to tidy things up, and corrected the namespaces as necessary so that the autoloader just works.

This is possible now (as opposed to before the backend registration overhaul) since the identifier saved in the config is separate from the actual class used. Thanks to identifier aliases, even if someone has an old config containing one of these class names, it will be correctly detected.

cc @PVince81 @rullzer @icewind1991 @MorrisJobke 

Also cc @jmaciasportela in case WND needs a fixup (it probably has \OC\Files\Storage\SMB somewhere, just change that to \OCA\Files_External\Lib\Storage\SMB)
