### PR TITLE
Add pending shares OCS endpoint

### DIFF
--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -24,6 +24,7 @@
 
 namespace OCA\FederatedFileSharing;
 
+use OC\Share20\Exception\ProviderException;
 use OC\Share20\Share;
 use OCP\Files\IRootFolder;
 use OCP\IConfig;
@@ -441,6 +442,13 @@ class FederatedShareProvider implements IShareProvider {
 		 * federated shares.
 		 */
 		return $share;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function accept(\OCP\Share\IShare $share, $recipient) {
+		throw new ProviderException('Not supported');
 	}
 
 	/**

--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -81,6 +81,21 @@ API::register('post',
 		'files_sharing');
 
 API::register('get',
+	'/apps/files_sharing/api/v1/shares/pending',
+	[$OCSShare, 'getPendingShares'],
+	'files_sharing');
+
+API::register('get',
+	'/apps/files_sharing/api/v1/shares/pending/{id}',
+	[$OCSShare, 'getPendingShare'],
+	'files_sharing');
+
+API::register('post',
+	'/apps/files_sharing/api/v1/shares/pending/{id}',
+	[$OCSShare, 'acceptPendingShare'],
+	'files_sharing');
+
+API::register('get',
 		'/apps/files_sharing/api/v1/shares/{id}',
 		[$OCSShare, 'getShare'],
 		'files_sharing');

--- a/apps/files_sharing/lib/API/OCSShareWrapper.php
+++ b/apps/files_sharing/lib/API/OCSShareWrapper.php
@@ -39,26 +39,61 @@ class OCSShareWrapper {
 		);
 	}
 
+	/**
+	 * @return \OC_OCS_Result
+	 */
 	public function getAllShares() {
 		return $this->getShare20OCS()->getShares();
 	}
 
+	/**
+	 * @return \OC_OCS_Result
+	 */
 	public function createShare() {
 		return $this->getShare20OCS()->createShare();
 	}
 
+	/**
+	 * @param string[] $params
+	 * @return \OC_OCS_Result
+	 */
 	public function getShare($params) {
 		$id = $params['id'];
 		return $this->getShare20OCS()->getShare($id);
 	}
 
+	/**
+	 * @param string[] $params
+	 * @return \OC_OCS_Result
+	 */
 	public function updateShare($params) {
 		$id = $params['id'];
 		return $this->getShare20OCS()->updateShare($id);
 	}
 
+	/**
+	 * @param string[] $params
+	 * @return \OC_OCS_Result
+	 */
 	public function deleteShare($params) {
 		$id = $params['id'];
 		return $this->getShare20OCS()->deleteShare($id);
+	}
+
+	/**
+	 * @return \OC_OCS_Result
+	 */
+	public function getPendingShares() {
+		return $this->getShare20OCS()->getPendingShares();
+	}
+
+	public function getPendingShare($params) {
+		$id = $params['id'];
+		return $this->getShare20OCS()->getPendingShare($id);
+	}
+
+	public function acceptPendingShare($params) {
+		$id = $params['id'];
+		return $this->getShare20OCS()->acceptPendingShare($id);
 	}
 }

