### PR TITLE
Properly handle exception within templates

### DIFF
--- a/lib/private/template/base.php
+++ b/lib/private/template/base.php
@@ -168,8 +168,13 @@ class Base {
 
 		// Include
 		ob_start();
-		include $file;
-		$data = ob_get_contents();
+		try {
+			include $file;
+			$data = ob_get_contents();
+		} catch (\Exception $e) {
+			@ob_end_clean();
+			throw $e;
+		}
 		@ob_end_clean();
 
 		// Return data


### PR DESCRIPTION
- fixes partial printed templates when exception is thrown while loading template file

Fixes for example this:

Before:
<img width="1156" alt="bildschirmfoto 2016-04-14 um 11 23 40" src="https://cloud.githubusercontent.com/assets/245432/14523338/6bbecfb6-0233-11e6-8fcc-ee36a69ed569.png">

After:
<img width="853" alt="bildschirmfoto 2016-04-14 um 11 23 46" src="https://cloud.githubusercontent.com/assets/245432/14523340/70e6ffb8-0233-11e6-8ac5-f0fcdb97f043.png">

Easy test case:
- configure redis in config.php but don't run the redis server

cc @nickvergessen @LukasReschke @rullzer 
