### PR TITLE
[WIP] Allow indices to be only applied on new installations

### DIFF
--- a/core/Command/Db/ApplyIndexes.php
+++ b/core/Command/Db/ApplyIndexes.php
@@ -59,10 +59,10 @@ class ApplyIndexes extends Command {
 				$migrator->applyDiff($diff, $connection);
 			}
 			$progress->finish();
+			$output->writeln('');
 		} catch (\Exception $e) {
 			$output->writeln('Failed to update database structure ('.$e.')');
 		}
-
 	}
 
 	/**

--- a/core/Command/Db/ApplyIndexes.php
+++ b/core/Command/Db/ApplyIndexes.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\Db;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\SchemaDiff;
+use Doctrine\DBAL\Schema\TableDiff;
+use OC\DB\MDB2SchemaManager;
+use OCP\IDBConnection;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ApplyIndexes extends Command {
+	protected function configure() {
+		$this
+			->setName('db:apply-indexes')
+			->setDescription('Applies indexes which are marked as <only-on-create/>. This allows to run upgrades fast by applying the indexes later during live operations.');
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+
+		/** @var Connection | IDBConnection $connection */
+		$connection = \OC::$server->getDatabaseConnection();
+		$schemaManager = new MDB2SchemaManager($connection);
+
+		try {
+			$files = $this->getFiles();
+			$progress = new ProgressBar($output);
+			$progress->start(count($files));
+
+			foreach ($files as $file) {
+				$progress->advance();
+				$toSchema = $schemaManager->readSchemaFromFile($file, true);
+				$migrator = $schemaManager->getMigrator();
+				$diff = $migrator->getDiff($toSchema, $connection);
+				$diff = $this->filterDiff($diff);
+				$migrator->applyDiff($diff, $connection);
+			}
+			$progress->finish();
+		} catch (\Exception $e) {
+			$output->writeln('Failed to update database structure ('.$e.')');
+		}
+
+	}
+
+	/**
+	 * @return array
+	 */
+	protected function getFiles() {
+		$files = [__DIR__ . '/../../../db_structure.xml'];
+
+		$appManager = \OC::$server->getAppManager();
+		$apps = $appManager->getInstalledApps();
+		foreach ($apps as $app) {
+			$path = \OC_App::getAppPath($app);
+			if ($path === false) {
+				continue;
+			}
+			$schema = $path . '/appinfo/database.xml';
+			if (file_exists($schema)) {
+				$files[]= $schema;
+			}
+		}
+
+		return $files;
+	}
+
+	/**
+	 * @param SchemaDiff $diff
+	 * @return SchemaDiff
+	 */
+	private function filterDiff($diff) {
+		$newDiff = new SchemaDiff();
+		foreach ($diff->changedTables as $table) {
+			if (count($table->addedIndexes) > 0) {
+				$newTable = new TableDiff($table->name);
+				$newTable->addedIndexes = $table->addedIndexes;
+
+				$newDiff->changedTables[] = $newTable;
+			}
+		}
+		return $newDiff;
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -80,6 +80,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Config\System\GetConfig(\OC::$server->getSystemConfig()));
 	$application->add(new OC\Core\Command\Config\System\SetConfig(\OC::$server->getSystemConfig()));
 
+	$application->add(new OC\Core\Command\Db\ApplyIndexes());
 	$application->add(new OC\Core\Command\Db\GenerateChangeScript());
 	$application->add(new OC\Core\Command\Db\ConvertType(\OC::$server->getConfig(), new \OC\DB\ConnectionFactory()));
 

--- a/db_structure.xml
+++ b/db_structure.xml
@@ -406,7 +406,7 @@
 			</field>
 
 
-            <index>
+			<index>
 				<name>fs_storage_path_hash</name>
 				<unique>true</unique>
 				<field>
@@ -416,6 +416,21 @@
 				<field>
 					<name>path_hash</name>
 					<sorting>ascending</sorting>
