### PR TITLE
Use a CappedCache in the user database backend

### DIFF
--- a/lib/private/user/database.php
+++ b/lib/private/user/database.php
@@ -48,11 +48,21 @@
  *
  */
 
+use OC\Cache\CappedMemoryCache;
+
 /**
  * Class for user management in a SQL Database (e.g. MySQL, SQLite)
  */
 class OC_User_Database extends OC_User_Backend implements \OCP\IUserBackend {
-	private $cache = array();
+	/** @var CappedMemoryCache */
+	private $cache;
+
+	/**
+	 * OC_User_Database constructor.
+	 */
+	public function __construct() {
+		$this->cache = new CappedMemoryCache();
+	}
 
 	/**
 	 * Create a new user


### PR DESCRIPTION
When running with a user database backend on large installations the
cache can grow to significant sizes. This can be especially problematic
when running big cron/repair jobs.

During normal operations we probabaly never hit the cache limit.

@DeepDiver1975 as discussed

CC: @butonic @nickvergessen @MorrisJobke @PVince81 
