### PR TITLE
add IClientService to DI container

### DIFF
--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -148,6 +148,10 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return $this->getServer()->getRootFolder();
 		});
 
+		$this->registerService('OCP\\Http\\Client\\IClientService', function($c) {
+			return $this->getServer()->getHTTPClientService();
+		});
+
 		$this->registerService('OCP\\IGroupManager', function($c) {
 			return $this->getServer()->getGroupManager();
 		});


### PR DESCRIPTION
It was missing, hence apps were not able to automatically inject it
