### PR TITLE
on clone Connection, do not take over the existing LDAP resource

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -1295,9 +1295,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 		if(!$testConnection->setConfiguration($credentials)) {
 			return false;
 		}
-		$result=$testConnection->bind();
-		$this->ldap->unbind($this->connection->getConnectionResource());
-		return $result;
+		return $testConnection->bind();
 	}
 
 	/**

--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -49,9 +49,6 @@ class Connection extends LDAPUtility {
 	private $configPrefix;
 	private $configID;
 	private $configured = false;
-
-	//whether connection should be kept on __destruct
-	private $dontDestruct = false;
 	private $hasPagedResultSupport = true;
 
 	/**
@@ -94,8 +91,7 @@ class Connection extends LDAPUtility {
 	}
 
 	public function __destruct() {
-		if(!$this->dontDestruct &&
-			$this->ldap->isResource($this->ldapConnectionRes)) {
+		if($this->ldap->isResource($this->ldapConnectionRes)) {
 			@$this->ldap->unbind($this->ldapConnectionRes);
 		};
 	}
@@ -104,11 +100,9 @@ class Connection extends LDAPUtility {
 	 * defines behaviour when the instance is cloned
 	 */
 	public function __clone() {
-		//a cloned instance inherits the connection resource. It may use it,
-		//but it may not disconnect it
-		$this->dontDestruct = true;
 		$this->configuration = new Configuration($this->configPrefix,
 												 !is_null($this->configID));
+		$this->ldapConnectionRes = null;
 	}
 
 	/**


### PR DESCRIPTION
For one, it solves potential conflicts when using the resource. For the
other, one on the login check (the only place where a clone happens
currently) we do not need to rebind after confirming the user's login
was successful.

Fixes https://github.com/owncloud/android/issues/1527

Also might fix other issues with strange behaviour, when LDAP actions are performed after authentication took place. 

The issue was introduced with https://github.com/owncloud/core/pull/22102

@MarcoO74 can you confirm this solves your issue as well?

@owncloud/ldap @MorrisJobke please review 

@GitHubUser4234 also interesting for you: once this is approved and merged, you could also clone the Connection here https://github.com/owncloud/core/pull/23992/files#diff-a13c5e86ca62f41df254847023a9de3eR53 and don't need to have the deepCopy().

@karlitschek would require a backport down to 8.2, ok?
