### PR TITLE
Mark $usersSetup only if user was found in initMountPoints

### DIFF
--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -378,8 +378,6 @@ class Filesystem {
 		if (isset(self::$usersSetup[$user])) {
 			return;
 		}
-		self::$usersSetup[$user] = true;
-
 		$root = \OC_User::getHome($user);
 
 		$userManager = \OC::$server->getUserManager();
@@ -389,6 +387,8 @@ class Filesystem {
 			\OCP\Util::writeLog('files', ' Backends provided no user object for ' . $user, \OCP\Util::ERROR);
 			throw new \OC\User\NoUserException('Backends provided no user object for ' . $user);
 		}
+
+		self::$usersSetup[$user] = true;
 
 		$homeStorage = \OC::$server->getConfig()->getSystemValue('objectstore');
 		if (!empty($homeStorage)) {

--- a/tests/lib/files/filesystem.php
+++ b/tests/lib/files/filesystem.php
@@ -342,6 +342,28 @@ class Filesystem extends \Test\TestCase {
 	}
 
 	/**
+	 * Tests that an exception is thrown when passed user does not exist.
+	 */
+	public function testLocalMountWhenUserDoesNotExistTwice() {
+		$thrown = 0;
+		$userId = $this->getUniqueID('user_');
+
+		try {
+			\OC\Files\Filesystem::initMountPoints($userId);
+		} catch (NoUserException $e) {
+			$thrown++;
+		}
+
+		try {
+			\OC\Files\Filesystem::initMountPoints($userId);
+		} catch (NoUserException $e) {
+			$thrown++;
+		}
+
+		$this->assertEquals(2, $thrown);
+	}
+
+	/**
 	 * Tests that the home storage is used for the user's mount point
 	 */
 	public function testHomeMount() {


### PR DESCRIPTION
initMountPoints is marking a user as successfully initialized too
early. If the user was not found an NoUserException was thrown, the
second time initMountPoints is called would not rethrow the exception
and happily continue.

This fix makes sure that we consistently throw NoUserException when
initMountPoints is called repeatedly with invalid users.

I raised this separately from https://github.com/owncloud/core/pull/24186 because I think this change has more potential for regression. We should probably only backport #24186 but not this one here which can be considered hardening / extra safety.

Please review @icewind1991 @nickvergessen @blizzz @rullzer @schiesbn @MorrisJobke 
