### PR TITLE
Don't rely on the notify socket but on the service responding

### DIFF
--- a/apps/files_external/tests/env/start-swift-ceph.sh
+++ b/apps/files_external/tests/env/start-swift-ceph.sh
@@ -74,6 +74,11 @@ if [[ $ready != 'READY=1' ]]; then
     docker logs $container
     exit 1
 fi
+if ! "$thisFolder"/env/wait-for-connection ${host} 80 600; then
+    echo "[ERROR] Waited 600 seconds, no response" >&2
+    docker logs $container
+    exit 1
+fi
 echo "Waiting another 15 seconds"
 sleep 15
 

--- a/autotest.sh
+++ b/autotest.sh
@@ -192,8 +192,8 @@ function execute_tests {
 			DATABASEHOST=$(docker inspect --format="{{.NetworkSettings.IPAddress}}" "$DOCKER_CONTAINER_ID")
 
 			echo "Waiting for MySQL initialisation ..."
-			if ! apps/files_external/tests/env/wait-for-connection $DATABASEHOST 3306 60; then
-				echo "[ERROR] Waited 60 seconds, no response" >&2
+			if ! apps/files_external/tests/env/wait-for-connection $DATABASEHOST 3306 600; then
+				echo "[ERROR] Waited 600 seconds, no response" >&2
 				exit 1
 			fi
 
@@ -221,8 +221,8 @@ function execute_tests {
 			DATABASEHOST=$(docker inspect --format="{{.NetworkSettings.IPAddress}}" "$DOCKER_CONTAINER_ID")
 
 			echo "Waiting for MariaDB initialisation ..."
-			if ! apps/files_external/tests/env/wait-for-connection $DATABASEHOST 3306 60; then
-				echo "[ERROR] Waited 60 seconds, no response" >&2
+			if ! apps/files_external/tests/env/wait-for-connection $DATABASEHOST 3306 600; then
+				echo "[ERROR] Waited 600 seconds, no response" >&2
 				exit 1
 			fi
 


### PR DESCRIPTION
Let's try to fight this one ....

```
05:47:08 Digest: sha256:ec4c5c087a1802678ae90043687ea616a2465cad399c1d23114c8b47e03737f8
05:47:08 Status: Image is up to date for xenopathic/ceph-keystone:latest
05:47:09 xenopathic/ceph-keystone container: ac672de348f3ece4391d772b2223e60e955cd4846cf45d2874ed6eb3a087ddff
05:47:09 Waiting for ceph initialization
05:47:34 Waiting another 15 seconds
05:47:49 PHPUnit 4.8.24 by Sebastian Bergmann and contributors.
05:47:49 
05:47:49 Runtime:   PHP 5.6.20-0+deb8u1 with Xdebug 2.2.5
05:47:49 Configuration: /var/lib/jenkins/jenkins-slave/workspace/server-master-linux-externals/database/sqlite/external/swift-ceph/label/SLAVE/tests/phpunit-autotest-external.xml
05:47:49 
05:47:55 SEEEEE........................................................... 65 / 80 ( 81%)
05:54:34 ...............
05:55:39 
05:55:39 Time: 7.83 minutes, Memory: 64.00Mb
05:55:39 
05:55:39 There were 5 errors:
05:55:39 
05:55:39 1) OCA\Files_External\Tests\Storage\SwiftTest::testRoot
05:55:39 Guzzle\Http\Exception\CurlException: [curl] 7: Failed to connect to 172.17.0.125 port 80: Connection refused [url] http://172.17.0.125/swift/v1/swift
05:55:39 
05:55:39 /var/lib/jenkins/jenkins-slave/workspace/server-master-linux-externals/database/sqlite/external/swift-ceph/label/SLAVE/3rdparty/guzzle/http/Guzzle/Http/Curl/CurlMulti.php:338
05:55:39 /var/lib/jenkins/jenkins-slave/workspace/server-master-linux-externals/database/sqlite/external/swift-ceph/label/SLAVE/3rdparty/guzzle/http/Guzzle/Http/Curl/CurlMulti.php:279
05:55:39 /var/lib/jenkins/jenkins-slave/workspace/server-master-linux-externals/database/sqlite/external/swift-ceph/label/SLAVE/3rdparty/guzzle/http/Guzzle/Http/Curl/CurlMulti.php:244
05:55:39 /var/lib/jenkins/jenkins-slave/workspace/server-master-linux-externals/database/sqlite/external/swift-ceph/label/SLAVE/3rdparty/guzzle/http/Guzzle/Http/Curl/CurlMulti.php:227
05:55:39 /var/lib/jenkins/jenkins-slave/workspace/server-master-linux-externals/database/sqlite/external/swift-ceph/label/SLAVE/3rdparty/guzzle/http/Guzzle/Http/Curl/CurlMulti.php:211
05:55:39 /var/lib/jenkins/jenkins-slave/workspace/server-master-linux-externals/database/sqlite/external/swift-ceph/label/SLAVE/3rdparty/guzzle/http/Guzzle/Http/Curl/CurlMulti.php:105
05:55:39 /var/lib/jenkins/jenkins-slave/workspace/server-master-linux-externals/database/sqlite/external/swift-ceph/label/SLAVE/3rdparty/guzzle/http/Guzzle/Http/Curl/CurlMultiProxy.php:91
05:55:39 /var/lib/jenkins/jenkins-slave/workspace/server-master-linux-externals/database/sqlite/external/swift-ceph/label/SLAVE/3rdparty/guzzle/http/Guzzle/Http/Client.php:282
05:55:39 /var/lib/jenkins/jenkins-slave/workspace/server-master-linux-externals/database/sqlite/external/swift-ceph/label/SLAVE/3rdparty/guzzle/http/Guzzle/Http/Message/Request.php:198
05:55:39 /var/lib/jenkins/jenkins-slave/workspace/server-master-linux-externals/database/sqlite/external/swift-ceph/label/SLAVE/3rdparty/rackspace/php-opencloud/lib/OpenCloud/ObjectStore
```
