### PR TITLE
Add Same Site Cookie Support

### DIFF
--- a/apps/files/lib/Controller/ApiController.php
+++ b/apps/files/lib/Controller/ApiController.php
@@ -86,6 +86,7 @@ class ApiController extends Controller {
 	 *
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @StrictCookieRequired
 	 *
 	 * @param int $x
 	 * @param int $y

--- a/lib/base.php
+++ b/lib/base.php
@@ -473,6 +473,69 @@ class OC {
 		@ini_set('gd.jpeg_ignore_warning', 1);
 	}
 
+	/**
+	 * Send the same site cookies
+	 */
+	private static function sendSameSiteCookies() {
+		$cookieParams = session_get_cookie_params();
+		$secureCookie = ($cookieParams['secure'] === true) ? 'secure; ' : '';
+		$policies = [
+			'lax',
+			'strict',
+		];
+		foreach($policies as $policy) {
+			header(
+				sprintf(
+					'Set-Cookie: oc_sameSiteCookie%s=true; path=%s; httponly;' . $secureCookie . 'expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=%s',
+					$policy,
+					$cookieParams['path'],
+					$policy
+				),
+				false
+			);
+		}
+	}
+
+	/**
+	 * Same Site cookie to further mitigate CSRF attacks. This cookie has to
+	 * be set in every request if cookies are sent to add a second level of
+	 * defense against CSRF.
+	 *
+	 * If the cookie is not sent this will set the cookie and reload the page.
+	 * We use an additional cookie since we want to protect logout CSRF and
+	 * also we can't directly interfere with PHP's session mechanism.
+	 */
+	private static function performSameSiteCookieProtection() {
+		if(count($_COOKIE) > 0) {
+			$request = \OC::$server->getRequest();
+			$requestUri = $request->getScriptName();
+			$processingScript = explode('/', $requestUri);
+			$processingScript = $processingScript[count($processingScript)-1];
+
+			// For the "index.php" endpoint only a lax cookie is required.
+			if($processingScript === 'index.php') {
+				if(!$request->passesLaxCookieCheck()) {
+					self::sendSameSiteCookies();
+					header('Location: '.$_SERVER['REQUEST_URI']);
+					exit();
+				}
+			} else {
+				// All other endpoints require the lax and the strict cookie
+				if(!$request->passesStrictCookieCheck()) {
+					self::sendSameSiteCookies();
+					// Debug mode gets access to the resources without strict cookie
+					// due to the fact that the SabreDAV browser also lives there.
+					if(!\OC::$server->getConfig()->getSystemValue('debug', false)) {
+						http_response_code(\OCP\AppFramework\Http::STATUS_SERVICE_UNAVAILABLE);
+						exit();
+					}
+				}
+			}
+		} elseif(!isset($_COOKIE['oc_sameSiteCookielax']) || !isset($_COOKIE['oc_sameSiteCookiestrict'])) {
+			self::sendSameSiteCookies();
+		}
+	}
+
 	public static function init() {
 		// calculate the root directories
 		OC::$SERVERROOT = str_replace("\\", '/', substr(__DIR__, 0, -4));
@@ -577,6 +640,7 @@ class OC {
 		if(self::$server->getRequest()->getServerProtocol() === 'https') {
 			ini_set('session.cookie_secure', true);
 		}
+		self::performSameSiteCookieProtection();
 
 		if (!defined('OC_CONSOLE')) {
 			$errors = OC_Util::checkServer(\OC::$server->getConfig());

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -455,6 +455,10 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 			return false;
 		}
 
+		if(!$this->passesStrictCookieCheck()) {
+			return false;
+		}
+
 		if (isset($this->items['get']['requesttoken'])) {
 			$token = $this->items['get']['requesttoken'];
 		} elseif (isset($this->items['post']['requesttoken'])) {
@@ -468,6 +472,35 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		$token = new CsrfToken($token);
 
 		return $this->csrfTokenManager->isTokenValid($token);
+	}
+
+	/**
+	 * Checks if the strict cookie has been sent with the request
+	 *
+	 * @return bool
+	 * @since 9.1.0
+	 */
+	public function passesStrictCookieCheck() {
+		if($this->getCookie('oc_sameSiteCookiestrict') === 'true'
+			&& $this->passesLaxCookieCheck()) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks if the lax cookie has been sent with the request
+	 *
+	 * @return bool
+	 * @since 9.1.0
+	 */
+	public function passesLaxCookieCheck() {
+		if($this->getCookie('oc_sameSiteCookielax') === 'true') {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -30,6 +30,7 @@ use OC\AppFramework\Middleware\Security\Exceptions\AppNotEnabledException;
 use OC\AppFramework\Middleware\Security\Exceptions\CrossSiteRequestForgeryException;
 use OC\AppFramework\Middleware\Security\Exceptions\NotAdminException;
 use OC\AppFramework\Middleware\Security\Exceptions\NotLoggedInException;
+use OC\AppFramework\Middleware\Security\Exceptions\StrictCookieMissingException;
 use OC\AppFramework\Utility\ControllerMethodReflector;
 use OC\Security\CSP\ContentSecurityPolicyManager;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
@@ -132,6 +133,13 @@ class SecurityMiddleware extends Middleware {
 			}
 		}
 
+		// Check for strict cookie requirement
+		if($this->reflector->hasAnnotation('StrictCookieRequired') || !$this->reflector->hasAnnotation('NoCSRFRequired')) {
+			if(!$this->request->passesStrictCookieCheck()) {
+				throw new StrictCookieMissingException();
+			}
+		}
+
 		// CSRF check - also registers the CSRF token since the session may be closed later
 		Util::callRegister();
 		if(!$this->reflector->hasAnnotation('NoCSRFRequired')) {
@@ -184,6 +192,10 @@ class SecurityMiddleware extends Middleware {
 	 */
 	public function afterException($controller, $methodName, \Exception $exception) {
 		if($exception instanceof SecurityException) {
+
+			if($exception instanceof StrictCookieMissingException) {
+				return new RedirectResponse(\OC::$WEBROOT);
+			}
 
 			if (stripos($this->request->getHeader('Accept'),'html') === false) {
 				$response = new JSONResponse(

--- a/lib/private/appframework/middleware/security/exceptions/strictcookiemissingexception.php
+++ b/lib/private/appframework/middleware/security/exceptions/strictcookiemissingexception.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @author Lukas Reschke <lukas@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Appframework\Middleware\Security\Exceptions;
+
+use OCP\AppFramework\Http;
+
+/**
+ * Class StrictCookieMissingException is thrown when the strict cookie has not
+ * been sent with the request but is required.
+ *
+ * @package OC\Appframework\Middleware\Security\Exceptions
+ */
+class StrictCookieMissingException extends SecurityException {
+	public function __construct() {
+		parent::__construct('Strict Cookie has not been found in request.', Http::STATUS_PRECONDITION_FAILED);
+	}
+}

--- a/lib/private/legacy/eventsource.php
+++ b/lib/private/legacy/eventsource.php
@@ -76,6 +76,10 @@ class OC_EventSource implements \OCP\IEventSource {
 		} else {
 			header("Content-Type: text/event-stream");
 		}
+		if(!\OC::$server->getRequest()->passesStrictCookieCheck()) {
+			header('Location: '.\OC::$WEBROOT);
+			exit();
+		}
 		if (!(\OC::$server->getRequest()->passesCSRFCheck())) {
 			$this->send('error', 'Possible CSRF attack. Connection will be closed.');
 			$this->close();

--- a/lib/private/legacy/json.php
+++ b/lib/private/legacy/json.php
@@ -77,6 +77,10 @@ class OC_JSON{
 	 * @deprecated Use annotation based CSRF checks from the AppFramework instead
 	 */
 	public static function callCheck() {
+		if(!\OC::$server->getRequest()->passesStrictCookieCheck()) {
+			header('Location: '.\OC::$WEBROOT);
+			exit();
+		}
 		if( !(\OC::$server->getRequest()->passesCSRFCheck())) {
 			$l = \OC::$server->getL10N('lib');
 			self::error(array( 'data' => array( 'message' => $l->t('Token expired. Please reload page.'), 'error' => 'token_expired' )));

--- a/lib/public/irequest.php
+++ b/lib/public/irequest.php
@@ -144,6 +144,22 @@ interface IRequest {
 	public function passesCSRFCheck();
 
 	/**
+	 * Checks if the strict cookie has been sent with the request
+	 *
+	 * @return bool
+	 * @since 9.1.0
+	 */
+	public function passesStrictCookieCheck();
+
+	/**
+	 * Checks if the lax cookie has been sent with the request
+	 *
+	 * @return bool
+	 * @since 9.1.0
+	 */
+	public function passesLaxCookieCheck();
+
+	/**
 	 * Returns an ID for the request, value is not guaranteed to be unique and is mostly meant for logging
 	 * If `mod_unique_id` is installed this value will be taken.
 	 *

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -504,6 +504,10 @@ class Util {
 	 * @deprecated 9.0.0 Use annotations based on the app framework.
 	 */
 	public static function callCheck() {
+		if(!\OC::$server->getRequest()->passesStrictCookieCheck()) {
+			header('Location: '.\OC::$WEBROOT);
+			exit();
+		}
 		if (!(\OC::$server->getRequest()->passesCSRFCheck())) {
 			exit();
 		}

--- a/tests/lib/appframework/http/RequestTest.php
+++ b/tests/lib/appframework/http/RequestTest.php
@@ -1322,6 +1322,10 @@ class RequestTest extends \Test\TestCase {
 					'get' => [
 						'requesttoken' => 'AAAHGxsTCTc3BgMQESAcNR0OAR0=:MyTotalSecretShareds',
 					],
+					'cookies' => [
+						'oc_sameSiteCookiestrict' => 'true',
+						'oc_sameSiteCookielax' => 'true',
+					],
 				],
 				$this->secureRandom,
 				$this->config,
@@ -1347,6 +1351,10 @@ class RequestTest extends \Test\TestCase {
 				[
 					'post' => [
 						'requesttoken' => 'AAAHGxsTCTc3BgMQESAcNR0OAR0=:MyTotalSecretShareds',
+					],
+					'cookies' => [
+						'oc_sameSiteCookiestrict' => 'true',
+						'oc_sameSiteCookielax' => 'true',
 					],
 				],
 				$this->secureRandom,
@@ -1374,6 +1382,10 @@ class RequestTest extends \Test\TestCase {
 					'server' => [
 						'HTTP_REQUESTTOKEN' => 'AAAHGxsTCTc3BgMQESAcNR0OAR0=:MyTotalSecretShareds',
 					],
+					'cookies' => [
+						'oc_sameSiteCookiestrict' => 'true',
+						'oc_sameSiteCookielax' => 'true',
+					],
 				],
 				$this->secureRandom,
 				$this->config,
@@ -1389,6 +1401,217 @@ class RequestTest extends \Test\TestCase {
 				->willReturn(true);
 
 		$this->assertTrue($request->passesCSRFCheck());
+	}
+
+	public function testFailsCSRFCheckWithGetAndWithoutCookies() {
+		/** @var Request $request */
+		$request = $this->getMockBuilder('\OC\AppFramework\Http\Request')
+			->setMethods(['getScriptName'])
+			->setConstructorArgs([
+				[
+					'get' => [
+						'requesttoken' => 'AAAHGxsTCTc3BgMQESAcNR0OAR0=:MyTotalSecretShareds',
+					],
+				],
+				$this->secureRandom,
+				$this->config,
+				$this->csrfTokenManager,
+				$this->stream
+			])
+			->getMock();
+		$this->csrfTokenManager
+			->expects($this->never())
+			->method('isTokenValid');
+
+		$this->assertFalse($request->passesCSRFCheck());
+	}
+
+	public function testFailsCSRFCheckWithPostAndWithoutCookies() {
+		/** @var Request $request */
+		$request = $this->getMockBuilder('\OC\AppFramework\Http\Request')
+			->setMethods(['getScriptName'])
+			->setConstructorArgs([
+				[
+					'post' => [
+						'requesttoken' => 'AAAHGxsTCTc3BgMQESAcNR0OAR0=:MyTotalSecretShareds',
+					],
+				],
+				$this->secureRandom,
+				$this->config,
+				$this->csrfTokenManager,
+				$this->stream
+			])
+			->getMock();
+		$this->csrfTokenManager
+			->expects($this->never())
+			->method('isTokenValid');
+
+		$this->assertFalse($request->passesCSRFCheck());
+	}
+
+	public function testFailsCSRFCheckWithHeaderAndWithoutCookies() {
+		/** @var Request $request */
+		$request = $this->getMockBuilder('\OC\AppFramework\Http\Request')
+			->setMethods(['getScriptName'])
+			->setConstructorArgs([
+				[
+					'server' => [
+						'HTTP_REQUESTTOKEN' => 'AAAHGxsTCTc3BgMQESAcNR0OAR0=:MyTotalSecretShareds',
+					],
+				],
+				$this->secureRandom,
+				$this->config,
+				$this->csrfTokenManager,
+				$this->stream
+			])
+			->getMock();
+		$this->csrfTokenManager
+			->expects($this->never())
+			->method('isTokenValid');
+
+		$this->assertFalse($request->passesCSRFCheck());
+	}
+
+	public function testFailsCSRFCheckWithHeaderAndNotAllChecksPassing() {
+		/** @var Request $request */
+		$request = $this->getMockBuilder('\OC\AppFramework\Http\Request')
+			->setMethods(['getScriptName'])
+			->setConstructorArgs([
+				[
+					'server' => [
+						'HTTP_REQUESTTOKEN' => 'AAAHGxsTCTc3BgMQESAcNR0OAR0=:MyTotalSecretShareds',
+					],
+					'cookies' => [
+						'oc_sameSiteCookiestrict' => 'true',
+					],
+				],
+				$this->secureRandom,
+				$this->config,
+				$this->csrfTokenManager,
+				$this->stream
+			])
+			->getMock();
+		$this->csrfTokenManager
+			->expects($this->never())
+			->method('isTokenValid');
+
+		$this->assertFalse($request->passesCSRFCheck());
+	}
+
+	public function testPassesStrictCookieCheckWithAllCookies() {
+		/** @var Request $request */
+		$request = $this->getMockBuilder('\OC\AppFramework\Http\Request')
+			->setMethods(['getScriptName'])
+			->setConstructorArgs([
+				[
+					'server' => [
+						'HTTP_REQUESTTOKEN' => 'AAAHGxsTCTc3BgMQESAcNR0OAR0=:MyTotalSecretShareds',
+					],
+					'cookies' => [
+						'oc_sameSiteCookiestrict' => 'true',
+						'oc_sameSiteCookielax' => 'true',
+					],
+				],
+				$this->secureRandom,
+				$this->config,
+				$this->csrfTokenManager,
+				$this->stream
+			])
+			->getMock();
+
+		$this->assertTrue($request->passesStrictCookieCheck());
+	}
+
+	public function testFailStrictCookieCheckWithOnlyLaxCookie() {
+		/** @var Request $request */
+		$request = $this->getMockBuilder('\OC\AppFramework\Http\Request')
+			->setMethods(['getScriptName'])
+			->setConstructorArgs([
+				[
+					'server' => [
+						'HTTP_REQUESTTOKEN' => 'AAAHGxsTCTc3BgMQESAcNR0OAR0=:MyTotalSecretShareds',
+					],
+					'cookies' => [
+						'oc_sameSiteCookielax' => 'true',
+					],
+				],
+				$this->secureRandom,
+				$this->config,
+				$this->csrfTokenManager,
+				$this->stream
+			])
+			->getMock();
+
+		$this->assertFalse($request->passesStrictCookieCheck());
+	}
+
+	public function testFailStrictCookieCheckWithOnlyStrictCookie() {
+		/** @var Request $request */
+		$request = $this->getMockBuilder('\OC\AppFramework\Http\Request')
+			->setMethods(['getScriptName'])
+			->setConstructorArgs([
+				[
+					'server' => [
+						'HTTP_REQUESTTOKEN' => 'AAAHGxsTCTc3BgMQESAcNR0OAR0=:MyTotalSecretShareds',
+					],
+					'cookies' => [
+						'oc_sameSiteCookiestrict' => 'true',
+					],
+				],
+				$this->secureRandom,
+				$this->config,
+				$this->csrfTokenManager,
+				$this->stream
+			])
+			->getMock();
+
+		$this->assertFalse($request->passesStrictCookieCheck());
+	}
+
+	public function testPassesLaxCookieCheck() {
+		/** @var Request $request */
+		$request = $this->getMockBuilder('\OC\AppFramework\Http\Request')
+			->setMethods(['getScriptName'])
+			->setConstructorArgs([
+				[
+					'server' => [
+						'HTTP_REQUESTTOKEN' => 'AAAHGxsTCTc3BgMQESAcNR0OAR0=:MyTotalSecretShareds',
+					],
+					'cookies' => [
+						'oc_sameSiteCookielax' => 'true',
+					],
+				],
+				$this->secureRandom,
+				$this->config,
+				$this->csrfTokenManager,
+				$this->stream
+			])
+			->getMock();
+
+		$this->assertTrue($request->passesLaxCookieCheck());
+	}
+
+	public function testFailsLaxCookieCheckWithOnlyStrictCookie() {
+		/** @var Request $request */
+		$request = $this->getMockBuilder('\OC\AppFramework\Http\Request')
+			->setMethods(['getScriptName'])
+			->setConstructorArgs([
+				[
+					'server' => [
+						'HTTP_REQUESTTOKEN' => 'AAAHGxsTCTc3BgMQESAcNR0OAR0=:MyTotalSecretShareds',
+					],
+					'cookies' => [
+						'oc_sameSiteCookiestrict' => 'true',
+					],
+				],
+				$this->secureRandom,
+				$this->config,
+				$this->csrfTokenManager,
+				$this->stream
+			])
+			->getMock();
+
+		$this->assertFalse($request->passesLaxCookieCheck());
 	}
 
 	/**

--- a/tests/lib/appframework/middleware/security/SecurityMiddlewareTest.php
+++ b/tests/lib/appframework/middleware/security/SecurityMiddlewareTest.php
@@ -31,6 +31,7 @@ use OC\AppFramework\Middleware\Security\Exceptions\CrossSiteRequestForgeryExcept
 use OC\AppFramework\Middleware\Security\Exceptions\NotAdminException;
 use OC\AppFramework\Middleware\Security\Exceptions\NotLoggedInException;
 use OC\AppFramework\Middleware\Security\Exceptions\SecurityException;
+use OC\Appframework\Middleware\Security\Exceptions\StrictCookieMissingException;
 use OC\AppFramework\Utility\ControllerMethodReflector;
 use OC\Security\CSP\ContentSecurityPolicy;
 use OCP\AppFramework\Http\RedirectResponse;
@@ -255,6 +256,9 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->request->expects($this->once())
 			->method('passesCSRFCheck')
 			->will($this->returnValue(false));
+		$this->request->expects($this->once())
+			->method('passesStrictCookieCheck')
+			->will($this->returnValue(true));
 
 		$this->reader->reflect(__CLASS__, __FUNCTION__);
 		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
@@ -278,15 +282,78 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	/**
 	 * @PublicPage
 	 */
-	public function testFailCsrfCheck(){
+	public function testPassesCsrfCheck(){
 		$this->request->expects($this->once())
 			->method('passesCSRFCheck')
+			->will($this->returnValue(true));
+		$this->request->expects($this->once())
+			->method('passesStrictCookieCheck')
 			->will($this->returnValue(true));
 
 		$this->reader->reflect(__CLASS__, __FUNCTION__);
 		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
 	}
 
+	/**
+	 * @PublicPage
+	 * @expectedException \OC\AppFramework\Middleware\Security\Exceptions\CrossSiteRequestForgeryException
+	 */
+	public function testFailCsrfCheck(){
+		$this->request->expects($this->once())
+			->method('passesCSRFCheck')
+			->will($this->returnValue(false));
+		$this->request->expects($this->once())
+			->method('passesStrictCookieCheck')
+			->will($this->returnValue(true));
+
+		$this->reader->reflect(__CLASS__, __FUNCTION__);
+		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
+	}
+
+	/**
+	 * @PublicPage
+	 * @StrictCookieRequired
+	 * @expectedException \OC\Appframework\Middleware\Security\Exceptions\StrictCookieMissingException
+	 */
+	public function testStrictCookieRequiredCheck() {
+		$this->request->expects($this->never())
+			->method('passesCSRFCheck');
+		$this->request->expects($this->once())
+			->method('passesStrictCookieCheck')
+			->will($this->returnValue(false));
+
+		$this->reader->reflect(__CLASS__, __FUNCTION__);
+		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
+	}
+
+
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 */
+	public function testNoStrictCookieRequiredCheck() {
+		$this->request->expects($this->never())
+			->method('passesStrictCookieCheck')
+			->will($this->returnValue(false));
+
+		$this->reader->reflect(__CLASS__, __FUNCTION__);
+		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
+	}
+
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 * @StrictCookieRequired
+	 */
+	public function testPassesStrictCookieRequiredCheck() {
+		$this->request
+			->expects($this->once())
+			->method('passesStrictCookieCheck')
+			->willReturn(true);
+
+		$this->reader->reflect(__CLASS__, __FUNCTION__);
+		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
+	}
 
 	/**
 	 * @NoCSRFRequired
@@ -362,6 +429,29 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		);
 
 		$expected = new RedirectResponse('http://localhost/index.php/login?redirect_url=owncloud%2Findex.php%2Fapps%2Fspecialapp');
+		$this->assertEquals($expected , $response);
+	}
+
+	public function testAfterExceptionRedirectsToWebRootAfterStrictCookieFail() {
+		$this->request = new Request(
+			[
+				'server' =>
+					[
+						'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+						'REQUEST_URI' => 'owncloud/index.php/apps/specialapp'
+					]
+			],
+			$this->getMock('\OCP\Security\ISecureRandom'),
+			$this->getMock('\OCP\IConfig')
+		);
+		$this->middleware = $this->getMiddleware(false, false);
+		$response = $this->middleware->afterException(
+			$this->controller,
+			'test',
+			new StrictCookieMissingException()
+		);
+
+		$expected = new RedirectResponse(\OC::$WEBROOT);
 		$this->assertEquals($expected , $response);
 	}
 


### PR DESCRIPTION
This adds Same Site Cookie Support, a new security feature supported by Chrome 51 (to be released in May to the stable channel) and Firefox has intentions to add it in Q2 2016 as well.

SameSite Cookies allows to specify from which origins a cookie is sent. The policy of "lax" prevents the cookie from being sent to ownCloud from any other domain than the one that ownCloud is running on. Effectively this prevents CSRF attacks on any HTTP method other than GET which is a very important and big security hardening.

This implementation behaves as following:
1. For browsers: If the cookie is not sent AND cookies are supported then add the cookie and reload the page.
2. For DAV clients: If the cookie is not sent AND cookies are supported then add the cookie and issue a 503 status code.

The implementation has the advantage that it is not intrusive and does not break existing clients or pages.

**Todo:**
- [x] Add strict cookie requirement for all other endpoints than "index.php"
- [x] Add annotation to AppFramework to opt-in controllers to strict cookie requirement
- [x] Add strict cookie requirement to CSRF check 
- [x] Add unit tests 

<hr/>

http://www.sjoerdlangkemper.nl/2016/04/14/preventing-csrf-with-samesite-cookie-attribute/ has a nice overview and introduction to the topic.
