### PR TITLE
Adding mimetypes for m4a and m4b

### DIFF
--- a/resources/config/mimetypemapping.dist.json
+++ b/resources/config/mimetypemapping.dist.json
@@ -78,6 +78,8 @@
 	"kra": ["application/x-krita"],
 	"lwp": ["application/vnd.lotus-wordpro"],
 	"m2t": ["video/mp2t"],
+	"m4a": ["audio/mp4"],
+	"m4b": ["audio/m4b"],
 	"m4v": ["video/mp4"],
 	"markdown": ["text/markdown"],
 	"mdown": ["text/markdown"],


### PR DESCRIPTION
This PR is about to add the correct mimetypes for m4a and m4b (formats used by iTunes) to `core/resources/config/mimetypemapping.dist.json`. These mimetypes were missing and when a scan run, the wrongly `application/octet-stream` mimetype was used instead.

With this addition, the Music App and the Files App get now the correct mimetypes for further handling.
