### PR TITLE
Add loadAdditionalScripts events to admin and personal settings

### DIFF
--- a/settings/admin.php
+++ b/settings/admin.php
@@ -41,6 +41,8 @@ OC_Util::addScript('settings', 'certificates');
 OC_Util::addScript('files', 'jquery.iframe-transport');
 OC_Util::addScript('files', 'jquery.fileupload');
 
+\OC::$server->getEventDispatcher()->dispatch('OC\Settings\Admin::loadAdditionalScripts');
+
 $showLog = (\OC::$server->getConfig()->getSystemValue('log_type', 'owncloud') === 'owncloud');
 $numEntriesToLoad = 3;
 $entries = OC_Log_Owncloud::getEntries($numEntriesToLoad + 1);

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -54,6 +54,8 @@ if ($config->getSystemValue('enable_avatars', true) === true) {
 	\OC_Util::addVendorStyle('jcrop/css/jquery.Jcrop');
 }
 
+\OC::$server->getEventDispatcher()->dispatch('OC\Settings\Personal::loadAdditionalScripts');
+
 // Highlight navigation entry
 OC::$server->getNavigationManager()->setActiveEntry('personal');
 


### PR DESCRIPTION
Required for workflow plugins, which have no admin/personal section themselves, but need to be able to load JS files there to register their plugin to `OC.Plugins`. (Ref owncloud/workflow#94)
Event name is mirrored from [`OCA\Files::loadAdditionalScripts`](https://github.com/owncloud/core/blob/576f7244e6b3b4d5568bebbe17966eb6490210f2/apps/files/controller/viewcontroller.php#L212-L212)

cc @PVince81 @MorrisJobke @DeepDiver1975 
