### PR TITLE
Permalinks

### DIFF
--- a/apps/files/appinfo/application.php
+++ b/apps/files/appinfo/application.php
@@ -26,6 +26,7 @@ use OCA\Files\Controller\ApiController;
 use OCP\AppFramework\App;
 use \OCA\Files\Service\TagService;
 use \OCP\IContainer;
+use OCA\Files\Controller\ViewController;
 
 class Application extends App {
 	public function __construct(array $urlParams=array()) {
@@ -45,6 +46,20 @@ class Application extends App {
 				$server->getPreviewManager(),
 				$server->getShareManager(),
 				$server->getConfig()
+			);
+		});
+
+		$container->registerService('ViewController', function (IContainer $c) use ($server) {
+			return new ViewController(
+				$c->query('AppName'),
+				$c->query('Request'),
+				$server->getURLGenerator(),
+				$server->getNavigationManager(),
+				$c->query('L10N'),
+				$server->getConfig(),
+				$server->getEventDispatcher(),
+				$server->getUserSession(),
+				$server->getUserFolder()
 			);
 		});
 

--- a/apps/files/css/detailsView.css
+++ b/apps/files/css/detailsView.css
@@ -14,6 +14,19 @@
 	width: 100%;
 }
 
+#app-sidebar .mainFileInfoView .icon {
+	display: inline-block;
+}
+
+#app-sidebar .mainFileInfoView .permalink {
+	margin-left: 10px;
+	opacity: .5;
+}
+#app-sidebar .mainFileInfoView .permalink-field>input {
+	clear: both;
+	width: 90%;
+}
+
 #app-sidebar .file-details-container {
 	display: inline-block;
 	float: left;

