### PR TITLE
Handle app loading error

### DIFF
--- a/console.php
+++ b/console.php
@@ -95,4 +95,6 @@ try {
 	$application->run();
 } catch (Exception $ex) {
 	exceptionHandler($ex);
+} catch (Error $ex) {
+	exceptionHandler($ex);
 }

--- a/cron.php
+++ b/cron.php
@@ -175,4 +175,6 @@ try {
 
 } catch (Exception $ex) {
 	\OCP\Util::writeLog('cron', $ex->getMessage(), \OCP\Util::FATAL);
+} catch (Error $ex) {
+	\OCP\Util::writeLog('cron', $ex->getMessage(), \OCP\Util::FATAL);
 }

--- a/index.php
+++ b/index.php
@@ -39,7 +39,7 @@ try {
 	OC::handleRequest();
 
 } catch(\OC\ServiceUnavailableException $ex) {
-	\OCP\Util::logException('index', $ex);
+	\OC::$server->getLogger()->logException($ex, ['app' => 'index']);
 
 	//show the user a detailed error page
 	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
@@ -48,9 +48,13 @@ try {
 	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
 	OC_Template::printErrorPage($ex->getMessage(), $ex->getHint());
 } catch (Exception $ex) {
-	\OCP\Util::logException('index', $ex);
+	\OC::$server->getLogger()->logException($ex, ['app' => 'index']);
 
 	//show the user a detailed error page
+	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
+	OC_Template::printExceptionErrorPage($ex);
+} catch (Error $ex) {
+	\OC::$server->getLogger()->logException($ex, ['app' => 'index']);
 	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
 	OC_Template::printExceptionErrorPage($ex);
 }

--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -159,8 +159,16 @@ class OC_App {
 	 * @param string $app app name
 	 */
 	private static function requireAppFile($app) {
-		// encapsulated here to avoid variable scope conflicts
-		require_once $app . '/appinfo/app.php';
+		try {
+			// encapsulated here to avoid variable scope conflicts
+			require_once $app . '/appinfo/app.php';
+		} catch (Error $ex) {
+			\OC::$server->getLogger()->logException($ex);
+			$blacklist = \OC::$server->getAppManager()->getAlwaysEnabledApps();
+			if (!in_array($app, $blacklist)) {
+				self::disable($app);
+			}
+		}
 	}
 
 	/**

--- a/lib/private/log.php
+++ b/lib/private/log.php
@@ -270,12 +270,12 @@ class Log implements ILogger {
 	/**
 	 * Logs an exception very detailed
 	 *
-	 * @param \Exception $exception
+	 * @param \Exception | \Throwable $exception
 	 * @param array $context
 	 * @return void
 	 * @since 8.2.0
 	 */
-	public function logException(\Exception $exception, array $context = array()) {
+	public function logException($exception, array $context = array()) {
 		$exception = array(
 			'Exception' => get_class($exception),
 			'Message' => $exception->getMessage(),

--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -333,7 +333,7 @@ class OC_Template extends \OC\Template\Base {
 
 	/**
 	 * print error page using Exception details
-	 * @param Exception $exception
+	 * @param Exception | Throwable $exception
 	 */
 	public static function printExceptionErrorPage($exception, $fetchPage = false) {
 		try {

--- a/lib/public/ilogger.php
+++ b/lib/public/ilogger.php
@@ -135,10 +135,10 @@ interface ILogger {
 	 * ]);
 	 * </code>
 	 *
-	 * @param \Exception $exception
+	 * @param \Exception | \Throwable $exception
 	 * @param array $context
 	 * @return void
 	 * @since 8.2.0
 	 */
-	public function logException(\Exception $exception, array $context = array());
+	public function logException($exception, array $context = array());
 }

--- a/public.php
+++ b/public.php
@@ -49,7 +49,7 @@ try {
 		$pathInfo = trim($pathInfo, '/');
 		list($service) = explode('/', $pathInfo);
 	}
-	$file = OCP\CONFIG::getAppValue('core', 'public_' . strip_tags($service));
+	$file = OCP\Config::getAppValue('core', 'public_' . strip_tags($service));
 	if (is_null($file)) {
 		header('HTTP/1.0 404 Not Found');
 		exit;
@@ -73,14 +73,18 @@ try {
 
 	require_once OC_App::getAppPath($app) . '/' . $parts[1];
 
-} catch (\OC\ServiceUnavailableException $ex) {
-	//show the user a detailed error page
-	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
-	\OCP\Util::writeLog('remote', $ex->getMessage(), \OCP\Util::FATAL);
-	OC_Template::printExceptionErrorPage($ex);
 } catch (Exception $ex) {
+	if ($ex instanceof \OC\ServiceUnavailableException) {
+		OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
+	} else {
+		OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
+	}
+	//show the user a detailed error page
+	\OC::$server->getLogger()->logException($ex, ['app' => 'public']);
+	OC_Template::printExceptionErrorPage($ex);
+} catch (Error $ex) {
 	//show the user a detailed error page
 	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
-	\OCP\Util::writeLog('remote', $ex->getMessage(), \OCP\Util::FATAL);
+	\OC::$server->getLogger()->logException($ex, ['app' => 'public']);
 	OC_Template::printExceptionErrorPage($ex);
 }

--- a/remote.php
+++ b/remote.php
@@ -40,9 +40,9 @@ class RemoteException extends Exception {
 }
 
 /**
- * @param Exception $e
+ * @param Exception | Error $e
  */
-function handleException(Exception $e) {
+function handleException($e) {
 	$request = \OC::$server->getRequest();
 	// in case the request content type is text/xml - we assume it's a WebDAV request
 	$isXmlContentType = strpos($request->getHeader('Content-Type'), 'text/xml');
@@ -77,7 +77,7 @@ function handleException(Exception $e) {
 			OC_Response::setStatus($e->getCode());
 			OC_Template::printErrorPage($e->getMessage());
 		} else {
-			\OCP\Util::writeLog('remote', $e->getMessage(), \OCP\Util::FATAL);
+			\OC::$server->getLogger()->logException($e, ['app' => 'remote']);
 			OC_Response::setStatus($statusCode);
 			OC_Template::printExceptionErrorPage($e);
 		}
@@ -164,5 +164,7 @@ try {
 	require_once $file;
 
 } catch (Exception $ex) {
+	handleException($ex);
+} catch (Error $e) {
 	handleException($ex);
 }


### PR DESCRIPTION
Using PHP7 capabilities to react on issue while an app is being loaded.
## Test Scenario
1. introduce an parse error in app.php in any enabled app which is not enabled by default
2. reload the browser
3. see owncloud still properly responding - the erroneous app is disabled
