### PR TITLE
First tests about enabling and disabling users

### DIFF
--- a/build/integration/features/bootstrap/Provisioning.php
+++ b/build/integration/features/bootstrap/Provisioning.php
@@ -529,6 +529,73 @@ trait Provisioning {
 	}
 
 	/**
+	 * @Then /^user :user is disabled$/
+	 * @param string $user
+	 */
+	public function userIsDisabled($user) {
+		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
+		$client = new Client();
+		$options = [];
+		if ($this->currentUser === 'admin') {
+			$options['auth'] = $this->adminUser;
+		}
+
+		$this->response = $client->get($fullUrl, $options);
+		PHPUnit_Framework_Assert::assertEquals("false", $this->response->xml()->data[0]->enabled);
+	}
+
+	/**
+	 * @Then /^user "([^"]*)" is disabled$/
+	 * @param string $user
+	 */
+	public function userIsDisabled($user) {
+		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
+		$client = new Client();
+		$options = [];
+		if ($this->currentUser === 'admin') {
+			$options['auth'] = $this->adminUser;
+		}
+
+		$this->response = $client->get($fullUrl, $options);
+		PHPUnit_Framework_Assert::assertEquals("false", $this->response->xml()->data[0]->enabled);
+	}
+
+	/**
+	 * @Then /^user "([^"]*)" is enabled$/
+	 * @param string $user
+	 */
+	public function userIsEnabled($user) {
+		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
+		$client = new Client();
+		$options = [];
+		if ($this->currentUser === 'admin') {
+			$options['auth'] = $this->adminUser;
+		}
+
+		$this->response = $client->get($fullUrl, $options);
+		PHPUnit_Framework_Assert::assertEquals("true", $this->response->xml()->data[0]->enabled);
+	}
+
+	/**
+	 * @Given /^Assure user "([^"]*)" is subadmin of group "([^"]*)"$/
+	 * @param string $user
+	 * @param string $group
+	 */
+	public function assureUserIsSubadminOfGroup($user, $group) {
+		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user/subadmins";
+		$client = new Client();
+		$options = [];
+		if ($this->currentUser === 'admin') {
+			$options['auth'] = $this->adminUser;
+		}
+		$options['body'] = [
+							'groupid' => $group
+							];
+		$this->response = $client->send($client->createRequest("POST", $fullUrl, $options));
+		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
+	}
+
+	/**
 	 * @Given user :user has a quota of :quota
 	 * @param string $user
 	 * @param string $quota

--- a/build/integration/features/bootstrap/Provisioning.php
+++ b/build/integration/features/bootstrap/Provisioning.php
@@ -529,22 +529,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^user :user is disabled$/
-	 * @param string $user
-	 */
-	public function userIsDisabled($user) {
-		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
-		$client = new Client();
-		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
-		}
-
-		$this->response = $client->get($fullUrl, $options);
-		PHPUnit_Framework_Assert::assertEquals("false", $this->response->xml()->data[0]->enabled);
-	}
-
-	/**
 	 * @Then /^user "([^"]*)" is disabled$/
 	 * @param string $user
 	 */

--- a/build/integration/features/bootstrap/Provisioning.php
+++ b/build/integration/features/bootstrap/Provisioning.php
@@ -545,6 +545,20 @@ trait Provisioning {
 	}
 
 	/**
+	 * @When /^Assure user "([^"]*)" is disabled$/
+	 */
+	public function assureUserIsDisabled($user) {
+		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user/disable";
+		$client = new Client();
+		$options = [];
+		if ($this->currentUser === 'admin') {
+			$options['auth'] = $this->adminUser;
+		}
+
+		$this->response = $client->send($client->createRequest("PUT", $fullUrl, $options));
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" is enabled$/
 	 * @param string $user
 	 */

--- a/build/integration/features/bootstrap/WebDav.php
+++ b/build/integration/features/bootstrap/WebDav.php
@@ -423,6 +423,16 @@ trait WebDav {
 		]);
 	}
 
+	/**
+	 * @Given /^Downloading file "([^"]*)" as "([^"]*)"$/
+	 */
+	public function downloadingFileAs($fileName, $user) {
+		try {
+			$this->response = $this->makeDavRequest($user, 'GET', $fileName, []);
+		} catch (\GuzzleHttp\Exception\ServerException $ex) {
+			$this->response = $ex->getResponse();
+		}
+	}
 
 }
 

--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -347,3 +347,19 @@ Feature: provisioning
 		Then the HTTP status code should be "200"
 		And As an "admin"
 		And user "user1" is disabled
+
+	Scenario: Subadmin should not be able to enable or disable an user not in their group
+		Given As an "admin"
+		And user "subadmin" exists
+		And user "user1" exists
+		And group "new-group" exists
+		And group "another-group" exists
+		And user "subadmin" belongs to group "new-group"
+		And user "user1" belongs to group "another-group"
+		And Assure user "subadmin" is subadmin of group "new-group"
+		And As an "subadmin"
+		When sending "PUT" to "/cloud/users/user1/disable"
+		Then the OCS status code should be "997"
+		Then the HTTP status code should be "401"
+		And As an "admin"
+		And user "user1" is enabled

--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -315,3 +315,35 @@ Feature: provisioning
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And app "files_external" is disabled
+
+	Scenario: disable an user
+		Given As an "admin"
+		And user "user1" exists
+		When sending "PUT" to "/cloud/users/user1/disable"
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And user "user1" is disabled
+
+	Scenario: enable an user
+		Given As an "admin"
+		And user "user1" exists
+		And assure user "user1" is disabled
+		When sending "PUT" to "/cloud/users/user1/enable"
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And user "user1" is enabled
+
+	Scenario: Subadmin should be able to enable or disable an user in their group
+		Given As an "admin"
+		And user "subadmin" exists
+		And user "user1" exists
+		And group "new-group" exists
+		And user "subadmin" belongs to group "new-group"
+		And user "user1" belongs to group "new-group"
+		And Assure user "subadmin" is subadmin of group "new-group"
+		And As an "subadmin"
+		When sending "PUT" to "/cloud/users/user1/disable"
+		Then the OCS status code should be "100"
+		Then the HTTP status code should be "200"
+		And As an "admin"
+		And user "user1" is disabled

--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -286,3 +286,10 @@ Feature: webdav-related
 		When As an "user0"
 		And Downloading file "/files/user0/myChunkedFile.txt"
 		Then Downloaded content should be "AAAAABBBBBCCCCC"
+
+	Scenario: A disabled user cannot use webdav
+		Given user "userToBeDisabled" exists
+		And As an "admin"
+		And Assure user "userToBeDisabled" is disabled
+		When Downloading file "/welcome.txt" as "userToBeDisabled"
+		Then the HTTP status code should be "503"


### PR DESCRIPTION
- [x] Subadmin should be able to enable or disable an user in their group
- [x] Subadmins should NOT be able to enable or disable an user not in their group
- [x] Subadmins should not be able to disable users that have admin permissions even if they are in their group
- [ ] Admins can enable and disable any user
- [ ] Regular users will get an exception
- [ ] It should not be possible to disable or enable ones own account, neither as admin nor as subadmin
- [x] Disable user
- [x] 503 is received via dav
- [ ] 503 is received via ocs api calls
- [ ] 503 is received via web requests
