### PR TITLE
[8.2] Catch the AutoloadNotAllowedException also for legacy jobs

### DIFF
--- a/lib/private/backgroundjob/legacy/regularjob.php
+++ b/lib/private/backgroundjob/legacy/regularjob.php
@@ -22,10 +22,17 @@
 
 namespace OC\BackgroundJob\Legacy;
 
+use OCP\AutoloadNotAllowedException;
+
 class RegularJob extends \OC\BackgroundJob\Job {
 	public function run($argument) {
-		if (is_callable($argument)) {
-			call_user_func($argument);
+		try {
+			if (is_callable($argument)) {
+				call_user_func($argument);
+			}
+		} catch (AutoloadNotAllowedException $e) {
+			// job is from a disabled app, ignore
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/23901

Fix https://github.com/owncloud/core/issues/24487

@karlitschek goes against 8.2, we already backported to 9.0 with your approval: https://github.com/owncloud/core/pull/23901#issuecomment-208289780

So I guess this is okay as well.

@PVince81 @MorrisJobke @mokkin
