### PR TITLE
Do not save the language as request lang for apps when we didn't find…

### DIFF
--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -263,7 +263,7 @@ class Factory implements IFactory {
 			}
 		}
 
-		if (!$this->requestLanguage) {
+		if ($app === null && !$this->requestLanguage) {
 			$this->requestLanguage = 'en';
 		}
 		return 'en'; // Last try: English

--- a/tests/lib/l10n/factorytest.php
+++ b/tests/lib/l10n/factorytest.php
@@ -343,6 +343,15 @@ class FactoryTest extends TestCase {
 			[null, 'de', 'ru', ['de'], 'de', 'ru'],
 			[null, 'de,en', 'ru', ['de'], 'de', 'ru'],
 			[null, 'de-DE,en-US;q=0.8,en;q=0.6', 'ru', ['de'], 'de', 'ru'],
+
+			// Request lang should not be set for apps: Language is available
+			['files_pdfviewer', 'de', null, ['de'], 'de', ''],
+			['files_pdfviewer', 'de,en', null, ['de'], 'de', ''],
+			['files_pdfviewer', 'de-DE,en-US;q=0.8,en;q=0.6', null, ['de'], 'de', ''],
+			// Request lang should not be set for apps: Language is not available
+			['files_pdfviewer', 'de', null, ['ru'], 'en', ''],
+			['files_pdfviewer', 'de,en', null, ['ru', 'en'], 'en', ''],
+			['files_pdfviewer', 'de-DE,en-US;q=0.8,en;q=0.6', null, ['ru', 'en'], 'en', ''],
 		];
 	}
 


### PR DESCRIPTION
… any

Fix #24270 

The problem why this only happens with IE, Edge and Safari is, that Chrome and Firefox send en as accept language by default as well, instead of only your OS language.
Since we find en for all apps, we never reached the end of the loop and returned with an available language instead.
There the requestLanguage is only set with `$app === null` already and only this last occurance was missing it.

@PluueeR @CCXX2016 @pako81 @MorrisJobke please test

@karlitschek should backport to 9.0.x
