### PR TITLE
Add the DB group for preview tests that require the database

### DIFF
--- a/tests/lib/preview/movie.php
+++ b/tests/lib/preview/movie.php
@@ -21,6 +21,13 @@
 
 namespace Test\Preview;
 
+/**
+ * Class Movie
+ *
+ * @group DB
+ *
+ * @package Test\Preview
+ */
 class Movie extends Provider {
 
 	public function setUp() {

--- a/tests/lib/preview/office.php
+++ b/tests/lib/preview/office.php
@@ -21,6 +21,13 @@
 
 namespace Test\Preview;
 
+/**
+ * Class Office
+ *
+ * @group DB
+ *
+ * @package Test\Preview
+ */
 class Office extends Provider {
 
 	public function setUp() {


### PR DESCRIPTION
Got 8 failures otherwise:

```
1) Test\Preview\Movie::testGetThumbnail with data set #0 (-93, -72)
Your test case is not allowed to access the database.

/home/nickv/ownCloud/master/core/tests/lib/testcase.php:110
/home/nickv/ownCloud/master/core/3rdparty/pimple/pimple/src/Pimple/Container.php:113
/home/nickv/ownCloud/master/core/lib/private/AppFramework/Utility/SimpleContainer.php:102
/home/nickv/ownCloud/master/core/lib/private/servercontainer.php:87
/home/nickv/ownCloud/master/core/lib/private/Server.php:907
/home/nickv/ownCloud/master/core/lib/private/db.php:56
/home/nickv/ownCloud/master/core/lib/private/db.php:133
/home/nickv/ownCloud/master/core/lib/private/Files/Cache/Storage.php:81
/home/nickv/ownCloud/master/core/lib/private/Files/Cache/Storage.php:133
/home/nickv/ownCloud/master/core/lib/private/Files/Cache/Storage.php:170
/home/nickv/ownCloud/master/core/lib/private/Files/Filesystem.php:434
/home/nickv/ownCloud/master/core/lib/private/Files/Filesystem.php:370
/home/nickv/ownCloud/master/core/lib/private/util.php:220
/home/nickv/ownCloud/master/core/tests/lib/testcase.php:331
/home/nickv/ownCloud/master/core/tests/lib/preview/provider.php:57
/home/nickv/ownCloud/master/core/tests/lib/preview/movie.php:31
```
