### PR TITLE
Also add new storage wrapper when initializing mount points

### DIFF
--- a/lib/private/Files/Storage/StorageFactory.php
+++ b/lib/private/Files/Storage/StorageFactory.php
@@ -50,12 +50,13 @@ class StorageFactory implements IStorageFactory {
 			return false;
 		}
 
+		$this->storageWrappers[$wrapperName] = ['wrapper' => $callback, 'priority' => $priority];
+
 		// apply to existing mounts before registering it to prevent applying it double in MountPoint::createStorage
 		foreach ($existingMounts as $mount) {
 			$mount->wrapStorage($callback);
 		}
 
-		$this->storageWrappers[$wrapperName] = ['wrapper' => $callback, 'priority' => $priority];
 		return true;
 	}
 


### PR DESCRIPTION
Fixes #24249

When a storage wrapper registers itself before the FS is initialized
this can create problems.

It happens when uploading files via the webUI. (Not webdav yet).

Steps from #24249 
1. As user1 create folder test1/test2/
2. Share test2 with user2
3. Tag test1 with "Tag"
4. Create a workflow autotagging rule to tag files with "Tag" when a parent is tagged with "Tag"
5. As user2 upload a file
6. Check that the file is tagged

So what happens when user2 uploads a file.
1. The workflow apps regsiters its storage wrapper first. And arrives as https://github.com/owncloud/core/blob/master/lib/private/Files/Filesystem.php#L216.
2. Now there are no mounts yet since the FS is not setup yet. So we go setup the FS and collect all mount points.
3. The mounts points are
   1. `/`
   2. `/user2/`
   3. `/user2/files/test2/`
4. Now all is fine and we add the aqtual storage wrapper and we go to https://github.com/owncloud/core/blob/master/lib/private/Files/Storage/StorageFactory.php#L48
5. And we arrive at https://github.com/owncloud/core/blob/master/lib/private/Files/Storage/StorageFactory.php#L54-L56 where we attemt to wrap the mountpoints

Now this goes :boom: because with the new sharedStorage approach the sharedStorage is a Jail. So when we get the storage for the mountpoint `/user2/files/test2/` we add another mountpoint: `/user1/`.

Now before we only added the storage wrapper after this. So the storage of mountpoint `/user1/` would not be wrapper by the new stroage wrapper (in this case the workflow storage wrapper).

This small patch moves adding the storage wrapper up so new storages get also wrapped in the new storage wrapper.

Review time: @nickvergessen @icewind1991 @PVince81 @MorrisJobke 
