### PR TITLE
OCA.Files.App is not available on public page

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -147,7 +147,7 @@
 		/**
 		 * @type Backbone.Model
 		 */
-		_filesConfig: null,
+		_filesConfig: undefined,
 
 		/**
 		 * Sort attribute
@@ -205,12 +205,15 @@
 
 			if (options.config) {
 				this._filesConfig = options.config;
-			} else {
+			} else if (!_.isUndefined(OCA.Files) && !_.isUndefined(OCA.Files.App)) {
 				this._filesConfig = OCA.Files.App.getFilesConfig();
 			}
-			this._filesConfig.on('change:showhidden', function() {
-				self.setFiles(self.files);
-			});
+
+			if (!_.isUndefined(this._filesConfig)) {
+				this._filesConfig.on('change:showhidden', function() {
+					self.setFiles(self.files);
+				});
+			}
 
 			if (options.dragOptions) {
 				this._dragOptions = options.dragOptions;
@@ -984,7 +987,7 @@
 		 * @returns {array}
 		 */
 		_filterHiddenFiles: function(files) {
-			if (this._filesConfig.get('showhidden')) {
+			if (_.isUndefined(this._filesConfig) || this._filesConfig.get('showhidden')) {
 				return files;
 			}
 			return _.filter(files, function(file) {


### PR DESCRIPTION
fixes #24147

This adds an fallback to the fallback – if the config is not injected and OCA.Files.App is not available, no config used.

This covers all three situations:
1. filelist is used in the files app -> config is injected
2. other apps extend the filelist, but existing code should not break -> config is requested via the files app
3. if the files app is not available (e.g. public page), no config is used

@PVince81 @rullzer @MorrisJobke 
