### PR TITLE
Throw NoUserException when attempting to init mount point for null user

### DIFF
--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -372,6 +372,9 @@ class Filesystem {
 		if ($user == '') {
 			$user = \OC_User::getUser();
 		}
+		if ($user === null || $user === false || $user === '') {
+			throw new \OC\User\NoUserException('Attempted to initialize mount points for null user and no user in session');
+		}
 		if (isset(self::$usersSetup[$user])) {
 			return;
 		}

--- a/tests/lib/files/filesystem.php
+++ b/tests/lib/files/filesystem.php
@@ -320,6 +320,28 @@ class Filesystem extends \Test\TestCase {
 	}
 
 	/**
+	 * @expectedException \OC\User\NoUserException
+	 */
+	public function testNullUserThrows() {
+		\OC\Files\Filesystem::initMountPoints(null);
+	}
+
+	public function testNullUserThrowsTwice() {
+		$thrown = 0;
+		try {
+			\OC\Files\Filesystem::initMountPoints(null);
+		} catch (NoUserException $e) {
+			$thrown++;
+		}
+		try {
+			\OC\Files\Filesystem::initMountPoints(null);
+		} catch (NoUserException $e) {
+			$thrown++;
+		}
+		$this->assertEquals(2, $thrown);
+	}
+
+	/**
 	 * Tests that the home storage is used for the user's mount point
 	 */
 	public function testHomeMount() {


### PR DESCRIPTION
In some scenarios initMountPoints is called with an empty user, and
also there is no user in the session.

In such cases, it is unsafe to let the code move on with an empty user.

Fixes https://github.com/owncloud/core/issues/23513
See steps https://github.com/owncloud/core/issues/23513#issuecomment-213336384

This is a better fix than https://github.com/owncloud/core/pull/24160

Please review @icewind1991 @nickvergessen @schiesbn @blizzz @MorrisJobke @rullzer 
