### PR TITLE
[stable8] Make update server URL configurable

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -432,6 +432,11 @@ $CONFIG = array(
 'updatechecker' => true,
 
 /**
+ * URL that ownCloud should use to look for updates
+ */
+'updater.server.url' => 'https://updates.owncloud.com/server/',
+
+/**
  * Is ownCloud connected to the Internet or running in a closed network?
  */
 'has_internet_connection' => true,

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -98,19 +98,16 @@ class Updater extends BasicEmitter {
 	/**
 	 * Check if a new version is available
 	 *
-	 * @param string $updaterUrl the url to check, i.e. 'https://updates.owncloud.com/server/'
 	 * @return array|bool
 	 */
-	public function check($updaterUrl = null) {
+	public function check() {
 
 		// Look up the cache - it is invalidated all 30 minutes
 		if (((int)$this->config->getAppValue('core', 'lastupdatedat') + 1800) > time()) {
 			return json_decode($this->config->getAppValue('core', 'lastupdateResult'), true);
 		}
 
-		if (is_null($updaterUrl)) {
-			$updaterUrl = 'https://updates.owncloud.com/server/';
-		}
+		$updaterUrl = $this->config->getSystemValue('updater.server.url', 'https://updates.owncloud.com/server/');
 
 		$this->config->setAppValue('core', 'lastupdatedat', time());
 

--- a/tests/lib/updater.php
+++ b/tests/lib/updater.php
@@ -50,7 +50,7 @@ class UpdaterTest extends \Test\TestCase {
 
 	public function testValidEmptyXmlResponse(){
 		$updater = $this->getUpdaterMock(
-				'<?xml version="1.0"?><owncloud><version></version><versionstring></versionstring><url></url><web></web></owncloud>'
+			'<?xml version="1.0"?><owncloud><version></version><versionstring></versionstring><url></url><web></web></owncloud>'
 		);
 		$result = array_map('strval', $updater->check());
 
@@ -66,7 +66,7 @@ class UpdaterTest extends \Test\TestCase {
 
 	public function testValidUpdateResponse(){
 		$newUpdater = $this->getUpdaterMock(
-				'<?xml version="1.0"?>
+			'<?xml version="1.0"?>
 <owncloud>
   <version>7.0.3.4</version>
   <versionstring>ownCloud 7.0.3</versionstring>
@@ -89,14 +89,14 @@ class UpdaterTest extends \Test\TestCase {
 	protected function getUpdaterMock($content){
 		// Invalidate cache
 		$mockedConfig = $this->getMockBuilder('\OCP\IConfig')
-				->disableOriginalConstructor()
-				->getMock()
+			->disableOriginalConstructor()
+			->getMock()
 		;
 
 		$certificateManager = $this->getMock('\OCP\ICertificateManager');
 		$mockedHTTPHelper = $this->getMockBuilder('\OC\HTTPHelper')
-				->setConstructorArgs(array(\OC::$server->getConfig(), $certificateManager))
-				->getMock()
+			->setConstructorArgs(array(\OC::$server->getConfig(), $certificateManager))
+			->getMock()
 		;
 
 		$mockedHTTPHelper->expects($this->once())->method('getUrlContent')->will($this->returnValue($content));


### PR DESCRIPTION
Currently testing the updates is a big problem and not really super easy possible. Since we now have a new updater server we should also make this configurable so that people can properly test updates.
