### PR TITLE
Fix rgb values

### DIFF
--- a/core/js/placeholder.js
+++ b/core/js/placeholder.js
@@ -92,7 +92,7 @@
 		// Init vars
 		var result = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 		var rgb = [0, 0, 0];
-		var sat = 80;
+		var sat = 70;
 		var lum = 68;
 		var modulo = 16;
 
@@ -106,6 +106,12 @@
 		for(var count=1;count<modulo;count++) {
 			rgb[count%3] += parseInt(result[count]);
 		}
+
+		// Reduce values bigger than rgb requirements
+		rgb[0] = rgb[0]%255;
+		rgb[1] = rgb[1]%255;
+		rgb[2] = rgb[2]%255;
+
 		var hsl = rgbToHsl(rgb[0], rgb[1], rgb[2]);
 
 		// Classic formulla to check the brigtness for our eye


### PR DESCRIPTION
A fix was required because values was too big for rgb and breaking the brightness calculation.
Now we have the initial sat (70%) and the reduction to 60 if too bright working again.

cc @jancborchardt @DeepDiver1975 @PVince81 @MorrisJobke 

Testing:
- Install commit
- Load a page using the color generator (contacts list, users list...)
- Inspect the colors and look the values in hsl mode (maj+click for chrome)
