### PR TITLE
Change the sort order of background jobs to be DESC instead of ASC

### DIFF
--- a/lib/private/backgroundjob/joblist.php
+++ b/lib/private/backgroundjob/joblist.php
@@ -172,8 +172,8 @@ class JobList implements IJobList {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')
 			->from('jobs')
-			->where($query->expr()->gt('id', $query->createNamedParameter($lastId, IQueryBuilder::PARAM_INT)))
-			->orderBy('id', 'ASC')
+			->where($query->expr()->lt('id', $query->createNamedParameter($lastId, IQueryBuilder::PARAM_INT)))
+			->orderBy('id', 'DESC')
 			->setMaxResults(1);
 		$result = $query->execute();
 		$row = $result->fetch();
@@ -187,7 +187,7 @@ class JobList implements IJobList {
 			$query = $this->connection->getQueryBuilder();
 			$query->select('*')
 				->from('jobs')
-				->orderBy('id', 'ASC')
+				->orderBy('id', 'DESC')
 				->setMaxResults(1);
 			$result = $query->execute();
 			$row = $result->fetch();


### PR DESCRIPTION
In theory, if your instance ever creates more jobs then your system cron can
handle, the default background jobs get never executed anymore. Because
everytime when the joblist returns the next job it looks for the next ID,
however there is always a new next ID, so it will never wrap back to execute
the low IDs. But when we change the sort order to be DESC, we make sure that
these low IDs are always executed, before the system jumps back up to
execute the new IDs.

Should also help with https://github.com/owncloud/enterprise/issues/1279

@MorrisJobke @DeepDiver1975 @PVince81 
