### PR TITLE
[stable9] Check for hash instead of file existence

### DIFF
--- a/lib/private/repair/brokenupdaterrepair.php
+++ b/lib/private/repair/brokenupdaterrepair.php
@@ -70,9 +70,10 @@ class BrokenUpdaterRepair extends BasicEmitter implements \OC\RepairStep {
 			'sabre/dav/lib/DAV/Version.php',
 		];
 
-		// First check whether the files have been copied the first time already
-		// if so there is no need to run the move routine.
-		if(file_exists($thirdPartyDir . '/icewind/streams/src/RetryWrapper.php')) {
+		// Check the hash for the autoload_classmap.php file, if the hash does match
+		// the expected value then the third-party folder has already been copied
+		// properly.
+		if(hash_file('sha512', $thirdPartyDir . '/composer/autoload_classmap.php') === 'abe09be19b6d427283cbfa7c4156d2c342cd9368d7d0564828a00ae02c435b642e7092cef444f94635f370dbe507eb6b2aa05109b32d8fb5d8a65c3a5a1c658f') {
 			$this->emit('\OC\Repair', 'info', ['Third-party files seem already to have been copied. No repair necessary.']);
 			return false;
 		}


### PR DESCRIPTION
The previous logic did not necessarily trigger in every case. This logic is more error-resistant, the autoload_classmap.php file has a guaranteed different hash on 9.0.0, 9.0.1 and 9.0.2

Fixes https://github.com/owncloud/updater/issues/342

@davitol Mind patching the downloaded archive to include this patch? THX a lot.
@karlitschek FYI - I'd propose that we merge this to 9.0.2 and then tomorrow we can do another round of daily testings. (or we release a new daily earlier)
