### PR TITLE
Optimize isSharingDisabledForUser

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1212,6 +1212,10 @@ class Manager implements IManager {
 	 * @return bool
 	 */
 	public function sharingDisabledForUser($userId) {
+		if ($userId === null) {
+			return false;
+		}
+
 		if (isset($this->sharingDisabledForUsersCache[$userId])) {
 			return $this->sharingDisabledForUsersCache[$userId];
 		}

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -181,7 +181,12 @@ class Util {
 			self::$shareManager = \OC::$server->getShareManager();
 		}
 
-		return self::$shareManager->sharingDisabledForUser(\OC::$server->getUserSession()->getUser()->getUID());
+		$user = \OC::$server->getUserSession()->getUser();
+		if ($user !== null) {
+			$user = $user->getUID();
+		}
+
+		return self::$shareManager->sharingDisabledForUser($user);
 	}
 
 	/**

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -63,6 +63,9 @@ class Util {
 	const ERROR=3;
 	const FATAL=4;
 
+	/** \OCP\Share\IManager */
+	private static $shareManager;
+
 	/**
 	 * get the current installed version of ownCloud
 	 * @return array
@@ -171,13 +174,14 @@ class Util {
 	 *
 	 * @return boolean
 	 * @since 7.0.0
+	 * @deprecated 9.1.0 Use \OC::$server->getShareManager()->sharingDisabledForUser
 	 */
 	public static function isSharingDisabledForUser() {
-		return \OC_Util::isSharingDisabledForUser(
-				\OC::$server->getConfig(),
-				\OC::$server->getGroupManager(),
-				\OC::$server->getUserSession()->getUser()
-		);
+		if (self::$shareManager === null) {
+			self::$shareManager = \OC::$server->getShareManager();
+		}
+
+		return self::$shareManager->sharingDisabledForUser(\OC::$server->getUserSession()->getUser()->getUID());
 	}
 
 	/**

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -7,6 +7,7 @@
 
 namespace Test\Files;
 
+use OC\Cache\CappedMemoryCache;
 use OC\Files\Cache\Watcher;
 use OC\Files\Storage\Common;
 use OC\Files\Mount\MountPoint;
@@ -269,6 +270,9 @@ class ViewTest extends \Test\TestCase {
 	 * @dataProvider sharingDisabledPermissionProvider
 	 */
 	public function testRemoveSharePermissionWhenSharingDisabledForUser($excludeGroups, $excludeGroupsList, $expectedShareable) {
+		// Reset sharing disabled for users cache
+		$this->invokePrivate(\OC::$server->getShareManager(), 'sharingDisabledForUsersCache', [new CappedMemoryCache()]);
+
 		$appConfig = \OC::$server->getAppConfig();
 		$oldExcludeGroupsFlag = $appConfig->getValue('core', 'shareapi_exclude_groups', 'no');
 		$oldExcludeGroupsList = $appConfig->getValue('core', 'shareapi_exclude_groups_list', '');
@@ -290,6 +294,9 @@ class ViewTest extends \Test\TestCase {
 
 		$appConfig->setValue('core', 'shareapi_exclude_groups', $oldExcludeGroupsFlag);
 		$appConfig->setValue('core', 'shareapi_exclude_groups_list', $oldExcludeGroupsList);
+
+		// Reset sharing disabled for users cache
+		$this->invokePrivate(\OC::$server->getShareManager(), 'sharingDisabledForUsersCache', [new CappedMemoryCache()]);
 	}
 
 	public function testCacheIncompleteFolder() {


### PR DESCRIPTION
I was doing some benchmarking and profiling for the common propfinds of the client. And on a directory with 20K entries I noticed a significant impact of the isSharingDisabledForUser function.

[Blackfire graph](https://blackfire.io/profiles/compare/939ac718-4d11-4d2a-8c7a-87ce89b6b13c/graph)

Our own perf tool (https://github.com/owncloud/administration/tree/master/performance-tests-c%2B%2B) also show improvements for the propfinds:

|  | master | branch |
| --- | --- | --- |
| RequestEtagJob | 251.1 ms | 234.1 ms |
| ConnectionValidator | 267.1 ms | 256.3 ms |
| DiscoverySingleDirectoryJob | 612.8 ms | 529.0 ms |
| CheckQuotaJob | 253.0 ms | 246.3 ms |

Eventaully we should properly inject the sharemanager. But this was already such a nice preformance improvement.

CC: @icewind1991 @PVince81 @MorrisJobke @nickvergessen 
