### PR TITLE
Prevent concurrent storage availability checks

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Availability.php
+++ b/lib/private/Files/Storage/Wrapper/Availability.php
@@ -40,9 +40,13 @@ class Availability extends Wrapper {
 	}
 
 	/**
+	 * Only called if availability === false
+	 *
 	 * @return bool
 	 */
 	private function updateAvailability() {
+		// reset availability to false so that multiple requests don't recheck concurrently
+		$this->setAvailability(false);
 		try {
 			$result = $this->test();
 		} catch (\Exception $e) {

--- a/tests/lib/files/storage/wrapper/availability.php
+++ b/tests/lib/files/storage/wrapper/availability.php
@@ -74,9 +74,12 @@ class Availability extends \Test\TestCase {
 		$storage->expects($this->once())
 			->method('test')
 			->willReturn(true);
-		$storage->expects($this->once())
+		$storage->expects($this->exactly(2))
 			->method('setAvailability')
-			->with($this->equalTo(true));
+			->withConsecutive(
+				[$this->equalTo(false)], // prevents concurrent rechecks
+				[$this->equalTo(true)] // sets correct availability
+			);
 		$storage->expects($this->once())
 			->method('mkdir');
 


### PR DESCRIPTION
If a (failed) storage has its availability rechecked after its TTL expires, and the `test()` method takes a long time since the storage is still failing, we don't want every request to attempt another recheck (since the DB still contains the expired TTL). Long rechecks can prevent PHP processes from doing work, causing resource exhaustion. This should prevent those PHP lockups that sometimes occur when testing SMB storages with the native extension, for example.

This PR resets the availability in the DB to 'false' again before testing the storage, updating the TTL and preventing concurrent rechecks. Note, this cannot by design cause a working storage to intermittently be marked as unavailable during the test, since the `updateAvailability()` method is only ever run if the storage is marked as unavailable.

cc @PVince81 @icewind1991 
