### PR TITLE
Bail out if the user does not exist in version expire

### DIFF
--- a/apps/files_versions/lib/storage.php
+++ b/apps/files_versions/lib/storage.php
@@ -687,6 +687,9 @@ class Storage {
 
 			// get available disk space for user
 			$user = \OC::$server->getUserManager()->get($uid);
+			if ($user === null) {
+				return false;
+			}
 			$softQuota = true;
 			$quota = $user->getQuota();
 			if ( $quota === null || $quota === 'none' ) {


### PR DESCRIPTION
In some weird situations it can happen that the user is null even
though there were earlier existence checks.

To make sure to not stumble upon a null error when calling
$user->getQuota(), this fix makes the code bail out earlier.

Please review @nickvergessen @schiesbn @MorrisJobke @VicDeo 

Fixes https://github.com/owncloud/core/issues/23513

@karlitschek backport to 9.0.0 ?
8.2.x might be affected as well, will check later