+				</field>
+			</index>
+
+			<index>
+				<only-on-create/>
+				<name>fs_storage_path</name>
+				<unique>true</unique>
+				<field>
+					<name>storage</name>
+					<sorting>ascending</sorting>
+				</field>
+				<field>
+					<name>path</name>
+					<sorting>ascending</sorting>
+					<length>250</length>
 				</field>
 			</index>
 

--- a/lib/private/DB/MDB2SchemaManager.php
+++ b/lib/private/DB/MDB2SchemaManager.php
@@ -97,7 +97,7 @@ class MDB2SchemaManager {
 	 * @param bool $isCreate
 	 * @return \Doctrine\DBAL\Schema\Schema
 	 */
-	private function readSchemaFromFile($file, $isCreate) {
+	public function readSchemaFromFile($file, $isCreate) {
 		$platform = $this->conn->getDatabasePlatform();
 		$schemaReader = new MDB2SchemaReader(\OC::$server->getConfig(), $platform, $isCreate);
 		return $schemaReader->loadSchemaFromFile($file);

--- a/lib/private/DB/MDB2SchemaManager.php
+++ b/lib/private/DB/MDB2SchemaManager.php
@@ -64,7 +64,7 @@ class MDB2SchemaManager {
 	 * TODO: write more documentation
 	 */
 	public function createDbFromStructure($file) {
-		$schemaReader = new MDB2SchemaReader(\OC::$server->getConfig(), $this->conn->getDatabasePlatform());
+		$schemaReader = new MDB2SchemaReader(\OC::$server->getConfig(), $this->conn->getDatabasePlatform(), true);
 		$toSchema = $schemaReader->loadSchemaFromFile($file);
 		return $this->executeSchemaChange($toSchema);
 	}
@@ -94,11 +94,12 @@ class MDB2SchemaManager {
 	 * Reads database schema from file
 	 *
 	 * @param string $file file to read from
+	 * @param bool $isCreate
 	 * @return \Doctrine\DBAL\Schema\Schema
 	 */
-	private function readSchemaFromFile($file) {
+	private function readSchemaFromFile($file, $isCreate) {
 		$platform = $this->conn->getDatabasePlatform();
-		$schemaReader = new MDB2SchemaReader(\OC::$server->getConfig(), $platform);
+		$schemaReader = new MDB2SchemaReader(\OC::$server->getConfig(), $platform, $isCreate);
 		return $schemaReader->loadSchemaFromFile($file);
 	}
 
@@ -109,7 +110,7 @@ class MDB2SchemaManager {
 	 * @return string|boolean
 	 */
 	public function updateDbFromStructure($file, $generateSql = false) {
-		$toSchema = $this->readSchemaFromFile($file);
+		$toSchema = $this->readSchemaFromFile($file, false);
 		$migrator = $this->getMigrator();
 
 		if ($generateSql) {
@@ -135,7 +136,7 @@ class MDB2SchemaManager {
 	 * @param string $file the xml file describing the tables
 	 */
 	public function removeDBStructure($file) {
-		$schemaReader = new MDB2SchemaReader(\OC::$server->getConfig(), $this->conn->getDatabasePlatform());
+		$schemaReader = new MDB2SchemaReader(\OC::$server->getConfig(), $this->conn->getDatabasePlatform(), false);
 		$fromSchema = $schemaReader->loadSchemaFromFile($file);
 		$toSchema = clone $fromSchema;
 		/** @var $table \Doctrine\DBAL\Schema\Table */

--- a/lib/private/DB/MDB2SchemaReader.php
+++ b/lib/private/DB/MDB2SchemaReader.php
@@ -35,29 +35,27 @@ use Doctrine\DBAL\Schema\SchemaConfig;
 use OCP\IConfig;
 
 class MDB2SchemaReader {
-	/**
-	 * @var string $DBNAME
-	 */
+	/** @var string $DBNAME */
 	protected $DBNAME;
 
-	/**
-	 * @var string $DBTABLEPREFIX
-	 */
+	/** @var string $DBTABLEPREFIX */
 	protected $DBTABLEPREFIX;
 
-	/**
-	 * @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform
-	 */
+	/** @var AbstractPlatform $platform */
 	protected $platform;
 
-	/** @var \Doctrine\DBAL\Schema\SchemaConfig $schemaConfig */
+	/** @var SchemaConfig $schemaConfig */
 	protected $schemaConfig;
 
+	/** @var boolean */
+	private $isCreate;
+
 	/**
-	 * @param \OCP\IConfig $config
-	 * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+	 * @param IConfig $config
+	 * @param AbstractPlatform $platform
 	 */
-	public function __construct(IConfig $config, AbstractPlatform $platform) {
+	public function __construct(IConfig $config, AbstractPlatform $platform, $isCreate) {
+		$this->isCreate = $isCreate;
 		$this->platform = $platform;
 		$this->DBNAME = $config->getSystemValue('dbname', 'owncloud');
 		$this->DBTABLEPREFIX = $config->getSystemValue('dbtableprefix', 'oc_');
@@ -291,6 +289,12 @@ class MDB2SchemaReader {
 			 * @var \SimpleXMLElement $child
 			 */
 			switch ($child->getName()) {
+				case 'only-on-create':
+					// the index will only be created in case the instance is newly being installed
+					if (!$this->isCreate) {
+						return;
+					}
+				break;
 				case 'name':
 					$name = (string)$child;
 					break;

--- a/lib/private/DB/MDB2SchemaReader.php
+++ b/lib/private/DB/MDB2SchemaReader.php
@@ -284,6 +284,8 @@ class MDB2SchemaReader {
 	private function loadIndex($table, $xml) {
 		$name = null;
 		$fields = [];
+		$lengths = [];
+
 		foreach ($xml->children() as $child) {
 			/**
 			 * @var \SimpleXMLElement $child
@@ -305,23 +307,29 @@ class MDB2SchemaReader {
 					$unique = $this->asBool($child);
 					break;
 				case 'field':
+					$fieldName = null;
+					$length = null;
 					foreach ($child->children() as $field) {
-						/**
-						 * @var \SimpleXMLElement $field
-						 */
+						/** @var \SimpleXMLElement $field */
 						switch ($field->getName()) {
 							case 'name':
-								$field_name = (string)$field;
-								$field_name = $this->platform->quoteIdentifier($field_name);
-								$fields[] = $field_name;
+								$fieldName = (string)$field;
+								$fieldName = $this->platform->quoteIdentifier($fieldName);
 								break;
 							case 'sorting':
 								break;
+							case 'length':
+								$length = (string)$field;
+								break;
 							default:
 								throw new \DomainException('Unknown element: ' . $field->getName());
-
 						}
 					}
+					$fields[] = $fieldName;
+					if (!is_null($length)) {
+						$lengths[$fieldName] = $length;
+					}
+
 					break;
 				default:
 					throw new \DomainException('Unknown element: ' . $child->getName());
@@ -335,10 +343,14 @@ class MDB2SchemaReader {
 				}
 				$table->setPrimaryKey($fields, $name);
 			} else {
+				$options = [];
+				if (count($lengths) > 0) {
+					$options['oc-length'] = $lengths;
+				}
 				if (isset($unique) && $unique) {
-					$table->addUniqueIndex($fields, $name);
+					$table->addUniqueIndex($fields, $name, $options);
 				} else {
-					$table->addIndex($fields, $name);
+					$table->addIndex($fields, $name, [], $options);
 				}
 			}
 		} else {

--- a/lib/private/DB/Migrator.php
+++ b/lib/private/DB/Migrator.php
@@ -27,6 +27,7 @@
 
 namespace OC\DB;
 
+use Doctrine\DBAL\Connection;
 use \Doctrine\DBAL\DBALException;
 use \Doctrine\DBAL\Schema\Index;
 use \Doctrine\DBAL\Schema\Table;
@@ -43,7 +44,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 class Migrator {
 
 	/**
-	 * @var \Doctrine\DBAL\Connection $connection
+	 * @var Connection $connection
 	 */
 	protected $connection;
 
@@ -62,12 +63,12 @@ class Migrator {
 	private $noEmit = false;
 
 	/**
-	 * @param \Doctrine\DBAL\Connection|Connection $connection
+	 * @param Connection|Connection $connection
 	 * @param ISecureRandom $random
 	 * @param IConfig $config
 	 * @param EventDispatcher $dispatcher
 	 */
-	public function __construct(\Doctrine\DBAL\Connection $connection,
+	public function __construct(Connection $connection,
 								ISecureRandom $random,
 								IConfig $config,
 								EventDispatcher $dispatcher = null) {
@@ -240,9 +241,9 @@ class Migrator {
 
 	/**
 	 * @param \Doctrine\DBAL\Schema\Schema $targetSchema
-	 * @param \Doctrine\DBAL\Connection $connection
+	 * @param Connection $connection
 	 */
-	protected function applySchema(Schema $targetSchema, \Doctrine\DBAL\Connection $connection = null) {
+	protected function applySchema(Schema $targetSchema, Connection $connection = null) {
 		if (is_null($connection)) {
 			$connection = $this->connection;
 		}

--- a/lib/private/DB/MySQLMigrator.php
+++ b/lib/private/DB/MySQLMigrator.php
@@ -33,7 +33,7 @@ class MySQLMigrator extends Migrator {
 	 * @param \Doctrine\DBAL\Connection $connection
 	 * @return \Doctrine\DBAL\Schema\SchemaDiff
 	 */
-	protected function getDiff(Schema $targetSchema, \Doctrine\DBAL\Connection $connection) {
+	public function getDiff(Schema $targetSchema, \Doctrine\DBAL\Connection $connection) {
 		$platform = $connection->getDatabasePlatform();
 		$platform->registerDoctrineTypeMapping('enum', 'string');
 		$platform->registerDoctrineTypeMapping('bit', 'string');

--- a/lib/private/DB/MySQLMigrator.php
+++ b/lib/private/DB/MySQLMigrator.php
@@ -24,6 +24,7 @@
 
 namespace OC\DB;
 
+use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 
@@ -40,12 +41,35 @@ class MySQLMigrator extends Migrator {
 
 		$schemaDiff = parent::getDiff($targetSchema, $connection);
 
-		// identifiers need to be quoted for mysql
 		foreach ($schemaDiff->changedTables as $tableDiff) {
+			// identifiers need to be quoted for mysql
 			$tableDiff->name = $this->connection->quoteIdentifier($tableDiff->name);
 			foreach ($tableDiff->changedColumns as $column) {
 				$column->oldColumnName = $this->connection->quoteIdentifier($column->oldColumnName);
 			}
+
+			// adjust max index length if needed
+			$addedIndexes = [];
+			foreach ($tableDiff->addedIndexes as $index) {
+				if ($index->hasOption('oc-length')) {
+					$columnLength = $index->getOption('oc-length');
+					$columns = [];
+					foreach ($index->getUnquotedColumns() as $c) {
+						$quotedC = $this->connection->quoteIdentifier($c);
+						if (array_key_exists($quotedC, $columnLength)) {
+							$l = $columnLength[$quotedC];
+							// HACK: the whitespace in the beginning prevents Doctrine to remove the quotes
+							$c = "$c($l)";
+						}
+						$columns[]= $c;
+					}
+					$newIndex = new Index($index->getName(), $columns);
+					$addedIndexes[] = $newIndex;
+				} else {
+					$addedIndexes[] = $index;
+				}
+			}
+			$tableDiff->addedIndexes = $addedIndexes;
 		}
 
 		return $schemaDiff;

--- a/lib/private/DB/OracleMigrator.php
+++ b/lib/private/DB/OracleMigrator.php
@@ -32,7 +32,7 @@ class OracleMigrator extends NoCheckMigrator {
 	 * @param \Doctrine\DBAL\Connection $connection
 	 * @return \Doctrine\DBAL\Schema\SchemaDiff
 	 */
-	protected function getDiff(Schema $targetSchema, \Doctrine\DBAL\Connection $connection) {
+	public function getDiff(Schema $targetSchema, \Doctrine\DBAL\Connection $connection) {
 		$schemaDiff = parent::getDiff($targetSchema, $connection);
 
 		// oracle forces us to quote the identifiers

--- a/lib/private/DB/SQLiteMigrator.php
+++ b/lib/private/DB/SQLiteMigrator.php
@@ -72,7 +72,7 @@ class SQLiteMigrator extends Migrator {
 	 * @param \Doctrine\DBAL\Connection $connection
 	 * @return \Doctrine\DBAL\Schema\SchemaDiff
 	 */
-	protected function getDiff(Schema $targetSchema, \Doctrine\DBAL\Connection $connection) {
+	public function getDiff(Schema $targetSchema, \Doctrine\DBAL\Connection $connection) {
 		$platform = $connection->getDatabasePlatform();
 		$platform->registerDoctrineTypeMapping('tinyint unsigned', 'integer');
 		$platform->registerDoctrineTypeMapping('smallint unsigned', 'integer');

--- a/tests/lib/DB/MDB2SchemaReaderTest.php
+++ b/tests/lib/DB/MDB2SchemaReaderTest.php
@@ -10,15 +10,16 @@
 namespace Test\DB;
 
 use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Test\TestCase;
 
-class MDB2SchemaReaderTest extends \Test\TestCase {
+class MDB2SchemaReader extends TestCase {
 	/**
 	 * @var \OC\DB\MDB2SchemaReader $reader
 	 */
 	protected $reader;
 
 	/**
-	 * @return \OC\Config
+	 * @return \OCP\IConfig
 	 */
 	protected function getConfig() {
 		$config = $this->getMockBuilder('\OCP\IConfig')
@@ -34,7 +35,7 @@ class MDB2SchemaReaderTest extends \Test\TestCase {
 	}
 
 	public function testRead() {
-		$reader = new \OC\DB\MDB2SchemaReader($this->getConfig(), new MySqlPlatform());
+		$reader = new \OC\DB\MDB2SchemaReader($this->getConfig(), new MySqlPlatform(), true);
 		$schema = $reader->loadSchemaFromFile(__DIR__ . '/testschema.xml');
 		$this->assertCount(1, $schema->getTables());
 

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 2, 0, 1);
+$OC_Version = array(9, 2, 0, 2);
 
 // The human readable string
 $OC_VersionString = '9.2.0 pre alpha';


### PR DESCRIPTION
So ... what is this all about?
# Background

On MySql we have limitation on the index length (767 bytes in total) which means we cannot create an index over the path of filecache for example.
But MySql offers the possibility to define length on the column to be used for the index which means we can define an index over the path column of filecache which will index at least the first 254 characters of the path - http://dev.mysql.com/doc/refman/5.7/en/create-index.html

This means we might not get a full hit on the path but at least can limit the set within the like query will be performed. (An assumption we need to prove - I'm work on that)
# Problem

Adding an index to oc_filecache is a no go for all live systems out there!
# Solution
- We allow a length to be specified in the schema xml on the column definition of an index
- On MySql we respect this length definition (others as well :question: )
- Indexes can now be defined as <only-on-create/> which results in this index to be only created on new installations
- An occ command db:apply-indexes can be used to apply these indexes after migration during live operations.

@karlitschek @icewind1991 @MorrisJobke objections? Am I walking a total crazy and stupid path? THX
# ToDos
- [ ] fix columns length on initial setup
- [ ] prove performance benefit for sync of many small files
- [ ] prove index helps by reducing the result set for the like query
