### PR TITLE
Fix repeating user list in webUI

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -274,13 +274,21 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 					$reshare = false;
 				}
 				if ($_GET['checkShares'] == 'true') {
-					$shares = OCP\Share::getItemShared(
+					$sharesTMP = OCP\Share::getItemShared(
 						(string)$_GET['itemType'],
 						(string)$_GET['itemSource'],
 						OCP\Share::FORMAT_NONE,
 						null,
 						true
 					);
+					$ids = [];
+					$shares = [];
+					foreach($sharesTMP as $share) {
+						if (!isset($ids[$share['id']])) {
+							$ids[$share['id']] = true;
+							$shares[] = $share;
+						}
+					}
 				} else {
 					$shares = false;
 				}


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/18910

Steps:
1. create a folder A
2. share A with user1, user2 and user3
3. create a folder A/B
4. share A/B with user4 ("Shared in A with user1, user2, user3" appears in the sidebar below the share input field)
5. share A/B with user5 (the text is expanded with ", user1, user2, user3")

After:

user1, user2, user3 is only shown once

CC: @MorrisJobke @cdamken @PVince81 @schiesbn @butonic @cdamken @gig13 
