### PR TITLE
Better comments in activity sidebar

### DIFF
--- a/apps/comments/appinfo/app.php
+++ b/apps/comments/appinfo/app.php
@@ -31,6 +31,7 @@ $eventDispatcher->addListener(
 		\OCP\Util::addScript('comments', 'commentsummarymodel');
 		\OCP\Util::addScript('comments', 'commentstabview');
 		\OCP\Util::addScript('comments', 'filesplugin');
+		\OCP\Util::addScript('comments', 'activitytabviewplugin');
 		\OCP\Util::addStyle('comments', 'comments');
 	}
 );

--- a/apps/comments/css/comments.css
+++ b/apps/comments/css/comments.css
@@ -36,6 +36,7 @@
 	z-index: 1;
 }
 
+#activityTabView li.comment.collapsed .activitymessage,
 #commentsTabView .comment.collapsed .message {
 	white-space: -moz-pre-wrap !important;  /* Mozilla, since 1999 */
 	white-space: -webkit-pre-wrap; /*Chrome & Safari */ 
@@ -47,31 +48,34 @@
 	white-space: normal;
 }
 
+#activityTabView li.comment.collapsed .activitymessage,
 #commentsTabView .comment.collapsed .message {
 	max-height: 70px;
 	overflow: hidden;
 }
 
+#activityTabView li.comment .message-overlay,
 #commentsTabView .comment .message-overlay {
 	display: none;
 }
 
+#activityTabView li.comment.collapsed .message-overlay,
 #commentsTabView .comment.collapsed .message-overlay {
 	display: block;
-    position: absolute;
+	position: absolute;
 	z-index: 2;
-    height: 50px;
-    pointer-events: none;
+	height: 50px;
+	pointer-events: none;
 	left: 0;
 	right: 0;
-    bottom: 0;
+	bottom: 0;
 	background: -moz-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
 	background: -webkit-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
 	background: -o-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
 	background: -ms-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
 	background: linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
 	filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0,startColorstr='#00FFFFFF', endColorstr='#FFFFFFFF');
-    background-repeat: no-repeat;
+	background-repeat: no-repeat;
 }
 
 #commentsTabView .authorRow>div {

--- a/apps/comments/js/activitytabviewplugin.js
+++ b/apps/comments/js/activitytabviewplugin.js
@@ -56,4 +56,4 @@
 
 })();
 
-OC.Plugins.register('OCA.Activity.Plugins', OCA.Comments.ActivityTabViewPlugin);
+OC.Plugins.register('OCA.Activity.RenderingPlugins', OCA.Comments.ActivityTabViewPlugin);

--- a/apps/comments/js/activitytabviewplugin.js
+++ b/apps/comments/js/activitytabviewplugin.js
@@ -34,6 +34,9 @@
 			}
 		},
 
+		/*
+		 * Copy of CommentsTabView._onClickComment()
+		 */
 		_onClickCollapsedComment: function(ev) {
 			var $row = $(ev.target);
 			if (!$row.is('.comment')) {
@@ -42,9 +45,8 @@
 			$row.removeClass('collapsed');
 		},
 
-		/**
-		 * Returns whether the given message is long and needs
-		 * collapsing
+		/*
+		 * Copy of CommentsTabView._isLong()
 		 */
 		_isLong: function(message) {
 			return message.length > 250 || (message.match(/\n/g) || []).length > 1;

--- a/apps/comments/js/activitytabviewplugin.js
+++ b/apps/comments/js/activitytabviewplugin.js
@@ -1,0 +1,57 @@
+/*
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ * Copyright (c) 2016
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ */
+
+(function() {
+	OCA.Comments.ActivityTabViewPlugin = {
+
+		/**
+		 * Prepare activity for display
+		 *
+		 * @param {OCA.Activity.ActivityModel} model for this activity
+		 * @param {jQuery} $el jQuery handle for this activity
+		 * @param {string} view The view that displayes this activity
+		 */
+		prepareModelForDisplay: function (model, $el, view) {
+			if (model.get('app') !== 'comments' || model.get('type') !== 'comments') {
+				return;
+			}
+
+			if (view === 'ActivityTabView') {
+				$el.addClass('comment');
+				if (this._isLong(model.get('message_prepared'))) {
+					$el.addClass('collapsed');
+					var $overlay = $('<div>').addClass('message-overlay');
+					$el.find('.activitymessage').after($overlay);
+					$el.on('click', this._onClickCollapsedComment);
+				}
+			}
+		},
+
+		_onClickCollapsedComment: function(ev) {
+			var $row = $(ev.target);
+			if (!$row.is('.comment')) {
+				$row = $row.closest('.comment');
+			}
+			$row.removeClass('collapsed');
+		},
+
+		/**
+		 * Returns whether the given message is long and needs
+		 * collapsing
+		 */
+		_isLong: function(message) {
+			return message.length > 250 || (message.match(/\n/g) || []).length > 1;
+		}
+	};
+
+
+})();
+
+OC.Plugins.register('OCA.Activity.Plugins', OCA.Comments.ActivityTabViewPlugin);

--- a/apps/comments/lib/Activity/Extension.php
+++ b/apps/comments/lib/Activity/Extension.php
@@ -195,7 +195,6 @@ class Extension implements IExtension {
 		try {
 			return strip_tags($user) === $this->activityManager->getCurrentUserId();
 		} catch (\UnexpectedValueException $e) {
-			// FIXME this is awkward, but we have no access to the current user in emails
 			return false;
 		}
 	}

--- a/apps/comments/lib/Activity/Extension.php
+++ b/apps/comments/lib/Activity/Extension.php
@@ -158,7 +158,7 @@ class Extension implements IExtension {
 				}
 				return (string) $l->t('%1$s commented', $params);
 			case self::ADD_COMMENT_MESSAGE:
-				return $this->convertParameterToComment($params[0], 120);
+				return $this->convertParameterToComment($params[0]);
 		}
 
 		return false;
@@ -303,21 +303,12 @@ class Extension implements IExtension {
 	 * @param string $parameter
 	 * @return string
 	 */
-	protected function convertParameterToComment($parameter, $maxLength = 0) {
+	protected function convertParameterToComment($parameter) {
 		if (preg_match('/^\<parameter\>(\d*)\<\/parameter\>$/', $parameter, $matches)) {
 			try {
 				$comment = $this->commentsManager->get((int) $matches[1]);
 				$message = $comment->getMessage();
 				$message = str_replace("\n", '<br />', str_replace(['<', '>'], ['&lt;', '&gt;'], $message));
-
-				if ($maxLength && isset($message[$maxLength + 20])) {
-					$findSpace = strpos($message, ' ', $maxLength);
-					if ($findSpace !== false && $findSpace < $maxLength + 20) {
-						return substr($message, 0, $findSpace) . '…';
-					}
-					return substr($message, 0, $maxLength + 20) . '…';
-				}
-
 				return $message;
 			} catch (NotFoundException $e) {
 				return '';


### PR DESCRIPTION
Comments in the activityTabView are now shorten the same way as in the commentsTabView, so you can click on them to expand the message.
- [x] Requires https://github.com/owncloud/activity/pull/518
