### PR TITLE
solves problem with moving files via WebDAV

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -726,7 +726,7 @@ class View {
 						$result = false;
 					}
 					// moving a file/folder within the same mount point
-				} elseif ($storage1 == $storage2) {
+				} elseif ($storage1 === $storage2) {
 					if ($storage1) {
 						$result = $storage1->rename($internalPath1, $internalPath2);
 					} else {


### PR DESCRIPTION
When moving files via WebDAV I sometimes got 

PHP Fatal error:  Nesting level too deep - recursive dependency? in /var/www/owncloud/lib/private/files/view.php on line 729

This small change has fixed the problem for me

Fix #24318
