### PR TITLE
Cleanup Files_Sharing CLASSPATH

### DIFF
--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -33,13 +33,6 @@ $l = \OC::$server->getL10N('files_sharing');
 \OC::$CLASSPATH['OC_Share_Backend_File'] = 'files_sharing/lib/share/file.php';
 \OC::$CLASSPATH['OC_Share_Backend_Folder'] = 'files_sharing/lib/share/folder.php';
 \OC::$CLASSPATH['OC\Files\Storage\Shared'] = 'files_sharing/lib/sharedstorage.php';
-\OC::$CLASSPATH['OC\Files\Cache\SharedScanner'] = 'files_sharing/lib/scanner.php';
-\OC::$CLASSPATH['OC\Files\Cache\Shared_Cache'] = 'files_sharing/lib/cache.php';
-\OC::$CLASSPATH['OC\Files\Cache\Shared_Permissions'] = 'files_sharing/lib/permissions.php';
-\OC::$CLASSPATH['OC\Files\Cache\Shared_Updater'] = 'files_sharing/lib/updater.php';
-\OC::$CLASSPATH['OC\Files\Cache\Shared_Watcher'] = 'files_sharing/lib/watcher.php';
-\OC::$CLASSPATH['OCA\Files\Share\Maintainer'] = 'files_sharing/lib/maintainer.php';
-\OC::$CLASSPATH['OCA\Files\Share\Proxy'] = 'files_sharing/lib/proxy.php';
 
 $application = new Application();
 $application->registerMountProviders();

--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -23,7 +23,7 @@
  *
  */
 
-namespace OC\Files\Cache;
+namespace OCA\Files_Sharing;
 
 use OC\Files\Cache\Wrapper\CacheJail;
 use OCP\Files\Cache\ICacheEntry;
@@ -34,7 +34,7 @@ use OCP\Files\Storage\IStorage;
  *
  * don't use this class directly if you need to get metadata, use \OC\Files\Filesystem::getFileInfo instead
  */
-class Shared_Cache extends CacheJail {
+class Cache extends CacheJail {
 	/**
 	 * @var \OC\Files\Storage\Shared
 	 */

--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -36,9 +36,9 @@ use OCP\User;
 class Helper {
 
 	public static function registerHooks() {
-		\OCP\Util::connectHook('OC_Filesystem', 'post_rename', '\OC\Files\Cache\Shared_Updater', 'renameHook');
+		\OCP\Util::connectHook('OC_Filesystem', 'post_rename', '\OCA\Files_Sharing\Updater', 'renameHook');
 		\OCP\Util::connectHook('OC_Filesystem', 'post_delete', '\OCA\Files_Sharing\Hooks', 'unshareChildren');
-		\OCP\Util::connectHook('OC_Appconfig', 'post_set_value', '\OCA\Files\Share\Maintainer', 'configChangeHook');
+		\OCP\Util::connectHook('OC_Appconfig', 'post_set_value', '\OCA\Files_Sharing\Maintainer', 'configChangeHook');
 
 		\OCP\Util::connectHook('OC_User', 'post_deleteUser', '\OCA\Files_Sharing\Hooks', 'deleteUser');
 	}

--- a/apps/files_sharing/lib/maintainer.php
+++ b/apps/files_sharing/lib/maintainer.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace OCA\Files\Share;
+namespace OCA\Files_Sharing;
 
 /**
  * Maintains stuff around the sharing functionality

--- a/apps/files_sharing/lib/scanner.php
+++ b/apps/files_sharing/lib/scanner.php
@@ -21,15 +21,14 @@
  *
  */
 
-namespace OC\Files\Cache;
+namespace OCA\Files_Sharing;
 
 use OC\Files\ObjectStore\NoopScanner;
-use OC\Files\Storage\Shared;
 
 /**
  * Scanner for SharedStorage
  */
-class SharedScanner extends Scanner {
+class Scanner extends \OC\Files\Cache\Scanner {
 	private $sourceScanner;
 
 	/**

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -318,14 +318,14 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 		if (!$storage) {
 			$storage = $this;
 		}
-		return new \OC\Files\Cache\Shared_Cache($storage, $this->sourceStorage, $this->sourceRootInfo);
+		return new \OCA\Files_Sharing\Cache($storage, $this->sourceStorage, $this->sourceRootInfo);
 	}
 
 	public function getScanner($path = '', $storage = null) {
 		if (!$storage) {
 			$storage = $this;
 		}
-		return new \OC\Files\Cache\SharedScanner($storage);
+		return new \OCA\Files_Sharing\Scanner($storage);
 	}
 
 	public function getPropagator($storage = null) {

--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -25,9 +25,9 @@
  *
  */
 
-namespace OC\Files\Cache;
+namespace OCA\Files_Sharing;
 
-class Shared_Updater {
+class Updater {
 
 	/**
 	 * @param array $params


### PR DESCRIPTION
- OC\Files\Cache\SharedScanner
- OC\Files\Cache\Shared_Cache
- OC\Files\Cache\Shared_Permissions
- OC\Files\Cache\Shared_Updater
- OC\Files\Cache\Shared_Watcher
- OCA\Files\Share\Maintainer
- OCA\Files\Share\Proxy

Cleansup the CLASSPATH a bit. I want to move \OC\Files\Storage\Shared eventually as well but that is not possible in the current state.

CC: @schiesbn @nickvergessen @PVince81 @MorrisJobke 
