### PR TITLE
Cacheappconfig

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -294,9 +294,7 @@ class Server extends ServerContainer implements IServerContainer {
 			$config = $c->getConfig();
 
 			if ($config->getSystemValue('installed', false) && !(defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
-				$v = \OC_App::getAppVersions();
-				$v['core'] = md5(file_get_contents(\OC::$SERVERROOT . '/version.php'));
-				$version = implode(',', $v);
+				$version = md5(file_get_contents(\OC::$SERVERROOT . '/version.php'));
 				$instanceId = \OC_Util::getInstanceId();
 				$path = \OC::$SERVERROOT;
 				$prefix = md5($instanceId . '-' . $version . '-' . $path);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -264,7 +264,9 @@ class Server extends ServerContainer implements IServerContainer {
 			return new \OC\SystemConfig($config);
 		});
 		$this->registerService('AppConfig', function (Server $c) {
-			return new \OC\AppConfig($c->getDatabaseConnection());
+			$cacheFactory = $c->getMemCacheFactory();
+			$cache = $cacheFactory->create('appconfig');
+			return new \OC\AppConfig($c->getDatabaseConnection(), $cache);
 		});
 		$this->registerService('L10NFactory', function (Server $c) {
 			return new \OC\L10N\Factory(

--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -217,7 +217,7 @@ class OC_App {
 			$appTypes = '';
 		}
 
-		\OC::$server->getAppConfig()->setValue($app, 'types', $appTypes);
+		\OC::$server->getConfig()->setAppValue($app, 'types', $appTypes);
 	}
 
 	/**
@@ -295,6 +295,7 @@ class OC_App {
 	 */
 	public static function enable($app, $groups = null) {
 		self::$enabledAppsCache = array(); // flush
+
 		if (!OC_Installer::isInstalled($app)) {
 			$app = self::installApp($app);
 		}
@@ -796,7 +797,7 @@ class OC_App {
 					continue;
 				}
 
-				$enabled = \OC::$server->getAppConfig()->getValue($app, 'enabled', 'no');
+				$enabled = \OC::$server->getConfig()->getAppValue($app, 'enabled', 'no');
 				$info['groups'] = null;
 				if ($enabled === 'yes') {
 					$active = true;
@@ -1167,7 +1168,7 @@ class OC_App {
 		self::setAppTypes($appId);
 
 		$version = \OC_App::getAppVersion($appId);
-		\OC::$server->getAppConfig()->setValue($appId, 'installed_version', $version);
+		\OC::$server->getConfig()->setAppValue($appId, 'installed_version', $version);
 
 		return true;
 	}

--- a/lib/private/appconfig.php
+++ b/lib/private/appconfig.php
@@ -29,6 +29,7 @@
 namespace OC;
 
 use OCP\IAppConfig;
+use OCP\ICache;
 use OCP\IDBConnection;
 
 /**
@@ -43,12 +44,15 @@ class AppConfig implements IAppConfig {
 
 	private $cache = array();
 
+	private $cacheTime = 600; // 10 minutes
+
 	/**
 	 * @param IDBConnection $conn
+	 * @param ICache $cache
 	 */
-	public function __construct(IDBConnection $conn) {
+	public function __construct(IDBConnection $conn, ICache $cache = null) {
 		$this->conn = $conn;
-		$this->configLoaded = false;
+		$this->cache = $cache;
 	}
 
 	/**
@@ -56,13 +60,22 @@ class AppConfig implements IAppConfig {
 	 * @return array
 	 */
 	private function getAppValues($app) {
-		$this->loadConfigValues();
-
-		if (isset($this->cache[$app])) {
-			return $this->cache[$app];
+		$cacheKey = 'app/' . $app;
+		if ($values = $this->cache->get($cacheKey)) {
+			return $values;
 		}
-
-		return [];
+		$values = [];
+		$sql = $this->conn->getQueryBuilder();
+		$sql->select(['configkey', 'configvalue'])
+			->from('appconfig')
+			->where($sql->expr()->eq('appid', $sql->createParameter('appid')))
+			->setParameter('appid', $app);
+		$result = $sql->execute();
+		while ($row = $result->fetch()) {
+			$values[$row['configkey']] = $row['configvalue'];
+		}
+		$this->cache->set($cacheKey, $values, $this->cacheTime);
+		return $values;
 	}
 
 	/**
@@ -74,9 +87,20 @@ class AppConfig implements IAppConfig {
 	 * entry in the appconfig table.
 	 */
 	public function getApps() {
-		$this->loadConfigValues();
+		if ($values = $this->cache->get('apps')) {
+			return $values;
+		}
+		$sql = $this->conn->getQueryBuilder();
+		$sql->selectDistinct(['appid'])
+			->from('appconfig');
+		$result = $sql->execute();
 
-		return $this->getSortedKeys($this->cache);
+		$apps = [];
+		while ($appid = $result->fetchColumn()) {
+			$apps[] = $appid;
+		}
+		$this->cache->set('apps', $apps, $this->cacheTime);
+		return $apps;
 	}
 
 	/**
@@ -89,17 +113,8 @@ class AppConfig implements IAppConfig {
 	 * not returned.
 	 */
 	public function getKeys($app) {
-		$this->loadConfigValues();
-
-		if (isset($this->cache[$app])) {
-			return $this->getSortedKeys($this->cache[$app]);
-		}
-
-		return [];
-	}
-
-	public function getSortedKeys($data) {
-		$keys = array_keys($data);
+		$values = $this->getAppValues($app);
+		$keys = array_keys($values);
 		sort($keys);
 		return $keys;
 	}
@@ -116,13 +131,12 @@ class AppConfig implements IAppConfig {
 	 * not exist the default value will be returned
 	 */
 	public function getValue($app, $key, $default = null) {
-		$this->loadConfigValues();
-
-		if ($this->hasKey($app, $key)) {
-			return $this->cache[$app][$key];
+		$values = $this->getAppValues($app);
+		if (isset($values[$key])) {
+			return $values[$key];
+		} else {
+			return $default;
 		}
-
-		return $default;
 	}
 
 	/**
@@ -133,9 +147,8 @@ class AppConfig implements IAppConfig {
 	 * @return bool
 	 */
 	public function hasKey($app, $key) {
-		$this->loadConfigValues();
-
-		return isset($this->cache[$app][$key]);
+		$values = $this->getAppValues($app);
+		return array_key_exists($key, $values);
 	}
 
 	/**
@@ -147,51 +160,40 @@ class AppConfig implements IAppConfig {
 	 * @return bool True if the value was inserted or updated, false if the value was the same
 	 */
 	public function setValue($app, $key, $value) {
+		// Does the key exist? no: insert, yes: update.
+		$this->cache->remove('app/' . $app);
 		if (!$this->hasKey($app, $key)) {
-			$inserted = (bool) $this->conn->insertIfNotExist('*PREFIX*appconfig', [
-				'appid' => $app,
-				'configkey' => $key,
-				'configvalue' => $value,
-			], [
-				'appid',
-				'configkey',
-			]);
-
-			if ($inserted) {
-				if (!isset($this->cache[$app])) {
-					$this->cache[$app] = [];
-				}
-
-				$this->cache[$app][$key] = $value;
-				return true;
+			$sql = $this->conn->getQueryBuilder();
+			$sql->insert('appconfig')
+				->values([
+					'appid' => $sql->createParameter('appid'),
+					'configkey' => $sql->createParameter('configkey'),
+					'configvalue' => $sql->createParameter('configvalue'),
+				])
+				->setParameters([
+					'appid' => $app,
+					'configkey' => $key,
+					'configvalue' => $value,
+				]);
+			$sql->execute();
+		} else {
+			$oldValue = $this->getValue($app, $key);
+			if($oldValue === strval($value)) {
+				return false;
 			}
+			$sql = $this->conn->getQueryBuilder();
+			$sql->update('appconfig')
+				->set('configvalue', $sql->createParameter('configvalue'))
+				->where($sql->expr()->eq('appid', $sql->createParameter('app')))
+				->andWhere($sql->expr()->eq('configkey', $sql->createParameter('configkey')))
+				->setParameter('app', $app)
+				->setParameter('configkey', $key);
+			$sql->execute();
 		}
-
-		$sql = $this->conn->getQueryBuilder();
-		$sql->update('appconfig')
-			->set('configvalue', $sql->createParameter('configvalue'))
-			->where($sql->expr()->eq('appid', $sql->createParameter('app')))
-			->andWhere($sql->expr()->eq('configkey', $sql->createParameter('configkey')))
-			->setParameter('configvalue', $value)
-			->setParameter('app', $app)
-			->setParameter('configkey', $key);
-
-		/*
-		 * Only limit to the existing value for non-Oracle DBs:
-		 * http://docs.oracle.com/cd/E11882_01/server.112/e26088/conditions002.htm#i1033286
-		 * > Large objects (LOBs) are not supported in comparison conditions.
-		 */
-		if (!($this->conn instanceof \OC\DB\OracleConnection)) {
-			// Only update the value when it is not the same
-			$sql->andWhere($sql->expr()->neq('configvalue', $sql->createParameter('configvalue')))
-				->setParameter('configvalue', $value);
-		}
-
-		$changedRow = (bool) $sql->execute();
-
-		$this->cache[$app][$key] = $value;
-
-		return $changedRow;
+		$this->cache->remove('app/' . $app);
+		$this->cache->remove('key/' . $key);
+		$this->cache->remove('apps');
+		return true;
 	}
 
 	/**
@@ -202,8 +204,6 @@ class AppConfig implements IAppConfig {
 	 * @return boolean|null
 	 */
 	public function deleteKey($app, $key) {
-		$this->loadConfigValues();
-
 		$sql = $this->conn->getQueryBuilder();
 		$sql->delete('appconfig')
 			->where($sql->expr()->eq('appid', $sql->createParameter('app')))
@@ -212,7 +212,8 @@ class AppConfig implements IAppConfig {
 			->setParameter('configkey', $key);
 		$sql->execute();
 
-		unset($this->cache[$app][$key]);
+		$this->cache->remove('app/' . $app);
+		$this->cache->remove('key/' . $key);
 	}
 
 	/**
@@ -224,15 +225,15 @@ class AppConfig implements IAppConfig {
 	 * Removes all keys in appconfig belonging to the app.
 	 */
 	public function deleteApp($app) {
-		$this->loadConfigValues();
-
 		$sql = $this->conn->getQueryBuilder();
 		$sql->delete('appconfig')
 			->where($sql->expr()->eq('appid', $sql->createParameter('app')))
 			->setParameter('app', $app);
 		$sql->execute();
 
-		unset($this->cache[$app]);
+		$this->cache->remove('app/' . $app);
+		$this->cache->remove('apps');
+		$this->cache->clear('key/');
 	}
 
 	/**
@@ -250,38 +251,24 @@ class AppConfig implements IAppConfig {
 		if ($key === false) {
 			return $this->getAppValues($app);
 		} else {
-			$appIds = $this->getApps();
-			$values = array_map(function($appId) use ($key) {
-				return isset($this->cache[$appId][$key]) ? $this->cache[$appId][$key] : null;
-			}, $appIds);
-			$result = array_combine($appIds, $values);
+			$cacheKey = 'key/' . $key;
+			if ($values = $this->cache->get($cacheKey)) {
+				return $values;
+			}
+			$sql = $this->conn->getQueryBuilder();
+			$sql->select(['configvalue', 'appid'])
+				->from('appconfig')
+				->where($sql->expr()->eq('configkey', $sql->createParameter('configkey')))
+				->setParameter('configkey', $key);
+			$result = $sql->execute();
 
-			return array_filter($result);
-		}
-	}
-
-	/**
-	 * Load all the app config values
-	 */
-	protected function loadConfigValues() {
-		if ($this->configLoaded) return;
-
-		$this->cache = [];
-
-		$sql = $this->conn->getQueryBuilder();
-		$sql->select('*')
-			->from('appconfig');
-		$result = $sql->execute();
-
-		while ($row = $result->fetch()) {
-			if (!isset($this->cache[$row['appid']])) {
-				$this->cache[$row['appid']] = [];
+			$values = array();
+			while ($row = $result->fetch((\PDO::FETCH_ASSOC))) {
+				$values[$row['appid']] = $row['configvalue'];
 			}
 
-			$this->cache[$row['appid']][$row['configkey']] = $row['configvalue'];
+			$this->cache->set($cacheKey, $values, $this->cacheTime);
+			return $values;
 		}
-		$result->closeCursor();
-
-		$this->configLoaded = true;
 	}
 }

--- a/lib/private/appconfig.php
+++ b/lib/private/appconfig.php
@@ -184,9 +184,10 @@ class AppConfig implements IAppConfig {
 			$sql = $this->conn->getQueryBuilder();
 			$sql->update('appconfig')
 				->set('configvalue', $sql->createParameter('configvalue'))
-				->where($sql->expr()->eq('appid', $sql->createParameter('app')))
+				->where($sql->expr()->eq('appid', $sql->createParameter('appid')))
 				->andWhere($sql->expr()->eq('configkey', $sql->createParameter('configkey')))
-				->setParameter('app', $app)
+				->setParameter('configvalue', $value)
+				->setParameter('appid', $app)
 				->setParameter('configkey', $key);
 			$sql->execute();
 		}


### PR DESCRIPTION
I tried reviving https://github.com/owncloud/core/pull/13417 for an oracle based installation of OC8.2.3 and was rewarded with a status.php page load speedup from ~1080ms down to ~550ms. Oracle has a high connection creation latency (~400-500ms) and I would really like to avoid doing a db trip if possible because they are expensive as well, see https://github.com/owncloud/core/pull/23835 for the fetch cost for status.php

In OC 8 OC_App uses a db query to determine the app versions. In OC9 we are using the AppCache, which creates a cyclic dependency that I removed by removing the app versions from the memcache prefix. @LukasReschke How important are they? AFAICT having them in the cache prefix automagically invalidates the cache on app enable/disable. Couldn't we achieve the same thing by invalidating the cache manually?

What about deleting appconfig entries from the DB when an app is disabled? Currently there are tons of todos in OC_Installer::removeApp() https://github.com/owncloud/core/blob/master/lib/private/installer.php#L493 This is currently not included in the PR.

A review with a db not on the same host / some latency to the db would be nice to verify or falsify my observations.

cc @MorrisJobke @DeepDiver1975 @Xenopathic 

00004686
