### PR TITLE
[stable9] Throw NoUserException when attempting to init mount point for null user

### DIFF
--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -372,6 +372,9 @@ class Filesystem {
 		if ($user == '') {
 			$user = \OC_User::getUser();
 		}
+		if ($user === null || $user === false || $user === '') {
+			throw new \OC\User\NoUserException('Attempted to initialize mount points for null user and no user in session');
+		}
 		if (isset(self::$usersSetup[$user])) {
 			return;
 		}

--- a/tests/lib/files/filesystem.php
+++ b/tests/lib/files/filesystem.php
@@ -320,6 +320,28 @@ class Filesystem extends \Test\TestCase {
 	}
 
 	/**
+	 * @expectedException \OC\User\NoUserException
+	 */
+	public function testNullUserThrows() {
+		\OC\Files\Filesystem::initMountPoints(null);
+	}
+
+	public function testNullUserThrowsTwice() {
+		$thrown = 0;
+		try {
+			\OC\Files\Filesystem::initMountPoints(null);
+		} catch (NoUserException $e) {
+			$thrown++;
+		}
+		try {
+			\OC\Files\Filesystem::initMountPoints(null);
+		} catch (NoUserException $e) {
+			$thrown++;
+		}
+		$this->assertEquals(2, $thrown);
+	}
+
+	/**
 	 * Tests that the home storage is used for the user's mount point
 	 */
 	public function testHomeMount() {


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/24186 to stable9

Please review @icewind1991 @nickvergessen @schiesbn @blizzz @MorrisJobke @rullzer
