### PR TITLE
When calling file_put_contents clear the checksum

### DIFF
--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -195,6 +195,8 @@ class Scanner extends BasicEmitter implements IScanner {
 					$fileId = -1;
 				}
 				if (!empty($newData)) {
+					// Reset the checksum if the data has changed
+					$newData['checksum'] = '';
 					$data['fileid'] = $this->addToCache($file, $newData, $fileId);
 				}
 				if (isset($cacheData['size'])) {

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -2424,4 +2424,24 @@ class View extends \Test\TestCase {
 
 		$this->assertEquals($expected, $files);
 	}
+
+	public function testFilePutContentsClearsChecksum() {
+		$storage = new Temporary(array());
+		$scanner = $storage->getScanner();
+		$storage->file_put_contents('foo.txt', 'bar');
+		\OC\Files\Filesystem::mount($storage, array(), '/test/');
+		$scanner->scan('');
+
+		$view = new \OC\Files\View('/test/foo.txt');
+		$view->putFileInfo('.', ['checksum' => '42']);
+
+		$this->assertEquals('bar', $view->file_get_contents(''));
+		$fh = tmpfile();
+		fwrite($fh, 'fooo');
+		rewind($fh);
+		$view->file_put_contents('', $fh);
+		$this->assertEquals('fooo', $view->file_get_contents(''));
+		$data = $view->getFileInfo('.');
+		$this->assertEquals('', $data->getChecksum());
+	}
 }


### PR DESCRIPTION
Fixes #23782 and #23783

If a file is changed we should reset the checksum.
- Unit test added

To test:
- Upload a file with checksum
  `curl -u admin:admin http://localhost/master/remote.php/webdav/foo.txt -X PUT -T foo.txt -H "OC-Checksum: foobar"`
- Check the file cache. This file should have the checksum foobar
- Download the file the OC-Checksum header should be set
- Now edit the file in the texteditor and close it
- Check the file cache. This file should have an empty checksum
- Download the file the OC-Checksum header should not be set

Test 2:
- Upload a file with checksum
  `curl -u admin:admin http://localhost/master/remote.php/webdav/foo.txt -X PUT -T foo.txt -H "OC-Checksum: foobar"`
- Check the file cache. This file should have the checksum foobar
- Download the file the OC-Checksum header should be set
- Now edit the file directly on disk
- Run `./occ files:scan admin`
- Check the file cache. This file should have an empty checksum
- Download the file the OC-Checksum header should not be set

CC: @PVince81 @nickvergessen @MorrisJobke @dragotin 