--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -271,6 +271,19 @@
 		},
 
 		/**
+		 * Encode URL params into a string, except for the "dir" attribute
+		 * that gets encoded as path where "/" is not encoded
+		 *
+		 * @param {Object.<string>} params
+		 * @return {string} encoded params
+		 */
+		_makeUrlParams: function(params) {
+			var dir = params.dir;
+			delete params.dir;
+			return 'dir=' + OC.encodePath(dir) + '&' + OC.buildQueryString(params);
+		},
+
+		/**
 		 * Change the URL to point to the given dir and view
 		 */
 		_changeUrl: function(view, dir, fileId) {
@@ -283,9 +296,9 @@
 			var currentParams = OC.Util.History.parseUrlQuery();
 			if (currentParams.dir === params.dir && currentParams.view === params.view && currentParams.fileid !== params.fileid) {
 				// if only fileid changed or was added, replace instead of push
-				OC.Util.History.replaceState(params);
+				OC.Util.History.replaceState(this._makeUrlParams(params));
 			} else {
-				OC.Util.History.pushState(params);
+				OC.Util.History.pushState(this._makeUrlParams(params));
 			}
 		}
 	};

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -619,7 +619,7 @@
 
 			this.register('dir', 'Open', OC.PERMISSION_READ, '', function (filename, context) {
 				var dir = context.$file.attr('data-path') || context.fileList.getCurrentDirectory();
-				context.fileList.changeDirectory(OC.joinPaths(dir, filename));
+				context.fileList.changeDirectory(OC.joinPaths(dir, filename), true, false, parseInt(context.$file.attr('data-id'), 10));
 			});
 
 			this.registerAction({

--- a/apps/files/js/mainfileinfodetailview.js
+++ b/apps/files/js/mainfileinfodetailview.js
@@ -12,7 +12,13 @@
 	var TEMPLATE =
 		'<div class="thumbnailContainer"><a href="#" class="thumbnail action-default"><div class="stretcher"/></a></div>' +
 		'<div class="file-details-container">' +
-		'<div class="fileName"><h3 title="{{name}}" class="ellipsis">{{name}}</h3></div>' +
+		'<div class="fileName">' +
+			'<h3 title="{{name}}" class="ellipsis">{{name}}</h3>' +
+			'<a class="permalink" href="{{permalink}}" title="{{permalinkTitle}}">' +
+				'<span class="icon icon-public"></span>' +
+				'<span class="hidden-visually">{{permalinkTitle}}</span>' +
+			'</a>' +
+		'</div>' +
 		'	<div class="file-details ellipsis">' +
 		'		<a href="#" ' +
 		'		class="action action-favorite favorite">' +
@@ -20,6 +26,9 @@
 		'		</a>' +
 		'		{{#if hasSize}}<span class="size" title="{{altSize}}">{{size}}</span>, {{/if}}<span class="date" title="{{altDate}}">{{date}}</span>' +
 		'	</div>' +
+		'</div>' +
+		'<div class="hidden permalink-field">' +
+			'<input type="text" value="{{permalink}}" placeholder="{{permalinkTitle}}" readonly="readonly"/>' +
 		'</div>';
 
 	/**
@@ -50,7 +59,9 @@
 
 		events: {
 			'click a.action-favorite': '_onClickFavorite',
-			'click a.action-default': '_onClickDefaultAction'
+			'click a.action-default': '_onClickDefaultAction',
+			'click a.permalink': '_onClickPermalink',
+			'focus .permalink-field>input': '_onFocusPermalink'
 		},
 
 		template: function(data) {
@@ -72,6 +83,20 @@
 			}
 		},
 
+		_onClickPermalink: function() {
+			var $row = this.$('.permalink-field');
+			$row.toggleClass('hidden');
+			if (!$row.hasClass('hidden')) {
+				$row.find('>input').focus();
+			}
+			// cancel click, user must right-click + copy or middle click
+			return false;
+		},
+
+		_onFocusPermalink: function() {
+			this.$('.permalink-field>input').select();
+		},
+
 		_onClickFavorite: function(event) {
 			event.preventDefault();
 			this._fileActions.triggerAction('Favorite', this.model, this._fileList);
@@ -85,6 +110,11 @@
 		_onModelChanged: function() {
 			// simply re-render
 			this.render();
+		},
+
+		_makePermalink: function(fileId) {
+			var baseUrl = OC.getProtocol() + '://' + OC.getHost();
+			return baseUrl + OC.generateUrl('/f/{fileId}', {fileId: fileId});
 		},
 
 		setFileInfo: function(fileInfo) {
@@ -118,7 +148,9 @@
 					altDate: OC.Util.formatDate(this.model.get('mtime')),
 					date: OC.Util.relativeModifiedDate(this.model.get('mtime')),
 					starAltText: isFavorite ? t('files', 'Favorited') : t('files', 'Favorite'),
-					starIcon: OC.imagePath('core', isFavorite ? 'actions/starred' : 'actions/star')
+					starIcon: OC.imagePath('core', isFavorite ? 'actions/starred' : 'actions/star'),
+					permalink: this._makePermalink(this.model.get('id')),
+					permalinkTitle: t('files', 'Local link')
 				}));
 
 				// TODO: we really need OC.Previews

--- a/apps/files/tests/js/appSpec.js
+++ b/apps/files/tests/js/appSpec.js
@@ -122,35 +122,39 @@ describe('OCA.Files.App tests', function() {
 
 	describe('URL handling', function() {
 		it('pushes the state to the URL when current app changed directory', function() {
-			$('#app-content-files').trigger(new $.Event('changeDirectory', {dir: 'subdir'}));
+			$('#app-content-files').trigger(new $.Event('changeDirectory', {dir: 'sub dir'}));
 			expect(pushStateStub.calledOnce).toEqual(true);
-			expect(pushStateStub.getCall(0).args[0].dir).toEqual('subdir');
-			expect(pushStateStub.getCall(0).args[0].view).not.toBeDefined();
+			var params = OC.parseQueryString(pushStateStub.getCall(0).args[0]);
+			expect(params.dir).toEqual('sub dir');
+			expect(params.view).not.toBeDefined();
 
 			$('li[data-id=other]>a').click();
 			pushStateStub.reset();
 
-			$('#app-content-other').trigger(new $.Event('changeDirectory', {dir: 'subdir'}));
+			$('#app-content-other').trigger(new $.Event('changeDirectory', {dir: 'sub dir'}));
 			expect(pushStateStub.calledOnce).toEqual(true);
-			expect(pushStateStub.getCall(0).args[0].dir).toEqual('subdir');
-			expect(pushStateStub.getCall(0).args[0].view).toEqual('other');
+			params = OC.parseQueryString(pushStateStub.getCall(0).args[0]);
+			expect(params.dir).toEqual('sub dir');
+			expect(params.view).toEqual('other');
 		});
 		it('replaces the state to the URL when fileid is known', function() {
-			$('#app-content-files').trigger(new $.Event('changeDirectory', {dir: 'subdir'}));
+			$('#app-content-files').trigger(new $.Event('changeDirectory', {dir: 'sub dir'}));
 			expect(pushStateStub.calledOnce).toEqual(true);
-			expect(pushStateStub.getCall(0).args[0].dir).toEqual('subdir');
-			expect(pushStateStub.getCall(0).args[0].view).not.toBeDefined();
+			var params = OC.parseQueryString(pushStateStub.getCall(0).args[0]);
+			expect(params.dir).toEqual('sub dir');
+			expect(params.view).not.toBeDefined();
 			expect(replaceStateStub.notCalled).toEqual(true);
 
-			parseUrlQueryStub.returns({dir: 'subdir'});
+			parseUrlQueryStub.returns({dir: 'sub dir'});
 
-			$('#app-content-files').trigger(new $.Event('afterChangeDirectory', {dir: 'subdir', fileId: 123}));
+			$('#app-content-files').trigger(new $.Event('afterChangeDirectory', {dir: 'sub dir', fileId: 123}));
 
 			expect(pushStateStub.calledOnce).toEqual(true);
 			expect(replaceStateStub.calledOnce).toEqual(true);
-			expect(replaceStateStub.getCall(0).args[0].dir).toEqual('subdir');
-			expect(replaceStateStub.getCall(0).args[0].view).not.toBeDefined();
-			expect(replaceStateStub.getCall(0).args[0].fileid).toEqual(123);
+			params = OC.parseQueryString(replaceStateStub.getCall(0).args[0]);
+			expect(params.dir).toEqual('sub dir');
+			expect(params.view).not.toBeDefined();
+			expect(params.fileid).toEqual('123');
 		});
 		describe('onpopstate', function() {
 			it('sends "urlChanged" event to current app', function() {

--- a/apps/files/tests/js/appSpec.js
+++ b/apps/files/tests/js/appSpec.js
@@ -22,6 +22,7 @@
 describe('OCA.Files.App tests', function() {
 	var App = OCA.Files.App;
 	var pushStateStub;
+	var replaceStateStub;
 	var parseUrlQueryStub;
 	var oldLegacyFileActions;
 
@@ -48,6 +49,7 @@ describe('OCA.Files.App tests', function() {
 		OCA.Files.fileActions = new OCA.Files.FileActions();
 
 		pushStateStub = sinon.stub(OC.Util.History, 'pushState');
+		replaceStateStub = sinon.stub(OC.Util.History, 'replaceState');
 		parseUrlQueryStub = sinon.stub(OC.Util.History, 'parseUrlQuery');
 		parseUrlQueryStub.returns({});
 
@@ -59,6 +61,7 @@ describe('OCA.Files.App tests', function() {
 		window.FileActions = oldLegacyFileActions;
 
 		pushStateStub.restore();
+		replaceStateStub.restore();
 		parseUrlQueryStub.restore();
 	});
 
@@ -131,6 +134,23 @@ describe('OCA.Files.App tests', function() {
 			expect(pushStateStub.calledOnce).toEqual(true);
 			expect(pushStateStub.getCall(0).args[0].dir).toEqual('subdir');
 			expect(pushStateStub.getCall(0).args[0].view).toEqual('other');
+		});
+		it('replaces the state to the URL when fileid is known', function() {
+			$('#app-content-files').trigger(new $.Event('changeDirectory', {dir: 'subdir'}));
+			expect(pushStateStub.calledOnce).toEqual(true);
+			expect(pushStateStub.getCall(0).args[0].dir).toEqual('subdir');
+			expect(pushStateStub.getCall(0).args[0].view).not.toBeDefined();
+			expect(replaceStateStub.notCalled).toEqual(true);
+
+			parseUrlQueryStub.returns({dir: 'subdir'});
+
+			$('#app-content-files').trigger(new $.Event('afterChangeDirectory', {dir: 'subdir', fileId: 123}));
+
+			expect(pushStateStub.calledOnce).toEqual(true);
+			expect(replaceStateStub.calledOnce).toEqual(true);
+			expect(replaceStateStub.getCall(0).args[0].dir).toEqual('subdir');
+			expect(replaceStateStub.getCall(0).args[0].view).not.toBeDefined();
+			expect(replaceStateStub.getCall(0).args[0].fileid).toEqual(123);
 		});
 		describe('onpopstate', function() {
 			it('sends "urlChanged" event to current app', function() {

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1358,6 +1358,15 @@ describe('OCA.Files.FileList tests', function() {
 			expect(handler.calledOnce).toEqual(true);
 			expect(handler.getCall(0).args[0].dir).toEqual('/somedir');
 		});
+		it('triggers "afterChangeDirectory" event with fileid after changing directory', function() {
+			var handler = sinon.stub();
+			$('#app-content-files').on('afterChangeDirectory', handler);
+			fileList.changeDirectory('/somedir');
+			deferredList.resolve(200, [testRoot].concat(testFiles));
+			expect(handler.calledOnce).toEqual(true);
+			expect(handler.getCall(0).args[0].dir).toEqual('/somedir');
+			expect(handler.getCall(0).args[0].fileId).toEqual(99);
+		});
 		it('changes the directory when receiving "urlChanged" event', function() {
 			$('#app-content-files').trigger(new $.Event('urlChanged', {view: 'files', dir: '/somedir'}));
 			expect(fileList.getCurrentDirectory()).toEqual('/somedir');

--- a/apps/files/tests/js/mainfileinfodetailviewSpec.js
+++ b/apps/files/tests/js/mainfileinfodetailviewSpec.js
@@ -62,6 +62,11 @@ describe('OCA.Files.MainFileInfoDetailView tests', function() {
 			expect(view.$el.find('.date').attr('title')).toEqual(dateExpected);
 			clock.restore();
 		});
+		it('displays permalink', function() {
+			view.setFileInfo(testFileInfo);
+			expect(view.$el.find('.permalink').attr('href'))
+				.toEqual(OC.getProtocol() + '://' + OC.getHost() + OC.generateUrl('/f/5'));
+		});
 		it('displays favorite icon', function() {
 			testFileInfo.set('tags', [OC.TAG_FAVORITE]);
 			view.setFileInfo(testFileInfo);

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -2050,8 +2050,9 @@ OC.Util.History = {
 	 *
 	 * @param params to append to the URL, can be either a string
 	 * or a map
+	 * @param {boolean} [replace=false] whether to replace instead of pushing
 	 */
-	pushState: function(params) {
+	_pushState: function(params, replace) {
 		var strParams;
 		if (typeof(params) === 'string') {
 			strParams = params;
@@ -2061,7 +2062,11 @@ OC.Util.History = {
 		}
 		if (window.history.pushState) {
 			var url = location.pathname + '?' + strParams;
-			window.history.pushState(params, '', url);
+			if (replace) {
+				window.history.replaceState(params, '', url);
+			} else {
+				window.history.pushState(params, '', url);
+			}
 		}
 		// use URL hash for IE8
 		else {
@@ -2070,6 +2075,32 @@ OC.Util.History = {
 			// to the event queue
 			this._cancelPop = true;
 		}
+	},
+
+	/**
+	 * Push the current URL parameters to the history stack
+	 * and change the visible URL.
+	 * Note: this includes a workaround for IE8/IE9 that uses
+	 * the hash part instead of the search part.
+	 *
+	 * @param params to append to the URL, can be either a string
+	 * or a map
+	 */
+	pushState: function(params) {
+		return this._pushState(params, false);
+	},
+
+	/**
+	 * Push the current URL parameters to the history stack
+	 * and change the visible URL.
+	 * Note: this includes a workaround for IE8/IE9 that uses
+	 * the hash part instead of the search part.
+	 *
+	 * @param params to append to the URL, can be either a string
+	 * or a map
+	 */
+	replaceState: function(params) {
+		return this._pushState(params, true);
 	},
 
 	/**

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -2160,7 +2160,12 @@ OC.Util.History = {
 		if (!this._handlers.length) {
 			return;
 		}
-		params = (e && e.state) || this.parseUrlQuery() || {};
+		params = (e && e.state);
+		if (_.isString(params)) {
+			params = OC.parseQueryString(params);
+		} else if (!params) {
+			params = this.parseUrlQuery() || {};
+		}
 		for (var i = 0; i < this._handlers.length; i++) {
 			this._handlers[i](params);
 		}

--- a/core/routes.php
+++ b/core/routes.php
@@ -108,6 +108,12 @@ $this->create('core_ajax_preview', '/core/preview.png')
 $this->create('core_ajax_update', '/core/ajax/update.php')
 	->actionInclude('core/ajax/update.php');
 
+// File routes
+$this->create('files.viewcontroller.showFile', '/f/{fileId}')->action(function($urlParams) {
+	$app = new \OCA\Files\AppInfo\Application($urlParams);
+	$app->dispatch('ViewController', 'showFile');
+});
+
 // Sharing routes
 $this->create('files_sharing.sharecontroller.showShare', '/s/{token}')->action(function($urlParams) {
 	$app = new \OCA\Files_Sharing\AppInfo\Application($urlParams);

--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -119,27 +119,9 @@ class MailNotifications {
 				}
 			}
 
-			// Link to folder, or root folder if a file
-
-			if ($itemType === 'folder') {
-				$args = array(
-					'dir' => $filename,
-				);
-			} else if (strpos($filename, '/')) {
-				$args = array(
-					'dir' => '/' . dirname($filename),
-					'scrollto' => basename($filename),
-				);
-			} else {
-				$args = array(
-					'dir' => '/',
-					'scrollto' => $filename,
-				);
-			}
-
 			$link = $this->urlGenerator->linkToRouteAbsolute(
-				'files.view.index',
-				$args
+				'files.viewcontroller.showFile',
+				['fileId' => $items[0]['item_source']]
 			);
 
 			list($htmlBody, $textBody) = $this->createMailBody($filename, $link, $expiration, 'internal');

--- a/tests/lib/share/MailNotificationsTest.php
+++ b/tests/lib/share/MailNotificationsTest.php
@@ -222,7 +222,7 @@ class MailNotificationsTest extends \Test\TestCase {
 		$mailNotifications->method('getItemSharedWithUser')
 			->withAnyParameters()
 			->willReturn([
-				['file_target' => '/welcome.txt']
+				['file_target' => '/welcome.txt', 'item_source' => 123],
 			]);
 
 		$recipient = $this->getMockBuilder('\OCP\IUser')
@@ -239,10 +239,9 @@ class MailNotificationsTest extends \Test\TestCase {
 		$this->urlGenerator->expects($this->once())
 			->method('linkToRouteAbsolute')
 			->with(
-				$this->equalTo('files.view.index'),
+				$this->equalTo('files.viewcontroller.showFile'),
 				$this->equalTo([
-					'dir' => '/',
-					'scrollto' => 'welcome.txt'
+					'fileId' => 123,
 				])
 			);
 


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/11732

The following routes will redirect to the files app and display the
matching folder. If the fileid is a file, it will scroll to it.
- http://localhost/owncloud/index.php/f/$fileid
- http://localhost/owncloud/index.php/files/?dir=somedir&fileid=$fileid

Missing parts and challenges:
- [x] have the JS code append "fileid" when switching dirs and using history API
- [x] what if the user hits the back button and the URL contains an older fileid ? => no problem
- [x] have "fileid" always appear in the URL when switching dirs (and avoid infinite redirect loop)
- [x] fileid with other views than "All files" ?!! => not supported
