### PR TITLE
optimize releaselock for memcache based locking backends

### DIFF
--- a/lib/private/Lock/AbstractLockingProvider.php
+++ b/lib/private/Lock/AbstractLockingProvider.php
@@ -116,4 +116,8 @@ abstract class AbstractLockingProvider implements ILockingProvider {
 			$this->releaseLock($path, self::LOCK_EXCLUSIVE);
 		}
 	}
+
+	protected function getOwnSharedLockCount($path) {
+		return isset($this->acquiredLocks['shared'][$path]) ? $this->acquiredLocks['shared'][$path] : 0;
+	}
 }

--- a/lib/private/Lock/MemcacheLockingProvider.php
+++ b/lib/private/Lock/MemcacheLockingProvider.php
@@ -88,9 +88,14 @@ class MemcacheLockingProvider extends AbstractLockingProvider {
 	 */
 	public function releaseLock($path, $type) {
 		if ($type === self::LOCK_SHARED) {
-			if (isset($this->acquiredLocks['shared'][$path]) and $this->acquiredLocks['shared'][$path] > 0) {
+			if ($this->getOwnSharedLockCount($path) === 1) {
+				$removed = $this->memcache->cad($path, 1); // if we're the only one having a shared lock we can remove it in one go
+				if (!$removed) { //someone else also has a shared lock, decrease only
+					$this->memcache->dec($path);
+				}
+			} else {
+				// if we own more than one lock ourselves just decrease
 				$this->memcache->dec($path);
-				$this->memcache->cad($path, 0);
 			}
 		} else if ($type === self::LOCK_EXCLUSIVE) {
 			$this->memcache->cad($path, 'exclusive');


### PR DESCRIPTION
Instead of always doing a `dec` and a `cad` when releasing a lock we can be a bit smarter about it and do only only a `cad` or `dec` in cases where we are the only shared lock holder on a file.

In case another process also holds a lock on the file we still do both a `cad` and a `dec`

Gives a good performance increase on lock heavy operations: [comparison(https://blackfire.io/profiles/compare/b174b20e-3d81-4873-a692-56fa4aa60b5d/graph)

cc @PVince81 @DeepDiver1975 
