### PR TITLE
Allow setting can edit permissions on federated shares in webUI

### DIFF
--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -280,6 +280,17 @@
 				permissions |= $(checkbox).data('permissions');
 			});
 
+			// The federated share UI is a bit different so handle it properly
+			if (shareType === OC.Share.SHARE_TYPE_REMOTE &&
+				$element.attr('name') === 'edit' &&
+				$element.is(':checked')) {
+				permissions |= OC.PERMISSION_UPDATE;
+
+				if (this.model.deletePermissionPossible()) {
+					permissions |= OC.PERMISSION_CREATE;
+				}
+			}
+
 			this.model.updateShare(shareId, {permissions: permissions});
 		},
 


### PR DESCRIPTION
Fixes #24032

Since we have a slightly different UI for the federated shares our
normal logic fails us. This makes sure to add the correct permissions
when it is a federated share.

@michaelstingl please have a look

CC: @schiesbn @PVince81 @MorrisJobke
