### PR TITLE
Delay reloading the page if an ajax error occurs, show notification

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -752,7 +752,8 @@ var OC={
 			// sometimes "beforeunload" happens later, so need to defer the reload a bit
 			setTimeout(function() {
 				if (!self._userIsNavigatingAway && !self._reloadCalled) {
-					OC.reload();
+					OC.Notification.show(t('core', 'Problem loading page, reloading in 5 seconds'));
+					setTimeout(OC.reload, 5000);
 					// only call reload once
 					self._reloadCalled = true;
 				}

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -936,10 +936,13 @@ describe('Core base tests', function() {
 	});
 	describe('global ajax errors', function() {
 		var reloadStub, ajaxErrorStub, clock;
+		var notificationStub;
+		var waitTimeMs = 6000;
 
 		beforeEach(function() {
 			clock = sinon.useFakeTimers();
 			reloadStub = sinon.stub(OC, 'reload');
+			notificationStub = sinon.stub(OC.Notification, 'show');
 			// unstub the error processing method
 			ajaxErrorStub = OC._processAjaxError;
 			ajaxErrorStub.restore();
@@ -947,6 +950,7 @@ describe('Core base tests', function() {
 		});
 		afterEach(function() {
 			reloadStub.restore();
+			notificationStub.restore();
 			clock.restore();
 		});
 
@@ -971,7 +975,7 @@ describe('Core base tests', function() {
 				$(document).trigger(new $.Event('ajaxError'), xhr);
 
 				// trigger timers
-				clock.tick(1000);
+				clock.tick(waitTimeMs);
 
 				if (expectedCall) {
 					expect(reloadStub.calledOnce).toEqual(true);
@@ -987,7 +991,7 @@ describe('Core base tests', function() {
 			$(document).trigger(new $.Event('ajaxError'), xhr);
 
 			// trigger timers
-			clock.tick(1000);
+			clock.tick(waitTimeMs);
 
 			expect(reloadStub.calledOnce).toEqual(true);
 		});
@@ -998,8 +1002,16 @@ describe('Core base tests', function() {
 
 			$(document).trigger(new $.Event('ajaxError'), xhr);
 
-			clock.tick(1000);
+			clock.tick(waitTimeMs);
 			expect(reloadStub.notCalled).toEqual(true);
+		});
+		it('displays notification', function() {
+			var xhr = { status: 401 };
+
+			$(document).trigger(new $.Event('ajaxError'), xhr);
+
+			clock.tick(waitTimeMs);
+			expect(notificationStub.calledOnce).toEqual(true);
 		});
 	});
 });


### PR DESCRIPTION
E.g. if there's an error loading some part of the admin settings page (just happened to me), the page will reload continuously with no clear indication that there's something wrong. This PR puts a 5 second delay on the reload, and prints a notification to make things clear. I would have liked to also print the URL that was failing, but the xhr object doesn't store the right information and getting the URL through to the error handler seems awkward.

cc @PVince81 @jancborchardt 
