### PR TITLE
Make sure that CLI cron doesn't run for ever, but makes use of the ne…

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -131,6 +131,10 @@ try {
 		// Work
 		$jobList = \OC::$server->getJobList();
 
+		// We only ask for jobs for 14 minutes, because after 15 minutes the next
+		// system cron task should spawn.
+		$endTime = time() + 14 * 60;
+
 		$executedJobs = [];
 		while ($job = $jobList->getNext()) {
 			if (isset($executedJobs[$job->getId()])) {
@@ -144,6 +148,10 @@ try {
 			$jobList->setLastJob($job);
 			$executedJobs[$job->getId()] = true;
 			unset($job);
+
+			if (time() > $endTime) {
+				break;
+			}
 		}
 
 		// unlock the file


### PR DESCRIPTION
…xt spawn

This should help people which have so many versions and trashbin tasks incoming, that the process simply is never done. This causes the process to live for ever instead of a limited time. So the PR stops asking for new jobs after some time so the process can terminate.
The next system cron call will then start a new process that continues the journey.

Yes, I know that we are working on another end to fix this. But this solution here is backportable to 9.0 and 8.2

Fix #23621

@MorrisJobke @DeepDiver1975 @PVince81 
