### PR TITLE
Introduce OCP\Migration\IRepairStep and adopt all repair steps to thi…

### DIFF
--- a/lib/private/Repair/AssetCache.php
+++ b/lib/private/Repair/AssetCache.php
@@ -23,23 +23,23 @@
 
 namespace OC\Repair;
 
-use Doctrine\DBAL\Platforms\MySqlPlatform;
-use OC\Hooks\BasicEmitter;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 
-class AssetCache extends BasicEmitter implements \OC\RepairStep {
+class AssetCache implements IRepairStep {
 
 	public function getName() {
 		return 'Clear asset cache after upgrade';
 	}
 
-	public function run() {
+	public function run(IOutput $output) {
 		if (!\OC_Template::isAssetPipelineEnabled()) {
-			$this->emit('\OC\Repair', 'info', array('Asset pipeline disabled -> nothing to do'));
+			$output->info('Asset pipeline disabled -> nothing to do');
 			return;
 		}
 		$assetDir = \OC::$server->getConfig()->getSystemValue('assetdirectory', \OC::$SERVERROOT) . '/assets';
 		\OC_Helper::rmdirr($assetDir, false);
-		$this->emit('\OC\Repair', 'info', array('Asset cache cleared.'));
+		$output->info('Asset cache cleared.');
 	}
 }
 

--- a/lib/private/Repair/Collation.php
+++ b/lib/private/Repair/Collation.php
@@ -23,9 +23,10 @@
 namespace OC\Repair;
 
 use Doctrine\DBAL\Platforms\MySqlPlatform;
-use OC\Hooks\BasicEmitter;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 
-class Collation extends BasicEmitter implements \OC\RepairStep {
+class Collation implements IRepairStep {
 	/**
 	 * @var \OCP\IConfig
 	 */
@@ -52,15 +53,15 @@ class Collation extends BasicEmitter implements \OC\RepairStep {
 	/**
 	 * Fix mime types
 	 */
-	public function run() {
+	public function run(IOutput $output) {
 		if (!$this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
-			$this->emit('\OC\Repair', 'info', array('Not a mysql database -> nothing to no'));
+			$output->info('Not a mysql database -> nothing to no');
 			return;
 		}
 
 		$tables = $this->getAllNonUTF8BinTables($this->connection);
 		foreach ($tables as $table) {
-			$this->emit('\OC\Repair', 'info', array("Change collation for $table ..."));
+			$output->info("Change collation for $table ...");
 			$query = $this->connection->prepare('ALTER TABLE `' . $table . '` CONVERT TO CHARACTER SET utf8 COLLATE utf8_bin;');
 			$query->execute();
 		}

--- a/lib/private/Repair/DropOldJobs.php
+++ b/lib/private/Repair/DropOldJobs.php
@@ -22,11 +22,11 @@
 
 namespace OC\Repair;
 
-use OC\Hooks\BasicEmitter;
-use OC\RepairStep;
 use OCP\BackgroundJob\IJobList;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 
-class DropOldJobs extends BasicEmitter implements RepairStep {
+class DropOldJobs implements IRepairStep {
 
 	/** @var IJobList */
 	protected $jobList;
@@ -53,7 +53,7 @@ class DropOldJobs extends BasicEmitter implements RepairStep {
 	 *
 	 * @throws \Exception in case of failure
 	 */
-	public function run() {
+	public function run(IOutput $output) {
 		$oldJobs = $this->oldJobs();
 		foreach($oldJobs as $job) {
 			if($this->jobList->has($job['class'], $job['arguments'])) {

--- a/lib/private/Repair/DropOldTables.php
+++ b/lib/private/Repair/DropOldTables.php
@@ -23,11 +23,11 @@
 namespace OC\Repair;
 
 
-use OC\Hooks\BasicEmitter;
-use OC\RepairStep;
 use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 
-class DropOldTables extends BasicEmitter implements RepairStep {
+class DropOldTables implements IRepairStep {
 
 	/** @var IDBConnection */
 	protected $connection;
@@ -54,12 +54,10 @@ class DropOldTables extends BasicEmitter implements RepairStep {
 	 *
 	 * @throws \Exception in case of failure
 	 */
-	public function run() {
+	public function run(IOutput $output) {
 		foreach ($this->oldDatabaseTables() as $tableName) {
 			if ($this->connection->tableExists($tableName)){
-				$this->emit('\OC\Repair', 'info', [
-					sprintf('Table %s has been deleted', $tableName)
-				]);
+				$output->info(sprintf('Table %s has been deleted', $tableName));
 				$this->connection->dropTable($tableName);
 			}
 		}

--- a/lib/private/Repair/FillETags.php
+++ b/lib/private/Repair/FillETags.php
@@ -23,9 +23,10 @@
 
 namespace OC\Repair;
 
-use OC\Hooks\BasicEmitter;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 
-class FillETags extends BasicEmitter implements \OC\RepairStep {
+class FillETags implements IRepairStep {
 
 	/** @var \OCP\IDBConnection */
 	protected $connection;
@@ -41,7 +42,7 @@ class FillETags extends BasicEmitter implements \OC\RepairStep {
 		return 'Generate ETags for file where no ETag is present.';
 	}
 
-	public function run() {
+	public function run(IOutput $output) {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->update('filecache')
 			->set('etag', $qb->expr()->literal('xxx'))
@@ -49,7 +50,7 @@ class FillETags extends BasicEmitter implements \OC\RepairStep {
 			->orWhere($qb->expr()->isNull('etag'));
 
 		$result = $qb->execute();
-		$this->emit('\OC\Repair', 'info', array("ETags have been fixed for $result files/folders."));
+		$output->info("ETags have been fixed for $result files/folders.");
 	}
 }
 

--- a/lib/private/Repair/InnoDB.php
+++ b/lib/private/Repair/InnoDB.php
@@ -25,9 +25,10 @@
 namespace OC\Repair;
 
 use Doctrine\DBAL\Platforms\MySqlPlatform;
-use OC\Hooks\BasicEmitter;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 
-class InnoDB extends BasicEmitter implements \OC\RepairStep {
+class InnoDB implements IRepairStep {
 
 	public function getName() {
 		return 'Repair MySQL database engine';
@@ -36,10 +37,10 @@ class InnoDB extends BasicEmitter implements \OC\RepairStep {
 	/**
 	 * Fix mime types
 	 */
-	public function run() {
+	public function run(IOutput $output) {
 		$connection = \OC::$server->getDatabaseConnection();
 		if (!$connection->getDatabasePlatform() instanceof MySqlPlatform) {
-			$this->emit('\OC\Repair', 'info', array('Not a mysql database -> nothing to do'));
+			$output->info('Not a mysql database -> nothing to do');
 			return;
 		}
 
@@ -47,7 +48,7 @@ class InnoDB extends BasicEmitter implements \OC\RepairStep {
 		if (is_array($tables)) {
 			foreach ($tables as $table) {
 				$connection->exec("ALTER TABLE $table ENGINE=InnoDB;");
-				$this->emit('\OC\Repair', 'info', array("Fixed $table"));
+				$output->info("Fixed $table");
 			}
 		}
 	}

--- a/lib/private/Repair/OldGroupMembershipShares.php
+++ b/lib/private/Repair/OldGroupMembershipShares.php
@@ -21,14 +21,13 @@
 
 namespace OC\Repair;
 
-
-use OC\Hooks\BasicEmitter;
-use OC\RepairStep;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 use OCP\Share;
 
-class OldGroupMembershipShares extends BasicEmitter implements RepairStep {
+class OldGroupMembershipShares implements IRepairStep {
 
 	/** @var \OCP\IDBConnection */
 	protected $connection;
@@ -65,7 +64,7 @@ class OldGroupMembershipShares extends BasicEmitter implements RepairStep {
 	 *
 	 * @throws \Exception in case of failure
 	 */
-	public function run() {
+	public function run(IOutput $output) {
 		$deletedEntries = 0;
 
 		$query = $this->connection->getQueryBuilder();
@@ -92,7 +91,7 @@ class OldGroupMembershipShares extends BasicEmitter implements RepairStep {
 		$result->closeCursor();
 
 		if ($deletedEntries) {
-			$this->emit('\OC\Repair', 'info', array('Removed ' . $deletedEntries . ' shares where user is not a member of the group anymore'));
+			$output->info('Removed ' . $deletedEntries . ' shares where user is not a member of the group anymore');
 		}
 	}
 

--- a/lib/private/Repair/RemoveGetETagEntries.php
+++ b/lib/private/Repair/RemoveGetETagEntries.php
@@ -21,10 +21,11 @@
 
 namespace OC\Repair;
 
-use OC\Hooks\BasicEmitter;
 use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 
-class RemoveGetETagEntries extends BasicEmitter {
+class RemoveGetETagEntries implements IRepairStep {
 
 	/**
 	 * @var IDBConnection
@@ -45,15 +46,11 @@ class RemoveGetETagEntries extends BasicEmitter {
 	/**
 	 * Removes all entries with the key "{DAV:}getetag" from the table properties
 	 */
-	public function run() {
+	public function run(IOutput $out) {
 		$sql = 'DELETE FROM `*PREFIX*properties`'
 			. ' WHERE `propertyname` = ?';
 		$deletedRows = $this->connection->executeUpdate($sql, ['{DAV:}getetag']);
 
-		$this->emit(
-			'\OC\Repair',
-			'info',
-			['Removed ' . $deletedRows . ' unneeded "{DAV:}getetag" entries from properties table.']
-		);
+		$out->info('Removed ' . $deletedRows . ' unneeded "{DAV:}getetag" entries from properties table.');
 	}
 }

--- a/lib/private/Repair/RepairMimeTypes.php
+++ b/lib/private/Repair/RepairMimeTypes.php
@@ -28,9 +28,10 @@
 
 namespace OC\Repair;
 
-use OC\Hooks\BasicEmitter;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 
-class RepairMimeTypes extends BasicEmitter implements \OC\RepairStep {
+class RepairMimeTypes implements IRepairStep {
 	/**
 	 * @var \OCP\IConfig
 	 */
@@ -308,7 +309,7 @@ class RepairMimeTypes extends BasicEmitter implements \OC\RepairStep {
 	/**
 	 * Fix mime types
 	 */
-	public function run() {
+	public function run(IOutput $out) {
 
 		$ocVersionFromBeforeUpdate = $this->config->getSystemValue('version', '0.0.0');
 
@@ -318,60 +319,60 @@ class RepairMimeTypes extends BasicEmitter implements \OC\RepairStep {
 		// only update mime types if necessary as it can be expensive
 		if (version_compare($ocVersionFromBeforeUpdate, '8.2.0', '<')) {
 			if ($this->fixOfficeMimeTypes()) {
-				$this->emit('\OC\Repair', 'info', array('Fixed office mime types'));
+				$out->info('Fixed office mime types');
 			}
 
 			if ($this->fixApkMimeType()) {
-				$this->emit('\OC\Repair', 'info', array('Fixed APK mime type'));
+				$out->info('Fixed APK mime type');
 			}
 
 			if ($this->fixFontsMimeTypes()) {
-				$this->emit('\OC\Repair', 'info', array('Fixed fonts mime types'));
+				$out->info('Fixed fonts mime types');
 			}
 
 			if ($this->fixPostscriptMimeType()) {
-				$this->emit('\OC\Repair', 'info', array('Fixed Postscript mime types'));
+				$out->info('Fixed Postscript mime types');
 			}
 
 			if ($this->introduceRawMimeType()) {
-				$this->emit('\OC\Repair', 'info', array('Fixed Raw mime types'));
+				$out->info('Fixed Raw mime types');
 			}
 
 			if ($this->introduce3dImagesMimeType()) {
-				$this->emit('\OC\Repair', 'info', array('Fixed 3D images mime types'));
+				$out->info('Fixed 3D images mime types');
 			}
 
 			if ($this->introduceConfMimeType()) {
-				$this->emit('\OC\Repair', 'info', array('Fixed Conf/cnf mime types'));
+				$out->info('Fixed Conf/cnf mime types');
 			}
 
 			if ($this->introduceYamlMimeType()) {
-				$this->emit('\OC\Repair', 'info', array('Fixed Yaml/Yml mime types'));
+				$out->info('Fixed Yaml/Yml mime types');
 			}
 		}
 
 		// Mimetype updates from #19272
 		if (version_compare($ocVersionFromBeforeUpdate, '8.2.0.8', '<')) {
 			if ($this->introduceJavaMimeType()) {
-				$this->emit('\OC\Repair', 'info', array('Fixed java/class mime types'));
+				$out->info('Fixed java/class mime types');
 			}
 
 			if ($this->introduceHppMimeType()) {
-				$this->emit('\OC\Repair', 'info', array('Fixed hpp mime type'));
+				$out->info('Fixed hpp mime type');
 			}
 
 			if ($this->introduceRssMimeType()) {
-				$this->emit('\OC\Repair', 'info', array('Fixed rss mime type'));
+				$out->info('Fixed rss mime type');
 			}
 
 			if ($this->introduceRtfMimeType()) {
-				$this->emit('\OC\Repair', 'info', array('Fixed rtf mime type'));
+				$out->info('Fixed rtf mime type');
 			}
 		}
 
 		if (version_compare($ocVersionFromBeforeUpdate, '9.0.0.10', '<')) {
 			if ($this->introduceRichDocumentsMimeTypes()) {
-				$this->emit('\OC\Repair', 'info', array('Fixed richdocuments additional office mime types'));
+				$out->info('Fixed richdocuments additional office mime types');
 			}
 		}
 	}

--- a/lib/private/Repair/SearchLuceneTables.php
+++ b/lib/private/Repair/SearchLuceneTables.php
@@ -22,9 +22,10 @@
 
 namespace OC\Repair;
 
-use OC\Hooks\BasicEmitter;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 
-class SearchLuceneTables extends BasicEmitter implements \OC\RepairStep {
+class SearchLuceneTables implements IRepairStep {
 
 	public function getName() {
 		return 'Repair duplicate entries in oc_lucene_status';
@@ -51,10 +52,10 @@ class SearchLuceneTables extends BasicEmitter implements \OC\RepairStep {
 	 *
 	 * search_lucene will then reindex the fileids without a status when the next indexing job is executed
 	 */
-	public function run() {
+	public function run(IOutput $out) {
 		$connection = \OC::$server->getDatabaseConnection();
 		if ($connection->tableExists('lucene_status')) {
-			$this->emit('\OC\Repair', 'info', array('removing duplicate entries from lucene_status'));
+			$out->info('removing duplicate entries from lucene_status');
 
 			$query = $connection->prepare('
 				DELETE FROM `*PREFIX*lucene_status`
@@ -69,7 +70,7 @@ class SearchLuceneTables extends BasicEmitter implements \OC\RepairStep {
 				)');
 			$query->execute();
 		} else {
-			$this->emit('\OC\Repair', 'info', array('lucene_status table does not exist -> nothing to do'));
+			$out->info('lucene_status table does not exist -> nothing to do');
 		}
 	}
 

--- a/lib/private/Repair/SharePropagation.php
+++ b/lib/private/Repair/SharePropagation.php
@@ -20,10 +20,12 @@
  */
 namespace OC\Repair;
 
-use OC\Hooks\BasicEmitter;
 use OCP\IConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 
-class SharePropagation extends BasicEmitter implements \OC\RepairStep {
+class SharePropagation implements IRepairStep {
+
 	/** @var  IConfig */
 	private $config;
 
@@ -40,7 +42,7 @@ class SharePropagation extends BasicEmitter implements \OC\RepairStep {
 		return 'Remove old share propagation app entries';
 	}
 
-	public function run() {
+	public function run(IOutput $out ) {
 		$keys = $this->config->getAppKeys('files_sharing');
 
 		foreach ($keys as $key) {

--- a/lib/private/Repair/SqliteAutoincrement.php
+++ b/lib/private/Repair/SqliteAutoincrement.php
@@ -26,13 +26,14 @@ use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Schema\ColumnDiff;
-use OC\Hooks\BasicEmitter;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 
 /**
  * Fixes Sqlite autoincrement by forcing the SQLite table schemas to be
  * altered in order to retrigger SQL schema generation through OCSqlitePlatform.
  */
-class SqliteAutoincrement extends BasicEmitter implements \OC\RepairStep {
+class SqliteAutoincrement implements IRepairStep {
 	/**
 	 * @var \OC\DB\Connection
 	 */
@@ -52,7 +53,7 @@ class SqliteAutoincrement extends BasicEmitter implements \OC\RepairStep {
 	/**
 	 * Fix mime types
 	 */
-	public function run() {
+	public function run(IOutput $out) {
 		if (!$this->connection->getDatabasePlatform() instanceof SqlitePlatform) {
 			return;
 		}

--- a/lib/private/Repair/UpdateCertificateStore.php
+++ b/lib/private/Repair/UpdateCertificateStore.php
@@ -22,10 +22,10 @@
 namespace OC\Repair;
 
 use OC\Files\View;
-use OC\Hooks\BasicEmitter;
-use OC\RepairStep;
 use OC\Server;
 use OCP\IConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 
 /**
  * Class UpdateCertificateStore rewrites the user specific certificate store after
@@ -34,7 +34,7 @@ use OCP\IConfig;
  *
  * @package OC\Repair
  */
-class UpdateCertificateStore extends BasicEmitter implements RepairStep {
+class UpdateCertificateStore implements IRepairStep {
 	/**
 	 * FIXME: The certificate manager does only allow specifying the user
 	 *        within the constructor. This makes DI impossible.
@@ -60,7 +60,7 @@ class UpdateCertificateStore extends BasicEmitter implements RepairStep {
 	}
 
 	/** {@inheritDoc} */
-	public function run() {
+	public function run(IOutput $out) {
 		$rootView = new View();
 		$dataDirectory = $this->config->getSystemValue('datadirectory', null);
 		if(is_null($dataDirectory)) {

--- a/lib/private/Repair/UpdateOutdatedOcsIds.php
+++ b/lib/private/Repair/UpdateOutdatedOcsIds.php
@@ -21,9 +21,9 @@
 
 namespace OC\Repair;
 
-use OC\Hooks\BasicEmitter;
-use OC\RepairStep;
 use OCP\IConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 
 /**
  * Class UpdateOutdatedOcsIds is used to update invalid outdated OCS IDs, this is
@@ -33,7 +33,7 @@ use OCP\IConfig;
  *
  * @package OC\Repair
  */
-class UpdateOutdatedOcsIds extends BasicEmitter implements RepairStep {
+class UpdateOutdatedOcsIds implements IRepairStep {
 	/** @var IConfig */
 	private $config;
 
@@ -71,7 +71,7 @@ class UpdateOutdatedOcsIds extends BasicEmitter implements RepairStep {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function run() {
+	public function run(IOutput $output) {
 		$appsToUpdate = [
 			'contacts' => [
 				'old' => '166044',
@@ -97,11 +97,7 @@ class UpdateOutdatedOcsIds extends BasicEmitter implements RepairStep {
 
 		foreach($appsToUpdate as $appName => $ids) {
 			if ($this->fixOcsId($appName, $ids['old'], $ids['new'])) {
-				$this->emit(
-					'\OC\Repair',
-					'info',
-					[sprintf('Fixed invalid %s OCS id', $appName)]
-				);
+				$output->info("Fixed invalid $appName OCS id");
 			}
 		}
 	}

--- a/lib/public/migration/ioutput.php
+++ b/lib/public/migration/ioutput.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @author Georg Ehrke <georg@owncloud.com>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  * @license AGPL-3.0
@@ -18,29 +18,44 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-namespace OC\Repair;
+namespace OCP\Migration;
 
-use OC\Files\View;
-use OCP\Migration\IOutput;
-use OCP\Migration\IRepairStep;
+/**
+ * Interface IOutput
+ *
+ * @package OCP\Migration
+ * @since 9.1.0
+ */
+interface IOutput {
 
-class Preview implements IRepairStep {
+	/**
+	 * @param string $message
+	 * @since 9.1.0
+	 */
+	public function info($message);
 
-	public function getName() {
-		return 'Cleaning-up broken previews';
-	}
+	/**
+	 * @param string $message
+	 * @since 9.1.0
+	 */
+	public function warning($message);
 
-	public function run(IOutput $out) {
-		$view = new View('/');
-		$children = $view->getDirectoryContent('/');
+	/**
+	 * @param int $max
+	 * @since 9.1.0
+	 */
+	public function startProgress($max = 0);
 
-		foreach ($children as $child) {
-			if ($view->is_dir($child->getPath())) {
-				$thumbnailsFolder = $child->getPath() . '/thumbnails';
-				if ($view->is_dir($thumbnailsFolder)) {
-					$view->rmdir($thumbnailsFolder);
-				}
-			}
-		}
-	}
+	/**
+	 * @param int $step
+	 * @since 9.1.0
+	 */
+	public function advance($step = 1);
+
+	/**
+	 * @param int $max
+	 * @since 9.1.0
+	 */
+	public function finishProgress();
+
 }

--- a/lib/public/migration/irepairstep.php
+++ b/lib/public/migration/irepairstep.php
@@ -18,17 +18,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-namespace OC;
+namespace OCP\Migration;
 
 /**
  * Repair step
+ * @since 9.1.0
  */
-interface RepairStep {
+interface IRepairStep {
 
 	/**
 	 * Returns the step's name
 	 *
 	 * @return string
+	 * @since 9.1.0
 	 */
 	public function getName();
 
@@ -36,8 +38,9 @@ interface RepairStep {
 	 * Run repair step.
 	 * Must throw exception on error.
 	 *
+	 * @since 9.1.0
 	 * @throws \Exception in case of failure
 	 */
-	public function run();
+	public function run(IOutput $output);
 
 }

--- a/tests/lib/repair.php
+++ b/tests/lib/repair.php
@@ -6,9 +6,9 @@
  * See the COPYING-README file.
  */
 
-use OC\Hooks\BasicEmitter;
+use OCP\Migration\IRepairStep;
 
-class TestRepairStep extends BasicEmitter implements \OC\RepairStep{
+class TestRepairStep implements IRepairStep {
 	private $warning;
 
 	public function __construct($warning = false) {
@@ -19,12 +19,12 @@ class TestRepairStep extends BasicEmitter implements \OC\RepairStep{
 		return 'Test Name';
 	}
 
-	public function run() {
+	public function run(\OCP\Migration\IOutput $out) {
 		if ($this->warning) {
-			$this->emit('\OC\Repair', 'warning', array('Simulated warning'));
+			$out->warning('Simulated warning');
 		}
 		else {
-			$this->emit('\OC\Repair', 'info', array('Simulated info'));
+			$out->info('Simulated info');
 		}
 	}
 }

--- a/tests/lib/repair/cleantags.php
+++ b/tests/lib/repair/cleantags.php
@@ -8,6 +8,7 @@
 
 namespace Test\Repair;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Migration\IOutput;
 
 /**
  * Tests for the cleaning the tags tables
@@ -18,7 +19,7 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
  */
 class CleanTags extends \Test\TestCase {
 
-	/** @var \OC\RepairStep */
+	/** @var \OC\Repair\CleanTags */
 	protected $repair;
 
 	/** @var \OCP\IDBConnection */
@@ -27,8 +28,15 @@ class CleanTags extends \Test\TestCase {
 	/** @var int */
 	protected $createdFile;
 
+	/** @var IOutput */
+	private $outputMock;
+
 	protected function setUp() {
 		parent::setUp();
+
+		$this->outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->connection = \OC::$server->getDatabaseConnection();
 		$this->repair = new \OC\Repair\CleanTags($this->connection);
@@ -67,15 +75,15 @@ class CleanTags extends \Test\TestCase {
 		$this->assertEntryCount('vcategory_to_object', 4, 'Assert tag entries count before repair step');
 		$this->assertEntryCount('vcategory', 4, 'Assert tag categories count before repair step');
 
-		self::invokePrivate($this->repair, 'deleteOrphanFileEntries');
+		self::invokePrivate($this->repair, 'deleteOrphanFileEntries', [$this->outputMock]);
 		$this->assertEntryCount('vcategory_to_object', 3, 'Assert tag entries count after cleaning file entries');
 		$this->assertEntryCount('vcategory', 4, 'Assert tag categories count after cleaning file entries');
 
-		self::invokePrivate($this->repair, 'deleteOrphanTagEntries');
+		self::invokePrivate($this->repair, 'deleteOrphanTagEntries', [$this->outputMock]);
 		$this->assertEntryCount('vcategory_to_object', 2, 'Assert tag entries count after cleaning tag entries');
 		$this->assertEntryCount('vcategory', 4, 'Assert tag categories count after cleaning tag entries');
 
-		self::invokePrivate($this->repair, 'deleteOrphanCategoryEntries');
+		self::invokePrivate($this->repair, 'deleteOrphanCategoryEntries', [$this->outputMock]);
 		$this->assertEntryCount('vcategory_to_object', 2, 'Assert tag entries count after cleaning category entries');
 		$this->assertEntryCount('vcategory', 2, 'Assert tag categories count after cleaning category entries');
 	}

--- a/tests/lib/repair/dropoldjobs.php
+++ b/tests/lib/repair/dropoldjobs.php
@@ -9,6 +9,7 @@
 namespace Test\Repair;
 
 use OCP\BackgroundJob\IJobList;
+use OCP\Migration\IOutput;
 
 /**
  * Tests for the dropping old tables
@@ -33,8 +34,13 @@ class DropOldJobs extends \Test\TestCase {
 		$this->assertTrue($this->jobList->has('OC\Cache\FileGlobalGC', null), 'Asserting that the job OC\Cache\FileGlobalGC exists before repairing');
 		$this->assertTrue($this->jobList->has('OC_Cache_FileGlobalGC', null), 'Asserting that the job OC_Cache_FileGlobalGC exists before repairing');
 
+		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
+			->disableOriginalConstructor()
+			->getMock();
+
 		$repair = new \OC\Repair\DropOldJobs($this->jobList);
-		$repair->run();
+		$repair->run($outputMock);
 
 		$this->assertFalse($this->jobList->has('OC\Cache\FileGlobalGC', null), 'Asserting that the job OC\Cache\FileGlobalGC does not exist after repairing');
 		$this->assertFalse($this->jobList->has('OC_Cache_FileGlobalGC', null), 'Asserting that the job OC_Cache_FileGlobalGC does not exist after repairing');

--- a/tests/lib/repair/dropoldtables.php
+++ b/tests/lib/repair/dropoldtables.php
@@ -7,6 +7,7 @@
  */
 
 namespace Test\Repair;
+use OCP\Migration\IOutput;
 
 /**
  * Tests for the dropping old tables
@@ -31,8 +32,13 @@ class DropOldTables extends \Test\TestCase {
 		$this->assertFalse($this->connection->tableExists('sharing'), 'Asserting that the table oc_sharing does not exist before repairing');
 		$this->assertTrue($this->connection->tableExists('permissions'), 'Asserting that the table oc_permissions does exist before repairing');
 
+		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
+			->disableOriginalConstructor()
+			->getMock();
+
 		$repair = new \OC\Repair\DropOldTables($this->connection);
-		$repair->run();
+		$repair->run($outputMock);
 
 		$this->assertFalse($this->connection->tableExists('sharing'), 'Asserting that the table oc_sharing does not exist after repairing');
 		$this->assertFalse($this->connection->tableExists('permissions'), 'Asserting that the table oc_permissions does not exist after repairing');

--- a/tests/lib/repair/oldgroupmembershipsharestest.php
+++ b/tests/lib/repair/oldgroupmembershipsharestest.php
@@ -10,6 +10,7 @@ namespace Test\Repair;
 
 use OC\Repair\OldGroupMembershipShares;
 use OC\Share\Constants;
+use OCP\Migration\IOutput;
 
 /**
  * Class OldGroupMembershipSharesTest
@@ -82,7 +83,12 @@ class OldGroupMembershipSharesTest extends \Test\TestCase {
 		$this->assertEquals([['id' => $parent], ['id' => $group2], ['id' => $user1], ['id' => $member], ['id' => $notAMember]], $rows);
 		$result->closeCursor();
 
-		$repair->run();
+		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$repair->run($outputMock);
 
 		$query = $this->connection->getQueryBuilder();
 		$result = $query->select('id')

--- a/tests/lib/repair/removegetetagentriestest.php
+++ b/tests/lib/repair/removegetetagentriestest.php
@@ -22,6 +22,7 @@
 namespace Test\Repair;
 
 use OC\Repair\RemoveGetETagEntries;
+use OCP\Migration\IOutput;
 use Test\TestCase;
 
 /**
@@ -65,9 +66,14 @@ class RemoveGetETagEntriesTest extends TestCase {
 			$this->assertTrue(in_array($entry, $data), 'Asserts that the entries are the ones from the test data set');
 		}
 
+		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
+			->disableOriginalConstructor()
+			->getMock();
+
 		// run repair step
 		$repair = new RemoveGetETagEntries($this->connection);
-		$repair->run();
+		$repair->run($outputMock);
 
 		// check if test data is correctly modified in DB
 		$stmt = $this->connection->executeQuery($sqlToFetchProperties, [$userName]);

--- a/tests/lib/repair/repaircollation.php
+++ b/tests/lib/repair/repaircollation.php
@@ -1,4 +1,6 @@
 <?php
+use OCP\Migration\IOutput;
+
 /**
  * Copyright (c) 2014 Thomas Müller <deepdiver@owncloud.com>
  * This file is licensed under the Affero General Public License version 3 or
@@ -70,7 +72,12 @@ class TestRepairCollation extends \Test\TestCase {
 		$tables = $this->repair->getAllNonUTF8BinTables($this->connection);
 		$this->assertGreaterThanOrEqual(1, count($tables));
 
-		$this->repair->run();
+		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->repair->run($outputMock);
 
 		$tables = $this->repair->getAllNonUTF8BinTables($this->connection);
 		$this->assertCount(0, $tables);

--- a/tests/lib/repair/repairinnodb.php
+++ b/tests/lib/repair/repairinnodb.php
@@ -6,6 +6,8 @@
  * See the COPYING-README file.
  */
 namespace Test\Repair;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 
 /**
  * Tests for the converting of MySQL tables to InnoDB engine
@@ -16,7 +18,7 @@ namespace Test\Repair;
  */
 class RepairInnoDB extends \Test\TestCase {
 
-	/** @var \OC\RepairStep */
+	/** @var IRepairStep */
 	private $repair;
 
 	/** @var \Doctrine\DBAL\Connection */
@@ -49,7 +51,12 @@ class RepairInnoDB extends \Test\TestCase {
 		$result = $this->countMyIsamTables();
 		$this->assertEquals(1, $result);
 
-		$this->repair->run();
+		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->repair->run($outputMock);
 
 		$result = $this->countMyIsamTables();
 		$this->assertEquals(0, $result);

--- a/tests/lib/repair/repairinvalidsharestest.php
+++ b/tests/lib/repair/repairinvalidsharestest.php
@@ -11,6 +11,8 @@ namespace Test\Repair;
 
 use OC\Repair\RepairInvalidShares;
 use OC\Share\Constants;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 use Test\TestCase;
 
 /**
@@ -22,7 +24,7 @@ use Test\TestCase;
  */
 class RepairInvalidSharesTest extends TestCase {
 
-	/** @var \OC\RepairStep */
+	/** @var IRepairStep */
 	private $repair;
 
 	/** @var \OCP\IDBConnection */
@@ -98,7 +100,12 @@ class RepairInvalidSharesTest extends TestCase {
 				'token' => $qb->expr()->literal('abcdefg')
 			])->execute();
 
-		$this->repair->run();
+		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->repair->run($outputMock);
 
 		$results = $this->connection->getQueryBuilder()
 			->select('*')
@@ -167,7 +174,12 @@ class RepairInvalidSharesTest extends TestCase {
 		$this->assertEquals([['id' => $parent], ['id' => $validChild], ['id' => $invalidChild]], $rows);
 		$result->closeCursor();
 
-		$this->repair->run();
+		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->repair->run($outputMock);
 
 		$query = $this->connection->getQueryBuilder();
 		$result = $query->select('id')

--- a/tests/lib/repair/repairmimetypes.php
+++ b/tests/lib/repair/repairmimetypes.php
@@ -8,6 +8,12 @@
  */
 namespace Test\Repair;
 
+use OC\Files\Storage\Temporary;
+use OCP\Files\IMimeTypeLoader;
+use OCP\IConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
 /**
  * Tests for the converting of legacy storages to home storages.
  *
@@ -17,10 +23,14 @@ namespace Test\Repair;
  */
 class RepairMimeTypes extends \Test\TestCase {
 
-	/** @var \OC\RepairStep */
+	/** @var IRepairStep */
 	private $repair;
 
+	/** @var Temporary */
 	private $storage;
+
+	/** @var IMimeTypeLoader */
+	private $mimetypeLoader;
 
 	protected function setUp() {
 		parent::setUp();
@@ -28,6 +38,7 @@ class RepairMimeTypes extends \Test\TestCase {
 		$this->savedMimetypeLoader = \OC::$server->getMimeTypeLoader();
 		$this->mimetypeLoader = \OC::$server->getMimeTypeLoader();
 
+		/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject $config */
 		$config = $this->getMockBuilder('OCP\IConfig')
 			->disableOriginalConstructor()
 			->getMock();
@@ -96,7 +107,12 @@ class RepairMimeTypes extends \Test\TestCase {
 	private function renameMimeTypes($currentMimeTypes, $fixedMimeTypes) {
 		$this->addEntries($currentMimeTypes);
 
-		$this->repair->run();
+		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->repair->run($outputMock);
 
 		// force mimetype reload
 		$this->mimetypeLoader->reset();

--- a/tests/lib/repair/repairsharepropagation.php
+++ b/tests/lib/repair/repairsharepropagation.php
@@ -9,6 +9,7 @@
 namespace Test\Repair;
 
 use OC\Repair\SharePropagation;
+use OCP\Migration\IOutput;
 
 class RepairSharePropagation extends \Test\TestCase {
 	public function keyProvider() {
@@ -40,8 +41,13 @@ class RepairSharePropagation extends \Test\TestCase {
 				$removedKeys[] = $key;
 			}));
 
+		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
+			->disableOriginalConstructor()
+			->getMock();
+
 		$step = new SharePropagation($config);
-		$step->run();
+		$step->run($outputMock);
 
 		sort($expectedRemovedKeys);
 		sort($removedKeys);

--- a/tests/lib/repair/repairsqliteautoincrement.php
+++ b/tests/lib/repair/repairsqliteautoincrement.php
@@ -7,6 +7,7 @@
  */
 
 namespace Test\Repair;
+use OCP\Migration\IOutput;
 
 /**
  * Tests for fixing the SQLite id recycling
@@ -76,7 +77,12 @@ class RepairSqliteAutoincrement extends \Test\TestCase {
 	public function testConvertIdColumn() {
 		$this->assertFalse($this->checkAutoincrement());
 
-		$this->repair->run();
+		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->repair->run($outputMock);
 
 		$this->assertTrue($this->checkAutoincrement());
 	}

--- a/tests/lib/repair/updateoutdatedocsids.php
+++ b/tests/lib/repair/updateoutdatedocsids.php
@@ -30,7 +30,7 @@ use Test\TestCase;
  * @package Test\Repair
  */
 class UpdateOutdatedOcsIds extends TestCase {
-	/** @var IConfig */
+	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
 	private $config;
 	/** @var \OC\Repair\UpdateOutdatedOcsIds */
 	private $updateOutdatedOcsIds;


### PR DESCRIPTION
…s new interface - refs #24198 
An new public api is defined OCP\Migration\IRepairStep - https://github.com/owncloud/core/pull/24199/files#diff-34802a4ab7d05fa78a2e53e6ef6bc177 and any output of an individual repair step implementation can be passed through methods of OCP\Migration\IOutput

``` php
interface IOutput {

    /**
     * @param string $message
     */
    public function info($message);

    /**
     * @param string $message
     */
    public function warning($message);

    /**
     * @param int $max
     */
    public function startProgress($max = 0);

    /**
     * @param int $step
     */
    public function advance($step = 1);

    /**
     * @param int $max
     */
    public function finishProgress();

}
```
