### PR TITLE
[stable8.2] Make update server URL configurable

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -473,6 +473,11 @@ $CONFIG = array(
 'updatechecker' => true,
 
 /**
+ * URL that ownCloud should use to look for updates
+ */
+'updater.server.url' => 'https://updates.owncloud.com/server/',
+
+/**
  * Is ownCloud connected to the Internet or running in a closed network?
  */
 'has_internet_connection' => true,

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -126,19 +126,16 @@ class Updater extends BasicEmitter {
 	/**
 	 * Check if a new version is available
 	 *
-	 * @param string $updaterUrl the url to check, i.e. 'http://apps.owncloud.com/updater.php'
 	 * @return array|bool
 	 */
-	public function check($updaterUrl = null) {
+	public function check() {
 
 		// Look up the cache - it is invalidated all 30 minutes
 		if (((int)$this->config->getAppValue('core', 'lastupdatedat') + 1800) > time()) {
 			return json_decode($this->config->getAppValue('core', 'lastupdateResult'), true);
 		}
 
-		if (is_null($updaterUrl)) {
-			$updaterUrl = 'https://updates.owncloud.com/server/';
-		}
+		$updaterUrl = $this->config->getSystemValue('updater.server.url', 'https://updates.owncloud.com/server/');
 
 		$this->config->setAppValue('core', 'lastupdatedat', time());
 

--- a/tests/lib/updater.php
+++ b/tests/lib/updater.php
@@ -202,20 +202,25 @@ class UpdaterTest extends \Test\TestCase {
 			->will($this->returnValue(0));
 		$this->config
 			->expects($this->at(1))
+			->method('getSystemValue')
+			->with('updater.server.url', 'https://updates.owncloud.com/server/')
+			->willReturn('https://updates.owncloud.com/server/');
+		$this->config
+			->expects($this->at(2))
 			->method('setAppValue')
 			->with('core', 'lastupdatedat', $this->isType('integer'));
 		$this->config
-			->expects($this->at(3))
+			->expects($this->at(4))
 			->method('getAppValue')
 			->with('core', 'installedat')
 			->will($this->returnValue('installedat'));
 		$this->config
-			->expects($this->at(4))
+			->expects($this->at(5))
 			->method('getAppValue')
 			->with('core', 'lastupdatedat')
 			->will($this->returnValue('lastupdatedat'));
 		$this->config
-			->expects($this->at(5))
+			->expects($this->at(6))
 			->method('setAppValue')
 			->with('core', 'lastupdateResult', json_encode($expectedResult));
 
@@ -243,20 +248,25 @@ class UpdaterTest extends \Test\TestCase {
 			->will($this->returnValue(0));
 		$this->config
 			->expects($this->at(1))
+			->method('getSystemValue')
+			->with('updater.server.url', 'https://updates.owncloud.com/server/')
+			->willReturn('https://updates.owncloud.com/server/');
+		$this->config
+			->expects($this->at(2))
 			->method('setAppValue')
 			->with('core', 'lastupdatedat', $this->isType('integer'));
 		$this->config
-			->expects($this->at(3))
+			->expects($this->at(4))
 			->method('getAppValue')
 			->with('core', 'installedat')
 			->will($this->returnValue('installedat'));
 		$this->config
-			->expects($this->at(4))
+			->expects($this->at(5))
 			->method('getAppValue')
 			->with('core', 'lastupdatedat')
 			->will($this->returnValue('lastupdatedat'));
 		$this->config
-			->expects($this->at(5))
+			->expects($this->at(6))
 			->method('setAppValue')
 			->with('core', 'lastupdateResult', 'false');
 
@@ -268,54 +278,6 @@ class UpdaterTest extends \Test\TestCase {
 			->will($this->returnValue($updateXml));
 
 		$this->assertSame([], $this->updater->check());
-	}
-
-	public function testCheckWithUpdateUrl() {
-		$expectedResult = [
-			'version' => '8.0.4.2',
-			'versionstring' => 'ownCloud 8.0.4',
-			'url' => 'https://download.owncloud.org/community/owncloud-8.0.4.zip',
-			'web' => 'http://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
-		];
-
-		$this->config
-			->expects($this->at(0))
-			->method('getAppValue')
-			->with('core', 'lastupdatedat')
-			->will($this->returnValue(0));
-		$this->config
-			->expects($this->at(1))
-			->method('setAppValue')
-			->with('core', 'lastupdatedat', $this->isType('integer'));
-		$this->config
-			->expects($this->at(3))
-			->method('getAppValue')
-			->with('core', 'installedat')
-			->will($this->returnValue('installedat'));
-		$this->config
-			->expects($this->at(4))
-			->method('getAppValue')
-			->with('core', 'lastupdatedat')
-			->will($this->returnValue('lastupdatedat'));
-		$this->config
-			->expects($this->at(5))
-			->method('setAppValue')
-			->with('core', 'lastupdateResult', json_encode($expectedResult));
-
-		$updateXml = '<?xml version="1.0"?>
-<owncloud>
-  <version>8.0.4.2</version>
-  <versionstring>ownCloud 8.0.4</versionstring>
-  <url>https://download.owncloud.org/community/owncloud-8.0.4.zip</url>
-  <web>http://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html</web>
-</owncloud>';
-		$this->httpHelper
-			->expects($this->once())
-			->method('getUrlContent')
-			->with($this->buildUpdateUrl('https://myupdater.com/'))
-			->will($this->returnValue($updateXml));
-
-		$this->assertSame($expectedResult, $this->updater->check('https://myupdater.com/'));
 	}
 
 	public function testCheckWithEmptyValidXmlResponse() {
@@ -333,15 +295,20 @@ class UpdaterTest extends \Test\TestCase {
 			->will($this->returnValue(0));
 		$this->config
 			->expects($this->at(1))
+			->method('getSystemValue')
+			->with('updater.server.url', 'https://updates.owncloud.com/server/')
+			->willReturn('https://updates.owncloud.com/server/');
+		$this->config
+			->expects($this->at(2))
 			->method('setAppValue')
 			->with('core', 'lastupdatedat', $this->isType('integer'));
 		$this->config
-			->expects($this->at(3))
+			->expects($this->at(4))
 			->method('getAppValue')
 			->with('core', 'installedat')
 			->will($this->returnValue('installedat'));
 		$this->config
-			->expects($this->at(4))
+			->expects($this->at(5))
 			->method('getAppValue')
 			->with('core', 'lastupdatedat')
 			->will($this->returnValue('lastupdatedat'));
@@ -372,20 +339,25 @@ class UpdaterTest extends \Test\TestCase {
 			->will($this->returnValue(0));
 		$this->config
 			->expects($this->at(1))
+			->method('getSystemValue')
+			->with('updater.server.url', 'https://updates.owncloud.com/server/')
+			->willReturn('https://updates.owncloud.com/server/');
+		$this->config
+			->expects($this->at(2))
 			->method('setAppValue')
 			->with('core', 'lastupdatedat', $this->isType('integer'));
 		$this->config
-			->expects($this->at(3))
+			->expects($this->at(4))
 			->method('getAppValue')
 			->with('core', 'installedat')
 			->will($this->returnValue('installedat'));
 		$this->config
-			->expects($this->at(4))
+			->expects($this->at(5))
 			->method('getAppValue')
 			->with('core', 'lastupdatedat')
 			->will($this->returnValue('lastupdatedat'));
 		$this->config
-			->expects($this->at(5))
+			->expects($this->at(6))
 			->method('setAppValue')
 			->with('core', 'lastupdateResult', json_encode($expectedResult));
 


### PR DESCRIPTION
Currently testing the updates is a big problem and not really super easy possible. Since we now have a new updater server we should also make this configurable so that people can properly test updates.
