### PR TITLE
preserve information if it is a rename operation or not

### DIFF
--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -627,9 +627,10 @@ class Encryption extends Wrapper {
 	 * @param string $sourceInternalPath
 	 * @param string $targetInternalPath
 	 * @param bool $preserveMtime
+	 * @param bool $isRename
 	 * @return bool
 	 */
-	public function copyFromStorage(Storage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false) {
+	public function copyFromStorage(Storage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false, $isRename = false) {
 
 		// TODO clean this up once the underlying moveFromStorage in OC\Files\Storage\Wrapper\Common is fixed:
 		// - call $this->storage->copyFromStorage() instead of $this->copyBetweenStorage
@@ -637,7 +638,7 @@ class Encryption extends Wrapper {
 		// - copy the copyKeys() call from  $this->copyBetweenStorage to this method
 		// - remove $this->copyBetweenStorage
 
-		return $this->copyBetweenStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime, false);
+		return $this->copyBetweenStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime, $isRename);
 	}
 
 	/**
@@ -732,7 +733,7 @@ class Encryption extends Wrapper {
 			if (is_resource($dh)) {
 				while ($result and ($file = readdir($dh)) !== false) {
 					if (!Filesystem::isIgnoredDir($file)) {
-						$result &= $this->copyFromStorage($sourceStorage, $sourceInternalPath . '/' . $file, $targetInternalPath . '/' . $file);
+						$result &= $this->copyFromStorage($sourceStorage, $sourceInternalPath . '/' . $file, $targetInternalPath . '/' . $file, false, $isRename);
 					}
 				}
 			}


### PR DESCRIPTION
fix https://github.com/owncloud/core/issues/24095

Steps to test:
1. Create 2 oC users, user1 and user2
2. Log in with user1
3. Create a file.txt with some content
4. Log in as admin user and enable encryption
5. Log out and log in as admin.
6. login as user2 (to make sure that user2 has a private and a public key)
7. As admin via CLI run --> sudo -u www-data ./occ files:transfer-ownership user1 user2

Without this patch user2 can't read the transfered files because 'encrypted' is set to '0' 
With this patch 'encrypted' is set correctly to '1' and user2 can read the transfered files.

please review... @LukasReschke @owncloud/encryption 
@davitol maybe you can verify the fix too... Thanks!
