### PR TITLE
dont do optimized size propagation for encrypted files

### DIFF
--- a/apps/files_sharing/tests/encryptedsizepropagation.php
+++ b/apps/files_sharing/tests/encryptedsizepropagation.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_sharing\Tests;
+
+use OC\Files\View;
+use Test\Traits\EncryptionTrait;
+
+/**
+ * @group DB
+ */
+class EncryptedSizePropagation extends SizePropagation {
+	use EncryptionTrait;
+
+	protected function setupUser($name, $password = '') {
+		$this->createUser($name, $password);
+		$tmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
+		$this->registerMount($name, '\OC\Files\Storage\Local', '/' . $name, ['datadir' => $tmpFolder]);
+		$this->setupForUser($name, $password);
+		$this->loginWithEncryption($name);
+		return new View('/' . $name . '/files');
+	}
+}

--- a/apps/files_sharing/tests/sizepropagation.php
+++ b/apps/files_sharing/tests/sizepropagation.php
@@ -24,6 +24,8 @@
 namespace OCA\Files_sharing\Tests;
 
 use OC\Files\View;
+use Test\Traits\MountProviderTrait;
+use Test\Traits\UserTrait;
 
 /**
  * Class SizePropagation
@@ -33,13 +35,21 @@ use OC\Files\View;
  * @package OCA\Files_sharing\Tests
  */
 class SizePropagation extends TestCase {
+	use UserTrait;
+	use MountProviderTrait;
+
+	protected function setupUser($name, $password = '') {
+		$this->createUser($name, $password);
+		$tmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
+		$this->registerMount($name, '\OC\Files\Storage\Local', '/' . $name, ['datadir' => $tmpFolder]);
+		$this->loginAsUser($name);
+		return new View('/' . $name . '/files');
+	}
 
 	public function testSizePropagationWhenOwnerChangesFile() {
-		$this->loginHelper(self::TEST_FILES_SHARING_API_USER1);
-		$recipientView = new View('/' . self::TEST_FILES_SHARING_API_USER1 . '/files');
+		$recipientView = $this->setupUser(self::TEST_FILES_SHARING_API_USER1);
 
-		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		$ownerView = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$ownerView = $this->setupUser(self::TEST_FILES_SHARING_API_USER2);
 		$ownerView->mkdir('/sharedfolder/subfolder');
 		$ownerView->file_put_contents('/sharedfolder/subfolder/foo.txt', 'bar');
 
@@ -52,31 +62,29 @@ class SizePropagation extends TestCase {
 		);
 		$ownerRootInfo = $ownerView->getFileInfo('', false);
 
-		$this->loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER1);
 		$this->assertTrue($recipientView->file_exists('/sharedfolder/subfolder/foo.txt'));
 		$recipientRootInfo = $recipientView->getFileInfo('', false);
 
 		// when file changed as owner
-		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
+		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER2);
 		$ownerView->file_put_contents('/sharedfolder/subfolder/foo.txt', 'foobar');
 
 		// size of recipient's root stays the same
-		$this->loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER1);
 		$newRecipientRootInfo = $recipientView->getFileInfo('', false);
 		$this->assertEquals($recipientRootInfo->getSize(), $newRecipientRootInfo->getSize());
 
 		// size of owner's root increases
-		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
+		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER2);
 		$newOwnerRootInfo = $ownerView->getFileInfo('', false);
 		$this->assertEquals($ownerRootInfo->getSize() + 3, $newOwnerRootInfo->getSize());
 	}
 
 	public function testSizePropagationWhenRecipientChangesFile() {
-		$this->loginHelper(self::TEST_FILES_SHARING_API_USER1);
-		$recipientView = new View('/' . self::TEST_FILES_SHARING_API_USER1 . '/files');
+		$recipientView = $this->setupUser(self::TEST_FILES_SHARING_API_USER1);
 
-		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		$ownerView = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$ownerView = $this->setupUser(self::TEST_FILES_SHARING_API_USER2);
 		$ownerView->mkdir('/sharedfolder/subfolder');
 		$ownerView->file_put_contents('/sharedfolder/subfolder/foo.txt', 'bar');
 
@@ -89,9 +97,10 @@ class SizePropagation extends TestCase {
 		);
 		$ownerRootInfo = $ownerView->getFileInfo('', false);
 
-		$this->loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER1);
 		$this->assertTrue($recipientView->file_exists('/sharedfolder/subfolder/foo.txt'));
 		$recipientRootInfo = $recipientView->getFileInfo('', false);
+		$recipientRootInfoWithMounts = $recipientView->getFileInfo('', true);
 
 		// when file changed as recipient
 		$recipientView->file_put_contents('/sharedfolder/subfolder/foo.txt', 'foobar');
@@ -100,8 +109,12 @@ class SizePropagation extends TestCase {
 		$newRecipientRootInfo = $recipientView->getFileInfo('', false);
 		$this->assertEquals($recipientRootInfo->getSize(), $newRecipientRootInfo->getSize());
 
+		// but the size including mountpoints increases
+		$newRecipientRootInfo = $recipientView->getFileInfo('', true);
+		$this->assertEquals($recipientRootInfoWithMounts->getSize() +3, $newRecipientRootInfo->getSize());
+
 		// size of owner's root increases
-		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
+		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER2);
 		$newOwnerRootInfo = $ownerView->getFileInfo('', false);
 		$this->assertEquals($ownerRootInfo->getSize() + 3, $newOwnerRootInfo->getSize());
 	}

--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -205,6 +205,10 @@ class Scanner extends BasicEmitter implements IScanner {
 					$data['oldSize'] = 0;
 				}
 
+				if (isset($cacheData['encrypted'])) {
+					$data['encrypted'] = $cacheData['encrypted'];
+				}
+
 				// post-emit only if it was a file. By that we avoid counting/treating folders as files
 				if ($data['mimetype'] !== 'httpd/unix-directory') {
 					$this->emit('\OC\Files\Cache\Scanner', 'postScanFile', array($file, $this->storageId));
@@ -222,6 +226,9 @@ class Scanner extends BasicEmitter implements IScanner {
 				}
 			}
 
+			if ($data && !isset($data['encrypted'])) {
+				$data['encrypted'] = false;
+			}
 			return $data;
 		}
 

--- a/lib/private/files/cache/updater.php
+++ b/lib/private/files/cache/updater.php
@@ -118,7 +118,10 @@ class Updater implements IUpdater {
 		}
 
 		$data = $this->scanner->scan($path, Scanner::SCAN_SHALLOW, -1, false);
-		if (isset($data['oldSize']) && isset($data['size'])) {
+		if (
+			isset($data['oldSize']) && isset($data['size']) &&
+			!$data['encrypted'] // encryption is a pita and touches the cache itself
+		) {
 			$sizeDifference = $data['size'] - $data['oldSize'];
 		} else {
 			// scanner didn't provide size info, fallback to full size calculation


### PR DESCRIPTION
Since it updates the the size in the storage wrapper

A great example of why storage classes should never touch the cache directly :speak_no_evil: 

Fixes https://github.com/owncloud/core/issues/24105

cc @rullzer @schiesbn @PVince81 

Should be backported to 9.0.2 ( @karlitschek )