--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -768,6 +768,99 @@ class Share20OCS {
 	}
 
 	/**
+	 * @param Share\IShare $share
+	 * @return array
+	 */
+	private function formatPendingShare(\OCP\Share\IShare $share) {
+		$data = [
+			'id' => $share->getFullId(),
+			'type' => $share->getShareType(),
+		];
+
+		$initiator = $this->userManager->get($share->getSharedBy());
+		$owner = $this->userManager->get($share->getShareOwner());
+
+		$data['initiator'] = $initiator !== null ? $initiator->getDisplayName() : $share->getSharedBy();
+		$data['owner'] = $owner !== null ? $owner->getDisplayName() : $share->getShareOwner();
+
+		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
+			$data['recipient'] = $share->getSharedWith();
+		}
+
+		$data['mimetype'] = $share->getNode()->getMimeType();
+		$data['name'] = $share->getNode()->getName();
+		$data['mtime'] = $share->getShareTime()->getTimestamp();
+
+
+		return $data;
+	}
+
+	/**
+	 * @return \OC_OCS_Result
+	 */
+	public function getPendingShares() {
+		// Get all group shares to this user
+		$shares = $this->shareManager->getSharedWith(
+			$this->currentUser->getUID(),
+			\OCP\Share::SHARE_TYPE_GROUP,
+			null,
+			-1,
+			0);
+
+		//Filter group shares
+		$shares = array_filter($shares, function (\OCP\Share\IShare $share) {
+			return $share->getPermissions() === 0;
+		});
+
+		$result = [];
+		foreach($shares as $share) {
+			$result[] = $this->formatPendingShare($share);
+		}
+
+		return new \OC_OCS_Result($result);
+	}
+
+	/**
+	 * @param string $id
+	 * @return \OC_OCS_Result
+	 */
+	public function getPendingShare($id) {
+		try {
+			$share = $this->shareManager->getShareById($id, $this->currentUser->getUID());
+		} catch (ShareNotFound $e) {
+			return new \OC_OCS_Result(null, 404, $this->l->t('Wrong share ID, share doesn\'t exist'));
+		}
+
+		if ($share->getPermissions() !== 0) {
+			return new \OC_OCS_Result(null, 404, $this->l->t('Share is not pending'));
+		}
+
+		return new \OC_OCS_Result($this->formatPendingShare($share));
+	}
+
+	/**
+	 * @param string $id
+	 * @return \OC_OCS_Result
+	 */
+	public function acceptPendingShare($id) {
+		try {
+			$share = $this->shareManager->getShareById($id, $this->currentUser->getUID());
+		} catch (ShareNotFound $e) {
+			return new \OC_OCS_Result(null, 404, $this->l->t('Wrong share ID, share doesn\'t exist'));
+		}
+
+		if ($share->getPermissions() !== 0) {
+			return new \OC_OCS_Result(null, 404, $this->l->t('Share is not pending'));
+		}
+
+		$this->shareManager->acceptShare($share, $this->currentUser->getUID());
+		$share = $this->shareManager->getShareById($id, $this->currentUser->getUID());
+
+		$result = $this->formatShare($share);
+		return new \OC_OCS_Result($result);
+	}
+
+	/**
 	 * @param \OCP\Share\IShare $share
 	 * @return bool
 	 */

--- a/apps/files_sharing/tests/API/Share20OCSTest.php
+++ b/apps/files_sharing/tests/API/Share20OCSTest.php
@@ -2741,4 +2741,96 @@ class Share20OCSTest extends TestCase {
 
 		$this->assertEquals($expected, $result);
 	}
