### PR TITLE
[stable8.2] on clone Connection, do not take over the existing LDAP resource

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -1254,9 +1254,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 		if(!$testConnection->setConfiguration($credentials)) {
 			return false;
 		}
-		$result=$testConnection->bind();
-		$this->ldap->unbind($this->connection->getConnectionResource());
-		return $result;
+		return $testConnection->bind();
 	}
 
 	/**

--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -48,9 +48,6 @@ class Connection extends LDAPUtility {
 	private $configPrefix;
 	private $configID;
 	private $configured = false;
-
-	//whether connection should be kept on __destruct
-	private $dontDestruct = false;
 	private $hasPagedResultSupport = true;
 
 	/**
@@ -92,8 +89,7 @@ class Connection extends LDAPUtility {
 	}
 
 	public function __destruct() {
-		if(!$this->dontDestruct &&
-			$this->ldap->isResource($this->ldapConnectionRes)) {
+		if($this->ldap->isResource($this->ldapConnectionRes)) {
 			@$this->ldap->unbind($this->ldapConnectionRes);
 		};
 	}
@@ -102,11 +98,9 @@ class Connection extends LDAPUtility {
 	 * defines behaviour when the instance is cloned
 	 */
 	public function __clone() {
-		//a cloned instance inherits the connection resource. It may use it,
-		//but it may not disconnect it
-		$this->dontDestruct = true;
 		$this->configuration = new Configuration($this->configPrefix,
 												 !is_null($this->configID));
+		$this->ldapConnectionRes = null;
 	}
 
 	/**


### PR DESCRIPTION
For one, it solves potential conflicts when using the resource. For the
other, one on the login check (the only place where a clone happens
currently) we do not need to rebind after confirming the user's login
was successful.

Backport of #24214

Please test and review @owncloud/ldap @MorrisJobke @MarcoO74 @PVince81 @owncloud/qa 
