### PR TITLE
Read only once

### DIFF
--- a/lib/private/Route/CachingRouter.php
+++ b/lib/private/Route/CachingRouter.php
@@ -50,8 +50,9 @@ class CachingRouter extends Router {
 	public function generate($name, $parameters = array(), $absolute = false) {
 		asort($parameters);
 		$key = $this->context->getHost() . '#' . $this->context->getBaseUrl() . $name . sha1(json_encode($parameters)) . intval($absolute);
-		if ($this->cache->hasKey($key)) {
-			return $this->cache->get($key);
+		$cachedKey = $this->cache->get($key);
+		if ($cachedKey) {
+			return $cachedKey;
 		} else {
 			$url = parent::generate($name, $parameters, $absolute);
 			$this->cache->set($key, $url, 3600);

--- a/lib/public/icache.php
+++ b/lib/public/icache.php
@@ -60,6 +60,7 @@ interface ICache {
 	 * @param string $key
 	 * @return bool
 	 * @since 6.0.0
+	 * @deprecated 9.1.0 Directly read from GET to prevent race conditions
 	 */
 	public function hasKey($key);
 


### PR DESCRIPTION
This can lead to race conditions otherwise. The entry can disappear after the `hasKey` leading to unexpected return values.

cc @MorrisJobke Thoughts?
