### PR TITLE
Move the group dummy backend to test

### DIFF
--- a/apps/files_sharing/tests/testcase.php
+++ b/apps/files_sharing/tests/testcase.php
@@ -82,7 +82,7 @@ abstract class TestCase extends \Test\TestCase {
 		$backend->createUser(self::TEST_FILES_SHARING_API_USER4, self::TEST_FILES_SHARING_API_USER4);
 
 		// create group
-		$groupBackend = new \OC_Group_Dummy();
+		$groupBackend = new \Test\Util\Group\Dummy();
 		$groupBackend->createGroup(self::TEST_FILES_SHARING_API_GROUP1);
 		$groupBackend->createGroup('group');
 		$groupBackend->createGroup('group1');

--- a/tests/lib/group.php
+++ b/tests/lib/group.php
@@ -32,7 +32,7 @@ class Test_Group extends \Test\TestCase {
 	public function testSingleBackend() {
 		$userBackend = new \Test\Util\User\Dummy();
 		\OC::$server->getUserManager()->registerBackend($userBackend);
-		OC_Group::useBackend(new OC_Group_Dummy());
+		OC_Group::useBackend(new \Test\Util\Group\Dummy());
 
 		$group1 = $this->getUniqueID();
 		$group2 = $this->getUniqueID();
@@ -72,7 +72,7 @@ class Test_Group extends \Test\TestCase {
 
 
 	public function testNoEmptyGIDs() {
-		OC_Group::useBackend(new OC_Group_Dummy());
+		OC_Group::useBackend(new \Test\Util\Group\Dummy());
 		$emptyGroup = null;
 
 		$this->assertFalse(OC_Group::createGroup($emptyGroup));
@@ -80,7 +80,7 @@ class Test_Group extends \Test\TestCase {
 
 
 	public function testNoGroupsTwice() {
-		OC_Group::useBackend(new OC_Group_Dummy());
+		OC_Group::useBackend(new \Test\Util\Group\Dummy());
 		$group = $this->getUniqueID();
 		OC_Group::createGroup($group);
 
@@ -92,7 +92,7 @@ class Test_Group extends \Test\TestCase {
 
 
 	public function testDontDeleteAdminGroup() {
-		OC_Group::useBackend(new OC_Group_Dummy());
+		OC_Group::useBackend(new \Test\Util\Group\Dummy());
 		$adminGroup = 'admin';
 		OC_Group::createGroup($adminGroup);
 
@@ -102,7 +102,7 @@ class Test_Group extends \Test\TestCase {
 
 
 	public function testDontAddUserToNonexistentGroup() {
-		OC_Group::useBackend(new OC_Group_Dummy());
+		OC_Group::useBackend(new \Test\Util\Group\Dummy());
 		$groupNonExistent = 'notExistent';
 		$user = $this->getUniqueID();
 
@@ -111,7 +111,7 @@ class Test_Group extends \Test\TestCase {
 	}
 
 	public function testUsersInGroup() {
-		OC_Group::useBackend(new OC_Group_Dummy());
+		OC_Group::useBackend(new \Test\Util\Group\Dummy());
 		$userBackend = new \Test\Util\User\Dummy();
 		\OC::$server->getUserManager()->registerBackend($userBackend);
 
@@ -143,8 +143,8 @@ class Test_Group extends \Test\TestCase {
 	public function testMultiBackend() {
 		$userBackend = new \Test\Util\User\Dummy();
 		\OC::$server->getUserManager()->registerBackend($userBackend);
-		$backend1 = new OC_Group_Dummy();
-		$backend2 = new OC_Group_Dummy();
+		$backend1 = new \Test\Util\Group\Dummy();
+		$backend2 = new \Test\Util\Group\Dummy();
 		OC_Group::useBackend($backend1);
 		OC_Group::useBackend($backend2);
 

--- a/tests/lib/group/dummy.php
+++ b/tests/lib/group/dummy.php
@@ -28,6 +28,6 @@
 class Test_Group_Dummy extends Test_Group_Backend {
 	protected function setUp() {
 		parent::setUp();
-		$this->backend=new OC_Group_Dummy();
+		$this->backend=new \Test\Util\Group\Dummy();
 	}
 }

--- a/tests/lib/group/manager.php
+++ b/tests/lib/group/manager.php
@@ -65,7 +65,7 @@ class Manager extends \Test\TestCase {
 	}
 
 	public function testGetDeleted() {
-		$backend = new \OC_Group_Dummy();
+		$backend = new \Test\Util\Group\Dummy();
 		$backend->createGroup('group1');
 
 		/**

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -63,7 +63,7 @@ class Test_Share extends \Test\TestCase {
 		\OC::$server->getUserManager()->createUser($this->groupAndUser, 'pass');
 		OC_User::setUserId($this->user1);
 		OC_Group::clearBackends();
-		OC_Group::useBackend(new OC_Group_Dummy);
+		OC_Group::useBackend(new \Test\Util\Group\Dummy());
 		$this->group1 = $this->getUniqueID('group1_');
 		$this->group2 = $this->getUniqueID('group2_');
 		OC_Group::createGroup($this->group1);

--- a/tests/lib/util/group/dummy.php
+++ b/tests/lib/util/group/dummy.php
@@ -27,10 +27,14 @@
  *
  */
 
+namespace Test\Util\Group;
+
+use OC_Group_Backend;
+
 /**
  * dummy group backend, does not keep state, only for testing use
  */
-class OC_Group_Dummy extends OC_Group_Backend {
+class Dummy extends OC_Group_Backend {
 	private $groups=array();
 	/**
 	 * Try to create a new group


### PR DESCRIPTION
The dummy backend is only used for testing and should thus reside in
tests.

It now resides in a simmilar location as the dummy user backend.

CC: @LukasReschke @MorrisJobke @nickvergessen @DeepDiver1975 
