### PR TITLE
init users mount point before recovery

### DIFF
--- a/apps/encryption/hooks/userhooks.php
+++ b/apps/encryption/hooks/userhooks.php
@@ -24,6 +24,7 @@
 namespace OCA\Encryption\Hooks;
 
 
+use OC\Files\Filesystem;
 use OCP\IUserManager;
 use OCP\Util as OCUtil;
 use OCA\Encryption\Hooks\Contracts\IHook;
@@ -243,6 +244,7 @@ class UserHooks implements IHook {
 			// used to decrypt it has changed
 		} else { // admin changed the password for a different user, create new keys and re-encrypt file keys
 			$user = $params['uid'];
+			$this->initMountPoints($user);
 			$recoveryPassword = isset($params['recoveryPassword']) ? $params['recoveryPassword'] : null;
 
 			// we generate new keys if...
@@ -281,6 +283,15 @@ class UserHooks implements IHook {
 		}
 	}
 
+	/**
+	 * init mount points for given user
+	 *
+	 * @param string $user
+	 * @throws \OC\User\NoUserException
+	 */
+	protected function initMountPoints($user) {
+		Filesystem::initMountPoints($user);
+	}
 
 
 	/**

--- a/apps/encryption/tests/hooks/UserHooksTest.php
+++ b/apps/encryption/tests/hooks/UserHooksTest.php
@@ -29,6 +29,12 @@ use OCA\Encryption\Crypto\Crypt;
 use OCA\Encryption\Hooks\UserHooks;
 use Test\TestCase;
 
+/**
+ * Class UserHooksTest
+ *
+ * @group DB
+ * @package OCA\Encryption\Tests\Hooks
+ */
 class UserHooksTest extends TestCase {
 	/**
 	 * @var \PHPUnit_Framework_MockObject_MockObject
@@ -190,6 +196,23 @@ class UserHooksTest extends TestCase {
 			->willReturnOnConsecutiveCalls(true, false);
 
 
+		$this->instance = $this->getMockBuilder('OCA\Encryption\Hooks\UserHooks')
+			->setConstructorArgs(
+				[
+					$this->keyManagerMock,
+					$this->userManagerMock,
+					$this->loggerMock,
+					$this->userSetupMock,
+					$this->userSessionMock,
+					$this->utilMock,
+					$this->sessionMock,
+					$this->cryptMock,
+					$this->recoveryMock
+				]
+			)->setMethods(['initMountPoints'])->getMock();
+
+		$this->instance->expects($this->exactly(3))->method('initMountPoints');
+
 		// Test first if statement
 		$this->assertNull($this->instance->setPassphrase($this->params));
 
@@ -236,16 +259,20 @@ class UserHooksTest extends TestCase {
 			->with('testUser')
 			->willReturn(false);
 
-		$userHooks = new UserHooks($this->keyManagerMock,
-			$this->userManagerMock,
-			$this->loggerMock,
-			$this->userSetupMock,
-			$userSessionMock,
-			$this->utilMock,
-			$this->sessionMock,
-			$this->cryptMock,
-			$this->recoveryMock
-		);
+		$userHooks = $this->getMockBuilder('OCA\Encryption\Hooks\UserHooks')
+			->setConstructorArgs(
+				[
+					$this->keyManagerMock,
+					$this->userManagerMock,
+					$this->loggerMock,
+					$this->userSetupMock,
+					$userSessionMock,
+					$this->utilMock,
+					$this->sessionMock,
+					$this->cryptMock,
+					$this->recoveryMock
+				]
+			)->setMethods(['initMountPoints'])->getMock();
 
 		$this->assertNull($userHooks->setPassphrase($this->params));
 	}


### PR DESCRIPTION
we need to initialize the mount points of the given user before we recover access to his files

fix https://github.com/owncloud/core/issues/23632
