### PR TITLE
Fix deprecated usages of libre office commands

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -725,7 +725,7 @@ $CONFIG = array(
  */
 'preview_office_cl_parameters' =>
 	' --headless --nologo --nofirststartwizard --invisible --norestore '.
-	'-convert-to pdf -outdir ',
+	'--convert-to pdf --outdir ',
 
 /**
  * Only register providers that have been explicitly enabled


### PR DESCRIPTION
```
Warning: -convert-to is deprecated.  Use --convert-to instead.
Warning: -outdir is deprecated.  Use --outdir instead.
```