+
+	public function testGetPendingShare() {
+		$node = $this->getMock('\OCP\Files\Node');
+		$node->method('getMimeType')->willReturn('myMime');
+		$node->method('getName')->willReturn('myName');
+
+		$now = new \DateTime();
+		$share = \OC::$server->getShareManager()->newShare();
+		$share->setShareType(\OCP\Share::SHARE_TYPE_GROUP)
+			->setId('42')
+			->setProviderId('foo')
+			->setSharedBy('initiator')
+			->setSharedWith('recipient')
+			->setShareOwner('owner')
+			->setNode($node)
+			->setPermissions(0)
+			->setShareTime($now);
+
+		$this->userManager
+			->expects($this->exactly(2))
+			->method('get')
+			->willReturn(null);
+
+		$this->shareManager->method('getShareById')
+			->willReturn($share);
+
+		$result = $this->ocs->getPendingShare('foo:42');
+
+		$expected = new \OC_OCS_Result([
+			'id' => 'foo:42',
+			'type' => \OCP\Share::SHARE_TYPE_GROUP,
+			'initiator' => 'initiator',
+			'owner' => 'owner',
+			'recipient' => 'recipient',
+			'mimetype' => 'myMime',
+			'name' => 'myName',
+			'mtime' => $now->getTimestamp(),
+		]);
+
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testGetGetPendingShares() {
+		$node = $this->getMock('\OCP\Files\Node');
+		$node->method('getMimeType')->willReturn('myMime');
+		$node->method('getName')->willReturn('myName');
+
+		$now = new \DateTime();
+		$share = \OC::$server->getShareManager()->newShare();
+		$share->setShareType(\OCP\Share::SHARE_TYPE_GROUP)
+			->setId('42')
+			->setProviderId('foo')
+			->setSharedBy('initiator')
+			->setSharedWith('recipient')
+			->setShareOwner('owner')
+			->setNode($node)
+			->setPermissions(0)
+			->setShareTime($now);
+
+		$share2 = \OC::$server->getShareManager()->newShare();
+		$share2->setShareType(\OCP\Share::SHARE_TYPE_GROUP)
+			->setId('42')
+			->setProviderId('foo')
+			->setSharedBy('initiator')
+			->setSharedWith('recipient')
+			->setShareOwner('owner')
+			->setNode($node)
+			->setPermissions(\OCP\Constants::PERMISSION_READ);
+
+		$this->userManager
+			->expects($this->exactly(2))
+			->method('get')
+			->willReturn(null);
+
+		$this->shareManager->method('getSharedWith')
+			->willReturn([$share, $share2]);
+
+		$result = $this->ocs->getPendingShares();
+
+		$expected = new \OC_OCS_Result([[
+			'id' => 'foo:42',
+			'type' => \OCP\Share::SHARE_TYPE_GROUP,
+			'initiator' => 'initiator',
+			'owner' => 'owner',
+			'recipient' => 'recipient',
+			'mimetype' => 'myMime',
+			'name' => 'myName',
+			'mtime' => $now->getTimestamp(),
+		]]);
+
+		$this->assertEquals($expected, $result);
+	}
 }

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -469,6 +469,59 @@ class DefaultShareProvider implements IShareProvider {
 	}
 
 	/**
+	 * Accepting a share for now only means reaccepting a group share
+	 *
+	 * @param \OCP\Share\IShare $share
+	 * @param string $recipient
+	 */
+	public function accept(\OCP\Share\IShare $share, $recipient) {
+		if ($share->getShareType() !== \OCP\Share::SHARE_TYPE_GROUP) {
+			throw new ProviderException('Can\'t accept this share');
+		}
+
+		// Check if there is a usergroup share
+		$qb = $this->dbConn->getQueryBuilder();
+		$stmt = $qb->select('id')
+			->from('share')
+			->where($qb->expr()->eq('share_type', $qb->createNamedParameter(self::SHARE_TYPE_USERGROUP)))
+			->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($recipient)))
+			->andWhere($qb->expr()->eq('parent', $qb->createNamedParameter($share->getId())))
+			->andWhere($qb->expr()->orX(
+				$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
+				$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
+			))
+			->setMaxResults(1)
+			->execute();
+
+		$data = $stmt->fetch();
+		$stmt->closeCursor();
+
+		// No user group share so no need to update
+		if ($data === false) {
+			return;
+		}
+		$id = $data['id'];
+
+		// Get permissions
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->select('permissions')
+			->from('share')
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())));
+		$stmt = $qb->execute();
+
+		$data = $stmt->fetch();
+		$permissions = $data['permissions'];
+		$stmt->closeCursor();
+
+		// Update permissions
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->update('share')
+			->set('permissions', $qb->createNamedParameter($permissions))
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
+		$qb->execute();
+	}
+
+	/**
 	 * @inheritdoc
 	 */
 	public function getAllSharesBy($userId, $shareTypes, $nodeIDs, $reshares) {

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -947,6 +947,17 @@ class Manager implements IManager {
 		return $shares;
 	}
 
+	public function acceptShare(\OCP\Share\IShare $share, $recipientId) {
+		if ($share->getShareType() !== \OCP\Share::SHARE_TYPE_GROUP) {
+			throw new \InvalidArgumentException('(re-)Accepting shares only implemeneted for group shares');
+		}
+
+		list($providerId, ) = $this->splitFullId($share->getFullId());
+		$provider = $this->factory->getProvider($providerId);
+
+		$provider->accept($share, $recipientId);
+	}
+
 	/**
 	 * @inheritdoc
 	 */

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -80,7 +80,6 @@ interface IManager {
 	 *
 	 * @param IShare $share
 	 * @param string $recipientId
-	 * @return IShare
 	 * @throws \InvalidArgumentException If $share is a link share or the $recipient does not match
 	 * @since 9.0.0
 	 */
@@ -98,6 +97,17 @@ interface IManager {
 	 */
 	public function getAllSharesBy($userId, $shareTypes, $nodeIDs, $reshares = false);
 	
+	/**
+	 * Accept the share as recipient.
+	 * This can also be reaccepting if the user deleted the share before but
+	 * th original share is still there (e.g. group shares)
+	 *
+	 * @param IShare $share
+	 * @param string $recipientId
+	 * @since 9.1.0
+	 */
+	public function acceptShare(IShare $share, $recipientId);
+
 	/**
 	 * Get shares shared by (initiated) by the provided user.
 	 *

--- a/lib/public/Share/IShareProvider.php
+++ b/lib/public/Share/IShareProvider.php
@@ -91,6 +91,16 @@ interface IShareProvider {
 	public function move(\OCP\Share\IShare $share, $recipient);
 
 	/**
+	 * Accept a share as recipient
+	 * This can also be reaccepting (for for example group shares)
+	 *
+	 * @param \OCP\Share\IShare $share
+	 * @param string $recipient userId of recipient
+	 * @since 9.1.0
+	 */
+	public function accept(\OCP\Share\IShare $share, $recipient);
+
+	/**
 	 * Get all shares by the given user
 	 *
 	 * @param string $userId

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -2785,4 +2785,51 @@ class DefaultShareProviderTest extends TestCase {
 
 		$this->assertCount($toDelete ? 0 : 1, $data);
 	}
+
+	public function dataAccept() {
+		return [
+			['user1'],
+			['user2'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataAccept
+	 * @param string $user
+	 */
+	public function testAccept($user) {
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->insert('share')
+			->setValue('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_GROUP))
+			->setValue('uid_owner', $qb->createNamedParameter('owner'))
+			->setValue('uid_initiator', $qb->createNamedParameter('initiator'))
+			->setValue('share_with', $qb->createNamedParameter('group1'))
+			->setValue('item_type', $qb->createNamedParameter('file'))
+			->setValue('item_source', $qb->createNamedParameter(42))
+			->setValue('file_source', $qb->createNamedParameter(42))
+			->setValue('permissions', $qb->createNamedParameter(19));
+		$qb->execute();
+		$id = $qb->getLastInsertId();
+
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->insert('share')
+			->setValue('share_type', $qb->createNamedParameter(2))
+			->setValue('uid_owner', $qb->createNamedParameter('owner'))
+			->setValue('uid_initiator', $qb->createNamedParameter('initiator'))
+			->setValue('share_with', $qb->createNamedParameter('user1'))
+			->setValue('item_type', $qb->createNamedParameter('file'))
+			->setValue('item_source', $qb->createNamedParameter(42))
+			->setValue('file_source', $qb->createNamedParameter(42))
+			->setValue('permissions', $qb->createNamedParameter(0))
+			->setValue('parent', $qb->createNamedParameter($id));
+		$qb->execute();
+
+		$share = $this->provider->getShareById($id, $user);
+
+		$this->provider->accept($share, $user);
+
+		$share = $this->provider->getShareById($id, $user);
+
+		$this->assertSame(19, $share->getPermissions());
+	}
 }

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -2771,6 +2771,33 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertCount(2, $shares);
 		$this->assertSame($shares, [$share1, $share2]);
 	}
+
+	public function testAcceptShare() {
+		$share = $this->manager->newShare();
+		$share->setShareType(\OCP\Share::SHARE_TYPE_GROUP)
+			->setId('42')
+			->setProviderId('foo');
+
+		$this->defaultProvider->expects($this->once())
+			->method('accept')
+			->with(
+				$this->equalTo($share),
+				$this->equalTo('recipient')
+			);
+
+		$this->manager->acceptShare($share, 'recipient');
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 * @expectedExceptionMessage (re-)Accepting shares only implemeneted for group shares
+	 */
+	public function testAcceptShareInvalid() {
+		$share = $this->manager->newShare();
+		$share->setShareType(\OCP\Share::SHARE_TYPE_USER);
+
+		$this->manager->acceptShare($share, 'recipient');
+	}
 }
 
 class DummyPassword {


### PR DESCRIPTION
This adds new endpoints to list pending shares. So far pending shares are only deleted group shares.

The endpoints are:
- GET `../apps/files_sharing/api/v1/shares/pending`: Listing all pending shares
- GET `../apps/files_sharing/api/v1/shares/pending/<FULLSHAREID>`: Get info on 1 pending share
- POST ``../apps/files_sharing/api/v1/shares/pending/<FULLSHAREID>`: (re)-Accept pending share

This allows the user to accept a pending share.

In order to do so new methods have been added to the ShareManager and the ShareProviders
