### PR TITLE
Add data-fingerprint property

### DIFF
--- a/apps/dav/lib/connector/sabre/serverfactory.php
+++ b/apps/dav/lib/connector/sabre/serverfactory.php
@@ -137,8 +137,15 @@ class ServerFactory {
 			}
 			$objectTree->init($root, $view, $this->mountManager);
 
-			$server->addPlugin(new \OCA\DAV\Connector\Sabre\FilesPlugin($objectTree, $view, false,
-				!$this->config->getSystemValue('debug', false)));
+			$server->addPlugin(
+				new \OCA\DAV\Connector\Sabre\FilesPlugin(
+					$objectTree,
+					$view,
+					$this->config,
+					false,
+					!$this->config->getSystemValue('debug', false)
+				)
+			);
 			$server->addPlugin(new \OCA\DAV\Connector\Sabre\QuotaPlugin($view));
 
 			if($this->userSession->isLoggedIn()) {

--- a/apps/dav/lib/server.php
+++ b/apps/dav/lib/server.php
@@ -132,8 +132,15 @@ class Server {
 			$user = \OC::$server->getUserSession()->getUser();
 			if (!is_null($user)) {
 				$view = \OC\Files\Filesystem::getView();
-				$this->server->addPlugin(new FilesPlugin($this->server->tree, $view, false,
-					!\OC::$server->getConfig()->getSystemValue('debug', false)));
+				$this->server->addPlugin(
+					new FilesPlugin(
+						$this->server->tree,
+						$view,
+						\OC::$server->getConfig(),
+						false,
+						!\OC::$server->getConfig()->getSystemValue('debug', false)
+					)
+				);
 
 				$this->server->addPlugin(
 					new \Sabre\DAV\PropertyStorage\Plugin(

--- a/apps/dav/tests/unit/connector/sabre/filesreportplugin.php
+++ b/apps/dav/tests/unit/connector/sabre/filesreportplugin.php
@@ -336,7 +336,15 @@ class FilesReportPlugin extends \Test\TestCase {
 			->method('getSize')
 			->will($this->returnValue(1024));
 
-		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\FilesPlugin($this->tree, $this->view));
+		$config = $this->getMock('\OCP\IConfig');
+
+		$this->server->addPlugin(
+			new \OCA\DAV\Connector\Sabre\FilesPlugin(
+				$this->tree,
+				$this->view,
+				$config
+			)
+		);
 		$this->plugin->initialize($this->server);
 		$responses = $this->plugin->prepareResponses($requestedProps, [$node1, $node2]);
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1205,6 +1205,19 @@ $CONFIG = array(
 'debug' => false,
 
 /**
+ * Sets the data-fingerprint of the current data served
+ *
+ * This is a property used by the clients to find out if a backup has been
+ * restored on the server. Once a backup is restored run
+ * ./occ maintenance:data-fingerprint
+ * To set this to a new value.
+ *
+ * Updating/Deleting this value can make connected clients stall until
+ * the user has resolved conflicts.
+ */
+'data-fingerprint' => '',
+
+/**
  * This entry is just here to show a warning in case somebody copied the sample
  * configuration. DO NOT ADD THIS SWITCH TO YOUR CONFIGURATION!
  *

--- a/core/Command/Maintenance/DataFingerprint.php
+++ b/core/Command/Maintenance/DataFingerprint.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Core\Command\Maintenance;
+
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IConfig;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+class DataFingerprint extends Command {
+
+	/** @var IConfig */
+	protected $config;
+	/** @var ITimeFactory */
+	protected $timeFactory;
+
+	public function __construct(IConfig $config,
+								ITimeFactory $timeFactory) {
+		$this->config = $config;
+		$this->timeFactory = $timeFactory;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('maintenance:data-fingerprint')
+			->setDescription('update the systems data-fingerprint after a backup is restored');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$this->config->setSystemValue('data-fingerprint', md5($this->timeFactory->getTime()));
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -108,6 +108,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	);
 	$application->add(new OC\Core\Command\Encryption\ShowKeyStorageRoot($util));
 
+	$application->add(new OC\Core\Command\Maintenance\DataFingerprint(\OC::$server->getConfig(), new \OC\AppFramework\Utility\TimeFactory()));
 	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateDB(\OC::$server->getMimeTypeDetector(), \OC::$server->getMimeTypeLoader()));
 	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateJS(\OC::$server->getMimeTypeDetector()));
 	$application->add(new OC\Core\Command\Maintenance\Mode(\OC::$server->getConfig()));

--- a/tests/core/command/maintenance/datafingerprinttest.php
+++ b/tests/core/command/maintenance/datafingerprinttest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Core\Command\Maintenance;
+
+use OC\Core\Command\Maintenance\DataFingerprint;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IConfig;
+use Test\TestCase;
+
+class DataFingerprintTest extends TestCase {
+	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	protected $config;
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	protected $consoleInput;
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	protected $consoleOutput;
+	/** @var ITimeFactory|\PHPUnit_Framework_MockObject_MockObject */
+	protected $timeFactory;
+
+	/** @var \Symfony\Component\Console\Command\Command */
+	protected $command;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->config = $this->getMock('OCP\IConfig');
+		$this->timeFactory = $this->getMock('OCP\AppFramework\Utility\ITimeFactory');
+		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
+		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+
+		/** @var \OCP\IConfig $config */
+		$this->command = new DataFingerprint($this->config, $this->timeFactory);
+	}
+
+	public function testSetFingerPrint() {
+		$this->timeFactory->expects($this->once())
+			->method('getTime')
+			->willReturn(42);
+		$this->config->expects($this->once())
+			->method('setSystemValue')
+			->with('data-fingerprint', md5(42));
+
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
+}


### PR DESCRIPTION
To signal connected clients that a backup has been restored on the server we will use the data-fingerprint property.
- The `data-fingerprint` property is added on the file root so
  - `../remote.php/webdav`
  - `../remote.php/dav/files/<USER>`
- The `data-fingerprint` property is initially empty
- A command `./occ maintenance:data-fingerprint` will update the `data-fingerprint` with the md5 of the current time.
- Unit tests added.

To test use the following propfind file:

``` xml
<?xml version="1.0"?>
<a:propfind xmlns:a="DAV:" xmlns:oc="http://owncloud.org/ns">
<a:prop>
    <oc:data-fingerprint />
</a:prop>
</a:propfind>
```

And to propfinds on:
- `../remote.php/webdav` : should succeed but be empty
- `../remote.php/dav/files/<USER>` : should succeed but be empty
- `../remote.php/webdav/foo` : should return 404 on the property
- `../remote.php/dav/files/<USER>/bar` : should return 404 on the propery

Now run: `./occ maintenance:data-fingerprint`
- `../remote.php/webdav` : should succeed with fingerprint
- `../remote.php/dav/files/<USER>` : should succeed with fingerprint
- `../remote.php/webdav/foo` : should return 404 on the property
- `../remote.php/dav/files/<USER>/bar` : should return 404 on the propery

CC: @PVince81 @nickvergessen @MorrisJobke @icewind1991 
