### PR TITLE
Add files:scan warning when NFD or incompatible encoding found

### DIFF
--- a/apps/files_external/lib/storage/smb.php
+++ b/apps/files_external/lib/storage/smb.php
@@ -100,7 +100,7 @@ class SMB extends \OC\Files\Storage\Common {
 	 * @return string
 	 */
 	protected function buildPath($path) {
-		return Filesystem::normalizePath($this->root . '/' . $path);
+		return Filesystem::normalizePath($this->root . '/' . $path, true, false, true);
 	}
 
 	/**


### PR DESCRIPTION
Also comes with an additional fix for SMB and adds an option to `normalizePaths` to optionally disable UTF-8 normalizing which will be needed further for https://github.com/owncloud/core/issues/21365

Please review @icewind1991 @nickvergessen @schiesbn @rullzer 
