### PR TITLE
free up memory when releasing the last shared lock

### DIFF
--- a/lib/private/Lock/AbstractLockingProvider.php
+++ b/lib/private/Lock/AbstractLockingProvider.php
@@ -77,6 +77,9 @@ abstract class AbstractLockingProvider implements ILockingProvider {
 		if ($type === self::LOCK_SHARED) {
 			if (isset($this->acquiredLocks['shared'][$path]) and $this->acquiredLocks['shared'][$path] > 0) {
 				$this->acquiredLocks['shared'][$path]--;
+				if ($this->acquiredLocks['shared'][$path] === 0) {
+					unset($this->acquiredLocks['shared'][$path]);
+				}
 			}
 		} else if ($type === self::LOCK_EXCLUSIVE) {
 			unset($this->acquiredLocks['exclusive'][$path]);


### PR DESCRIPTION
Reduces memory usage when using a lot of locks (file scanner)

[comparison](https://blackfire.io/profiles/compare/b74b9540-e881-4c30-9853-3136904ff289/graph)

cc @MorrisJobke @PVince81 
