### PR TITLE
PSR-4 for apps

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -103,6 +103,9 @@ class OC {
 	 */
 	public static $loader = null;
 
+	/** @var \Composer\Autoload\ClassLoader $composerAutoloader */
+	public static $composerAutoloader = null;
+
 	/**
 	 * @var \OC\Server
 	 */
@@ -493,7 +496,7 @@ class OC {
 		self::$CLI = (php_sapi_name() == 'cli');
 
 		// Add default composer PSR-4 autoloader
-		require_once OC::$SERVERROOT . '/lib/composer/autoload.php';
+		self::$composerAutoloader = require_once OC::$SERVERROOT . '/lib/composer/autoload.php';
 
 		try {
 			self::initPaths();

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -164,7 +164,7 @@ class OC_App {
 	protected static function registerAutoloading($app, $path) {
 		// Register on PSR-4 composer autoloader
 		$appNamespace = \OC\AppFramework\App::buildAppNamespace($app);
-		\OC::$composerAutoloader->addPsr4($appNamespace . '\\', $path . '/src/', true);
+		\OC::$composerAutoloader->addPsr4($appNamespace . '\\', $path . '/lib/', true);
 		if (defined('PHPUNIT_RUN')) {
 			\OC::$composerAutoloader->addPsr4($appNamespace . '\\Tests\\', $path . '/tests/', true);
 		}


### PR DESCRIPTION
Sample PR on an app: https://github.com/owncloud/announcementcenter/pull/73

@DeepDiver1975 @rullzer @MorrisJobke 

The following directories remain unchanged, since they should not contain namespaces classes and have hardcoded usage. Otherwise we would always need to check two directories:
- appinfo/
- css/
- img/
- js/
- l10n/
- templates/
