### PR TITLE
Update google-api-php-client to 1.1.7

### DIFF
--- a/apps/files_external/3rdparty/google-api-php-client/README.md
+++ b/apps/files_external/3rdparty/google-api-php-client/README.md
@@ -25,10 +25,13 @@ For the latest installation and setup instructions, see [the documentation](http
 See the examples/ directory for examples of the key client features.
 ```PHP
 <?php
-  require_once 'google-api-php-client/autoload.php'; // or wherever autoload.php is located
+
+  require_once 'google-api-php-client/src/Google/autoload.php'; // or wherever autoload.php is located
+  
   $client = new Google_Client();
   $client->setApplicationName("Client_Library_Examples");
   $client->setDeveloperKey("YOUR_APP_KEY");
+  
   $service = new Google_Service_Books($client);
   $optParams = array('filter' => 'free-ebooks');
   $results = $service->volumes->listVolumes('Henry David Thoreau', $optParams);
@@ -36,7 +39,12 @@ See the examples/ directory for examples of the key client features.
   foreach ($results as $item) {
     echo $item['volumeInfo']['title'], "<br /> \n";
   }
+  
 ```
+
+### Service Specific Examples ###
+
+YouTube: https://github.com/youtube/api-samples/tree/master/php
 
 ## Frequently Asked Questions ##
 
@@ -49,6 +57,10 @@ If there is a specific bug with the library, please file a issue in the Github i
 ### How do I contribute? ###
 
 We accept contributions via Github Pull Requests, but all contributors need to be covered by the standard Google Contributor License Agreement. You can find links, and more instructions, in the documentation: https://developers.google.com/api-client-library/php/contribute
+
+### I want an example of X! ### 
+
+If X is a feature of the library, file away! If X is an example of using a specific service, the best place to go is to the teams for those specific APIs - our preference is to link to their examples rather than add them to the library, as they can then pin to specific versions of the library. If you have any examples for other APIs, let us know and we will happily add a link to the README above!
 
 ### Why do you still support 5.2? ###
 
@@ -68,10 +80,26 @@ $opt_params = array(
 );
 ```
 
+### How do I set a field to null? ###
+
+The library strips out nulls from the objects sent to the Google APIs as its the default value of all of the uninitialised properties. To work around this, set the field you want to null to Google_Model::NULL_VALUE. This is a placeholder that will be replaced with a true null when sent over the wire.
+
 ## Code Quality ##
 
-Copy the ruleset.xml in style/ into a new directory named GAPI/ in your
-/usr/share/php/PHP/CodeSniffer/Standards (or appropriate equivalent directory),
-and run code sniffs with:
+Run the PHPUnit tests with PHPUnit. You can configure an API key and token in BaseTest.php to run all calls, but this will require some setup on the Google Developer Console.
 
-        phpcs --standard=GAPI src/
+    phpunit tests/
+
+### Coding Style
+
+To check for coding style violations, run
+
+```
+vendor/bin/phpcs src --standard=style/ruleset.xml -np 
+```
+
+To automatically fix (fixable) coding style violations, run  
+
+```
+vendor/bin/phpcbf src --standard=style/ruleset.xml
+```

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/Abstract.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/Abstract.php
@@ -14,7 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-require_once "Google/Http/Request.php";
+
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
 
 /**
  * Abstract class for the Authentication in the API client

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/AppIdentity.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/AppIdentity.php
@@ -1,0 +1,120 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * WARNING - this class depends on the Google App Engine PHP library
+ * which is 5.3 and above only, so if you include this in a PHP 5.2
+ * setup or one without 5.3 things will blow up.
+ */
+use google\appengine\api\app_identity\AppIdentityService;
+
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
+
+/**
+ * Authentication via the Google App Engine App Identity service.
+ */
+class Google_Auth_AppIdentity extends Google_Auth_Abstract
+{
+  const CACHE_PREFIX = "Google_Auth_AppIdentity::";
+  private $client;
+  private $token = false;
+  private $tokenScopes = false;
+
+  public function __construct(Google_Client $client, $config = null)
+  {
+    $this->client = $client;
+  }
+
+  /**
+   * Retrieve an access token for the scopes supplied.
+   */
+  public function authenticateForScope($scopes)
+  {
+    if ($this->token && $this->tokenScopes == $scopes) {
+      return $this->token;
+    }
+
+    $cacheKey = self::CACHE_PREFIX;
+    if (is_string($scopes)) {
+      $cacheKey .= $scopes;
+    } else if (is_array($scopes)) {
+      $cacheKey .= implode(":", $scopes);
+    }
+
+    $this->token = $this->client->getCache()->get($cacheKey);
+    if (!$this->token) {
+      $this->retrieveToken($scopes, $cacheKey);
+    } else if ($this->token['expiration_time'] < time()) {
+      $this->client->getCache()->delete($cacheKey);
+      $this->retrieveToken($scopes, $cacheKey);
+    }
+
+    $this->tokenScopes = $scopes;
+    return $this->token;
+  }
+
+  /**
+   * Retrieve a new access token and store it in cache
+   * @param mixed $scopes
+   * @param string $cacheKey
+   */
+  private function retrieveToken($scopes, $cacheKey)
+  {
+    $this->token = AppIdentityService::getAccessToken($scopes);
+    if ($this->token) {
+      $this->client->getCache()->set(
+          $cacheKey,
+          $this->token
+      );
+    }
+  }
+
+  /**
+   * Perform an authenticated / signed apiHttpRequest.
+   * This function takes the apiHttpRequest, calls apiAuth->sign on it
+   * (which can modify the request in what ever way fits the auth mechanism)
+   * and then calls apiCurlIO::makeRequest on the signed request
+   *
+   * @param Google_Http_Request $request
+   * @return Google_Http_Request The resulting HTTP response including the
+   * responseHttpCode, responseHeaders and responseBody.
+   */
+  public function authenticatedRequest(Google_Http_Request $request)
+  {
+    $request = $this->sign($request);
+    return $this->client->getIo()->makeRequest($request);
+  }
+
+  public function sign(Google_Http_Request $request)
+  {
+    if (!$this->token) {
+      // No token, so nothing to do.
+      return $request;
+    }
+
+    $this->client->getLogger()->debug('App Identity authentication');
+
+    // Add the OAuth2 header to the request
+    $request->setRequestHeaders(
+        array('Authorization' => 'Bearer ' . $this->token['access_token'])
+    );
+
+    return $request;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/AssertionCredentials.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/AssertionCredentials.php
@@ -15,14 +15,12 @@
  * limitations under the License.
  */
 
-require_once "Google/Auth/OAuth2.php";
-require_once "Google/Signer/P12.php";
-require_once "Google/Utils.php";
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
 
 /**
  * Credentials object used for OAuth 2.0 Signed JWT assertion grants.
- *
- * @author Chirag Shah <chirags@google.com>
  */
 class Google_Auth_AssertionCredentials
 {

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/ComputeEngine.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/ComputeEngine.php
@@ -1,0 +1,146 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
+
+/**
+ * Authentication via built-in Compute Engine service accounts.
+ * The instance must be pre-configured with a service account
+ * and the appropriate scopes.
+ * @author Jonathan Parrott <jon.wayne.parrott@gmail.com>
+ */
+class Google_Auth_ComputeEngine extends Google_Auth_Abstract
+{
+  const METADATA_AUTH_URL =
+      'http://metadata/computeMetadata/v1/instance/service-accounts/default/token';
+  private $client;
+  private $token;
+
+  public function __construct(Google_Client $client, $config = null)
+  {
+    $this->client = $client;
+  }
+
+  /**
+   * Perform an authenticated / signed apiHttpRequest.
+   * This function takes the apiHttpRequest, calls apiAuth->sign on it
+   * (which can modify the request in what ever way fits the auth mechanism)
+   * and then calls apiCurlIO::makeRequest on the signed request
+   *
+   * @param Google_Http_Request $request
+   * @return Google_Http_Request The resulting HTTP response including the
+   * responseHttpCode, responseHeaders and responseBody.
+   */
+  public function authenticatedRequest(Google_Http_Request $request)
+  {
+    $request = $this->sign($request);
+    return $this->client->getIo()->makeRequest($request);
+  }
+
+  /**
+   * @param string $token
+   * @throws Google_Auth_Exception
+   */
+  public function setAccessToken($token)
+  {
+    $token = json_decode($token, true);
+    if ($token == null) {
+      throw new Google_Auth_Exception('Could not json decode the token');
+    }
+    if (! isset($token['access_token'])) {
+      throw new Google_Auth_Exception("Invalid token format");
+    }
+    $token['created'] = time();
+    $this->token = $token;
+  }
+
+  public function getAccessToken()
+  {
+    return json_encode($this->token);
+  }
+
+  /**
+   * Acquires a new access token from the compute engine metadata server.
+   * @throws Google_Auth_Exception
+   */
+  public function acquireAccessToken()
+  {
+    $request = new Google_Http_Request(
+        self::METADATA_AUTH_URL,
+        'GET',
+        array(
+          'Metadata-Flavor' => 'Google'
+        )
+    );
+    $request->disableGzip();
+    $response = $this->client->getIo()->makeRequest($request);
+
+    if ($response->getResponseHttpCode() == 200) {
+      $this->setAccessToken($response->getResponseBody());
+      $this->token['created'] = time();
+      return $this->getAccessToken();
+    } else {
+      throw new Google_Auth_Exception(
+          sprintf(
+              "Error fetching service account access token, message: '%s'",
+              $response->getResponseBody()
+          ),
+          $response->getResponseHttpCode()
+      );
+    }
+  }
+
+  /**
+   * Include an accessToken in a given apiHttpRequest.
+   * @param Google_Http_Request $request
+   * @return Google_Http_Request
+   * @throws Google_Auth_Exception
+   */
+  public function sign(Google_Http_Request $request)
+  {
+    if ($this->isAccessTokenExpired()) {
+      $this->acquireAccessToken();
+    }
+
+    $this->client->getLogger()->debug('Compute engine service account authentication');
+
+    $request->setRequestHeaders(
+        array('Authorization' => 'Bearer ' . $this->token['access_token'])
+    );
+
+    return $request;
+  }
+
+  /**
+   * Returns if the access_token is expired.
+   * @return bool Returns True if the access_token is expired.
+   */
+  public function isAccessTokenExpired()
+  {
+    if (!$this->token || !isset($this->token['created'])) {
+      return true;
+    }
+
+    // If the token is set to expire in the next 30 seconds.
+    $expired = ($this->token['created']
+        + ($this->token['expires_in'] - 30)) < time();
+
+    return $expired;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/Exception.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/Exception.php
@@ -15,7 +15,9 @@
  * limitations under the License.
  */
 
-require_once "Google/Exception.php";
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
 
 class Google_Auth_Exception extends Google_Exception
 {

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/LoginTicket.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/LoginTicket.php
@@ -15,7 +15,9 @@
  * limitations under the License.
  */
 
-require_once "Google/Auth/Exception.php";
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
 
 /**
  * Class to hold information about an authenticated login.

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/Simple.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/Simple.php
@@ -15,19 +15,17 @@
  * limitations under the License.
  */
 
-require_once "Google/Auth/Abstract.php";
-require_once "Google/Http/Request.php";
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
 
 /**
  * Simple API access implementation. Can either be used to make requests
  * completely unauthenticated, or by using a Simple API Access developer
  * key.
- * @author Chris Chabot <chabotc@google.com>
- * @author Chirag Shah <chirags@google.com>
  */
 class Google_Auth_Simple extends Google_Auth_Abstract
 {
-  private $key = null;
   private $client;
 
   public function __construct(Google_Client $client, $config = null)
@@ -55,6 +53,9 @@ class Google_Auth_Simple extends Google_Auth_Abstract
   {
     $key = $this->client->getClassConfig($this, 'developer_key');
     if ($key) {
+      $this->client->getLogger()->debug(
+          'Simple API Access developer key authentication'
+      );
       $request->setQueryParam('key', $key);
     }
     return $request;

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Cache/Apc.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Cache/Apc.php
@@ -14,9 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-require_once "Google/Cache/Abstract.php";
-require_once "Google/Cache/Exception.php";
+
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
 
 /**
  * A persistent storage class based on the APC cache, which is not
@@ -28,11 +29,21 @@ require_once "Google/Cache/Exception.php";
  */
 class Google_Cache_Apc extends Google_Cache_Abstract
 {
+  /**
+   * @var Google_Client the current client
+   */
+  private $client;
+
   public function __construct(Google_Client $client)
   {
     if (! function_exists('apc_add') ) {
-      throw new Google_Cache_Exception("Apc functions not available");
+      $error = "Apc functions not available";
+
+      $client->getLogger()->error($error);
+      throw new Google_Cache_Exception($error);
     }
+
+    $this->client = $client;
   }
 
    /**
@@ -42,12 +53,26 @@ class Google_Cache_Apc extends Google_Cache_Abstract
   {
     $ret = apc_fetch($key);
     if ($ret === false) {
+      $this->client->getLogger()->debug(
+          'APC cache miss',
+          array('key' => $key)
+      );
       return false;
     }
     if (is_numeric($expiration) && (time() - $ret['time'] > $expiration)) {
+      $this->client->getLogger()->debug(
+          'APC cache miss (expired)',
+          array('key' => $key, 'var' => $ret)
+      );
       $this->delete($key);
       return false;
     }
+
+    $this->client->getLogger()->debug(
+        'APC cache hit',
+        array('key' => $key, 'var' => $ret)
+    );
+
     return $ret['data'];
   }
 
@@ -56,10 +81,21 @@ class Google_Cache_Apc extends Google_Cache_Abstract
    */
   public function set($key, $value)
   {
-    $rc = apc_store($key, array('time' => time(), 'data' => $value));
+    $var = array('time' => time(), 'data' => $value);
+    $rc = apc_store($key, $var);
+
     if ($rc == false) {
+      $this->client->getLogger()->error(
+          'APC cache set failed',
+          array('key' => $key, 'var' => $var)
+      );
       throw new Google_Cache_Exception("Couldn't store data");
     }
+
+    $this->client->getLogger()->debug(
+        'APC cache set',
+        array('key' => $key, 'var' => $var)
+    );
   }
 
   /**
@@ -68,6 +104,10 @@ class Google_Cache_Apc extends Google_Cache_Abstract
    */
   public function delete($key)
   {
+    $this->client->getLogger()->debug(
+        'APC cache delete',
+        array('key' => $key)
+    );
     apc_delete($key);
   }
 }

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Cache/Exception.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Cache/Exception.php
@@ -14,7 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-require_once "Google/Exception.php";
+
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
 
 class Google_Cache_Exception extends Google_Exception
 {

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Cache/Memcache.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Cache/Memcache.php
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-require_once "Google/Cache/Abstract.php";
-require_once "Google/Cache/Exception.php";
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
 
 /**
  * A persistent storage class based on the memcache, which is not
@@ -35,11 +36,22 @@ class Google_Cache_Memcache extends Google_Cache_Abstract
   private $host;
   private $port;
 
+  /**
+   * @var Google_Client the current client
+   */
+  private $client;
+
   public function __construct(Google_Client $client)
   {
     if (!function_exists('memcache_connect') && !class_exists("Memcached")) {
-      throw new Google_Cache_Exception("Memcache functions not available");
+      $error = "Memcache functions not available";
+
+      $client->getLogger()->error($error);
+      throw new Google_Cache_Exception($error);
     }
+
+    $this->client = $client;
+
     if ($client->isAppEngine()) {
       // No credentials needed for GAE.
       $this->mc = new Memcached();
@@ -48,11 +60,14 @@ class Google_Cache_Memcache extends Google_Cache_Abstract
       $this->host = $client->getClassConfig($this, 'host');
       $this->port = $client->getClassConfig($this, 'port');
       if (empty($this->host) || (empty($this->port) && (string) $this->port != "0")) {
-        throw new Google_Cache_Exception("You need to supply a valid memcache host and port");
+        $error = "You need to supply a valid memcache host and port";
+
+        $client->getLogger()->error($error);
+        throw new Google_Cache_Exception($error);
       }
     }
   }
-  
+
   /**
    * @inheritDoc
    */
@@ -66,12 +81,26 @@ class Google_Cache_Memcache extends Google_Cache_Abstract
       $ret = memcache_get($this->connection, $key);
     }
     if ($ret === false) {
+      $this->client->getLogger()->debug(
+          'Memcache cache miss',
+          array('key' => $key)
+      );
       return false;
     }
     if (is_numeric($expiration) && (time() - $ret['time'] > $expiration)) {
+      $this->client->getLogger()->debug(
+          'Memcache cache miss (expired)',
+          array('key' => $key, 'var' => $ret)
+      );
       $this->delete($key);
       return false;
     }
+
+    $this->client->getLogger()->debug(
+        'Memcache cache hit',
+        array('key' => $key, 'var' => $ret)
+    );
+
     return $ret['data'];
   }
 
@@ -94,8 +123,18 @@ class Google_Cache_Memcache extends Google_Cache_Abstract
       $rc = memcache_set($this->connection, $key, $data, false);
     }
     if ($rc == false) {
+      $this->client->getLogger()->error(
+          'Memcache cache set failed',
+          array('key' => $key, 'var' => $data)
+      );
+
       throw new Google_Cache_Exception("Couldn't store data in cache");
     }
+
+    $this->client->getLogger()->debug(
+        'Memcache cache set',
+        array('key' => $key, 'var' => $data)
+    );
   }
 
   /**
@@ -110,11 +149,16 @@ class Google_Cache_Memcache extends Google_Cache_Abstract
     } else {
       memcache_delete($this->connection, $key, 0);
     }
+
+    $this->client->getLogger()->debug(
+        'Memcache cache delete',
+        array('key' => $key)
+    );
   }
 
   /**
-   * Lazy initialiser for memcache connection. Uses pconnect for to take 
-   * advantage of the persistence pool where possible. 
+   * Lazy initialiser for memcache connection. Uses pconnect for to take
+   * advantage of the persistence pool where possible.
    */
   private function connect()
   {
@@ -129,9 +173,12 @@ class Google_Cache_Memcache extends Google_Cache_Abstract
     } else {
       $this->connection = memcache_pconnect($this->host, $this->port);
     }
-    
+
     if (! $this->connection) {
-      throw new Google_Cache_Exception("Couldn't connect to memcache server");
+      $error = "Couldn't connect to memcache server";
+
+      $this->client->getLogger()->error($error);
+      throw new Google_Cache_Exception($error);
     }
   }
 }

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Cache/Null.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Cache/Null.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
+
+/**
+ * A blank storage class, for cases where caching is not
+ * required.
+ */
+class Google_Cache_Null extends Google_Cache_Abstract
+{
+  public function __construct(Google_Client $client)
+  {
+
+  }
+
+   /**
+   * @inheritDoc
+   */
+  public function get($key, $expiration = false)
+  {
+    return false;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function set($key, $value)
+  {
+    // Nop.
+  }
+
+  /**
+   * @inheritDoc
+   * @param String $key
+   */
+  public function delete($key)
+  {
+    // Nop.
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Client.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Client.php
@@ -15,28 +15,17 @@
  * limitations under the License.
  */
 
-require_once 'Google/Auth/AssertionCredentials.php';
-require_once 'Google/Cache/File.php';
-require_once 'Google/Cache/Memcache.php';
-require_once 'Google/Config.php';
-require_once 'Google/Collection.php';
-require_once 'Google/Exception.php';
-require_once 'Google/IO/Curl.php';
-require_once 'Google/IO/Stream.php';
-require_once 'Google/Model.php';
-require_once 'Google/Service.php';
-require_once 'Google/Service/Resource.php';
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/autoload.php';
+}
 
 /**
  * The Google API Client
- * http://code.google.com/p/google-api-php-client/
- *
- * @author Chris Chabot <chabotc@google.com>
- * @author Chirag Shah <chirags@google.com>
+ * https://github.com/google/google-api-php-client
  */
 class Google_Client
 {
-  const LIBVER = "1.0.6-beta";
+  const LIBVER = "1.1.5";
   const USER_AGENT_SUFFIX = "google-api-php-client/";
   /**
    * @var Google_Auth_Abstract $auth
@@ -57,6 +46,11 @@ class Google_Client
    * @var Google_Config $config
    */
   private $config;
+
+  /**
+   * @var Google_Logger_Abstract $logger
+   */
+  private $logger;
 
   /**
    * @var boolean $deferExecution
@@ -97,7 +91,8 @@ class Google_Client
     }
 
     if ($config->getIoClass() == Google_Config::USE_AUTO_IO_SELECTION) {
-      if (function_exists('curl_version') && function_exists('curl_exec')) {
+      if (function_exists('curl_version') && function_exists('curl_exec')
+          && !$this->isAppEngine()) {
         $config->setIoClass("Google_IO_Curl");
       } else {
         $config->setIoClass("Google_IO_Stream");
@@ -119,15 +114,45 @@ class Google_Client
 
   /**
    * Attempt to exchange a code for an valid authentication token.
+   * If $crossClient is set to true, the request body will not include
+   * the request_uri argument
    * Helper wrapped around the OAuth 2.0 implementation.
    *
    * @param $code string code from accounts.google.com
+   * @param $crossClient boolean, whether this is a cross-client authentication
    * @return string token
    */
-  public function authenticate($code)
+  public function authenticate($code, $crossClient = false)
   {
     $this->authenticated = true;
-    return $this->getAuth()->authenticate($code);
+    return $this->getAuth()->authenticate($code, $crossClient);
+  }
+  
+  /**
+   * Loads a service account key and parameters from a JSON
+   * file from the Google Developer Console. Uses that and the
+   * given array of scopes to return an assertion credential for
+   * use with refreshTokenWithAssertionCredential.
+   *
+   * @param string $jsonLocation File location of the project-key.json.
+   * @param array $scopes The scopes to assert.
+   * @return Google_Auth_AssertionCredentials.
+   * @
+   */
+  public function loadServiceAccountJson($jsonLocation, $scopes)
+  {
+    $data = json_decode(file_get_contents($jsonLocation));
+    if (isset($data->type) && $data->type == 'service_account') {
+      // Service Account format.
+      $cred = new Google_Auth_AssertionCredentials(
+          $data->client_email,
+          $scopes,
+          $data->private_key
+      );
+      return $cred;
+    } else {
+      throw new Google_Exception("Invalid service account JSON file.");
+    }
   }
 
   /**
@@ -136,6 +161,7 @@ class Google_Client
    * the "Download JSON" button on in the Google Developer
    * Console.
    * @param string $json the configuration json
+   * @throws Google_Exception
    */
   public function setAuthConfig($json)
   {
@@ -164,6 +190,7 @@ class Google_Client
   }
 
   /**
+   * @throws Google_Auth_Exception
    * @return array
    * @visible For Testing
    */
@@ -205,9 +232,9 @@ class Google_Client
 
   /**
    * Set the IO object
-   * @param Google_Io_Abstract $auth
+   * @param Google_IO_Abstract $io
    */
-  public function setIo(Google_Io_Abstract $io)
+  public function setIo(Google_IO_Abstract $io)
   {
     $this->config->setIoClass(get_class($io));
     $this->io = $io;
@@ -215,12 +242,22 @@ class Google_Client
 
   /**
    * Set the Cache object
-   * @param Google_Cache_Abstract $auth
+   * @param Google_Cache_Abstract $cache
    */
   public function setCache(Google_Cache_Abstract $cache)
   {
     $this->config->setCacheClass(get_class($cache));
     $this->cache = $cache;
+  }
+
+  /**
+   * Set the Logger object
+   * @param Google_Logger_Abstract $logger
+   */
+  public function setLogger(Google_Logger_Abstract $logger)
+  {
+    $this->config->setLoggerClass(get_class($logger));
+    $this->logger = $logger;
   }
 
   /**
@@ -414,11 +451,10 @@ class Google_Client
   /**
    * Fetches a fresh OAuth 2.0 access token with the given refresh token.
    * @param string $refreshToken
-   * @return void
    */
   public function refreshToken($refreshToken)
   {
-    return $this->getAuth()->refreshToken($refreshToken);
+    $this->getAuth()->refreshToken($refreshToken);
   }
 
   /**
@@ -449,12 +485,12 @@ class Google_Client
   /**
    * Verify a JWT that was signed with your own certificates.
    *
-   * @param $jwt the token
-   * @param $certs array of certificates
-   * @param $required_audience the expected consumer of the token
-   * @param [$issuer] the expected issues, defaults to Google
+   * @param $id_token string The JWT token
+   * @param $cert_location array of certificates
+   * @param $audience string the expected consumer of the token
+   * @param $issuer string the expected issuer, defaults to Google
    * @param [$max_expiry] the max lifetime of a token, defaults to MAX_TOKEN_LIFETIME_SECS
-   * @return token information if valid, false if not
+   * @return mixed token information if valid, false if not
    */
   public function verifySignedJwt($id_token, $cert_location, $audience, $issuer, $max_expiry = null)
   {
@@ -464,8 +500,7 @@ class Google_Client
   }
 
   /**
-   * @param Google_Auth_AssertionCredentials $creds
-   * @return void
+   * @param $creds Google_Auth_AssertionCredentials
    */
   public function setAssertionCredentials(Google_Auth_AssertionCredentials $creds)
   {
@@ -539,6 +574,8 @@ class Google_Client
   /**
    * Helper method to execute deferred HTTP requests.
    *
+   * @param $request Google_Http_Request|Google_Http_Batch
+   * @throws Google_Exception
    * @return object of the type of the expected class or array.
    */
   public function execute($request)
@@ -607,9 +644,22 @@ class Google_Client
   }
 
   /**
+   * @return Google_Logger_Abstract Logger implementation
+   */
+  public function getLogger()
+  {
+    if (!isset($this->logger)) {
+      $class = $this->config->getLoggerClass();
+      $this->logger = new $class($this);
+    }
+    return $this->logger;
+  }
+
+  /**
    * Retrieve custom configuration for a specific class.
    * @param $class string|object - class or instance of class to retrieve
    * @param $key string optional - key to retrieve
+   * @return array
    */
   public function getClassConfig($class, $key = null)
   {
@@ -623,9 +673,9 @@ class Google_Client
    * Set configuration specific to a given class.
    * $config->setClassConfig('Google_Cache_File',
    *   array('directory' => '/tmp/cache'));
-   * @param $class The class name for the configuration
+   * @param $class string|object - The class name for the configuration
    * @param $config string key or an array of configuration values
-   * @param $value optional - if $config is a key, the value
+   * @param $value string optional - if $config is a key, the value
    *
    */
   public function setClassConfig($class, $config, $value = null)
@@ -633,7 +683,7 @@ class Google_Client
     if (!is_string($class)) {
       $class = get_class($class);
     }
-    return $this->config->setClassConfig($class, $config, $value);
+    $this->config->setClassConfig($class, $config, $value);
 
   }
 

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Collection.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Collection.php
@@ -1,6 +1,8 @@
 <?php
 
-require_once "Google/Model.php";
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/autoload.php';
+}
 
 /**
  * Extension to the regular Google_Model that automatically
@@ -48,10 +50,13 @@ class Google_Collection extends Google_Model implements Iterator, Countable
 
   public function count()
   {
+    if (!isset($this->modelData[$this->collection_key])) {
+      return 0;
+    }
     return count($this->modelData[$this->collection_key]);
   }
 
-  public function offsetExists ($offset)
+  public function offsetExists($offset)
   {
     if (!is_numeric($offset)) {
       return parent::offsetExists($offset);

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Config.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Config.php
@@ -25,6 +25,9 @@ class Google_Config
   const GZIP_UPLOADS_ENABLED = true;
   const GZIP_UPLOADS_DISABLED = false;
   const USE_AUTO_IO_SELECTION = "auto";
+  const TASK_RETRY_NEVER = 0;
+  const TASK_RETRY_ONCE = 1;
+  const TASK_RETRY_ALWAYS = -1;
   protected $configuration;
 
   /**
@@ -44,6 +47,7 @@ class Google_Config
       'auth_class'    => 'Google_Auth_OAuth2',
       'io_class'      => self::USE_AUTO_IO_SELECTION,
       'cache_class'   => 'Google_Cache_File',
+      'logger_class'  => 'Google_Logger_Null',
 
       // Don't change these unless you're working against a special development
       // or testing environment.
@@ -53,6 +57,21 @@ class Google_Config
       'classes' => array(
         'Google_IO_Abstract' => array(
           'request_timeout_seconds' => 100,
+        ),
+        'Google_IO_Curl' => array(
+          'disable_proxy_workaround' => false,
+          'options' => null,
+        ),
+        'Google_Logger_Abstract' => array(
+          'level' => 'debug',
+          'log_format' => "[%datetime%] %level%: %message% %context%\n",
+          'date_format' => 'd/M/Y:H:i:s O',
+          'allow_newlines' => true
+        ),
+        'Google_Logger_File' => array(
+          'file' => 'php://stdout',
+          'mode' => 0640,
+          'lock' => false,
         ),
         'Google_Http_Request' => array(
           // Disable the use of gzip on calls if set to true. Defaults to false.
@@ -89,6 +108,36 @@ class Google_Config
           'federated_signon_certs_url' =>
               'https://www.googleapis.com/oauth2/v1/certs',
         ),
+        'Google_Task_Runner' => array(
+          // Delays are specified in seconds
+          'initial_delay' => 1,
+          'max_delay' => 60,
+          // Base number for exponential backoff
+          'factor' => 2,
+          // A random number between -jitter and jitter will be added to the
+          // factor on each iteration to allow for better distribution of
+          // retries.
+          'jitter' => .5,
+          // Maximum number of retries allowed
+          'retries' => 0
+        ),
+        'Google_Service_Exception' => array(
+          'retry_map' => array(
+            '500' => self::TASK_RETRY_ALWAYS,
+            '503' => self::TASK_RETRY_ALWAYS,
+            'rateLimitExceeded' => self::TASK_RETRY_ALWAYS,
+            'userRateLimitExceeded' => self::TASK_RETRY_ALWAYS
+          )
+        ),
+        'Google_IO_Exception' => array(
+          'retry_map' => !extension_loaded('curl') ? array() : array(
+            CURLE_COULDNT_RESOLVE_HOST => self::TASK_RETRY_ALWAYS,
+            CURLE_COULDNT_CONNECT => self::TASK_RETRY_ALWAYS,
+            CURLE_OPERATION_TIMEOUTED => self::TASK_RETRY_ALWAYS,
+            CURLE_SSL_CONNECT_ERROR => self::TASK_RETRY_ALWAYS,
+            CURLE_GOT_NOTHING => self::TASK_RETRY_ALWAYS
+          )
+        ),
         // Set a default directory for the file cache.
         'Google_Cache_File' => array(
           'directory' => sys_get_temp_dir() . '/Google_Client'
@@ -98,7 +147,11 @@ class Google_Config
     if ($ini_file_location) {
       $ini = parse_ini_file($ini_file_location, true);
       if (is_array($ini) && count($ini)) {
-        $this->configuration = array_merge($this->configuration, $ini);
+        $merged_configuration = $ini + $this->configuration;
+        if (isset($ini['classes']) && isset($this->configuration['classes'])) {
+          $merged_configuration['classes'] = $ini['classes'] + $this->configuration['classes'];
+        }
+        $this->configuration = $merged_configuration;
       }
     }
   }
@@ -107,9 +160,9 @@ class Google_Config
    * Set configuration specific to a given class.
    * $config->setClassConfig('Google_Cache_File',
    *   array('directory' => '/tmp/cache'));
-   * @param $class The class name for the configuration
+   * @param $class string The class name for the configuration
    * @param $config string key or an array of configuration values
-   * @param $value optional - if $config is a key, the value
+   * @param $value string optional - if $config is a key, the value
    */
   public function setClassConfig($class, $config, $value = null)
   {
@@ -145,6 +198,15 @@ class Google_Config
   }
 
   /**
+   * Return the configured logger class.
+   * @return string
+   */
+  public function getLoggerClass()
+  {
+    return $this->configuration['logger_class'];
+  }
+
+  /**
    * Return the configured Auth class.
    * @return string
    */
@@ -156,7 +218,7 @@ class Google_Config
   /**
    * Set the auth class.
    *
-   * @param $class the class name to set
+   * @param $class string the class name to set
    */
   public function setAuthClass($class)
   {
@@ -172,7 +234,7 @@ class Google_Config
   /**
    * Set the IO class.
    *
-   * @param $class the class name to set
+   * @param $class string the class name to set
    */
   public function setIoClass($class)
   {
@@ -188,7 +250,7 @@ class Google_Config
   /**
    * Set the cache class.
    *
-   * @param $class the class name to set
+   * @param $class string the class name to set
    */
   public function setCacheClass($class)
   {
@@ -202,7 +264,24 @@ class Google_Config
   }
 
   /**
+   * Set the logger class.
+   *
+   * @param $class string the class name to set
+   */
+  public function setLoggerClass($class)
+  {
+    $prev = $this->configuration['logger_class'];
+    if (!isset($this->configuration['classes'][$class]) &&
+        isset($this->configuration['classes'][$prev])) {
+      $this->configuration['classes'][$class] =
+          $this->configuration['classes'][$prev];
+    }
+    $this->configuration['logger_class'] = $class;
+  }
+
+  /**
    * Return the configured IO class.
+   *
    * @return string
    */
   public function getIoClass()
@@ -229,7 +308,7 @@ class Google_Config
 
   /**
    * Set the client ID for the auth class.
-   * @param $key string - the API console client ID
+   * @param $clientId string - the API console client ID
    */
   public function setClientId($clientId)
   {
@@ -238,7 +317,7 @@ class Google_Config
 
   /**
    * Set the client secret for the auth class.
-   * @param $key string - the API console client secret
+   * @param $secret string - the API console client secret
    */
   public function setClientSecret($secret)
   {
@@ -248,7 +327,8 @@ class Google_Config
   /**
    * Set the redirect uri for the auth class. Note that if using the
    * Javascript based sign in flow, this should be the string 'postmessage'.
-   * @param $key string - the URI that users should be redirected to
+   *
+   * @param $uri string - the URI that users should be redirected to
    */
   public function setRedirectUri($uri)
   {
@@ -305,6 +385,11 @@ class Google_Config
    * Set the hd (hosted domain) parameter streamlines the login process for
    * Google Apps hosted accounts. By including the domain of the user, you
    * restrict sign-in to accounts at that domain.
+   *
+   * This should not be used to ensure security on your application - check
+   * the hd values within an id token (@see Google_Auth_LoginTicket) after sign
+   * in to ensure that the user is from the domain you were expecting.
+   *
    * @param $hd string - the domain to use.
    */
   public function setHostedDomain($hd)

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Http/Batch.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Http/Batch.php
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-require_once 'Google/Client.php';
-require_once 'Google/Http/Request.php';
-require_once 'Google/Http/REST.php';
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
 
 /**
- * @author Chirag Shah <chirags@google.com>
+ * Class to handle batched requests to the Google API service.
  */
 class Google_Http_Batch
 {
@@ -35,12 +35,15 @@ class Google_Http_Batch
 
   private $expected_classes = array();
 
-  private $base_path;
+  private $root_url;
 
-  public function __construct(Google_Client $client, $boundary = false)
+  private $batch_path;
+
+  public function __construct(Google_Client $client, $boundary = false, $rootUrl = '', $batchPath = '')
   {
     $this->client = $client;
-    $this->base_path = $this->client->getBasePath();
+    $this->root_url = rtrim($rootUrl ? $rootUrl : $this->client->getBasePath(), '/');
+    $this->batch_path = $batchPath ? $batchPath : 'batch';
     $this->expected_classes = array();
     $boundary = (false == $boundary) ? mt_rand() : $boundary;
     $this->boundary = str_replace('"', '', $boundary);
@@ -62,14 +65,13 @@ class Google_Http_Batch
     /** @var Google_Http_Request $req */
     foreach ($this->requests as $key => $req) {
       $body .= "--{$this->boundary}\n";
-      $body .= $req->toBatchString($key) . "\n";
+      $body .= $req->toBatchString($key) . "\n\n";
       $this->expected_classes["response-" . $key] = $req->getExpectedClass();
     }
 
-    $body = rtrim($body);
-    $body .= "\n--{$this->boundary}--";
+    $body .= "--{$this->boundary}--";
 
-    $url = $this->base_path . '/batch';
+    $url = $this->root_url . '/' . $this->batch_path;
     $httpRequest = new Google_Http_Request($url, 'POST');
     $httpRequest->setRequestHeaders(
         array('Content-Type' => 'multipart/mixed; boundary=' . $this->boundary)
@@ -125,10 +127,10 @@ class Google_Http_Batch
           }
 
           try {
-            $response = Google_Http_REST::decodeHttpResponse($response);
+            $response = Google_Http_REST::decodeHttpResponse($response, $this->client);
             $responses[$key] = $response;
           } catch (Google_Service_Exception $e) {
-            // Store the exception as the response, so succesful responses
+            // Store the exception as the response, so successful responses
             // can be processed.
             $responses[$key] = $e;
           }

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Http/CacheParser.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Http/CacheParser.php
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-require_once 'Google/Http/Request.php';
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
 
 /**
  * Implement the caching directives specified in rfc2616. This
  * implementation is guided by the guidance offered in rfc2616-sec13.
- * @author Chirag Shah <chirags@google.com>
  */
 class Google_Http_CacheParser
 {

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Http/REST.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Http/REST.php
@@ -15,21 +15,18 @@
  * limitations under the License.
  */
 
-require_once 'Google/Client.php';
-require_once 'Google/Http/Request.php';
-require_once 'Google/Service/Exception.php';
-require_once 'Google/Utils/URITemplate.php';
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
 
 /**
  * This class implements the RESTful transport of apiServiceRequest()'s
- *
- * @author Chris Chabot <chabotc@google.com>
- * @author Chirag Shah <chirags@google.com>
  */
 class Google_Http_REST
 {
   /**
-   * Executes a Google_Http_Request
+   * Executes a Google_Http_Request and (if applicable) automatically retries
+   * when errors occur.
    *
    * @param Google_Client $client
    * @param Google_Http_Request $req
@@ -39,9 +36,30 @@ class Google_Http_REST
    */
   public static function execute(Google_Client $client, Google_Http_Request $req)
   {
+    $runner = new Google_Task_Runner(
+        $client,
+        sprintf('%s %s', $req->getRequestMethod(), $req->getUrl()),
+        array(get_class(), 'doExecute'),
+        array($client, $req)
+    );
+
+    return $runner->run();
+  }
+
+  /**
+   * Executes a Google_Http_Request
+   *
+   * @param Google_Client $client
+   * @param Google_Http_Request $req
+   * @return array decoded result
+   * @throws Google_Service_Exception on server side error (ie: not authenticated,
+   *  invalid or malformed post body, invalid url)
+   */
+  public static function doExecute(Google_Client $client, Google_Http_Request $req)
+  {
     $httpRequest = $client->getIo()->makeRequest($req);
     $httpRequest->setExpectedClass($req->getExpectedClass());
-    return self::decodeHttpResponse($httpRequest);
+    return self::decodeHttpResponse($httpRequest, $client);
   }
 
   /**
@@ -49,9 +67,10 @@ class Google_Http_REST
    * @static
    * @throws Google_Service_Exception
    * @param Google_Http_Request $response The http response to be decoded.
+   * @param Google_Client $client
    * @return mixed|null
    */
-  public static function decodeHttpResponse($response)
+  public static function decodeHttpResponse($response, Google_Client $client = null)
   {
     $code = $response->getResponseHttpCode();
     $body = $response->getResponseBody();
@@ -76,14 +95,34 @@ class Google_Http_REST
         $errors = $decoded['error']['errors'];
       }
 
-      throw new Google_Service_Exception($err, $code, null, $errors);
+      $map = null;
+      if ($client) {
+        $client->getLogger()->error(
+            $err,
+            array('code' => $code, 'errors' => $errors)
+        );
+
+        $map = $client->getClassConfig(
+            'Google_Service_Exception',
+            'retry_map'
+        );
+      }
+      throw new Google_Service_Exception($err, $code, null, $errors, $map);
     }
 
     // Only attempt to decode the response, if the response code wasn't (204) 'no content'
     if ($code != '204') {
+      if ($response->getExpectedRaw()) {
+        return $body;
+      }
+      
       $decoded = json_decode($body, true);
       if ($decoded === null || $decoded === "") {
-        throw new Google_Service_Exception("Invalid json in service response: $body");
+        $error = "Invalid json in service response: $body";
+        if ($client) {
+          $client->getLogger()->error($error);
+        }
+        throw new Google_Service_Exception($error);
       }
 
       if ($response->getExpectedClass()) {
@@ -117,10 +156,10 @@ class Google_Http_REST
       } else if ($paramSpec['location'] == 'query') {
         if (isset($paramSpec['repeated']) && is_array($paramSpec['value'])) {
           foreach ($paramSpec['value'] as $value) {
-            $queryVars[] = $paramName . '=' . rawurlencode($value);
+            $queryVars[] = $paramName . '=' . rawurlencode(rawurldecode($value));
           }
         } else {
-          $queryVars[] = $paramName . '=' . rawurlencode($paramSpec['value']);
+          $queryVars[] = $paramName . '=' . rawurlencode(rawurldecode($paramSpec['value']));
         }
       }
     }

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Http/Request.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Http/Request.php
@@ -15,7 +15,9 @@
  * limitations under the License.
  */
 
-require_once 'Google/Utils.php';
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
 
 /**
  * HTTP Request to be executed by IO classes. Upon execution, the
@@ -49,6 +51,7 @@ class Google_Http_Request
   protected $responseBody;
   
   protected $expectedClass;
+  protected $expectedRaw = false;
 
   public $accessKey;
 
@@ -80,7 +83,7 @@ class Google_Http_Request
    */
   public function setBaseComponent($baseComponent)
   {
-    $this->baseComponent = $baseComponent;
+    $this->baseComponent = rtrim($baseComponent, '/');
   }
   
   /**
@@ -127,7 +130,7 @@ class Google_Http_Request
     return $this->queryParams;
   }
 
-  /** 
+  /**
    * Set a new query parameter.
    * @param $key - string to set, does not need to be URL encoded
    * @param $value - string to set, does not need to be URL encoded
@@ -186,6 +189,31 @@ class Google_Http_Request
   public function getExpectedClass()
   {
     return $this->expectedClass;
+  }
+
+  /**
+   * Enable expected raw response
+   */
+  public function enableExpectedRaw()
+  {
+    $this->expectedRaw = true;
+  }
+
+  /**
+   * Disable expected raw response
+   */
+  public function disableExpectedRaw()
+  {
+    $this->expectedRaw = false;
+  }
+
+  /**
+   * Expected raw response or not.
+   * @return boolean expected raw response
+   */
+  public function getExpectedRaw()
+  {
+    return $this->expectedRaw;
   }
 
   /**
@@ -413,7 +441,7 @@ class Google_Http_Request
   
   /**
    * Our own version of parse_str that allows for multiple variables
-   * with the same name. 
+   * with the same name.
    * @param $string - the query string to parse
    */
   private function parseQuery($string)
@@ -437,7 +465,7 @@ class Google_Http_Request
   
   /**
    * A version of build query that allows for multiple
-   * duplicate keys. 
+   * duplicate keys.
    * @param $parts array of key value pairs
    */
   private function buildQuery($parts)
@@ -455,7 +483,7 @@ class Google_Http_Request
     return implode('&', $return);
   }
   
-  /** 
+  /**
    * If we're POSTing and have no body to send, we can send the query
    * parameters in there, which avoids length issues with longer query
    * params.

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/IO/Curl.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/IO/Curl.php
@@ -21,7 +21,9 @@
  * @author Stuart Langley <slangley@google.com>
  */
 
-require_once 'Google/IO/Abstract.php';
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
 
 class Google_IO_Curl extends Google_IO_Abstract
 {
@@ -29,12 +31,31 @@ class Google_IO_Curl extends Google_IO_Abstract
   const NO_QUIRK_VERSION = 0x071E00;
 
   private $options = array();
+
+  /** @var bool $disableProxyWorkaround */
+  private $disableProxyWorkaround;
+
+  public function __construct(Google_Client $client)
+  {
+    if (!extension_loaded('curl')) {
+      $error = 'The cURL IO handler requires the cURL extension to be enabled';
+      $client->getLogger()->critical($error);
+      throw new Google_IO_Exception($error);
+    }
+
+    parent::__construct($client);
+
+    $this->disableProxyWorkaround = $this->client->getClassConfig(
+        'Google_IO_Curl',
+        'disable_proxy_workaround'
+    );
+  }
+
   /**
    * Execute an HTTP Request
    *
-   * @param Google_HttpRequest $request the http request to be executed
-   * @return Google_HttpRequest http request with the response http code,
-   * response headers and response body filled in
+   * @param Google_Http_Request $request the http request to be executed
+   * @return array containing response headers, body, and http code
    * @throws Google_IO_Exception on curl or IO error
    */
   public function executeRequest(Google_Http_Request $request)
@@ -53,21 +74,30 @@ class Google_IO_Curl extends Google_IO_Abstract
       }
       curl_setopt($curl, CURLOPT_HTTPHEADER, $curlHeaders);
     }
-
     curl_setopt($curl, CURLOPT_URL, $request->getUrl());
-    
+
     curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $request->getRequestMethod());
     curl_setopt($curl, CURLOPT_USERAGENT, $request->getUserAgent());
 
     curl_setopt($curl, CURLOPT_FOLLOWLOCATION, false);
     curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
+
+    // The SSL version will be determined by the underlying library
+    // @see https://github.com/google/google-api-php-client/pull/644
+    //curl_setopt($curl, CURLOPT_SSLVERSION, 1);
+
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($curl, CURLOPT_HEADER, true);
 
     if ($request->canGzip()) {
       curl_setopt($curl, CURLOPT_ENCODING, 'gzip,deflate');
     }
-
+    
+    $options = $this->client->getClassConfig('Google_IO_Curl', 'options');
+    if (is_array($options)) {
+      $this->setOptions($options);
+    }
+    
     foreach ($this->options as $key => $var) {
       curl_setopt($curl, $key, $var);
     }
@@ -76,15 +106,38 @@ class Google_IO_Curl extends Google_IO_Abstract
       curl_setopt($curl, CURLOPT_CAINFO, dirname(__FILE__) . '/cacerts.pem');
     }
 
+    $this->client->getLogger()->debug(
+        'cURL request',
+        array(
+            'url' => $request->getUrl(),
+            'method' => $request->getRequestMethod(),
+            'headers' => $requestHeaders,
+            'body' => $request->getPostBody()
+        )
+    );
+
     $response = curl_exec($curl);
     if ($response === false) {
-      throw new Google_IO_Exception(curl_error($curl));
+      $error = curl_error($curl);
+      $code = curl_errno($curl);
+      $map = $this->client->getClassConfig('Google_IO_Exception', 'retry_map');
+
+      $this->client->getLogger()->error('cURL ' . $error);
+      throw new Google_IO_Exception($error, $code, null, $map);
     }
     $headerSize = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
 
     list($responseHeaders, $responseBody) = $this->parseHttpResponse($response, $headerSize);
-
     $responseCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+
+    $this->client->getLogger()->debug(
+        'cURL response',
+        array(
+            'code' => $responseCode,
+            'headers' => $responseHeaders,
+            'body' => $responseBody,
+        )
+    );
 
     return array($responseBody, $responseHeaders, $responseCode);
   }
@@ -106,7 +159,7 @@ class Google_IO_Curl extends Google_IO_Abstract
   {
     // Since this timeout is really for putting a bound on the time
     // we'll set them both to the same. If you need to specify a longer
-    // CURLOPT_TIMEOUT, or a tigher CONNECTTIMEOUT, the best thing to
+    // CURLOPT_TIMEOUT, or a higher CONNECTTIMEOUT, the best thing to
     // do is use the setOptions method for the values individually.
     $this->options[CURLOPT_CONNECTTIMEOUT] = $timeout;
     $this->options[CURLOPT_TIMEOUT] = $timeout;
@@ -130,6 +183,10 @@ class Google_IO_Curl extends Google_IO_Abstract
    */
   protected function needsQuirk()
   {
+    if ($this->disableProxyWorkaround) {
+      return false;
+    }
+
     $ver = curl_version();
     $versionNum = $ver['version_number'];
     return $versionNum < Google_IO_Curl::NO_QUIRK_VERSION;

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/IO/Exception.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/IO/Exception.php
@@ -15,8 +15,55 @@
  * limitations under the License.
  */
 
-require_once 'Google/Exception.php';
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
 
-class Google_IO_Exception extends Google_Exception
+class Google_IO_Exception extends Google_Exception implements Google_Task_Retryable
 {
+  /**
+   * @var array $retryMap Map of errors with retry counts.
+   */
+  private $retryMap = array();
+
+  /**
+   * Creates a new IO exception with an optional retry map.
+   *
+   * @param string $message
+   * @param int $code
+   * @param Exception|null $previous
+   * @param array|null $retryMap Map of errors with retry counts.
+   */
+  public function __construct(
+      $message,
+      $code = 0,
+      Exception $previous = null,
+      array $retryMap = null
+  ) {
+    if (version_compare(PHP_VERSION, '5.3.0') >= 0) {
+      parent::__construct($message, $code, $previous);
+    } else {
+      parent::__construct($message, $code);
+    }
+
+    if (is_array($retryMap)) {
+      $this->retryMap = $retryMap;
+    }
+  }
+
+  /**
+   * Gets the number of times the associated task can be retried.
+   *
+   * NOTE: -1 is returned if the task can be retried indefinitely
+   *
+   * @return integer
+   */
+  public function allowedRetries()
+  {
+    if (isset($this->retryMap[$this->code])) {
+      return $this->retryMap[$this->code];
+    }
+
+    return 0;
+  }
 }

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/IO/Stream.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/IO/Stream.php
@@ -21,7 +21,9 @@
  * @author Stuart Langley <slangley@google.com>
  */
 
-require_once 'Google/IO/Abstract.php';
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
 
 class Google_IO_Stream extends Google_IO_Abstract
 {
@@ -40,12 +42,23 @@ class Google_IO_Stream extends Google_IO_Abstract
     "verify_peer" => true,
   );
 
+  public function __construct(Google_Client $client)
+  {
+    if (!ini_get('allow_url_fopen')) {
+      $error = 'The stream IO handler requires the allow_url_fopen runtime ' .
+               'configuration to be enabled';
+      $client->getLogger()->critical($error);
+      throw new Google_IO_Exception($error);
+    }
+
+    parent::__construct($client);
+  }
+
   /**
    * Execute an HTTP Request
    *
-   * @param Google_HttpRequest $request the http request to be executed
-   * @return Google_HttpRequest http request with the response http code,
-   * response headers and response body filled in
+   * @param Google_Http_Request $request the http request to be executed
+   * @return array containing response headers, body, and http code
    * @throws Google_IO_Exception on curl or IO error
    */
   public function executeRequest(Google_Http_Request $request)
@@ -74,7 +87,7 @@ class Google_IO_Stream extends Google_IO_Abstract
     $requestSslContext = array_key_exists('ssl', $default_options) ?
         $default_options['ssl'] : array();
 
-    if (!array_key_exists("cafile", $requestSslContext)) {
+    if (!$this->client->isAppEngine() && !array_key_exists("cafile", $requestSslContext)) {
       $requestSslContext["cafile"] = dirname(__FILE__) . '/cacerts.pem';
     }
 
@@ -97,6 +110,16 @@ class Google_IO_Stream extends Google_IO_Abstract
       $url = self::ZLIB . $url;
     }
 
+    $this->client->getLogger()->debug(
+        'Stream request',
+        array(
+            'url' => $url,
+            'method' => $request->getRequestMethod(),
+            'headers' => $requestHeaders,
+            'body' => $request->getPostBody()
+        )
+    );
+
     // We are trapping any thrown errors in this method only and
     // throwing an exception.
     $this->trappedErrorNumber = null;
@@ -109,13 +132,13 @@ class Google_IO_Stream extends Google_IO_Abstract
     // END - error trap.
 
     if ($this->trappedErrorNumber) {
-      throw new Google_IO_Exception(
-          sprintf(
-              "HTTP Error: Unable to connect: '%s'",
-              $this->trappedErrorString
-          ),
-          $this->trappedErrorNumber
+      $error = sprintf(
+          "HTTP Error: Unable to connect: '%s'",
+          $this->trappedErrorString
       );
+
+      $this->client->getLogger()->error('Stream ' . $error);
+      throw new Google_IO_Exception($error, $this->trappedErrorNumber);
     }
 
     $response_data = false;
@@ -132,16 +155,25 @@ class Google_IO_Stream extends Google_IO_Abstract
     }
 
     if (false === $response_data) {
-      throw new Google_IO_Exception(
-          sprintf(
-              "HTTP Error: Unable to connect: '%s'",
-              $respHttpCode
-          ),
+      $error = sprintf(
+          "HTTP Error: Unable to connect: '%s'",
           $respHttpCode
       );
+
+      $this->client->getLogger()->error('Stream ' . $error);
+      throw new Google_IO_Exception($error, $respHttpCode);
     }
 
     $responseHeaders = $this->getHttpResponseHeaders($http_response_header);
+
+    $this->client->getLogger()->debug(
+        'Stream response',
+        array(
+            'code' => $respHttpCode,
+            'headers' => $responseHeaders,
+            'body' => $response_data,
+        )
+    );
 
     return array($response_data, $responseHeaders, $respHttpCode);
   }

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/IO/cacerts.pem
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/IO/cacerts.pem
@@ -1,135 +1,33 @@
-# Certifcate Authority certificates for validating SSL connections.
-#
-# This file contains PEM format certificates generated from
-# http://mxr.mozilla.org/seamonkey/source/security/nss/lib/ckfw/builtins/certdata.txt
-#
-# ***** BEGIN LICENSE BLOCK *****
-# Version: MPL 1.1/GPL 2.0/LGPL 2.1
-#
-# The contents of this file are subject to the Mozilla Public License Version
-# 1.1 (the "License"); you may not use this file except in compliance with
-# the License. You may obtain a copy of the License at
-# http://www.mozilla.org/MPL/
-#
-# Software distributed under the License is distributed on an "AS IS" basis,
-# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
-# for the specific language governing rights and limitations under the
-# License.
-#
-# The Original Code is the Netscape security libraries.
-#
-# The Initial Developer of the Original Code is
-# Netscape Communications Corporation.
-# Portions created by the Initial Developer are Copyright (C) 1994-2000
-# the Initial Developer. All Rights Reserved.
-#
-# Contributor(s):
-#
-# Alternatively, the contents of this file may be used under the terms of
-# either the GNU General Public License Version 2 or later (the "GPL"), or
-# the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
-# in which case the provisions of the GPL or the LGPL are applicable instead
-# of those above. If you wish to allow use of your version of this file only
-# under the terms of either the GPL or the LGPL, and not to allow others to
-# use your version of this file under the terms of the MPL, indicate your
-# decision by deleting the provisions above and replace them with the notice
-# and other provisions required by the GPL or the LGPL. If you do not delete
-# the provisions above, a recipient may use your version of this file under
-# the terms of any one of the MPL, the GPL or the LGPL.
-#
-# ***** END LICENSE BLOCK *****
-
-Verisign/RSA Secure Server CA
-=============================
-
+# Issuer: CN=GTE CyberTrust Global Root O=GTE Corporation OU=GTE CyberTrust Solutions, Inc.
+# Subject: CN=GTE CyberTrust Global Root O=GTE Corporation OU=GTE CyberTrust Solutions, Inc.
+# Label: "GTE CyberTrust Global Root"
+# Serial: 421
+# MD5 Fingerprint: ca:3d:d3:68:f1:03:5c:d0:32:fa:b8:2b:59:e8:5a:db
+# SHA1 Fingerprint: 97:81:79:50:d8:1c:96:70:cc:34:d8:09:cf:79:44:31:36:7e:f4:74
+# SHA256 Fingerprint: a5:31:25:18:8d:21:10:aa:96:4b:02:c7:b7:c6:da:32:03:17:08:94:e5:fb:71:ff:fb:66:67:d5:e6:81:0a:36
 -----BEGIN CERTIFICATE-----
-MIICNDCCAaECEAKtZn5ORf5eV288mBle3cAwDQYJKoZIhvcNAQECBQAwXzELMAkG
-A1UEBhMCVVMxIDAeBgNVBAoTF1JTQSBEYXRhIFNlY3VyaXR5LCBJbmMuMS4wLAYD
-VQQLEyVTZWN1cmUgU2VydmVyIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MB4XDTk0
-MTEwOTAwMDAwMFoXDTEwMDEwNzIzNTk1OVowXzELMAkGA1UEBhMCVVMxIDAeBgNV
-BAoTF1JTQSBEYXRhIFNlY3VyaXR5LCBJbmMuMS4wLAYDVQQLEyVTZWN1cmUgU2Vy
-dmVyIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MIGbMA0GCSqGSIb3DQEBAQUAA4GJ
-ADCBhQJ+AJLOesGugz5aqomDV6wlAXYMra6OLDfO6zV4ZFQD5YRAUcm/jwjiioII
-0haGN1XpsSECrXZogZoFokvJSyVmIlZsiAeP94FZbYQHZXATcXY+m3dM41CJVphI
-uR2nKRoTLkoRWZweFdVJVCxzOmmCsZc5nG1wZ0jl3S3WyB57AgMBAAEwDQYJKoZI
-hvcNAQECBQADfgBl3X7hsuyw4jrg7HFGmhkRuNPHoLQDQCYCPgmc4RKz0Vr2N6W3
-YQO2WxZpO8ZECAyIUwxrl0nHPjXcbLm7qt9cuzovk2C2qUtN8iD3zV9/ZHuO3ABc
-1/p3yjkWWW8O6tO1g39NTUJWdrTJXwT4OPjr0l91X817/OWOgHz8UA==
+MIICWjCCAcMCAgGlMA0GCSqGSIb3DQEBBAUAMHUxCzAJBgNVBAYTAlVTMRgwFgYD
+VQQKEw9HVEUgQ29ycG9yYXRpb24xJzAlBgNVBAsTHkdURSBDeWJlclRydXN0IFNv
+bHV0aW9ucywgSW5jLjEjMCEGA1UEAxMaR1RFIEN5YmVyVHJ1c3QgR2xvYmFsIFJv
+b3QwHhcNOTgwODEzMDAyOTAwWhcNMTgwODEzMjM1OTAwWjB1MQswCQYDVQQGEwJV
+UzEYMBYGA1UEChMPR1RFIENvcnBvcmF0aW9uMScwJQYDVQQLEx5HVEUgQ3liZXJU
+cnVzdCBTb2x1dGlvbnMsIEluYy4xIzAhBgNVBAMTGkdURSBDeWJlclRydXN0IEds
+b2JhbCBSb290MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCVD6C28FCc6HrH
+iM3dFw4usJTQGz0O9pTAipTHBsiQl8i4ZBp6fmw8U+E3KHNgf7KXUwefU/ltWJTS
+r41tiGeA5u2ylc9yMcqlHHK6XALnZELn+aks1joNrI1CqiQBOeacPwGFVw1Yh0X4
+04Wqk2kmhXBIgD8SFcd5tB8FLztimQIDAQABMA0GCSqGSIb3DQEBBAUAA4GBAG3r
+GwnpXtlR22ciYaQqPEh346B8pt5zohQDhT37qw4wxYMWM4ETCJ57NE7fQMh017l9
+3PR2VX2bY1QY6fDq81yx2YtCHrnAlU66+tXifPVoYb+O7AWXX1uw16OFNMQkpw0P
+lZPvy5TYnh+dXIVtx6quTx8itc2VrbqnzPmrC3p/
 -----END CERTIFICATE-----
 
-Thawte Personal Basic CA
-========================
-
------BEGIN CERTIFICATE-----
-MIIDITCCAoqgAwIBAgIBADANBgkqhkiG9w0BAQQFADCByzELMAkGA1UEBhMCWkEx
-FTATBgNVBAgTDFdlc3Rlcm4gQ2FwZTESMBAGA1UEBxMJQ2FwZSBUb3duMRowGAYD
-VQQKExFUaGF3dGUgQ29uc3VsdGluZzEoMCYGA1UECxMfQ2VydGlmaWNhdGlvbiBT
-ZXJ2aWNlcyBEaXZpc2lvbjEhMB8GA1UEAxMYVGhhd3RlIFBlcnNvbmFsIEJhc2lj
-IENBMSgwJgYJKoZIhvcNAQkBFhlwZXJzb25hbC1iYXNpY0B0aGF3dGUuY29tMB4X
-DTk2MDEwMTAwMDAwMFoXDTIwMTIzMTIzNTk1OVowgcsxCzAJBgNVBAYTAlpBMRUw
-EwYDVQQIEwxXZXN0ZXJuIENhcGUxEjAQBgNVBAcTCUNhcGUgVG93bjEaMBgGA1UE
-ChMRVGhhd3RlIENvbnN1bHRpbmcxKDAmBgNVBAsTH0NlcnRpZmljYXRpb24gU2Vy
-dmljZXMgRGl2aXNpb24xITAfBgNVBAMTGFRoYXd0ZSBQZXJzb25hbCBCYXNpYyBD
-QTEoMCYGCSqGSIb3DQEJARYZcGVyc29uYWwtYmFzaWNAdGhhd3RlLmNvbTCBnzAN
-BgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAvLyTU23AUE+CFeZIlDWmWr5vQvoPR+53
-dXLdjUmbllegeNTKP1GzaQuRdhciB5dqxFGTS+CN7zeVoQxN2jSQHReJl+A1OFdK
-wPQIcOk8RHtQfmGakOMj04gRRif1CwcOu93RfyAKiLlWCy4cgNrx454p7xS9CkT7
-G1sY0b8jkyECAwEAAaMTMBEwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQQF
-AAOBgQAt4plrsD16iddZopQBHyvdEktTwq1/qqcAXJFAVyVKOKqEcLnZgA+le1z7
-c8a914phXAPjLSeoF+CEhULcXpvGt7Jtu3Sv5D/Lp7ew4F2+eIMllNLbgQ95B21P
-9DkVWlIBe94y1k049hJcBlDfBVu9FEuh3ym6O0GN92NWod8isQ==
------END CERTIFICATE-----
-
-Thawte Personal Premium CA
-==========================
-
------BEGIN CERTIFICATE-----
-MIIDKTCCApKgAwIBAgIBADANBgkqhkiG9w0BAQQFADCBzzELMAkGA1UEBhMCWkEx
-FTATBgNVBAgTDFdlc3Rlcm4gQ2FwZTESMBAGA1UEBxMJQ2FwZSBUb3duMRowGAYD
-VQQKExFUaGF3dGUgQ29uc3VsdGluZzEoMCYGA1UECxMfQ2VydGlmaWNhdGlvbiBT
-ZXJ2aWNlcyBEaXZpc2lvbjEjMCEGA1UEAxMaVGhhd3RlIFBlcnNvbmFsIFByZW1p
-dW0gQ0ExKjAoBgkqhkiG9w0BCQEWG3BlcnNvbmFsLXByZW1pdW1AdGhhd3RlLmNv
-bTAeFw05NjAxMDEwMDAwMDBaFw0yMDEyMzEyMzU5NTlaMIHPMQswCQYDVQQGEwJa
-QTEVMBMGA1UECBMMV2VzdGVybiBDYXBlMRIwEAYDVQQHEwlDYXBlIFRvd24xGjAY
-BgNVBAoTEVRoYXd0ZSBDb25zdWx0aW5nMSgwJgYDVQQLEx9DZXJ0aWZpY2F0aW9u
-IFNlcnZpY2VzIERpdmlzaW9uMSMwIQYDVQQDExpUaGF3dGUgUGVyc29uYWwgUHJl
-bWl1bSBDQTEqMCgGCSqGSIb3DQEJARYbcGVyc29uYWwtcHJlbWl1bUB0aGF3dGUu
-Y29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDJZtn4B0TPuYwu8KHvE0Vs
-Bd/eJxZRNkERbGw77f4QfRKe5ZtCmv5gMcNmt3M6SK5O0DI3lIi1DbbZ8/JE2dWI
-Et12TfIa/G8jHnrx2JhFTgcQ7xZC0EN1bUre4qrJMf8fAHB8Zs8QJQi6+u4A6UYD
-ZicRFTuqW/KY3TZCstqIdQIDAQABoxMwETAPBgNVHRMBAf8EBTADAQH/MA0GCSqG
-SIb3DQEBBAUAA4GBAGk2ifc0KjNyL2071CKyuG+axTZmDhs8obF1Wub9NdP4qPIH
-b4Vnjt4rueIXsDqg8A6iAJrf8xQVbrvIhVqYgPn/vnQdPfP+MCXRNzRn+qVxeTBh
-KXLA4CxM+1bkOqhv5TJZUtt1KFBZDPgLGeSs2a+WjS9Q2wfD6h+rM+D1KzGJ
------END CERTIFICATE-----
-
-Thawte Personal Freemail CA
-===========================
-
------BEGIN CERTIFICATE-----
-MIIDLTCCApagAwIBAgIBADANBgkqhkiG9w0BAQQFADCB0TELMAkGA1UEBhMCWkEx
-FTATBgNVBAgTDFdlc3Rlcm4gQ2FwZTESMBAGA1UEBxMJQ2FwZSBUb3duMRowGAYD
-VQQKExFUaGF3dGUgQ29uc3VsdGluZzEoMCYGA1UECxMfQ2VydGlmaWNhdGlvbiBT
-ZXJ2aWNlcyBEaXZpc2lvbjEkMCIGA1UEAxMbVGhhd3RlIFBlcnNvbmFsIEZyZWVt
-YWlsIENBMSswKQYJKoZIhvcNAQkBFhxwZXJzb25hbC1mcmVlbWFpbEB0aGF3dGUu
-Y29tMB4XDTk2MDEwMTAwMDAwMFoXDTIwMTIzMTIzNTk1OVowgdExCzAJBgNVBAYT
-AlpBMRUwEwYDVQQIEwxXZXN0ZXJuIENhcGUxEjAQBgNVBAcTCUNhcGUgVG93bjEa
-MBgGA1UEChMRVGhhd3RlIENvbnN1bHRpbmcxKDAmBgNVBAsTH0NlcnRpZmljYXRp
-b24gU2VydmljZXMgRGl2aXNpb24xJDAiBgNVBAMTG1RoYXd0ZSBQZXJzb25hbCBG
-cmVlbWFpbCBDQTErMCkGCSqGSIb3DQEJARYccGVyc29uYWwtZnJlZW1haWxAdGhh
-d3RlLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA1GnX1LCUZFtx6UfY
-DFG26nKRsIRefS0Nj3sS34UldSh0OkIsYyeflXtL734Zhx2G6qPduc6WZBrCFG5E
-rHzmj+hND3EfQDimAKOHePb5lIZererAXnbr2RSjXW56fAylS1V/Bhkpf56aJtVq
-uzgkCGqYx7Hao5iR/Xnb5VrEHLkCAwEAAaMTMBEwDwYDVR0TAQH/BAUwAwEB/zAN
-BgkqhkiG9w0BAQQFAAOBgQDH7JJ+Tvj1lqVnYiqk8E0RYNBvjWBYYawmu1I1XAjP
-MPuoSpaKH2JCI4wXD/S6ZJwXrEcp352YXtJsYHFcoqzceePnbgBHH7UNKOgCneSa
-/RP0ptl8sfjcXyMmCZGAc9AUG95DqYMl8uacLxXK/qarigd1iwzdUYRr5PjRznei
-gQ==
------END CERTIFICATE-----
-
-Thawte Server CA
-================
-
+# Issuer: CN=Thawte Server CA O=Thawte Consulting cc OU=Certification Services Division
+# Subject: CN=Thawte Server CA O=Thawte Consulting cc OU=Certification Services Division
+# Label: "Thawte Server CA"
+# Serial: 1
+# MD5 Fingerprint: c5:70:c4:a2:ed:53:78:0c:c8:10:53:81:64:cb:d0:1d
+# SHA1 Fingerprint: 23:e5:94:94:51:95:f2:41:48:03:b4:d5:64:d2:a3:a3:f5:d8:8b:8c
+# SHA256 Fingerprint: b4:41:0b:73:e2:e6:ea:ca:47:fb:c4:2f:8f:a4:01:8a:f4:38:1d:c5:4c:fa:a8:44:50:46:1e:ed:09:45:4d:e9
 -----BEGIN CERTIFICATE-----
 MIIDEzCCAnygAwIBAgIBATANBgkqhkiG9w0BAQQFADCBxDELMAkGA1UEBhMCWkEx
 FTATBgNVBAgTDFdlc3Rlcm4gQ2FwZTESMBAGA1UEBxMJQ2FwZSBUb3duMR0wGwYD
@@ -150,9 +48,13 @@ QNuozDJ0uW8NxuOzRAvZim+aKZuZGCg70eNAKJpaPNW15yAbi8qkq43pUdniTCxZ
 qdq5snUb9kLy78fyGPmJvKP/iiMucEc=
 -----END CERTIFICATE-----
 
-Thawte Premium Server CA
-========================
-
+# Issuer: CN=Thawte Premium Server CA O=Thawte Consulting cc OU=Certification Services Division
+# Subject: CN=Thawte Premium Server CA O=Thawte Consulting cc OU=Certification Services Division
+# Label: "Thawte Premium Server CA"
+# Serial: 1
+# MD5 Fingerprint: 06:9f:69:79:16:66:90:02:1b:8c:8c:a2:c3:07:6f:3a
+# SHA1 Fingerprint: 62:7f:8d:78:27:65:63:99:d2:7d:7f:90:44:c9:fe:b3:f3:3e:fa:9a
+# SHA256 Fingerprint: ab:70:36:36:5c:71:54:aa:29:c2:c2:9f:5d:41:91:16:3b:16:2a:22:25:01:13:57:d5:6d:07:ff:a7:bc:1f:72
 -----BEGIN CERTIFICATE-----
 MIIDJzCCApCgAwIBAgIBATANBgkqhkiG9w0BAQQFADCBzjELMAkGA1UEBhMCWkEx
 FTATBgNVBAgTDFdlc3Rlcm4gQ2FwZTESMBAGA1UEBxMJQ2FwZSBUb3duMR0wGwYD
@@ -173,9 +75,13 @@ hfzJATj/Tb7yFkJD57taRvvBxhEf8UqwKEbJw8RCfbz6q1lu1bdRiBHjpIUZa4JM
 pAwSremkrj/xw0llmozFyD4lt5SZu5IycQfwhl7tUCemDaYj+bvLpgcUQg==
 -----END CERTIFICATE-----
 
-Equifax Secure CA
-=================
-
+# Issuer: O=Equifax OU=Equifax Secure Certificate Authority
+# Subject: O=Equifax OU=Equifax Secure Certificate Authority
+# Label: "Equifax Secure CA"
+# Serial: 903804111
+# MD5 Fingerprint: 67:cb:9d:c0:13:24:8a:82:9b:b2:17:1e:d1:1b:ec:d4
+# SHA1 Fingerprint: d2:32:09:ad:23:d3:14:23:21:74:e4:0d:7f:9d:62:13:97:86:63:3a
+# SHA256 Fingerprint: 08:29:7a:40:47:db:a2:36:80:c7:31:db:6e:31:76:53:ca:78:48:e1:be:bd:3a:0b:01:79:a7:07:f9:2c:f1:78
 -----BEGIN CERTIFICATE-----
 MIIDIDCCAomgAwIBAgIENd70zzANBgkqhkiG9w0BAQUFADBOMQswCQYDVQQGEwJV
 UzEQMA4GA1UEChMHRXF1aWZheDEtMCsGA1UECxMkRXF1aWZheCBTZWN1cmUgQ2Vy
@@ -196,46 +102,13 @@ A4GBAFjOKer89961zgK5F7WF0bnj4JXMJTENAKaSbn+2kmOeUJXRmm/kEd5jhW6Y
 1voqZiegDfqnc1zqcPGUIWVEX/r87yloqaKHee9570+sB3c4
 -----END CERTIFICATE-----
 
-Verisign Class 1 Public Primary Certification Authority
-=======================================================
-
------BEGIN CERTIFICATE-----
-MIICPTCCAaYCEQDNun9W8N/kvFT+IqyzcqpVMA0GCSqGSIb3DQEBAgUAMF8xCzAJ
-BgNVBAYTAlVTMRcwFQYDVQQKEw5WZXJpU2lnbiwgSW5jLjE3MDUGA1UECxMuQ2xh
-c3MgMSBQdWJsaWMgUHJpbWFyeSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTAeFw05
-NjAxMjkwMDAwMDBaFw0yODA4MDEyMzU5NTlaMF8xCzAJBgNVBAYTAlVTMRcwFQYD
-VQQKEw5WZXJpU2lnbiwgSW5jLjE3MDUGA1UECxMuQ2xhc3MgMSBQdWJsaWMgUHJp
-bWFyeSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTCBnzANBgkqhkiG9w0BAQEFAAOB
-jQAwgYkCgYEA5Rm/baNWYS2ZSHH2Z965jeu3noaACpEO+jglr0aIguVzqKCbJF0N
-H8xlbgyw0FaEGIeaBpsQoXPftFg5a27B9hXVqKg/qhIGjTGsf7A01480Z4gJzRQR
-4k5FVmkfeAKA2txHkSm7NsljXMXg1y2He6G3MrB7MLoqLzGq7qNn2tsCAwEAATAN
-BgkqhkiG9w0BAQIFAAOBgQBMP7iLxmjf7kMzDl3ppssHhE16M/+SG/Q2rdiVIjZo
-EWx8QszznC7EBz8UsA9P/5CSdvnivErpj82ggAr3xSnxgiJduLHdgSOjeyUVRjB5
-FvjqBUuUfx3CHMjjt/QQQDwTw18fU+hI5Ia0e6E1sHslurjTjqs/OJ0ANACY89Fx
-lA==
------END CERTIFICATE-----
-
-Verisign Class 2 Public Primary Certification Authority
-=======================================================
-
------BEGIN CERTIFICATE-----
-MIICPDCCAaUCEC0b/EoXjaOR6+f/9YtFvgswDQYJKoZIhvcNAQECBQAwXzELMAkG
-A1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMTcwNQYDVQQLEy5DbGFz
-cyAyIFB1YmxpYyBQcmltYXJ5IENlcnRpZmljYXRpb24gQXV0aG9yaXR5MB4XDTk2
-MDEyOTAwMDAwMFoXDTI4MDgwMTIzNTk1OVowXzELMAkGA1UEBhMCVVMxFzAVBgNV
-BAoTDlZlcmlTaWduLCBJbmMuMTcwNQYDVQQLEy5DbGFzcyAyIFB1YmxpYyBQcmlt
-YXJ5IENlcnRpZmljYXRpb24gQXV0aG9yaXR5MIGfMA0GCSqGSIb3DQEBAQUAA4GN
-ADCBiQKBgQC2WoujDWojg4BrzzmH9CETMwZMJaLtVRKXxaeAufqDwSCg+i8VDXyh
-YGt+eSz6Bg86rvYbb7HS/y8oUl+DfUvEerf4Zh+AVPy3wo5ZShRXRtGak75BkQO7
-FYCTXOvnzAhsPz6zSvz/S2wj1VCCJkQZjiPDceoZJEcEnnW/yKYAHwIDAQABMA0G
-CSqGSIb3DQEBAgUAA4GBAIobK/o5wXTXXtgZZKJYSi034DNHD6zt96rbHuSLBlxg
-J8pFUs4W7z8GZOeUaHxgMxURaa+dYo2jA1Rrpr7l7gUYYAS/QoD90KioHgE796Nc
-r6Pc5iaAIzy4RHT3Cq5Ji2F4zCS/iIqnDupzGUH9TQPwiNHleI2lKk/2lw0Xd8rY
------END CERTIFICATE-----
-
-Verisign Class 3 Public Primary Certification Authority
-=======================================================
-
+# Issuer: O=VeriSign, Inc. OU=Class 3 Public Primary Certification Authority
+# Subject: O=VeriSign, Inc. OU=Class 3 Public Primary Certification Authority
+# Label: "Verisign Class 3 Public Primary Certification Authority"
+# Serial: 149843929435818692848040365716851702463
+# MD5 Fingerprint: 10:fc:63:5d:f6:26:3e:0d:f3:25:be:5f:79:cd:67:67
+# SHA1 Fingerprint: 74:2c:31:92:e6:07:e4:24:eb:45:49:54:2b:e1:bb:c5:3e:61:74:e2
+# SHA256 Fingerprint: e7:68:56:34:ef:ac:f6:9a:ce:93:9a:6b:25:5b:7b:4f:ab:ef:42:93:5b:50:a2:65:ac:b5:cb:60:27:e4:4e:70
 -----BEGIN CERTIFICATE-----
 MIICPDCCAaUCEHC65B0Q2Sk0tjjKewPMur8wDQYJKoZIhvcNAQECBQAwXzELMAkG
 A1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMTcwNQYDVQQLEy5DbGFz
@@ -251,55 +124,13 @@ lbwdj2wsqFHMc9ikwFPwTtYmwHYBV4GSXiHx0bH/59AhWM1pF+NEHJwZRDmJXNyc
 AA9WjQKZ7aKQRUzkuxCkPfAyAw7xzvjoyVGM5mKf5p/AfbdynMk2OmufTqj/ZA1k
 -----END CERTIFICATE-----
 
-Verisign Class 1 Public Primary Certification Authority - G2
-============================================================
-
------BEGIN CERTIFICATE-----
-MIIDAjCCAmsCEEzH6qqYPnHTkxD4PTqJkZIwDQYJKoZIhvcNAQEFBQAwgcExCzAJ
-BgNVBAYTAlVTMRcwFQYDVQQKEw5WZXJpU2lnbiwgSW5jLjE8MDoGA1UECxMzQ2xh
-c3MgMSBQdWJsaWMgUHJpbWFyeSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eSAtIEcy
-MTowOAYDVQQLEzEoYykgMTk5OCBWZXJpU2lnbiwgSW5jLiAtIEZvciBhdXRob3Jp
-emVkIHVzZSBvbmx5MR8wHQYDVQQLExZWZXJpU2lnbiBUcnVzdCBOZXR3b3JrMB4X
-DTk4MDUxODAwMDAwMFoXDTI4MDgwMTIzNTk1OVowgcExCzAJBgNVBAYTAlVTMRcw
-FQYDVQQKEw5WZXJpU2lnbiwgSW5jLjE8MDoGA1UECxMzQ2xhc3MgMSBQdWJsaWMg
-UHJpbWFyeSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eSAtIEcyMTowOAYDVQQLEzEo
-YykgMTk5OCBWZXJpU2lnbiwgSW5jLiAtIEZvciBhdXRob3JpemVkIHVzZSBvbmx5
-MR8wHQYDVQQLExZWZXJpU2lnbiBUcnVzdCBOZXR3b3JrMIGfMA0GCSqGSIb3DQEB
-AQUAA4GNADCBiQKBgQCq0Lq+Fi24g9TK0g+8djHKlNgdk4xWArzZbxpvUjZudVYK
-VdPfQ4chEWWKfo+9Id5rMj8bhDSVBZ1BNeuS65bdqlk/AVNtmU/t5eIqWpDBucSm
-Fc/IReumXY6cPvBkJHalzasab7bYe1FhbqZ/h8jit+U03EGI6glAvnOSPWvndQID
-AQABMA0GCSqGSIb3DQEBBQUAA4GBAKlPww3HZ74sy9mozS11534Vnjty637rXC0J
-h9ZrbWB85a7FkCMMXErQr7Fd88e2CtvgFZMN3QO8x3aKtd1Pw5sTdbgBwObJW2ul
-uIncrKTdcu1OofdPvAbT6shkdHvClUGcZXNY8ZCaPGqxmMnEh7zPRW1F4m4iP/68
-DzFc6PLZ
------END CERTIFICATE-----
-
-Verisign Class 2 Public Primary Certification Authority - G2
-============================================================
-
------BEGIN CERTIFICATE-----
-MIIDAzCCAmwCEQC5L2DMiJ+hekYJuFtwbIqvMA0GCSqGSIb3DQEBBQUAMIHBMQsw
-CQYDVQQGEwJVUzEXMBUGA1UEChMOVmVyaVNpZ24sIEluYy4xPDA6BgNVBAsTM0Ns
-YXNzIDIgUHVibGljIFByaW1hcnkgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkgLSBH
-MjE6MDgGA1UECxMxKGMpIDE5OTggVmVyaVNpZ24sIEluYy4gLSBGb3IgYXV0aG9y
-aXplZCB1c2Ugb25seTEfMB0GA1UECxMWVmVyaVNpZ24gVHJ1c3QgTmV0d29yazAe
-Fw05ODA1MTgwMDAwMDBaFw0yODA4MDEyMzU5NTlaMIHBMQswCQYDVQQGEwJVUzEX
-MBUGA1UEChMOVmVyaVNpZ24sIEluYy4xPDA6BgNVBAsTM0NsYXNzIDIgUHVibGlj
-IFByaW1hcnkgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkgLSBHMjE6MDgGA1UECxMx
-KGMpIDE5OTggVmVyaVNpZ24sIEluYy4gLSBGb3IgYXV0aG9yaXplZCB1c2Ugb25s
-eTEfMB0GA1UECxMWVmVyaVNpZ24gVHJ1c3QgTmV0d29yazCBnzANBgkqhkiG9w0B
-AQEFAAOBjQAwgYkCgYEAp4gBIXQs5xoD8JjhlzwPIQjxnNuX6Zr8wgQGE75fUsjM
-HiwSViy4AWkszJkfrbCWrnkE8hM5wXuYuggs6MKEEyyqaekJ9MepAqRCwiNPStjw
-DqL7MWzJ5m+ZJwf15vRMeJ5t60aG+rmGyVTyssSv1EYcWskVMP8NbPUtDm3Of3cC
-AwEAATANBgkqhkiG9w0BAQUFAAOBgQByLvl/0fFx+8Se9sVeUYpAmLho+Jscg9ji
-nb3/7aHmZuovCfTK1+qlK5X2JGCGTUQug6XELaDTrnhpb3LabK4I8GOSN+a7xDAX
-rXfMSTWqz9iP0b63GJZHc2pUIjRkLbYWm1lbtFFZOrMLFPQS32eg9K0yZF6xRnIn
-jBJ7xUS0rg==
------END CERTIFICATE-----
-
-Verisign Class 3 Public Primary Certification Authority - G2
-============================================================
-
+# Issuer: O=VeriSign, Inc. OU=Class 3 Public Primary Certification Authority - G2/(c) 1998 VeriSign, Inc. - For authorized use only/VeriSign Trust Network
+# Subject: O=VeriSign, Inc. OU=Class 3 Public Primary Certification Authority - G2/(c) 1998 VeriSign, Inc. - For authorized use only/VeriSign Trust Network
+# Label: "Verisign Class 3 Public Primary Certification Authority - G2"
+# Serial: 167285380242319648451154478808036881606
+# MD5 Fingerprint: a2:33:9b:4c:74:78:73:d4:6c:e7:c1:f3:8d:cb:5c:e9
+# SHA1 Fingerprint: 85:37:1c:a6:e5:50:14:3d:ce:28:03:47:1b:de:3a:09:e8:f8:77:0f
+# SHA256 Fingerprint: 83:ce:3c:12:29:68:8a:59:3d:48:5f:81:97:3c:0f:91:95:43:1e:da:37:cc:5e:36:43:0e:79:c7:a8:88:63:8b
 -----BEGIN CERTIFICATE-----
 MIIDAjCCAmsCEH3Z/gfPqB63EHln+6eJNMYwDQYJKoZIhvcNAQEFBQAwgcExCzAJ
 BgNVBAYTAlVTMRcwFQYDVQQKEw5WZXJpU2lnbiwgSW5jLjE8MDoGA1UECxMzQ2xh
@@ -320,88 +151,150 @@ F6YM40AIOw7n60RzKprxaZLvcRTDOaxxp5EJb+RxBrO6WVcmeQD2+A2iMzAo1KpY
 oJ2daZH9
 -----END CERTIFICATE-----
 
-Verisign Class 4 Public Primary Certification Authority - G2
-============================================================
-
+# Issuer: CN=GlobalSign Root CA O=GlobalSign nv-sa OU=Root CA
+# Subject: CN=GlobalSign Root CA O=GlobalSign nv-sa OU=Root CA
+# Label: "GlobalSign Root CA"
+# Serial: 4835703278459707669005204
+# MD5 Fingerprint: 3e:45:52:15:09:51:92:e1:b7:5d:37:9f:b1:87:29:8a
+# SHA1 Fingerprint: b1:bc:96:8b:d4:f4:9d:62:2a:a8:9a:81:f2:15:01:52:a4:1d:82:9c
+# SHA256 Fingerprint: eb:d4:10:40:e4:bb:3e:c7:42:c9:e3:81:d3:1e:f2:a4:1a:48:b6:68:5c:96:e7:ce:f3:c1:df:6c:d4:33:1c:99
 -----BEGIN CERTIFICATE-----
-MIIDAjCCAmsCEDKIjprS9esTR/h/xCA3JfgwDQYJKoZIhvcNAQEFBQAwgcExCzAJ
-BgNVBAYTAlVTMRcwFQYDVQQKEw5WZXJpU2lnbiwgSW5jLjE8MDoGA1UECxMzQ2xh
-c3MgNCBQdWJsaWMgUHJpbWFyeSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eSAtIEcy
-MTowOAYDVQQLEzEoYykgMTk5OCBWZXJpU2lnbiwgSW5jLiAtIEZvciBhdXRob3Jp
-emVkIHVzZSBvbmx5MR8wHQYDVQQLExZWZXJpU2lnbiBUcnVzdCBOZXR3b3JrMB4X
-DTk4MDUxODAwMDAwMFoXDTI4MDgwMTIzNTk1OVowgcExCzAJBgNVBAYTAlVTMRcw
-FQYDVQQKEw5WZXJpU2lnbiwgSW5jLjE8MDoGA1UECxMzQ2xhc3MgNCBQdWJsaWMg
-UHJpbWFyeSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eSAtIEcyMTowOAYDVQQLEzEo
-YykgMTk5OCBWZXJpU2lnbiwgSW5jLiAtIEZvciBhdXRob3JpemVkIHVzZSBvbmx5
-MR8wHQYDVQQLExZWZXJpU2lnbiBUcnVzdCBOZXR3b3JrMIGfMA0GCSqGSIb3DQEB
-AQUAA4GNADCBiQKBgQC68OTP+cSuhVS5B1f5j8V/aBH4xBewRNzjMHPVKmIquNDM
-HO0oW369atyzkSTKQWI8/AIBvxwWMZQFl3Zuoq29YRdsTjCG8FE3KlDHqGKB3FtK
-qsGgtG7rL+VXxbErQHDbWk2hjh+9Ax/YA9SPTJlxvOKCzFjomDqG04Y48wApHwID
-AQABMA0GCSqGSIb3DQEBBQUAA4GBAIWMEsGnuVAVess+rLhDityq3RS6iYF+ATwj
-cSGIL4LcY/oCRaxFWdcqWERbt5+BO5JoPeI3JPV7bI92NZYJqFmduc4jq3TWg/0y
-cyfYaT5DdPauxYma51N86Xv2S/PBZYPejYqcPIiNOVn8qj8ijaHBZlCBckztImRP
-T8qAkbYp
+MIIDdTCCAl2gAwIBAgILBAAAAAABFUtaw5QwDQYJKoZIhvcNAQEFBQAwVzELMAkG
+A1UEBhMCQkUxGTAXBgNVBAoTEEdsb2JhbFNpZ24gbnYtc2ExEDAOBgNVBAsTB1Jv
+b3QgQ0ExGzAZBgNVBAMTEkdsb2JhbFNpZ24gUm9vdCBDQTAeFw05ODA5MDExMjAw
+MDBaFw0yODAxMjgxMjAwMDBaMFcxCzAJBgNVBAYTAkJFMRkwFwYDVQQKExBHbG9i
+YWxTaWduIG52LXNhMRAwDgYDVQQLEwdSb290IENBMRswGQYDVQQDExJHbG9iYWxT
+aWduIFJvb3QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDaDuaZ
+jc6j40+Kfvvxi4Mla+pIH/EqsLmVEQS98GPR4mdmzxzdzxtIK+6NiY6arymAZavp
+xy0Sy6scTHAHoT0KMM0VjU/43dSMUBUc71DuxC73/OlS8pF94G3VNTCOXkNz8kHp
+1Wrjsok6Vjk4bwY8iGlbKk3Fp1S4bInMm/k8yuX9ifUSPJJ4ltbcdG6TRGHRjcdG
+snUOhugZitVtbNV4FpWi6cgKOOvyJBNPc1STE4U6G7weNLWLBYy5d4ux2x8gkasJ
+U26Qzns3dLlwR5EiUWMWea6xrkEmCMgZK9FGqkjWZCrXgzT/LCrBbBlDSgeF59N8
+9iFo7+ryUp9/k5DPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8E
+BTADAQH/MB0GA1UdDgQWBBRge2YaRQ2XyolQL30EzTSo//z9SzANBgkqhkiG9w0B
+AQUFAAOCAQEA1nPnfE920I2/7LqivjTFKDK1fPxsnCwrvQmeU79rXqoRSLblCKOz
+yj1hTdNGCbM+w6DjY1Ub8rrvrTnhQ7k4o+YviiY776BQVvnGCv04zcQLcFGUl5gE
+38NflNUVyRRBnMRddWQVDf9VMOyGj/8N7yy5Y0b2qvzfvGn9LhJIZJrglfCm7ymP
+AbEVtQwdpf5pLGkkeB6zpxxxYu7KyJesF12KwvhHhm4qxFYxldBniYUr+WymXUad
+DKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveCX4XSQRjbgbME
+HMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==
 -----END CERTIFICATE-----
 
-Verisign Class 1 Public Primary Certification Authority - G3
-============================================================
-
+# Issuer: CN=GlobalSign O=GlobalSign OU=GlobalSign Root CA - R2
+# Subject: CN=GlobalSign O=GlobalSign OU=GlobalSign Root CA - R2
+# Label: "GlobalSign Root CA - R2"
+# Serial: 4835703278459682885658125
+# MD5 Fingerprint: 94:14:77:7e:3e:5e:fd:8f:30:bd:41:b0:cf:e7:d0:30
+# SHA1 Fingerprint: 75:e0:ab:b6:13:85:12:27:1c:04:f8:5f:dd:de:38:e4:b7:24:2e:fe
+# SHA256 Fingerprint: ca:42:dd:41:74:5f:d0:b8:1e:b9:02:36:2c:f9:d8:bf:71:9d:a1:bd:1b:1e:fc:94:6f:5b:4c:99:f4:2c:1b:9e
 -----BEGIN CERTIFICATE-----
-MIIEGjCCAwICEQCLW3VWhFSFCwDPrzhIzrGkMA0GCSqGSIb3DQEBBQUAMIHKMQsw
-CQYDVQQGEwJVUzEXMBUGA1UEChMOVmVyaVNpZ24sIEluYy4xHzAdBgNVBAsTFlZl
-cmlTaWduIFRydXN0IE5ldHdvcmsxOjA4BgNVBAsTMShjKSAxOTk5IFZlcmlTaWdu
-LCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNlIG9ubHkxRTBDBgNVBAMTPFZlcmlT
-aWduIENsYXNzIDEgUHVibGljIFByaW1hcnkgQ2VydGlmaWNhdGlvbiBBdXRob3Jp
-dHkgLSBHMzAeFw05OTEwMDEwMDAwMDBaFw0zNjA3MTYyMzU5NTlaMIHKMQswCQYD
-VQQGEwJVUzEXMBUGA1UEChMOVmVyaVNpZ24sIEluYy4xHzAdBgNVBAsTFlZlcmlT
-aWduIFRydXN0IE5ldHdvcmsxOjA4BgNVBAsTMShjKSAxOTk5IFZlcmlTaWduLCBJ
-bmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNlIG9ubHkxRTBDBgNVBAMTPFZlcmlTaWdu
-IENsYXNzIDEgUHVibGljIFByaW1hcnkgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkg
-LSBHMzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN2E1Lm0+afY8wR4
-nN493GwTFtl63SRRZsDHJlkNrAYIwpTRMx/wgzUfbhvI3qpuFU5UJ+/EbRrsC+MO
-8ESlV8dAWB6jRx9x7GD2bZTIGDnt/kIYVt/kTEkQeE4BdjVjEjbdZrwBBDajVWjV
-ojYJrKshJlQGrT/KFOCsyq0GHZXi+J3x4GD/wn91K0zM2v6HmSHquv4+VNfSWXjb
-PG7PoBMAGrgnoeS+Z5bKoMWznN3JdZ7rMJpfo83ZrngZPyPpXNspva1VyBtUjGP2
-6KbqxzcSXKMpHgLZ2x87tNcPVkeBFQRKr4Mn0cVYiMHd9qqnoxjaaKptEVHhv2Vr
-n5Z20T0CAwEAATANBgkqhkiG9w0BAQUFAAOCAQEAq2aN17O6x5q25lXQBfGfMY1a
-qtmqRiYPce2lrVNWYgFHKkTp/j90CxObufRNG7LRX7K20ohcs5/Ny9Sn2WCVhDr4
-wTcdYcrnsMXlkdpUpqwxga6X3s0IrLjAl4B/bnKk52kTlWUfxJM8/XmPBNQ+T+r3
-ns7NZ3xPZQL/kYVUc8f/NveGLezQXk//EZ9yBta4GvFMDSZl4kSAHsef493oCtrs
-pSCAaWihT37ha88HQfqDjrw43bAuEbFrskLMmrz5SCJ5ShkPshw+IHTZasO+8ih4
-E1Z5T21Q6huwtVexN2ZYI/PcD98Kh8TvhgXVOBRgmaNL3gaWcSzy27YfpO8/7g==
+MIIDujCCAqKgAwIBAgILBAAAAAABD4Ym5g0wDQYJKoZIhvcNAQEFBQAwTDEgMB4G
+A1UECxMXR2xvYmFsU2lnbiBSb290IENBIC0gUjIxEzARBgNVBAoTCkdsb2JhbFNp
+Z24xEzARBgNVBAMTCkdsb2JhbFNpZ24wHhcNMDYxMjE1MDgwMDAwWhcNMjExMjE1
+MDgwMDAwWjBMMSAwHgYDVQQLExdHbG9iYWxTaWduIFJvb3QgQ0EgLSBSMjETMBEG
+A1UEChMKR2xvYmFsU2lnbjETMBEGA1UEAxMKR2xvYmFsU2lnbjCCASIwDQYJKoZI
+hvcNAQEBBQADggEPADCCAQoCggEBAKbPJA6+Lm8omUVCxKs+IVSbC9N/hHD6ErPL
+v4dfxn+G07IwXNb9rfF73OX4YJYJkhD10FPe+3t+c4isUoh7SqbKSaZeqKeMWhG8
+eoLrvozps6yWJQeXSpkqBy+0Hne/ig+1AnwblrjFuTosvNYSuetZfeLQBoZfXklq
+tTleiDTsvHgMCJiEbKjNS7SgfQx5TfC4LcshytVsW33hoCmEofnTlEnLJGKRILzd
+C9XZzPnqJworc5HGnRusyMvo4KD0L5CLTfuwNhv2GXqF4G3yYROIXJ/gkwpRl4pa
+zq+r1feqCapgvdzZX99yqWATXgAByUr6P6TqBwMhAo6CygPCm48CAwEAAaOBnDCB
+mTAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUm+IH
+V2ccHsBqBt5ZtJot39wZhi4wNgYDVR0fBC8wLTAroCmgJ4YlaHR0cDovL2NybC5n
+bG9iYWxzaWduLm5ldC9yb290LXIyLmNybDAfBgNVHSMEGDAWgBSb4gdXZxwewGoG
+3lm0mi3f3BmGLjANBgkqhkiG9w0BAQUFAAOCAQEAmYFThxxol4aR7OBKuEQLq4Gs
+J0/WwbgcQ3izDJr86iw8bmEbTUsp9Z8FHSbBuOmDAGJFtqkIk7mpM0sYmsL4h4hO
+291xNBrBVNpGP+DTKqttVCL1OmLNIG+6KYnX3ZHu01yiPqFbQfXf5WRDLenVOavS
+ot+3i9DAgBkcRcAtjOj4LaR0VknFBbVPFd5uRHg5h6h+u/N5GJG79G+dwfCMNYxd
+AfvDbbnvRG15RjF+Cv6pgsH/76tuIMRQyV+dTZsXjAzlAcmgQWpzU/qlULRuJQ/7
+TBj0/VLZjmmx6BEP3ojY+x1J96relc8geMJgEtslQIxq/H5COEBkEveegeGTLg==
 -----END CERTIFICATE-----
 
-Verisign Class 2 Public Primary Certification Authority - G3
-============================================================
-
+# Issuer: CN=http://www.valicert.com/ O=ValiCert, Inc. OU=ValiCert Class 1 Policy Validation Authority
+# Subject: CN=http://www.valicert.com/ O=ValiCert, Inc. OU=ValiCert Class 1 Policy Validation Authority
+# Label: "ValiCert Class 1 VA"
+# Serial: 1
+# MD5 Fingerprint: 65:58:ab:15:ad:57:6c:1e:a8:a7:b5:69:ac:bf:ff:eb
+# SHA1 Fingerprint: e5:df:74:3c:b6:01:c4:9b:98:43:dc:ab:8c:e8:6a:81:10:9f:e4:8e
+# SHA256 Fingerprint: f4:c1:49:55:1a:30:13:a3:5b:c7:bf:fe:17:a7:f3:44:9b:c1:ab:5b:5a:0a:e7:4b:06:c2:3b:90:00:4c:01:04
 -----BEGIN CERTIFICATE-----
-MIIEGTCCAwECEGFwy0mMX5hFKeewptlQW3owDQYJKoZIhvcNAQEFBQAwgcoxCzAJ
-BgNVBAYTAlVTMRcwFQYDVQQKEw5WZXJpU2lnbiwgSW5jLjEfMB0GA1UECxMWVmVy
-aVNpZ24gVHJ1c3QgTmV0d29yazE6MDgGA1UECxMxKGMpIDE5OTkgVmVyaVNpZ24s
-IEluYy4gLSBGb3IgYXV0aG9yaXplZCB1c2Ugb25seTFFMEMGA1UEAxM8VmVyaVNp
-Z24gQ2xhc3MgMiBQdWJsaWMgUHJpbWFyeSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0
-eSAtIEczMB4XDTk5MTAwMTAwMDAwMFoXDTM2MDcxNjIzNTk1OVowgcoxCzAJBgNV
-BAYTAlVTMRcwFQYDVQQKEw5WZXJpU2lnbiwgSW5jLjEfMB0GA1UECxMWVmVyaVNp
-Z24gVHJ1c3QgTmV0d29yazE6MDgGA1UECxMxKGMpIDE5OTkgVmVyaVNpZ24sIElu
-Yy4gLSBGb3IgYXV0aG9yaXplZCB1c2Ugb25seTFFMEMGA1UEAxM8VmVyaVNpZ24g
-Q2xhc3MgMiBQdWJsaWMgUHJpbWFyeSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eSAt
-IEczMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArwoNwtUs22e5LeWU
-J92lvuCwTY+zYVY81nzD9M0+hsuiiOLh2KRpxbXiv8GmR1BeRjmL1Za6tW8UvxDO
-JxOeBUebMXoT2B/Z0wI3i60sR/COgQanDTAM6/c8DyAd3HJG7qUCyFvDyVZpTMUY
-wZF7C9UTAJu878NIPkZgIIUq1ZC2zYugzDLdt/1AVbJQHFauzI13TccgTacxdu9o
-koqQHgiBVrKtaaNS0MscxCM9H5n+TOgWY47GCI72MfbS+uV23bUckqNJzc0BzWjN
-qWm6o+sdDZykIKbBoMXRRkwXbdKsZj+WjOCE1Db/IlnF+RFgqF8EffIa9iVCYQ/E
-Srg+iQIDAQABMA0GCSqGSIb3DQEBBQUAA4IBAQA0JhU8wI1NQ0kdvekhktdmnLfe
-xbjQ5F1fdiLAJvmEOjr5jLX77GDx6M4EsMjdpwOPMPOY36TmpDHf0xwLRtxyID+u
-7gU8pDM/CzmscHhzS5kr3zDCVLCoO1Wh/hYozUK9dG6A2ydEp85EXdQbkJgNHkKU
-sQAsBNB0owIFImNjzYO1+8FtYmtpdf1dcEG59b98377BMnMiIYtYgXsVkXq642RI
-sH/7NiXaldDxJBQX3RiAa0YjOVT1jmIJBB2UkKab5iXiQkWquJCtvgiPqQtCGJTP
-cjnhsUPgKM+351psE2tJs//jGHyJizNdrDPXp/naOlXJWBD5qu9ats9LS98q
+MIIC5zCCAlACAQEwDQYJKoZIhvcNAQEFBQAwgbsxJDAiBgNVBAcTG1ZhbGlDZXJ0
+IFZhbGlkYXRpb24gTmV0d29yazEXMBUGA1UEChMOVmFsaUNlcnQsIEluYy4xNTAz
+BgNVBAsTLFZhbGlDZXJ0IENsYXNzIDEgUG9saWN5IFZhbGlkYXRpb24gQXV0aG9y
+aXR5MSEwHwYDVQQDExhodHRwOi8vd3d3LnZhbGljZXJ0LmNvbS8xIDAeBgkqhkiG
+9w0BCQEWEWluZm9AdmFsaWNlcnQuY29tMB4XDTk5MDYyNTIyMjM0OFoXDTE5MDYy
+NTIyMjM0OFowgbsxJDAiBgNVBAcTG1ZhbGlDZXJ0IFZhbGlkYXRpb24gTmV0d29y
+azEXMBUGA1UEChMOVmFsaUNlcnQsIEluYy4xNTAzBgNVBAsTLFZhbGlDZXJ0IENs
+YXNzIDEgUG9saWN5IFZhbGlkYXRpb24gQXV0aG9yaXR5MSEwHwYDVQQDExhodHRw
+Oi8vd3d3LnZhbGljZXJ0LmNvbS8xIDAeBgkqhkiG9w0BCQEWEWluZm9AdmFsaWNl
+cnQuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDYWYJ6ibiWuqYvaG9Y
+LqdUHAZu9OqNSLwxlBfw8068srg1knaw0KWlAdcAAxIiGQj4/xEjm84H9b9pGib+
+TunRf50sQB1ZaG6m+FiwnRqP0z/x3BkGgagO4DrdyFNFCQbmD3DD+kCmDuJWBQ8Y
+TfwggtFzVXSNdnKgHZ0dwN0/cQIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAFBoPUn0
+LBwGlN+VYH+Wexf+T3GtZMjdd9LvWVXoP+iOBSoh8gfStadS/pyxtuJbdxdA6nLW
+I8sogTLDAHkY7FkXicnGah5xyf23dKUlRWnFSKsZ4UWKJWsZ7uW7EvV/96aNUcPw
+nXS3qT6gpf+2SQMT2iLM7XGCK5nPOrf1LXLI
 -----END CERTIFICATE-----
 
-Verisign Class 3 Public Primary Certification Authority - G3
-============================================================
+# Issuer: CN=http://www.valicert.com/ O=ValiCert, Inc. OU=ValiCert Class 2 Policy Validation Authority
+# Subject: CN=http://www.valicert.com/ O=ValiCert, Inc. OU=ValiCert Class 2 Policy Validation Authority
+# Label: "ValiCert Class 2 VA"
+# Serial: 1
+# MD5 Fingerprint: a9:23:75:9b:ba:49:36:6e:31:c2:db:f2:e7:66:ba:87
+# SHA1 Fingerprint: 31:7a:2a:d0:7f:2b:33:5e:f5:a1:c3:4e:4b:57:e8:b7:d8:f1:fc:a6
+# SHA256 Fingerprint: 58:d0:17:27:9c:d4:dc:63:ab:dd:b1:96:a6:c9:90:6c:30:c4:e0:87:83:ea:e8:c1:60:99:54:d6:93:55:59:6b
+-----BEGIN CERTIFICATE-----
+MIIC5zCCAlACAQEwDQYJKoZIhvcNAQEFBQAwgbsxJDAiBgNVBAcTG1ZhbGlDZXJ0
+IFZhbGlkYXRpb24gTmV0d29yazEXMBUGA1UEChMOVmFsaUNlcnQsIEluYy4xNTAz
+BgNVBAsTLFZhbGlDZXJ0IENsYXNzIDIgUG9saWN5IFZhbGlkYXRpb24gQXV0aG9y
+aXR5MSEwHwYDVQQDExhodHRwOi8vd3d3LnZhbGljZXJ0LmNvbS8xIDAeBgkqhkiG
+9w0BCQEWEWluZm9AdmFsaWNlcnQuY29tMB4XDTk5MDYyNjAwMTk1NFoXDTE5MDYy
+NjAwMTk1NFowgbsxJDAiBgNVBAcTG1ZhbGlDZXJ0IFZhbGlkYXRpb24gTmV0d29y
+azEXMBUGA1UEChMOVmFsaUNlcnQsIEluYy4xNTAzBgNVBAsTLFZhbGlDZXJ0IENs
+YXNzIDIgUG9saWN5IFZhbGlkYXRpb24gQXV0aG9yaXR5MSEwHwYDVQQDExhodHRw
+Oi8vd3d3LnZhbGljZXJ0LmNvbS8xIDAeBgkqhkiG9w0BCQEWEWluZm9AdmFsaWNl
+cnQuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDOOnHK5avIWZJV16vY
+dA757tn2VUdZZUcOBVXc65g2PFxTXdMwzzjsvUGJ7SVCCSRrCl6zfN1SLUzm1NZ9
+WlmpZdRJEy0kTRxQb7XBhVQ7/nHk01xC+YDgkRoKWzk2Z/M/VXwbP7RfZHM047QS
+v4dk+NoS/zcnwbNDu+97bi5p9wIDAQABMA0GCSqGSIb3DQEBBQUAA4GBADt/UG9v
+UJSZSWI4OB9L+KXIPqeCgfYrx+jFzug6EILLGACOTb2oWH+heQC1u+mNr0HZDzTu
+IYEZoDJJKPTEjlbVUjP9UNV+mWwD5MlM/Mtsq2azSiGM5bUMMj4QssxsodyamEwC
+W/POuZ6lcg5Ktz885hZo+L7tdEy8W9ViH0Pd
+-----END CERTIFICATE-----
 
+# Issuer: CN=http://www.valicert.com/ O=ValiCert, Inc. OU=ValiCert Class 3 Policy Validation Authority
+# Subject: CN=http://www.valicert.com/ O=ValiCert, Inc. OU=ValiCert Class 3 Policy Validation Authority
+# Label: "RSA Root Certificate 1"
+# Serial: 1
+# MD5 Fingerprint: a2:6f:53:b7:ee:40:db:4a:68:e7:fa:18:d9:10:4b:72
+# SHA1 Fingerprint: 69:bd:8c:f4:9c:d3:00:fb:59:2e:17:93:ca:55:6a:f3:ec:aa:35:fb
+# SHA256 Fingerprint: bc:23:f9:8a:31:3c:b9:2d:e3:bb:fc:3a:5a:9f:44:61:ac:39:49:4c:4a:e1:5a:9e:9d:f1:31:e9:9b:73:01:9a
+-----BEGIN CERTIFICATE-----
+MIIC5zCCAlACAQEwDQYJKoZIhvcNAQEFBQAwgbsxJDAiBgNVBAcTG1ZhbGlDZXJ0
+IFZhbGlkYXRpb24gTmV0d29yazEXMBUGA1UEChMOVmFsaUNlcnQsIEluYy4xNTAz
+BgNVBAsTLFZhbGlDZXJ0IENsYXNzIDMgUG9saWN5IFZhbGlkYXRpb24gQXV0aG9y
+aXR5MSEwHwYDVQQDExhodHRwOi8vd3d3LnZhbGljZXJ0LmNvbS8xIDAeBgkqhkiG
+9w0BCQEWEWluZm9AdmFsaWNlcnQuY29tMB4XDTk5MDYyNjAwMjIzM1oXDTE5MDYy
+NjAwMjIzM1owgbsxJDAiBgNVBAcTG1ZhbGlDZXJ0IFZhbGlkYXRpb24gTmV0d29y
+azEXMBUGA1UEChMOVmFsaUNlcnQsIEluYy4xNTAzBgNVBAsTLFZhbGlDZXJ0IENs
+YXNzIDMgUG9saWN5IFZhbGlkYXRpb24gQXV0aG9yaXR5MSEwHwYDVQQDExhodHRw
+Oi8vd3d3LnZhbGljZXJ0LmNvbS8xIDAeBgkqhkiG9w0BCQEWEWluZm9AdmFsaWNl
+cnQuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDjmFGWHOjVsQaBalfD
+cnWTq8+epvzzFlLWLU2fNUSoLgRNB0mKOCn1dzfnt6td3zZxFJmP3MKS8edgkpfs
+2Ejcv8ECIMYkpChMMFp2bbFc893enhBxoYjHW5tBbcqwuI4V7q0zK89HBFx1cQqY
+JJgpp0lZpd34t0NiYfPT4tBVPwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAFa7AliE
+Zwgs3x/be0kz9dNnnfS0ChCzycUs4pJqcXgn8nCDQtM+z6lU9PHYkhaM0QTLS6vJ
+n0WuPIqpsHEzXcjFV9+vqDWzf4mH6eglkrh/hXqu1rweN1gqZ8mRzyqBPu3GOd/A
+PhmcGcwTTYJBtYze4D1gCCAPRX5ron+jjBXu
+-----END CERTIFICATE-----
+
+# Issuer: CN=VeriSign Class 3 Public Primary Certification Authority - G3 O=VeriSign, Inc. OU=VeriSign Trust Network/(c) 1999 VeriSign, Inc. - For authorized use only
+# Subject: CN=VeriSign Class 3 Public Primary Certification Authority - G3 O=VeriSign, Inc. OU=VeriSign Trust Network/(c) 1999 VeriSign, Inc. - For authorized use only
+# Label: "Verisign Class 3 Public Primary Certification Authority - G3"
+# Serial: 206684696279472310254277870180966723415
+# MD5 Fingerprint: cd:68:b6:a7:c7:c4:ce:75:e0:1d:4f:57:44:61:92:09
+# SHA1 Fingerprint: 13:2d:0d:45:53:4b:69:97:cd:b2:d5:c3:39:e2:55:76:60:9b:5c:c6
+# SHA256 Fingerprint: eb:04:cf:5e:b1:f3:9a:fa:76:2f:2b:b1:20:f2:96:cb:a5:20:c1:b9:7d:b1:58:95:65:b8:1c:b9:a1:7b:72:44
 -----BEGIN CERTIFICATE-----
 MIIEGjCCAwICEQCbfgZJoz5iudXukEhxKe9XMA0GCSqGSIb3DQEBBQUAMIHKMQsw
 CQYDVQQGEwJVUzEXMBUGA1UEChMOVmVyaVNpZ24sIEluYy4xHzAdBgNVBAsTFlZl
@@ -427,9 +320,13 @@ F4ErWjfJXir0xuKhXFSbplQAz/DxwceYMBo7Nhbbo27q/a2ywtrvAkcTisDxszGt
 TxzhT5yvDwyd93gN2PQ1VoDat20Xj50egWTh/sVFuq1ruQp6Tk9LhO5L8X3dEQ==
 -----END CERTIFICATE-----
 
-Verisign Class 4 Public Primary Certification Authority - G3
-============================================================
-
+# Issuer: CN=VeriSign Class 4 Public Primary Certification Authority - G3 O=VeriSign, Inc. OU=VeriSign Trust Network/(c) 1999 VeriSign, Inc. - For authorized use only
+# Subject: CN=VeriSign Class 4 Public Primary Certification Authority - G3 O=VeriSign, Inc. OU=VeriSign Trust Network/(c) 1999 VeriSign, Inc. - For authorized use only
+# Label: "Verisign Class 4 Public Primary Certification Authority - G3"
+# Serial: 314531972711909413743075096039378935511
+# MD5 Fingerprint: db:c8:f2:27:2e:b1:ea:6a:29:23:5d:fe:56:3e:33:df
+# SHA1 Fingerprint: c8:ec:8c:87:92:69:cb:4b:ab:39:e9:8d:7e:57:67:f3:14:95:73:9d
+# SHA256 Fingerprint: e3:89:36:0d:0f:db:ae:b3:d2:50:58:4b:47:30:31:4e:22:2f:39:c1:56:a0:20:14:4e:8d:96:05:61:79:15:06
 -----BEGIN CERTIFICATE-----
 MIIEGjCCAwICEQDsoKeLbnVqAc/EfMwvlF7XMA0GCSqGSIb3DQEBBQUAMIHKMQsw
 CQYDVQQGEwJVUzEXMBUGA1UEChMOVmVyaVNpZ24sIEluYy4xHzAdBgNVBAsTFlZl
@@ -455,154 +352,13 @@ fjaF3H48ZwC15DtS4KjrXRX5xm3wrR0OhbepmnMUWluPQSjA1egtTaRezarZ7c7c
 bLvSHgCwIe34QWKCudiyxLtGUPMxxY8BqHTr9Xgn2uf3ZkPznoM+IKrDNWCRzg==
 -----END CERTIFICATE-----
 
-Equifax Secure Global eBusiness CA
-==================================
-
------BEGIN CERTIFICATE-----
-MIICkDCCAfmgAwIBAgIBATANBgkqhkiG9w0BAQQFADBaMQswCQYDVQQGEwJVUzEc
-MBoGA1UEChMTRXF1aWZheCBTZWN1cmUgSW5jLjEtMCsGA1UEAxMkRXF1aWZheCBT
-ZWN1cmUgR2xvYmFsIGVCdXNpbmVzcyBDQS0xMB4XDTk5MDYyMTA0MDAwMFoXDTIw
-MDYyMTA0MDAwMFowWjELMAkGA1UEBhMCVVMxHDAaBgNVBAoTE0VxdWlmYXggU2Vj
-dXJlIEluYy4xLTArBgNVBAMTJEVxdWlmYXggU2VjdXJlIEdsb2JhbCBlQnVzaW5l
-c3MgQ0EtMTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAuucXkAJlsTRVPEnC
-UdXfp9E3j9HngXNBUmCbnaEXJnitx7HoJpQytd4zjTov2/KaelpzmKNc6fuKcxtc
-58O/gGzNqfTWK8D3+ZmqY6KxRwIP1ORROhI8bIpaVIRw28HFkM9yRcuoWcDNM50/
-o5brhTMhHD4ePmBudpxnhcXIw2ECAwEAAaNmMGQwEQYJYIZIAYb4QgEBBAQDAgAH
-MA8GA1UdEwEB/wQFMAMBAf8wHwYDVR0jBBgwFoAUvqigdHJQa0S3ySPY+6j/s1dr
-aGwwHQYDVR0OBBYEFL6ooHRyUGtEt8kj2Puo/7NXa2hsMA0GCSqGSIb3DQEBBAUA
-A4GBADDiAVGqx+pf2rnQZQ8w1j7aDRRJbpGTJxQx78T3LUX47Me/okENI7SS+RkA
-Z70Br83gcfxaz2TE4JaY0KNA4gGK7ycH8WUBikQtBmV1UsCGECAhX2xrD2yuCRyv
-8qIYNMR1pHMc8Y3c7635s3a0kr/clRAevsvIO1qEYBlWlKlV
------END CERTIFICATE-----
-
-Equifax Secure eBusiness CA 1
-=============================
-
------BEGIN CERTIFICATE-----
-MIICgjCCAeugAwIBAgIBBDANBgkqhkiG9w0BAQQFADBTMQswCQYDVQQGEwJVUzEc
-MBoGA1UEChMTRXF1aWZheCBTZWN1cmUgSW5jLjEmMCQGA1UEAxMdRXF1aWZheCBT
-ZWN1cmUgZUJ1c2luZXNzIENBLTEwHhcNOTkwNjIxMDQwMDAwWhcNMjAwNjIxMDQw
-MDAwWjBTMQswCQYDVQQGEwJVUzEcMBoGA1UEChMTRXF1aWZheCBTZWN1cmUgSW5j
-LjEmMCQGA1UEAxMdRXF1aWZheCBTZWN1cmUgZUJ1c2luZXNzIENBLTEwgZ8wDQYJ
-KoZIhvcNAQEBBQADgY0AMIGJAoGBAM4vGbwXt3fek6lfWg0XTzQaDJj0ItlZ1MRo
-RvC0NcWFAyDGr0WlIVFFQesWWDYyb+JQYmT5/VGcqiTZ9J2DKocKIdMSODRsjQBu
-WqDZQu4aIZX5UkxVWsUPOE9G+m34LjXWHXzr4vCwdYDIqROsvojvOm6rXyo4YgKw
-Env+j6YDAgMBAAGjZjBkMBEGCWCGSAGG+EIBAQQEAwIABzAPBgNVHRMBAf8EBTAD
-AQH/MB8GA1UdIwQYMBaAFEp4MlIR21kWNl7fwRQ2QGpHfEyhMB0GA1UdDgQWBBRK
-eDJSEdtZFjZe38EUNkBqR3xMoTANBgkqhkiG9w0BAQQFAAOBgQB1W6ibAxHm6VZM
-zfmpTMANmvPMZWnmJXbMWbfWVMMdzZmsGd20hdXgPfxiIKeES1hl8eL5lSE/9dR+
-WB5Hh1Q+WKG1tfgq73HnvMP2sUlG4tega+VWeponmHxGYhTnyfxuAxJ5gDgdSIKN
-/Bf+KpYrtWKmpj29f5JZzVoqgrI3eQ==
------END CERTIFICATE-----
-
-Equifax Secure eBusiness CA 2
-=============================
-
------BEGIN CERTIFICATE-----
-MIIDIDCCAomgAwIBAgIEN3DPtTANBgkqhkiG9w0BAQUFADBOMQswCQYDVQQGEwJV
-UzEXMBUGA1UEChMORXF1aWZheCBTZWN1cmUxJjAkBgNVBAsTHUVxdWlmYXggU2Vj
-dXJlIGVCdXNpbmVzcyBDQS0yMB4XDTk5MDYyMzEyMTQ0NVoXDTE5MDYyMzEyMTQ0
-NVowTjELMAkGA1UEBhMCVVMxFzAVBgNVBAoTDkVxdWlmYXggU2VjdXJlMSYwJAYD
-VQQLEx1FcXVpZmF4IFNlY3VyZSBlQnVzaW5lc3MgQ0EtMjCBnzANBgkqhkiG9w0B
-AQEFAAOBjQAwgYkCgYEA5Dk5kx5SBhsoNviyoynF7Y6yEb3+6+e0dMKP/wXn2Z0G
-vxLIPw7y1tEkshHe0XMJitSxLJgJDR5QRrKDpkWNYmi7hRsgcDKqQM2mll/EcTc/
-BPO3QSQ5BxoeLmFYoBIL5aXfxavqN3HMHMg3OrmXUqesxWoklE6ce8/AatbfIb0C
-AwEAAaOCAQkwggEFMHAGA1UdHwRpMGcwZaBjoGGkXzBdMQswCQYDVQQGEwJVUzEX
-MBUGA1UEChMORXF1aWZheCBTZWN1cmUxJjAkBgNVBAsTHUVxdWlmYXggU2VjdXJl
-IGVCdXNpbmVzcyBDQS0yMQ0wCwYDVQQDEwRDUkwxMBoGA1UdEAQTMBGBDzIwMTkw
-NjIzMTIxNDQ1WjALBgNVHQ8EBAMCAQYwHwYDVR0jBBgwFoAUUJ4L6q9euSBIplBq
-y/3YIHqngnYwHQYDVR0OBBYEFFCeC+qvXrkgSKZQasv92CB6p4J2MAwGA1UdEwQF
-MAMBAf8wGgYJKoZIhvZ9B0EABA0wCxsFVjMuMGMDAgbAMA0GCSqGSIb3DQEBBQUA
-A4GBAAyGgq3oThr1jokn4jVYPSm0B482UJW/bsGe68SQsoWou7dC4A8HOd/7npCy
-0cE+U58DRLB+S/Rv5Hwf5+Kx5Lia78O9zt4LMjTZ3ijtM2vE1Nc9ElirfQkty3D1
-E4qUoSek1nDFbZS1yX2doNLGCEnZZpum0/QL3MUmV+GRMOrN
------END CERTIFICATE-----
-
-Thawte Time Stamping CA
-=======================
-
------BEGIN CERTIFICATE-----
-MIICoTCCAgqgAwIBAgIBADANBgkqhkiG9w0BAQQFADCBizELMAkGA1UEBhMCWkEx
-FTATBgNVBAgTDFdlc3Rlcm4gQ2FwZTEUMBIGA1UEBxMLRHVyYmFudmlsbGUxDzAN
-BgNVBAoTBlRoYXd0ZTEdMBsGA1UECxMUVGhhd3RlIENlcnRpZmljYXRpb24xHzAd
-BgNVBAMTFlRoYXd0ZSBUaW1lc3RhbXBpbmcgQ0EwHhcNOTcwMTAxMDAwMDAwWhcN
-MjAxMjMxMjM1OTU5WjCBizELMAkGA1UEBhMCWkExFTATBgNVBAgTDFdlc3Rlcm4g
-Q2FwZTEUMBIGA1UEBxMLRHVyYmFudmlsbGUxDzANBgNVBAoTBlRoYXd0ZTEdMBsG
-A1UECxMUVGhhd3RlIENlcnRpZmljYXRpb24xHzAdBgNVBAMTFlRoYXd0ZSBUaW1l
-c3RhbXBpbmcgQ0EwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBANYrWHhhRYZT
-6jR7UZztsOYuGA7+4F+oJ9O0yeB8WU4WDnNUYMF/9p8u6TqFJBU820cEY8OexJQa
-Wt9MevPZQx08EHp5JduQ/vBR5zDWQQD9nyjfeb6Uu522FOMjhdepQeBMpHmwKxqL
-8vg7ij5FrHGSALSQQZj7X+36ty6K+Ig3AgMBAAGjEzARMA8GA1UdEwEB/wQFMAMB
-Af8wDQYJKoZIhvcNAQEEBQADgYEAZ9viwuaHPUCDhjc1fR/OmsMMZiCouqoEiYbC
-9RAIDb/LogWK0E02PvTX72nGXuSwlG9KuefeW4i2e9vjJ+V2w/A1wcu1J5szedyQ
-pgCed/r8zSeUQhac0xxo7L9c3eWpexAKMnRUEzGLhQOEkbdYATAUOK8oyvyxUBkZ
-CayJSdM=
------END CERTIFICATE-----
-
-thawte Primary Root CA
-======================
-
------BEGIN CERTIFICATE-----
-MIIEIDCCAwigAwIBAgIQNE7VVyDV7exJ9C/ON9srbTANBgkqhkiG9w0BAQUFADCB
-qTELMAkGA1UEBhMCVVMxFTATBgNVBAoTDHRoYXd0ZSwgSW5jLjEoMCYGA1UECxMf
-Q2VydGlmaWNhdGlvbiBTZXJ2aWNlcyBEaXZpc2lvbjE4MDYGA1UECxMvKGMpIDIw
-MDYgdGhhd3RlLCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNlIG9ubHkxHzAdBgNV
-BAMTFnRoYXd0ZSBQcmltYXJ5IFJvb3QgQ0EwHhcNMDYxMTE3MDAwMDAwWhcNMzYw
-NzE2MjM1OTU5WjCBqTELMAkGA1UEBhMCVVMxFTATBgNVBAoTDHRoYXd0ZSwgSW5j
-LjEoMCYGA1UECxMfQ2VydGlmaWNhdGlvbiBTZXJ2aWNlcyBEaXZpc2lvbjE4MDYG
-A1UECxMvKGMpIDIwMDYgdGhhd3RlLCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNl
-IG9ubHkxHzAdBgNVBAMTFnRoYXd0ZSBQcmltYXJ5IFJvb3QgQ0EwggEiMA0GCSqG
-SIb3DQEBAQUAA4IBDwAwggEKAoIBAQCsoPD7gFnUnMekz52hWXMJEEUMDSxuaPFs
-W0hoSVk3/AszGcJ3f8wQLZU0HObrTQmnHNK4yZc2AreJ1CRfBsDMRJSUjQJib+ta
-3RGNKJpchJAQeg29dGYvajig4tVUROsdB58Hum/u6f1OCyn1PoSgAfGcq/gcfomk
-6KHYcWUNo1F77rzSImANuVud37r8UVsLr5iy6S7pBOhih94ryNdOwUxkHt3Ph1i6
-Sk/KaAcdHJ1KxtUvkcx8cXIcxcBn6zL9yZJclNqFwJu/U30rCfSMnZEfl2pSy94J
-NqR32HuHUETVPm4pafs5SSYeCaWAe0At6+gnhcn+Yf1+5nyXHdWdAgMBAAGjQjBA
-MA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBR7W0XP
-r87Lev0xkhpqtvNG61dIUDANBgkqhkiG9w0BAQUFAAOCAQEAeRHAS7ORtvzw6WfU
-DW5FvlXok9LOAz/t2iWwHVfLHjp2oEzsUHboZHIMpKnxuIvW1oeEuzLlQRHAd9mz
-YJ3rG9XRbkREqaYB7FViHXe4XI5ISXycO1cRrK1zN44veFyQaEfZYGDm/Ac9IiAX
-xPcW6cTYcvnIc3zfFi8VqT79aie2oetaupgf1eNNZAqdE8hhuvU5HIe6uL17In/2
-/qxAeeWsEG89jxt5dovEN7MhGITlNgDrYyCZuen+MwS7QcjBAvlEYyCegc5C09Y/
-LHbTY5xZ3Y+m4Q6gLkH3LpVHz7z9M/P2C2F+fpErgUfCJzDupxBdN49cOSvkBPB7
-jVaMaA==
------END CERTIFICATE-----
-
-VeriSign Class 3 Public Primary Certification Authority - G5
-============================================================
-
------BEGIN CERTIFICATE-----
-MIIE0zCCA7ugAwIBAgIQGNrRniZ96LtKIVjNzGs7SjANBgkqhkiG9w0BAQUFADCB
-yjELMAkGA1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMR8wHQYDVQQL
-ExZWZXJpU2lnbiBUcnVzdCBOZXR3b3JrMTowOAYDVQQLEzEoYykgMjAwNiBWZXJp
-U2lnbiwgSW5jLiAtIEZvciBhdXRob3JpemVkIHVzZSBvbmx5MUUwQwYDVQQDEzxW
-ZXJpU2lnbiBDbGFzcyAzIFB1YmxpYyBQcmltYXJ5IENlcnRpZmljYXRpb24gQXV0
-aG9yaXR5IC0gRzUwHhcNMDYxMTA4MDAwMDAwWhcNMzYwNzE2MjM1OTU5WjCByjEL
-MAkGA1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMR8wHQYDVQQLExZW
-ZXJpU2lnbiBUcnVzdCBOZXR3b3JrMTowOAYDVQQLEzEoYykgMjAwNiBWZXJpU2ln
-biwgSW5jLiAtIEZvciBhdXRob3JpemVkIHVzZSBvbmx5MUUwQwYDVQQDEzxWZXJp
-U2lnbiBDbGFzcyAzIFB1YmxpYyBQcmltYXJ5IENlcnRpZmljYXRpb24gQXV0aG9y
-aXR5IC0gRzUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCvJAgIKXo1
-nmAMqudLO07cfLw8RRy7K+D+KQL5VwijZIUVJ/XxrcgxiV0i6CqqpkKzj/i5Vbex
-t0uz/o9+B1fs70PbZmIVYc9gDaTY3vjgw2IIPVQT60nKWVSFJuUrjxuf6/WhkcIz
-SdhDY2pSS9KP6HBRTdGJaXvHcPaz3BJ023tdS1bTlr8Vd6Gw9KIl8q8ckmcY5fQG
-BO+QueQA5N06tRn/Arr0PO7gi+s3i+z016zy9vA9r911kTMZHRxAy3QkGSGT2RT+
-rCpSx4/VBEnkjWNHiDxpg8v+R70rfk/Fla4OndTRQ8Bnc+MUCH7lP59zuDMKz10/
-NIeWiu5T6CUVAgMBAAGjgbIwga8wDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8E
-BAMCAQYwbQYIKwYBBQUHAQwEYTBfoV2gWzBZMFcwVRYJaW1hZ2UvZ2lmMCEwHzAH
-BgUrDgMCGgQUj+XTGoasjY5rw8+AatRIGCx7GS4wJRYjaHR0cDovL2xvZ28udmVy
-aXNpZ24uY29tL3ZzbG9nby5naWYwHQYDVR0OBBYEFH/TZafC3ey78DAJ80M5+gKv
-MzEzMA0GCSqGSIb3DQEBBQUAA4IBAQCTJEowX2LP2BqYLz3q3JktvXf2pXkiOOzE
-p6B4Eq1iDkVwZMXnl2YtmAl+X6/WzChl8gGqCBpH3vn5fJJaCGkgDdk+bW48DW7Y
-5gaRQBi5+MHt39tBquCWIMnNZBU4gcmU7qKEKQsTb47bDN0lAtukixlE0kF6BWlK
-WE9gyn6CagsCqiUXObXbf+eEZSqVir2G3l6BFoMtEMze/aiCKm0oHw0LxOXnGiYZ
-4fQRbxC1lfznQgUy286dUV4otp6F01vvpX1FQHKOtw5rDgb7MzVIcbidJ4vEZV8N
-hnacRHr2lVz2XTIIM6RUthg/aFzyQkqFOFSDX9HoLPKsEdao7WNq
------END CERTIFICATE-----
-
-Entrust.net Secure Server Certification Authority
-=================================================
-
+# Issuer: CN=Entrust.net Secure Server Certification Authority O=Entrust.net OU=www.entrust.net/CPS incorp. by ref. (limits liab.)/(c) 1999 Entrust.net Limited
+# Subject: CN=Entrust.net Secure Server Certification Authority O=Entrust.net OU=www.entrust.net/CPS incorp. by ref. (limits liab.)/(c) 1999 Entrust.net Limited
+# Label: "Entrust.net Secure Server CA"
+# Serial: 927650371
+# MD5 Fingerprint: df:f2:80:73:cc:f1:e6:61:73:fc:f5:42:e9:c5:7c:ee
+# SHA1 Fingerprint: 99:a6:9b:e6:1a:fe:88:6b:4d:2b:82:00:7c:b8:54:fc:31:7e:15:39
+# SHA256 Fingerprint: 62:f2:40:27:8c:56:4c:4d:d8:bf:7d:9d:4f:6f:36:6e:a8:94:d2:2f:5f:34:d9:89:a9:83:ac:ec:2f:ff:ed:50
 -----BEGIN CERTIFICATE-----
 MIIE2DCCBEGgAwIBAgIEN0rSQzANBgkqhkiG9w0BAQUFADCBwzELMAkGA1UEBhMC
 VVMxFDASBgNVBAoTC0VudHJ1c3QubmV0MTswOQYDVQQLEzJ3d3cuZW50cnVzdC5u
@@ -632,107 +388,1796 @@ hvcNAQEFBQADgYEAkNwwAvpkdMKnCqV8IY00F6j7Rw7/JXyNEwr75Ji174z4xRAN
 2cNgQ4xYDiKWL2KjLB+6rQXvqzJ4h6BUcxm1XAX5Uj5tLUUL9wqT6u0G+bI=
 -----END CERTIFICATE-----
 
-Go Daddy Certification Authority Root Certificate Bundle
-========================================================
-
+# Issuer: CN=Entrust.net Certification Authority (2048) O=Entrust.net OU=www.entrust.net/CPS_2048 incorp. by ref. (limits liab.)/(c) 1999 Entrust.net Limited
+# Subject: CN=Entrust.net Certification Authority (2048) O=Entrust.net OU=www.entrust.net/CPS_2048 incorp. by ref. (limits liab.)/(c) 1999 Entrust.net Limited
+# Label: "Entrust.net Premium 2048 Secure Server CA"
+# Serial: 946059622
+# MD5 Fingerprint: ba:21:ea:20:d6:dd:db:8f:c1:57:8b:40:ad:a1:fc:fc
+# SHA1 Fingerprint: 80:1d:62:d0:7b:44:9d:5c:5c:03:5c:98:ea:61:fa:44:3c:2a:58:fe
+# SHA256 Fingerprint: d1:c3:39:ea:27:84:eb:87:0f:93:4f:c5:63:4e:4a:a9:ad:55:05:01:64:01:f2:64:65:d3:7a:57:46:63:35:9f
 -----BEGIN CERTIFICATE-----
-MIIE3jCCA8agAwIBAgICAwEwDQYJKoZIhvcNAQEFBQAwYzELMAkGA1UEBhMCVVMx
-ITAfBgNVBAoTGFRoZSBHbyBEYWRkeSBHcm91cCwgSW5jLjExMC8GA1UECxMoR28g
-RGFkZHkgQ2xhc3MgMiBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTAeFw0wNjExMTYw
-MTU0MzdaFw0yNjExMTYwMTU0MzdaMIHKMQswCQYDVQQGEwJVUzEQMA4GA1UECBMH
-QXJpem9uYTETMBEGA1UEBxMKU2NvdHRzZGFsZTEaMBgGA1UEChMRR29EYWRkeS5j
-b20sIEluYy4xMzAxBgNVBAsTKmh0dHA6Ly9jZXJ0aWZpY2F0ZXMuZ29kYWRkeS5j
-b20vcmVwb3NpdG9yeTEwMC4GA1UEAxMnR28gRGFkZHkgU2VjdXJlIENlcnRpZmlj
-YXRpb24gQXV0aG9yaXR5MREwDwYDVQQFEwgwNzk2OTI4NzCCASIwDQYJKoZIhvcN
-AQEBBQADggEPADCCAQoCggEBAMQt1RWMnCZM7DI161+4WQFapmGBWTtwY6vj3D3H
-KrjJM9N55DrtPDAjhI6zMBS2sofDPZVUBJ7fmd0LJR4h3mUpfjWoqVTr9vcyOdQm
-VZWt7/v+WIbXnvQAjYwqDL1CBM6nPwT27oDyqu9SoWlm2r4arV3aLGbqGmu75RpR
-SgAvSMeYddi5Kcju+GZtCpyz8/x4fKL4o/K1w/O5epHBp+YlLpyo7RJlbmr2EkRT
-cDCVw5wrWCs9CHRK8r5RsL+H0EwnWGu1NcWdrxcx+AuP7q2BNgWJCJjPOq8lh8BJ
-6qf9Z/dFjpfMFDniNoW1fho3/Rb2cRGadDAW/hOUoz+EDU8CAwEAAaOCATIwggEu
-MB0GA1UdDgQWBBT9rGEyk2xF1uLuhV+auud2mWjM5zAfBgNVHSMEGDAWgBTSxLDS
-kdRMEXGzYcs9of7dqGrU4zASBgNVHRMBAf8ECDAGAQH/AgEAMDMGCCsGAQUFBwEB
-BCcwJTAjBggrBgEFBQcwAYYXaHR0cDovL29jc3AuZ29kYWRkeS5jb20wRgYDVR0f
-BD8wPTA7oDmgN4Y1aHR0cDovL2NlcnRpZmljYXRlcy5nb2RhZGR5LmNvbS9yZXBv
-c2l0b3J5L2dkcm9vdC5jcmwwSwYDVR0gBEQwQjBABgRVHSAAMDgwNgYIKwYBBQUH
-AgEWKmh0dHA6Ly9jZXJ0aWZpY2F0ZXMuZ29kYWRkeS5jb20vcmVwb3NpdG9yeTAO
-BgNVHQ8BAf8EBAMCAQYwDQYJKoZIhvcNAQEFBQADggEBANKGwOy9+aG2Z+5mC6IG
-OgRQjhVyrEp0lVPLN8tESe8HkGsz2ZbwlFalEzAFPIUyIXvJxwqoJKSQ3kbTJSMU
-A2fCENZvD117esyfxVgqwcSeIaha86ykRvOe5GPLL5CkKSkB2XIsKd83ASe8T+5o
-0yGPwLPk9Qnt0hCqU7S+8MxZC9Y7lhyVJEnfzuz9p0iRFEUOOjZv2kWzRaJBydTX
-RE4+uXR21aITVSzGh6O1mawGhId/dQb8vxRMDsxuxN89txJx9OjxUUAiKEngHUuH
-qDTMBqLdElrRhjZkAzVvb3du6/KFUJheqwNTrZEjYx8WnM25sgVjOuH0aBsXBTWV
-U+4=
------END CERTIFICATE-----
------BEGIN CERTIFICATE-----
-MIIE+zCCBGSgAwIBAgICAQ0wDQYJKoZIhvcNAQEFBQAwgbsxJDAiBgNVBAcTG1Zh
-bGlDZXJ0IFZhbGlkYXRpb24gTmV0d29yazEXMBUGA1UEChMOVmFsaUNlcnQsIElu
-Yy4xNTAzBgNVBAsTLFZhbGlDZXJ0IENsYXNzIDIgUG9saWN5IFZhbGlkYXRpb24g
-QXV0aG9yaXR5MSEwHwYDVQQDExhodHRwOi8vd3d3LnZhbGljZXJ0LmNvbS8xIDAe
-BgkqhkiG9w0BCQEWEWluZm9AdmFsaWNlcnQuY29tMB4XDTA0MDYyOTE3MDYyMFoX
-DTI0MDYyOTE3MDYyMFowYzELMAkGA1UEBhMCVVMxITAfBgNVBAoTGFRoZSBHbyBE
-YWRkeSBHcm91cCwgSW5jLjExMC8GA1UECxMoR28gRGFkZHkgQ2xhc3MgMiBDZXJ0
-aWZpY2F0aW9uIEF1dGhvcml0eTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgC
-ggEBAN6d1+pXGEmhW+vXX0iG6r7d/+TvZxz0ZWizV3GgXne77ZtJ6XCAPVYYYwhv
-2vLM0D9/AlQiVBDYsoHUwHU9S3/Hd8M+eKsaA7Ugay9qK7HFiH7Eux6wwdhFJ2+q
-N1j3hybX2C32qRe3H3I2TqYXP2WYktsqbl2i/ojgC95/5Y0V4evLOtXiEqITLdiO
-r18SPaAIBQi2XKVlOARFmR6jYGB0xUGlcmIbYsUfb18aQr4CUWWoriMYavx4A6lN
-f4DD+qta/KFApMoZFv6yyO9ecw3ud72a9nmYvLEHZ6IVDd2gWMZEewo+YihfukEH
-U1jPEX44dMX4/7VpkI+EdOqXG68CAQOjggHhMIIB3TAdBgNVHQ4EFgQU0sSw0pHU
-TBFxs2HLPaH+3ahq1OMwgdIGA1UdIwSByjCBx6GBwaSBvjCBuzEkMCIGA1UEBxMb
-VmFsaUNlcnQgVmFsaWRhdGlvbiBOZXR3b3JrMRcwFQYDVQQKEw5WYWxpQ2VydCwg
-SW5jLjE1MDMGA1UECxMsVmFsaUNlcnQgQ2xhc3MgMiBQb2xpY3kgVmFsaWRhdGlv
-biBBdXRob3JpdHkxITAfBgNVBAMTGGh0dHA6Ly93d3cudmFsaWNlcnQuY29tLzEg
-MB4GCSqGSIb3DQEJARYRaW5mb0B2YWxpY2VydC5jb22CAQEwDwYDVR0TAQH/BAUw
-AwEB/zAzBggrBgEFBQcBAQQnMCUwIwYIKwYBBQUHMAGGF2h0dHA6Ly9vY3NwLmdv
-ZGFkZHkuY29tMEQGA1UdHwQ9MDswOaA3oDWGM2h0dHA6Ly9jZXJ0aWZpY2F0ZXMu
-Z29kYWRkeS5jb20vcmVwb3NpdG9yeS9yb290LmNybDBLBgNVHSAERDBCMEAGBFUd
-IAAwODA2BggrBgEFBQcCARYqaHR0cDovL2NlcnRpZmljYXRlcy5nb2RhZGR5LmNv
-bS9yZXBvc2l0b3J5MA4GA1UdDwEB/wQEAwIBBjANBgkqhkiG9w0BAQUFAAOBgQC1
-QPmnHfbq/qQaQlpE9xXUhUaJwL6e4+PrxeNYiY+Sn1eocSxI0YGyeR+sBjUZsE4O
-WBsUs5iB0QQeyAfJg594RAoYC5jcdnplDQ1tgMQLARzLrUc+cb53S8wGd9D0Vmsf
-SxOaFIqII6hR8INMqzW/Rn453HWkrugp++85j09VZw==
------END CERTIFICATE-----
------BEGIN CERTIFICATE-----
-MIIC5zCCAlACAQEwDQYJKoZIhvcNAQEFBQAwgbsxJDAiBgNVBAcTG1ZhbGlDZXJ0
-IFZhbGlkYXRpb24gTmV0d29yazEXMBUGA1UEChMOVmFsaUNlcnQsIEluYy4xNTAz
-BgNVBAsTLFZhbGlDZXJ0IENsYXNzIDIgUG9saWN5IFZhbGlkYXRpb24gQXV0aG9y
-aXR5MSEwHwYDVQQDExhodHRwOi8vd3d3LnZhbGljZXJ0LmNvbS8xIDAeBgkqhkiG
-9w0BCQEWEWluZm9AdmFsaWNlcnQuY29tMB4XDTk5MDYyNjAwMTk1NFoXDTE5MDYy
-NjAwMTk1NFowgbsxJDAiBgNVBAcTG1ZhbGlDZXJ0IFZhbGlkYXRpb24gTmV0d29y
-azEXMBUGA1UEChMOVmFsaUNlcnQsIEluYy4xNTAzBgNVBAsTLFZhbGlDZXJ0IENs
-YXNzIDIgUG9saWN5IFZhbGlkYXRpb24gQXV0aG9yaXR5MSEwHwYDVQQDExhodHRw
-Oi8vd3d3LnZhbGljZXJ0LmNvbS8xIDAeBgkqhkiG9w0BCQEWEWluZm9AdmFsaWNl
-cnQuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDOOnHK5avIWZJV16vY
-dA757tn2VUdZZUcOBVXc65g2PFxTXdMwzzjsvUGJ7SVCCSRrCl6zfN1SLUzm1NZ9
-WlmpZdRJEy0kTRxQb7XBhVQ7/nHk01xC+YDgkRoKWzk2Z/M/VXwbP7RfZHM047QS
-v4dk+NoS/zcnwbNDu+97bi5p9wIDAQABMA0GCSqGSIb3DQEBBQUAA4GBADt/UG9v
-UJSZSWI4OB9L+KXIPqeCgfYrx+jFzug6EILLGACOTb2oWH+heQC1u+mNr0HZDzTu
-IYEZoDJJKPTEjlbVUjP9UNV+mWwD5MlM/Mtsq2azSiGM5bUMMj4QssxsodyamEwC
-W/POuZ6lcg5Ktz885hZo+L7tdEy8W9ViH0Pd
+MIIEXDCCA0SgAwIBAgIEOGO5ZjANBgkqhkiG9w0BAQUFADCBtDEUMBIGA1UEChML
+RW50cnVzdC5uZXQxQDA+BgNVBAsUN3d3dy5lbnRydXN0Lm5ldC9DUFNfMjA0OCBp
+bmNvcnAuIGJ5IHJlZi4gKGxpbWl0cyBsaWFiLikxJTAjBgNVBAsTHChjKSAxOTk5
+IEVudHJ1c3QubmV0IExpbWl0ZWQxMzAxBgNVBAMTKkVudHJ1c3QubmV0IENlcnRp
+ZmljYXRpb24gQXV0aG9yaXR5ICgyMDQ4KTAeFw05OTEyMjQxNzUwNTFaFw0xOTEy
+MjQxODIwNTFaMIG0MRQwEgYDVQQKEwtFbnRydXN0Lm5ldDFAMD4GA1UECxQ3d3d3
+LmVudHJ1c3QubmV0L0NQU18yMDQ4IGluY29ycC4gYnkgcmVmLiAobGltaXRzIGxp
+YWIuKTElMCMGA1UECxMcKGMpIDE5OTkgRW50cnVzdC5uZXQgTGltaXRlZDEzMDEG
+A1UEAxMqRW50cnVzdC5uZXQgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkgKDIwNDgp
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArU1LqRKGsuqjIAcVFmQq
+K0vRvwtKTY7tgHalZ7d4QMBzQshowNtTK91euHaYNZOLGp18EzoOH1u3Hs/lJBQe
+sYGpjX24zGtLA/ECDNyrpUAkAH90lKGdCCmziAv1h3edVc3kw37XamSrhRSGlVuX
+MlBvPci6Zgzj/L24ScF2iUkZ/cCovYmjZy/Gn7xxGWC4LeksyZB2ZnuU4q941mVT
+XTzWnLLPKQP5L6RQstRIzgUyVYr9smRMDuSYB3Xbf9+5CFVghTAp+XtIpGmG4zU/
+HoZdenoVve8AjhUiVBcAkCaTvA5JaJG/+EfTnZVCwQ5N328mz8MYIWJmQ3DW1cAH
+4QIDAQABo3QwcjARBglghkgBhvhCAQEEBAMCAAcwHwYDVR0jBBgwFoAUVeSB0RGA
+vtiJuQijMfmhJAkWuXAwHQYDVR0OBBYEFFXkgdERgL7YibkIozH5oSQJFrlwMB0G
+CSqGSIb2fQdBAAQQMA4bCFY1LjA6NC4wAwIEkDANBgkqhkiG9w0BAQUFAAOCAQEA
+WUesIYSKF8mciVMeuoCFGsY8Tj6xnLZ8xpJdGGQC49MGCBFhfGPjK50xA3B20qMo
+oPS7mmNz7W3lKtvtFKkrxjYR0CvrB4ul2p5cGZ1WEvVUKcgF7bISKo30Axv/55IQ
+h7A6tcOdBTcSo8f0FbnVpDkWm1M6I5HxqIKiaohowXkCIryqptau37AUX7iH0N18
+f3v/rxzP5tsHrV7bhZ3QKw0z2wTR5klAEyt2+z7pnIkPFc4YsIV4IU9rTw76NmfN
+B/L/CNDi3tm/Kq+4h4YhPATKt5Rof8886ZjXOP/swNlQ8C5LWK5Gb9Auw2DaclVy
+vUxFnmG6v4SBkgPR0ml8xQ==
 -----END CERTIFICATE-----
 
-GeoTrust Global CA
-==================
-
+# Issuer: CN=Baltimore CyberTrust Root O=Baltimore OU=CyberTrust
+# Subject: CN=Baltimore CyberTrust Root O=Baltimore OU=CyberTrust
+# Label: "Baltimore CyberTrust Root"
+# Serial: 33554617
+# MD5 Fingerprint: ac:b6:94:a5:9c:17:e0:d7:91:52:9b:b1:97:06:a6:e4
+# SHA1 Fingerprint: d4:de:20:d0:5e:66:fc:53:fe:1a:50:88:2c:78:db:28:52:ca:e4:74
+# SHA256 Fingerprint: 16:af:57:a9:f6:76:b0:ab:12:60:95:aa:5e:ba:de:f2:2a:b3:11:19:d6:44:ac:95:cd:4b:93:db:f3:f2:6a:eb
 -----BEGIN CERTIFICATE-----
-MIIDfTCCAuagAwIBAgIDErvmMA0GCSqGSIb3DQEBBQUAME4xCzAJBgNVBAYTAlVT
-MRAwDgYDVQQKEwdFcXVpZmF4MS0wKwYDVQQLEyRFcXVpZmF4IFNlY3VyZSBDZXJ0
-aWZpY2F0ZSBBdXRob3JpdHkwHhcNMDIwNTIxMDQwMDAwWhcNMTgwODIxMDQwMDAw
-WjBCMQswCQYDVQQGEwJVUzEWMBQGA1UEChMNR2VvVHJ1c3QgSW5jLjEbMBkGA1UE
-AxMSR2VvVHJ1c3QgR2xvYmFsIENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
-CgKCAQEA2swYYzD99BcjGlZ+W988bDjkcbd4kdS8odhM+KhDtgPpTSEHCIjaWC9m
-OSm9BXiLnTjoBbdqfnGk5sRgprDvgOSJKA+eJdbtg/OtppHHmMlCGDUUna2YRpIu
-T8rxh0PBFpVXLVDviS2Aelet8u5fa9IAjbkU+BQVNdnARqN7csiRv8lVK83Qlz6c
-JmTM386DGXHKTubU1XupGc1V3sjs0l44U+VcT4wt/lAjNvxm5suOpDkZALeVAjmR
-Cw7+OC7RHQWa9k0+bw8HHa8sHo9gOeL6NlMTOdReJivbPagUvTLrGAMoUgRx5asz
-PeE4uwc2hGKceeoWMPRfwCvocWvk+QIDAQABo4HwMIHtMB8GA1UdIwQYMBaAFEjm
-aPkr0rKV10fYIyAQTzOYkJ/UMB0GA1UdDgQWBBTAephojYn7qwVkDBF9qn1luMrM
-TjAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjA6BgNVHR8EMzAxMC+g
-LaArhilodHRwOi8vY3JsLmdlb3RydXN0LmNvbS9jcmxzL3NlY3VyZWNhLmNybDBO
-BgNVHSAERzBFMEMGBFUdIAAwOzA5BggrBgEFBQcCARYtaHR0cHM6Ly93d3cuZ2Vv
-dHJ1c3QuY29tL3Jlc291cmNlcy9yZXBvc2l0b3J5MA0GCSqGSIb3DQEBBQUAA4GB
-AHbhEm5OSxYShjAGsoEIz/AIx8dxfmbuwu3UOx//8PDITtZDOLC5MH0Y0FWDomrL
-NhGc6Ehmo21/uBPUR/6LWlxz/K7ZGzIZOKuXNBSqltLroxwUCEm2u+WR74M26x1W
-b8ravHNjkOR/ez4iyz0H7V84dJzjA1BOoa+Y7mHyhD8S
+MIIDdzCCAl+gAwIBAgIEAgAAuTANBgkqhkiG9w0BAQUFADBaMQswCQYDVQQGEwJJ
+RTESMBAGA1UEChMJQmFsdGltb3JlMRMwEQYDVQQLEwpDeWJlclRydXN0MSIwIAYD
+VQQDExlCYWx0aW1vcmUgQ3liZXJUcnVzdCBSb290MB4XDTAwMDUxMjE4NDYwMFoX
+DTI1MDUxMjIzNTkwMFowWjELMAkGA1UEBhMCSUUxEjAQBgNVBAoTCUJhbHRpbW9y
+ZTETMBEGA1UECxMKQ3liZXJUcnVzdDEiMCAGA1UEAxMZQmFsdGltb3JlIEN5YmVy
+VHJ1c3QgUm9vdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKMEuyKr
+mD1X6CZymrV51Cni4eiVgLGw41uOKymaZN+hXe2wCQVt2yguzmKiYv60iNoS6zjr
+IZ3AQSsBUnuId9Mcj8e6uYi1agnnc+gRQKfRzMpijS3ljwumUNKoUMMo6vWrJYeK
+mpYcqWe4PwzV9/lSEy/CG9VwcPCPwBLKBsua4dnKM3p31vjsufFoREJIE9LAwqSu
+XmD+tqYF/LTdB1kC1FkYmGP1pWPgkAx9XbIGevOF6uvUA65ehD5f/xXtabz5OTZy
+dc93Uk3zyZAsuT3lySNTPx8kmCFcB5kpvcY67Oduhjprl3RjM71oGDHweI12v/ye
+jl0qhqdNkNwnGjkCAwEAAaNFMEMwHQYDVR0OBBYEFOWdWTCCR1jMrPoIVDaGezq1
+BE3wMBIGA1UdEwEB/wQIMAYBAf8CAQMwDgYDVR0PAQH/BAQDAgEGMA0GCSqGSIb3
+DQEBBQUAA4IBAQCFDF2O5G9RaEIFoN27TyclhAO992T9Ldcw46QQF+vaKSm2eT92
+9hkTI7gQCvlYpNRhcL0EYWoSihfVCr3FvDB81ukMJY2GQE/szKN+OMY3EU/t3Wgx
+jkzSswF07r51XgdIGn9w/xZchMB5hbgF/X++ZRGjD8ACtPhSNzkE1akxehi/oCr0
+Epn3o0WC4zxe9Z2etciefC7IpJ5OCBRLbf1wbWsaY71k5h+3zvDyny67G7fyUIhz
+ksLi4xaNmjICq44Y3ekQEe5+NauQrz4wlHrQMz2nZQ/1/I6eYs9HRCwBXbsdtTLS
+R9I4LtD+gdwyah617jzV/OeBHRnDJELqYzmp
+-----END CERTIFICATE-----
+
+# Issuer: CN=Equifax Secure Global eBusiness CA-1 O=Equifax Secure Inc.
+# Subject: CN=Equifax Secure Global eBusiness CA-1 O=Equifax Secure Inc.
+# Label: "Equifax Secure Global eBusiness CA"
+# Serial: 1
+# MD5 Fingerprint: 8f:5d:77:06:27:c4:98:3c:5b:93:78:e7:d7:7d:9b:cc
+# SHA1 Fingerprint: 7e:78:4a:10:1c:82:65:cc:2d:e1:f1:6d:47:b4:40:ca:d9:0a:19:45
+# SHA256 Fingerprint: 5f:0b:62:ea:b5:e3:53:ea:65:21:65:16:58:fb:b6:53:59:f4:43:28:0a:4a:fb:d1:04:d7:7d:10:f9:f0:4c:07
+-----BEGIN CERTIFICATE-----
+MIICkDCCAfmgAwIBAgIBATANBgkqhkiG9w0BAQQFADBaMQswCQYDVQQGEwJVUzEc
+MBoGA1UEChMTRXF1aWZheCBTZWN1cmUgSW5jLjEtMCsGA1UEAxMkRXF1aWZheCBT
+ZWN1cmUgR2xvYmFsIGVCdXNpbmVzcyBDQS0xMB4XDTk5MDYyMTA0MDAwMFoXDTIw
+MDYyMTA0MDAwMFowWjELMAkGA1UEBhMCVVMxHDAaBgNVBAoTE0VxdWlmYXggU2Vj
+dXJlIEluYy4xLTArBgNVBAMTJEVxdWlmYXggU2VjdXJlIEdsb2JhbCBlQnVzaW5l
+c3MgQ0EtMTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAuucXkAJlsTRVPEnC
+UdXfp9E3j9HngXNBUmCbnaEXJnitx7HoJpQytd4zjTov2/KaelpzmKNc6fuKcxtc
+58O/gGzNqfTWK8D3+ZmqY6KxRwIP1ORROhI8bIpaVIRw28HFkM9yRcuoWcDNM50/
+o5brhTMhHD4ePmBudpxnhcXIw2ECAwEAAaNmMGQwEQYJYIZIAYb4QgEBBAQDAgAH
+MA8GA1UdEwEB/wQFMAMBAf8wHwYDVR0jBBgwFoAUvqigdHJQa0S3ySPY+6j/s1dr
+aGwwHQYDVR0OBBYEFL6ooHRyUGtEt8kj2Puo/7NXa2hsMA0GCSqGSIb3DQEBBAUA
+A4GBADDiAVGqx+pf2rnQZQ8w1j7aDRRJbpGTJxQx78T3LUX47Me/okENI7SS+RkA
+Z70Br83gcfxaz2TE4JaY0KNA4gGK7ycH8WUBikQtBmV1UsCGECAhX2xrD2yuCRyv
+8qIYNMR1pHMc8Y3c7635s3a0kr/clRAevsvIO1qEYBlWlKlV
+-----END CERTIFICATE-----
+
+# Issuer: CN=Equifax Secure eBusiness CA-1 O=Equifax Secure Inc.
+# Subject: CN=Equifax Secure eBusiness CA-1 O=Equifax Secure Inc.
+# Label: "Equifax Secure eBusiness CA 1"
+# Serial: 4
+# MD5 Fingerprint: 64:9c:ef:2e:44:fc:c6:8f:52:07:d0:51:73:8f:cb:3d
+# SHA1 Fingerprint: da:40:18:8b:91:89:a3:ed:ee:ae:da:97:fe:2f:9d:f5:b7:d1:8a:41
+# SHA256 Fingerprint: cf:56:ff:46:a4:a1:86:10:9d:d9:65:84:b5:ee:b5:8a:51:0c:42:75:b0:e5:f9:4f:40:bb:ae:86:5e:19:f6:73
+-----BEGIN CERTIFICATE-----
+MIICgjCCAeugAwIBAgIBBDANBgkqhkiG9w0BAQQFADBTMQswCQYDVQQGEwJVUzEc
+MBoGA1UEChMTRXF1aWZheCBTZWN1cmUgSW5jLjEmMCQGA1UEAxMdRXF1aWZheCBT
+ZWN1cmUgZUJ1c2luZXNzIENBLTEwHhcNOTkwNjIxMDQwMDAwWhcNMjAwNjIxMDQw
+MDAwWjBTMQswCQYDVQQGEwJVUzEcMBoGA1UEChMTRXF1aWZheCBTZWN1cmUgSW5j
+LjEmMCQGA1UEAxMdRXF1aWZheCBTZWN1cmUgZUJ1c2luZXNzIENBLTEwgZ8wDQYJ
+KoZIhvcNAQEBBQADgY0AMIGJAoGBAM4vGbwXt3fek6lfWg0XTzQaDJj0ItlZ1MRo
+RvC0NcWFAyDGr0WlIVFFQesWWDYyb+JQYmT5/VGcqiTZ9J2DKocKIdMSODRsjQBu
+WqDZQu4aIZX5UkxVWsUPOE9G+m34LjXWHXzr4vCwdYDIqROsvojvOm6rXyo4YgKw
+Env+j6YDAgMBAAGjZjBkMBEGCWCGSAGG+EIBAQQEAwIABzAPBgNVHRMBAf8EBTAD
+AQH/MB8GA1UdIwQYMBaAFEp4MlIR21kWNl7fwRQ2QGpHfEyhMB0GA1UdDgQWBBRK
+eDJSEdtZFjZe38EUNkBqR3xMoTANBgkqhkiG9w0BAQQFAAOBgQB1W6ibAxHm6VZM
+zfmpTMANmvPMZWnmJXbMWbfWVMMdzZmsGd20hdXgPfxiIKeES1hl8eL5lSE/9dR+
+WB5Hh1Q+WKG1tfgq73HnvMP2sUlG4tega+VWeponmHxGYhTnyfxuAxJ5gDgdSIKN
+/Bf+KpYrtWKmpj29f5JZzVoqgrI3eQ==
+-----END CERTIFICATE-----
+
+# Issuer: O=Equifax Secure OU=Equifax Secure eBusiness CA-2
+# Subject: O=Equifax Secure OU=Equifax Secure eBusiness CA-2
+# Label: "Equifax Secure eBusiness CA 2"
+# Serial: 930140085
+# MD5 Fingerprint: aa:bf:bf:64:97:da:98:1d:6f:c6:08:3a:95:70:33:ca
+# SHA1 Fingerprint: 39:4f:f6:85:0b:06:be:52:e5:18:56:cc:10:e1:80:e8:82:b3:85:cc
+# SHA256 Fingerprint: 2f:27:4e:48:ab:a4:ac:7b:76:59:33:10:17:75:50:6d:c3:0e:e3:8e:f6:ac:d5:c0:49:32:cf:e0:41:23:42:20
+-----BEGIN CERTIFICATE-----
+MIIDIDCCAomgAwIBAgIEN3DPtTANBgkqhkiG9w0BAQUFADBOMQswCQYDVQQGEwJV
+UzEXMBUGA1UEChMORXF1aWZheCBTZWN1cmUxJjAkBgNVBAsTHUVxdWlmYXggU2Vj
+dXJlIGVCdXNpbmVzcyBDQS0yMB4XDTk5MDYyMzEyMTQ0NVoXDTE5MDYyMzEyMTQ0
+NVowTjELMAkGA1UEBhMCVVMxFzAVBgNVBAoTDkVxdWlmYXggU2VjdXJlMSYwJAYD
+VQQLEx1FcXVpZmF4IFNlY3VyZSBlQnVzaW5lc3MgQ0EtMjCBnzANBgkqhkiG9w0B
+AQEFAAOBjQAwgYkCgYEA5Dk5kx5SBhsoNviyoynF7Y6yEb3+6+e0dMKP/wXn2Z0G
+vxLIPw7y1tEkshHe0XMJitSxLJgJDR5QRrKDpkWNYmi7hRsgcDKqQM2mll/EcTc/
+BPO3QSQ5BxoeLmFYoBIL5aXfxavqN3HMHMg3OrmXUqesxWoklE6ce8/AatbfIb0C
+AwEAAaOCAQkwggEFMHAGA1UdHwRpMGcwZaBjoGGkXzBdMQswCQYDVQQGEwJVUzEX
+MBUGA1UEChMORXF1aWZheCBTZWN1cmUxJjAkBgNVBAsTHUVxdWlmYXggU2VjdXJl
+IGVCdXNpbmVzcyBDQS0yMQ0wCwYDVQQDEwRDUkwxMBoGA1UdEAQTMBGBDzIwMTkw
+NjIzMTIxNDQ1WjALBgNVHQ8EBAMCAQYwHwYDVR0jBBgwFoAUUJ4L6q9euSBIplBq
+y/3YIHqngnYwHQYDVR0OBBYEFFCeC+qvXrkgSKZQasv92CB6p4J2MAwGA1UdEwQF
+MAMBAf8wGgYJKoZIhvZ9B0EABA0wCxsFVjMuMGMDAgbAMA0GCSqGSIb3DQEBBQUA
+A4GBAAyGgq3oThr1jokn4jVYPSm0B482UJW/bsGe68SQsoWou7dC4A8HOd/7npCy
+0cE+U58DRLB+S/Rv5Hwf5+Kx5Lia78O9zt4LMjTZ3ijtM2vE1Nc9ElirfQkty3D1
+E4qUoSek1nDFbZS1yX2doNLGCEnZZpum0/QL3MUmV+GRMOrN
+-----END CERTIFICATE-----
+
+# Issuer: CN=AddTrust Class 1 CA Root O=AddTrust AB OU=AddTrust TTP Network
+# Subject: CN=AddTrust Class 1 CA Root O=AddTrust AB OU=AddTrust TTP Network
+# Label: "AddTrust Low-Value Services Root"
+# Serial: 1
+# MD5 Fingerprint: 1e:42:95:02:33:92:6b:b9:5f:c0:7f:da:d6:b2:4b:fc
+# SHA1 Fingerprint: cc:ab:0e:a0:4c:23:01:d6:69:7b:dd:37:9f:cd:12:eb:24:e3:94:9d
+# SHA256 Fingerprint: 8c:72:09:27:9a:c0:4e:27:5e:16:d0:7f:d3:b7:75:e8:01:54:b5:96:80:46:e3:1f:52:dd:25:76:63:24:e9:a7
+-----BEGIN CERTIFICATE-----
+MIIEGDCCAwCgAwIBAgIBATANBgkqhkiG9w0BAQUFADBlMQswCQYDVQQGEwJTRTEU
+MBIGA1UEChMLQWRkVHJ1c3QgQUIxHTAbBgNVBAsTFEFkZFRydXN0IFRUUCBOZXR3
+b3JrMSEwHwYDVQQDExhBZGRUcnVzdCBDbGFzcyAxIENBIFJvb3QwHhcNMDAwNTMw
+MTAzODMxWhcNMjAwNTMwMTAzODMxWjBlMQswCQYDVQQGEwJTRTEUMBIGA1UEChML
+QWRkVHJ1c3QgQUIxHTAbBgNVBAsTFEFkZFRydXN0IFRUUCBOZXR3b3JrMSEwHwYD
+VQQDExhBZGRUcnVzdCBDbGFzcyAxIENBIFJvb3QwggEiMA0GCSqGSIb3DQEBAQUA
+A4IBDwAwggEKAoIBAQCWltQhSWDia+hBBwzexODcEyPNwTXH+9ZOEQpnXvUGW2ul
+CDtbKRY654eyNAbFvAWlA3yCyykQruGIgb3WntP+LVbBFc7jJp0VLhD7Bo8wBN6n
+tGO0/7Gcrjyvd7ZWxbWroulpOj0OM3kyP3CCkplhbY0wCI9xP6ZIVxn4JdxLZlyl
+dI+Yrsj5wAYi56xz36Uu+1LcsRVlIPo1Zmne3yzxbrww2ywkEtvrNTVokMsAsJch
+PXQhI2U0K7t4WaPW4XY5mqRJjox0r26kmqPZm9I4XJuiGMx1I4S+6+JNM3GOGvDC
++Mcdoq0Dlyz4zyXG9rgkMbFjXZJ/Y/AlyVMuH79NAgMBAAGjgdIwgc8wHQYDVR0O
+BBYEFJWxtPCUtr3H2tERCSG+wa9J/RB7MAsGA1UdDwQEAwIBBjAPBgNVHRMBAf8E
+BTADAQH/MIGPBgNVHSMEgYcwgYSAFJWxtPCUtr3H2tERCSG+wa9J/RB7oWmkZzBl
+MQswCQYDVQQGEwJTRTEUMBIGA1UEChMLQWRkVHJ1c3QgQUIxHTAbBgNVBAsTFEFk
+ZFRydXN0IFRUUCBOZXR3b3JrMSEwHwYDVQQDExhBZGRUcnVzdCBDbGFzcyAxIENB
+IFJvb3SCAQEwDQYJKoZIhvcNAQEFBQADggEBACxtZBsfzQ3duQH6lmM0MkhHma6X
+7f1yFqZzR1r0693p9db7RcwpiURdv0Y5PejuvE1Uhh4dbOMXJ0PhiVYrqW9yTkkz
+43J8KiOavD7/KCrto/8cI7pDVwlnTUtiBi34/2ydYB7YHEt9tTEv2dB8Xfjea4MY
+eDdXL+gzB2ffHsdrKpV2ro9Xo/D0UrSpUwjP4E/TelOL/bscVjby/rK25Xa71SJl
+pz/+0WatC7xrmYbvP33zGDLKe8bjq2RGlfgmadlVg3sslgf/WSxEo8bl6ancoWOA
+WiFeIc9TVPC6b4nbqKqVz4vjccweGyBECMB6tkD9xOQ14R0WHNC8K47Wcdk=
+-----END CERTIFICATE-----
+
+# Issuer: CN=AddTrust External CA Root O=AddTrust AB OU=AddTrust External TTP Network
+# Subject: CN=AddTrust External CA Root O=AddTrust AB OU=AddTrust External TTP Network
+# Label: "AddTrust External Root"
+# Serial: 1
+# MD5 Fingerprint: 1d:35:54:04:85:78:b0:3f:42:42:4d:bf:20:73:0a:3f
+# SHA1 Fingerprint: 02:fa:f3:e2:91:43:54:68:60:78:57:69:4d:f5:e4:5b:68:85:18:68
+# SHA256 Fingerprint: 68:7f:a4:51:38:22:78:ff:f0:c8:b1:1f:8d:43:d5:76:67:1c:6e:b2:bc:ea:b4:13:fb:83:d9:65:d0:6d:2f:f2
+-----BEGIN CERTIFICATE-----
+MIIENjCCAx6gAwIBAgIBATANBgkqhkiG9w0BAQUFADBvMQswCQYDVQQGEwJTRTEU
+MBIGA1UEChMLQWRkVHJ1c3QgQUIxJjAkBgNVBAsTHUFkZFRydXN0IEV4dGVybmFs
+IFRUUCBOZXR3b3JrMSIwIAYDVQQDExlBZGRUcnVzdCBFeHRlcm5hbCBDQSBSb290
+MB4XDTAwMDUzMDEwNDgzOFoXDTIwMDUzMDEwNDgzOFowbzELMAkGA1UEBhMCU0Ux
+FDASBgNVBAoTC0FkZFRydXN0IEFCMSYwJAYDVQQLEx1BZGRUcnVzdCBFeHRlcm5h
+bCBUVFAgTmV0d29yazEiMCAGA1UEAxMZQWRkVHJ1c3QgRXh0ZXJuYWwgQ0EgUm9v
+dDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALf3GjPm8gAELTngTlvt
+H7xsD821+iO2zt6bETOXpClMfZOfvUq8k+0DGuOPz+VtUFrWlymUWoCwSXrbLpX9
+uMq/NzgtHj6RQa1wVsfwTz/oMp50ysiQVOnGXw94nZpAPA6sYapeFI+eh6FqUNzX
+mk6vBbOmcZSccbNQYArHE504B4YCqOmoaSYYkKtMsE8jqzpPhNjfzp/haW+710LX
+a0Tkx63ubUFfclpxCDezeWWkWaCUN/cALw3CknLa0Dhy2xSoRcRdKn23tNbE7qzN
+E0S3ySvdQwAl+mG5aWpYIxG3pzOPVnVZ9c0p10a3CitlttNCbxWyuHv77+ldU9U0
+WicCAwEAAaOB3DCB2TAdBgNVHQ4EFgQUrb2YejS0Jvf6xCZU7wO94CTLVBowCwYD
+VR0PBAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wgZkGA1UdIwSBkTCBjoAUrb2YejS0
+Jvf6xCZU7wO94CTLVBqhc6RxMG8xCzAJBgNVBAYTAlNFMRQwEgYDVQQKEwtBZGRU
+cnVzdCBBQjEmMCQGA1UECxMdQWRkVHJ1c3QgRXh0ZXJuYWwgVFRQIE5ldHdvcmsx
+IjAgBgNVBAMTGUFkZFRydXN0IEV4dGVybmFsIENBIFJvb3SCAQEwDQYJKoZIhvcN
+AQEFBQADggEBALCb4IUlwtYj4g+WBpKdQZic2YR5gdkeWxQHIzZlj7DYd7usQWxH
+YINRsPkyPef89iYTx4AWpb9a/IfPeHmJIZriTAcKhjW88t5RxNKWt9x+Tu5w/Rw5
+6wwCURQtjr0W4MHfRnXnJK3s9EK0hZNwEGe6nQY1ShjTK3rMUUKhemPR5ruhxSvC
+Nr4TDea9Y355e6cJDUCrat2PisP29owaQgVR1EX1n6diIWgVIEM8med8vSTYqZEX
+c4g/VhsxOBi0cQ+azcgOno4uG+GMmIPLHzHxREzGBHNJdmAPx/i9F4BrLunMTA5a
+mnkPIAou1Z5jJh5VkpTYghdae9C8x49OhgQ=
+-----END CERTIFICATE-----
+
+# Issuer: CN=AddTrust Public CA Root O=AddTrust AB OU=AddTrust TTP Network
+# Subject: CN=AddTrust Public CA Root O=AddTrust AB OU=AddTrust TTP Network
+# Label: "AddTrust Public Services Root"
+# Serial: 1
+# MD5 Fingerprint: c1:62:3e:23:c5:82:73:9c:03:59:4b:2b:e9:77:49:7f
+# SHA1 Fingerprint: 2a:b6:28:48:5e:78:fb:f3:ad:9e:79:10:dd:6b:df:99:72:2c:96:e5
+# SHA256 Fingerprint: 07:91:ca:07:49:b2:07:82:aa:d3:c7:d7:bd:0c:df:c9:48:58:35:84:3e:b2:d7:99:60:09:ce:43:ab:6c:69:27
+-----BEGIN CERTIFICATE-----
+MIIEFTCCAv2gAwIBAgIBATANBgkqhkiG9w0BAQUFADBkMQswCQYDVQQGEwJTRTEU
+MBIGA1UEChMLQWRkVHJ1c3QgQUIxHTAbBgNVBAsTFEFkZFRydXN0IFRUUCBOZXR3
+b3JrMSAwHgYDVQQDExdBZGRUcnVzdCBQdWJsaWMgQ0EgUm9vdDAeFw0wMDA1MzAx
+MDQxNTBaFw0yMDA1MzAxMDQxNTBaMGQxCzAJBgNVBAYTAlNFMRQwEgYDVQQKEwtB
+ZGRUcnVzdCBBQjEdMBsGA1UECxMUQWRkVHJ1c3QgVFRQIE5ldHdvcmsxIDAeBgNV
+BAMTF0FkZFRydXN0IFB1YmxpYyBDQSBSb290MIIBIjANBgkqhkiG9w0BAQEFAAOC
+AQ8AMIIBCgKCAQEA6Rowj4OIFMEg2Dybjxt+A3S72mnTRqX4jsIMEZBRpS9mVEBV
+6tsfSlbunyNu9DnLoblv8n75XYcmYZ4c+OLspoH4IcUkzBEMP9smcnrHAZcHF/nX
+GCwwfQ56HmIexkvA/X1id9NEHif2P0tEs7c42TkfYNVRknMDtABp4/MUTu7R3AnP
+dzRGULD4EfL+OHn3Bzn+UZKXC1sIXzSGAa2Il+tmzV7R/9x98oTaunet3IAIx6eH
+1lWfl2royBFkuucZKT8Rs3iQhCBSWxHveNCD9tVIkNAwHM+A+WD+eeSI8t0A65RF
+62WUaUC6wNW0uLp9BBGo6zEFlpROWCGOn9Bg/QIDAQABo4HRMIHOMB0GA1UdDgQW
+BBSBPjfYkrAfd59ctKtzquf2NGAv+jALBgNVHQ8EBAMCAQYwDwYDVR0TAQH/BAUw
+AwEB/zCBjgYDVR0jBIGGMIGDgBSBPjfYkrAfd59ctKtzquf2NGAv+qFopGYwZDEL
+MAkGA1UEBhMCU0UxFDASBgNVBAoTC0FkZFRydXN0IEFCMR0wGwYDVQQLExRBZGRU
+cnVzdCBUVFAgTmV0d29yazEgMB4GA1UEAxMXQWRkVHJ1c3QgUHVibGljIENBIFJv
+b3SCAQEwDQYJKoZIhvcNAQEFBQADggEBAAP3FUr4JNojVhaTdt02KLmuG7jD8WS6
+IBh4lSknVwW8fCr0uVFV2ocC3g8WFzH4qnkuCRO7r7IgGRLlk/lL+YPoRNWyQSW/
+iHVv/xD8SlTQX/D67zZzfRs2RcYhbbQVuE7PnFylPVoAjgbjPGsye/Kf8Lb93/Ao
+GEjwxrzQvzSAlsJKsW2Ox5BF3i9nrEUEo3rcVZLJR2bYGozH7ZxOmuASu7VqTITh
+4SINhwBk/ox9Yjllpu9CtoAlEmEBqCQTcAARJl/6NVDFSMwGR+gn2HCNX2TmoUQm
+XiLsks3/QppEIW1cxeMiHV9HEufOX1362KqxMy3ZdvJOOjMMK7MtkAY=
+-----END CERTIFICATE-----
+
+# Issuer: CN=AddTrust Qualified CA Root O=AddTrust AB OU=AddTrust TTP Network
+# Subject: CN=AddTrust Qualified CA Root O=AddTrust AB OU=AddTrust TTP Network
+# Label: "AddTrust Qualified Certificates Root"
+# Serial: 1
+# MD5 Fingerprint: 27:ec:39:47:cd:da:5a:af:e2:9a:01:65:21:a9:4c:bb
+# SHA1 Fingerprint: 4d:23:78:ec:91:95:39:b5:00:7f:75:8f:03:3b:21:1e:c5:4d:8b:cf
+# SHA256 Fingerprint: 80:95:21:08:05:db:4b:bc:35:5e:44:28:d8:fd:6e:c2:cd:e3:ab:5f:b9:7a:99:42:98:8e:b8:f4:dc:d0:60:16
+-----BEGIN CERTIFICATE-----
+MIIEHjCCAwagAwIBAgIBATANBgkqhkiG9w0BAQUFADBnMQswCQYDVQQGEwJTRTEU
+MBIGA1UEChMLQWRkVHJ1c3QgQUIxHTAbBgNVBAsTFEFkZFRydXN0IFRUUCBOZXR3
+b3JrMSMwIQYDVQQDExpBZGRUcnVzdCBRdWFsaWZpZWQgQ0EgUm9vdDAeFw0wMDA1
+MzAxMDQ0NTBaFw0yMDA1MzAxMDQ0NTBaMGcxCzAJBgNVBAYTAlNFMRQwEgYDVQQK
+EwtBZGRUcnVzdCBBQjEdMBsGA1UECxMUQWRkVHJ1c3QgVFRQIE5ldHdvcmsxIzAh
+BgNVBAMTGkFkZFRydXN0IFF1YWxpZmllZCBDQSBSb290MIIBIjANBgkqhkiG9w0B
+AQEFAAOCAQ8AMIIBCgKCAQEA5B6a/twJWoekn0e+EV+vhDTbYjx5eLfpMLXsDBwq
+xBb/4Oxx64r1EW7tTw2R0hIYLUkVAcKkIhPHEWT/IhKauY5cLwjPcWqzZwFZ8V1G
+87B4pfYOQnrjfxvM0PC3KP0q6p6zsLkEqv32x7SxuCqg+1jxGaBvcCV+PmlKfw8i
+2O+tCBGaKZnhqkRFmhJePp1tUvznoD1oL/BLcHwTOK28FSXx1s6rosAx1i+f4P8U
+WfyEk9mHfExUE+uf0S0R+Bg6Ot4l2ffTQO2kBhLEO+GRwVY18BTcZTYJbqukB8c1
+0cIDMzZbdSZtQvESa0NvS3GU+jQd7RNuyoB/mC9suWXY6QIDAQABo4HUMIHRMB0G
+A1UdDgQWBBQ5lYtii1zJ1IC6WA+XPxUIQ8yYpzALBgNVHQ8EBAMCAQYwDwYDVR0T
+AQH/BAUwAwEB/zCBkQYDVR0jBIGJMIGGgBQ5lYtii1zJ1IC6WA+XPxUIQ8yYp6Fr
+pGkwZzELMAkGA1UEBhMCU0UxFDASBgNVBAoTC0FkZFRydXN0IEFCMR0wGwYDVQQL
+ExRBZGRUcnVzdCBUVFAgTmV0d29yazEjMCEGA1UEAxMaQWRkVHJ1c3QgUXVhbGlm
+aWVkIENBIFJvb3SCAQEwDQYJKoZIhvcNAQEFBQADggEBABmrder4i2VhlRO6aQTv
+hsoToMeqT2QbPxj2qC0sVY8FtzDqQmodwCVRLae/DLPt7wh/bDxGGuoYQ992zPlm
+hpwsaPXpF/gxsxjE1kh9I0xowX67ARRvxdlu3rsEQmr49lx95dr6h+sNNVJn0J6X
+dgWTP5XHAeZpVTh/EGGZyeNfpso+gmNIquIISD6q8rKFYqa0p9m9N5xotS1WfbC3
+P6CxB9bpT9zeRXEwMn8bLgn5v1Kh7sKAPgZcLlVAwRv1cEWw3F369nJad9Jjzc9Y
+iQBCYz95OdBEsIJuQRno3eDBiFrRHnGTHyQwdOUeqN48Jzd/g66ed8/wMLH/S5no
+xqE=
+-----END CERTIFICATE-----
+
+# Issuer: CN=Entrust Root Certification Authority O=Entrust, Inc. OU=www.entrust.net/CPS is incorporated by reference/(c) 2006 Entrust, Inc.
+# Subject: CN=Entrust Root Certification Authority O=Entrust, Inc. OU=www.entrust.net/CPS is incorporated by reference/(c) 2006 Entrust, Inc.
+# Label: "Entrust Root Certification Authority"
+# Serial: 1164660820
+# MD5 Fingerprint: d6:a5:c3:ed:5d:dd:3e:00:c1:3d:87:92:1f:1d:3f:e4
+# SHA1 Fingerprint: b3:1e:b1:b7:40:e3:6c:84:02:da:dc:37:d4:4d:f5:d4:67:49:52:f9
+# SHA256 Fingerprint: 73:c1:76:43:4f:1b:c6:d5:ad:f4:5b:0e:76:e7:27:28:7c:8d:e5:76:16:c1:e6:e6:14:1a:2b:2c:bc:7d:8e:4c
+-----BEGIN CERTIFICATE-----
+MIIEkTCCA3mgAwIBAgIERWtQVDANBgkqhkiG9w0BAQUFADCBsDELMAkGA1UEBhMC
+VVMxFjAUBgNVBAoTDUVudHJ1c3QsIEluYy4xOTA3BgNVBAsTMHd3dy5lbnRydXN0
+Lm5ldC9DUFMgaXMgaW5jb3Jwb3JhdGVkIGJ5IHJlZmVyZW5jZTEfMB0GA1UECxMW
+KGMpIDIwMDYgRW50cnVzdCwgSW5jLjEtMCsGA1UEAxMkRW50cnVzdCBSb290IENl
+cnRpZmljYXRpb24gQXV0aG9yaXR5MB4XDTA2MTEyNzIwMjM0MloXDTI2MTEyNzIw
+NTM0MlowgbAxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1FbnRydXN0LCBJbmMuMTkw
+NwYDVQQLEzB3d3cuZW50cnVzdC5uZXQvQ1BTIGlzIGluY29ycG9yYXRlZCBieSBy
+ZWZlcmVuY2UxHzAdBgNVBAsTFihjKSAyMDA2IEVudHJ1c3QsIEluYy4xLTArBgNV
+BAMTJEVudHJ1c3QgUm9vdCBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBALaVtkNC+sZtKm9I35RMOVcF7sN5EUFo
+Nu3s/poBj6E4KPz3EEZmLk0eGrEaTsbRwJWIsMn/MYszA9u3g3s+IIRe7bJWKKf4
+4LlAcTfFy0cOlypowCKVYhXbR9n10Cv/gkvJrT7eTNuQgFA/CYqEAOwwCj0Yzfv9
+KlmaI5UXLEWeH25DeW0MXJj+SKfFI0dcXv1u5x609mhF0YaDW6KKjbHjKYD+JXGI
+rb68j6xSlkuqUY3kEzEZ6E5Nn9uss2rVvDlUccp6en+Q3X0dgNmBu1kmwhH+5pPi
+94DkZfs0Nw4pgHBNrziGLp5/V6+eF67rHMsoIV+2HNjnogQi+dPa2MsCAwEAAaOB
+sDCBrTAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zArBgNVHRAEJDAi
+gA8yMDA2MTEyNzIwMjM0MlqBDzIwMjYxMTI3MjA1MzQyWjAfBgNVHSMEGDAWgBRo
+kORnpKZTgMeGZqTx90tD+4S9bTAdBgNVHQ4EFgQUaJDkZ6SmU4DHhmak8fdLQ/uE
+vW0wHQYJKoZIhvZ9B0EABBAwDhsIVjcuMTo0LjADAgSQMA0GCSqGSIb3DQEBBQUA
+A4IBAQCT1DCw1wMgKtD5Y+iRDAUgqV8ZyntyTtSx29CW+1RaGSwMCPeyvIWonX9t
+O1KzKtvn1ISMY/YPyyYBkVBs9F8U4pN0wBOeMDpQ47RgxRzwIkSNcUesyBrJ6Zua
+AGAT/3B+XxFNSRuzFVJ7yVTav52Vr2ua2J7p8eRDjeIRRDq/r72DQnNSi6q7pynP
+9WQcCk3RvKqsnyrQ/39/2n3qse0wJcGE2jTSW3iDVuycNsMm4hH2Z0kdkquM++v/
+eu6FSqdQgPCnXEqULl8FmTxSQeDNtGPPAUO6nIPcj2A781q0tHuu2guQOHXvgR1m
+0vdXcDazv/wor3ElhVsT/h5/WrQ8
+-----END CERTIFICATE-----
+
+# Issuer: CN=GeoTrust Global CA O=GeoTrust Inc.
+# Subject: CN=GeoTrust Global CA O=GeoTrust Inc.
+# Label: "GeoTrust Global CA"
+# Serial: 144470
+# MD5 Fingerprint: f7:75:ab:29:fb:51:4e:b7:77:5e:ff:05:3c:99:8e:f5
+# SHA1 Fingerprint: de:28:f4:a4:ff:e5:b9:2f:a3:c5:03:d1:a3:49:a7:f9:96:2a:82:12
+# SHA256 Fingerprint: ff:85:6a:2d:25:1d:cd:88:d3:66:56:f4:50:12:67:98:cf:ab:aa:de:40:79:9c:72:2d:e4:d2:b5:db:36:a7:3a
+-----BEGIN CERTIFICATE-----
+MIIDVDCCAjygAwIBAgIDAjRWMA0GCSqGSIb3DQEBBQUAMEIxCzAJBgNVBAYTAlVT
+MRYwFAYDVQQKEw1HZW9UcnVzdCBJbmMuMRswGQYDVQQDExJHZW9UcnVzdCBHbG9i
+YWwgQ0EwHhcNMDIwNTIxMDQwMDAwWhcNMjIwNTIxMDQwMDAwWjBCMQswCQYDVQQG
+EwJVUzEWMBQGA1UEChMNR2VvVHJ1c3QgSW5jLjEbMBkGA1UEAxMSR2VvVHJ1c3Qg
+R2xvYmFsIENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2swYYzD9
+9BcjGlZ+W988bDjkcbd4kdS8odhM+KhDtgPpTSEHCIjaWC9mOSm9BXiLnTjoBbdq
+fnGk5sRgprDvgOSJKA+eJdbtg/OtppHHmMlCGDUUna2YRpIuT8rxh0PBFpVXLVDv
+iS2Aelet8u5fa9IAjbkU+BQVNdnARqN7csiRv8lVK83Qlz6cJmTM386DGXHKTubU
+1XupGc1V3sjs0l44U+VcT4wt/lAjNvxm5suOpDkZALeVAjmRCw7+OC7RHQWa9k0+
+bw8HHa8sHo9gOeL6NlMTOdReJivbPagUvTLrGAMoUgRx5aszPeE4uwc2hGKceeoW
+MPRfwCvocWvk+QIDAQABo1MwUTAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTA
+ephojYn7qwVkDBF9qn1luMrMTjAfBgNVHSMEGDAWgBTAephojYn7qwVkDBF9qn1l
+uMrMTjANBgkqhkiG9w0BAQUFAAOCAQEANeMpauUvXVSOKVCUn5kaFOSPeCpilKIn
+Z57QzxpeR+nBsqTP3UEaBU6bS+5Kb1VSsyShNwrrZHYqLizz/Tt1kL/6cdjHPTfS
+tQWVYrmm3ok9Nns4d0iXrKYgjy6myQzCsplFAMfOEVEiIuCl6rYVSAlk6l5PdPcF
+PseKUgzbFbS9bZvlxrFUaKnjaZC2mqUPuLk/IH2uSrW4nOQdtqvmlKXBx4Ot2/Un
+hw4EbNX/3aBd7YdStysVAq45pmp06drE57xNNB6pXE0zX5IJL4hmXXeXxx12E6nV
+5fEWCRE11azbJHFwLJhWC9kXtNHjUStedejV0NxPNO3CBWaAocvmMw==
+-----END CERTIFICATE-----
+
+# Issuer: CN=GeoTrust Global CA 2 O=GeoTrust Inc.
+# Subject: CN=GeoTrust Global CA 2 O=GeoTrust Inc.
+# Label: "GeoTrust Global CA 2"
+# Serial: 1
+# MD5 Fingerprint: 0e:40:a7:6c:de:03:5d:8f:d1:0f:e4:d1:8d:f9:6c:a9
+# SHA1 Fingerprint: a9:e9:78:08:14:37:58:88:f2:05:19:b0:6d:2b:0d:2b:60:16:90:7d
+# SHA256 Fingerprint: ca:2d:82:a0:86:77:07:2f:8a:b6:76:4f:f0:35:67:6c:fe:3e:5e:32:5e:01:21:72:df:3f:92:09:6d:b7:9b:85
+-----BEGIN CERTIFICATE-----
+MIIDZjCCAk6gAwIBAgIBATANBgkqhkiG9w0BAQUFADBEMQswCQYDVQQGEwJVUzEW
+MBQGA1UEChMNR2VvVHJ1c3QgSW5jLjEdMBsGA1UEAxMUR2VvVHJ1c3QgR2xvYmFs
+IENBIDIwHhcNMDQwMzA0MDUwMDAwWhcNMTkwMzA0MDUwMDAwWjBEMQswCQYDVQQG
+EwJVUzEWMBQGA1UEChMNR2VvVHJ1c3QgSW5jLjEdMBsGA1UEAxMUR2VvVHJ1c3Qg
+R2xvYmFsIENBIDIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDvPE1A
+PRDfO1MA4Wf+lGAVPoWI8YkNkMgoI5kF6CsgncbzYEbYwbLVjDHZ3CB5JIG/NTL8
+Y2nbsSpr7iFY8gjpeMtvy/wWUsiRxP89c96xPqfCfWbB9X5SJBri1WeR0IIQ13hL
+TytCOb1kLUCgsBDTOEhGiKEMuzozKmKY+wCdE1l/bztyqu6mD4b5BWHqZ38MN5aL
+5mkWRxHCJ1kDs6ZgwiFAVvqgx306E+PsV8ez1q6diYD3Aecs9pYrEw15LNnA5IZ7
+S4wMcoKK+xfNAGw6EzywhIdLFnopsk/bHdQL82Y3vdj2V7teJHq4PIu5+pIaGoSe
+2HSPqht/XvT+RSIhAgMBAAGjYzBhMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYE
+FHE4NvICMVNHK266ZUapEBVYIAUJMB8GA1UdIwQYMBaAFHE4NvICMVNHK266ZUap
+EBVYIAUJMA4GA1UdDwEB/wQEAwIBhjANBgkqhkiG9w0BAQUFAAOCAQEAA/e1K6td
+EPx7srJerJsOflN4WT5CBP51o62sgU7XAotexC3IUnbHLB/8gTKY0UvGkpMzNTEv
+/NgdRN3ggX+d6YvhZJFiCzkIjKx0nVnZellSlxG5FntvRdOW2TF9AjYPnDtuzywN
+A0ZF66D0f0hExghAzN4bcLUprbqLOzRldRtxIR0sFAqwlpW41uryZfspuk/qkZN0
+abby/+Ea0AzRdoXLiiW9l14sbxWZJue2Kf8i7MkCx1YAzUm5s2x7UwQa4qjJqhIF
+I8LO57sEAszAR6LkxCkvW0VXiVHuPOtSCP8HNR6fNWpHSlaY0VqFH4z1Ir+rzoPz
+4iIprn2DQKi6bA==
+-----END CERTIFICATE-----
+
+# Issuer: CN=GeoTrust Universal CA O=GeoTrust Inc.
+# Subject: CN=GeoTrust Universal CA O=GeoTrust Inc.
+# Label: "GeoTrust Universal CA"
+# Serial: 1
+# MD5 Fingerprint: 92:65:58:8b:a2:1a:31:72:73:68:5c:b4:a5:7a:07:48
+# SHA1 Fingerprint: e6:21:f3:35:43:79:05:9a:4b:68:30:9d:8a:2f:74:22:15:87:ec:79
+# SHA256 Fingerprint: a0:45:9b:9f:63:b2:25:59:f5:fa:5d:4c:6d:b3:f9:f7:2f:f1:93:42:03:35:78:f0:73:bf:1d:1b:46:cb:b9:12
+-----BEGIN CERTIFICATE-----
+MIIFaDCCA1CgAwIBAgIBATANBgkqhkiG9w0BAQUFADBFMQswCQYDVQQGEwJVUzEW
+MBQGA1UEChMNR2VvVHJ1c3QgSW5jLjEeMBwGA1UEAxMVR2VvVHJ1c3QgVW5pdmVy
+c2FsIENBMB4XDTA0MDMwNDA1MDAwMFoXDTI5MDMwNDA1MDAwMFowRTELMAkGA1UE
+BhMCVVMxFjAUBgNVBAoTDUdlb1RydXN0IEluYy4xHjAcBgNVBAMTFUdlb1RydXN0
+IFVuaXZlcnNhbCBDQTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKYV
+VaCjxuAfjJ0hUNfBvitbtaSeodlyWL0AG0y/YckUHUWCq8YdgNY96xCcOq9tJPi8
+cQGeBvV8Xx7BDlXKg5pZMK4ZyzBIle0iN430SppyZj6tlcDgFgDgEB8rMQ7XlFTT
+QjOgNB0eRXbdT8oYN+yFFXoZCPzVx5zw8qkuEKmS5j1YPakWaDwvdSEYfyh3peFh
+F7em6fgemdtzbvQKoiFs7tqqhZJmr/Z6a4LauiIINQ/PQvE1+mrufislzDoR5G2v
+c7J2Ha3QsnhnGqQ5HFELZ1aD/ThdDc7d8Lsrlh/eezJS/R27tQahsiFepdaVaH/w
+mZ7cRQg+59IJDTWU3YBOU5fXtQlEIGQWFwMCTFMNaN7VqnJNk22CDtucvc+081xd
+VHppCZbW2xHBjXWotM85yM48vCR85mLK4b19p71XZQvk/iXttmkQ3CgaRr0BHdCX
+teGYO8A3ZNY9lO4L4fUorgtWv3GLIylBjobFS1J72HGrH4oVpjuDWtdYAVHGTEHZ
+f9hBZ3KiKN9gg6meyHv8U3NyWfWTehd2Ds735VzZC1U0oqpbtWpU5xPKV+yXbfRe
+Bi9Fi1jUIxaS5BZuKGNZMN9QAZxjiRqf2xeUgnA3wySemkfWWspOqGmJch+RbNt+
+nhutxx9z3SxPGWX9f5NAEC7S8O08ni4oPmkmM8V7AgMBAAGjYzBhMA8GA1UdEwEB
+/wQFMAMBAf8wHQYDVR0OBBYEFNq7LqqwDLiIJlF0XG0D08DYj3rWMB8GA1UdIwQY
+MBaAFNq7LqqwDLiIJlF0XG0D08DYj3rWMA4GA1UdDwEB/wQEAwIBhjANBgkqhkiG
+9w0BAQUFAAOCAgEAMXjmx7XfuJRAyXHEqDXsRh3ChfMoWIawC/yOsjmPRFWrZIRc
+aanQmjg8+uUfNeVE44B5lGiku8SfPeE0zTBGi1QrlaXv9z+ZhP015s8xxtxqv6fX
+IwjhmF7DWgh2qaavdy+3YL1ERmrvl/9zlcGO6JP7/TG37FcREUWbMPEaiDnBTzyn
+ANXH/KttgCJwpQzgXQQpAvvLoJHRfNbDflDVnVi+QTjruXU8FdmbyUqDWcDaU/0z
+uzYYm4UPFd3uLax2k7nZAY1IEKj79TiG8dsKxr2EoyNB3tZ3b4XUhRxQ4K5RirqN
+Pnbiucon8l+f725ZDQbYKxek0nxru18UGkiPGkzns0ccjkxFKyDuSN/n3QmOGKja
+QI2SJhFTYXNd673nxE0pN2HrrDktZy4W1vUAg4WhzH92xH3kt0tm7wNFYGm2DFKW
+koRepqO1pD4r2czYG0eq8kTaT/kD6PAUyz/zg97QwVTjt+gKN02LIFkDMBmhLMi9
+ER/frslKxfMnZmaGrGiR/9nmUxwPi1xpZQomyB40w11Re9epnAahNt3ViZS82eQt
+DF4JbAiXfKM9fJP/P6EUp8+1Xevb2xzEdt+Iub1FBZUbrvxGakyvSOPOrg/Sfuvm
+bJxPgWp6ZKy7PtXny3YuxadIwVyQD8vIP/rmMuGNG2+k5o7Y+SlIis5z/iw=
+-----END CERTIFICATE-----
+
+# Issuer: CN=GeoTrust Universal CA 2 O=GeoTrust Inc.
+# Subject: CN=GeoTrust Universal CA 2 O=GeoTrust Inc.
+# Label: "GeoTrust Universal CA 2"
+# Serial: 1
+# MD5 Fingerprint: 34:fc:b8:d0:36:db:9e:14:b3:c2:f2:db:8f:e4:94:c7
+# SHA1 Fingerprint: 37:9a:19:7b:41:85:45:35:0c:a6:03:69:f3:3c:2e:af:47:4f:20:79
+# SHA256 Fingerprint: a0:23:4f:3b:c8:52:7c:a5:62:8e:ec:81:ad:5d:69:89:5d:a5:68:0d:c9:1d:1c:b8:47:7f:33:f8:78:b9:5b:0b
+-----BEGIN CERTIFICATE-----
+MIIFbDCCA1SgAwIBAgIBATANBgkqhkiG9w0BAQUFADBHMQswCQYDVQQGEwJVUzEW
+MBQGA1UEChMNR2VvVHJ1c3QgSW5jLjEgMB4GA1UEAxMXR2VvVHJ1c3QgVW5pdmVy
+c2FsIENBIDIwHhcNMDQwMzA0MDUwMDAwWhcNMjkwMzA0MDUwMDAwWjBHMQswCQYD
+VQQGEwJVUzEWMBQGA1UEChMNR2VvVHJ1c3QgSW5jLjEgMB4GA1UEAxMXR2VvVHJ1
+c3QgVW5pdmVyc2FsIENBIDIwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoIC
+AQCzVFLByT7y2dyxUxpZKeexw0Uo5dfR7cXFS6GqdHtXr0om/Nj1XqduGdt0DE81
+WzILAePb63p3NeqqWuDW6KFXlPCQo3RWlEQwAx5cTiuFJnSCegx2oG9NzkEtoBUG
+FF+3Qs17j1hhNNwqCPkuwwGmIkQcTAeC5lvO0Ep8BNMZcyfwqph/Lq9O64ceJHdq
+XbboW0W63MOhBW9Wjo8QJqVJwy7XQYci4E+GymC16qFjwAGXEHm9ADwSbSsVsaxL
+se4YuU6W3Nx2/zu+z18DwPw76L5GG//aQMJS9/7jOvdqdzXQ2o3rXhhqMcceujwb
+KNZrVMaqW9eiLBsZzKIC9ptZvTdrhrVtgrrY6slWvKk2WP0+GfPtDCapkzj4T8Fd
+IgbQl+rhrcZV4IErKIM6+vR7IVEAvlI4zs1meaj0gVbi0IMJR1FbUGrP20gaXT73
+y/Zl92zxlfgCOzJWgjl6W70viRu/obTo/3+NjN8D8WBOWBFM66M/ECuDmgFz2ZRt
+hAAnZqzwcEAJQpKtT5MNYQlRJNiS1QuUYbKHsu3/mjX/hVTK7URDrBs8FmtISgoc
+QIgfksILAAX/8sgCSqSqqcyZlpwvWOB94b67B9xfBHJcMTTD7F8t4D1kkCLm0ey4
+Lt1ZrtmhN79UNdxzMk+MBB4zsslG8dhcyFVQyWi9qLo2CQIDAQABo2MwYTAPBgNV
+HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR281Xh+qQ2+/CfXGJx7Tz0RzgQKzAfBgNV
+HSMEGDAWgBR281Xh+qQ2+/CfXGJx7Tz0RzgQKzAOBgNVHQ8BAf8EBAMCAYYwDQYJ
+KoZIhvcNAQEFBQADggIBAGbBxiPz2eAubl/oz66wsCVNK/g7WJtAJDday6sWSf+z
+dXkzoS9tcBc0kf5nfo/sm+VegqlVHy/c1FEHEv6sFj4sNcZj/NwQ6w2jqtB8zNHQ
+L1EuxBRa3ugZ4T7GzKQp5y6EqgYweHZUcyiYWTjgAA1i00J9IZ+uPTqM1fp3DRgr
+Fg5fNuH8KrUwJM/gYwx7WBr+mbpCErGR9Hxo4sjoryzqyX6uuyo9DRXcNJW2GHSo
+ag/HtPQTxORb7QrSpJdMKu0vbBKJPfEncKpqA1Ihn0CoZ1Dy81of398j9tx4TuaY
+T1U6U+Pv8vSfx3zYWK8pIpe44L2RLrB27FcRz+8pRPPphXpgY+RdM4kX2TGq2tbz
+GDVyz4crL2MjhF2EjD9XoIj8mZEoJmmZ1I+XRL6O1UixpCgp8RW04eWe3fiPpm8m
+1wk8OhwRDqZsN/etRIcsKMfYdIKz0G9KV7s1KSegi+ghp4dkNl3M2Basx7InQJJV
+OCiNUW7dFGdTbHFcJoRNdVq2fmBWqU2t+5sel/MN2dKXVHfaPRK34B7vCAas+YWH
+6aLcr34YEoP9VhdBLtUpgn2Z9DH2canPLAEnpQW5qrJITirvn5NSUZU8UnOOVkwX
+QMAJKOSLakhT2+zNVVXxxvjpoixMptEmX36vWkzaH6byHCx+rgIW0lbQL1dTR+iS
+-----END CERTIFICATE-----
+
+# Issuer: CN=America Online Root Certification Authority 1 O=America Online Inc.
+# Subject: CN=America Online Root Certification Authority 1 O=America Online Inc.
+# Label: "America Online Root Certification Authority 1"
+# Serial: 1
+# MD5 Fingerprint: 14:f1:08:ad:9d:fa:64:e2:89:e7:1c:cf:a8:ad:7d:5e
+# SHA1 Fingerprint: 39:21:c1:15:c1:5d:0e:ca:5c:cb:5b:c4:f0:7d:21:d8:05:0b:56:6a
+# SHA256 Fingerprint: 77:40:73:12:c6:3a:15:3d:5b:c0:0b:4e:51:75:9c:df:da:c2:37:dc:2a:33:b6:79:46:e9:8e:9b:fa:68:0a:e3
+-----BEGIN CERTIFICATE-----
+MIIDpDCCAoygAwIBAgIBATANBgkqhkiG9w0BAQUFADBjMQswCQYDVQQGEwJVUzEc
+MBoGA1UEChMTQW1lcmljYSBPbmxpbmUgSW5jLjE2MDQGA1UEAxMtQW1lcmljYSBP
+bmxpbmUgUm9vdCBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eSAxMB4XDTAyMDUyODA2
+MDAwMFoXDTM3MTExOTIwNDMwMFowYzELMAkGA1UEBhMCVVMxHDAaBgNVBAoTE0Ft
+ZXJpY2EgT25saW5lIEluYy4xNjA0BgNVBAMTLUFtZXJpY2EgT25saW5lIFJvb3Qg
+Q2VydGlmaWNhdGlvbiBBdXRob3JpdHkgMTCCASIwDQYJKoZIhvcNAQEBBQADggEP
+ADCCAQoCggEBAKgv6KRpBgNHw+kqmP8ZonCaxlCyfqXfaE0bfA+2l2h9LaaLl+lk
+hsmj76CGv2BlnEtUiMJIxUo5vxTjWVXlGbR0yLQFOVwWpeKVBeASrlmLojNoWBym
+1BW32J/X3HGrfpq/m44zDyL9Hy7nBzbvYjnF3cu6JRQj3gzGPTzOggjmZj7aUTsW
+OqMFf6Dch9Wc/HKpoH145LcxVR5lu9RhsCFg7RAycsWSJR74kEoYeEfffjA3PlAb
+2xzTa5qGUwew76wGePiEmf4hjUyAtgyC9mZweRrTT6PP8c9GsEsPPt2IYriMqQko
+O3rHl+Ee5fSfwMCuJKDIodkP1nsmgmkyPacCAwEAAaNjMGEwDwYDVR0TAQH/BAUw
+AwEB/zAdBgNVHQ4EFgQUAK3Zo/Z59m50qX8zPYEX10zPM94wHwYDVR0jBBgwFoAU
+AK3Zo/Z59m50qX8zPYEX10zPM94wDgYDVR0PAQH/BAQDAgGGMA0GCSqGSIb3DQEB
+BQUAA4IBAQB8itEfGDeC4Liwo+1WlchiYZwFos3CYiZhzRAW18y0ZTTQEYqtqKkF
+Zu90821fnZmv9ov761KyBZiibyrFVL0lvV+uyIbqRizBs73B6UlwGBaXCBOMIOAb
+LjpHyx7kADCVW/RFo8AasAFOq73AI25jP4BKxQft3OJvx8Fi8eNy1gTIdGcL+oir
+oQHIb/AUr9KZzVGTfu0uOMe9zkZQPXLjeSWdm4grECDdpbgyn43gKd8hdIaC2y+C
+MMbHNYaz+ZZfRtsMRf3zUMNvxsNIrUam4SdHCh0Om7bCd39j8uB9Gr784N/Xx6ds
+sPmuujz9dLQR6FgNgLzTqIA6me11zEZ7
+-----END CERTIFICATE-----
+
+# Issuer: CN=America Online Root Certification Authority 2 O=America Online Inc.
+# Subject: CN=America Online Root Certification Authority 2 O=America Online Inc.
+# Label: "America Online Root Certification Authority 2"
+# Serial: 1
+# MD5 Fingerprint: d6:ed:3c:ca:e2:66:0f:af:10:43:0d:77:9b:04:09:bf
+# SHA1 Fingerprint: 85:b5:ff:67:9b:0c:79:96:1f:c8:6e:44:22:00:46:13:db:17:92:84
+# SHA256 Fingerprint: 7d:3b:46:5a:60:14:e5:26:c0:af:fc:ee:21:27:d2:31:17:27:ad:81:1c:26:84:2d:00:6a:f3:73:06:cc:80:bd
+-----BEGIN CERTIFICATE-----
+MIIFpDCCA4ygAwIBAgIBATANBgkqhkiG9w0BAQUFADBjMQswCQYDVQQGEwJVUzEc
+MBoGA1UEChMTQW1lcmljYSBPbmxpbmUgSW5jLjE2MDQGA1UEAxMtQW1lcmljYSBP
+bmxpbmUgUm9vdCBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eSAyMB4XDTAyMDUyODA2
+MDAwMFoXDTM3MDkyOTE0MDgwMFowYzELMAkGA1UEBhMCVVMxHDAaBgNVBAoTE0Ft
+ZXJpY2EgT25saW5lIEluYy4xNjA0BgNVBAMTLUFtZXJpY2EgT25saW5lIFJvb3Qg
+Q2VydGlmaWNhdGlvbiBBdXRob3JpdHkgMjCCAiIwDQYJKoZIhvcNAQEBBQADggIP
+ADCCAgoCggIBAMxBRR3pPU0Q9oyxQcngXssNt79Hc9PwVU3dxgz6sWYFas14tNwC
+206B89enfHG8dWOgXeMHDEjsJcQDIPT/DjsS/5uN4cbVG7RtIuOx238hZK+GvFci
+KtZHgVdEglZTvYYUAQv8f3SkWq7xuhG1m1hagLQ3eAkzfDJHA1zEpYNI9FdWboE2
+JxhP7JsowtS013wMPgwr38oE18aO6lhOqKSlGBxsRZijQdEt0sdtjRnxrXm3gT+9
+BoInLRBYBbV4Bbkv2wxrkJB+FFk4u5QkE+XRnRTf04JNRvCAOVIyD+OEsnpD8l7e
+Xz8d3eOyG6ChKiMDbi4BFYdcpnV1x5dhvt6G3NRI270qv0pV2uh9UPu0gBe4lL8B
+PeraunzgWGcXuVjgiIZGZ2ydEEdYMtA1fHkqkKJaEBEjNa0vzORKW6fIJ/KD3l67
+Xnfn6KVuY8INXWHQjNJsWiEOyiijzirplcdIz5ZvHZIlyMbGwcEMBawmxNJ10uEq
+Z8A9W6Wa6897GqidFEXlD6CaZd4vKL3Ob5Rmg0gp2OpljK+T2WSfVVcmv2/LNzGZ
+o2C7HK2JNDJiuEMhBnIMoVxtRsX6Kc8w3onccVvdtjc+31D1uAclJuW8tf48ArO3
++L5DwYcRlJ4jbBeKuIonDFRH8KmzwICMoCfrHRnjB453cMor9H124HhnAgMBAAGj
+YzBhMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFE1FwWg4u3OpaaEg5+31IqEj
+FNeeMB8GA1UdIwQYMBaAFE1FwWg4u3OpaaEg5+31IqEjFNeeMA4GA1UdDwEB/wQE
+AwIBhjANBgkqhkiG9w0BAQUFAAOCAgEAZ2sGuV9FOypLM7PmG2tZTiLMubekJcmn
+xPBUlgtk87FYT15R/LKXeydlwuXK5w0MJXti4/qftIe3RUavg6WXSIylvfEWK5t2
+LHo1YGwRgJfMqZJS5ivmae2p+DYtLHe/YUjRYwu5W1LtGLBDQiKmsXeu3mnFzccc
+obGlHBD7GL4acN3Bkku+KVqdPzW+5X1R+FXgJXUjhx5c3LqdsKyzadsXg8n33gy8
+CNyRnqjQ1xU3c6U1uPx+xURABsPr+CKAXEfOAuMRn0T//ZoyzH1kUQ7rVyZ2OuMe
+IjzCpjbdGe+n/BLzJsBZMYVMnNjP36TMzCmT/5RtdlwTCJfy7aULTd3oyWgOZtMA
+DjMSW7yV5TKQqLPGbIOtd+6Lfn6xqavT4fG2wLHqiMDn05DpKJKUe2h7lyoKZy2F
+AjgQ5ANh1NolNscIWC2hp1GvMApJ9aZphwctREZ2jirlmjvXGKL8nDgQzMY70rUX
+Om/9riW99XJZZLF0KjhfGEzfz3EEWjbUvy+ZnOjZurGV5gJLIaFb1cFPj65pbVPb
+AZO1XB4Y3WRayhgoPmMEEf0cjQAPuDffZ4qdZqkCapH/E8ovXYO8h5Ns3CRRFgQl
+Zvqz2cK6Kb6aSDiCmfS/O0oxGfm/jiEzFMpPVF/7zvuPcX/9XhmgD0uRuMRUvAaw
+RY8mkaKO/qk=
+-----END CERTIFICATE-----
+
+# Issuer: CN=AAA Certificate Services O=Comodo CA Limited
+# Subject: CN=AAA Certificate Services O=Comodo CA Limited
+# Label: "Comodo AAA Services root"
+# Serial: 1
+# MD5 Fingerprint: 49:79:04:b0:eb:87:19:ac:47:b0:bc:11:51:9b:74:d0
+# SHA1 Fingerprint: d1:eb:23:a4:6d:17:d6:8f:d9:25:64:c2:f1:f1:60:17:64:d8:e3:49
+# SHA256 Fingerprint: d7:a7:a0:fb:5d:7e:27:31:d7:71:e9:48:4e:bc:de:f7:1d:5f:0c:3e:0a:29:48:78:2b:c8:3e:e0:ea:69:9e:f4
+-----BEGIN CERTIFICATE-----
+MIIEMjCCAxqgAwIBAgIBATANBgkqhkiG9w0BAQUFADB7MQswCQYDVQQGEwJHQjEb
+MBkGA1UECAwSR3JlYXRlciBNYW5jaGVzdGVyMRAwDgYDVQQHDAdTYWxmb3JkMRow
+GAYDVQQKDBFDb21vZG8gQ0EgTGltaXRlZDEhMB8GA1UEAwwYQUFBIENlcnRpZmlj
+YXRlIFNlcnZpY2VzMB4XDTA0MDEwMTAwMDAwMFoXDTI4MTIzMTIzNTk1OVowezEL
+MAkGA1UEBhMCR0IxGzAZBgNVBAgMEkdyZWF0ZXIgTWFuY2hlc3RlcjEQMA4GA1UE
+BwwHU2FsZm9yZDEaMBgGA1UECgwRQ29tb2RvIENBIExpbWl0ZWQxITAfBgNVBAMM
+GEFBQSBDZXJ0aWZpY2F0ZSBTZXJ2aWNlczCCASIwDQYJKoZIhvcNAQEBBQADggEP
+ADCCAQoCggEBAL5AnfRu4ep2hxxNRUSOvkbIgwadwSr+GB+O5AL686tdUIoWMQua
+BtDFcCLNSS1UY8y2bmhGC1Pqy0wkwLxyTurxFa70VJoSCsN6sjNg4tqJVfMiWPPe
+3M/vg4aijJRPn2jymJBGhCfHdr/jzDUsi14HZGWCwEiwqJH5YZ92IFCokcdmtet4
+YgNW8IoaE+oxox6gmf049vYnMlhvB/VruPsUK6+3qszWY19zjNoFmag4qMsXeDZR
+rOme9Hg6jc8P2ULimAyrL58OAd7vn5lJ8S3frHRNG5i1R8XlKdH5kBjHYpy+g8cm
+ez6KJcfA3Z3mNWgQIJ2P2N7Sw4ScDV7oL8kCAwEAAaOBwDCBvTAdBgNVHQ4EFgQU
+oBEKIz6W8Qfs4q8p74Klf9AwpLQwDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQF
+MAMBAf8wewYDVR0fBHQwcjA4oDagNIYyaHR0cDovL2NybC5jb21vZG9jYS5jb20v
+QUFBQ2VydGlmaWNhdGVTZXJ2aWNlcy5jcmwwNqA0oDKGMGh0dHA6Ly9jcmwuY29t
+b2RvLm5ldC9BQUFDZXJ0aWZpY2F0ZVNlcnZpY2VzLmNybDANBgkqhkiG9w0BAQUF
+AAOCAQEACFb8AvCb6P+k+tZ7xkSAzk/ExfYAWMymtrwUSWgEdujm7l3sAg9g1o1Q
+GE8mTgHj5rCl7r+8dFRBv/38ErjHT1r0iWAFf2C3BUrz9vHCv8S5dIa2LX1rzNLz
+Rt0vxuBqw8M0Ayx9lt1awg6nCpnBBYurDC/zXDrPbDdVCYfeU0BsWO/8tqtlbgT2
+G9w84FoVxp7Z8VlIMCFlA2zs6SFz7JsDoeA3raAVGI/6ugLOpyypEBMs1OUIJqsi
+l2D4kF501KKaU73yqWjgom7C12yxow+ev+to51byrvLjKzg6CYG1a4XXvi3tPxq3
+smPi9WIsgtRqAEFQ8TmDn5XpNpaYbg==
+-----END CERTIFICATE-----
+
+# Issuer: CN=Secure Certificate Services O=Comodo CA Limited
+# Subject: CN=Secure Certificate Services O=Comodo CA Limited
+# Label: "Comodo Secure Services root"
+# Serial: 1
+# MD5 Fingerprint: d3:d9:bd:ae:9f:ac:67:24:b3:c8:1b:52:e1:b9:a9:bd
+# SHA1 Fingerprint: 4a:65:d5:f4:1d:ef:39:b8:b8:90:4a:4a:d3:64:81:33:cf:c7:a1:d1
+# SHA256 Fingerprint: bd:81:ce:3b:4f:65:91:d1:1a:67:b5:fc:7a:47:fd:ef:25:52:1b:f9:aa:4e:18:b9:e3:df:2e:34:a7:80:3b:e8
+-----BEGIN CERTIFICATE-----
+MIIEPzCCAyegAwIBAgIBATANBgkqhkiG9w0BAQUFADB+MQswCQYDVQQGEwJHQjEb
+MBkGA1UECAwSR3JlYXRlciBNYW5jaGVzdGVyMRAwDgYDVQQHDAdTYWxmb3JkMRow
+GAYDVQQKDBFDb21vZG8gQ0EgTGltaXRlZDEkMCIGA1UEAwwbU2VjdXJlIENlcnRp
+ZmljYXRlIFNlcnZpY2VzMB4XDTA0MDEwMTAwMDAwMFoXDTI4MTIzMTIzNTk1OVow
+fjELMAkGA1UEBhMCR0IxGzAZBgNVBAgMEkdyZWF0ZXIgTWFuY2hlc3RlcjEQMA4G
+A1UEBwwHU2FsZm9yZDEaMBgGA1UECgwRQ29tb2RvIENBIExpbWl0ZWQxJDAiBgNV
+BAMMG1NlY3VyZSBDZXJ0aWZpY2F0ZSBTZXJ2aWNlczCCASIwDQYJKoZIhvcNAQEB
+BQADggEPADCCAQoCggEBAMBxM4KK0HDrc4eCQNUd5MvJDkKQ+d40uaG6EfQlhfPM
+cm3ye5drswfxdySRXyWP9nQ95IDC+DwN879A6vfIUtFyb+/Iq0G4bi4XKpVpDM3S
+HpR7LZQdqnXXs5jLrLxkU0C8j6ysNstcrbvd4JQX7NFc0L/vpZXJkMWwrPsbQ996
+CF23uPJAGysnnlDOXmWCiIxe004MeuoIkbY2qitC++rCoznl2yY4rYsK7hljxxwk
+3wN42ubqwUcaCwtGCd0C/N7Lh1/XMGNooa7cMqG6vv5Eq2i2pRcV/b3Vp6ea5EQz
+6YiO/O1R65NxTq0B50SOqy3LqP4BSUjwwN3HaNiS/j0CAwEAAaOBxzCBxDAdBgNV
+HQ4EFgQUPNiTiMLAggnMAZkGkyDpnnAJY08wDgYDVR0PAQH/BAQDAgEGMA8GA1Ud
+EwEB/wQFMAMBAf8wgYEGA1UdHwR6MHgwO6A5oDeGNWh0dHA6Ly9jcmwuY29tb2Rv
+Y2EuY29tL1NlY3VyZUNlcnRpZmljYXRlU2VydmljZXMuY3JsMDmgN6A1hjNodHRw
+Oi8vY3JsLmNvbW9kby5uZXQvU2VjdXJlQ2VydGlmaWNhdGVTZXJ2aWNlcy5jcmww
+DQYJKoZIhvcNAQEFBQADggEBAIcBbSMdflsXfcFhMs+P5/OKlFlm4J4oqF7Tt/Q0
+5qo5spcWxYJvMqTpjOev/e/C6LlLqqP05tqNZSH7uoDrJiiFGv45jN5bBAS0VPmj
+Z55B+glSzAVIqMk/IQQezkhr/IXownuvf7fM+F86/TXGDe+X3EyrEeFryzHRbPtI
+gKvcnDe4IRRLDXE97IMzbtFuMhbsmMcWi1mmNKsFVy2T96oTy9IT4rcuO81rUBcJ
+aD61JlfutuC23bkpgHl9j6PwpCikFcSF9CfUa7/lXORlAnZUtOM3ZiTTGWHIUhDl
+izeauan5Hb/qmZJhlv8BzaFfDbxxvA6sCx1HRR3B7Hzs/Sk=
+-----END CERTIFICATE-----
+
+# Issuer: CN=Trusted Certificate Services O=Comodo CA Limited
+# Subject: CN=Trusted Certificate Services O=Comodo CA Limited
+# Label: "Comodo Trusted Services root"
+# Serial: 1
+# MD5 Fingerprint: 91:1b:3f:6e:cd:9e:ab:ee:07:fe:1f:71:d2:b3:61:27
+# SHA1 Fingerprint: e1:9f:e3:0e:8b:84:60:9e:80:9b:17:0d:72:a8:c5:ba:6e:14:09:bd
+# SHA256 Fingerprint: 3f:06:e5:56:81:d4:96:f5:be:16:9e:b5:38:9f:9f:2b:8f:f6:1e:17:08:df:68:81:72:48:49:cd:5d:27:cb:69
+-----BEGIN CERTIFICATE-----
+MIIEQzCCAyugAwIBAgIBATANBgkqhkiG9w0BAQUFADB/MQswCQYDVQQGEwJHQjEb
+MBkGA1UECAwSR3JlYXRlciBNYW5jaGVzdGVyMRAwDgYDVQQHDAdTYWxmb3JkMRow
+GAYDVQQKDBFDb21vZG8gQ0EgTGltaXRlZDElMCMGA1UEAwwcVHJ1c3RlZCBDZXJ0
+aWZpY2F0ZSBTZXJ2aWNlczAeFw0wNDAxMDEwMDAwMDBaFw0yODEyMzEyMzU5NTla
+MH8xCzAJBgNVBAYTAkdCMRswGQYDVQQIDBJHcmVhdGVyIE1hbmNoZXN0ZXIxEDAO
+BgNVBAcMB1NhbGZvcmQxGjAYBgNVBAoMEUNvbW9kbyBDQSBMaW1pdGVkMSUwIwYD
+VQQDDBxUcnVzdGVkIENlcnRpZmljYXRlIFNlcnZpY2VzMIIBIjANBgkqhkiG9w0B
+AQEFAAOCAQ8AMIIBCgKCAQEA33FvNlhTWvI2VFeAxHQIIO0Yfyod5jWaHiWsnOWW
+fnJSoBVC21ndZHoa0Lh73TkVvFVIxO06AOoxEbrycXQaZ7jPM8yoMa+j49d/vzMt
+TGo87IvDktJTdyR0nAducPy9C1t2ul/y/9c3S0pgePfw+spwtOpZqqPOSC+pw7IL
+fhdyFgymBwwbOM/JYrc/oJOlh0Hyt3BAd9i+FHzjqMB6juljatEPmsbS9Is6FARW
+1O24zG71++IsWL1/T2sr92AkWCTOJu80kTrV44HQsvAEAtdbtz6SrGsSivnkBbA7
+kUlcsutT6vifR4buv5XAwAaf0lteERv0xwQ1KdJVXOTt6wIDAQABo4HJMIHGMB0G
+A1UdDgQWBBTFe1i97doladL3WRaoszLAeydb9DAOBgNVHQ8BAf8EBAMCAQYwDwYD
+VR0TAQH/BAUwAwEB/zCBgwYDVR0fBHwwejA8oDqgOIY2aHR0cDovL2NybC5jb21v
+ZG9jYS5jb20vVHJ1c3RlZENlcnRpZmljYXRlU2VydmljZXMuY3JsMDqgOKA2hjRo
+dHRwOi8vY3JsLmNvbW9kby5uZXQvVHJ1c3RlZENlcnRpZmljYXRlU2VydmljZXMu
+Y3JsMA0GCSqGSIb3DQEBBQUAA4IBAQDIk4E7ibSvuIQSTI3S8NtwuleGFTQQuS9/
+HrCoiWChisJ3DFBKmwCL2Iv0QeLQg4pKHBQGsKNoBXAxMKdTmw7pSqBYaWcOrp32
+pSxBvzwGa+RZzG0Q8ZZvH9/0BAKkn0U+yNj6NkZEUD+Cl5EfKNsYEYwq5GWDVxIS
+jBc/lDb+XbDABHcTuPQV1T84zJQ6VdCsmPW6AF/ghhmBeC8owH7TzEIK9a5QoNE+
+xqFx7D+gIIxmOom0jtTYsU0lR+4viMi14QVFwL4Ucd56/Y57fU0IlqUSc/Atyjcn
+dBInTMu2l+nZrghtWjlA3QVHdWpaIbOjGM9O9y5Xt5hwXsjEeLBi
+-----END CERTIFICATE-----
+
+# Issuer: CN=UTN - DATACorp SGC O=The USERTRUST Network OU=http://www.usertrust.com
+# Subject: CN=UTN - DATACorp SGC O=The USERTRUST Network OU=http://www.usertrust.com
+# Label: "UTN DATACorp SGC Root CA"
+# Serial: 91374294542884689855167577680241077609
+# MD5 Fingerprint: b3:a5:3e:77:21:6d:ac:4a:c0:c9:fb:d5:41:3d:ca:06
+# SHA1 Fingerprint: 58:11:9f:0e:12:82:87:ea:50:fd:d9:87:45:6f:4f:78:dc:fa:d6:d4
+# SHA256 Fingerprint: 85:fb:2f:91:dd:12:27:5a:01:45:b6:36:53:4f:84:02:4a:d6:8b:69:b8:ee:88:68:4f:f7:11:37:58:05:b3:48
+-----BEGIN CERTIFICATE-----
+MIIEXjCCA0agAwIBAgIQRL4Mi1AAIbQR0ypoBqmtaTANBgkqhkiG9w0BAQUFADCB
+kzELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAlVUMRcwFQYDVQQHEw5TYWx0IExha2Ug
+Q2l0eTEeMBwGA1UEChMVVGhlIFVTRVJUUlVTVCBOZXR3b3JrMSEwHwYDVQQLExho
+dHRwOi8vd3d3LnVzZXJ0cnVzdC5jb20xGzAZBgNVBAMTElVUTiAtIERBVEFDb3Jw
+IFNHQzAeFw05OTA2MjQxODU3MjFaFw0xOTA2MjQxOTA2MzBaMIGTMQswCQYDVQQG
+EwJVUzELMAkGA1UECBMCVVQxFzAVBgNVBAcTDlNhbHQgTGFrZSBDaXR5MR4wHAYD
+VQQKExVUaGUgVVNFUlRSVVNUIE5ldHdvcmsxITAfBgNVBAsTGGh0dHA6Ly93d3cu
+dXNlcnRydXN0LmNvbTEbMBkGA1UEAxMSVVROIC0gREFUQUNvcnAgU0dDMIIBIjAN
+BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3+5YEKIrblXEjr8uRgnn4AgPLit6
+E5Qbvfa2gI5lBZMAHryv4g+OGQ0SR+ysraP6LnD43m77VkIVni5c7yPeIbkFdicZ
+D0/Ww5y0vpQZY/KmEQrrU0icvvIpOxboGqBMpsn0GFlowHDyUwDAXlCCpVZvNvlK
+4ESGoE1O1kduSUrLZ9emxAW5jh70/P/N5zbgnAVssjMiFdC04MwXwLLA9P4yPykq
+lXvY8qdOD1R8oQ2AswkDwf9c3V6aPryuvEeKaq5xyh+xKrhfQgUL7EYw0XILyulW
+bfXv33i+Ybqypa4ETLyorGkVl73v67SMvzX41MPRKA5cOp9wGDMgd8SirwIDAQAB
+o4GrMIGoMAsGA1UdDwQEAwIBxjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRT
+MtGzz3/64PGgXYVOktKeRR20TzA9BgNVHR8ENjA0MDKgMKAuhixodHRwOi8vY3Js
+LnVzZXJ0cnVzdC5jb20vVVROLURBVEFDb3JwU0dDLmNybDAqBgNVHSUEIzAhBggr
+BgEFBQcDAQYKKwYBBAGCNwoDAwYJYIZIAYb4QgQBMA0GCSqGSIb3DQEBBQUAA4IB
+AQAnNZcAiosovcYzMB4p/OL31ZjUQLtgyr+rFywJNn9Q+kHcrpY6CiM+iVnJowft
+Gzet/Hy+UUla3joKVAgWRcKZsYfNjGjgaQPpxE6YsjuMFrMOoAyYUJuTqXAJyCyj
+j98C5OBxOvG0I3KgqgHf35g+FFCgMSa9KOlaMCZ1+XtgHI3zzVAmbQQnmt/VDUVH
+KWss5nbZqSl9Mt3JNjy9rjXxEZ4du5A/EkdOjtd+D2JzHVImOBwYSf0wdJrE5SIv
+2MCN7ZF6TACPcn9d2t0bi0Vr591pl6jFVkwPDPafepE39peC4N1xaf92P2BNPM/3
+mfnGV/TJVTl4uix5yaaIK/QI
+-----END CERTIFICATE-----
+
+# Issuer: CN=UTN-USERFirst-Hardware O=The USERTRUST Network OU=http://www.usertrust.com
+# Subject: CN=UTN-USERFirst-Hardware O=The USERTRUST Network OU=http://www.usertrust.com
+# Label: "UTN USERFirst Hardware Root CA"
+# Serial: 91374294542884704022267039221184531197
+# MD5 Fingerprint: 4c:56:41:e5:0d:bb:2b:e8:ca:a3:ed:18:08:ad:43:39
+# SHA1 Fingerprint: 04:83:ed:33:99:ac:36:08:05:87:22:ed:bc:5e:46:00:e3:be:f9:d7
+# SHA256 Fingerprint: 6e:a5:47:41:d0:04:66:7e:ed:1b:48:16:63:4a:a3:a7:9e:6e:4b:96:95:0f:82:79:da:fc:8d:9b:d8:81:21:37
+-----BEGIN CERTIFICATE-----
+MIIEdDCCA1ygAwIBAgIQRL4Mi1AAJLQR0zYq/mUK/TANBgkqhkiG9w0BAQUFADCB
+lzELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAlVUMRcwFQYDVQQHEw5TYWx0IExha2Ug
+Q2l0eTEeMBwGA1UEChMVVGhlIFVTRVJUUlVTVCBOZXR3b3JrMSEwHwYDVQQLExho
+dHRwOi8vd3d3LnVzZXJ0cnVzdC5jb20xHzAdBgNVBAMTFlVUTi1VU0VSRmlyc3Qt
+SGFyZHdhcmUwHhcNOTkwNzA5MTgxMDQyWhcNMTkwNzA5MTgxOTIyWjCBlzELMAkG
+A1UEBhMCVVMxCzAJBgNVBAgTAlVUMRcwFQYDVQQHEw5TYWx0IExha2UgQ2l0eTEe
+MBwGA1UEChMVVGhlIFVTRVJUUlVTVCBOZXR3b3JrMSEwHwYDVQQLExhodHRwOi8v
+d3d3LnVzZXJ0cnVzdC5jb20xHzAdBgNVBAMTFlVUTi1VU0VSRmlyc3QtSGFyZHdh
+cmUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCx98M4P7Sof885glFn
+0G2f0v9Y8+efK+wNiVSZuTiZFvfgIXlIwrthdBKWHTxqctU8EGc6Oe0rE81m65UJ
+M6Rsl7HoxuzBdXmcRl6Nq9Bq/bkqVRcQVLMZ8Jr28bFdtqdt++BxF2uiiPsA3/4a
+MXcMmgF6sTLjKwEHOG7DpV4jvEWbe1DByTCP2+UretNb+zNAHqDVmBe8i4fDidNd
+oI6yqqr2jmmIBsX6iSHzCJ1pLgkzmykNRg+MzEk0sGlRvfkGzWitZky8PqxhvQqI
+DsjfPe58BEydCl5rkdbux+0ojatNh4lz0G6k0B4WixThdkQDf2Os5M1JnMWS9Ksy
+oUhbAgMBAAGjgbkwgbYwCwYDVR0PBAQDAgHGMA8GA1UdEwEB/wQFMAMBAf8wHQYD
+VR0OBBYEFKFyXyYbKJhDlV0HN9WFlp1L0sNFMEQGA1UdHwQ9MDswOaA3oDWGM2h0
+dHA6Ly9jcmwudXNlcnRydXN0LmNvbS9VVE4tVVNFUkZpcnN0LUhhcmR3YXJlLmNy
+bDAxBgNVHSUEKjAoBggrBgEFBQcDAQYIKwYBBQUHAwUGCCsGAQUFBwMGBggrBgEF
+BQcDBzANBgkqhkiG9w0BAQUFAAOCAQEARxkP3nTGmZev/K0oXnWO6y1n7k57K9cM
+//bey1WiCuFMVGWTYGufEpytXoMs61quwOQt9ABjHbjAbPLPSbtNk28Gpgoiskli
+CE7/yMgUsogWXecB5BKV5UU0s4tpvc+0hY91UZ59Ojg6FEgSxvunOxqNDYJAB+gE
+CJChicsZUN/KHAG8HQQZexB2lzvukJDKxA4fFm517zP4029bHpbj4HR3dHuKom4t
+3XbWOTCC8KucUvIqx69JXn7HaOWCgchqJ/kniCrVWFCVH/A7HFe7fRQ5YiuayZSS
+KqMiDP+JJn1fIytH1xUdqWqeUQ0qUZ6B+dQ7XnASfxAynB67nfhmqA==
+-----END CERTIFICATE-----
+
+# Issuer: CN=XRamp Global Certification Authority O=XRamp Security Services Inc OU=www.xrampsecurity.com
+# Subject: CN=XRamp Global Certification Authority O=XRamp Security Services Inc OU=www.xrampsecurity.com
+# Label: "XRamp Global CA Root"
+# Serial: 107108908803651509692980124233745014957
+# MD5 Fingerprint: a1:0b:44:b3:ca:10:d8:00:6e:9d:0f:d8:0f:92:0a:d1
+# SHA1 Fingerprint: b8:01:86:d1:eb:9c:86:a5:41:04:cf:30:54:f3:4c:52:b7:e5:58:c6
+# SHA256 Fingerprint: ce:cd:dc:90:50:99:d8:da:df:c5:b1:d2:09:b7:37:cb:e2:c1:8c:fb:2c:10:c0:ff:0b:cf:0d:32:86:fc:1a:a2
+-----BEGIN CERTIFICATE-----
+MIIEMDCCAxigAwIBAgIQUJRs7Bjq1ZxN1ZfvdY+grTANBgkqhkiG9w0BAQUFADCB
+gjELMAkGA1UEBhMCVVMxHjAcBgNVBAsTFXd3dy54cmFtcHNlY3VyaXR5LmNvbTEk
+MCIGA1UEChMbWFJhbXAgU2VjdXJpdHkgU2VydmljZXMgSW5jMS0wKwYDVQQDEyRY
+UmFtcCBHbG9iYWwgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMDQxMTAxMTcx
+NDA0WhcNMzUwMTAxMDUzNzE5WjCBgjELMAkGA1UEBhMCVVMxHjAcBgNVBAsTFXd3
+dy54cmFtcHNlY3VyaXR5LmNvbTEkMCIGA1UEChMbWFJhbXAgU2VjdXJpdHkgU2Vy
+dmljZXMgSW5jMS0wKwYDVQQDEyRYUmFtcCBHbG9iYWwgQ2VydGlmaWNhdGlvbiBB
+dXRob3JpdHkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCYJB69FbS6
+38eMpSe2OAtp87ZOqCwuIR1cRN8hXX4jdP5efrRKt6atH67gBhbim1vZZ3RrXYCP
+KZ2GG9mcDZhtdhAoWORlsH9KmHmf4MMxfoArtYzAQDsRhtDLooY2YKTVMIJt2W7Q
+DxIEM5dfT2Fa8OT5kavnHTu86M/0ay00fOJIYRyO82FEzG+gSqmUsE3a56k0enI4
+qEHMPJQRfevIpoy3hsvKMzvZPTeL+3o+hiznc9cKV6xkmxnr9A8ECIqsAxcZZPRa
+JSKNNCyy9mgdEm3Tih4U2sSPpuIjhdV6Db1q4Ons7Be7QhtnqiXtRYMh/MHJfNVi
+PvryxS3T/dRlAgMBAAGjgZ8wgZwwEwYJKwYBBAGCNxQCBAYeBABDAEEwCwYDVR0P
+BAQDAgGGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFMZPoj0GY4QJnM5i5ASs
+jVy16bYbMDYGA1UdHwQvMC0wK6ApoCeGJWh0dHA6Ly9jcmwueHJhbXBzZWN1cml0
+eS5jb20vWEdDQS5jcmwwEAYJKwYBBAGCNxUBBAMCAQEwDQYJKoZIhvcNAQEFBQAD
+ggEBAJEVOQMBG2f7Shz5CmBbodpNl2L5JFMn14JkTpAuw0kbK5rc/Kh4ZzXxHfAR
+vbdI4xD2Dd8/0sm2qlWkSLoC295ZLhVbO50WfUfXN+pfTXYSNrsf16GBBEYgoyxt
+qZ4Bfj8pzgCT3/3JknOJiWSe5yvkHJEs0rnOfc5vMZnT5r7SHpDwCRR5XCOrTdLa
+IR9NmXmd4c8nnxCbHIgNsIpkQTG4DmyQJKSbXHGPurt+HBvbaoAPIbzp26a3QPSy
+i6mx5O+aGtA9aZnuqCij4Tyz8LIRnM98QObd50N9otg6tamN8jSZxNQQ4Qb9CYQQ
+O+7ETPTsJ3xCwnR8gooJybQDJbw=
+-----END CERTIFICATE-----
+
+# Issuer: O=The Go Daddy Group, Inc. OU=Go Daddy Class 2 Certification Authority
+# Subject: O=The Go Daddy Group, Inc. OU=Go Daddy Class 2 Certification Authority
+# Label: "Go Daddy Class 2 CA"
+# Serial: 0
+# MD5 Fingerprint: 91:de:06:25:ab:da:fd:32:17:0c:bb:25:17:2a:84:67
+# SHA1 Fingerprint: 27:96:ba:e6:3f:18:01:e2:77:26:1b:a0:d7:77:70:02:8f:20:ee:e4
+# SHA256 Fingerprint: c3:84:6b:f2:4b:9e:93:ca:64:27:4c:0e:c6:7c:1e:cc:5e:02:4f:fc:ac:d2:d7:40:19:35:0e:81:fe:54:6a:e4
+-----BEGIN CERTIFICATE-----
+MIIEADCCAuigAwIBAgIBADANBgkqhkiG9w0BAQUFADBjMQswCQYDVQQGEwJVUzEh
+MB8GA1UEChMYVGhlIEdvIERhZGR5IEdyb3VwLCBJbmMuMTEwLwYDVQQLEyhHbyBE
+YWRkeSBDbGFzcyAyIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MB4XDTA0MDYyOTE3
+MDYyMFoXDTM0MDYyOTE3MDYyMFowYzELMAkGA1UEBhMCVVMxITAfBgNVBAoTGFRo
+ZSBHbyBEYWRkeSBHcm91cCwgSW5jLjExMC8GA1UECxMoR28gRGFkZHkgQ2xhc3Mg
+MiBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTCCASAwDQYJKoZIhvcNAQEBBQADggEN
+ADCCAQgCggEBAN6d1+pXGEmhW+vXX0iG6r7d/+TvZxz0ZWizV3GgXne77ZtJ6XCA
+PVYYYwhv2vLM0D9/AlQiVBDYsoHUwHU9S3/Hd8M+eKsaA7Ugay9qK7HFiH7Eux6w
+wdhFJ2+qN1j3hybX2C32qRe3H3I2TqYXP2WYktsqbl2i/ojgC95/5Y0V4evLOtXi
+EqITLdiOr18SPaAIBQi2XKVlOARFmR6jYGB0xUGlcmIbYsUfb18aQr4CUWWoriMY
+avx4A6lNf4DD+qta/KFApMoZFv6yyO9ecw3ud72a9nmYvLEHZ6IVDd2gWMZEewo+
+YihfukEHU1jPEX44dMX4/7VpkI+EdOqXG68CAQOjgcAwgb0wHQYDVR0OBBYEFNLE
+sNKR1EwRcbNhyz2h/t2oatTjMIGNBgNVHSMEgYUwgYKAFNLEsNKR1EwRcbNhyz2h
+/t2oatTjoWekZTBjMQswCQYDVQQGEwJVUzEhMB8GA1UEChMYVGhlIEdvIERhZGR5
+IEdyb3VwLCBJbmMuMTEwLwYDVQQLEyhHbyBEYWRkeSBDbGFzcyAyIENlcnRpZmlj
+YXRpb24gQXV0aG9yaXR5ggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQAD
+ggEBADJL87LKPpH8EsahB4yOd6AzBhRckB4Y9wimPQoZ+YeAEW5p5JYXMP80kWNy
+OO7MHAGjHZQopDH2esRU1/blMVgDoszOYtuURXO1v0XJJLXVggKtI3lpjbi2Tc7P
+TMozI+gciKqdi0FuFskg5YmezTvacPd+mSYgFFQlq25zheabIZ0KbIIOqPjCDPoQ
+HmyW74cNxA9hi63ugyuV+I6ShHI56yDqg+2DzZduCLzrTia2cyvk0/ZM/iZx4mER
+dEr/VxqHD3VILs9RaRegAhJhldXRQLIQTO7ErBBDpqWeCtWVYpoNz4iCxTIM5Cuf
+ReYNnyicsbkqWletNw+vHX/bvZ8=
+-----END CERTIFICATE-----
+
+# Issuer: O=Starfield Technologies, Inc. OU=Starfield Class 2 Certification Authority
+# Subject: O=Starfield Technologies, Inc. OU=Starfield Class 2 Certification Authority
+# Label: "Starfield Class 2 CA"
+# Serial: 0
+# MD5 Fingerprint: 32:4a:4b:bb:c8:63:69:9b:be:74:9a:c6:dd:1d:46:24
+# SHA1 Fingerprint: ad:7e:1c:28:b0:64:ef:8f:60:03:40:20:14:c3:d0:e3:37:0e:b5:8a
+# SHA256 Fingerprint: 14:65:fa:20:53:97:b8:76:fa:a6:f0:a9:95:8e:55:90:e4:0f:cc:7f:aa:4f:b7:c2:c8:67:75:21:fb:5f:b6:58
+-----BEGIN CERTIFICATE-----
+MIIEDzCCAvegAwIBAgIBADANBgkqhkiG9w0BAQUFADBoMQswCQYDVQQGEwJVUzEl
+MCMGA1UEChMcU3RhcmZpZWxkIFRlY2hub2xvZ2llcywgSW5jLjEyMDAGA1UECxMp
+U3RhcmZpZWxkIENsYXNzIDIgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMDQw
+NjI5MTczOTE2WhcNMzQwNjI5MTczOTE2WjBoMQswCQYDVQQGEwJVUzElMCMGA1UE
+ChMcU3RhcmZpZWxkIFRlY2hub2xvZ2llcywgSW5jLjEyMDAGA1UECxMpU3RhcmZp
+ZWxkIENsYXNzIDIgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwggEgMA0GCSqGSIb3
+DQEBAQUAA4IBDQAwggEIAoIBAQC3Msj+6XGmBIWtDBFk385N78gDGIc/oav7PKaf
+8MOh2tTYbitTkPskpD6E8J7oX+zlJ0T1KKY/e97gKvDIr1MvnsoFAZMej2YcOadN
++lq2cwQlZut3f+dZxkqZJRRU6ybH838Z1TBwj6+wRir/resp7defqgSHo9T5iaU0
+X9tDkYI22WY8sbi5gv2cOj4QyDvvBmVmepsZGD3/cVE8MC5fvj13c7JdBmzDI1aa
+K4UmkhynArPkPw2vCHmCuDY96pzTNbO8acr1zJ3o/WSNF4Azbl5KXZnJHoe0nRrA
+1W4TNSNe35tfPe/W93bC6j67eA0cQmdrBNj41tpvi/JEoAGrAgEDo4HFMIHCMB0G
+A1UdDgQWBBS/X7fRzt0fhvRbVazc1xDCDqmI5zCBkgYDVR0jBIGKMIGHgBS/X7fR
+zt0fhvRbVazc1xDCDqmI56FspGowaDELMAkGA1UEBhMCVVMxJTAjBgNVBAoTHFN0
+YXJmaWVsZCBUZWNobm9sb2dpZXMsIEluYy4xMjAwBgNVBAsTKVN0YXJmaWVsZCBD
+bGFzcyAyIENlcnRpZmljYXRpb24gQXV0aG9yaXR5ggEAMAwGA1UdEwQFMAMBAf8w
+DQYJKoZIhvcNAQEFBQADggEBAAWdP4id0ckaVaGsafPzWdqbAYcaT1epoXkJKtv3
+L7IezMdeatiDh6GX70k1PncGQVhiv45YuApnP+yz3SFmH8lU+nLMPUxA2IGvd56D
+eruix/U0F47ZEUD0/CwqTRV/p2JdLiXTAAsgGh1o+Re49L2L7ShZ3U0WixeDyLJl
+xy16paq8U4Zt3VekyvggQQto8PT7dL5WXXp59fkdheMtlb71cZBDzI0fmgAKhynp
+VSJYACPq4xJDKVtHCN2MQWplBqjlIapBtJUhlbl90TSrE9atvNziPTnNvT51cKEY
+WQPJIrSPnNVeKtelttQKbfi3QBFGmh95DmK/D5fs4C8fF5Q=
+-----END CERTIFICATE-----
+
+# Issuer: CN=StartCom Certification Authority O=StartCom Ltd. OU=Secure Digital Certificate Signing
+# Subject: CN=StartCom Certification Authority O=StartCom Ltd. OU=Secure Digital Certificate Signing
+# Label: "StartCom Certification Authority"
+# Serial: 1
+# MD5 Fingerprint: 22:4d:8f:8a:fc:f7:35:c2:bb:57:34:90:7b:8b:22:16
+# SHA1 Fingerprint: 3e:2b:f7:f2:03:1b:96:f3:8c:e6:c4:d8:a8:5d:3e:2d:58:47:6a:0f
+# SHA256 Fingerprint: c7:66:a9:be:f2:d4:07:1c:86:3a:31:aa:49:20:e8:13:b2:d1:98:60:8c:b7:b7:cf:e2:11:43:b8:36:df:09:ea
+-----BEGIN CERTIFICATE-----
+MIIHyTCCBbGgAwIBAgIBATANBgkqhkiG9w0BAQUFADB9MQswCQYDVQQGEwJJTDEW
+MBQGA1UEChMNU3RhcnRDb20gTHRkLjErMCkGA1UECxMiU2VjdXJlIERpZ2l0YWwg
+Q2VydGlmaWNhdGUgU2lnbmluZzEpMCcGA1UEAxMgU3RhcnRDb20gQ2VydGlmaWNh
+dGlvbiBBdXRob3JpdHkwHhcNMDYwOTE3MTk0NjM2WhcNMzYwOTE3MTk0NjM2WjB9
+MQswCQYDVQQGEwJJTDEWMBQGA1UEChMNU3RhcnRDb20gTHRkLjErMCkGA1UECxMi
+U2VjdXJlIERpZ2l0YWwgQ2VydGlmaWNhdGUgU2lnbmluZzEpMCcGA1UEAxMgU3Rh
+cnRDb20gQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwggIiMA0GCSqGSIb3DQEBAQUA
+A4ICDwAwggIKAoICAQDBiNsJvGxGfHiflXu1M5DycmLWwTYgIiRezul38kMKogZk
+pMyONvg45iPwbm2xPN1yo4UcodM9tDMr0y+v/uqwQVlntsQGfQqedIXWeUyAN3rf
+OQVSWff0G0ZDpNKFhdLDcfN1YjS6LIp/Ho/u7TTQEceWzVI9ujPW3U3eCztKS5/C
+Ji/6tRYccjV3yjxd5srhJosaNnZcAdt0FCX+7bWgiA/deMotHweXMAEtcnn6RtYT
+Kqi5pquDSR3l8u/d5AGOGAqPY1MWhWKpDhk6zLVmpsJrdAfkK+F2PrRt2PZE4XNi
+HzvEvqBTViVsUQn3qqvKv3b9bZvzndu/PWa8DFaqr5hIlTpL36dYUNk4dalb6kMM
+Av+Z6+hsTXBbKWWc3apdzK8BMewM69KN6Oqce+Zu9ydmDBpI125C4z/eIT574Q1w
++2OqqGwaVLRcJXrJosmLFqa7LH4XXgVNWG4SHQHuEhANxjJ/GP/89PrNbpHoNkm+
+Gkhpi8KWTRoSsmkXwQqQ1vp5Iki/untp+HDH+no32NgN0nZPV/+Qt+OR0t3vwmC3
+Zzrd/qqc8NSLf3Iizsafl7b4r4qgEKjZ+xjGtrVcUjyJthkqcwEKDwOzEmDyei+B
+26Nu/yYwl/WL3YlXtq09s68rxbd2AvCl1iuahhQqcvbjM4xdCUsT37uMdBNSSwID
+AQABo4ICUjCCAk4wDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMCAa4wHQYDVR0OBBYE
+FE4L7xqkQFulF2mHMMo0aEPQQa7yMGQGA1UdHwRdMFswLKAqoCiGJmh0dHA6Ly9j
+ZXJ0LnN0YXJ0Y29tLm9yZy9zZnNjYS1jcmwuY3JsMCugKaAnhiVodHRwOi8vY3Js
+LnN0YXJ0Y29tLm9yZy9zZnNjYS1jcmwuY3JsMIIBXQYDVR0gBIIBVDCCAVAwggFM
+BgsrBgEEAYG1NwEBATCCATswLwYIKwYBBQUHAgEWI2h0dHA6Ly9jZXJ0LnN0YXJ0
+Y29tLm9yZy9wb2xpY3kucGRmMDUGCCsGAQUFBwIBFilodHRwOi8vY2VydC5zdGFy
+dGNvbS5vcmcvaW50ZXJtZWRpYXRlLnBkZjCB0AYIKwYBBQUHAgIwgcMwJxYgU3Rh
+cnQgQ29tbWVyY2lhbCAoU3RhcnRDb20pIEx0ZC4wAwIBARqBl0xpbWl0ZWQgTGlh
+YmlsaXR5LCByZWFkIHRoZSBzZWN0aW9uICpMZWdhbCBMaW1pdGF0aW9ucyogb2Yg
+dGhlIFN0YXJ0Q29tIENlcnRpZmljYXRpb24gQXV0aG9yaXR5IFBvbGljeSBhdmFp
+bGFibGUgYXQgaHR0cDovL2NlcnQuc3RhcnRjb20ub3JnL3BvbGljeS5wZGYwEQYJ
+YIZIAYb4QgEBBAQDAgAHMDgGCWCGSAGG+EIBDQQrFilTdGFydENvbSBGcmVlIFNT
+TCBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTANBgkqhkiG9w0BAQUFAAOCAgEAFmyZ
+9GYMNPXQhV59CuzaEE44HF7fpiUFS5Eyweg78T3dRAlbB0mKKctmArexmvclmAk8
+jhvh3TaHK0u7aNM5Zj2gJsfyOZEdUauCe37Vzlrk4gNXcGmXCPleWKYK34wGmkUW
+FjgKXlf2Ysd6AgXmvB618p70qSmD+LIU424oh0TDkBreOKk8rENNZEXO3SipXPJz
+ewT4F+irsfMuXGRuczE6Eri8sxHkfY+BUZo7jYn0TZNmezwD7dOaHZrzZVD1oNB1
+ny+v8OqCQ5j4aZyJecRDjkZy42Q2Eq/3JR44iZB3fsNrarnDy0RLrHiQi+fHLB5L
+EUTINFInzQpdn4XBidUaePKVEFMy3YCEZnXZtWgo+2EuvoSoOMCZEoalHmdkrQYu
+L6lwhceWD3yJZfWOQ1QOq92lgDmUYMA0yZZwLKMS9R9Ie70cfmu3nZD0Ijuu+Pwq
+yvqCUqDvr0tVk+vBtfAii6w0TiYiBKGHLHVKt+V9E9e4DGTANtLJL4YSjCMJwRuC
+O3NJo2pXh5Tl1njFmUNj403gdy3hZZlyaQQaRwnmDwFWJPsfvw55qVguucQJAX6V
+um0ABj6y6koQOdjQK/W/7HW/lwLFCRsI3FU34oH7N4RDYiDK51ZLZer+bMEkkySh
+NOsF/5oirpt9P/FlUQqmMGqz9IgcgA38corog14=
+-----END CERTIFICATE-----
+
+# Issuer: CN=DigiCert Assured ID Root CA O=DigiCert Inc OU=www.digicert.com
+# Subject: CN=DigiCert Assured ID Root CA O=DigiCert Inc OU=www.digicert.com
+# Label: "DigiCert Assured ID Root CA"
+# Serial: 17154717934120587862167794914071425081
+# MD5 Fingerprint: 87:ce:0b:7b:2a:0e:49:00:e1:58:71:9b:37:a8:93:72
+# SHA1 Fingerprint: 05:63:b8:63:0d:62:d7:5a:bb:c8:ab:1e:4b:df:b5:a8:99:b2:4d:43
+# SHA256 Fingerprint: 3e:90:99:b5:01:5e:8f:48:6c:00:bc:ea:9d:11:1e:e7:21:fa:ba:35:5a:89:bc:f1:df:69:56:1e:3d:c6:32:5c
+-----BEGIN CERTIFICATE-----
+MIIDtzCCAp+gAwIBAgIQDOfg5RfYRv6P5WD8G/AwOTANBgkqhkiG9w0BAQUFADBl
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+d3cuZGlnaWNlcnQuY29tMSQwIgYDVQQDExtEaWdpQ2VydCBBc3N1cmVkIElEIFJv
+b3QgQ0EwHhcNMDYxMTEwMDAwMDAwWhcNMzExMTEwMDAwMDAwWjBlMQswCQYDVQQG
+EwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3d3cuZGlnaWNl
+cnQuY29tMSQwIgYDVQQDExtEaWdpQ2VydCBBc3N1cmVkIElEIFJvb3QgQ0EwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCtDhXO5EOAXLGH87dg+XESpa7c
+JpSIqvTO9SA5KFhgDPiA2qkVlTJhPLWxKISKityfCgyDF3qPkKyK53lTXDGEKvYP
+mDI2dsze3Tyoou9q+yHyUmHfnyDXH+Kx2f4YZNISW1/5WBg1vEfNoTb5a3/UsDg+
+wRvDjDPZ2C8Y/igPs6eD1sNuRMBhNZYW/lmci3Zt1/GiSw0r/wty2p5g0I6QNcZ4
+VYcgoc/lbQrISXwxmDNsIumH0DJaoroTghHtORedmTpyoeb6pNnVFzF1roV9Iq4/
+AUaG9ih5yLHa5FcXxH4cDrC0kqZWs72yl+2qp/C3xag/lRbQ/6GW6whfGHdPAgMB
+AAGjYzBhMA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQW
+BBRF66Kv9JLLgjEtUYunpyGd823IDzAfBgNVHSMEGDAWgBRF66Kv9JLLgjEtUYun
+pyGd823IDzANBgkqhkiG9w0BAQUFAAOCAQEAog683+Lt8ONyc3pklL/3cmbYMuRC
+dWKuh+vy1dneVrOfzM4UKLkNl2BcEkxY5NM9g0lFWJc1aRqoR+pWxnmrEthngYTf
+fwk8lOa4JiwgvT2zKIn3X/8i4peEH+ll74fg38FnSbNd67IJKusm7Xi+fT8r87cm
+NW1fiQG2SVufAQWbqz0lwcy2f8Lxb4bG+mRo64EtlOtCt/qMHt1i8b5QZ7dsvfPx
+H2sMNgcWfzd8qVttevESRmCD1ycEvkvOl77DZypoEd+A5wwzZr8TDRRu838fYxAe
++o0bJW1sj6W3YQGx0qMmoRBxna3iw/nDmVG3KwcIzi7mULKn+gpFL6Lw8g==
+-----END CERTIFICATE-----
+
+# Issuer: CN=DigiCert Global Root CA O=DigiCert Inc OU=www.digicert.com
+# Subject: CN=DigiCert Global Root CA O=DigiCert Inc OU=www.digicert.com
+# Label: "DigiCert Global Root CA"
+# Serial: 10944719598952040374951832963794454346
+# MD5 Fingerprint: 79:e4:a9:84:0d:7d:3a:96:d7:c0:4f:e2:43:4c:89:2e
+# SHA1 Fingerprint: a8:98:5d:3a:65:e5:e5:c4:b2:d7:d6:6d:40:c6:dd:2f:b1:9c:54:36
+# SHA256 Fingerprint: 43:48:a0:e9:44:4c:78:cb:26:5e:05:8d:5e:89:44:b4:d8:4f:96:62:bd:26:db:25:7f:89:34:a4:43:c7:01:61
+-----BEGIN CERTIFICATE-----
+MIIDrzCCApegAwIBAgIQCDvgVpBCRrGhdWrJWZHHSjANBgkqhkiG9w0BAQUFADBh
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+d3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBD
+QTAeFw0wNjExMTAwMDAwMDBaFw0zMTExMTAwMDAwMDBaMGExCzAJBgNVBAYTAlVT
+MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5j
+b20xIDAeBgNVBAMTF0RpZ2lDZXJ0IEdsb2JhbCBSb290IENBMIIBIjANBgkqhkiG
+9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4jvhEXLeqKTTo1eqUKKPC3eQyaKl7hLOllsB
+CSDMAZOnTjC3U/dDxGkAV53ijSLdhwZAAIEJzs4bg7/fzTtxRuLWZscFs3YnFo97
+nh6Vfe63SKMI2tavegw5BmV/Sl0fvBf4q77uKNd0f3p4mVmFaG5cIzJLv07A6Fpt
+43C/dxC//AH2hdmoRBBYMql1GNXRor5H4idq9Joz+EkIYIvUX7Q6hL+hqkpMfT7P
+T19sdl6gSzeRntwi5m3OFBqOasv+zbMUZBfHWymeMr/y7vrTC0LUq7dBMtoM1O/4
+gdW7jVg/tRvoSSiicNoxBN33shbyTApOB6jtSj1etX+jkMOvJwIDAQABo2MwYTAO
+BgNVHQ8BAf8EBAMCAYYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUA95QNVbR
+TLtm8KPiGxvDl7I90VUwHwYDVR0jBBgwFoAUA95QNVbRTLtm8KPiGxvDl7I90VUw
+DQYJKoZIhvcNAQEFBQADggEBAMucN6pIExIK+t1EnE9SsPTfrgT1eXkIoyQY/Esr
+hMAtudXH/vTBH1jLuG2cenTnmCmrEbXjcKChzUyImZOMkXDiqw8cvpOp/2PV5Adg
+06O/nVsJ8dWO41P0jmP6P6fbtGbfYmbW0W5BjfIttep3Sp+dWOIrWcBAI+0tKIJF
+PnlUkiaY4IBIqDfv8NZ5YBberOgOzW6sRBc4L0na4UU+Krk2U886UAb3LujEV0ls
+YSEY1QSteDwsOoBrp+uvFRTp2InBuThs4pFsiv9kuXclVzDAGySj4dzp30d8tbQk
+CAUw7C29C79Fv1C5qfPrmAESrciIxpg0X40KPMbp1ZWVbd4=
+-----END CERTIFICATE-----
+
+# Issuer: CN=DigiCert High Assurance EV Root CA O=DigiCert Inc OU=www.digicert.com
+# Subject: CN=DigiCert High Assurance EV Root CA O=DigiCert Inc OU=www.digicert.com
+# Label: "DigiCert High Assurance EV Root CA"
+# Serial: 3553400076410547919724730734378100087
+# MD5 Fingerprint: d4:74:de:57:5c:39:b2:d3:9c:85:83:c5:c0:65:49:8a
+# SHA1 Fingerprint: 5f:b7:ee:06:33:e2:59:db:ad:0c:4c:9a:e6:d3:8f:1a:61:c7:dc:25
+# SHA256 Fingerprint: 74:31:e5:f4:c3:c1:ce:46:90:77:4f:0b:61:e0:54:40:88:3b:a9:a0:1e:d0:0b:a6:ab:d7:80:6e:d3:b1:18:cf
+-----BEGIN CERTIFICATE-----
+MIIDxTCCAq2gAwIBAgIQAqxcJmoLQJuPC3nyrkYldzANBgkqhkiG9w0BAQUFADBs
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+d3cuZGlnaWNlcnQuY29tMSswKQYDVQQDEyJEaWdpQ2VydCBIaWdoIEFzc3VyYW5j
+ZSBFViBSb290IENBMB4XDTA2MTExMDAwMDAwMFoXDTMxMTExMDAwMDAwMFowbDEL
+MAkGA1UEBhMCVVMxFTATBgNVBAoTDERpZ2lDZXJ0IEluYzEZMBcGA1UECxMQd3d3
+LmRpZ2ljZXJ0LmNvbTErMCkGA1UEAxMiRGlnaUNlcnQgSGlnaCBBc3N1cmFuY2Ug
+RVYgUm9vdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMbM5XPm
++9S75S0tMqbf5YE/yc0lSbZxKsPVlDRnogocsF9ppkCxxLeyj9CYpKlBWTrT3JTW
+PNt0OKRKzE0lgvdKpVMSOO7zSW1xkX5jtqumX8OkhPhPYlG++MXs2ziS4wblCJEM
+xChBVfvLWokVfnHoNb9Ncgk9vjo4UFt3MRuNs8ckRZqnrG0AFFoEt7oT61EKmEFB
+Ik5lYYeBQVCmeVyJ3hlKV9Uu5l0cUyx+mM0aBhakaHPQNAQTXKFx01p8VdteZOE3
+hzBWBOURtCmAEvF5OYiiAhF8J2a3iLd48soKqDirCmTCv2ZdlYTBoSUeh10aUAsg
+EsxBu24LUTi4S8sCAwEAAaNjMGEwDgYDVR0PAQH/BAQDAgGGMA8GA1UdEwEB/wQF
+MAMBAf8wHQYDVR0OBBYEFLE+w2kD+L9HAdSYJhoIAu9jZCvDMB8GA1UdIwQYMBaA
+FLE+w2kD+L9HAdSYJhoIAu9jZCvDMA0GCSqGSIb3DQEBBQUAA4IBAQAcGgaX3Nec
+nzyIZgYIVyHbIUf4KmeqvxgydkAQV8GK83rZEWWONfqe/EW1ntlMMUu4kehDLI6z
+eM7b41N5cdblIZQB2lWHmiRk9opmzN6cN82oNLFpmyPInngiK3BD41VHMWEZ71jF
+hS9OMPagMRYjyOfiZRYzy78aG6A9+MpeizGLYAiJLQwGXFK3xPkKmNEVX58Svnw2
+Yzi9RKR/5CYrCsSXaQ3pjOLAEFe4yHYSkVXySGnYvCoCWw9E1CAx2/S6cCZdkGCe
+vEsXCS+0yx5DaMkHJ8HSXPfqIbloEpw8nL+e/IBcm2PN7EeqJSdnoDfzAIJ9VNep
++OkuE6N36B9K
+-----END CERTIFICATE-----
+
+# Issuer: CN=GeoTrust Primary Certification Authority O=GeoTrust Inc.
+# Subject: CN=GeoTrust Primary Certification Authority O=GeoTrust Inc.
+# Label: "GeoTrust Primary Certification Authority"
+# Serial: 32798226551256963324313806436981982369
+# MD5 Fingerprint: 02:26:c3:01:5e:08:30:37:43:a9:d0:7d:cf:37:e6:bf
+# SHA1 Fingerprint: 32:3c:11:8e:1b:f7:b8:b6:52:54:e2:e2:10:0d:d6:02:90:37:f0:96
+# SHA256 Fingerprint: 37:d5:10:06:c5:12:ea:ab:62:64:21:f1:ec:8c:92:01:3f:c5:f8:2a:e9:8e:e5:33:eb:46:19:b8:de:b4:d0:6c
+-----BEGIN CERTIFICATE-----
+MIIDfDCCAmSgAwIBAgIQGKy1av1pthU6Y2yv2vrEoTANBgkqhkiG9w0BAQUFADBY
+MQswCQYDVQQGEwJVUzEWMBQGA1UEChMNR2VvVHJ1c3QgSW5jLjExMC8GA1UEAxMo
+R2VvVHJ1c3QgUHJpbWFyeSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTAeFw0wNjEx
+MjcwMDAwMDBaFw0zNjA3MTYyMzU5NTlaMFgxCzAJBgNVBAYTAlVTMRYwFAYDVQQK
+Ew1HZW9UcnVzdCBJbmMuMTEwLwYDVQQDEyhHZW9UcnVzdCBQcmltYXJ5IENlcnRp
+ZmljYXRpb24gQXV0aG9yaXR5MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+AQEAvrgVe//UfH1nrYNke8hCUy3f9oQIIGHWAVlqnEQRr+92/ZV+zmEwu3qDXwK9
+AWbK7hWNb6EwnL2hhZ6UOvNWiAAxz9juapYC2e0DjPt1befquFUWBRaa9OBesYjA
+ZIVcFU2Ix7e64HXprQU9nceJSOC7KMgD4TCTZF5SwFlwIjVXiIrxlQqD17wxcwE0
+7e9GceBrAqg1cmuXm2bgyxx5X9gaBGgeRwLmnWDiNpcB3841kt++Z8dtd1k7j53W
+kBWUvEI0EME5+bEnPn7WinXFsq+W06Lem+SYvn3h6YGttm/81w7a4DSwDRp35+MI
+mO9Y+pyEtzavwt+s0vQQBnBxNQIDAQABo0IwQDAPBgNVHRMBAf8EBTADAQH/MA4G
+A1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQULNVQQZcVi/CPNmFbSvtr2ZnJM5IwDQYJ
+KoZIhvcNAQEFBQADggEBAFpwfyzdtzRP9YZRqSa+S7iq8XEN3GHHoOo0Hnp3DwQ1
+6CePbJC/kRYkRj5KTs4rFtULUh38H2eiAkUxT87z+gOneZ1TatnaYzr4gNfTmeGl
+4b7UVXGYNTq+k+qurUKykG/g/CFNNWMziUnWm07Kx+dOCQD32sfvmWKZd7aVIl6K
+oKv0uHiYyjgZmclynnjNS6yvGaBzEi38wkG6gZHaFloxt/m0cYASSJlyc1pZU8Fj
+UjPtp8nSOQJw+uCxQmYpqptR7TBUIhRf2asdweSU8Pj1K/fqynhG1riR/aYNKxoU
+AT6A8EKglQdebc3MS6RFjasS6LPeWuWgfOgPIh1a6Vk=
+-----END CERTIFICATE-----
+
+# Issuer: CN=thawte Primary Root CA O=thawte, Inc. OU=Certification Services Division/(c) 2006 thawte, Inc. - For authorized use only
+# Subject: CN=thawte Primary Root CA O=thawte, Inc. OU=Certification Services Division/(c) 2006 thawte, Inc. - For authorized use only
+# Label: "thawte Primary Root CA"
+# Serial: 69529181992039203566298953787712940909
+# MD5 Fingerprint: 8c:ca:dc:0b:22:ce:f5:be:72:ac:41:1a:11:a8:d8:12
+# SHA1 Fingerprint: 91:c6:d6:ee:3e:8a:c8:63:84:e5:48:c2:99:29:5c:75:6c:81:7b:81
+# SHA256 Fingerprint: 8d:72:2f:81:a9:c1:13:c0:79:1d:f1:36:a2:96:6d:b2:6c:95:0a:97:1d:b4:6b:41:99:f4:ea:54:b7:8b:fb:9f
+-----BEGIN CERTIFICATE-----
+MIIEIDCCAwigAwIBAgIQNE7VVyDV7exJ9C/ON9srbTANBgkqhkiG9w0BAQUFADCB
+qTELMAkGA1UEBhMCVVMxFTATBgNVBAoTDHRoYXd0ZSwgSW5jLjEoMCYGA1UECxMf
+Q2VydGlmaWNhdGlvbiBTZXJ2aWNlcyBEaXZpc2lvbjE4MDYGA1UECxMvKGMpIDIw
+MDYgdGhhd3RlLCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNlIG9ubHkxHzAdBgNV
+BAMTFnRoYXd0ZSBQcmltYXJ5IFJvb3QgQ0EwHhcNMDYxMTE3MDAwMDAwWhcNMzYw
+NzE2MjM1OTU5WjCBqTELMAkGA1UEBhMCVVMxFTATBgNVBAoTDHRoYXd0ZSwgSW5j
+LjEoMCYGA1UECxMfQ2VydGlmaWNhdGlvbiBTZXJ2aWNlcyBEaXZpc2lvbjE4MDYG
+A1UECxMvKGMpIDIwMDYgdGhhd3RlLCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNl
+IG9ubHkxHzAdBgNVBAMTFnRoYXd0ZSBQcmltYXJ5IFJvb3QgQ0EwggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQCsoPD7gFnUnMekz52hWXMJEEUMDSxuaPFs
+W0hoSVk3/AszGcJ3f8wQLZU0HObrTQmnHNK4yZc2AreJ1CRfBsDMRJSUjQJib+ta
+3RGNKJpchJAQeg29dGYvajig4tVUROsdB58Hum/u6f1OCyn1PoSgAfGcq/gcfomk
+6KHYcWUNo1F77rzSImANuVud37r8UVsLr5iy6S7pBOhih94ryNdOwUxkHt3Ph1i6
+Sk/KaAcdHJ1KxtUvkcx8cXIcxcBn6zL9yZJclNqFwJu/U30rCfSMnZEfl2pSy94J
+NqR32HuHUETVPm4pafs5SSYeCaWAe0At6+gnhcn+Yf1+5nyXHdWdAgMBAAGjQjBA
+MA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBR7W0XP
+r87Lev0xkhpqtvNG61dIUDANBgkqhkiG9w0BAQUFAAOCAQEAeRHAS7ORtvzw6WfU
+DW5FvlXok9LOAz/t2iWwHVfLHjp2oEzsUHboZHIMpKnxuIvW1oeEuzLlQRHAd9mz
+YJ3rG9XRbkREqaYB7FViHXe4XI5ISXycO1cRrK1zN44veFyQaEfZYGDm/Ac9IiAX
+xPcW6cTYcvnIc3zfFi8VqT79aie2oetaupgf1eNNZAqdE8hhuvU5HIe6uL17In/2
+/qxAeeWsEG89jxt5dovEN7MhGITlNgDrYyCZuen+MwS7QcjBAvlEYyCegc5C09Y/
+LHbTY5xZ3Y+m4Q6gLkH3LpVHz7z9M/P2C2F+fpErgUfCJzDupxBdN49cOSvkBPB7
+jVaMaA==
+-----END CERTIFICATE-----
+
+# Issuer: CN=VeriSign Class 3 Public Primary Certification Authority - G5 O=VeriSign, Inc. OU=VeriSign Trust Network/(c) 2006 VeriSign, Inc. - For authorized use only
+# Subject: CN=VeriSign Class 3 Public Primary Certification Authority - G5 O=VeriSign, Inc. OU=VeriSign Trust Network/(c) 2006 VeriSign, Inc. - For authorized use only
+# Label: "VeriSign Class 3 Public Primary Certification Authority - G5"
+# Serial: 33037644167568058970164719475676101450
+# MD5 Fingerprint: cb:17:e4:31:67:3e:e2:09:fe:45:57:93:f3:0a:fa:1c
+# SHA1 Fingerprint: 4e:b6:d5:78:49:9b:1c:cf:5f:58:1e:ad:56:be:3d:9b:67:44:a5:e5
+# SHA256 Fingerprint: 9a:cf:ab:7e:43:c8:d8:80:d0:6b:26:2a:94:de:ee:e4:b4:65:99:89:c3:d0:ca:f1:9b:af:64:05:e4:1a:b7:df
+-----BEGIN CERTIFICATE-----
+MIIE0zCCA7ugAwIBAgIQGNrRniZ96LtKIVjNzGs7SjANBgkqhkiG9w0BAQUFADCB
+yjELMAkGA1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMR8wHQYDVQQL
+ExZWZXJpU2lnbiBUcnVzdCBOZXR3b3JrMTowOAYDVQQLEzEoYykgMjAwNiBWZXJp
+U2lnbiwgSW5jLiAtIEZvciBhdXRob3JpemVkIHVzZSBvbmx5MUUwQwYDVQQDEzxW
+ZXJpU2lnbiBDbGFzcyAzIFB1YmxpYyBQcmltYXJ5IENlcnRpZmljYXRpb24gQXV0
+aG9yaXR5IC0gRzUwHhcNMDYxMTA4MDAwMDAwWhcNMzYwNzE2MjM1OTU5WjCByjEL
+MAkGA1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMR8wHQYDVQQLExZW
+ZXJpU2lnbiBUcnVzdCBOZXR3b3JrMTowOAYDVQQLEzEoYykgMjAwNiBWZXJpU2ln
+biwgSW5jLiAtIEZvciBhdXRob3JpemVkIHVzZSBvbmx5MUUwQwYDVQQDEzxWZXJp
+U2lnbiBDbGFzcyAzIFB1YmxpYyBQcmltYXJ5IENlcnRpZmljYXRpb24gQXV0aG9y
+aXR5IC0gRzUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCvJAgIKXo1
+nmAMqudLO07cfLw8RRy7K+D+KQL5VwijZIUVJ/XxrcgxiV0i6CqqpkKzj/i5Vbex
+t0uz/o9+B1fs70PbZmIVYc9gDaTY3vjgw2IIPVQT60nKWVSFJuUrjxuf6/WhkcIz
+SdhDY2pSS9KP6HBRTdGJaXvHcPaz3BJ023tdS1bTlr8Vd6Gw9KIl8q8ckmcY5fQG
+BO+QueQA5N06tRn/Arr0PO7gi+s3i+z016zy9vA9r911kTMZHRxAy3QkGSGT2RT+
+rCpSx4/VBEnkjWNHiDxpg8v+R70rfk/Fla4OndTRQ8Bnc+MUCH7lP59zuDMKz10/
+NIeWiu5T6CUVAgMBAAGjgbIwga8wDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8E
+BAMCAQYwbQYIKwYBBQUHAQwEYTBfoV2gWzBZMFcwVRYJaW1hZ2UvZ2lmMCEwHzAH
+BgUrDgMCGgQUj+XTGoasjY5rw8+AatRIGCx7GS4wJRYjaHR0cDovL2xvZ28udmVy
+aXNpZ24uY29tL3ZzbG9nby5naWYwHQYDVR0OBBYEFH/TZafC3ey78DAJ80M5+gKv
+MzEzMA0GCSqGSIb3DQEBBQUAA4IBAQCTJEowX2LP2BqYLz3q3JktvXf2pXkiOOzE
+p6B4Eq1iDkVwZMXnl2YtmAl+X6/WzChl8gGqCBpH3vn5fJJaCGkgDdk+bW48DW7Y
+5gaRQBi5+MHt39tBquCWIMnNZBU4gcmU7qKEKQsTb47bDN0lAtukixlE0kF6BWlK
+WE9gyn6CagsCqiUXObXbf+eEZSqVir2G3l6BFoMtEMze/aiCKm0oHw0LxOXnGiYZ
+4fQRbxC1lfznQgUy286dUV4otp6F01vvpX1FQHKOtw5rDgb7MzVIcbidJ4vEZV8N
+hnacRHr2lVz2XTIIM6RUthg/aFzyQkqFOFSDX9HoLPKsEdao7WNq
+-----END CERTIFICATE-----
+
+# Issuer: CN=COMODO Certification Authority O=COMODO CA Limited
+# Subject: CN=COMODO Certification Authority O=COMODO CA Limited
+# Label: "COMODO Certification Authority"
+# Serial: 104350513648249232941998508985834464573
+# MD5 Fingerprint: 5c:48:dc:f7:42:72:ec:56:94:6d:1c:cc:71:35:80:75
+# SHA1 Fingerprint: 66:31:bf:9e:f7:4f:9e:b6:c9:d5:a6:0c:ba:6a:be:d1:f7:bd:ef:7b
+# SHA256 Fingerprint: 0c:2c:d6:3d:f7:80:6f:a3:99:ed:e8:09:11:6b:57:5b:f8:79:89:f0:65:18:f9:80:8c:86:05:03:17:8b:af:66
+-----BEGIN CERTIFICATE-----
+MIIEHTCCAwWgAwIBAgIQToEtioJl4AsC7j41AkblPTANBgkqhkiG9w0BAQUFADCB
+gTELMAkGA1UEBhMCR0IxGzAZBgNVBAgTEkdyZWF0ZXIgTWFuY2hlc3RlcjEQMA4G
+A1UEBxMHU2FsZm9yZDEaMBgGA1UEChMRQ09NT0RPIENBIExpbWl0ZWQxJzAlBgNV
+BAMTHkNPTU9ETyBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTAeFw0wNjEyMDEwMDAw
+MDBaFw0yOTEyMzEyMzU5NTlaMIGBMQswCQYDVQQGEwJHQjEbMBkGA1UECBMSR3Jl
+YXRlciBNYW5jaGVzdGVyMRAwDgYDVQQHEwdTYWxmb3JkMRowGAYDVQQKExFDT01P
+RE8gQ0EgTGltaXRlZDEnMCUGA1UEAxMeQ09NT0RPIENlcnRpZmljYXRpb24gQXV0
+aG9yaXR5MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0ECLi3LjkRv3
+UcEbVASY06m/weaKXTuH+7uIzg3jLz8GlvCiKVCZrts7oVewdFFxze1CkU1B/qnI
+2GqGd0S7WWaXUF601CxwRM/aN5VCaTwwxHGzUvAhTaHYujl8HJ6jJJ3ygxaYqhZ8
+Q5sVW7euNJH+1GImGEaaP+vB+fGQV+useg2L23IwambV4EajcNxo2f8ESIl33rXp
++2dtQem8Ob0y2WIC8bGoPW43nOIv4tOiJovGuFVDiOEjPqXSJDlqR6sA1KGzqSX+
+DT+nHbrTUcELpNqsOO9VUCQFZUaTNE8tja3G1CEZ0o7KBWFxB3NH5YoZEr0ETc5O
+nKVIrLsm9wIDAQABo4GOMIGLMB0GA1UdDgQWBBQLWOWLxkwVN6RAqTCpIb5HNlpW
+/zAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zBJBgNVHR8EQjBAMD6g
+PKA6hjhodHRwOi8vY3JsLmNvbW9kb2NhLmNvbS9DT01PRE9DZXJ0aWZpY2F0aW9u
+QXV0aG9yaXR5LmNybDANBgkqhkiG9w0BAQUFAAOCAQEAPpiem/Yb6dc5t3iuHXIY
+SdOH5EOC6z/JqvWote9VfCFSZfnVDeFs9D6Mk3ORLgLETgdxb8CPOGEIqB6BCsAv
+IC9Bi5HcSEW88cbeunZrM8gALTFGTO3nnc+IlP8zwFboJIYmuNg4ON8qa90SzMc/
+RxdMosIGlgnW2/4/PEZB31jiVg88O8EckzXZOFKs7sjsLjBOlDW0JB9LeGna8gI4
+zJVSk/BwJVmcIGfE7vmLV2H0knZ9P4SNVbfo5azV8fUZVqZa+5Acr5Pr5RzUZ5dd
+BA6+C4OmF4O5MBKgxTMVBbkN+8cFduPYSo38NBejxiEovjBFMR7HeL5YYTisO+IB
+ZQ==
+-----END CERTIFICATE-----
+
+# Issuer: CN=Network Solutions Certificate Authority O=Network Solutions L.L.C.
+# Subject: CN=Network Solutions Certificate Authority O=Network Solutions L.L.C.
+# Label: "Network Solutions Certificate Authority"
+# Serial: 116697915152937497490437556386812487904
+# MD5 Fingerprint: d3:f3:a6:16:c0:fa:6b:1d:59:b1:2d:96:4d:0e:11:2e
+# SHA1 Fingerprint: 74:f8:a3:c3:ef:e7:b3:90:06:4b:83:90:3c:21:64:60:20:e5:df:ce
+# SHA256 Fingerprint: 15:f0:ba:00:a3:ac:7a:f3:ac:88:4c:07:2b:10:11:a0:77:bd:77:c0:97:f4:01:64:b2:f8:59:8a:bd:83:86:0c
+-----BEGIN CERTIFICATE-----
+MIID5jCCAs6gAwIBAgIQV8szb8JcFuZHFhfjkDFo4DANBgkqhkiG9w0BAQUFADBi
+MQswCQYDVQQGEwJVUzEhMB8GA1UEChMYTmV0d29yayBTb2x1dGlvbnMgTC5MLkMu
+MTAwLgYDVQQDEydOZXR3b3JrIFNvbHV0aW9ucyBDZXJ0aWZpY2F0ZSBBdXRob3Jp
+dHkwHhcNMDYxMjAxMDAwMDAwWhcNMjkxMjMxMjM1OTU5WjBiMQswCQYDVQQGEwJV
+UzEhMB8GA1UEChMYTmV0d29yayBTb2x1dGlvbnMgTC5MLkMuMTAwLgYDVQQDEydO
+ZXR3b3JrIFNvbHV0aW9ucyBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkwggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDkvH6SMG3G2I4rC7xGzuAnlt7e+foS0zwz
+c7MEL7xxjOWftiJgPl9dzgn/ggwbmlFQGiaJ3dVhXRncEg8tCqJDXRfQNJIg6nPP
+OCwGJgl6cvf6UDL4wpPTaaIjzkGxzOTVHzbRijr4jGPiFFlp7Q3Tf2vouAPlT2rl
+mGNpSAW+Lv8ztumXWWn4Zxmuk2GWRBXTcrA/vGp97Eh/jcOrqnErU2lBUzS1sLnF
+BgrEsEX1QV1uiUV7PTsmjHTC5dLRfbIR1PtYMiKagMnc/Qzpf14Dl847ABSHJ3A4
+qY5usyd2mFHgBeMhqxrVhSI8KbWaFsWAqPS7azCPL0YCorEMIuDTAgMBAAGjgZcw
+gZQwHQYDVR0OBBYEFCEwyfsA106Y2oeqKtCnLrFAMadMMA4GA1UdDwEB/wQEAwIB
+BjAPBgNVHRMBAf8EBTADAQH/MFIGA1UdHwRLMEkwR6BFoEOGQWh0dHA6Ly9jcmwu
+bmV0c29sc3NsLmNvbS9OZXR3b3JrU29sdXRpb25zQ2VydGlmaWNhdGVBdXRob3Jp
+dHkuY3JsMA0GCSqGSIb3DQEBBQUAA4IBAQC7rkvnt1frf6ott3NHhWrB5KUd5Oc8
+6fRZZXe1eltajSU24HqXLjjAV2CDmAaDn7l2em5Q4LqILPxFzBiwmZVRDuwduIj/
+h1AcgsLj4DKAv6ALR8jDMe+ZZzKATxcheQxpXN5eNK4CtSbqUN9/GGUsyfJj4akH
+/nxxH2szJGoeBfcFaMBqEssuXmHLrijTfsK0ZpEmXzwuJF/LWA/rKOyvEZbz3Htv
+wKeI8lN3s2Berq4o2jUsbzRF0ybh3uxbTydrFny9RAQYgrOJeRcQcT16ohZO9QHN
+pGxlaKFJdlxDydi8NmdspZS11My5vWo1ViHe2MPr+8ukYEywVaCge1ey
+-----END CERTIFICATE-----
+
+# Issuer: CN=COMODO ECC Certification Authority O=COMODO CA Limited
+# Subject: CN=COMODO ECC Certification Authority O=COMODO CA Limited
+# Label: "COMODO ECC Certification Authority"
+# Serial: 41578283867086692638256921589707938090
+# MD5 Fingerprint: 7c:62:ff:74:9d:31:53:5e:68:4a:d5:78:aa:1e:bf:23
+# SHA1 Fingerprint: 9f:74:4e:9f:2b:4d:ba:ec:0f:31:2c:50:b6:56:3b:8e:2d:93:c3:11
+# SHA256 Fingerprint: 17:93:92:7a:06:14:54:97:89:ad:ce:2f:8f:34:f7:f0:b6:6d:0f:3a:e3:a3:b8:4d:21:ec:15:db:ba:4f:ad:c7
+-----BEGIN CERTIFICATE-----
+MIICiTCCAg+gAwIBAgIQH0evqmIAcFBUTAGem2OZKjAKBggqhkjOPQQDAzCBhTEL
+MAkGA1UEBhMCR0IxGzAZBgNVBAgTEkdyZWF0ZXIgTWFuY2hlc3RlcjEQMA4GA1UE
+BxMHU2FsZm9yZDEaMBgGA1UEChMRQ09NT0RPIENBIExpbWl0ZWQxKzApBgNVBAMT
+IkNPTU9ETyBFQ0MgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMDgwMzA2MDAw
+MDAwWhcNMzgwMTE4MjM1OTU5WjCBhTELMAkGA1UEBhMCR0IxGzAZBgNVBAgTEkdy
+ZWF0ZXIgTWFuY2hlc3RlcjEQMA4GA1UEBxMHU2FsZm9yZDEaMBgGA1UEChMRQ09N
+T0RPIENBIExpbWl0ZWQxKzApBgNVBAMTIkNPTU9ETyBFQ0MgQ2VydGlmaWNhdGlv
+biBBdXRob3JpdHkwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAQDR3svdcmCFYX7deSR
+FtSrYpn1PlILBs5BAH+X4QokPB0BBO490o0JlwzgdeT6+3eKKvUDYEs2ixYjFq0J
+cfRK9ChQtP6IHG4/bC8vCVlbpVsLM5niwz2J+Wos77LTBumjQjBAMB0GA1UdDgQW
+BBR1cacZSBm8nZ3qQUfflMRId5nTeTAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/
+BAUwAwEB/zAKBggqhkjOPQQDAwNoADBlAjEA7wNbeqy3eApyt4jf/7VGFAkK+qDm
+fQjGGoe9GKhzvSbKYAydzpmfz1wPMOG+FDHqAjAU9JM8SaczepBGR7NjfRObTrdv
+GDeAU/7dIOA1mjbRxwG55tzd8/8dLDoWV9mSOdY=
+-----END CERTIFICATE-----
+
+# Issuer: CN=TC TrustCenter Class 2 CA II O=TC TrustCenter GmbH OU=TC TrustCenter Class 2 CA
+# Subject: CN=TC TrustCenter Class 2 CA II O=TC TrustCenter GmbH OU=TC TrustCenter Class 2 CA
+# Label: "TC TrustCenter Class 2 CA II"
+# Serial: 941389028203453866782103406992443
+# MD5 Fingerprint: ce:78:33:5c:59:78:01:6e:18:ea:b9:36:a0:b9:2e:23
+# SHA1 Fingerprint: ae:50:83:ed:7c:f4:5c:bc:8f:61:c6:21:fe:68:5d:79:42:21:15:6e
+# SHA256 Fingerprint: e6:b8:f8:76:64:85:f8:07:ae:7f:8d:ac:16:70:46:1f:07:c0:a1:3e:ef:3a:1f:f7:17:53:8d:7a:ba:d3:91:b4
+-----BEGIN CERTIFICATE-----
+MIIEqjCCA5KgAwIBAgIOLmoAAQACH9dSISwRXDswDQYJKoZIhvcNAQEFBQAwdjEL
+MAkGA1UEBhMCREUxHDAaBgNVBAoTE1RDIFRydXN0Q2VudGVyIEdtYkgxIjAgBgNV
+BAsTGVRDIFRydXN0Q2VudGVyIENsYXNzIDIgQ0ExJTAjBgNVBAMTHFRDIFRydXN0
+Q2VudGVyIENsYXNzIDIgQ0EgSUkwHhcNMDYwMTEyMTQzODQzWhcNMjUxMjMxMjI1
+OTU5WjB2MQswCQYDVQQGEwJERTEcMBoGA1UEChMTVEMgVHJ1c3RDZW50ZXIgR21i
+SDEiMCAGA1UECxMZVEMgVHJ1c3RDZW50ZXIgQ2xhc3MgMiBDQTElMCMGA1UEAxMc
+VEMgVHJ1c3RDZW50ZXIgQ2xhc3MgMiBDQSBJSTCCASIwDQYJKoZIhvcNAQEBBQAD
+ggEPADCCAQoCggEBAKuAh5uO8MN8h9foJIIRszzdQ2Lu+MNF2ujhoF/RKrLqk2jf
+tMjWQ+nEdVl//OEd+DFwIxuInie5e/060smp6RQvkL4DUsFJzfb95AhmC1eKokKg
+uNV/aVyQMrKXDcpK3EY+AlWJU+MaWss2xgdW94zPEfRMuzBwBJWl9jmM/XOBCH2J
+XjIeIqkiRUuwZi4wzJ9l/fzLganx4Duvo4bRierERXlQXa7pIXSSTYtZgo+U4+lK
+8edJsBTj9WLL1XK9H7nSn6DNqPoByNkN39r8R52zyFTfSUrxIan+GE7uSNQZu+99
+5OKdy1u2bv/jzVrndIIFuoAlOMvkaZ6vQaoahPUCAwEAAaOCATQwggEwMA8GA1Ud
+EwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBTjq1RMgKHbVkO3
+kUrL84J6E1wIqzCB7QYDVR0fBIHlMIHiMIHfoIHcoIHZhjVodHRwOi8vd3d3LnRy
+dXN0Y2VudGVyLmRlL2NybC92Mi90Y19jbGFzc18yX2NhX0lJLmNybIaBn2xkYXA6
+Ly93d3cudHJ1c3RjZW50ZXIuZGUvQ049VEMlMjBUcnVzdENlbnRlciUyMENsYXNz
+JTIwMiUyMENBJTIwSUksTz1UQyUyMFRydXN0Q2VudGVyJTIwR21iSCxPVT1yb290
+Y2VydHMsREM9dHJ1c3RjZW50ZXIsREM9ZGU/Y2VydGlmaWNhdGVSZXZvY2F0aW9u
+TGlzdD9iYXNlPzANBgkqhkiG9w0BAQUFAAOCAQEAjNfffu4bgBCzg/XbEeprS6iS
+GNn3Bzn1LL4GdXpoUxUc6krtXvwjshOg0wn/9vYua0Fxec3ibf2uWWuFHbhOIprt
+ZjluS5TmVfwLG4t3wVMTZonZKNaL80VKY7f9ewthXbhtvsPcW3nS7Yblok2+XnR8
+au0WOB9/WIFaGusyiC2y8zl3gK9etmF1KdsjTYjKUCjLhdLTEKJZbtOTVAB6okaV
+hgWcqRmY5TFyDADiZ9lA4CQze28suVyrZZ0srHbqNZn1l7kPJOzHdiEoZa5X6AeI
+dUpWoNIFOqTmjZKILPPy4cHGYdtBxceb9w4aUUXCYWvcZCcXjFq32nQozZfkvQ==
+-----END CERTIFICATE-----
+
+# Issuer: CN=TC TrustCenter Class 3 CA II O=TC TrustCenter GmbH OU=TC TrustCenter Class 3 CA
+# Subject: CN=TC TrustCenter Class 3 CA II O=TC TrustCenter GmbH OU=TC TrustCenter Class 3 CA
+# Label: "TC TrustCenter Class 3 CA II"
+# Serial: 1506523511417715638772220530020799
+# MD5 Fingerprint: 56:5f:aa:80:61:12:17:f6:67:21:e6:2b:6d:61:56:8e
+# SHA1 Fingerprint: 80:25:ef:f4:6e:70:c8:d4:72:24:65:84:fe:40:3b:8a:8d:6a:db:f5
+# SHA256 Fingerprint: 8d:a0:84:fc:f9:9c:e0:77:22:f8:9b:32:05:93:98:06:fa:5c:b8:11:e1:c8:13:f6:a1:08:c7:d3:36:b3:40:8e
+-----BEGIN CERTIFICATE-----
+MIIEqjCCA5KgAwIBAgIOSkcAAQAC5aBd1j8AUb8wDQYJKoZIhvcNAQEFBQAwdjEL
+MAkGA1UEBhMCREUxHDAaBgNVBAoTE1RDIFRydXN0Q2VudGVyIEdtYkgxIjAgBgNV
+BAsTGVRDIFRydXN0Q2VudGVyIENsYXNzIDMgQ0ExJTAjBgNVBAMTHFRDIFRydXN0
+Q2VudGVyIENsYXNzIDMgQ0EgSUkwHhcNMDYwMTEyMTQ0MTU3WhcNMjUxMjMxMjI1
+OTU5WjB2MQswCQYDVQQGEwJERTEcMBoGA1UEChMTVEMgVHJ1c3RDZW50ZXIgR21i
+SDEiMCAGA1UECxMZVEMgVHJ1c3RDZW50ZXIgQ2xhc3MgMyBDQTElMCMGA1UEAxMc
+VEMgVHJ1c3RDZW50ZXIgQ2xhc3MgMyBDQSBJSTCCASIwDQYJKoZIhvcNAQEBBQAD
+ggEPADCCAQoCggEBALTgu1G7OVyLBMVMeRwjhjEQY0NVJz/GRcekPewJDRoeIMJW
+Ht4bNwcwIi9v8Qbxq63WyKthoy9DxLCyLfzDlml7forkzMA5EpBCYMnMNWju2l+Q
+Vl/NHE1bWEnrDgFPZPosPIlY2C8u4rBo6SI7dYnWRBpl8huXJh0obazovVkdKyT2
+1oQDZogkAHhg8fir/gKya/si+zXmFtGt9i4S5Po1auUZuV3bOx4a+9P/FRQI2Alq
+ukWdFHlgfa9Aigdzs5OW03Q0jTo3Kd5c7PXuLjHCINy+8U9/I1LZW+Jk2ZyqBwi1
+Rb3R0DHBq1SfqdLDYmAD8bs5SpJKPQq5ncWg/jcCAwEAAaOCATQwggEwMA8GA1Ud
+EwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBTUovyfs8PYA9NX
+XAek0CSnwPIA1DCB7QYDVR0fBIHlMIHiMIHfoIHcoIHZhjVodHRwOi8vd3d3LnRy
+dXN0Y2VudGVyLmRlL2NybC92Mi90Y19jbGFzc18zX2NhX0lJLmNybIaBn2xkYXA6
+Ly93d3cudHJ1c3RjZW50ZXIuZGUvQ049VEMlMjBUcnVzdENlbnRlciUyMENsYXNz
+JTIwMyUyMENBJTIwSUksTz1UQyUyMFRydXN0Q2VudGVyJTIwR21iSCxPVT1yb290
+Y2VydHMsREM9dHJ1c3RjZW50ZXIsREM9ZGU/Y2VydGlmaWNhdGVSZXZvY2F0aW9u
+TGlzdD9iYXNlPzANBgkqhkiG9w0BAQUFAAOCAQEANmDkcPcGIEPZIxpC8vijsrlN
+irTzwppVMXzEO2eatN9NDoqTSheLG43KieHPOh6sHfGcMrSOWXaiQYUlN6AT0PV8
+TtXqluJucsG7Kv5sbviRmEb8yRtXW+rIGjs/sFGYPAfaLFkB2otE6OF0/ado3VS6
+g0bsyEa1+K+XwDsJHI/OcpY9M1ZwvJbL2NV9IJqDnxrcOfHFcqMRA/07QlIp2+gB
+95tejNaNhk4Z+rwcvsUhpYeeeC422wlxo3I0+GzjBgnyXlal092Y+tTmBvTwtiBj
+S+opvaqCZh77gaqnN60TGOaSw4HBM7uIHqHn4rS9MWwOUT1v+5ZWgOI2F9Hc5A==
+-----END CERTIFICATE-----
+
+# Issuer: CN=TC TrustCenter Universal CA I O=TC TrustCenter GmbH OU=TC TrustCenter Universal CA
+# Subject: CN=TC TrustCenter Universal CA I O=TC TrustCenter GmbH OU=TC TrustCenter Universal CA
+# Label: "TC TrustCenter Universal CA I"
+# Serial: 601024842042189035295619584734726
+# MD5 Fingerprint: 45:e1:a5:72:c5:a9:36:64:40:9e:f5:e4:58:84:67:8c
+# SHA1 Fingerprint: 6b:2f:34:ad:89:58:be:62:fd:b0:6b:5c:ce:bb:9d:d9:4f:4e:39:f3
+# SHA256 Fingerprint: eb:f3:c0:2a:87:89:b1:fb:7d:51:19:95:d6:63:b7:29:06:d9:13:ce:0d:5e:10:56:8a:8a:77:e2:58:61:67:e7
+-----BEGIN CERTIFICATE-----
+MIID3TCCAsWgAwIBAgIOHaIAAQAC7LdggHiNtgYwDQYJKoZIhvcNAQEFBQAweTEL
+MAkGA1UEBhMCREUxHDAaBgNVBAoTE1RDIFRydXN0Q2VudGVyIEdtYkgxJDAiBgNV
+BAsTG1RDIFRydXN0Q2VudGVyIFVuaXZlcnNhbCBDQTEmMCQGA1UEAxMdVEMgVHJ1
+c3RDZW50ZXIgVW5pdmVyc2FsIENBIEkwHhcNMDYwMzIyMTU1NDI4WhcNMjUxMjMx
+MjI1OTU5WjB5MQswCQYDVQQGEwJERTEcMBoGA1UEChMTVEMgVHJ1c3RDZW50ZXIg
+R21iSDEkMCIGA1UECxMbVEMgVHJ1c3RDZW50ZXIgVW5pdmVyc2FsIENBMSYwJAYD
+VQQDEx1UQyBUcnVzdENlbnRlciBVbml2ZXJzYWwgQ0EgSTCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBAKR3I5ZEr5D0MacQ9CaHnPM42Q9e3s9B6DGtxnSR
+JJZ4Hgmgm5qVSkr1YnwCqMqs+1oEdjneX/H5s7/zA1hV0qq34wQi0fiU2iIIAI3T
+fCZdzHd55yx4Oagmcw6iXSVphU9VDprvxrlE4Vc93x9UIuVvZaozhDrzznq+VZeu
+jRIPFDPiUHDDSYcTvFHe15gSWu86gzOSBnWLknwSaHtwag+1m7Z3W0hZneTvWq3z
+wZ7U10VOylY0Ibw+F1tvdwxIAUMpsN0/lm7mlaoMwCC2/T42J5zjXM9OgdwZu5GQ
+fezmlwQek8wiSdeXhrYTCjxDI3d+8NzmzSQfO4ObNDqDNOMCAwEAAaNjMGEwHwYD
+VR0jBBgwFoAUkqR1LKSevoFE63n8isWVpesQdXMwDwYDVR0TAQH/BAUwAwEB/zAO
+BgNVHQ8BAf8EBAMCAYYwHQYDVR0OBBYEFJKkdSyknr6BROt5/IrFlaXrEHVzMA0G
+CSqGSIb3DQEBBQUAA4IBAQAo0uCG1eb4e/CX3CJrO5UUVg8RMKWaTzqwOuAGy2X1
+7caXJ/4l8lfmXpWMPmRgFVp/Lw0BxbFg/UU1z/CyvwbZ71q+s2IhtNerNXxTPqYn
+8aEt2hojnczd7Dwtnic0XQ/CNnm8yUpiLe1r2X1BQ3y2qsrtYbE3ghUJGooWMNjs
+ydZHcnhLEEYUjl8Or+zHL6sQ17bxbuyGssLoDZJz3KL0Dzq/YSMQiZxIQG5wALPT
+ujdEWBF6AmqI8Dc08BnprNRlc/ZpjGSUOnmFKbAWKwyCPwacx/0QK54PLLae4xW/
+2TYcuiUaUj0a7CIMHOCkoj3w6DnPgcB77V0fb8XQC9eY
+-----END CERTIFICATE-----
+
+# Issuer: CN=Cybertrust Global Root O=Cybertrust, Inc
+# Subject: CN=Cybertrust Global Root O=Cybertrust, Inc
+# Label: "Cybertrust Global Root"
+# Serial: 4835703278459682877484360
+# MD5 Fingerprint: 72:e4:4a:87:e3:69:40:80:77:ea:bc:e3:f4:ff:f0:e1
+# SHA1 Fingerprint: 5f:43:e5:b1:bf:f8:78:8c:ac:1c:c7:ca:4a:9a:c6:22:2b:cc:34:c6
+# SHA256 Fingerprint: 96:0a:df:00:63:e9:63:56:75:0c:29:65:dd:0a:08:67:da:0b:9c:bd:6e:77:71:4a:ea:fb:23:49:ab:39:3d:a3
+-----BEGIN CERTIFICATE-----
+MIIDoTCCAomgAwIBAgILBAAAAAABD4WqLUgwDQYJKoZIhvcNAQEFBQAwOzEYMBYG
+A1UEChMPQ3liZXJ0cnVzdCwgSW5jMR8wHQYDVQQDExZDeWJlcnRydXN0IEdsb2Jh
+bCBSb290MB4XDTA2MTIxNTA4MDAwMFoXDTIxMTIxNTA4MDAwMFowOzEYMBYGA1UE
+ChMPQ3liZXJ0cnVzdCwgSW5jMR8wHQYDVQQDExZDeWJlcnRydXN0IEdsb2JhbCBS
+b290MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA+Mi8vRRQZhP/8NN5
+7CPytxrHjoXxEnOmGaoQ25yiZXRadz5RfVb23CO21O1fWLE3TdVJDm71aofW0ozS
+J8bi/zafmGWgE07GKmSb1ZASzxQG9Dvj1Ci+6A74q05IlG2OlTEQXO2iLb3VOm2y
+HLtgwEZLAfVJrn5GitB0jaEMAs7u/OePuGtm839EAL9mJRQr3RAwHQeWP032a7iP
+t3sMpTjr3kfb1V05/Iin89cqdPHoWqI7n1C6poxFNcJQZZXcY4Lv3b93TZxiyWNz
+FtApD0mpSPCzqrdsxacwOUBdrsTiXSZT8M4cIwhhqJQZugRiQOwfOHB3EgZxpzAY
+XSUnpQIDAQABo4GlMIGiMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/
+MB0GA1UdDgQWBBS2CHsNesysIEyGVjJez6tuhS1wVzA/BgNVHR8EODA2MDSgMqAw
+hi5odHRwOi8vd3d3Mi5wdWJsaWMtdHJ1c3QuY29tL2NybC9jdC9jdHJvb3QuY3Js
+MB8GA1UdIwQYMBaAFLYIew16zKwgTIZWMl7Pq26FLXBXMA0GCSqGSIb3DQEBBQUA
+A4IBAQBW7wojoFROlZfJ+InaRcHUowAl9B8Tq7ejhVhpwjCt2BWKLePJzYFa+HMj
+Wqd8BfP9IjsO0QbE2zZMcwSO5bAi5MXzLqXZI+O4Tkogp24CJJ8iYGd7ix1yCcUx
+XOl5n4BHPa2hCwcUPUf/A2kaDAtE52Mlp3+yybh2hO0j9n0Hq0V+09+zv+mKts2o
+omcrUtW3ZfA5TGOgkXmTUg9U3YO7n9GPp1Nzw8v/MOx8BLjYRB+TX3EJIrduPuoc
+A06dGiBh+4E37F78CkWr1+cXVdCg6mCbpvbjjFspwgZgFJ0tl0ypkxWdYcQBX0jW
+WL1WMRJOEcgh4LMRkWXbtKaIOM5V
+-----END CERTIFICATE-----
+
+# Issuer: CN=GeoTrust Primary Certification Authority - G3 O=GeoTrust Inc. OU=(c) 2008 GeoTrust Inc. - For authorized use only
+# Subject: CN=GeoTrust Primary Certification Authority - G3 O=GeoTrust Inc. OU=(c) 2008 GeoTrust Inc. - For authorized use only
+# Label: "GeoTrust Primary Certification Authority - G3"
+# Serial: 28809105769928564313984085209975885599
+# MD5 Fingerprint: b5:e8:34:36:c9:10:44:58:48:70:6d:2e:83:d4:b8:05
+# SHA1 Fingerprint: 03:9e:ed:b8:0b:e7:a0:3c:69:53:89:3b:20:d2:d9:32:3a:4c:2a:fd
+# SHA256 Fingerprint: b4:78:b8:12:25:0d:f8:78:63:5c:2a:a7:ec:7d:15:5e:aa:62:5e:e8:29:16:e2:cd:29:43:61:88:6c:d1:fb:d4
+-----BEGIN CERTIFICATE-----
+MIID/jCCAuagAwIBAgIQFaxulBmyeUtB9iepwxgPHzANBgkqhkiG9w0BAQsFADCB
+mDELMAkGA1UEBhMCVVMxFjAUBgNVBAoTDUdlb1RydXN0IEluYy4xOTA3BgNVBAsT
+MChjKSAyMDA4IEdlb1RydXN0IEluYy4gLSBGb3IgYXV0aG9yaXplZCB1c2Ugb25s
+eTE2MDQGA1UEAxMtR2VvVHJ1c3QgUHJpbWFyeSBDZXJ0aWZpY2F0aW9uIEF1dGhv
+cml0eSAtIEczMB4XDTA4MDQwMjAwMDAwMFoXDTM3MTIwMTIzNTk1OVowgZgxCzAJ
+BgNVBAYTAlVTMRYwFAYDVQQKEw1HZW9UcnVzdCBJbmMuMTkwNwYDVQQLEzAoYykg
+MjAwOCBHZW9UcnVzdCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNlIG9ubHkxNjA0
+BgNVBAMTLUdlb1RydXN0IFByaW1hcnkgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkg
+LSBHMzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANziXmJYHTNXOTIz
++uvLh4yn1ErdBojqZI4xmKU4kB6Yzy5jK/BGvESyiaHAKAxJcCGVn2TAppMSAmUm
+hsalifD614SgcK9PGpc/BkTVyetyEH3kMSj7HGHmKAdEc5IiaacDiGydY8hS2pgn
+5whMcD60yRLBxWeDXTPzAxHsatBT4tG6NmCUgLthY2xbF37fQJQeqw3CIShwiP/W
+JmxsYAQlTlV+fe+/lEjetx3dcI0FX4ilm/LC7urRQEFtYjgdVgbFA0dRIBn8exAL
+DmKudlW/X3e+PkkBUz2YJQN2JFodtNuJ6nnltrM7P7pMKEF/BqxqjsHQ9gUdfeZC
+huOl1UcCAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYw
+HQYDVR0OBBYEFMR5yo6hTgMdHNxr2zFblD4/MH8tMA0GCSqGSIb3DQEBCwUAA4IB
+AQAtxRPPVoB7eni9n64smefv2t+UXglpp+duaIy9cr5HqQ6XErhK8WTTOd8lNNTB
+zU6B8A8ExCSzNJbGpqow32hhc9f5joWJ7w5elShKKiePEI4ufIbEAp7aDHdlDkQN
+kv39sxY2+hENHYwOB4lqKVb3cvTdFZx3NWZXqxNT2I7BQMXXExZacse3aQHEerGD
+AWh9jUGhlBjBJVz88P6DAod8DQ3PLghcSkANPuyBYeYk28rgDi0Hsj5W3I31QYUH
+SJsMC8tJP33st/3LjWeJGqvtux6jAAgIFyqCXDFdRootD4abdNlF+9RAsXqqaC2G
+spki4cErx5z481+oghLrGREt
+-----END CERTIFICATE-----
+
+# Issuer: CN=thawte Primary Root CA - G2 O=thawte, Inc. OU=(c) 2007 thawte, Inc. - For authorized use only
+# Subject: CN=thawte Primary Root CA - G2 O=thawte, Inc. OU=(c) 2007 thawte, Inc. - For authorized use only
+# Label: "thawte Primary Root CA - G2"
+# Serial: 71758320672825410020661621085256472406
+# MD5 Fingerprint: 74:9d:ea:60:24:c4:fd:22:53:3e:cc:3a:72:d9:29:4f
+# SHA1 Fingerprint: aa:db:bc:22:23:8f:c4:01:a1:27:bb:38:dd:f4:1d:db:08:9e:f0:12
+# SHA256 Fingerprint: a4:31:0d:50:af:18:a6:44:71:90:37:2a:86:af:af:8b:95:1f:fb:43:1d:83:7f:1e:56:88:b4:59:71:ed:15:57
+-----BEGIN CERTIFICATE-----
+MIICiDCCAg2gAwIBAgIQNfwmXNmET8k9Jj1Xm67XVjAKBggqhkjOPQQDAzCBhDEL
+MAkGA1UEBhMCVVMxFTATBgNVBAoTDHRoYXd0ZSwgSW5jLjE4MDYGA1UECxMvKGMp
+IDIwMDcgdGhhd3RlLCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNlIG9ubHkxJDAi
+BgNVBAMTG3RoYXd0ZSBQcmltYXJ5IFJvb3QgQ0EgLSBHMjAeFw0wNzExMDUwMDAw
+MDBaFw0zODAxMTgyMzU5NTlaMIGEMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMdGhh
+d3RlLCBJbmMuMTgwNgYDVQQLEy8oYykgMjAwNyB0aGF3dGUsIEluYy4gLSBGb3Ig
+YXV0aG9yaXplZCB1c2Ugb25seTEkMCIGA1UEAxMbdGhhd3RlIFByaW1hcnkgUm9v
+dCBDQSAtIEcyMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEotWcgnuVnfFSeIf+iha/
+BebfowJPDQfGAFG6DAJSLSKkQjnE/o/qycG+1E3/n3qe4rF8mq2nhglzh9HnmuN6
+papu+7qzcMBniKI11KOasf2twu8x+qi58/sIxpHR+ymVo0IwQDAPBgNVHRMBAf8E
+BTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUmtgAMADna3+FGO6Lts6K
+DPgR4bswCgYIKoZIzj0EAwMDaQAwZgIxAN344FdHW6fmCsO99YCKlzUNG4k8VIZ3
+KMqh9HneteY4sPBlcIx/AlTCv//YoT7ZzwIxAMSNlPzcU9LcnXgWHxUzI1NS41ox
+XZ3Krr0TKUQNJ1uo52icEvdYPy5yAlejj6EULg==
+-----END CERTIFICATE-----
+
+# Issuer: CN=thawte Primary Root CA - G3 O=thawte, Inc. OU=Certification Services Division/(c) 2008 thawte, Inc. - For authorized use only
+# Subject: CN=thawte Primary Root CA - G3 O=thawte, Inc. OU=Certification Services Division/(c) 2008 thawte, Inc. - For authorized use only
+# Label: "thawte Primary Root CA - G3"
+# Serial: 127614157056681299805556476275995414779
+# MD5 Fingerprint: fb:1b:5d:43:8a:94:cd:44:c6:76:f2:43:4b:47:e7:31
+# SHA1 Fingerprint: f1:8b:53:8d:1b:e9:03:b6:a6:f0:56:43:5b:17:15:89:ca:f3:6b:f2
+# SHA256 Fingerprint: 4b:03:f4:58:07:ad:70:f2:1b:fc:2c:ae:71:c9:fd:e4:60:4c:06:4c:f5:ff:b6:86:ba:e5:db:aa:d7:fd:d3:4c
+-----BEGIN CERTIFICATE-----
+MIIEKjCCAxKgAwIBAgIQYAGXt0an6rS0mtZLL/eQ+zANBgkqhkiG9w0BAQsFADCB
+rjELMAkGA1UEBhMCVVMxFTATBgNVBAoTDHRoYXd0ZSwgSW5jLjEoMCYGA1UECxMf
+Q2VydGlmaWNhdGlvbiBTZXJ2aWNlcyBEaXZpc2lvbjE4MDYGA1UECxMvKGMpIDIw
+MDggdGhhd3RlLCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNlIG9ubHkxJDAiBgNV
+BAMTG3RoYXd0ZSBQcmltYXJ5IFJvb3QgQ0EgLSBHMzAeFw0wODA0MDIwMDAwMDBa
+Fw0zNzEyMDEyMzU5NTlaMIGuMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMdGhhd3Rl
+LCBJbmMuMSgwJgYDVQQLEx9DZXJ0aWZpY2F0aW9uIFNlcnZpY2VzIERpdmlzaW9u
+MTgwNgYDVQQLEy8oYykgMjAwOCB0aGF3dGUsIEluYy4gLSBGb3IgYXV0aG9yaXpl
+ZCB1c2Ugb25seTEkMCIGA1UEAxMbdGhhd3RlIFByaW1hcnkgUm9vdCBDQSAtIEcz
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsr8nLPvb2FvdeHsbnndm
+gcs+vHyu86YnmjSjaDFxODNi5PNxZnmxqWWjpYvVj2AtP0LMqmsywCPLLEHd5N/8
+YZzic7IilRFDGF/Eth9XbAoFWCLINkw6fKXRz4aviKdEAhN0cXMKQlkC+BsUa0Lf
+b1+6a4KinVvnSr0eAXLbS3ToO39/fR8EtCab4LRarEc9VbjXsCZSKAExQGbY2SS9
+9irY7CFJXJv2eul/VTV+lmuNk5Mny5K76qxAwJ/C+IDPXfRa3M50hqY+bAtTyr2S
+zhkGcuYMXDhpxwTWvGzOW/b3aJzcJRVIiKHpqfiYnODz1TEoYRFsZ5aNOZnLwkUk
+OQIDAQABo0IwQDAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNV
+HQ4EFgQUrWyqlGCc7eT/+j4KdCtjA/e2Wb8wDQYJKoZIhvcNAQELBQADggEBABpA
+2JVlrAmSicY59BDlqQ5mU1143vokkbvnRFHfxhY0Cu9qRFHqKweKA3rD6z8KLFIW
+oCtDuSWQP3CpMyVtRRooOyfPqsMpQhvfO0zAMzRbQYi/aytlryjvsvXDqmbOe1bu
+t8jLZ8HJnBoYuMTDSQPxYA5QzUbF83d597YV4Djbxy8ooAw/dyZ02SUS2jHaGh7c
+KUGRIjxpp7sC8rZcJwOJ9Abqm+RyguOhCcHpABnTPtRwa7pxpqpYrvS76Wy274fM
+m7v/OeZWYdMKp8RcTGB7BXcmer/YB1IsYvdwY9k5vG8cwnncdimvzsUsZAReiDZu
+MdRAGmI0Nj81Aa6sY6A=
+-----END CERTIFICATE-----
+
+# Issuer: CN=GeoTrust Primary Certification Authority - G2 O=GeoTrust Inc. OU=(c) 2007 GeoTrust Inc. - For authorized use only
+# Subject: CN=GeoTrust Primary Certification Authority - G2 O=GeoTrust Inc. OU=(c) 2007 GeoTrust Inc. - For authorized use only
+# Label: "GeoTrust Primary Certification Authority - G2"
+# Serial: 80682863203381065782177908751794619243
+# MD5 Fingerprint: 01:5e:d8:6b:bd:6f:3d:8e:a1:31:f8:12:e0:98:73:6a
+# SHA1 Fingerprint: 8d:17:84:d5:37:f3:03:7d:ec:70:fe:57:8b:51:9a:99:e6:10:d7:b0
+# SHA256 Fingerprint: 5e:db:7a:c4:3b:82:a0:6a:87:61:e8:d7:be:49:79:eb:f2:61:1f:7d:d7:9b:f9:1c:1c:6b:56:6a:21:9e:d7:66
+-----BEGIN CERTIFICATE-----
+MIICrjCCAjWgAwIBAgIQPLL0SAoA4v7rJDteYD7DazAKBggqhkjOPQQDAzCBmDEL
+MAkGA1UEBhMCVVMxFjAUBgNVBAoTDUdlb1RydXN0IEluYy4xOTA3BgNVBAsTMChj
+KSAyMDA3IEdlb1RydXN0IEluYy4gLSBGb3IgYXV0aG9yaXplZCB1c2Ugb25seTE2
+MDQGA1UEAxMtR2VvVHJ1c3QgUHJpbWFyeSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0
+eSAtIEcyMB4XDTA3MTEwNTAwMDAwMFoXDTM4MDExODIzNTk1OVowgZgxCzAJBgNV
+BAYTAlVTMRYwFAYDVQQKEw1HZW9UcnVzdCBJbmMuMTkwNwYDVQQLEzAoYykgMjAw
+NyBHZW9UcnVzdCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNlIG9ubHkxNjA0BgNV
+BAMTLUdlb1RydXN0IFByaW1hcnkgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkgLSBH
+MjB2MBAGByqGSM49AgEGBSuBBAAiA2IABBWx6P0DFUPlrOuHNxFi79KDNlJ9RVcL
+So17VDs6bl8VAsBQps8lL33KSLjHUGMcKiEIfJo22Av+0SbFWDEwKCXzXV2juLal
+tJLtbCyf691DiaI8S0iRHVDsJt/WYC69IaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAO
+BgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFBVfNVdRVfslsq0DafwBo/q+EVXVMAoG
+CCqGSM49BAMDA2cAMGQCMGSWWaboCd6LuvpaiIjwH5HTRqjySkwCY/tsXzjbLkGT
+qQ7mndwxHLKgpxgceeHHNgIwOlavmnRs9vuD4DPTCF+hnMJbn0bWtsuRBmOiBucz
+rD6ogRLQy7rQkgu2npaqBA+K
+-----END CERTIFICATE-----
+
+# Issuer: CN=VeriSign Universal Root Certification Authority O=VeriSign, Inc. OU=VeriSign Trust Network/(c) 2008 VeriSign, Inc. - For authorized use only
+# Subject: CN=VeriSign Universal Root Certification Authority O=VeriSign, Inc. OU=VeriSign Trust Network/(c) 2008 VeriSign, Inc. - For authorized use only
+# Label: "VeriSign Universal Root Certification Authority"
+# Serial: 85209574734084581917763752644031726877
+# MD5 Fingerprint: 8e:ad:b5:01:aa:4d:81:e4:8c:1d:d1:e1:14:00:95:19
+# SHA1 Fingerprint: 36:79:ca:35:66:87:72:30:4d:30:a5:fb:87:3b:0f:a7:7b:b7:0d:54
+# SHA256 Fingerprint: 23:99:56:11:27:a5:71:25:de:8c:ef:ea:61:0d:df:2f:a0:78:b5:c8:06:7f:4e:82:82:90:bf:b8:60:e8:4b:3c
+-----BEGIN CERTIFICATE-----
+MIIEuTCCA6GgAwIBAgIQQBrEZCGzEyEDDrvkEhrFHTANBgkqhkiG9w0BAQsFADCB
+vTELMAkGA1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMR8wHQYDVQQL
+ExZWZXJpU2lnbiBUcnVzdCBOZXR3b3JrMTowOAYDVQQLEzEoYykgMjAwOCBWZXJp
+U2lnbiwgSW5jLiAtIEZvciBhdXRob3JpemVkIHVzZSBvbmx5MTgwNgYDVQQDEy9W
+ZXJpU2lnbiBVbml2ZXJzYWwgUm9vdCBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTAe
+Fw0wODA0MDIwMDAwMDBaFw0zNzEyMDEyMzU5NTlaMIG9MQswCQYDVQQGEwJVUzEX
+MBUGA1UEChMOVmVyaVNpZ24sIEluYy4xHzAdBgNVBAsTFlZlcmlTaWduIFRydXN0
+IE5ldHdvcmsxOjA4BgNVBAsTMShjKSAyMDA4IFZlcmlTaWduLCBJbmMuIC0gRm9y
+IGF1dGhvcml6ZWQgdXNlIG9ubHkxODA2BgNVBAMTL1ZlcmlTaWduIFVuaXZlcnNh
+bCBSb290IENlcnRpZmljYXRpb24gQXV0aG9yaXR5MIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAx2E3XrEBNNti1xWb/1hajCMj1mCOkdeQmIN65lgZOIzF
+9uVkhbSicfvtvbnazU0AtMgtc6XHaXGVHzk8skQHnOgO+k1KxCHfKWGPMiJhgsWH
+H26MfF8WIFFE0XBPV+rjHOPMee5Y2A7Cs0WTwCznmhcrewA3ekEzeOEz4vMQGn+H
+LL729fdC4uW/h2KJXwBL38Xd5HVEMkE6HnFuacsLdUYI0crSK5XQz/u5QGtkjFdN
+/BMReYTtXlT2NJ8IAfMQJQYXStrxHXpma5hgZqTZ79IugvHw7wnqRMkVauIDbjPT
+rJ9VAMf2CGqUuV/c4DPxhGD5WycRtPwW8rtWaoAljQIDAQABo4GyMIGvMA8GA1Ud
+EwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMG0GCCsGAQUFBwEMBGEwX6FdoFsw
+WTBXMFUWCWltYWdlL2dpZjAhMB8wBwYFKw4DAhoEFI/l0xqGrI2Oa8PPgGrUSBgs
+exkuMCUWI2h0dHA6Ly9sb2dvLnZlcmlzaWduLmNvbS92c2xvZ28uZ2lmMB0GA1Ud
+DgQWBBS2d/ppSEefUxLVwuoHMnYH0ZcHGTANBgkqhkiG9w0BAQsFAAOCAQEASvj4
+sAPmLGd75JR3Y8xuTPl9Dg3cyLk1uXBPY/ok+myDjEedO2Pzmvl2MpWRsXe8rJq+
+seQxIcaBlVZaDrHC1LGmWazxY8u4TB1ZkErvkBYoH1quEPuBUDgMbMzxPcP1Y+Oz
+4yHJJDnp/RVmRvQbEdBNc6N9Rvk97ahfYtTxP/jgdFcrGJ2BtMQo2pSXpXDrrB2+
+BxHw1dvd5Yzw1TKwg+ZX4o+/vqGqvz0dtdQ46tewXDpPaj+PwGZsY6rp2aQW9IHR
+lRQOfc2VNNnSj3BzgXucfr2YYdhFh5iQxeuGMMY1v/D/w1WIg0vvBZIGcfK4mJO3
+7M2CYfE45k+XmCpajQ==
+-----END CERTIFICATE-----
+
+# Issuer: CN=VeriSign Class 3 Public Primary Certification Authority - G4 O=VeriSign, Inc. OU=VeriSign Trust Network/(c) 2007 VeriSign, Inc. - For authorized use only
+# Subject: CN=VeriSign Class 3 Public Primary Certification Authority - G4 O=VeriSign, Inc. OU=VeriSign Trust Network/(c) 2007 VeriSign, Inc. - For authorized use only
+# Label: "VeriSign Class 3 Public Primary Certification Authority - G4"
+# Serial: 63143484348153506665311985501458640051
+# MD5 Fingerprint: 3a:52:e1:e7:fd:6f:3a:e3:6f:f3:6f:99:1b:f9:22:41
+# SHA1 Fingerprint: 22:d5:d8:df:8f:02:31:d1:8d:f7:9d:b7:cf:8a:2d:64:c9:3f:6c:3a
+# SHA256 Fingerprint: 69:dd:d7:ea:90:bb:57:c9:3e:13:5d:c8:5e:a6:fc:d5:48:0b:60:32:39:bd:c4:54:fc:75:8b:2a:26:cf:7f:79
+-----BEGIN CERTIFICATE-----
+MIIDhDCCAwqgAwIBAgIQL4D+I4wOIg9IZxIokYesszAKBggqhkjOPQQDAzCByjEL
+MAkGA1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMR8wHQYDVQQLExZW
+ZXJpU2lnbiBUcnVzdCBOZXR3b3JrMTowOAYDVQQLEzEoYykgMjAwNyBWZXJpU2ln
+biwgSW5jLiAtIEZvciBhdXRob3JpemVkIHVzZSBvbmx5MUUwQwYDVQQDEzxWZXJp
+U2lnbiBDbGFzcyAzIFB1YmxpYyBQcmltYXJ5IENlcnRpZmljYXRpb24gQXV0aG9y
+aXR5IC0gRzQwHhcNMDcxMTA1MDAwMDAwWhcNMzgwMTE4MjM1OTU5WjCByjELMAkG
+A1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMR8wHQYDVQQLExZWZXJp
+U2lnbiBUcnVzdCBOZXR3b3JrMTowOAYDVQQLEzEoYykgMjAwNyBWZXJpU2lnbiwg
+SW5jLiAtIEZvciBhdXRob3JpemVkIHVzZSBvbmx5MUUwQwYDVQQDEzxWZXJpU2ln
+biBDbGFzcyAzIFB1YmxpYyBQcmltYXJ5IENlcnRpZmljYXRpb24gQXV0aG9yaXR5
+IC0gRzQwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAASnVnp8Utpkmw4tXNherJI9/gHm
+GUo9FANL+mAnINmDiWn6VMaaGF5VKmTeBvaNSjutEDxlPZCIBIngMGGzrl0Bp3ve
+fLK+ymVhAIau2o970ImtTR1ZmkGxvEeA3J5iw/mjgbIwga8wDwYDVR0TAQH/BAUw
+AwEB/zAOBgNVHQ8BAf8EBAMCAQYwbQYIKwYBBQUHAQwEYTBfoV2gWzBZMFcwVRYJ
+aW1hZ2UvZ2lmMCEwHzAHBgUrDgMCGgQUj+XTGoasjY5rw8+AatRIGCx7GS4wJRYj
+aHR0cDovL2xvZ28udmVyaXNpZ24uY29tL3ZzbG9nby5naWYwHQYDVR0OBBYEFLMW
+kf3upm7ktS5Jj4d4gYDs5bG1MAoGCCqGSM49BAMDA2gAMGUCMGYhDBgmYFo4e1ZC
+4Kf8NoRRkSAsdk1DPcQdhCPQrNZ8NQbOzWm9kA3bbEhCHQ6qQgIxAJw9SDkjOVga
+FRJZap7v1VmyHVIsmXHNxynfGyphe3HR3vPA5Q06Sqotp9iGKt0uEA==
+-----END CERTIFICATE-----
+
+# Issuer: O=VeriSign, Inc. OU=Class 3 Public Primary Certification Authority
+# Subject: O=VeriSign, Inc. OU=Class 3 Public Primary Certification Authority
+# Label: "Verisign Class 3 Public Primary Certification Authority"
+# Serial: 80507572722862485515306429940691309246
+# MD5 Fingerprint: ef:5a:f1:33:ef:f1:cd:bb:51:02:ee:12:14:4b:96:c4
+# SHA1 Fingerprint: a1:db:63:93:91:6f:17:e4:18:55:09:40:04:15:c7:02:40:b0:ae:6b
+# SHA256 Fingerprint: a4:b6:b3:99:6f:c2:f3:06:b3:fd:86:81:bd:63:41:3d:8c:50:09:cc:4f:a3:29:c2:cc:f0:e2:fa:1b:14:03:05
+-----BEGIN CERTIFICATE-----
+MIICPDCCAaUCEDyRMcsf9tAbDpq40ES/Er4wDQYJKoZIhvcNAQEFBQAwXzELMAkG
+A1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMTcwNQYDVQQLEy5DbGFz
+cyAzIFB1YmxpYyBQcmltYXJ5IENlcnRpZmljYXRpb24gQXV0aG9yaXR5MB4XDTk2
+MDEyOTAwMDAwMFoXDTI4MDgwMjIzNTk1OVowXzELMAkGA1UEBhMCVVMxFzAVBgNV
+BAoTDlZlcmlTaWduLCBJbmMuMTcwNQYDVQQLEy5DbGFzcyAzIFB1YmxpYyBQcmlt
+YXJ5IENlcnRpZmljYXRpb24gQXV0aG9yaXR5MIGfMA0GCSqGSIb3DQEBAQUAA4GN
+ADCBiQKBgQDJXFme8huKARS0EN8EQNvjV69qRUCPhAwL0TPZ2RHP7gJYHyX3KqhE
+BarsAx94f56TuZoAqiN91qyFomNFx3InzPRMxnVx0jnvT0Lwdd8KkMaOIG+YD/is
+I19wKTakyYbnsZogy1Olhec9vn2a/iRFM9x2Fe0PonFkTGUugWhFpwIDAQABMA0G
+CSqGSIb3DQEBBQUAA4GBABByUqkFFBkyCEHwxWsKzH4PIRnN5GfcX6kb5sroc50i
+2JhucwNhkcV8sEVAbkSdjbCxlnRhLQ2pRdKkkirWmnWXbj9T/UWZYB2oK0z5XqcJ
+2HUw19JlYD1n1khVdWk/kfVIC0dpImmClr7JyDiGSnoscxlIaU5rfGW/D/xwzoiQ
+-----END CERTIFICATE-----
+
+# Issuer: CN=GlobalSign O=GlobalSign OU=GlobalSign Root CA - R3
+# Subject: CN=GlobalSign O=GlobalSign OU=GlobalSign Root CA - R3
+# Label: "GlobalSign Root CA - R3"
+# Serial: 4835703278459759426209954
+# MD5 Fingerprint: c5:df:b8:49:ca:05:13:55:ee:2d:ba:1a:c3:3e:b0:28
+# SHA1 Fingerprint: d6:9b:56:11:48:f0:1c:77:c5:45:78:c1:09:26:df:5b:85:69:76:ad
+# SHA256 Fingerprint: cb:b5:22:d7:b7:f1:27:ad:6a:01:13:86:5b:df:1c:d4:10:2e:7d:07:59:af:63:5a:7c:f4:72:0d:c9:63:c5:3b
+-----BEGIN CERTIFICATE-----
+MIIDXzCCAkegAwIBAgILBAAAAAABIVhTCKIwDQYJKoZIhvcNAQELBQAwTDEgMB4G
+A1UECxMXR2xvYmFsU2lnbiBSb290IENBIC0gUjMxEzARBgNVBAoTCkdsb2JhbFNp
+Z24xEzARBgNVBAMTCkdsb2JhbFNpZ24wHhcNMDkwMzE4MTAwMDAwWhcNMjkwMzE4
+MTAwMDAwWjBMMSAwHgYDVQQLExdHbG9iYWxTaWduIFJvb3QgQ0EgLSBSMzETMBEG
+A1UEChMKR2xvYmFsU2lnbjETMBEGA1UEAxMKR2xvYmFsU2lnbjCCASIwDQYJKoZI
+hvcNAQEBBQADggEPADCCAQoCggEBAMwldpB5BngiFvXAg7aEyiie/QV2EcWtiHL8
+RgJDx7KKnQRfJMsuS+FggkbhUqsMgUdwbN1k0ev1LKMPgj0MK66X17YUhhB5uzsT
+gHeMCOFJ0mpiLx9e+pZo34knlTifBtc+ycsmWQ1z3rDI6SYOgxXG71uL0gRgykmm
+KPZpO/bLyCiR5Z2KYVc3rHQU3HTgOu5yLy6c+9C7v/U9AOEGM+iCK65TpjoWc4zd
+QQ4gOsC0p6Hpsk+QLjJg6VfLuQSSaGjlOCZgdbKfd/+RFO+uIEn8rUAVSNECMWEZ
+XriX7613t2Saer9fwRPvm2L7DWzgVGkWqQPabumDk3F2xmmFghcCAwEAAaNCMEAw
+DgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFI/wS3+o
+LkUkrk1Q+mOai97i3Ru8MA0GCSqGSIb3DQEBCwUAA4IBAQBLQNvAUKr+yAzv95ZU
+RUm7lgAJQayzE4aGKAczymvmdLm6AC2upArT9fHxD4q/c2dKg8dEe3jgr25sbwMp
+jjM5RcOO5LlXbKr8EpbsU8Yt5CRsuZRj+9xTaGdWPoO4zzUhw8lo/s7awlOqzJCK
+6fBdRoyV3XpYKBovHd7NADdBj+1EbddTKJd+82cEHhXXipa0095MJ6RMG3NzdvQX
+mcIfeg7jLQitChws/zyrVQ4PkX4268NXSb7hLi18YIvDQVETI53O9zJrlAGomecs
+Mx86OyXShkDOOyyGeMlhLxS67ttVb9+E7gUJTb0o2HLO02JQZR7rkpeDMdmztcpH
+WD9f
+-----END CERTIFICATE-----
+
+# Issuer: CN=TC TrustCenter Universal CA III O=TC TrustCenter GmbH OU=TC TrustCenter Universal CA
+# Subject: CN=TC TrustCenter Universal CA III O=TC TrustCenter GmbH OU=TC TrustCenter Universal CA
+# Label: "TC TrustCenter Universal CA III"
+# Serial: 2010889993983507346460533407902964
+# MD5 Fingerprint: 9f:dd:db:ab:ff:8e:ff:45:21:5f:f0:6c:9d:8f:fe:2b
+# SHA1 Fingerprint: 96:56:cd:7b:57:96:98:95:d0:e1:41:46:68:06:fb:b8:c6:11:06:87
+# SHA256 Fingerprint: 30:9b:4a:87:f6:ca:56:c9:31:69:aa:a9:9c:6d:98:88:54:d7:89:2b:d5:43:7e:2d:07:b2:9c:be:da:55:d3:5d
+-----BEGIN CERTIFICATE-----
+MIID4TCCAsmgAwIBAgIOYyUAAQACFI0zFQLkbPQwDQYJKoZIhvcNAQEFBQAwezEL
+MAkGA1UEBhMCREUxHDAaBgNVBAoTE1RDIFRydXN0Q2VudGVyIEdtYkgxJDAiBgNV
+BAsTG1RDIFRydXN0Q2VudGVyIFVuaXZlcnNhbCBDQTEoMCYGA1UEAxMfVEMgVHJ1
+c3RDZW50ZXIgVW5pdmVyc2FsIENBIElJSTAeFw0wOTA5MDkwODE1MjdaFw0yOTEy
+MzEyMzU5NTlaMHsxCzAJBgNVBAYTAkRFMRwwGgYDVQQKExNUQyBUcnVzdENlbnRl
+ciBHbWJIMSQwIgYDVQQLExtUQyBUcnVzdENlbnRlciBVbml2ZXJzYWwgQ0ExKDAm
+BgNVBAMTH1RDIFRydXN0Q2VudGVyIFVuaXZlcnNhbCBDQSBJSUkwggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDC2pxisLlxErALyBpXsq6DFJmzNEubkKLF
+5+cvAqBNLaT6hdqbJYUtQCggbergvbFIgyIpRJ9Og+41URNzdNW88jBmlFPAQDYv
+DIRlzg9uwliT6CwLOunBjvvya8o84pxOjuT5fdMnnxvVZ3iHLX8LR7PH6MlIfK8v
+zArZQe+f/prhsq75U7Xl6UafYOPfjdN/+5Z+s7Vy+EutCHnNaYlAJ/Uqwa1D7KRT
+yGG299J5KmcYdkhtWyUB0SbFt1dpIxVbYYqt8Bst2a9c8SaQaanVDED1M4BDj5yj
+dipFtK+/fz6HP3bFzSreIMUWWMv5G/UPyw0RUmS40nZid4PxWJ//AgMBAAGjYzBh
+MB8GA1UdIwQYMBaAFFbn4VslQ4Dg9ozhcbyO5YAvxEjiMA8GA1UdEwEB/wQFMAMB
+Af8wDgYDVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBRW5+FbJUOA4PaM4XG8juWAL8RI
+4jANBgkqhkiG9w0BAQUFAAOCAQEAg8ev6n9NCjw5sWi+e22JLumzCecYV42Fmhfz
+dkJQEw/HkG8zrcVJYCtsSVgZ1OK+t7+rSbyUyKu+KGwWaODIl0YgoGhnYIg5IFHY
+aAERzqf2EQf27OysGh+yZm5WZ2B6dF7AbZc2rrUNXWZzwCUyRdhKBgePxLcHsU0G
+DeGl6/R1yrqc0L2z0zIkTO5+4nYES0lT2PLpVDP85XEfPRRclkvxOvIAu2y0+pZV
+CIgJwcyRGSmwIC3/yzikQOEXvnlhgP8HA4ZMTnsGnxGGjYnuJ8Tb4rwZjgvDwxPH
+LQNjO9Po5KIqwoIIlBZU8O8fJ5AluA0OKBtHd0e9HKgl8ZS0Zg==
+-----END CERTIFICATE-----
+
+# Issuer: CN=Go Daddy Root Certificate Authority - G2 O=GoDaddy.com, Inc.
+# Subject: CN=Go Daddy Root Certificate Authority - G2 O=GoDaddy.com, Inc.
+# Label: "Go Daddy Root Certificate Authority - G2"
+# Serial: 0
+# MD5 Fingerprint: 80:3a:bc:22:c1:e6:fb:8d:9b:3b:27:4a:32:1b:9a:01
+# SHA1 Fingerprint: 47:be:ab:c9:22:ea:e8:0e:78:78:34:62:a7:9f:45:c2:54:fd:e6:8b
+# SHA256 Fingerprint: 45:14:0b:32:47:eb:9c:c8:c5:b4:f0:d7:b5:30:91:f7:32:92:08:9e:6e:5a:63:e2:74:9d:d3:ac:a9:19:8e:da
+-----BEGIN CERTIFICATE-----
+MIIDxTCCAq2gAwIBAgIBADANBgkqhkiG9w0BAQsFADCBgzELMAkGA1UEBhMCVVMx
+EDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxGjAYBgNVBAoT
+EUdvRGFkZHkuY29tLCBJbmMuMTEwLwYDVQQDEyhHbyBEYWRkeSBSb290IENlcnRp
+ZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTA5MDkwMTAwMDAwMFoXDTM3MTIzMTIz
+NTk1OVowgYMxCzAJBgNVBAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQH
+EwpTY290dHNkYWxlMRowGAYDVQQKExFHb0RhZGR5LmNvbSwgSW5jLjExMC8GA1UE
+AxMoR28gRGFkZHkgUm9vdCBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgLSBHMjCCASIw
+DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL9xYgjx+lk09xvJGKP3gElY6SKD
+E6bFIEMBO4Tx5oVJnyfq9oQbTqC023CYxzIBsQU+B07u9PpPL1kwIuerGVZr4oAH
+/PMWdYA5UXvl+TW2dE6pjYIT5LY/qQOD+qK+ihVqf94Lw7YZFAXK6sOoBJQ7Rnwy
+DfMAZiLIjWltNowRGLfTshxgtDj6AozO091GB94KPutdfMh8+7ArU6SSYmlRJQVh
+GkSBjCypQ5Yj36w6gZoOKcUcqeldHraenjAKOc7xiID7S13MMuyFYkMlNAJWJwGR
+tDtwKj9useiciAF9n9T521NtYJ2/LOdYq7hfRvzOxBsDPAnrSTFcaUaz4EcCAwEA
+AaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYE
+FDqahQcQZyi27/a9BUFuIMGU2g/eMA0GCSqGSIb3DQEBCwUAA4IBAQCZ21151fmX
+WWcDYfF+OwYxdS2hII5PZYe096acvNjpL9DbWu7PdIxztDhC2gV7+AJ1uP2lsdeu
+9tfeE8tTEH6KRtGX+rcuKxGrkLAngPnon1rpN5+r5N9ss4UXnT3ZJE95kTXWXwTr
+gIOrmgIttRD02JDHBHNA7XIloKmf7J6raBKZV8aPEjoJpL1E/QYVN8Gb5DKj7Tjo
+2GTzLH4U/ALqn83/B2gX2yKQOC16jdFU8WnjXzPKej17CuPKf1855eJ1usV2GDPO
+LPAvTK33sefOT6jEm0pUBsV/fdUID+Ic/n4XuKxe9tQWskMJDE32p2u0mYRlynqI
+4uJEvlz36hz1
+-----END CERTIFICATE-----
+
+# Issuer: CN=Starfield Root Certificate Authority - G2 O=Starfield Technologies, Inc.
+# Subject: CN=Starfield Root Certificate Authority - G2 O=Starfield Technologies, Inc.
+# Label: "Starfield Root Certificate Authority - G2"
+# Serial: 0
+# MD5 Fingerprint: d6:39:81:c6:52:7e:96:69:fc:fc:ca:66:ed:05:f2:96
+# SHA1 Fingerprint: b5:1c:06:7c:ee:2b:0c:3d:f8:55:ab:2d:92:f4:fe:39:d4:e7:0f:0e
+# SHA256 Fingerprint: 2c:e1:cb:0b:f9:d2:f9:e1:02:99:3f:be:21:51:52:c3:b2:dd:0c:ab:de:1c:68:e5:31:9b:83:91:54:db:b7:f5
+-----BEGIN CERTIFICATE-----
+MIID3TCCAsWgAwIBAgIBADANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMx
+EDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxJTAjBgNVBAoT
+HFN0YXJmaWVsZCBUZWNobm9sb2dpZXMsIEluYy4xMjAwBgNVBAMTKVN0YXJmaWVs
+ZCBSb290IENlcnRpZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTA5MDkwMTAwMDAw
+MFoXDTM3MTIzMTIzNTk1OVowgY8xCzAJBgNVBAYTAlVTMRAwDgYDVQQIEwdBcml6
+b25hMRMwEQYDVQQHEwpTY290dHNkYWxlMSUwIwYDVQQKExxTdGFyZmllbGQgVGVj
+aG5vbG9naWVzLCBJbmMuMTIwMAYDVQQDEylTdGFyZmllbGQgUm9vdCBDZXJ0aWZp
+Y2F0ZSBBdXRob3JpdHkgLSBHMjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+ggEBAL3twQP89o/8ArFvW59I2Z154qK3A2FWGMNHttfKPTUuiUP3oWmb3ooa/RMg
+nLRJdzIpVv257IzdIvpy3Cdhl+72WoTsbhm5iSzchFvVdPtrX8WJpRBSiUZV9Lh1
+HOZ/5FSuS/hVclcCGfgXcVnrHigHdMWdSL5stPSksPNkN3mSwOxGXn/hbVNMYq/N
+Hwtjuzqd+/x5AJhhdM8mgkBj87JyahkNmcrUDnXMN/uLicFZ8WJ/X7NfZTD4p7dN
+dloedl40wOiWVpmKs/B/pM293DIxfJHP4F8R+GuqSVzRmZTRouNjWwl2tVZi4Ut0
+HZbUJtQIBFnQmA4O5t78w+wfkPECAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAO
+BgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFHwMMh+n2TB/xH1oo2Kooc6rB1snMA0G
+CSqGSIb3DQEBCwUAA4IBAQARWfolTwNvlJk7mh+ChTnUdgWUXuEok21iXQnCoKjU
+sHU48TRqneSfioYmUeYs0cYtbpUgSpIB7LiKZ3sx4mcujJUDJi5DnUox9g61DLu3
+4jd/IroAow57UvtruzvE03lRTs2Q9GcHGcg8RnoNAX3FWOdt5oUwF5okxBDgBPfg
+8n/Uqgr/Qh037ZTlZFkSIHc40zI+OIF1lnP6aI+xy84fxez6nH7PfrHxBy22/L/K
+pL/QlwVKvOoYKAKQvVR4CSFx09F9HdkWsKlhPdAKACL8x3vLCWRFCztAgfd9fDL1
+mMpYjn0q7pBZc2T5NnReJaH1ZgUufzkVqSr7UIuOhWn0
+-----END CERTIFICATE-----
+
+# Issuer: CN=Starfield Services Root Certificate Authority - G2 O=Starfield Technologies, Inc.
+# Subject: CN=Starfield Services Root Certificate Authority - G2 O=Starfield Technologies, Inc.
+# Label: "Starfield Services Root Certificate Authority - G2"
+# Serial: 0
+# MD5 Fingerprint: 17:35:74:af:7b:61:1c:eb:f4:f9:3c:e2:ee:40:f9:a2
+# SHA1 Fingerprint: 92:5a:8f:8d:2c:6d:04:e0:66:5f:59:6a:ff:22:d8:63:e8:25:6f:3f
+# SHA256 Fingerprint: 56:8d:69:05:a2:c8:87:08:a4:b3:02:51:90:ed:cf:ed:b1:97:4a:60:6a:13:c6:e5:29:0f:cb:2a:e6:3e:da:b5
+-----BEGIN CERTIFICATE-----
+MIID7zCCAtegAwIBAgIBADANBgkqhkiG9w0BAQsFADCBmDELMAkGA1UEBhMCVVMx
+EDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxJTAjBgNVBAoT
+HFN0YXJmaWVsZCBUZWNobm9sb2dpZXMsIEluYy4xOzA5BgNVBAMTMlN0YXJmaWVs
+ZCBTZXJ2aWNlcyBSb290IENlcnRpZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTA5
+MDkwMTAwMDAwMFoXDTM3MTIzMTIzNTk1OVowgZgxCzAJBgNVBAYTAlVTMRAwDgYD
+VQQIEwdBcml6b25hMRMwEQYDVQQHEwpTY290dHNkYWxlMSUwIwYDVQQKExxTdGFy
+ZmllbGQgVGVjaG5vbG9naWVzLCBJbmMuMTswOQYDVQQDEzJTdGFyZmllbGQgU2Vy
+dmljZXMgUm9vdCBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgLSBHMjCCASIwDQYJKoZI
+hvcNAQEBBQADggEPADCCAQoCggEBANUMOsQq+U7i9b4Zl1+OiFOxHz/Lz58gE20p
+OsgPfTz3a3Y4Y9k2YKibXlwAgLIvWX/2h/klQ4bnaRtSmpDhcePYLQ1Ob/bISdm2
+8xpWriu2dBTrz/sm4xq6HZYuajtYlIlHVv8loJNwU4PahHQUw2eeBGg6345AWh1K
+Ts9DkTvnVtYAcMtS7nt9rjrnvDH5RfbCYM8TWQIrgMw0R9+53pBlbQLPLJGmpufe
+hRhJfGZOozptqbXuNC66DQO4M99H67FrjSXZm86B0UVGMpZwh94CDklDhbZsc7tk
+6mFBrMnUVN+HL8cisibMn1lUaJ/8viovxFUcdUBgF4UCVTmLfwUCAwEAAaNCMEAw
+DwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFJxfAN+q
+AdcwKziIorhtSpzyEZGDMA0GCSqGSIb3DQEBCwUAA4IBAQBLNqaEd2ndOxmfZyMI
+bw5hyf2E3F/YNoHN2BtBLZ9g3ccaaNnRbobhiCPPE95Dz+I0swSdHynVv/heyNXB
+ve6SbzJ08pGCL72CQnqtKrcgfU28elUSwhXqvfdqlS5sdJ/PHLTyxQGjhdByPq1z
+qwubdQxtRbeOlKyWN7Wg0I8VRw7j6IPdj/3vQQF3zCepYoUz8jcI73HPdwbeyBkd
+iEDPfUYd/x7H4c7/I9vG+o1VTqkC50cRRj70/b17KSa7qWFiNyi2LSr2EIZkyXCn
+0q23KXB56jzaYyWf/Wi3MOxw+3WKt21gZ7IeyLnp2KhvAotnDU0mV3HaIPzBSlCN
+sSi6
+-----END CERTIFICATE-----
+
+# Issuer: CN=AffirmTrust Commercial O=AffirmTrust
+# Subject: CN=AffirmTrust Commercial O=AffirmTrust
+# Label: "AffirmTrust Commercial"
+# Serial: 8608355977964138876
+# MD5 Fingerprint: 82:92:ba:5b:ef:cd:8a:6f:a6:3d:55:f9:84:f6:d6:b7
+# SHA1 Fingerprint: f9:b5:b6:32:45:5f:9c:be:ec:57:5f:80:dc:e9:6e:2c:c7:b2:78:b7
+# SHA256 Fingerprint: 03:76:ab:1d:54:c5:f9:80:3c:e4:b2:e2:01:a0:ee:7e:ef:7b:57:b6:36:e8:a9:3c:9b:8d:48:60:c9:6f:5f:a7
+-----BEGIN CERTIFICATE-----
+MIIDTDCCAjSgAwIBAgIId3cGJyapsXwwDQYJKoZIhvcNAQELBQAwRDELMAkGA1UE
+BhMCVVMxFDASBgNVBAoMC0FmZmlybVRydXN0MR8wHQYDVQQDDBZBZmZpcm1UcnVz
+dCBDb21tZXJjaWFsMB4XDTEwMDEyOTE0MDYwNloXDTMwMTIzMTE0MDYwNlowRDEL
+MAkGA1UEBhMCVVMxFDASBgNVBAoMC0FmZmlybVRydXN0MR8wHQYDVQQDDBZBZmZp
+cm1UcnVzdCBDb21tZXJjaWFsMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+AQEA9htPZwcroRX1BiLLHwGy43NFBkRJLLtJJRTWzsO3qyxPxkEylFf6EqdbDuKP
+Hx6GGaeqtS25Xw2Kwq+FNXkyLbscYjfysVtKPcrNcV/pQr6U6Mje+SJIZMblq8Yr
+ba0F8PrVC8+a5fBQpIs7R6UjW3p6+DM/uO+Zl+MgwdYoic+U+7lF7eNAFxHUdPAL
+MeIrJmqbTFeurCA+ukV6BfO9m2kVrn1OIGPENXY6BwLJN/3HR+7o8XYdcxXyl6S1
+yHp52UKqK39c/s4mT6NmgTWvRLpUHhwwMmWd5jyTXlBOeuM61G7MGvv50jeuJCqr
+VwMiKA1JdX+3KNp1v47j3A55MQIDAQABo0IwQDAdBgNVHQ4EFgQUnZPGU4teyq8/
+nx4P5ZmVvCT2lI8wDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwDQYJ
+KoZIhvcNAQELBQADggEBAFis9AQOzcAN/wr91LoWXym9e2iZWEnStB03TX8nfUYG
+XUPGhi4+c7ImfU+TqbbEKpqrIZcUsd6M06uJFdhrJNTxFq7YpFzUf1GO7RgBsZNj
+vbz4YYCanrHOQnDiqX0GJX0nof5v7LMeJNrjS1UaADs1tDvZ110w/YETifLCBivt
+Z8SOyUOyXGsViQK8YvxO8rUzqrJv0wqiUOP2O+guRMLbZjipM1ZI8W0bM40NjD9g
+N53Tym1+NH4Nn3J2ixufcv1SNUFFApYvHLKac0khsUlHRUe072o0EclNmsxZt9YC
+nlpOZbWUrhvfKbAW8b8Angc6F2S1BLUjIZkKlTuXfO8=
+-----END CERTIFICATE-----
+
+# Issuer: CN=AffirmTrust Networking O=AffirmTrust
+# Subject: CN=AffirmTrust Networking O=AffirmTrust
+# Label: "AffirmTrust Networking"
+# Serial: 8957382827206547757
+# MD5 Fingerprint: 42:65:ca:be:01:9a:9a:4c:a9:8c:41:49:cd:c0:d5:7f
+# SHA1 Fingerprint: 29:36:21:02:8b:20:ed:02:f5:66:c5:32:d1:d6:ed:90:9f:45:00:2f
+# SHA256 Fingerprint: 0a:81:ec:5a:92:97:77:f1:45:90:4a:f3:8d:5d:50:9f:66:b5:e2:c5:8f:cd:b5:31:05:8b:0e:17:f3:f0:b4:1b
+-----BEGIN CERTIFICATE-----
+MIIDTDCCAjSgAwIBAgIIfE8EORzUmS0wDQYJKoZIhvcNAQEFBQAwRDELMAkGA1UE
+BhMCVVMxFDASBgNVBAoMC0FmZmlybVRydXN0MR8wHQYDVQQDDBZBZmZpcm1UcnVz
+dCBOZXR3b3JraW5nMB4XDTEwMDEyOTE0MDgyNFoXDTMwMTIzMTE0MDgyNFowRDEL
+MAkGA1UEBhMCVVMxFDASBgNVBAoMC0FmZmlybVRydXN0MR8wHQYDVQQDDBZBZmZp
+cm1UcnVzdCBOZXR3b3JraW5nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+AQEAtITMMxcua5Rsa2FSoOujz3mUTOWUgJnLVWREZY9nZOIG41w3SfYvm4SEHi3y
+YJ0wTsyEheIszx6e/jarM3c1RNg1lho9Nuh6DtjVR6FqaYvZ/Ls6rnla1fTWcbua
+kCNrmreIdIcMHl+5ni36q1Mr3Lt2PpNMCAiMHqIjHNRqrSK6mQEubWXLviRmVSRL
+QESxG9fhwoXA3hA/Pe24/PHxI1Pcv2WXb9n5QHGNfb2V1M6+oF4nI979ptAmDgAp
+6zxG8D1gvz9Q0twmQVGeFDdCBKNwV6gbh+0t+nvujArjqWaJGctB+d1ENmHP4ndG
+yH329JKBNv3bNPFyfvMMFr20FQIDAQABo0IwQDAdBgNVHQ4EFgQUBx/S55zawm6i
+QLSwelAQUHTEyL0wDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwDQYJ
+KoZIhvcNAQEFBQADggEBAIlXshZ6qML91tmbmzTCnLQyFE2npN/svqe++EPbkTfO
+tDIuUFUaNU52Q3Eg75N3ThVwLofDwR1t3Mu1J9QsVtFSUzpE0nPIxBsFZVpikpzu
+QY0x2+c06lkh1QF612S4ZDnNye2v7UsDSKegmQGA3GWjNq5lWUhPgkvIZfFXHeVZ
+Lgo/bNjR9eUJtGxUAArgFU2HdW23WJZa3W3SAKD0m0i+wzekujbgfIeFlxoVot4u
+olu9rxj5kFDNcFn4J2dHy8egBzp90SxdbBk6ZrV9/ZFvgrG+CJPbFEfxojfHRZ48
+x3evZKiT3/Zpg4Jg8klCNO1aAFSFHBY2kgxc+qatv9s=
+-----END CERTIFICATE-----
+
+# Issuer: CN=AffirmTrust Premium O=AffirmTrust
+# Subject: CN=AffirmTrust Premium O=AffirmTrust
+# Label: "AffirmTrust Premium"
+# Serial: 7893706540734352110
+# MD5 Fingerprint: c4:5d:0e:48:b6:ac:28:30:4e:0a:bc:f9:38:16:87:57
+# SHA1 Fingerprint: d8:a6:33:2c:e0:03:6f:b1:85:f6:63:4f:7d:6a:06:65:26:32:28:27
+# SHA256 Fingerprint: 70:a7:3f:7f:37:6b:60:07:42:48:90:45:34:b1:14:82:d5:bf:0e:69:8e:cc:49:8d:f5:25:77:eb:f2:e9:3b:9a
+-----BEGIN CERTIFICATE-----
+MIIFRjCCAy6gAwIBAgIIbYwURrGmCu4wDQYJKoZIhvcNAQEMBQAwQTELMAkGA1UE
+BhMCVVMxFDASBgNVBAoMC0FmZmlybVRydXN0MRwwGgYDVQQDDBNBZmZpcm1UcnVz
+dCBQcmVtaXVtMB4XDTEwMDEyOTE0MTAzNloXDTQwMTIzMTE0MTAzNlowQTELMAkG
+A1UEBhMCVVMxFDASBgNVBAoMC0FmZmlybVRydXN0MRwwGgYDVQQDDBNBZmZpcm1U
+cnVzdCBQcmVtaXVtMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAxBLf
+qV/+Qd3d9Z+K4/as4Tx4mrzY8H96oDMq3I0gW64tb+eT2TZwamjPjlGjhVtnBKAQ
+JG9dKILBl1fYSCkTtuG+kU3fhQxTGJoeJKJPj/CihQvL9Cl/0qRY7iZNyaqoe5rZ
++jjeRFcV5fiMyNlI4g0WJx0eyIOFJbe6qlVBzAMiSy2RjYvmia9mx+n/K+k8rNrS
+s8PhaJyJ+HoAVt70VZVs+7pk3WKL3wt3MutizCaam7uqYoNMtAZ6MMgpv+0GTZe5
+HMQxK9VfvFMSF5yZVylmd2EhMQcuJUmdGPLu8ytxjLW6OQdJd/zvLpKQBY0tL3d7
+70O/Nbua2Plzpyzy0FfuKE4mX4+QaAkvuPjcBukumj5Rp9EixAqnOEhss/n/fauG
+V+O61oV4d7pD6kh/9ti+I20ev9E2bFhc8e6kGVQa9QPSdubhjL08s9NIS+LI+H+S
+qHZGnEJlPqQewQcDWkYtuJfzt9WyVSHvutxMAJf7FJUnM7/oQ0dG0giZFmA7mn7S
+5u046uwBHjxIVkkJx0w3AJ6IDsBz4W9m6XJHMD4Q5QsDyZpCAGzFlH5hxIrff4Ia
+C1nEWTJ3s7xgaVY5/bQGeyzWZDbZvUjthB9+pSKPKrhC9IK31FOQeE4tGv2Bb0TX
+OwF0lkLgAOIua+rF7nKsu7/+6qqo+Nz2snmKtmcCAwEAAaNCMEAwHQYDVR0OBBYE
+FJ3AZ6YMItkm9UWrpmVSESfYRaxjMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/
+BAQDAgEGMA0GCSqGSIb3DQEBDAUAA4ICAQCzV00QYk465KzquByvMiPIs0laUZx2
+KI15qldGF9X1Uva3ROgIRL8YhNILgM3FEv0AVQVhh0HctSSePMTYyPtwni94loMg
+Nt58D2kTiKV1NpgIpsbfrM7jWNa3Pt668+s0QNiigfV4Py/VpfzZotReBA4Xrf5B
+8OWycvpEgjNC6C1Y91aMYj+6QrCcDFx+LmUmXFNPALJ4fqENmS2NuB2OosSw/WDQ
+MKSOyARiqcTtNd56l+0OOF6SL5Nwpamcb6d9Ex1+xghIsV5n61EIJenmJWtSKZGc
+0jlzCFfemQa0W50QBuHCAKi4HEoCChTQwUHK+4w1IX2COPKpVJEZNZOUbWo6xbLQ
+u4mGk+ibyQ86p3q4ofB4Rvr8Ny/lioTz3/4E2aFooC8k4gmVBtWVyuEklut89pMF
+u+1z6S3RdTnX5yTb2E5fQ4+e0BQ5v1VwSJlXMbSc7kqYA5YwH2AG7hsj/oFgIxpH
+YoWlzBk0gG+zrBrjn/B7SK3VAdlntqlyk+otZrWyuOQ9PLLvTIzq6we/qzWaVYa8
+GKa1qF60g2xraUDTn9zxw2lrueFtCfTxqlB2Cnp9ehehVZZCmTEJ3WARjQUwfuaO
+RtGdFNrHF+QFlozEJLUbzxQHskD4o55BhrwE0GuWyCqANP2/7waj3VjFhT0+j/6e
+KeC2uAloGRwYQw==
+-----END CERTIFICATE-----
+
+# Issuer: CN=AffirmTrust Premium ECC O=AffirmTrust
+# Subject: CN=AffirmTrust Premium ECC O=AffirmTrust
+# Label: "AffirmTrust Premium ECC"
+# Serial: 8401224907861490260
+# MD5 Fingerprint: 64:b0:09:55:cf:b1:d5:99:e2:be:13:ab:a6:5d:ea:4d
+# SHA1 Fingerprint: b8:23:6b:00:2f:1d:16:86:53:01:55:6c:11:a4:37:ca:eb:ff:c3:bb
+# SHA256 Fingerprint: bd:71:fd:f6:da:97:e4:cf:62:d1:64:7a:dd:25:81:b0:7d:79:ad:f8:39:7e:b4:ec:ba:9c:5e:84:88:82:14:23
+-----BEGIN CERTIFICATE-----
+MIIB/jCCAYWgAwIBAgIIdJclisc/elQwCgYIKoZIzj0EAwMwRTELMAkGA1UEBhMC
+VVMxFDASBgNVBAoMC0FmZmlybVRydXN0MSAwHgYDVQQDDBdBZmZpcm1UcnVzdCBQ
+cmVtaXVtIEVDQzAeFw0xMDAxMjkxNDIwMjRaFw00MDEyMzExNDIwMjRaMEUxCzAJ
+BgNVBAYTAlVTMRQwEgYDVQQKDAtBZmZpcm1UcnVzdDEgMB4GA1UEAwwXQWZmaXJt
+VHJ1c3QgUHJlbWl1bSBFQ0MwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAQNMF4bFZ0D
+0KF5Nbc6PJJ6yhUczWLznCZcBz3lVPqj1swS6vQUX+iOGasvLkjmrBhDeKzQN8O9
+ss0s5kfiGuZjuD0uL3jET9v0D6RoTFVya5UdThhClXjMNzyR4ptlKymjQjBAMB0G
+A1UdDgQWBBSaryl6wBE1NSZRMADDav5A1a7WPDAPBgNVHRMBAf8EBTADAQH/MA4G
+A1UdDwEB/wQEAwIBBjAKBggqhkjOPQQDAwNnADBkAjAXCfOHiFBar8jAQr9HX/Vs
+aobgxCd05DhT1wV/GzTjxi+zygk8N53X57hG8f2h4nECMEJZh0PUUd+60wkyWs6I
+flc9nF9Ca/UHLbXwgpP5WW+uZPpY5Yse42O+tYHNbwKMeQ==
+-----END CERTIFICATE-----
+
+# Issuer: CN=StartCom Certification Authority O=StartCom Ltd. OU=Secure Digital Certificate Signing
+# Subject: CN=StartCom Certification Authority O=StartCom Ltd. OU=Secure Digital Certificate Signing
+# Label: "StartCom Certification Authority"
+# Serial: 45
+# MD5 Fingerprint: c9:3b:0d:84:41:fc:a4:76:79:23:08:57:de:10:19:16
+# SHA1 Fingerprint: a3:f1:33:3f:e2:42:bf:cf:c5:d1:4e:8f:39:42:98:40:68:10:d1:a0
+# SHA256 Fingerprint: e1:78:90:ee:09:a3:fb:f4:f4:8b:9c:41:4a:17:d6:37:b7:a5:06:47:e9:bc:75:23:22:72:7f:cc:17:42:a9:11
+-----BEGIN CERTIFICATE-----
+MIIHhzCCBW+gAwIBAgIBLTANBgkqhkiG9w0BAQsFADB9MQswCQYDVQQGEwJJTDEW
+MBQGA1UEChMNU3RhcnRDb20gTHRkLjErMCkGA1UECxMiU2VjdXJlIERpZ2l0YWwg
+Q2VydGlmaWNhdGUgU2lnbmluZzEpMCcGA1UEAxMgU3RhcnRDb20gQ2VydGlmaWNh
+dGlvbiBBdXRob3JpdHkwHhcNMDYwOTE3MTk0NjM3WhcNMzYwOTE3MTk0NjM2WjB9
+MQswCQYDVQQGEwJJTDEWMBQGA1UEChMNU3RhcnRDb20gTHRkLjErMCkGA1UECxMi
+U2VjdXJlIERpZ2l0YWwgQ2VydGlmaWNhdGUgU2lnbmluZzEpMCcGA1UEAxMgU3Rh
+cnRDb20gQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwggIiMA0GCSqGSIb3DQEBAQUA
+A4ICDwAwggIKAoICAQDBiNsJvGxGfHiflXu1M5DycmLWwTYgIiRezul38kMKogZk
+pMyONvg45iPwbm2xPN1yo4UcodM9tDMr0y+v/uqwQVlntsQGfQqedIXWeUyAN3rf
+OQVSWff0G0ZDpNKFhdLDcfN1YjS6LIp/Ho/u7TTQEceWzVI9ujPW3U3eCztKS5/C
+Ji/6tRYccjV3yjxd5srhJosaNnZcAdt0FCX+7bWgiA/deMotHweXMAEtcnn6RtYT
+Kqi5pquDSR3l8u/d5AGOGAqPY1MWhWKpDhk6zLVmpsJrdAfkK+F2PrRt2PZE4XNi
+HzvEvqBTViVsUQn3qqvKv3b9bZvzndu/PWa8DFaqr5hIlTpL36dYUNk4dalb6kMM
+Av+Z6+hsTXBbKWWc3apdzK8BMewM69KN6Oqce+Zu9ydmDBpI125C4z/eIT574Q1w
++2OqqGwaVLRcJXrJosmLFqa7LH4XXgVNWG4SHQHuEhANxjJ/GP/89PrNbpHoNkm+
+Gkhpi8KWTRoSsmkXwQqQ1vp5Iki/untp+HDH+no32NgN0nZPV/+Qt+OR0t3vwmC3
+Zzrd/qqc8NSLf3Iizsafl7b4r4qgEKjZ+xjGtrVcUjyJthkqcwEKDwOzEmDyei+B
+26Nu/yYwl/WL3YlXtq09s68rxbd2AvCl1iuahhQqcvbjM4xdCUsT37uMdBNSSwID
+AQABo4ICEDCCAgwwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYD
+VR0OBBYEFE4L7xqkQFulF2mHMMo0aEPQQa7yMB8GA1UdIwQYMBaAFE4L7xqkQFul
+F2mHMMo0aEPQQa7yMIIBWgYDVR0gBIIBUTCCAU0wggFJBgsrBgEEAYG1NwEBATCC
+ATgwLgYIKwYBBQUHAgEWImh0dHA6Ly93d3cuc3RhcnRzc2wuY29tL3BvbGljeS5w
+ZGYwNAYIKwYBBQUHAgEWKGh0dHA6Ly93d3cuc3RhcnRzc2wuY29tL2ludGVybWVk
+aWF0ZS5wZGYwgc8GCCsGAQUFBwICMIHCMCcWIFN0YXJ0IENvbW1lcmNpYWwgKFN0
+YXJ0Q29tKSBMdGQuMAMCAQEagZZMaW1pdGVkIExpYWJpbGl0eSwgcmVhZCB0aGUg
+c2VjdGlvbiAqTGVnYWwgTGltaXRhdGlvbnMqIG9mIHRoZSBTdGFydENvbSBDZXJ0
+aWZpY2F0aW9uIEF1dGhvcml0eSBQb2xpY3kgYXZhaWxhYmxlIGF0IGh0dHA6Ly93
+d3cuc3RhcnRzc2wuY29tL3BvbGljeS5wZGYwEQYJYIZIAYb4QgEBBAQDAgAHMDgG
+CWCGSAGG+EIBDQQrFilTdGFydENvbSBGcmVlIFNTTCBDZXJ0aWZpY2F0aW9uIEF1
+dGhvcml0eTANBgkqhkiG9w0BAQsFAAOCAgEAjo/n3JR5fPGFf59Jb2vKXfuM/gTF
+wWLRfUKKvFO3lANmMD+x5wqnUCBVJX92ehQN6wQOQOY+2IirByeDqXWmN3PH/UvS
+Ta0XQMhGvjt/UfzDtgUx3M2FIk5xt/JxXrAaxrqTi3iSSoX4eA+D/i+tLPfkpLst
+0OcNOrg+zvZ49q5HJMqjNTbOx8aHmNrs++myziebiMMEofYLWWivydsQD032ZGNc
+pRJvkrKTlMeIFw6Ttn5ii5B/q06f/ON1FE8qMt9bDeD1e5MNq6HPh+GlBEXoPBKl
+CcWw0bdT82AUuoVpaiF8H3VhFyAXe2w7QSlc4axa0c2Mm+tgHRns9+Ww2vl5GKVF
+P0lDV9LdJNUso/2RjSe15esUBppMeyG7Oq0wBhjA2MFrLH9ZXF2RsXAiV+uKa0hK
+1Q8p7MZAwC+ITGgBF3f0JBlPvfrhsiAhS90a2Cl9qrjeVOwhVYBsHvUwyKMQ5bLm
+KhQxw4UtjJixhlpPiVktucf3HMiKf8CdBUrmQk9io20ppB+Fq9vlgcitKj1MXVuE
+JnHEhV5xJMqlG2zYYdMa4FTbzrqpMrUi9nNBCV24F10OD5mQ1kfabwo6YigUZ4LZ
+8dCAWZvLMdibD4x3TrVoivJs9iQOLWxwxXPR3hTQcY+203sC9uO41Alua551hDnm
+fyWl8kgAwKQB2j8=
+-----END CERTIFICATE-----
+
+# Issuer: CN=StartCom Certification Authority G2 O=StartCom Ltd.
+# Subject: CN=StartCom Certification Authority G2 O=StartCom Ltd.
+# Label: "StartCom Certification Authority G2"
+# Serial: 59
+# MD5 Fingerprint: 78:4b:fb:9e:64:82:0a:d3:b8:4c:62:f3:64:f2:90:64
+# SHA1 Fingerprint: 31:f1:fd:68:22:63:20:ee:c6:3b:3f:9d:ea:4a:3e:53:7c:7c:39:17
+# SHA256 Fingerprint: c7:ba:65:67:de:93:a7:98:ae:1f:aa:79:1e:71:2d:37:8f:ae:1f:93:c4:39:7f:ea:44:1b:b7:cb:e6:fd:59:95
+-----BEGIN CERTIFICATE-----
+MIIFYzCCA0ugAwIBAgIBOzANBgkqhkiG9w0BAQsFADBTMQswCQYDVQQGEwJJTDEW
+MBQGA1UEChMNU3RhcnRDb20gTHRkLjEsMCoGA1UEAxMjU3RhcnRDb20gQ2VydGlm
+aWNhdGlvbiBBdXRob3JpdHkgRzIwHhcNMTAwMTAxMDEwMDAxWhcNMzkxMjMxMjM1
+OTAxWjBTMQswCQYDVQQGEwJJTDEWMBQGA1UEChMNU3RhcnRDb20gTHRkLjEsMCoG
+A1UEAxMjU3RhcnRDb20gQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkgRzIwggIiMA0G
+CSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQC2iTZbB7cgNr2Cu+EWIAOVeq8Oo1XJ
+JZlKxdBWQYeQTSFgpBSHO839sj60ZwNq7eEPS8CRhXBF4EKe3ikj1AENoBB5uNsD
+vfOpL9HG4A/LnooUCri99lZi8cVytjIl2bLzvWXFDSxu1ZJvGIsAQRSCb0AgJnoo
+D/Uefyf3lLE3PbfHkffiAez9lInhzG7TNtYKGXmu1zSCZf98Qru23QumNK9LYP5/
+Q0kGi4xDuFby2X8hQxfqp0iVAXV16iulQ5XqFYSdCI0mblWbq9zSOdIxHWDirMxW
+RST1HFSr7obdljKF+ExP6JV2tgXdNiNnvP8V4so75qbsO+wmETRIjfaAKxojAuuK
+HDp2KntWFhxyKrOq42ClAJ8Em+JvHhRYW6Vsi1g8w7pOOlz34ZYrPu8HvKTlXcxN
+nw3h3Kq74W4a7I/htkxNeXJdFzULHdfBR9qWJODQcqhaX2YtENwvKhOuJv4KHBnM
+0D4LnMgJLvlblnpHnOl68wVQdJVznjAJ85eCXuaPOQgeWeU1FEIT/wCc976qUM/i
+UUjXuG+v+E5+M5iSFGI6dWPPe/regjupuznixL0sAA7IF6wT700ljtizkC+p2il9
+Ha90OrInwMEePnWjFqmveiJdnxMaz6eg6+OGCtP95paV1yPIN93EfKo2rJgaErHg
+TuixO/XWb/Ew1wIDAQABo0IwQDAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQE
+AwIBBjAdBgNVHQ4EFgQUS8W0QGutHLOlHGVuRjaJhwUMDrYwDQYJKoZIhvcNAQEL
+BQADggIBAHNXPyzVlTJ+N9uWkusZXn5T50HsEbZH77Xe7XRcxfGOSeD8bpkTzZ+K
+2s06Ctg6Wgk/XzTQLwPSZh0avZyQN8gMjgdalEVGKua+etqhqaRpEpKwfTbURIfX
+UfEpY9Z1zRbkJ4kd+MIySP3bmdCPX1R0zKxnNBFi2QwKN4fRoxdIjtIXHfbX/dtl
+6/2o1PXWT6RbdejF0mCy2wl+JYt7ulKSnj7oxXehPOBKc2thz4bcQ///If4jXSRK
+9dNtD2IEBVeC2m6kMyV5Sy5UGYvMLD0w6dEG/+gyRr61M3Z3qAFdlsHB1b6uJcDJ
+HgoJIIihDsnzb02CVAAgp9KP5DlUFy6NHrgbuxu9mk47EDTcnIhT76IxW1hPkWLI
+wpqazRVdOKnWvvgTtZ8SafJQYqz7Fzf07rh1Z2AQ+4NQ+US1dZxAF7L+/XldblhY
+XzD8AK6vM8EOTmy6p6ahfzLbOOCxchcKK5HsamMm7YnUeMx0HgX4a/6ManY5Ka5l
+IxKVCCIcl85bBu4M4ru8H0ST9tg4RQUh7eStqxK2A6RCLi3ECToDZ2mEmuFZkIoo
+hdVddLHRDiBYmxOlsGOm7XtH/UVVMKTumtTm4ofvmMkyghEpIrwACjFeLQ/Ajulr
+so8uBtjRkcfGEvRM/TAXw8HaOFvjqermobp573PYtlNXLfbQ4ddI
 -----END CERTIFICATE-----

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/Abstract.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/Abstract.php
@@ -1,0 +1,408 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
+
+/**
+ * Abstract logging class based on the PSR-3 standard.
+ *
+ * NOTE: We don't implement `Psr\Log\LoggerInterface` because we need to
+ * maintain PHP 5.2 support.
+ *
+ * @see https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md
+ */
+abstract class Google_Logger_Abstract
+{
+  /**
+   * Default log format
+   */
+  const DEFAULT_LOG_FORMAT = "[%datetime%] %level%: %message% %context%\n";
+  /**
+   * Default date format
+   *
+   * Example: 16/Nov/2014:03:26:16 -0500
+   */
+  const DEFAULT_DATE_FORMAT = 'd/M/Y:H:i:s O';
+
+  /**
+   * System is unusable
+   */
+  const EMERGENCY = 'emergency';
+  /**
+   * Action must be taken immediately
+   *
+   * Example: Entire website down, database unavailable, etc. This should
+   * trigger the SMS alerts and wake you up.
+   */
+  const ALERT = 'alert';
+  /**
+   * Critical conditions
+   *
+   * Example: Application component unavailable, unexpected exception.
+   */
+  const CRITICAL = 'critical';
+  /**
+   * Runtime errors that do not require immediate action but should typically
+   * be logged and monitored.
+   */
+  const ERROR = 'error';
+  /**
+   * Exceptional occurrences that are not errors.
+   *
+   * Example: Use of deprecated APIs, poor use of an API, undesirable things
+   * that are not necessarily wrong.
+   */
+  const WARNING = 'warning';
+  /**
+   * Normal but significant events.
+   */
+  const NOTICE = 'notice';
+  /**
+   * Interesting events.
+   *
+   * Example: User logs in, SQL logs.
+   */
+  const INFO = 'info';
+  /**
+   * Detailed debug information.
+   */
+  const DEBUG = 'debug';
+
+  /**
+   * @var array $levels Logging levels
+   */
+  protected static $levels = array(
+      self::EMERGENCY  => 600,
+      self::ALERT => 550,
+      self::CRITICAL => 500,
+      self::ERROR => 400,
+      self::WARNING => 300,
+      self::NOTICE => 250,
+      self::INFO => 200,
+      self::DEBUG => 100,
+  );
+
+  /**
+   * @var integer $level The minimum logging level
+   */
+  protected $level = self::DEBUG;
+
+  /**
+   * @var string $logFormat The current log format
+   */
+  protected $logFormat = self::DEFAULT_LOG_FORMAT;
+  /**
+   * @var string $dateFormat The current date format
+   */
+  protected $dateFormat = self::DEFAULT_DATE_FORMAT;
+
+  /**
+   * @var boolean $allowNewLines If newlines are allowed
+   */
+  protected $allowNewLines = false;
+
+  /**
+   * @param Google_Client $client  The current Google client
+   */
+  public function __construct(Google_Client $client)
+  {
+    $this->setLevel(
+        $client->getClassConfig('Google_Logger_Abstract', 'level')
+    );
+
+    $format = $client->getClassConfig('Google_Logger_Abstract', 'log_format');
+    $this->logFormat = $format ? $format : self::DEFAULT_LOG_FORMAT;
+
+    $format = $client->getClassConfig('Google_Logger_Abstract', 'date_format');
+    $this->dateFormat = $format ? $format : self::DEFAULT_DATE_FORMAT;
+
+    $this->allowNewLines = (bool) $client->getClassConfig(
+        'Google_Logger_Abstract',
+        'allow_newlines'
+    );
+  }
+
+  /**
+   * Sets the minimum logging level that this logger handles.
+   *
+   * @param integer $level
+   */
+  public function setLevel($level)
+  {
+    $this->level = $this->normalizeLevel($level);
+  }
+
+  /**
+   * Checks if the logger should handle messages at the provided level.
+   *
+   * @param  integer $level
+   * @return boolean
+   */
+  public function shouldHandle($level)
+  {
+    return $this->normalizeLevel($level) >= $this->level;
+  }
+
+  /**
+   * System is unusable.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function emergency($message, array $context = array())
+  {
+    $this->log(self::EMERGENCY, $message, $context);
+  }
+
+  /**
+   * Action must be taken immediately.
+   *
+   * Example: Entire website down, database unavailable, etc. This should
+   * trigger the SMS alerts and wake you up.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function alert($message, array $context = array())
+  {
+    $this->log(self::ALERT, $message, $context);
+  }
+
+  /**
+   * Critical conditions.
+   *
+   * Example: Application component unavailable, unexpected exception.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function critical($message, array $context = array())
+  {
+    $this->log(self::CRITICAL, $message, $context);
+  }
+
+  /**
+   * Runtime errors that do not require immediate action but should typically
+   * be logged and monitored.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function error($message, array $context = array())
+  {
+    $this->log(self::ERROR, $message, $context);
+  }
+
+  /**
+   * Exceptional occurrences that are not errors.
+   *
+   * Example: Use of deprecated APIs, poor use of an API, undesirable things
+   * that are not necessarily wrong.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function warning($message, array $context = array())
+  {
+    $this->log(self::WARNING, $message, $context);
+  }
+
+  /**
+   * Normal but significant events.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function notice($message, array $context = array())
+  {
+    $this->log(self::NOTICE, $message, $context);
+  }
+
+  /**
+   * Interesting events.
+   *
+   * Example: User logs in, SQL logs.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function info($message, array $context = array())
+  {
+    $this->log(self::INFO, $message, $context);
+  }
+
+  /**
+   * Detailed debug information.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function debug($message, array $context = array())
+  {
+    $this->log(self::DEBUG, $message, $context);
+  }
+
+  /**
+   * Logs with an arbitrary level.
+   *
+   * @param mixed $level    The log level
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function log($level, $message, array $context = array())
+  {
+    if (!$this->shouldHandle($level)) {
+      return false;
+    }
+
+    $levelName = is_int($level) ? array_search($level, self::$levels) : $level;
+    $message = $this->interpolate(
+        array(
+            'message' => $message,
+            'context' => $context,
+            'level' => strtoupper($levelName),
+            'datetime' => new DateTime(),
+        )
+    );
+
+    $this->write($message);
+  }
+
+  /**
+   * Interpolates log variables into the defined log format.
+   *
+   * @param  array $variables The log variables.
+   * @return string
+   */
+  protected function interpolate(array $variables = array())
+  {
+    $template = $this->logFormat;
+
+    if (!$variables['context']) {
+      $template = str_replace('%context%', '', $template);
+      unset($variables['context']);
+    } else {
+      $this->reverseJsonInContext($variables['context']);
+    }
+
+    foreach ($variables as $key => $value) {
+      if (strpos($template, '%'. $key .'%') !== false) {
+        $template = str_replace(
+            '%' . $key . '%',
+            $this->export($value),
+            $template
+        );
+      }
+    }
+
+    return $template;
+  }
+
+  /**
+   * Reverses JSON encoded PHP arrays and objects so that they log better.
+   *
+   * @param array $context The log context
+   */
+  protected function reverseJsonInContext(array &$context)
+  {
+    if (!$context) {
+      return;
+    }
+
+    foreach ($context as $key => $val) {
+      if (!$val || !is_string($val) || !($val[0] == '{' || $val[0] == '[')) {
+        continue;
+      }
+
+      $json = @json_decode($val);
+      if (is_object($json) || is_array($json)) {
+        $context[$key] = $json;
+      }
+    }
+  }
+
+  /**
+   * Exports a PHP value for logging to a string.
+   *
+   * @param mixed $value The value to
+   */
+  protected function export($value)
+  {
+    if (is_string($value)) {
+      if ($this->allowNewLines) {
+        return $value;
+      }
+
+      return preg_replace('/[\r\n]+/', ' ', $value);
+    }
+
+    if (is_resource($value)) {
+      return sprintf(
+          'resource(%d) of type (%s)',
+          $value,
+          get_resource_type($value)
+      );
+    }
+
+    if ($value instanceof DateTime) {
+      return $value->format($this->dateFormat);
+    }
+
+    if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+      $options = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+
+      if ($this->allowNewLines) {
+        $options |= JSON_PRETTY_PRINT;
+      }
+
+      return @json_encode($value, $options);
+    }
+
+    return str_replace('\\/', '/', @json_encode($value));
+  }
+
+  /**
+   * Converts a given log level to the integer form.
+   *
+   * @param  mixed $level   The logging level
+   * @return integer $level The normalized level
+   * @throws Google_Logger_Exception If $level is invalid
+   */
+  protected function normalizeLevel($level)
+  {
+    if (is_int($level) && array_search($level, self::$levels) !== false) {
+      return $level;
+    }
+
+    if (is_string($level) && isset(self::$levels[$level])) {
+      return self::$levels[$level];
+    }
+
+    throw new Google_Logger_Exception(
+        sprintf("Unknown LogLevel: '%s'", $level)
+    );
+  }
+
+  /**
+   * Writes a message to the current log implementation.
+   *
+   * @param string $message The message
+   */
+  abstract protected function write($message);
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/Exception.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/Exception.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
+
+class Google_Logger_Exception extends Google_Exception
+{
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/File.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/File.php
@@ -1,0 +1,158 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
+
+/**
+ * File logging class based on the PSR-3 standard.
+ *
+ * This logger writes to a PHP stream resource.
+ */
+class Google_Logger_File extends Google_Logger_Abstract
+{
+  /**
+   * @var string|resource $file Where logs are written
+   */
+  private $file;
+  /**
+   * @var integer $mode The mode to use if the log file needs to be created
+   */
+  private $mode = 0640;
+  /**
+   * @var boolean $lock If a lock should be attempted before writing to the log
+   */
+  private $lock = false;
+
+  /**
+   * @var integer $trappedErrorNumber Trapped error number
+   */
+  private $trappedErrorNumber;
+  /**
+   * @var string $trappedErrorString Trapped error string
+   */
+  private $trappedErrorString;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+
+    $file = $client->getClassConfig('Google_Logger_File', 'file');
+    if (!is_string($file) && !is_resource($file)) {
+      throw new Google_Logger_Exception(
+          'File logger requires a filename or a valid file pointer'
+      );
+    }
+
+    $mode = $client->getClassConfig('Google_Logger_File', 'mode');
+    if (!$mode) {
+      $this->mode = $mode;
+    }
+
+    $this->lock = (bool) $client->getClassConfig('Google_Logger_File', 'lock');
+    $this->file = $file;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function write($message)
+  {
+    if (is_string($this->file)) {
+      $this->open();
+    } elseif (!is_resource($this->file)) {
+      throw new Google_Logger_Exception('File pointer is no longer available');
+    }
+
+    if ($this->lock) {
+      flock($this->file, LOCK_EX);
+    }
+
+    fwrite($this->file, (string) $message);
+
+    if ($this->lock) {
+      flock($this->file, LOCK_UN);
+    }
+  }
+
+  /**
+   * Opens the log for writing.
+   *
+   * @return resource
+   */
+  private function open()
+  {
+    // Used for trapping `fopen()` errors.
+    $this->trappedErrorNumber = null;
+    $this->trappedErrorString = null;
+
+    $old = set_error_handler(array($this, 'trapError'));
+
+    $needsChmod = !file_exists($this->file);
+    $fh = fopen($this->file, 'a');
+
+    restore_error_handler();
+
+    // Handles trapped `fopen()` errors.
+    if ($this->trappedErrorNumber) {
+      throw new Google_Logger_Exception(
+          sprintf(
+              "Logger Error: '%s'",
+              $this->trappedErrorString
+          ),
+          $this->trappedErrorNumber
+      );
+    }
+
+    if ($needsChmod) {
+      @chmod($this->file, $this->mode & ~umask());
+    }
+
+    return $this->file = $fh;
+  }
+
+  /**
+   * Closes the log stream resource.
+   */
+  private function close()
+  {
+    if (is_resource($this->file)) {
+      fclose($this->file);
+    }
+  }
+
+  /**
+   * Traps `fopen()` errors.
+   *
+   * @param integer $errno The error number
+   * @param string $errstr The error string
+   */
+  private function trapError($errno, $errstr)
+  {
+    $this->trappedErrorNumber = $errno;
+    $this->trappedErrorString = $errstr;
+  }
+
+  public function __destruct()
+  {
+    $this->close();
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/Null.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/Null.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
+
+/**
+ * Null logger based on the PSR-3 standard.
+ *
+ * This logger simply discards all messages.
+ */
+class Google_Logger_Null extends Google_Logger_Abstract
+{
+  /**
+   * {@inheritdoc}
+   */
+  public function shouldHandle($level)
+  {
+    return false;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function write($message, array $context = array())
+  {
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/Psr.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/Psr.php
@@ -1,0 +1,93 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
+
+/**
+ * Psr logging class based on the PSR-3 standard.
+ *
+ * This logger will delegate all logging to a PSR-3 compatible logger specified
+ * with the `Google_Logger_Psr::setLogger()` method.
+ */
+class Google_Logger_Psr extends Google_Logger_Abstract
+{
+  /**
+   * @param Psr\Log\LoggerInterface $logger The PSR-3 logger
+   */
+  private $logger;
+
+  /**
+   * @param Google_Client $client           The current Google client
+   * @param Psr\Log\LoggerInterface $logger PSR-3 logger where logging will be delegated.
+   */
+  public function __construct(Google_Client $client, /*Psr\Log\LoggerInterface*/ $logger = null)
+  {
+    parent::__construct($client);
+
+    if ($logger) {
+      $this->setLogger($logger);
+    }
+  }
+
+  /**
+   * Sets the PSR-3 logger where logging will be delegated.
+   *
+   * NOTE: The `$logger` should technically implement
+   * `Psr\Log\LoggerInterface`, but we don't explicitly require this so that
+   * we can be compatible with PHP 5.2.
+   *
+   * @param Psr\Log\LoggerInterface $logger The PSR-3 logger
+   */
+  public function setLogger(/*Psr\Log\LoggerInterface*/ $logger)
+  {
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function shouldHandle($level)
+  {
+    return isset($this->logger) && parent::shouldHandle($level);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function log($level, $message, array $context = array())
+  {
+    if (!$this->shouldHandle($level)) {
+      return false;
+    }
+
+    if ($context) {
+      $this->reverseJsonInContext($context);
+    }
+
+    $levelName = is_int($level) ? array_search($level, self::$levels) : $level;
+    $this->logger->log($levelName, $message, $context);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function write($message, array $context = array())
+  {
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service.php
@@ -17,6 +17,8 @@
 
 class Google_Service
 {
+  public $batchPath;
+  public $rootUrl;
   public $version;
   public $servicePath;
   public $availableScopes;
@@ -35,5 +37,20 @@ class Google_Service
   public function getClient()
   {
     return $this->client;
+  }
+
+  /**
+   * Create a new HTTP Batch handler for this service
+   *
+   * @return Google_Http_Batch
+   */
+  public function createBatch()
+  {
+    return new Google_Http_Batch(
+        $this->client,
+        false,
+        $this->rootUrl,
+        $this->batchPath
+    );
   }
 }

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/AdExchangeBuyer.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/AdExchangeBuyer.php
@@ -1,0 +1,6646 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for AdExchangeBuyer (v1.4).
+ *
+ * <p>
+ * Accesses your bidding-account information, submits creatives for validation,
+ * finds available direct deals, and retrieves performance reports.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/ad-exchange/buyer-rest" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_AdExchangeBuyer extends Google_Service
+{
+  /** Manage your Ad Exchange buyer account configuration. */
+  const ADEXCHANGE_BUYER =
+      "https://www.googleapis.com/auth/adexchange.buyer";
+
+  public $accounts;
+  public $billingInfo;
+  public $budget;
+  public $clientaccess;
+  public $creatives;
+  public $deals;
+  public $marketplacedeals;
+  public $marketplacenotes;
+  public $marketplaceoffers;
+  public $marketplaceorders;
+  public $negotiationrounds;
+  public $negotiations;
+  public $offers;
+  public $performanceReport;
+  public $pretargetingConfig;
+  
+
+  /**
+   * Constructs the internal representation of the AdExchangeBuyer service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'adexchangebuyer/v1.4/';
+    $this->version = 'v1.4';
+    $this->serviceName = 'adexchangebuyer';
+
+    $this->accounts = new Google_Service_AdExchangeBuyer_Accounts_Resource(
+        $this,
+        $this->serviceName,
+        'accounts',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'accounts/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),'patch' => array(
+              'path' => 'accounts/{id}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'accounts/{id}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->billingInfo = new Google_Service_AdExchangeBuyer_BillingInfo_Resource(
+        $this,
+        $this->serviceName,
+        'billingInfo',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'billinginfo/{accountId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'billinginfo',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->budget = new Google_Service_AdExchangeBuyer_Budget_Resource(
+        $this,
+        $this->serviceName,
+        'budget',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'billinginfo/{accountId}/{billingId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'billingId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'billinginfo/{accountId}/{billingId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'billingId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'billinginfo/{accountId}/{billingId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'billingId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->clientaccess = new Google_Service_AdExchangeBuyer_Clientaccess_Resource(
+        $this,
+        $this->serviceName,
+        'clientaccess',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'clientAccess/{clientAccountId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'clientAccountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sponsorAccountId' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'clientAccess/{clientAccountId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'clientAccountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sponsorAccountId' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'clientAccess',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'clientAccountId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sponsorAccountId' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'clientAccess',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),'patch' => array(
+              'path' => 'clientAccess/{clientAccountId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'clientAccountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sponsorAccountId' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'clientAccess/{clientAccountId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'clientAccountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sponsorAccountId' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->creatives = new Google_Service_AdExchangeBuyer_Creatives_Resource(
+        $this,
+        $this->serviceName,
+        'creatives',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'creatives/{accountId}/{buyerCreativeId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'buyerCreativeId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'creatives',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'list' => array(
+              'path' => 'creatives',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'openAuctionStatusFilter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'buyerCreativeId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'dealsStatusFilter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'accountId' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'repeated' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->deals = new Google_Service_AdExchangeBuyer_Deals_Resource(
+        $this,
+        $this->serviceName,
+        'deals',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'deals/{dealId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'dealId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->marketplacedeals = new Google_Service_AdExchangeBuyer_Marketplacedeals_Resource(
+        $this,
+        $this->serviceName,
+        'marketplacedeals',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'marketplaceOrders/{orderId}/deals/delete',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'marketplaceOrders/{orderId}/deals/insert',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'marketplaceOrders/{orderId}/deals',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'marketplaceOrders/{orderId}/deals/update',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->marketplacenotes = new Google_Service_AdExchangeBuyer_Marketplacenotes_Resource(
+        $this,
+        $this->serviceName,
+        'marketplacenotes',
+        array(
+          'methods' => array(
+            'insert' => array(
+              'path' => 'marketplaceOrders/{orderId}/notes/insert',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'marketplaceOrders/{orderId}/notes',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->marketplaceoffers = new Google_Service_AdExchangeBuyer_Marketplaceoffers_Resource(
+        $this,
+        $this->serviceName,
+        'marketplaceoffers',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'marketplaceOffers/{offerId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'offerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'search' => array(
+              'path' => 'marketplaceOffers/search',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pqlQuery' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->marketplaceorders = new Google_Service_AdExchangeBuyer_Marketplaceorders_Resource(
+        $this,
+        $this->serviceName,
+        'marketplaceorders',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'marketplaceOrders/{orderId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'marketplaceOrders/insert',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'patch' => array(
+              'path' => 'marketplaceOrders/{orderId}/{revisionNumber}/{updateAction}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'revisionNumber' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'updateAction' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'search' => array(
+              'path' => 'marketplaceOrders/search',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pqlQuery' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'marketplaceOrders/{orderId}/{revisionNumber}/{updateAction}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'revisionNumber' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'updateAction' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->negotiationrounds = new Google_Service_AdExchangeBuyer_Negotiationrounds_Resource(
+        $this,
+        $this->serviceName,
+        'negotiationrounds',
+        array(
+          'methods' => array(
+            'insert' => array(
+              'path' => 'negotiations/{negotiationId}/negotiationrounds',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'negotiationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->negotiations = new Google_Service_AdExchangeBuyer_Negotiations_Resource(
+        $this,
+        $this->serviceName,
+        'negotiations',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'negotiations/{negotiationId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'negotiationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'negotiations',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'list' => array(
+              'path' => 'negotiations',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->offers = new Google_Service_AdExchangeBuyer_Offers_Resource(
+        $this,
+        $this->serviceName,
+        'offers',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'offers/{offerId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'offerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'offers',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'list' => array(
+              'path' => 'offers',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->performanceReport = new Google_Service_AdExchangeBuyer_PerformanceReport_Resource(
+        $this,
+        $this->serviceName,
+        'performanceReport',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'performancereport',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'endDateTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'startDateTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->pretargetingConfig = new Google_Service_AdExchangeBuyer_PretargetingConfig_Resource(
+        $this,
+        $this->serviceName,
+        'pretargetingConfig',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'pretargetingconfigs/{accountId}/{configId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'configId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'pretargetingconfigs/{accountId}/{configId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'configId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'pretargetingconfigs/{accountId}',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'pretargetingconfigs/{accountId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'pretargetingconfigs/{accountId}/{configId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'configId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'pretargetingconfigs/{accountId}/{configId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'configId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "accounts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangebuyerService = new Google_Service_AdExchangeBuyer(...);
+ *   $accounts = $adexchangebuyerService->accounts;
+ *  </code>
+ */
+class Google_Service_AdExchangeBuyer_Accounts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one account by ID. (accounts.get)
+   *
+   * @param int $id The account id
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_Account
+   */
+  public function get($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdExchangeBuyer_Account");
+  }
+
+  /**
+   * Retrieves the authenticated user's list of accounts. (accounts.listAccounts)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_AccountsList
+   */
+  public function listAccounts($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeBuyer_AccountsList");
+  }
+
+  /**
+   * Updates an existing account. This method supports patch semantics.
+   * (accounts.patch)
+   *
+   * @param int $id The account id
+   * @param Google_Account $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_Account
+   */
+  public function patch($id, Google_Service_AdExchangeBuyer_Account $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_AdExchangeBuyer_Account");
+  }
+
+  /**
+   * Updates an existing account. (accounts.update)
+   *
+   * @param int $id The account id
+   * @param Google_Account $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_Account
+   */
+  public function update($id, Google_Service_AdExchangeBuyer_Account $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AdExchangeBuyer_Account");
+  }
+}
+
+/**
+ * The "billingInfo" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangebuyerService = new Google_Service_AdExchangeBuyer(...);
+ *   $billingInfo = $adexchangebuyerService->billingInfo;
+ *  </code>
+ */
+class Google_Service_AdExchangeBuyer_BillingInfo_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns the billing information for one account specified by account ID.
+   * (billingInfo.get)
+   *
+   * @param int $accountId The account id.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_BillingInfo
+   */
+  public function get($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdExchangeBuyer_BillingInfo");
+  }
+
+  /**
+   * Retrieves a list of billing information for all accounts of the authenticated
+   * user. (billingInfo.listBillingInfo)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_BillingInfoList
+   */
+  public function listBillingInfo($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeBuyer_BillingInfoList");
+  }
+}
+
+/**
+ * The "budget" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangebuyerService = new Google_Service_AdExchangeBuyer(...);
+ *   $budget = $adexchangebuyerService->budget;
+ *  </code>
+ */
+class Google_Service_AdExchangeBuyer_Budget_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns the budget information for the adgroup specified by the accountId and
+   * billingId. (budget.get)
+   *
+   * @param string $accountId The account id to get the budget information for.
+   * @param string $billingId The billing id to get the budget information for.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_Budget
+   */
+  public function get($accountId, $billingId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'billingId' => $billingId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdExchangeBuyer_Budget");
+  }
+
+  /**
+   * Updates the budget amount for the budget of the adgroup specified by the
+   * accountId and billingId, with the budget amount in the request. This method
+   * supports patch semantics. (budget.patch)
+   *
+   * @param string $accountId The account id associated with the budget being
+   * updated.
+   * @param string $billingId The billing id associated with the budget being
+   * updated.
+   * @param Google_Budget $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_Budget
+   */
+  public function patch($accountId, $billingId, Google_Service_AdExchangeBuyer_Budget $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'billingId' => $billingId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_AdExchangeBuyer_Budget");
+  }
+
+  /**
+   * Updates the budget amount for the budget of the adgroup specified by the
+   * accountId and billingId, with the budget amount in the request.
+   * (budget.update)
+   *
+   * @param string $accountId The account id associated with the budget being
+   * updated.
+   * @param string $billingId The billing id associated with the budget being
+   * updated.
+   * @param Google_Budget $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_Budget
+   */
+  public function update($accountId, $billingId, Google_Service_AdExchangeBuyer_Budget $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'billingId' => $billingId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AdExchangeBuyer_Budget");
+  }
+}
+
+/**
+ * The "clientaccess" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangebuyerService = new Google_Service_AdExchangeBuyer(...);
+ *   $clientaccess = $adexchangebuyerService->clientaccess;
+ *  </code>
+ */
+class Google_Service_AdExchangeBuyer_Clientaccess_Resource extends Google_Service_Resource
+{
+
+  /**
+   * (clientaccess.delete)
+   *
+   * @param string $clientAccountId
+   * @param int $sponsorAccountId
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($clientAccountId, $sponsorAccountId, $optParams = array())
+  {
+    $params = array('clientAccountId' => $clientAccountId, 'sponsorAccountId' => $sponsorAccountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * (clientaccess.get)
+   *
+   * @param string $clientAccountId
+   * @param int $sponsorAccountId
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_ClientAccessCapabilities
+   */
+  public function get($clientAccountId, $sponsorAccountId, $optParams = array())
+  {
+    $params = array('clientAccountId' => $clientAccountId, 'sponsorAccountId' => $sponsorAccountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdExchangeBuyer_ClientAccessCapabilities");
+  }
+
+  /**
+   * (clientaccess.insert)
+   *
+   * @param Google_ClientAccessCapabilities $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string clientAccountId
+   * @opt_param int sponsorAccountId
+   * @return Google_Service_AdExchangeBuyer_ClientAccessCapabilities
+   */
+  public function insert(Google_Service_AdExchangeBuyer_ClientAccessCapabilities $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_AdExchangeBuyer_ClientAccessCapabilities");
+  }
+
+  /**
+   * (clientaccess.listClientaccess)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_ListClientAccessCapabilitiesResponse
+   */
+  public function listClientaccess($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeBuyer_ListClientAccessCapabilitiesResponse");
+  }
+
+  /**
+   * (clientaccess.patch)
+   *
+   * @param string $clientAccountId
+   * @param int $sponsorAccountId
+   * @param Google_ClientAccessCapabilities $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_ClientAccessCapabilities
+   */
+  public function patch($clientAccountId, $sponsorAccountId, Google_Service_AdExchangeBuyer_ClientAccessCapabilities $postBody, $optParams = array())
+  {
+    $params = array('clientAccountId' => $clientAccountId, 'sponsorAccountId' => $sponsorAccountId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_AdExchangeBuyer_ClientAccessCapabilities");
+  }
+
+  /**
+   * (clientaccess.update)
+   *
+   * @param string $clientAccountId
+   * @param int $sponsorAccountId
+   * @param Google_ClientAccessCapabilities $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_ClientAccessCapabilities
+   */
+  public function update($clientAccountId, $sponsorAccountId, Google_Service_AdExchangeBuyer_ClientAccessCapabilities $postBody, $optParams = array())
+  {
+    $params = array('clientAccountId' => $clientAccountId, 'sponsorAccountId' => $sponsorAccountId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AdExchangeBuyer_ClientAccessCapabilities");
+  }
+}
+
+/**
+ * The "creatives" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangebuyerService = new Google_Service_AdExchangeBuyer(...);
+ *   $creatives = $adexchangebuyerService->creatives;
+ *  </code>
+ */
+class Google_Service_AdExchangeBuyer_Creatives_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the status for a single creative. A creative will be available 30-40
+   * minutes after submission. (creatives.get)
+   *
+   * @param int $accountId The id for the account that will serve this creative.
+   * @param string $buyerCreativeId The buyer-specific id for this creative.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_Creative
+   */
+  public function get($accountId, $buyerCreativeId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'buyerCreativeId' => $buyerCreativeId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdExchangeBuyer_Creative");
+  }
+
+  /**
+   * Submit a new creative. (creatives.insert)
+   *
+   * @param Google_Creative $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_Creative
+   */
+  public function insert(Google_Service_AdExchangeBuyer_Creative $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_AdExchangeBuyer_Creative");
+  }
+
+  /**
+   * Retrieves a list of the authenticated user's active creatives. A creative
+   * will be available 30-40 minutes after submission. (creatives.listCreatives)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string openAuctionStatusFilter When specified, only creatives
+   * having the given open auction status are returned.
+   * @opt_param string maxResults Maximum number of entries returned on one result
+   * page. If not set, the default is 100. Optional.
+   * @opt_param string pageToken A continuation token, used to page through ad
+   * clients. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response. Optional.
+   * @opt_param string buyerCreativeId When specified, only creatives for the
+   * given buyer creative ids are returned.
+   * @opt_param string dealsStatusFilter When specified, only creatives having the
+   * given direct deals status are returned.
+   * @opt_param int accountId When specified, only creatives for the given account
+   * ids are returned.
+   * @return Google_Service_AdExchangeBuyer_CreativesList
+   */
+  public function listCreatives($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeBuyer_CreativesList");
+  }
+}
+
+/**
+ * The "deals" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangebuyerService = new Google_Service_AdExchangeBuyer(...);
+ *   $deals = $adexchangebuyerService->deals;
+ *  </code>
+ */
+class Google_Service_AdExchangeBuyer_Deals_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the requested deal. (deals.get)
+   *
+   * @param string $dealId
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_NegotiationDto
+   */
+  public function get($dealId, $optParams = array())
+  {
+    $params = array('dealId' => $dealId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdExchangeBuyer_NegotiationDto");
+  }
+}
+
+/**
+ * The "marketplacedeals" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangebuyerService = new Google_Service_AdExchangeBuyer(...);
+ *   $marketplacedeals = $adexchangebuyerService->marketplacedeals;
+ *  </code>
+ */
+class Google_Service_AdExchangeBuyer_Marketplacedeals_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete the specified deals from the order (marketplacedeals.delete)
+   *
+   * @param string $orderId The orderId to delete deals from.
+   * @param Google_DeleteOrderDealsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_DeleteOrderDealsResponse
+   */
+  public function delete($orderId, Google_Service_AdExchangeBuyer_DeleteOrderDealsRequest $postBody, $optParams = array())
+  {
+    $params = array('orderId' => $orderId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_AdExchangeBuyer_DeleteOrderDealsResponse");
+  }
+
+  /**
+   * Add new deals for the specified order (marketplacedeals.insert)
+   *
+   * @param string $orderId OrderId for which deals need to be added.
+   * @param Google_AddOrderDealsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_AddOrderDealsResponse
+   */
+  public function insert($orderId, Google_Service_AdExchangeBuyer_AddOrderDealsRequest $postBody, $optParams = array())
+  {
+    $params = array('orderId' => $orderId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_AdExchangeBuyer_AddOrderDealsResponse");
+  }
+
+  /**
+   * List all the deals for a given order (marketplacedeals.listMarketplacedeals)
+   *
+   * @param string $orderId The orderId to get deals for.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_GetOrderDealsResponse
+   */
+  public function listMarketplacedeals($orderId, $optParams = array())
+  {
+    $params = array('orderId' => $orderId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeBuyer_GetOrderDealsResponse");
+  }
+
+  /**
+   * Replaces all the deals in the order with the passed in deals
+   * (marketplacedeals.update)
+   *
+   * @param string $orderId The orderId to edit deals on.
+   * @param Google_EditAllOrderDealsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_EditAllOrderDealsResponse
+   */
+  public function update($orderId, Google_Service_AdExchangeBuyer_EditAllOrderDealsRequest $postBody, $optParams = array())
+  {
+    $params = array('orderId' => $orderId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AdExchangeBuyer_EditAllOrderDealsResponse");
+  }
+}
+
+/**
+ * The "marketplacenotes" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangebuyerService = new Google_Service_AdExchangeBuyer(...);
+ *   $marketplacenotes = $adexchangebuyerService->marketplacenotes;
+ *  </code>
+ */
+class Google_Service_AdExchangeBuyer_Marketplacenotes_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Add notes to the order (marketplacenotes.insert)
+   *
+   * @param string $orderId The orderId to add notes for.
+   * @param Google_AddOrderNotesRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_AddOrderNotesResponse
+   */
+  public function insert($orderId, Google_Service_AdExchangeBuyer_AddOrderNotesRequest $postBody, $optParams = array())
+  {
+    $params = array('orderId' => $orderId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_AdExchangeBuyer_AddOrderNotesResponse");
+  }
+
+  /**
+   * Get all the notes associated with an order
+   * (marketplacenotes.listMarketplacenotes)
+   *
+   * @param string $orderId The orderId to get notes for.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_GetOrderNotesResponse
+   */
+  public function listMarketplacenotes($orderId, $optParams = array())
+  {
+    $params = array('orderId' => $orderId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeBuyer_GetOrderNotesResponse");
+  }
+}
+
+/**
+ * The "marketplaceoffers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangebuyerService = new Google_Service_AdExchangeBuyer(...);
+ *   $marketplaceoffers = $adexchangebuyerService->marketplaceoffers;
+ *  </code>
+ */
+class Google_Service_AdExchangeBuyer_Marketplaceoffers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the requested negotiation. (marketplaceoffers.get)
+   *
+   * @param string $offerId The offerId for the offer to get the head revision
+   * for.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_MarketplaceOffer
+   */
+  public function get($offerId, $optParams = array())
+  {
+    $params = array('offerId' => $offerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdExchangeBuyer_MarketplaceOffer");
+  }
+
+  /**
+   * Gets the requested negotiation. (marketplaceoffers.search)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pqlQuery The pql query used to query for offers.
+   * @return Google_Service_AdExchangeBuyer_GetOffersResponse
+   */
+  public function search($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('search', array($params), "Google_Service_AdExchangeBuyer_GetOffersResponse");
+  }
+}
+
+/**
+ * The "marketplaceorders" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangebuyerService = new Google_Service_AdExchangeBuyer(...);
+ *   $marketplaceorders = $adexchangebuyerService->marketplaceorders;
+ *  </code>
+ */
+class Google_Service_AdExchangeBuyer_Marketplaceorders_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get an order given its id (marketplaceorders.get)
+   *
+   * @param string $orderId Id of the order to retrieve.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_MarketplaceOrder
+   */
+  public function get($orderId, $optParams = array())
+  {
+    $params = array('orderId' => $orderId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdExchangeBuyer_MarketplaceOrder");
+  }
+
+  /**
+   * Create the given list of orders (marketplaceorders.insert)
+   *
+   * @param Google_CreateOrdersRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_CreateOrdersResponse
+   */
+  public function insert(Google_Service_AdExchangeBuyer_CreateOrdersRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_AdExchangeBuyer_CreateOrdersResponse");
+  }
+
+  /**
+   * Update the given order. This method supports patch semantics.
+   * (marketplaceorders.patch)
+   *
+   * @param string $orderId The order id to update.
+   * @param string $revisionNumber The last known revision number to update. If
+   * the head revision in the marketplace database has since changed, an error
+   * will be thrown. The caller should then fetch the lastest order at head
+   * revision and retry the update at that revision.
+   * @param string $updateAction The proposed action to take on the order.
+   * @param Google_MarketplaceOrder $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_MarketplaceOrder
+   */
+  public function patch($orderId, $revisionNumber, $updateAction, Google_Service_AdExchangeBuyer_MarketplaceOrder $postBody, $optParams = array())
+  {
+    $params = array('orderId' => $orderId, 'revisionNumber' => $revisionNumber, 'updateAction' => $updateAction, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_AdExchangeBuyer_MarketplaceOrder");
+  }
+
+  /**
+   * Search for orders using pql query (marketplaceorders.search)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pqlQuery Query string to retrieve specific orders.
+   * @return Google_Service_AdExchangeBuyer_GetOrdersResponse
+   */
+  public function search($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('search', array($params), "Google_Service_AdExchangeBuyer_GetOrdersResponse");
+  }
+
+  /**
+   * Update the given order (marketplaceorders.update)
+   *
+   * @param string $orderId The order id to update.
+   * @param string $revisionNumber The last known revision number to update. If
+   * the head revision in the marketplace database has since changed, an error
+   * will be thrown. The caller should then fetch the lastest order at head
+   * revision and retry the update at that revision.
+   * @param string $updateAction The proposed action to take on the order.
+   * @param Google_MarketplaceOrder $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_MarketplaceOrder
+   */
+  public function update($orderId, $revisionNumber, $updateAction, Google_Service_AdExchangeBuyer_MarketplaceOrder $postBody, $optParams = array())
+  {
+    $params = array('orderId' => $orderId, 'revisionNumber' => $revisionNumber, 'updateAction' => $updateAction, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AdExchangeBuyer_MarketplaceOrder");
+  }
+}
+
+/**
+ * The "negotiationrounds" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangebuyerService = new Google_Service_AdExchangeBuyer(...);
+ *   $negotiationrounds = $adexchangebuyerService->negotiationrounds;
+ *  </code>
+ */
+class Google_Service_AdExchangeBuyer_Negotiationrounds_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Adds the requested negotiationRound to the requested negotiation.
+   * (negotiationrounds.insert)
+   *
+   * @param string $negotiationId
+   * @param Google_NegotiationRoundDto $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_NegotiationRoundDto
+   */
+  public function insert($negotiationId, Google_Service_AdExchangeBuyer_NegotiationRoundDto $postBody, $optParams = array())
+  {
+    $params = array('negotiationId' => $negotiationId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_AdExchangeBuyer_NegotiationRoundDto");
+  }
+}
+
+/**
+ * The "negotiations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangebuyerService = new Google_Service_AdExchangeBuyer(...);
+ *   $negotiations = $adexchangebuyerService->negotiations;
+ *  </code>
+ */
+class Google_Service_AdExchangeBuyer_Negotiations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the requested negotiation. (negotiations.get)
+   *
+   * @param string $negotiationId
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_NegotiationDto
+   */
+  public function get($negotiationId, $optParams = array())
+  {
+    $params = array('negotiationId' => $negotiationId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdExchangeBuyer_NegotiationDto");
+  }
+
+  /**
+   * Creates or updates the requested negotiation. (negotiations.insert)
+   *
+   * @param Google_NegotiationDto $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_NegotiationDto
+   */
+  public function insert(Google_Service_AdExchangeBuyer_NegotiationDto $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_AdExchangeBuyer_NegotiationDto");
+  }
+
+  /**
+   * Lists all negotiations the authenticated user has access to.
+   * (negotiations.listNegotiations)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_GetNegotiationsResponse
+   */
+  public function listNegotiations($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeBuyer_GetNegotiationsResponse");
+  }
+}
+
+/**
+ * The "offers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangebuyerService = new Google_Service_AdExchangeBuyer(...);
+ *   $offers = $adexchangebuyerService->offers;
+ *  </code>
+ */
+class Google_Service_AdExchangeBuyer_Offers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the requested offer. (offers.get)
+   *
+   * @param string $offerId
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_OfferDto
+   */
+  public function get($offerId, $optParams = array())
+  {
+    $params = array('offerId' => $offerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdExchangeBuyer_OfferDto");
+  }
+
+  /**
+   * Creates or updates the requested offer. (offers.insert)
+   *
+   * @param Google_OfferDto $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_OfferDto
+   */
+  public function insert(Google_Service_AdExchangeBuyer_OfferDto $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_AdExchangeBuyer_OfferDto");
+  }
+
+  /**
+   * Lists all offers the authenticated user has access to. (offers.listOffers)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_ListOffersResponse
+   */
+  public function listOffers($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeBuyer_ListOffersResponse");
+  }
+}
+
+/**
+ * The "performanceReport" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangebuyerService = new Google_Service_AdExchangeBuyer(...);
+ *   $performanceReport = $adexchangebuyerService->performanceReport;
+ *  </code>
+ */
+class Google_Service_AdExchangeBuyer_PerformanceReport_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the authenticated user's list of performance metrics.
+   * (performanceReport.listPerformanceReport)
+   *
+   * @param string $accountId The account id to get the reports.
+   * @param string $endDateTime The end time of the report in ISO 8601 timestamp
+   * format using UTC.
+   * @param string $startDateTime The start time of the report in ISO 8601
+   * timestamp format using UTC.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through
+   * performance reports. To retrieve the next page, set this parameter to the
+   * value of "nextPageToken" from the previous response. Optional.
+   * @opt_param string maxResults Maximum number of entries returned on one result
+   * page. If not set, the default is 100. Optional.
+   * @return Google_Service_AdExchangeBuyer_PerformanceReportList
+   */
+  public function listPerformanceReport($accountId, $endDateTime, $startDateTime, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'endDateTime' => $endDateTime, 'startDateTime' => $startDateTime);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeBuyer_PerformanceReportList");
+  }
+}
+
+/**
+ * The "pretargetingConfig" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangebuyerService = new Google_Service_AdExchangeBuyer(...);
+ *   $pretargetingConfig = $adexchangebuyerService->pretargetingConfig;
+ *  </code>
+ */
+class Google_Service_AdExchangeBuyer_PretargetingConfig_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes an existing pretargeting config. (pretargetingConfig.delete)
+   *
+   * @param string $accountId The account id to delete the pretargeting config
+   * for.
+   * @param string $configId The specific id of the configuration to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($accountId, $configId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'configId' => $configId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets a specific pretargeting configuration (pretargetingConfig.get)
+   *
+   * @param string $accountId The account id to get the pretargeting config for.
+   * @param string $configId The specific id of the configuration to retrieve.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_PretargetingConfig
+   */
+  public function get($accountId, $configId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'configId' => $configId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdExchangeBuyer_PretargetingConfig");
+  }
+
+  /**
+   * Inserts a new pretargeting configuration. (pretargetingConfig.insert)
+   *
+   * @param string $accountId The account id to insert the pretargeting config
+   * for.
+   * @param Google_PretargetingConfig $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_PretargetingConfig
+   */
+  public function insert($accountId, Google_Service_AdExchangeBuyer_PretargetingConfig $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_AdExchangeBuyer_PretargetingConfig");
+  }
+
+  /**
+   * Retrieves a list of the authenticated user's pretargeting configurations.
+   * (pretargetingConfig.listPretargetingConfig)
+   *
+   * @param string $accountId The account id to get the pretargeting configs for.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_PretargetingConfigList
+   */
+  public function listPretargetingConfig($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeBuyer_PretargetingConfigList");
+  }
+
+  /**
+   * Updates an existing pretargeting config. This method supports patch
+   * semantics. (pretargetingConfig.patch)
+   *
+   * @param string $accountId The account id to update the pretargeting config
+   * for.
+   * @param string $configId The specific id of the configuration to update.
+   * @param Google_PretargetingConfig $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_PretargetingConfig
+   */
+  public function patch($accountId, $configId, Google_Service_AdExchangeBuyer_PretargetingConfig $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'configId' => $configId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_AdExchangeBuyer_PretargetingConfig");
+  }
+
+  /**
+   * Updates an existing pretargeting config. (pretargetingConfig.update)
+   *
+   * @param string $accountId The account id to update the pretargeting config
+   * for.
+   * @param string $configId The specific id of the configuration to update.
+   * @param Google_PretargetingConfig $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeBuyer_PretargetingConfig
+   */
+  public function update($accountId, $configId, Google_Service_AdExchangeBuyer_PretargetingConfig $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'configId' => $configId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AdExchangeBuyer_PretargetingConfig");
+  }
+}
+
+
+
+
+class Google_Service_AdExchangeBuyer_Account extends Google_Collection
+{
+  protected $collection_key = 'bidderLocation';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $bidderLocationType = 'Google_Service_AdExchangeBuyer_AccountBidderLocation';
+  protected $bidderLocationDataType = 'array';
+  public $cookieMatchingNid;
+  public $cookieMatchingUrl;
+  public $id;
+  public $kind;
+  public $maximumActiveCreatives;
+  public $maximumTotalQps;
+  public $numberActiveCreatives;
+
+
+  public function setBidderLocation($bidderLocation)
+  {
+    $this->bidderLocation = $bidderLocation;
+  }
+  public function getBidderLocation()
+  {
+    return $this->bidderLocation;
+  }
+  public function setCookieMatchingNid($cookieMatchingNid)
+  {
+    $this->cookieMatchingNid = $cookieMatchingNid;
+  }
+  public function getCookieMatchingNid()
+  {
+    return $this->cookieMatchingNid;
+  }
+  public function setCookieMatchingUrl($cookieMatchingUrl)
+  {
+    $this->cookieMatchingUrl = $cookieMatchingUrl;
+  }
+  public function getCookieMatchingUrl()
+  {
+    return $this->cookieMatchingUrl;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMaximumActiveCreatives($maximumActiveCreatives)
+  {
+    $this->maximumActiveCreatives = $maximumActiveCreatives;
+  }
+  public function getMaximumActiveCreatives()
+  {
+    return $this->maximumActiveCreatives;
+  }
+  public function setMaximumTotalQps($maximumTotalQps)
+  {
+    $this->maximumTotalQps = $maximumTotalQps;
+  }
+  public function getMaximumTotalQps()
+  {
+    return $this->maximumTotalQps;
+  }
+  public function setNumberActiveCreatives($numberActiveCreatives)
+  {
+    $this->numberActiveCreatives = $numberActiveCreatives;
+  }
+  public function getNumberActiveCreatives()
+  {
+    return $this->numberActiveCreatives;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_AccountBidderLocation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $maximumQps;
+  public $region;
+  public $url;
+
+
+  public function setMaximumQps($maximumQps)
+  {
+    $this->maximumQps = $maximumQps;
+  }
+  public function getMaximumQps()
+  {
+    return $this->maximumQps;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_AccountsList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_AdExchangeBuyer_Account';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_AdSize extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_AdSlotDto extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $channelCode;
+  public $channelId;
+  public $description;
+  public $name;
+  public $size;
+  public $webPropertyId;
+
+
+  public function setChannelCode($channelCode)
+  {
+    $this->channelCode = $channelCode;
+  }
+  public function getChannelCode()
+  {
+    return $this->channelCode;
+  }
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSize($size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+  public function setWebPropertyId($webPropertyId)
+  {
+    $this->webPropertyId = $webPropertyId;
+  }
+  public function getWebPropertyId()
+  {
+    return $this->webPropertyId;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_AddOrderDealsRequest extends Google_Collection
+{
+  protected $collection_key = 'deals';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $dealsType = 'Google_Service_AdExchangeBuyer_MarketplaceDeal';
+  protected $dealsDataType = 'array';
+  public $orderRevisionNumber;
+  public $updateAction;
+
+
+  public function setDeals($deals)
+  {
+    $this->deals = $deals;
+  }
+  public function getDeals()
+  {
+    return $this->deals;
+  }
+  public function setOrderRevisionNumber($orderRevisionNumber)
+  {
+    $this->orderRevisionNumber = $orderRevisionNumber;
+  }
+  public function getOrderRevisionNumber()
+  {
+    return $this->orderRevisionNumber;
+  }
+  public function setUpdateAction($updateAction)
+  {
+    $this->updateAction = $updateAction;
+  }
+  public function getUpdateAction()
+  {
+    return $this->updateAction;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_AddOrderDealsResponse extends Google_Collection
+{
+  protected $collection_key = 'deals';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $dealsType = 'Google_Service_AdExchangeBuyer_MarketplaceDeal';
+  protected $dealsDataType = 'array';
+  public $orderRevisionNumber;
+
+
+  public function setDeals($deals)
+  {
+    $this->deals = $deals;
+  }
+  public function getDeals()
+  {
+    return $this->deals;
+  }
+  public function setOrderRevisionNumber($orderRevisionNumber)
+  {
+    $this->orderRevisionNumber = $orderRevisionNumber;
+  }
+  public function getOrderRevisionNumber()
+  {
+    return $this->orderRevisionNumber;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_AddOrderNotesRequest extends Google_Collection
+{
+  protected $collection_key = 'notes';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $notesType = 'Google_Service_AdExchangeBuyer_MarketplaceNote';
+  protected $notesDataType = 'array';
+
+
+  public function setNotes($notes)
+  {
+    $this->notes = $notes;
+  }
+  public function getNotes()
+  {
+    return $this->notes;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_AddOrderNotesResponse extends Google_Collection
+{
+  protected $collection_key = 'notes';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $notesType = 'Google_Service_AdExchangeBuyer_MarketplaceNote';
+  protected $notesDataType = 'array';
+
+
+  public function setNotes($notes)
+  {
+    $this->notes = $notes;
+  }
+  public function getNotes()
+  {
+    return $this->notes;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_AdvertiserDto extends Google_Collection
+{
+  protected $collection_key = 'brands';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $brandsType = 'Google_Service_AdExchangeBuyer_BrandDto';
+  protected $brandsDataType = 'array';
+  public $id;
+  public $name;
+  public $status;
+
+
+  public function setBrands($brands)
+  {
+    $this->brands = $brands;
+  }
+  public function getBrands()
+  {
+    return $this->brands;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_AudienceSegment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $id;
+  public $name;
+  public $numCookies;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNumCookies($numCookies)
+  {
+    $this->numCookies = $numCookies;
+  }
+  public function getNumCookies()
+  {
+    return $this->numCookies;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_BillingInfo extends Google_Collection
+{
+  protected $collection_key = 'billingId';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $accountName;
+  public $billingId;
+  public $kind;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAccountName($accountName)
+  {
+    $this->accountName = $accountName;
+  }
+  public function getAccountName()
+  {
+    return $this->accountName;
+  }
+  public function setBillingId($billingId)
+  {
+    $this->billingId = $billingId;
+  }
+  public function getBillingId()
+  {
+    return $this->billingId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_BillingInfoList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_AdExchangeBuyer_BillingInfo';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_BrandDto extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $advertiserId;
+  public $id;
+  public $name;
+
+
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_Budget extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $billingId;
+  public $budgetAmount;
+  public $currencyCode;
+  public $id;
+  public $kind;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setBillingId($billingId)
+  {
+    $this->billingId = $billingId;
+  }
+  public function getBillingId()
+  {
+    return $this->billingId;
+  }
+  public function setBudgetAmount($budgetAmount)
+  {
+    $this->budgetAmount = $budgetAmount;
+  }
+  public function getBudgetAmount()
+  {
+    return $this->budgetAmount;
+  }
+  public function setCurrencyCode($currencyCode)
+  {
+    $this->currencyCode = $currencyCode;
+  }
+  public function getCurrencyCode()
+  {
+    return $this->currencyCode;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_Buyer extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_BuyerDto extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $customerId;
+  public $displayName;
+  public $enabledForInterestTargetingDeals;
+  public $enabledForPreferredDeals;
+  public $id;
+  public $sponsorAccountId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setCustomerId($customerId)
+  {
+    $this->customerId = $customerId;
+  }
+  public function getCustomerId()
+  {
+    return $this->customerId;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setEnabledForInterestTargetingDeals($enabledForInterestTargetingDeals)
+  {
+    $this->enabledForInterestTargetingDeals = $enabledForInterestTargetingDeals;
+  }
+  public function getEnabledForInterestTargetingDeals()
+  {
+    return $this->enabledForInterestTargetingDeals;
+  }
+  public function setEnabledForPreferredDeals($enabledForPreferredDeals)
+  {
+    $this->enabledForPreferredDeals = $enabledForPreferredDeals;
+  }
+  public function getEnabledForPreferredDeals()
+  {
+    return $this->enabledForPreferredDeals;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setSponsorAccountId($sponsorAccountId)
+  {
+    $this->sponsorAccountId = $sponsorAccountId;
+  }
+  public function getSponsorAccountId()
+  {
+    return $this->sponsorAccountId;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_ClientAccessCapabilities extends Google_Collection
+{
+  protected $collection_key = 'capabilities';
+  protected $internal_gapi_mappings = array(
+  );
+  public $capabilities;
+  public $clientAccountId;
+
+
+  public function setCapabilities($capabilities)
+  {
+    $this->capabilities = $capabilities;
+  }
+  public function getCapabilities()
+  {
+    return $this->capabilities;
+  }
+  public function setClientAccountId($clientAccountId)
+  {
+    $this->clientAccountId = $clientAccountId;
+  }
+  public function getClientAccountId()
+  {
+    return $this->clientAccountId;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_ContactInformation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $email;
+  public $name;
+
+
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_CreateOrdersRequest extends Google_Collection
+{
+  protected $collection_key = 'orders';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $ordersType = 'Google_Service_AdExchangeBuyer_MarketplaceOrder';
+  protected $ordersDataType = 'array';
+  public $webPropertyCode;
+
+
+  public function setOrders($orders)
+  {
+    $this->orders = $orders;
+  }
+  public function getOrders()
+  {
+    return $this->orders;
+  }
+  public function setWebPropertyCode($webPropertyCode)
+  {
+    $this->webPropertyCode = $webPropertyCode;
+  }
+  public function getWebPropertyCode()
+  {
+    return $this->webPropertyCode;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_CreateOrdersResponse extends Google_Collection
+{
+  protected $collection_key = 'orders';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $ordersType = 'Google_Service_AdExchangeBuyer_MarketplaceOrder';
+  protected $ordersDataType = 'array';
+
+
+  public function setOrders($orders)
+  {
+    $this->orders = $orders;
+  }
+  public function getOrders()
+  {
+    return $this->orders;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_Creative extends Google_Collection
+{
+  protected $collection_key = 'vendorType';
+  protected $internal_gapi_mappings = array(
+        "hTMLSnippet" => "HTMLSnippet",
+        "apiUploadTimestamp" => "api_upload_timestamp",
+  );
+  public $hTMLSnippet;
+  public $accountId;
+  public $advertiserId;
+  public $advertiserName;
+  public $agencyId;
+  public $apiUploadTimestamp;
+  public $attribute;
+  public $buyerCreativeId;
+  public $clickThroughUrl;
+  protected $correctionsType = 'Google_Service_AdExchangeBuyer_CreativeCorrections';
+  protected $correctionsDataType = 'array';
+  public $dealsStatus;
+  protected $filteringReasonsType = 'Google_Service_AdExchangeBuyer_CreativeFilteringReasons';
+  protected $filteringReasonsDataType = '';
+  public $height;
+  public $impressionTrackingUrl;
+  public $kind;
+  protected $nativeAdType = 'Google_Service_AdExchangeBuyer_CreativeNativeAd';
+  protected $nativeAdDataType = '';
+  public $openAuctionStatus;
+  public $productCategories;
+  public $restrictedCategories;
+  public $sensitiveCategories;
+  protected $servingRestrictionsType = 'Google_Service_AdExchangeBuyer_CreativeServingRestrictions';
+  protected $servingRestrictionsDataType = 'array';
+  public $vendorType;
+  public $version;
+  public $videoURL;
+  public $width;
+
+
+  public function setHTMLSnippet($hTMLSnippet)
+  {
+    $this->hTMLSnippet = $hTMLSnippet;
+  }
+  public function getHTMLSnippet()
+  {
+    return $this->hTMLSnippet;
+  }
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAdvertiserName($advertiserName)
+  {
+    $this->advertiserName = $advertiserName;
+  }
+  public function getAdvertiserName()
+  {
+    return $this->advertiserName;
+  }
+  public function setAgencyId($agencyId)
+  {
+    $this->agencyId = $agencyId;
+  }
+  public function getAgencyId()
+  {
+    return $this->agencyId;
+  }
+  public function setApiUploadTimestamp($apiUploadTimestamp)
+  {
+    $this->apiUploadTimestamp = $apiUploadTimestamp;
+  }
+  public function getApiUploadTimestamp()
+  {
+    return $this->apiUploadTimestamp;
+  }
+  public function setAttribute($attribute)
+  {
+    $this->attribute = $attribute;
+  }
+  public function getAttribute()
+  {
+    return $this->attribute;
+  }
+  public function setBuyerCreativeId($buyerCreativeId)
+  {
+    $this->buyerCreativeId = $buyerCreativeId;
+  }
+  public function getBuyerCreativeId()
+  {
+    return $this->buyerCreativeId;
+  }
+  public function setClickThroughUrl($clickThroughUrl)
+  {
+    $this->clickThroughUrl = $clickThroughUrl;
+  }
+  public function getClickThroughUrl()
+  {
+    return $this->clickThroughUrl;
+  }
+  public function setCorrections($corrections)
+  {
+    $this->corrections = $corrections;
+  }
+  public function getCorrections()
+  {
+    return $this->corrections;
+  }
+  public function setDealsStatus($dealsStatus)
+  {
+    $this->dealsStatus = $dealsStatus;
+  }
+  public function getDealsStatus()
+  {
+    return $this->dealsStatus;
+  }
+  public function setFilteringReasons(Google_Service_AdExchangeBuyer_CreativeFilteringReasons $filteringReasons)
+  {
+    $this->filteringReasons = $filteringReasons;
+  }
+  public function getFilteringReasons()
+  {
+    return $this->filteringReasons;
+  }
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setImpressionTrackingUrl($impressionTrackingUrl)
+  {
+    $this->impressionTrackingUrl = $impressionTrackingUrl;
+  }
+  public function getImpressionTrackingUrl()
+  {
+    return $this->impressionTrackingUrl;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNativeAd(Google_Service_AdExchangeBuyer_CreativeNativeAd $nativeAd)
+  {
+    $this->nativeAd = $nativeAd;
+  }
+  public function getNativeAd()
+  {
+    return $this->nativeAd;
+  }
+  public function setOpenAuctionStatus($openAuctionStatus)
+  {
+    $this->openAuctionStatus = $openAuctionStatus;
+  }
+  public function getOpenAuctionStatus()
+  {
+    return $this->openAuctionStatus;
+  }
+  public function setProductCategories($productCategories)
+  {
+    $this->productCategories = $productCategories;
+  }
+  public function getProductCategories()
+  {
+    return $this->productCategories;
+  }
+  public function setRestrictedCategories($restrictedCategories)
+  {
+    $this->restrictedCategories = $restrictedCategories;
+  }
+  public function getRestrictedCategories()
+  {
+    return $this->restrictedCategories;
+  }
+  public function setSensitiveCategories($sensitiveCategories)
+  {
+    $this->sensitiveCategories = $sensitiveCategories;
+  }
+  public function getSensitiveCategories()
+  {
+    return $this->sensitiveCategories;
+  }
+  public function setServingRestrictions($servingRestrictions)
+  {
+    $this->servingRestrictions = $servingRestrictions;
+  }
+  public function getServingRestrictions()
+  {
+    return $this->servingRestrictions;
+  }
+  public function setVendorType($vendorType)
+  {
+    $this->vendorType = $vendorType;
+  }
+  public function getVendorType()
+  {
+    return $this->vendorType;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+  public function setVideoURL($videoURL)
+  {
+    $this->videoURL = $videoURL;
+  }
+  public function getVideoURL()
+  {
+    return $this->videoURL;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_CreativeCorrections extends Google_Collection
+{
+  protected $collection_key = 'details';
+  protected $internal_gapi_mappings = array(
+  );
+  public $details;
+  public $reason;
+
+
+  public function setDetails($details)
+  {
+    $this->details = $details;
+  }
+  public function getDetails()
+  {
+    return $this->details;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_CreativeFilteringReasons extends Google_Collection
+{
+  protected $collection_key = 'reasons';
+  protected $internal_gapi_mappings = array(
+  );
+  public $date;
+  protected $reasonsType = 'Google_Service_AdExchangeBuyer_CreativeFilteringReasonsReasons';
+  protected $reasonsDataType = 'array';
+
+
+  public function setDate($date)
+  {
+    $this->date = $date;
+  }
+  public function getDate()
+  {
+    return $this->date;
+  }
+  public function setReasons($reasons)
+  {
+    $this->reasons = $reasons;
+  }
+  public function getReasons()
+  {
+    return $this->reasons;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_CreativeFilteringReasonsReasons extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $filteringCount;
+  public $filteringStatus;
+
+
+  public function setFilteringCount($filteringCount)
+  {
+    $this->filteringCount = $filteringCount;
+  }
+  public function getFilteringCount()
+  {
+    return $this->filteringCount;
+  }
+  public function setFilteringStatus($filteringStatus)
+  {
+    $this->filteringStatus = $filteringStatus;
+  }
+  public function getFilteringStatus()
+  {
+    return $this->filteringStatus;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_CreativeNativeAd extends Google_Collection
+{
+  protected $collection_key = 'impressionTrackingUrl';
+  protected $internal_gapi_mappings = array(
+  );
+  public $advertiser;
+  protected $appIconType = 'Google_Service_AdExchangeBuyer_CreativeNativeAdAppIcon';
+  protected $appIconDataType = '';
+  public $body;
+  public $callToAction;
+  public $clickTrackingUrl;
+  public $headline;
+  protected $imageType = 'Google_Service_AdExchangeBuyer_CreativeNativeAdImage';
+  protected $imageDataType = '';
+  public $impressionTrackingUrl;
+  protected $logoType = 'Google_Service_AdExchangeBuyer_CreativeNativeAdLogo';
+  protected $logoDataType = '';
+  public $price;
+  public $starRating;
+  public $store;
+
+
+  public function setAdvertiser($advertiser)
+  {
+    $this->advertiser = $advertiser;
+  }
+  public function getAdvertiser()
+  {
+    return $this->advertiser;
+  }
+  public function setAppIcon(Google_Service_AdExchangeBuyer_CreativeNativeAdAppIcon $appIcon)
+  {
+    $this->appIcon = $appIcon;
+  }
+  public function getAppIcon()
+  {
+    return $this->appIcon;
+  }
+  public function setBody($body)
+  {
+    $this->body = $body;
+  }
+  public function getBody()
+  {
+    return $this->body;
+  }
+  public function setCallToAction($callToAction)
+  {
+    $this->callToAction = $callToAction;
+  }
+  public function getCallToAction()
+  {
+    return $this->callToAction;
+  }
+  public function setClickTrackingUrl($clickTrackingUrl)
+  {
+    $this->clickTrackingUrl = $clickTrackingUrl;
+  }
+  public function getClickTrackingUrl()
+  {
+    return $this->clickTrackingUrl;
+  }
+  public function setHeadline($headline)
+  {
+    $this->headline = $headline;
+  }
+  public function getHeadline()
+  {
+    return $this->headline;
+  }
+  public function setImage(Google_Service_AdExchangeBuyer_CreativeNativeAdImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setImpressionTrackingUrl($impressionTrackingUrl)
+  {
+    $this->impressionTrackingUrl = $impressionTrackingUrl;
+  }
+  public function getImpressionTrackingUrl()
+  {
+    return $this->impressionTrackingUrl;
+  }
+  public function setLogo(Google_Service_AdExchangeBuyer_CreativeNativeAdLogo $logo)
+  {
+    $this->logo = $logo;
+  }
+  public function getLogo()
+  {
+    return $this->logo;
+  }
+  public function setPrice($price)
+  {
+    $this->price = $price;
+  }
+  public function getPrice()
+  {
+    return $this->price;
+  }
+  public function setStarRating($starRating)
+  {
+    $this->starRating = $starRating;
+  }
+  public function getStarRating()
+  {
+    return $this->starRating;
+  }
+  public function setStore($store)
+  {
+    $this->store = $store;
+  }
+  public function getStore()
+  {
+    return $this->store;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_CreativeNativeAdAppIcon extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $url;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_CreativeNativeAdImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $url;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_CreativeNativeAdLogo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $url;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_CreativeServingRestrictions extends Google_Collection
+{
+  protected $collection_key = 'disapprovalReasons';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $contextsType = 'Google_Service_AdExchangeBuyer_CreativeServingRestrictionsContexts';
+  protected $contextsDataType = 'array';
+  protected $disapprovalReasonsType = 'Google_Service_AdExchangeBuyer_CreativeServingRestrictionsDisapprovalReasons';
+  protected $disapprovalReasonsDataType = 'array';
+  public $reason;
+
+
+  public function setContexts($contexts)
+  {
+    $this->contexts = $contexts;
+  }
+  public function getContexts()
+  {
+    return $this->contexts;
+  }
+  public function setDisapprovalReasons($disapprovalReasons)
+  {
+    $this->disapprovalReasons = $disapprovalReasons;
+  }
+  public function getDisapprovalReasons()
+  {
+    return $this->disapprovalReasons;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_CreativeServingRestrictionsContexts extends Google_Collection
+{
+  protected $collection_key = 'platform';
+  protected $internal_gapi_mappings = array(
+  );
+  public $auctionType;
+  public $contextType;
+  public $geoCriteriaId;
+  public $platform;
+
+
+  public function setAuctionType($auctionType)
+  {
+    $this->auctionType = $auctionType;
+  }
+  public function getAuctionType()
+  {
+    return $this->auctionType;
+  }
+  public function setContextType($contextType)
+  {
+    $this->contextType = $contextType;
+  }
+  public function getContextType()
+  {
+    return $this->contextType;
+  }
+  public function setGeoCriteriaId($geoCriteriaId)
+  {
+    $this->geoCriteriaId = $geoCriteriaId;
+  }
+  public function getGeoCriteriaId()
+  {
+    return $this->geoCriteriaId;
+  }
+  public function setPlatform($platform)
+  {
+    $this->platform = $platform;
+  }
+  public function getPlatform()
+  {
+    return $this->platform;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_CreativeServingRestrictionsDisapprovalReasons extends Google_Collection
+{
+  protected $collection_key = 'details';
+  protected $internal_gapi_mappings = array(
+  );
+  public $details;
+  public $reason;
+
+
+  public function setDetails($details)
+  {
+    $this->details = $details;
+  }
+  public function getDetails()
+  {
+    return $this->details;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_CreativesList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_AdExchangeBuyer_Creative';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_DateTime extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $day;
+  public $hour;
+  public $minute;
+  public $month;
+  public $second;
+  public $timeZoneId;
+  public $year;
+
+
+  public function setDay($day)
+  {
+    $this->day = $day;
+  }
+  public function getDay()
+  {
+    return $this->day;
+  }
+  public function setHour($hour)
+  {
+    $this->hour = $hour;
+  }
+  public function getHour()
+  {
+    return $this->hour;
+  }
+  public function setMinute($minute)
+  {
+    $this->minute = $minute;
+  }
+  public function getMinute()
+  {
+    return $this->minute;
+  }
+  public function setMonth($month)
+  {
+    $this->month = $month;
+  }
+  public function getMonth()
+  {
+    return $this->month;
+  }
+  public function setSecond($second)
+  {
+    $this->second = $second;
+  }
+  public function getSecond()
+  {
+    return $this->second;
+  }
+  public function setTimeZoneId($timeZoneId)
+  {
+    $this->timeZoneId = $timeZoneId;
+  }
+  public function getTimeZoneId()
+  {
+    return $this->timeZoneId;
+  }
+  public function setYear($year)
+  {
+    $this->year = $year;
+  }
+  public function getYear()
+  {
+    return $this->year;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_DealPartyDto extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $buyerType = 'Google_Service_AdExchangeBuyer_BuyerDto';
+  protected $buyerDataType = '';
+  public $buyerSellerRole;
+  public $customerId;
+  public $name;
+  protected $webPropertyType = 'Google_Service_AdExchangeBuyer_WebPropertyDto';
+  protected $webPropertyDataType = '';
+
+
+  public function setBuyer(Google_Service_AdExchangeBuyer_BuyerDto $buyer)
+  {
+    $this->buyer = $buyer;
+  }
+  public function getBuyer()
+  {
+    return $this->buyer;
+  }
+  public function setBuyerSellerRole($buyerSellerRole)
+  {
+    $this->buyerSellerRole = $buyerSellerRole;
+  }
+  public function getBuyerSellerRole()
+  {
+    return $this->buyerSellerRole;
+  }
+  public function setCustomerId($customerId)
+  {
+    $this->customerId = $customerId;
+  }
+  public function getCustomerId()
+  {
+    return $this->customerId;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setWebProperty(Google_Service_AdExchangeBuyer_WebPropertyDto $webProperty)
+  {
+    $this->webProperty = $webProperty;
+  }
+  public function getWebProperty()
+  {
+    return $this->webProperty;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_DealTerms extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  protected $guaranteedFixedPriceTermsType = 'Google_Service_AdExchangeBuyer_DealTermsGuaranteedFixedPriceTerms';
+  protected $guaranteedFixedPriceTermsDataType = '';
+  protected $nonGuaranteedAuctionTermsType = 'Google_Service_AdExchangeBuyer_DealTermsNonGuaranteedAuctionTerms';
+  protected $nonGuaranteedAuctionTermsDataType = '';
+  protected $nonGuaranteedFixedPriceTermsType = 'Google_Service_AdExchangeBuyer_DealTermsNonGuaranteedFixedPriceTerms';
+  protected $nonGuaranteedFixedPriceTermsDataType = '';
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setGuaranteedFixedPriceTerms(Google_Service_AdExchangeBuyer_DealTermsGuaranteedFixedPriceTerms $guaranteedFixedPriceTerms)
+  {
+    $this->guaranteedFixedPriceTerms = $guaranteedFixedPriceTerms;
+  }
+  public function getGuaranteedFixedPriceTerms()
+  {
+    return $this->guaranteedFixedPriceTerms;
+  }
+  public function setNonGuaranteedAuctionTerms(Google_Service_AdExchangeBuyer_DealTermsNonGuaranteedAuctionTerms $nonGuaranteedAuctionTerms)
+  {
+    $this->nonGuaranteedAuctionTerms = $nonGuaranteedAuctionTerms;
+  }
+  public function getNonGuaranteedAuctionTerms()
+  {
+    return $this->nonGuaranteedAuctionTerms;
+  }
+  public function setNonGuaranteedFixedPriceTerms(Google_Service_AdExchangeBuyer_DealTermsNonGuaranteedFixedPriceTerms $nonGuaranteedFixedPriceTerms)
+  {
+    $this->nonGuaranteedFixedPriceTerms = $nonGuaranteedFixedPriceTerms;
+  }
+  public function getNonGuaranteedFixedPriceTerms()
+  {
+    return $this->nonGuaranteedFixedPriceTerms;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_DealTermsGuaranteedFixedPriceTerms extends Google_Collection
+{
+  protected $collection_key = 'fixedPrices';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $fixedPricesType = 'Google_Service_AdExchangeBuyer_PricePerBuyer';
+  protected $fixedPricesDataType = 'array';
+  public $guaranteedImpressions;
+  public $guaranteedLooks;
+
+
+  public function setFixedPrices($fixedPrices)
+  {
+    $this->fixedPrices = $fixedPrices;
+  }
+  public function getFixedPrices()
+  {
+    return $this->fixedPrices;
+  }
+  public function setGuaranteedImpressions($guaranteedImpressions)
+  {
+    $this->guaranteedImpressions = $guaranteedImpressions;
+  }
+  public function getGuaranteedImpressions()
+  {
+    return $this->guaranteedImpressions;
+  }
+  public function setGuaranteedLooks($guaranteedLooks)
+  {
+    $this->guaranteedLooks = $guaranteedLooks;
+  }
+  public function getGuaranteedLooks()
+  {
+    return $this->guaranteedLooks;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_DealTermsNonGuaranteedAuctionTerms extends Google_Collection
+{
+  protected $collection_key = 'reservePricePerBuyers';
+  protected $internal_gapi_mappings = array(
+  );
+  public $privateAuctionId;
+  protected $reservePricePerBuyersType = 'Google_Service_AdExchangeBuyer_PricePerBuyer';
+  protected $reservePricePerBuyersDataType = 'array';
+
+
+  public function setPrivateAuctionId($privateAuctionId)
+  {
+    $this->privateAuctionId = $privateAuctionId;
+  }
+  public function getPrivateAuctionId()
+  {
+    return $this->privateAuctionId;
+  }
+  public function setReservePricePerBuyers($reservePricePerBuyers)
+  {
+    $this->reservePricePerBuyers = $reservePricePerBuyers;
+  }
+  public function getReservePricePerBuyers()
+  {
+    return $this->reservePricePerBuyers;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_DealTermsNonGuaranteedFixedPriceTerms extends Google_Collection
+{
+  protected $collection_key = 'fixedPrices';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $fixedPricesType = 'Google_Service_AdExchangeBuyer_PricePerBuyer';
+  protected $fixedPricesDataType = 'array';
+
+
+  public function setFixedPrices($fixedPrices)
+  {
+    $this->fixedPrices = $fixedPrices;
+  }
+  public function getFixedPrices()
+  {
+    return $this->fixedPrices;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_DeleteOrderDealsRequest extends Google_Collection
+{
+  protected $collection_key = 'dealIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $dealIds;
+  public $orderRevisionNumber;
+  public $updateAction;
+
+
+  public function setDealIds($dealIds)
+  {
+    $this->dealIds = $dealIds;
+  }
+  public function getDealIds()
+  {
+    return $this->dealIds;
+  }
+  public function setOrderRevisionNumber($orderRevisionNumber)
+  {
+    $this->orderRevisionNumber = $orderRevisionNumber;
+  }
+  public function getOrderRevisionNumber()
+  {
+    return $this->orderRevisionNumber;
+  }
+  public function setUpdateAction($updateAction)
+  {
+    $this->updateAction = $updateAction;
+  }
+  public function getUpdateAction()
+  {
+    return $this->updateAction;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_DeleteOrderDealsResponse extends Google_Collection
+{
+  protected $collection_key = 'deals';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $dealsType = 'Google_Service_AdExchangeBuyer_MarketplaceDeal';
+  protected $dealsDataType = 'array';
+  public $orderRevisionNumber;
+
+
+  public function setDeals($deals)
+  {
+    $this->deals = $deals;
+  }
+  public function getDeals()
+  {
+    return $this->deals;
+  }
+  public function setOrderRevisionNumber($orderRevisionNumber)
+  {
+    $this->orderRevisionNumber = $orderRevisionNumber;
+  }
+  public function getOrderRevisionNumber()
+  {
+    return $this->orderRevisionNumber;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_DeliveryControl extends Google_Collection
+{
+  protected $collection_key = 'frequencyCaps';
+  protected $internal_gapi_mappings = array(
+  );
+  public $deliveryRateType;
+  protected $frequencyCapsType = 'Google_Service_AdExchangeBuyer_DeliveryControlFrequencyCap';
+  protected $frequencyCapsDataType = 'array';
+
+
+  public function setDeliveryRateType($deliveryRateType)
+  {
+    $this->deliveryRateType = $deliveryRateType;
+  }
+  public function getDeliveryRateType()
+  {
+    return $this->deliveryRateType;
+  }
+  public function setFrequencyCaps($frequencyCaps)
+  {
+    $this->frequencyCaps = $frequencyCaps;
+  }
+  public function getFrequencyCaps()
+  {
+    return $this->frequencyCaps;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_DeliveryControlFrequencyCap extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $maxImpressions;
+  public $numTimeUnits;
+  public $timeUnitType;
+
+
+  public function setMaxImpressions($maxImpressions)
+  {
+    $this->maxImpressions = $maxImpressions;
+  }
+  public function getMaxImpressions()
+  {
+    return $this->maxImpressions;
+  }
+  public function setNumTimeUnits($numTimeUnits)
+  {
+    $this->numTimeUnits = $numTimeUnits;
+  }
+  public function getNumTimeUnits()
+  {
+    return $this->numTimeUnits;
+  }
+  public function setTimeUnitType($timeUnitType)
+  {
+    $this->timeUnitType = $timeUnitType;
+  }
+  public function getTimeUnitType()
+  {
+    return $this->timeUnitType;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_EditAllOrderDealsRequest extends Google_Collection
+{
+  protected $collection_key = 'deals';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $dealsType = 'Google_Service_AdExchangeBuyer_MarketplaceDeal';
+  protected $dealsDataType = 'array';
+  protected $orderType = 'Google_Service_AdExchangeBuyer_MarketplaceOrder';
+  protected $orderDataType = '';
+  public $orderRevisionNumber;
+  public $updateAction;
+
+
+  public function setDeals($deals)
+  {
+    $this->deals = $deals;
+  }
+  public function getDeals()
+  {
+    return $this->deals;
+  }
+  public function setOrder(Google_Service_AdExchangeBuyer_MarketplaceOrder $order)
+  {
+    $this->order = $order;
+  }
+  public function getOrder()
+  {
+    return $this->order;
+  }
+  public function setOrderRevisionNumber($orderRevisionNumber)
+  {
+    $this->orderRevisionNumber = $orderRevisionNumber;
+  }
+  public function getOrderRevisionNumber()
+  {
+    return $this->orderRevisionNumber;
+  }
+  public function setUpdateAction($updateAction)
+  {
+    $this->updateAction = $updateAction;
+  }
+  public function getUpdateAction()
+  {
+    return $this->updateAction;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_EditAllOrderDealsResponse extends Google_Collection
+{
+  protected $collection_key = 'deals';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $dealsType = 'Google_Service_AdExchangeBuyer_MarketplaceDeal';
+  protected $dealsDataType = 'array';
+
+
+  public function setDeals($deals)
+  {
+    $this->deals = $deals;
+  }
+  public function getDeals()
+  {
+    return $this->deals;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_EditHistoryDto extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $createdByLoginName;
+  public $createdTimeStamp;
+  public $lastUpdateTimeStamp;
+  public $lastUpdatedByLoginName;
+
+
+  public function setCreatedByLoginName($createdByLoginName)
+  {
+    $this->createdByLoginName = $createdByLoginName;
+  }
+  public function getCreatedByLoginName()
+  {
+    return $this->createdByLoginName;
+  }
+  public function setCreatedTimeStamp($createdTimeStamp)
+  {
+    $this->createdTimeStamp = $createdTimeStamp;
+  }
+  public function getCreatedTimeStamp()
+  {
+    return $this->createdTimeStamp;
+  }
+  public function setLastUpdateTimeStamp($lastUpdateTimeStamp)
+  {
+    $this->lastUpdateTimeStamp = $lastUpdateTimeStamp;
+  }
+  public function getLastUpdateTimeStamp()
+  {
+    return $this->lastUpdateTimeStamp;
+  }
+  public function setLastUpdatedByLoginName($lastUpdatedByLoginName)
+  {
+    $this->lastUpdatedByLoginName = $lastUpdatedByLoginName;
+  }
+  public function getLastUpdatedByLoginName()
+  {
+    return $this->lastUpdatedByLoginName;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_GetFinalizedNegotiationByExternalDealIdRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $includePrivateAuctions;
+
+
+  public function setIncludePrivateAuctions($includePrivateAuctions)
+  {
+    $this->includePrivateAuctions = $includePrivateAuctions;
+  }
+  public function getIncludePrivateAuctions()
+  {
+    return $this->includePrivateAuctions;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_GetNegotiationByIdRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $includePrivateAuctions;
+
+
+  public function setIncludePrivateAuctions($includePrivateAuctions)
+  {
+    $this->includePrivateAuctions = $includePrivateAuctions;
+  }
+  public function getIncludePrivateAuctions()
+  {
+    return $this->includePrivateAuctions;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_GetNegotiationsRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $finalized;
+  public $includePrivateAuctions;
+  public $sinceTimestampMillis;
+
+
+  public function setFinalized($finalized)
+  {
+    $this->finalized = $finalized;
+  }
+  public function getFinalized()
+  {
+    return $this->finalized;
+  }
+  public function setIncludePrivateAuctions($includePrivateAuctions)
+  {
+    $this->includePrivateAuctions = $includePrivateAuctions;
+  }
+  public function getIncludePrivateAuctions()
+  {
+    return $this->includePrivateAuctions;
+  }
+  public function setSinceTimestampMillis($sinceTimestampMillis)
+  {
+    $this->sinceTimestampMillis = $sinceTimestampMillis;
+  }
+  public function getSinceTimestampMillis()
+  {
+    return $this->sinceTimestampMillis;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_GetNegotiationsResponse extends Google_Collection
+{
+  protected $collection_key = 'negotiations';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $negotiationsType = 'Google_Service_AdExchangeBuyer_NegotiationDto';
+  protected $negotiationsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNegotiations($negotiations)
+  {
+    $this->negotiations = $negotiations;
+  }
+  public function getNegotiations()
+  {
+    return $this->negotiations;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_GetOffersResponse extends Google_Collection
+{
+  protected $collection_key = 'offers';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $offersType = 'Google_Service_AdExchangeBuyer_MarketplaceOffer';
+  protected $offersDataType = 'array';
+
+
+  public function setOffers($offers)
+  {
+    $this->offers = $offers;
+  }
+  public function getOffers()
+  {
+    return $this->offers;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_GetOrderDealsResponse extends Google_Collection
+{
+  protected $collection_key = 'deals';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $dealsType = 'Google_Service_AdExchangeBuyer_MarketplaceDeal';
+  protected $dealsDataType = 'array';
+
+
+  public function setDeals($deals)
+  {
+    $this->deals = $deals;
+  }
+  public function getDeals()
+  {
+    return $this->deals;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_GetOrderNotesResponse extends Google_Collection
+{
+  protected $collection_key = 'notes';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $notesType = 'Google_Service_AdExchangeBuyer_MarketplaceNote';
+  protected $notesDataType = 'array';
+
+
+  public function setNotes($notes)
+  {
+    $this->notes = $notes;
+  }
+  public function getNotes()
+  {
+    return $this->notes;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_GetOrdersResponse extends Google_Collection
+{
+  protected $collection_key = 'orders';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $ordersType = 'Google_Service_AdExchangeBuyer_MarketplaceOrder';
+  protected $ordersDataType = 'array';
+
+
+  public function setOrders($orders)
+  {
+    $this->orders = $orders;
+  }
+  public function getOrders()
+  {
+    return $this->orders;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_InventorySegmentTargeting extends Google_Collection
+{
+  protected $collection_key = 'positiveXfpPlacements';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $negativeAdSizesType = 'Google_Service_AdExchangeBuyer_AdSize';
+  protected $negativeAdSizesDataType = 'array';
+  public $negativeAdTypeSegments;
+  public $negativeAudienceSegments;
+  public $negativeDeviceCategories;
+  public $negativeIcmBrands;
+  public $negativeIcmInterests;
+  public $negativeInventorySlots;
+  protected $negativeKeyValuesType = 'Google_Service_AdExchangeBuyer_RuleKeyValuePair';
+  protected $negativeKeyValuesDataType = 'array';
+  public $negativeLocations;
+  public $negativeMobileApps;
+  public $negativeOperatingSystemVersions;
+  public $negativeOperatingSystems;
+  public $negativeSiteUrls;
+  public $negativeSizes;
+  public $negativeVideoAdPositionSegments;
+  public $negativeVideoDurationSegments;
+  public $negativeXfpAdSlots;
+  public $negativeXfpPlacements;
+  protected $positiveAdSizesType = 'Google_Service_AdExchangeBuyer_AdSize';
+  protected $positiveAdSizesDataType = 'array';
+  public $positiveAdTypeSegments;
+  public $positiveAudienceSegments;
+  public $positiveDeviceCategories;
+  public $positiveIcmBrands;
+  public $positiveIcmInterests;
+  public $positiveInventorySlots;
+  protected $positiveKeyValuesType = 'Google_Service_AdExchangeBuyer_RuleKeyValuePair';
+  protected $positiveKeyValuesDataType = 'array';
+  public $positiveLocations;
+  public $positiveMobileApps;
+  public $positiveOperatingSystemVersions;
+  public $positiveOperatingSystems;
+  public $positiveSiteUrls;
+  public $positiveSizes;
+  public $positiveVideoAdPositionSegments;
+  public $positiveVideoDurationSegments;
+  public $positiveXfpAdSlots;
+  public $positiveXfpPlacements;
+
+
+  public function setNegativeAdSizes($negativeAdSizes)
+  {
+    $this->negativeAdSizes = $negativeAdSizes;
+  }
+  public function getNegativeAdSizes()
+  {
+    return $this->negativeAdSizes;
+  }
+  public function setNegativeAdTypeSegments($negativeAdTypeSegments)
+  {
+    $this->negativeAdTypeSegments = $negativeAdTypeSegments;
+  }
+  public function getNegativeAdTypeSegments()
+  {
+    return $this->negativeAdTypeSegments;
+  }
+  public function setNegativeAudienceSegments($negativeAudienceSegments)
+  {
+    $this->negativeAudienceSegments = $negativeAudienceSegments;
+  }
+  public function getNegativeAudienceSegments()
+  {
+    return $this->negativeAudienceSegments;
+  }
+  public function setNegativeDeviceCategories($negativeDeviceCategories)
+  {
+    $this->negativeDeviceCategories = $negativeDeviceCategories;
+  }
+  public function getNegativeDeviceCategories()
+  {
+    return $this->negativeDeviceCategories;
+  }
+  public function setNegativeIcmBrands($negativeIcmBrands)
+  {
+    $this->negativeIcmBrands = $negativeIcmBrands;
+  }
+  public function getNegativeIcmBrands()
+  {
+    return $this->negativeIcmBrands;
+  }
+  public function setNegativeIcmInterests($negativeIcmInterests)
+  {
+    $this->negativeIcmInterests = $negativeIcmInterests;
+  }
+  public function getNegativeIcmInterests()
+  {
+    return $this->negativeIcmInterests;
+  }
+  public function setNegativeInventorySlots($negativeInventorySlots)
+  {
+    $this->negativeInventorySlots = $negativeInventorySlots;
+  }
+  public function getNegativeInventorySlots()
+  {
+    return $this->negativeInventorySlots;
+  }
+  public function setNegativeKeyValues($negativeKeyValues)
+  {
+    $this->negativeKeyValues = $negativeKeyValues;
+  }
+  public function getNegativeKeyValues()
+  {
+    return $this->negativeKeyValues;
+  }
+  public function setNegativeLocations($negativeLocations)
+  {
+    $this->negativeLocations = $negativeLocations;
+  }
+  public function getNegativeLocations()
+  {
+    return $this->negativeLocations;
+  }
+  public function setNegativeMobileApps($negativeMobileApps)
+  {
+    $this->negativeMobileApps = $negativeMobileApps;
+  }
+  public function getNegativeMobileApps()
+  {
+    return $this->negativeMobileApps;
+  }
+  public function setNegativeOperatingSystemVersions($negativeOperatingSystemVersions)
+  {
+    $this->negativeOperatingSystemVersions = $negativeOperatingSystemVersions;
+  }
+  public function getNegativeOperatingSystemVersions()
+  {
+    return $this->negativeOperatingSystemVersions;
+  }
+  public function setNegativeOperatingSystems($negativeOperatingSystems)
+  {
+    $this->negativeOperatingSystems = $negativeOperatingSystems;
+  }
+  public function getNegativeOperatingSystems()
+  {
+    return $this->negativeOperatingSystems;
+  }
+  public function setNegativeSiteUrls($negativeSiteUrls)
+  {
+    $this->negativeSiteUrls = $negativeSiteUrls;
+  }
+  public function getNegativeSiteUrls()
+  {
+    return $this->negativeSiteUrls;
+  }
+  public function setNegativeSizes($negativeSizes)
+  {
+    $this->negativeSizes = $negativeSizes;
+  }
+  public function getNegativeSizes()
+  {
+    return $this->negativeSizes;
+  }
+  public function setNegativeVideoAdPositionSegments($negativeVideoAdPositionSegments)
+  {
+    $this->negativeVideoAdPositionSegments = $negativeVideoAdPositionSegments;
+  }
+  public function getNegativeVideoAdPositionSegments()
+  {
+    return $this->negativeVideoAdPositionSegments;
+  }
+  public function setNegativeVideoDurationSegments($negativeVideoDurationSegments)
+  {
+    $this->negativeVideoDurationSegments = $negativeVideoDurationSegments;
+  }
+  public function getNegativeVideoDurationSegments()
+  {
+    return $this->negativeVideoDurationSegments;
+  }
+  public function setNegativeXfpAdSlots($negativeXfpAdSlots)
+  {
+    $this->negativeXfpAdSlots = $negativeXfpAdSlots;
+  }
+  public function getNegativeXfpAdSlots()
+  {
+    return $this->negativeXfpAdSlots;
+  }
+  public function setNegativeXfpPlacements($negativeXfpPlacements)
+  {
+    $this->negativeXfpPlacements = $negativeXfpPlacements;
+  }
+  public function getNegativeXfpPlacements()
+  {
+    return $this->negativeXfpPlacements;
+  }
+  public function setPositiveAdSizes($positiveAdSizes)
+  {
+    $this->positiveAdSizes = $positiveAdSizes;
+  }
+  public function getPositiveAdSizes()
+  {
+    return $this->positiveAdSizes;
+  }
+  public function setPositiveAdTypeSegments($positiveAdTypeSegments)
+  {
+    $this->positiveAdTypeSegments = $positiveAdTypeSegments;
+  }
+  public function getPositiveAdTypeSegments()
+  {
+    return $this->positiveAdTypeSegments;
+  }
+  public function setPositiveAudienceSegments($positiveAudienceSegments)
+  {
+    $this->positiveAudienceSegments = $positiveAudienceSegments;
+  }
+  public function getPositiveAudienceSegments()
+  {
+    return $this->positiveAudienceSegments;
+  }
+  public function setPositiveDeviceCategories($positiveDeviceCategories)
+  {
+    $this->positiveDeviceCategories = $positiveDeviceCategories;
+  }
+  public function getPositiveDeviceCategories()
+  {
+    return $this->positiveDeviceCategories;
+  }
+  public function setPositiveIcmBrands($positiveIcmBrands)
+  {
+    $this->positiveIcmBrands = $positiveIcmBrands;
+  }
+  public function getPositiveIcmBrands()
+  {
+    return $this->positiveIcmBrands;
+  }
+  public function setPositiveIcmInterests($positiveIcmInterests)
+  {
+    $this->positiveIcmInterests = $positiveIcmInterests;
+  }
+  public function getPositiveIcmInterests()
+  {
+    return $this->positiveIcmInterests;
+  }
+  public function setPositiveInventorySlots($positiveInventorySlots)
+  {
+    $this->positiveInventorySlots = $positiveInventorySlots;
+  }
+  public function getPositiveInventorySlots()
+  {
+    return $this->positiveInventorySlots;
+  }
+  public function setPositiveKeyValues($positiveKeyValues)
+  {
+    $this->positiveKeyValues = $positiveKeyValues;
+  }
+  public function getPositiveKeyValues()
+  {
+    return $this->positiveKeyValues;
+  }
+  public function setPositiveLocations($positiveLocations)
+  {
+    $this->positiveLocations = $positiveLocations;
+  }
+  public function getPositiveLocations()
+  {
+    return $this->positiveLocations;
+  }
+  public function setPositiveMobileApps($positiveMobileApps)
+  {
+    $this->positiveMobileApps = $positiveMobileApps;
+  }
+  public function getPositiveMobileApps()
+  {
+    return $this->positiveMobileApps;
+  }
+  public function setPositiveOperatingSystemVersions($positiveOperatingSystemVersions)
+  {
+    $this->positiveOperatingSystemVersions = $positiveOperatingSystemVersions;
+  }
+  public function getPositiveOperatingSystemVersions()
+  {
+    return $this->positiveOperatingSystemVersions;
+  }
+  public function setPositiveOperatingSystems($positiveOperatingSystems)
+  {
+    $this->positiveOperatingSystems = $positiveOperatingSystems;
+  }
+  public function getPositiveOperatingSystems()
+  {
+    return $this->positiveOperatingSystems;
+  }
+  public function setPositiveSiteUrls($positiveSiteUrls)
+  {
+    $this->positiveSiteUrls = $positiveSiteUrls;
+  }
+  public function getPositiveSiteUrls()
+  {
+    return $this->positiveSiteUrls;
+  }
+  public function setPositiveSizes($positiveSizes)
+  {
+    $this->positiveSizes = $positiveSizes;
+  }
+  public function getPositiveSizes()
+  {
+    return $this->positiveSizes;
+  }
+  public function setPositiveVideoAdPositionSegments($positiveVideoAdPositionSegments)
+  {
+    $this->positiveVideoAdPositionSegments = $positiveVideoAdPositionSegments;
+  }
+  public function getPositiveVideoAdPositionSegments()
+  {
+    return $this->positiveVideoAdPositionSegments;
+  }
+  public function setPositiveVideoDurationSegments($positiveVideoDurationSegments)
+  {
+    $this->positiveVideoDurationSegments = $positiveVideoDurationSegments;
+  }
+  public function getPositiveVideoDurationSegments()
+  {
+    return $this->positiveVideoDurationSegments;
+  }
+  public function setPositiveXfpAdSlots($positiveXfpAdSlots)
+  {
+    $this->positiveXfpAdSlots = $positiveXfpAdSlots;
+  }
+  public function getPositiveXfpAdSlots()
+  {
+    return $this->positiveXfpAdSlots;
+  }
+  public function setPositiveXfpPlacements($positiveXfpPlacements)
+  {
+    $this->positiveXfpPlacements = $positiveXfpPlacements;
+  }
+  public function getPositiveXfpPlacements()
+  {
+    return $this->positiveXfpPlacements;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_ListClientAccessCapabilitiesRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $sponsorAccountId;
+
+
+  public function setSponsorAccountId($sponsorAccountId)
+  {
+    $this->sponsorAccountId = $sponsorAccountId;
+  }
+  public function getSponsorAccountId()
+  {
+    return $this->sponsorAccountId;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_ListClientAccessCapabilitiesResponse extends Google_Collection
+{
+  protected $collection_key = 'clientAccessPermissions';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $clientAccessPermissionsType = 'Google_Service_AdExchangeBuyer_ClientAccessCapabilities';
+  protected $clientAccessPermissionsDataType = 'array';
+
+
+  public function setClientAccessPermissions($clientAccessPermissions)
+  {
+    $this->clientAccessPermissions = $clientAccessPermissions;
+  }
+  public function getClientAccessPermissions()
+  {
+    return $this->clientAccessPermissions;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_ListOffersRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $sinceTimestampMillis;
+
+
+  public function setSinceTimestampMillis($sinceTimestampMillis)
+  {
+    $this->sinceTimestampMillis = $sinceTimestampMillis;
+  }
+  public function getSinceTimestampMillis()
+  {
+    return $this->sinceTimestampMillis;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_ListOffersResponse extends Google_Collection
+{
+  protected $collection_key = 'offers';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $offersType = 'Google_Service_AdExchangeBuyer_OfferDto';
+  protected $offersDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setOffers($offers)
+  {
+    $this->offers = $offers;
+  }
+  public function getOffers()
+  {
+    return $this->offers;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_MarketplaceDeal extends Google_Collection
+{
+  protected $collection_key = 'sharedTargetings';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $buyerPrivateDataType = 'Google_Service_AdExchangeBuyer_PrivateData';
+  protected $buyerPrivateDataDataType = '';
+  public $creationTimeMs;
+  public $dealId;
+  protected $deliveryControlType = 'Google_Service_AdExchangeBuyer_DeliveryControl';
+  protected $deliveryControlDataType = '';
+  public $externalDealId;
+  public $flightEndTimeMs;
+  public $flightStartTimeMs;
+  public $inventoryDescription;
+  public $kind;
+  public $lastUpdateTimeMs;
+  public $name;
+  public $offerId;
+  public $offerRevisionNumber;
+  public $orderId;
+  protected $sellerContactsType = 'Google_Service_AdExchangeBuyer_ContactInformation';
+  protected $sellerContactsDataType = 'array';
+  protected $sharedTargetingsType = 'Google_Service_AdExchangeBuyer_SharedTargeting';
+  protected $sharedTargetingsDataType = 'array';
+  public $syndicationProduct;
+  protected $termsType = 'Google_Service_AdExchangeBuyer_DealTerms';
+  protected $termsDataType = '';
+  public $webPropertyCode;
+
+
+  public function setBuyerPrivateData(Google_Service_AdExchangeBuyer_PrivateData $buyerPrivateData)
+  {
+    $this->buyerPrivateData = $buyerPrivateData;
+  }
+  public function getBuyerPrivateData()
+  {
+    return $this->buyerPrivateData;
+  }
+  public function setCreationTimeMs($creationTimeMs)
+  {
+    $this->creationTimeMs = $creationTimeMs;
+  }
+  public function getCreationTimeMs()
+  {
+    return $this->creationTimeMs;
+  }
+  public function setDealId($dealId)
+  {
+    $this->dealId = $dealId;
+  }
+  public function getDealId()
+  {
+    return $this->dealId;
+  }
+  public function setDeliveryControl(Google_Service_AdExchangeBuyer_DeliveryControl $deliveryControl)
+  {
+    $this->deliveryControl = $deliveryControl;
+  }
+  public function getDeliveryControl()
+  {
+    return $this->deliveryControl;
+  }
+  public function setExternalDealId($externalDealId)
+  {
+    $this->externalDealId = $externalDealId;
+  }
+  public function getExternalDealId()
+  {
+    return $this->externalDealId;
+  }
+  public function setFlightEndTimeMs($flightEndTimeMs)
+  {
+    $this->flightEndTimeMs = $flightEndTimeMs;
+  }
+  public function getFlightEndTimeMs()
+  {
+    return $this->flightEndTimeMs;
+  }
+  public function setFlightStartTimeMs($flightStartTimeMs)
+  {
+    $this->flightStartTimeMs = $flightStartTimeMs;
+  }
+  public function getFlightStartTimeMs()
+  {
+    return $this->flightStartTimeMs;
+  }
+  public function setInventoryDescription($inventoryDescription)
+  {
+    $this->inventoryDescription = $inventoryDescription;
+  }
+  public function getInventoryDescription()
+  {
+    return $this->inventoryDescription;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastUpdateTimeMs($lastUpdateTimeMs)
+  {
+    $this->lastUpdateTimeMs = $lastUpdateTimeMs;
+  }
+  public function getLastUpdateTimeMs()
+  {
+    return $this->lastUpdateTimeMs;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOfferId($offerId)
+  {
+    $this->offerId = $offerId;
+  }
+  public function getOfferId()
+  {
+    return $this->offerId;
+  }
+  public function setOfferRevisionNumber($offerRevisionNumber)
+  {
+    $this->offerRevisionNumber = $offerRevisionNumber;
+  }
+  public function getOfferRevisionNumber()
+  {
+    return $this->offerRevisionNumber;
+  }
+  public function setOrderId($orderId)
+  {
+    $this->orderId = $orderId;
+  }
+  public function getOrderId()
+  {
+    return $this->orderId;
+  }
+  public function setSellerContacts($sellerContacts)
+  {
+    $this->sellerContacts = $sellerContacts;
+  }
+  public function getSellerContacts()
+  {
+    return $this->sellerContacts;
+  }
+  public function setSharedTargetings($sharedTargetings)
+  {
+    $this->sharedTargetings = $sharedTargetings;
+  }
+  public function getSharedTargetings()
+  {
+    return $this->sharedTargetings;
+  }
+  public function setSyndicationProduct($syndicationProduct)
+  {
+    $this->syndicationProduct = $syndicationProduct;
+  }
+  public function getSyndicationProduct()
+  {
+    return $this->syndicationProduct;
+  }
+  public function setTerms(Google_Service_AdExchangeBuyer_DealTerms $terms)
+  {
+    $this->terms = $terms;
+  }
+  public function getTerms()
+  {
+    return $this->terms;
+  }
+  public function setWebPropertyCode($webPropertyCode)
+  {
+    $this->webPropertyCode = $webPropertyCode;
+  }
+  public function getWebPropertyCode()
+  {
+    return $this->webPropertyCode;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_MarketplaceDealParty extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $buyerType = 'Google_Service_AdExchangeBuyer_Buyer';
+  protected $buyerDataType = '';
+  protected $sellerType = 'Google_Service_AdExchangeBuyer_Seller';
+  protected $sellerDataType = '';
+
+
+  public function setBuyer(Google_Service_AdExchangeBuyer_Buyer $buyer)
+  {
+    $this->buyer = $buyer;
+  }
+  public function getBuyer()
+  {
+    return $this->buyer;
+  }
+  public function setSeller(Google_Service_AdExchangeBuyer_Seller $seller)
+  {
+    $this->seller = $seller;
+  }
+  public function getSeller()
+  {
+    return $this->seller;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_MarketplaceLabel extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $createTimeMs;
+  protected $deprecatedMarketplaceDealPartyType = 'Google_Service_AdExchangeBuyer_MarketplaceDealParty';
+  protected $deprecatedMarketplaceDealPartyDataType = '';
+  public $label;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setCreateTimeMs($createTimeMs)
+  {
+    $this->createTimeMs = $createTimeMs;
+  }
+  public function getCreateTimeMs()
+  {
+    return $this->createTimeMs;
+  }
+  public function setDeprecatedMarketplaceDealParty(Google_Service_AdExchangeBuyer_MarketplaceDealParty $deprecatedMarketplaceDealParty)
+  {
+    $this->deprecatedMarketplaceDealParty = $deprecatedMarketplaceDealParty;
+  }
+  public function getDeprecatedMarketplaceDealParty()
+  {
+    return $this->deprecatedMarketplaceDealParty;
+  }
+  public function setLabel($label)
+  {
+    $this->label = $label;
+  }
+  public function getLabel()
+  {
+    return $this->label;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_MarketplaceNote extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $creatorRole;
+  public $dealId;
+  public $kind;
+  public $note;
+  public $noteId;
+  public $orderId;
+  public $orderRevisionNumber;
+  public $timestampMs;
+
+
+  public function setCreatorRole($creatorRole)
+  {
+    $this->creatorRole = $creatorRole;
+  }
+  public function getCreatorRole()
+  {
+    return $this->creatorRole;
+  }
+  public function setDealId($dealId)
+  {
+    $this->dealId = $dealId;
+  }
+  public function getDealId()
+  {
+    return $this->dealId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNote($note)
+  {
+    $this->note = $note;
+  }
+  public function getNote()
+  {
+    return $this->note;
+  }
+  public function setNoteId($noteId)
+  {
+    $this->noteId = $noteId;
+  }
+  public function getNoteId()
+  {
+    return $this->noteId;
+  }
+  public function setOrderId($orderId)
+  {
+    $this->orderId = $orderId;
+  }
+  public function getOrderId()
+  {
+    return $this->orderId;
+  }
+  public function setOrderRevisionNumber($orderRevisionNumber)
+  {
+    $this->orderRevisionNumber = $orderRevisionNumber;
+  }
+  public function getOrderRevisionNumber()
+  {
+    return $this->orderRevisionNumber;
+  }
+  public function setTimestampMs($timestampMs)
+  {
+    $this->timestampMs = $timestampMs;
+  }
+  public function getTimestampMs()
+  {
+    return $this->timestampMs;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_MarketplaceOffer extends Google_Collection
+{
+  protected $collection_key = 'sharedTargetings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimeMs;
+  protected $creatorContactsType = 'Google_Service_AdExchangeBuyer_ContactInformation';
+  protected $creatorContactsDataType = 'array';
+  public $flightEndTimeMs;
+  public $flightStartTimeMs;
+  public $hasCreatorSignedOff;
+  public $kind;
+  protected $labelsType = 'Google_Service_AdExchangeBuyer_MarketplaceLabel';
+  protected $labelsDataType = 'array';
+  public $lastUpdateTimeMs;
+  public $name;
+  public $offerId;
+  public $revisionNumber;
+  protected $sellerType = 'Google_Service_AdExchangeBuyer_Seller';
+  protected $sellerDataType = '';
+  protected $sharedTargetingsType = 'Google_Service_AdExchangeBuyer_SharedTargeting';
+  protected $sharedTargetingsDataType = 'array';
+  public $state;
+  public $syndicationProduct;
+  protected $termsType = 'Google_Service_AdExchangeBuyer_DealTerms';
+  protected $termsDataType = '';
+  public $webPropertyCode;
+
+
+  public function setCreationTimeMs($creationTimeMs)
+  {
+    $this->creationTimeMs = $creationTimeMs;
+  }
+  public function getCreationTimeMs()
+  {
+    return $this->creationTimeMs;
+  }
+  public function setCreatorContacts($creatorContacts)
+  {
+    $this->creatorContacts = $creatorContacts;
+  }
+  public function getCreatorContacts()
+  {
+    return $this->creatorContacts;
+  }
+  public function setFlightEndTimeMs($flightEndTimeMs)
+  {
+    $this->flightEndTimeMs = $flightEndTimeMs;
+  }
+  public function getFlightEndTimeMs()
+  {
+    return $this->flightEndTimeMs;
+  }
+  public function setFlightStartTimeMs($flightStartTimeMs)
+  {
+    $this->flightStartTimeMs = $flightStartTimeMs;
+  }
+  public function getFlightStartTimeMs()
+  {
+    return $this->flightStartTimeMs;
+  }
+  public function setHasCreatorSignedOff($hasCreatorSignedOff)
+  {
+    $this->hasCreatorSignedOff = $hasCreatorSignedOff;
+  }
+  public function getHasCreatorSignedOff()
+  {
+    return $this->hasCreatorSignedOff;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLabels($labels)
+  {
+    $this->labels = $labels;
+  }
+  public function getLabels()
+  {
+    return $this->labels;
+  }
+  public function setLastUpdateTimeMs($lastUpdateTimeMs)
+  {
+    $this->lastUpdateTimeMs = $lastUpdateTimeMs;
+  }
+  public function getLastUpdateTimeMs()
+  {
+    return $this->lastUpdateTimeMs;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOfferId($offerId)
+  {
+    $this->offerId = $offerId;
+  }
+  public function getOfferId()
+  {
+    return $this->offerId;
+  }
+  public function setRevisionNumber($revisionNumber)
+  {
+    $this->revisionNumber = $revisionNumber;
+  }
+  public function getRevisionNumber()
+  {
+    return $this->revisionNumber;
+  }
+  public function setSeller(Google_Service_AdExchangeBuyer_Seller $seller)
+  {
+    $this->seller = $seller;
+  }
+  public function getSeller()
+  {
+    return $this->seller;
+  }
+  public function setSharedTargetings($sharedTargetings)
+  {
+    $this->sharedTargetings = $sharedTargetings;
+  }
+  public function getSharedTargetings()
+  {
+    return $this->sharedTargetings;
+  }
+  public function setState($state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+  public function setSyndicationProduct($syndicationProduct)
+  {
+    $this->syndicationProduct = $syndicationProduct;
+  }
+  public function getSyndicationProduct()
+  {
+    return $this->syndicationProduct;
+  }
+  public function setTerms(Google_Service_AdExchangeBuyer_DealTerms $terms)
+  {
+    $this->terms = $terms;
+  }
+  public function getTerms()
+  {
+    return $this->terms;
+  }
+  public function setWebPropertyCode($webPropertyCode)
+  {
+    $this->webPropertyCode = $webPropertyCode;
+  }
+  public function getWebPropertyCode()
+  {
+    return $this->webPropertyCode;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_MarketplaceOrder extends Google_Collection
+{
+  protected $collection_key = 'sellerContacts';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $billedBuyerType = 'Google_Service_AdExchangeBuyer_Buyer';
+  protected $billedBuyerDataType = '';
+  protected $buyerType = 'Google_Service_AdExchangeBuyer_Buyer';
+  protected $buyerDataType = '';
+  protected $buyerContactsType = 'Google_Service_AdExchangeBuyer_ContactInformation';
+  protected $buyerContactsDataType = 'array';
+  protected $buyerPrivateDataType = 'Google_Service_AdExchangeBuyer_PrivateData';
+  protected $buyerPrivateDataDataType = '';
+  public $hasBuyerSignedOff;
+  public $hasSellerSignedOff;
+  public $isRenegotiating;
+  public $isSetupComplete;
+  public $kind;
+  protected $labelsType = 'Google_Service_AdExchangeBuyer_MarketplaceLabel';
+  protected $labelsDataType = 'array';
+  public $lastUpdaterOrCommentorRole;
+  public $lastUpdaterRole;
+  public $name;
+  public $orderId;
+  public $orderState;
+  public $originatorRole;
+  public $revisionNumber;
+  public $revisionTimeMs;
+  protected $sellerType = 'Google_Service_AdExchangeBuyer_Seller';
+  protected $sellerDataType = '';
+  protected $sellerContactsType = 'Google_Service_AdExchangeBuyer_ContactInformation';
+  protected $sellerContactsDataType = 'array';
+
+
+  public function setBilledBuyer(Google_Service_AdExchangeBuyer_Buyer $billedBuyer)
+  {
+    $this->billedBuyer = $billedBuyer;
+  }
+  public function getBilledBuyer()
+  {
+    return $this->billedBuyer;
+  }
+  public function setBuyer(Google_Service_AdExchangeBuyer_Buyer $buyer)
+  {
+    $this->buyer = $buyer;
+  }
+  public function getBuyer()
+  {
+    return $this->buyer;
+  }
+  public function setBuyerContacts($buyerContacts)
+  {
+    $this->buyerContacts = $buyerContacts;
+  }
+  public function getBuyerContacts()
+  {
+    return $this->buyerContacts;
+  }
+  public function setBuyerPrivateData(Google_Service_AdExchangeBuyer_PrivateData $buyerPrivateData)
+  {
+    $this->buyerPrivateData = $buyerPrivateData;
+  }
+  public function getBuyerPrivateData()
+  {
+    return $this->buyerPrivateData;
+  }
+  public function setHasBuyerSignedOff($hasBuyerSignedOff)
+  {
+    $this->hasBuyerSignedOff = $hasBuyerSignedOff;
+  }
+  public function getHasBuyerSignedOff()
+  {
+    return $this->hasBuyerSignedOff;
+  }
+  public function setHasSellerSignedOff($hasSellerSignedOff)
+  {
+    $this->hasSellerSignedOff = $hasSellerSignedOff;
+  }
+  public function getHasSellerSignedOff()
+  {
+    return $this->hasSellerSignedOff;
+  }
+  public function setIsRenegotiating($isRenegotiating)
+  {
+    $this->isRenegotiating = $isRenegotiating;
+  }
+  public function getIsRenegotiating()
+  {
+    return $this->isRenegotiating;
+  }
+  public function setIsSetupComplete($isSetupComplete)
+  {
+    $this->isSetupComplete = $isSetupComplete;
+  }
+  public function getIsSetupComplete()
+  {
+    return $this->isSetupComplete;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLabels($labels)
+  {
+    $this->labels = $labels;
+  }
+  public function getLabels()
+  {
+    return $this->labels;
+  }
+  public function setLastUpdaterOrCommentorRole($lastUpdaterOrCommentorRole)
+  {
+    $this->lastUpdaterOrCommentorRole = $lastUpdaterOrCommentorRole;
+  }
+  public function getLastUpdaterOrCommentorRole()
+  {
+    return $this->lastUpdaterOrCommentorRole;
+  }
+  public function setLastUpdaterRole($lastUpdaterRole)
+  {
+    $this->lastUpdaterRole = $lastUpdaterRole;
+  }
+  public function getLastUpdaterRole()
+  {
+    return $this->lastUpdaterRole;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOrderId($orderId)
+  {
+    $this->orderId = $orderId;
+  }
+  public function getOrderId()
+  {
+    return $this->orderId;
+  }
+  public function setOrderState($orderState)
+  {
+    $this->orderState = $orderState;
+  }
+  public function getOrderState()
+  {
+    return $this->orderState;
+  }
+  public function setOriginatorRole($originatorRole)
+  {
+    $this->originatorRole = $originatorRole;
+  }
+  public function getOriginatorRole()
+  {
+    return $this->originatorRole;
+  }
+  public function setRevisionNumber($revisionNumber)
+  {
+    $this->revisionNumber = $revisionNumber;
+  }
+  public function getRevisionNumber()
+  {
+    return $this->revisionNumber;
+  }
+  public function setRevisionTimeMs($revisionTimeMs)
+  {
+    $this->revisionTimeMs = $revisionTimeMs;
+  }
+  public function getRevisionTimeMs()
+  {
+    return $this->revisionTimeMs;
+  }
+  public function setSeller(Google_Service_AdExchangeBuyer_Seller $seller)
+  {
+    $this->seller = $seller;
+  }
+  public function getSeller()
+  {
+    return $this->seller;
+  }
+  public function setSellerContacts($sellerContacts)
+  {
+    $this->sellerContacts = $sellerContacts;
+  }
+  public function getSellerContacts()
+  {
+    return $this->sellerContacts;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_MoneyDto extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $currencyCode;
+  public $micros;
+
+
+  public function setCurrencyCode($currencyCode)
+  {
+    $this->currencyCode = $currencyCode;
+  }
+  public function getCurrencyCode()
+  {
+    return $this->currencyCode;
+  }
+  public function setMicros($micros)
+  {
+    $this->micros = $micros;
+  }
+  public function getMicros()
+  {
+    return $this->micros;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_NegotiationDto extends Google_Collection
+{
+  protected $collection_key = 'sellerEmailContacts';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $billedBuyerType = 'Google_Service_AdExchangeBuyer_DealPartyDto';
+  protected $billedBuyerDataType = '';
+  protected $buyerType = 'Google_Service_AdExchangeBuyer_DealPartyDto';
+  protected $buyerDataType = '';
+  public $buyerEmailContacts;
+  public $dealType;
+  public $externalDealId;
+  public $kind;
+  public $labelNames;
+  public $negotiationId;
+  protected $negotiationRoundsType = 'Google_Service_AdExchangeBuyer_NegotiationRoundDto';
+  protected $negotiationRoundsDataType = 'array';
+  public $negotiationState;
+  public $offerId;
+  protected $sellerType = 'Google_Service_AdExchangeBuyer_DealPartyDto';
+  protected $sellerDataType = '';
+  public $sellerEmailContacts;
+  protected $statsType = 'Google_Service_AdExchangeBuyer_StatsDto';
+  protected $statsDataType = '';
+  public $status;
+
+
+  public function setBilledBuyer(Google_Service_AdExchangeBuyer_DealPartyDto $billedBuyer)
+  {
+    $this->billedBuyer = $billedBuyer;
+  }
+  public function getBilledBuyer()
+  {
+    return $this->billedBuyer;
+  }
+  public function setBuyer(Google_Service_AdExchangeBuyer_DealPartyDto $buyer)
+  {
+    $this->buyer = $buyer;
+  }
+  public function getBuyer()
+  {
+    return $this->buyer;
+  }
+  public function setBuyerEmailContacts($buyerEmailContacts)
+  {
+    $this->buyerEmailContacts = $buyerEmailContacts;
+  }
+  public function getBuyerEmailContacts()
+  {
+    return $this->buyerEmailContacts;
+  }
+  public function setDealType($dealType)
+  {
+    $this->dealType = $dealType;
+  }
+  public function getDealType()
+  {
+    return $this->dealType;
+  }
+  public function setExternalDealId($externalDealId)
+  {
+    $this->externalDealId = $externalDealId;
+  }
+  public function getExternalDealId()
+  {
+    return $this->externalDealId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLabelNames($labelNames)
+  {
+    $this->labelNames = $labelNames;
+  }
+  public function getLabelNames()
+  {
+    return $this->labelNames;
+  }
+  public function setNegotiationId($negotiationId)
+  {
+    $this->negotiationId = $negotiationId;
+  }
+  public function getNegotiationId()
+  {
+    return $this->negotiationId;
+  }
+  public function setNegotiationRounds($negotiationRounds)
+  {
+    $this->negotiationRounds = $negotiationRounds;
+  }
+  public function getNegotiationRounds()
+  {
+    return $this->negotiationRounds;
+  }
+  public function setNegotiationState($negotiationState)
+  {
+    $this->negotiationState = $negotiationState;
+  }
+  public function getNegotiationState()
+  {
+    return $this->negotiationState;
+  }
+  public function setOfferId($offerId)
+  {
+    $this->offerId = $offerId;
+  }
+  public function getOfferId()
+  {
+    return $this->offerId;
+  }
+  public function setSeller(Google_Service_AdExchangeBuyer_DealPartyDto $seller)
+  {
+    $this->seller = $seller;
+  }
+  public function getSeller()
+  {
+    return $this->seller;
+  }
+  public function setSellerEmailContacts($sellerEmailContacts)
+  {
+    $this->sellerEmailContacts = $sellerEmailContacts;
+  }
+  public function getSellerEmailContacts()
+  {
+    return $this->sellerEmailContacts;
+  }
+  public function setStats(Google_Service_AdExchangeBuyer_StatsDto $stats)
+  {
+    $this->stats = $stats;
+  }
+  public function getStats()
+  {
+    return $this->stats;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_NegotiationRoundDto extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $action;
+  public $dbmPartnerId;
+  protected $editHistoryType = 'Google_Service_AdExchangeBuyer_EditHistoryDto';
+  protected $editHistoryDataType = '';
+  public $kind;
+  public $negotiationId;
+  public $notes;
+  public $originatorRole;
+  public $roundNumber;
+  protected $termsType = 'Google_Service_AdExchangeBuyer_TermsDto';
+  protected $termsDataType = '';
+
+
+  public function setAction($action)
+  {
+    $this->action = $action;
+  }
+  public function getAction()
+  {
+    return $this->action;
+  }
+  public function setDbmPartnerId($dbmPartnerId)
+  {
+    $this->dbmPartnerId = $dbmPartnerId;
+  }
+  public function getDbmPartnerId()
+  {
+    return $this->dbmPartnerId;
+  }
+  public function setEditHistory(Google_Service_AdExchangeBuyer_EditHistoryDto $editHistory)
+  {
+    $this->editHistory = $editHistory;
+  }
+  public function getEditHistory()
+  {
+    return $this->editHistory;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNegotiationId($negotiationId)
+  {
+    $this->negotiationId = $negotiationId;
+  }
+  public function getNegotiationId()
+  {
+    return $this->negotiationId;
+  }
+  public function setNotes($notes)
+  {
+    $this->notes = $notes;
+  }
+  public function getNotes()
+  {
+    return $this->notes;
+  }
+  public function setOriginatorRole($originatorRole)
+  {
+    $this->originatorRole = $originatorRole;
+  }
+  public function getOriginatorRole()
+  {
+    return $this->originatorRole;
+  }
+  public function setRoundNumber($roundNumber)
+  {
+    $this->roundNumber = $roundNumber;
+  }
+  public function getRoundNumber()
+  {
+    return $this->roundNumber;
+  }
+  public function setTerms(Google_Service_AdExchangeBuyer_TermsDto $terms)
+  {
+    $this->terms = $terms;
+  }
+  public function getTerms()
+  {
+    return $this->terms;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_OfferDto extends Google_Collection
+{
+  protected $collection_key = 'openToDealParties';
+  protected $internal_gapi_mappings = array(
+  );
+  public $anonymous;
+  protected $billedBuyerType = 'Google_Service_AdExchangeBuyer_DealPartyDto';
+  protected $billedBuyerDataType = '';
+  protected $closedToDealPartiesType = 'Google_Service_AdExchangeBuyer_DealPartyDto';
+  protected $closedToDealPartiesDataType = 'array';
+  protected $creatorType = 'Google_Service_AdExchangeBuyer_DealPartyDto';
+  protected $creatorDataType = '';
+  public $emailContacts;
+  public $isOpen;
+  public $kind;
+  public $labelNames;
+  public $offerId;
+  public $offerState;
+  protected $openToDealPartiesType = 'Google_Service_AdExchangeBuyer_DealPartyDto';
+  protected $openToDealPartiesDataType = 'array';
+  public $pointOfContact;
+  public $status;
+  protected $termsType = 'Google_Service_AdExchangeBuyer_TermsDto';
+  protected $termsDataType = '';
+
+
+  public function setAnonymous($anonymous)
+  {
+    $this->anonymous = $anonymous;
+  }
+  public function getAnonymous()
+  {
+    return $this->anonymous;
+  }
+  public function setBilledBuyer(Google_Service_AdExchangeBuyer_DealPartyDto $billedBuyer)
+  {
+    $this->billedBuyer = $billedBuyer;
+  }
+  public function getBilledBuyer()
+  {
+    return $this->billedBuyer;
+  }
+  public function setClosedToDealParties($closedToDealParties)
+  {
+    $this->closedToDealParties = $closedToDealParties;
+  }
+  public function getClosedToDealParties()
+  {
+    return $this->closedToDealParties;
+  }
+  public function setCreator(Google_Service_AdExchangeBuyer_DealPartyDto $creator)
+  {
+    $this->creator = $creator;
+  }
+  public function getCreator()
+  {
+    return $this->creator;
+  }
+  public function setEmailContacts($emailContacts)
+  {
+    $this->emailContacts = $emailContacts;
+  }
+  public function getEmailContacts()
+  {
+    return $this->emailContacts;
+  }
+  public function setIsOpen($isOpen)
+  {
+    $this->isOpen = $isOpen;
+  }
+  public function getIsOpen()
+  {
+    return $this->isOpen;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLabelNames($labelNames)
+  {
+    $this->labelNames = $labelNames;
+  }
+  public function getLabelNames()
+  {
+    return $this->labelNames;
+  }
+  public function setOfferId($offerId)
+  {
+    $this->offerId = $offerId;
+  }
+  public function getOfferId()
+  {
+    return $this->offerId;
+  }
+  public function setOfferState($offerState)
+  {
+    $this->offerState = $offerState;
+  }
+  public function getOfferState()
+  {
+    return $this->offerState;
+  }
+  public function setOpenToDealParties($openToDealParties)
+  {
+    $this->openToDealParties = $openToDealParties;
+  }
+  public function getOpenToDealParties()
+  {
+    return $this->openToDealParties;
+  }
+  public function setPointOfContact($pointOfContact)
+  {
+    $this->pointOfContact = $pointOfContact;
+  }
+  public function getPointOfContact()
+  {
+    return $this->pointOfContact;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setTerms(Google_Service_AdExchangeBuyer_TermsDto $terms)
+  {
+    $this->terms = $terms;
+  }
+  public function getTerms()
+  {
+    return $this->terms;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_PerformanceReport extends Google_Collection
+{
+  protected $collection_key = 'hostedMatchStatusRate';
+  protected $internal_gapi_mappings = array(
+  );
+  public $bidRate;
+  public $bidRequestRate;
+  public $calloutStatusRate;
+  public $cookieMatcherStatusRate;
+  public $creativeStatusRate;
+  public $filteredBidRate;
+  public $hostedMatchStatusRate;
+  public $inventoryMatchRate;
+  public $kind;
+  public $latency50thPercentile;
+  public $latency85thPercentile;
+  public $latency95thPercentile;
+  public $noQuotaInRegion;
+  public $outOfQuota;
+  public $pixelMatchRequests;
+  public $pixelMatchResponses;
+  public $quotaConfiguredLimit;
+  public $quotaThrottledLimit;
+  public $region;
+  public $successfulRequestRate;
+  public $timestamp;
+  public $unsuccessfulRequestRate;
+
+
+  public function setBidRate($bidRate)
+  {
+    $this->bidRate = $bidRate;
+  }
+  public function getBidRate()
+  {
+    return $this->bidRate;
+  }
+  public function setBidRequestRate($bidRequestRate)
+  {
+    $this->bidRequestRate = $bidRequestRate;
+  }
+  public function getBidRequestRate()
+  {
+    return $this->bidRequestRate;
+  }
+  public function setCalloutStatusRate($calloutStatusRate)
+  {
+    $this->calloutStatusRate = $calloutStatusRate;
+  }
+  public function getCalloutStatusRate()
+  {
+    return $this->calloutStatusRate;
+  }
+  public function setCookieMatcherStatusRate($cookieMatcherStatusRate)
+  {
+    $this->cookieMatcherStatusRate = $cookieMatcherStatusRate;
+  }
+  public function getCookieMatcherStatusRate()
+  {
+    return $this->cookieMatcherStatusRate;
+  }
+  public function setCreativeStatusRate($creativeStatusRate)
+  {
+    $this->creativeStatusRate = $creativeStatusRate;
+  }
+  public function getCreativeStatusRate()
+  {
+    return $this->creativeStatusRate;
+  }
+  public function setFilteredBidRate($filteredBidRate)
+  {
+    $this->filteredBidRate = $filteredBidRate;
+  }
+  public function getFilteredBidRate()
+  {
+    return $this->filteredBidRate;
+  }
+  public function setHostedMatchStatusRate($hostedMatchStatusRate)
+  {
+    $this->hostedMatchStatusRate = $hostedMatchStatusRate;
+  }
+  public function getHostedMatchStatusRate()
+  {
+    return $this->hostedMatchStatusRate;
+  }
+  public function setInventoryMatchRate($inventoryMatchRate)
+  {
+    $this->inventoryMatchRate = $inventoryMatchRate;
+  }
+  public function getInventoryMatchRate()
+  {
+    return $this->inventoryMatchRate;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLatency50thPercentile($latency50thPercentile)
+  {
+    $this->latency50thPercentile = $latency50thPercentile;
+  }
+  public function getLatency50thPercentile()
+  {
+    return $this->latency50thPercentile;
+  }
+  public function setLatency85thPercentile($latency85thPercentile)
+  {
+    $this->latency85thPercentile = $latency85thPercentile;
+  }
+  public function getLatency85thPercentile()
+  {
+    return $this->latency85thPercentile;
+  }
+  public function setLatency95thPercentile($latency95thPercentile)
+  {
+    $this->latency95thPercentile = $latency95thPercentile;
+  }
+  public function getLatency95thPercentile()
+  {
+    return $this->latency95thPercentile;
+  }
+  public function setNoQuotaInRegion($noQuotaInRegion)
+  {
+    $this->noQuotaInRegion = $noQuotaInRegion;
+  }
+  public function getNoQuotaInRegion()
+  {
+    return $this->noQuotaInRegion;
+  }
+  public function setOutOfQuota($outOfQuota)
+  {
+    $this->outOfQuota = $outOfQuota;
+  }
+  public function getOutOfQuota()
+  {
+    return $this->outOfQuota;
+  }
+  public function setPixelMatchRequests($pixelMatchRequests)
+  {
+    $this->pixelMatchRequests = $pixelMatchRequests;
+  }
+  public function getPixelMatchRequests()
+  {
+    return $this->pixelMatchRequests;
+  }
+  public function setPixelMatchResponses($pixelMatchResponses)
+  {
+    $this->pixelMatchResponses = $pixelMatchResponses;
+  }
+  public function getPixelMatchResponses()
+  {
+    return $this->pixelMatchResponses;
+  }
+  public function setQuotaConfiguredLimit($quotaConfiguredLimit)
+  {
+    $this->quotaConfiguredLimit = $quotaConfiguredLimit;
+  }
+  public function getQuotaConfiguredLimit()
+  {
+    return $this->quotaConfiguredLimit;
+  }
+  public function setQuotaThrottledLimit($quotaThrottledLimit)
+  {
+    $this->quotaThrottledLimit = $quotaThrottledLimit;
+  }
+  public function getQuotaThrottledLimit()
+  {
+    return $this->quotaThrottledLimit;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setSuccessfulRequestRate($successfulRequestRate)
+  {
+    $this->successfulRequestRate = $successfulRequestRate;
+  }
+  public function getSuccessfulRequestRate()
+  {
+    return $this->successfulRequestRate;
+  }
+  public function setTimestamp($timestamp)
+  {
+    $this->timestamp = $timestamp;
+  }
+  public function getTimestamp()
+  {
+    return $this->timestamp;
+  }
+  public function setUnsuccessfulRequestRate($unsuccessfulRequestRate)
+  {
+    $this->unsuccessfulRequestRate = $unsuccessfulRequestRate;
+  }
+  public function getUnsuccessfulRequestRate()
+  {
+    return $this->unsuccessfulRequestRate;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_PerformanceReportList extends Google_Collection
+{
+  protected $collection_key = 'performanceReport';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $performanceReportType = 'Google_Service_AdExchangeBuyer_PerformanceReport';
+  protected $performanceReportDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPerformanceReport($performanceReport)
+  {
+    $this->performanceReport = $performanceReport;
+  }
+  public function getPerformanceReport()
+  {
+    return $this->performanceReport;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_PretargetingConfig extends Google_Collection
+{
+  protected $collection_key = 'verticals';
+  protected $internal_gapi_mappings = array(
+  );
+  public $billingId;
+  public $configId;
+  public $configName;
+  public $creativeType;
+  protected $dimensionsType = 'Google_Service_AdExchangeBuyer_PretargetingConfigDimensions';
+  protected $dimensionsDataType = 'array';
+  public $excludedContentLabels;
+  public $excludedGeoCriteriaIds;
+  protected $excludedPlacementsType = 'Google_Service_AdExchangeBuyer_PretargetingConfigExcludedPlacements';
+  protected $excludedPlacementsDataType = 'array';
+  public $excludedUserLists;
+  public $excludedVerticals;
+  public $geoCriteriaIds;
+  public $isActive;
+  public $kind;
+  public $languages;
+  public $mobileCarriers;
+  public $mobileDevices;
+  public $mobileOperatingSystemVersions;
+  protected $placementsType = 'Google_Service_AdExchangeBuyer_PretargetingConfigPlacements';
+  protected $placementsDataType = 'array';
+  public $platforms;
+  public $supportedCreativeAttributes;
+  public $userLists;
+  public $vendorTypes;
+  public $verticals;
+
+
+  public function setBillingId($billingId)
+  {
+    $this->billingId = $billingId;
+  }
+  public function getBillingId()
+  {
+    return $this->billingId;
+  }
+  public function setConfigId($configId)
+  {
+    $this->configId = $configId;
+  }
+  public function getConfigId()
+  {
+    return $this->configId;
+  }
+  public function setConfigName($configName)
+  {
+    $this->configName = $configName;
+  }
+  public function getConfigName()
+  {
+    return $this->configName;
+  }
+  public function setCreativeType($creativeType)
+  {
+    $this->creativeType = $creativeType;
+  }
+  public function getCreativeType()
+  {
+    return $this->creativeType;
+  }
+  public function setDimensions($dimensions)
+  {
+    $this->dimensions = $dimensions;
+  }
+  public function getDimensions()
+  {
+    return $this->dimensions;
+  }
+  public function setExcludedContentLabels($excludedContentLabels)
+  {
+    $this->excludedContentLabels = $excludedContentLabels;
+  }
+  public function getExcludedContentLabels()
+  {
+    return $this->excludedContentLabels;
+  }
+  public function setExcludedGeoCriteriaIds($excludedGeoCriteriaIds)
+  {
+    $this->excludedGeoCriteriaIds = $excludedGeoCriteriaIds;
+  }
+  public function getExcludedGeoCriteriaIds()
+  {
+    return $this->excludedGeoCriteriaIds;
+  }
+  public function setExcludedPlacements($excludedPlacements)
+  {
+    $this->excludedPlacements = $excludedPlacements;
+  }
+  public function getExcludedPlacements()
+  {
+    return $this->excludedPlacements;
+  }
+  public function setExcludedUserLists($excludedUserLists)
+  {
+    $this->excludedUserLists = $excludedUserLists;
+  }
+  public function getExcludedUserLists()
+  {
+    return $this->excludedUserLists;
+  }
+  public function setExcludedVerticals($excludedVerticals)
+  {
+    $this->excludedVerticals = $excludedVerticals;
+  }
+  public function getExcludedVerticals()
+  {
+    return $this->excludedVerticals;
+  }
+  public function setGeoCriteriaIds($geoCriteriaIds)
+  {
+    $this->geoCriteriaIds = $geoCriteriaIds;
+  }
+  public function getGeoCriteriaIds()
+  {
+    return $this->geoCriteriaIds;
+  }
+  public function setIsActive($isActive)
+  {
+    $this->isActive = $isActive;
+  }
+  public function getIsActive()
+  {
+    return $this->isActive;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLanguages($languages)
+  {
+    $this->languages = $languages;
+  }
+  public function getLanguages()
+  {
+    return $this->languages;
+  }
+  public function setMobileCarriers($mobileCarriers)
+  {
+    $this->mobileCarriers = $mobileCarriers;
+  }
+  public function getMobileCarriers()
+  {
+    return $this->mobileCarriers;
+  }
+  public function setMobileDevices($mobileDevices)
+  {
+    $this->mobileDevices = $mobileDevices;
+  }
+  public function getMobileDevices()
+  {
+    return $this->mobileDevices;
+  }
+  public function setMobileOperatingSystemVersions($mobileOperatingSystemVersions)
+  {
+    $this->mobileOperatingSystemVersions = $mobileOperatingSystemVersions;
+  }
+  public function getMobileOperatingSystemVersions()
+  {
+    return $this->mobileOperatingSystemVersions;
+  }
+  public function setPlacements($placements)
+  {
+    $this->placements = $placements;
+  }
+  public function getPlacements()
+  {
+    return $this->placements;
+  }
+  public function setPlatforms($platforms)
+  {
+    $this->platforms = $platforms;
+  }
+  public function getPlatforms()
+  {
+    return $this->platforms;
+  }
+  public function setSupportedCreativeAttributes($supportedCreativeAttributes)
+  {
+    $this->supportedCreativeAttributes = $supportedCreativeAttributes;
+  }
+  public function getSupportedCreativeAttributes()
+  {
+    return $this->supportedCreativeAttributes;
+  }
+  public function setUserLists($userLists)
+  {
+    $this->userLists = $userLists;
+  }
+  public function getUserLists()
+  {
+    return $this->userLists;
+  }
+  public function setVendorTypes($vendorTypes)
+  {
+    $this->vendorTypes = $vendorTypes;
+  }
+  public function getVendorTypes()
+  {
+    return $this->vendorTypes;
+  }
+  public function setVerticals($verticals)
+  {
+    $this->verticals = $verticals;
+  }
+  public function getVerticals()
+  {
+    return $this->verticals;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_PretargetingConfigDimensions extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_PretargetingConfigExcludedPlacements extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $token;
+  public $type;
+
+
+  public function setToken($token)
+  {
+    $this->token = $token;
+  }
+  public function getToken()
+  {
+    return $this->token;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_PretargetingConfigList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_AdExchangeBuyer_PretargetingConfig';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_PretargetingConfigPlacements extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $token;
+  public $type;
+
+
+  public function setToken($token)
+  {
+    $this->token = $token;
+  }
+  public function getToken()
+  {
+    return $this->token;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_Price extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $amountMicros;
+  public $currencyCode;
+
+
+  public function setAmountMicros($amountMicros)
+  {
+    $this->amountMicros = $amountMicros;
+  }
+  public function getAmountMicros()
+  {
+    return $this->amountMicros;
+  }
+  public function setCurrencyCode($currencyCode)
+  {
+    $this->currencyCode = $currencyCode;
+  }
+  public function getCurrencyCode()
+  {
+    return $this->currencyCode;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_PricePerBuyer extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $buyerType = 'Google_Service_AdExchangeBuyer_Buyer';
+  protected $buyerDataType = '';
+  protected $priceType = 'Google_Service_AdExchangeBuyer_Price';
+  protected $priceDataType = '';
+
+
+  public function setBuyer(Google_Service_AdExchangeBuyer_Buyer $buyer)
+  {
+    $this->buyer = $buyer;
+  }
+  public function getBuyer()
+  {
+    return $this->buyer;
+  }
+  public function setPrice(Google_Service_AdExchangeBuyer_Price $price)
+  {
+    $this->price = $price;
+  }
+  public function getPrice()
+  {
+    return $this->price;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_PrivateData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $referenceId;
+  public $referencePayload;
+
+
+  public function setReferenceId($referenceId)
+  {
+    $this->referenceId = $referenceId;
+  }
+  public function getReferenceId()
+  {
+    return $this->referenceId;
+  }
+  public function setReferencePayload($referencePayload)
+  {
+    $this->referencePayload = $referencePayload;
+  }
+  public function getReferencePayload()
+  {
+    return $this->referencePayload;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_RuleKeyValuePair extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $keyName;
+  public $value;
+
+
+  public function setKeyName($keyName)
+  {
+    $this->keyName = $keyName;
+  }
+  public function getKeyName()
+  {
+    return $this->keyName;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_Seller extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $subAccountId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setSubAccountId($subAccountId)
+  {
+    $this->subAccountId = $subAccountId;
+  }
+  public function getSubAccountId()
+  {
+    return $this->subAccountId;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_SharedTargeting extends Google_Collection
+{
+  protected $collection_key = 'inclusions';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $exclusionsType = 'Google_Service_AdExchangeBuyer_TargetingValue';
+  protected $exclusionsDataType = 'array';
+  protected $inclusionsType = 'Google_Service_AdExchangeBuyer_TargetingValue';
+  protected $inclusionsDataType = 'array';
+  public $key;
+
+
+  public function setExclusions($exclusions)
+  {
+    $this->exclusions = $exclusions;
+  }
+  public function getExclusions()
+  {
+    return $this->exclusions;
+  }
+  public function setInclusions($inclusions)
+  {
+    $this->inclusions = $inclusions;
+  }
+  public function getInclusions()
+  {
+    return $this->inclusions;
+  }
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_StatsDto extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $bids;
+  public $goodBids;
+  public $impressions;
+  public $requests;
+  protected $revenueType = 'Google_Service_AdExchangeBuyer_MoneyDto';
+  protected $revenueDataType = '';
+  protected $spendType = 'Google_Service_AdExchangeBuyer_MoneyDto';
+  protected $spendDataType = '';
+
+
+  public function setBids($bids)
+  {
+    $this->bids = $bids;
+  }
+  public function getBids()
+  {
+    return $this->bids;
+  }
+  public function setGoodBids($goodBids)
+  {
+    $this->goodBids = $goodBids;
+  }
+  public function getGoodBids()
+  {
+    return $this->goodBids;
+  }
+  public function setImpressions($impressions)
+  {
+    $this->impressions = $impressions;
+  }
+  public function getImpressions()
+  {
+    return $this->impressions;
+  }
+  public function setRequests($requests)
+  {
+    $this->requests = $requests;
+  }
+  public function getRequests()
+  {
+    return $this->requests;
+  }
+  public function setRevenue(Google_Service_AdExchangeBuyer_MoneyDto $revenue)
+  {
+    $this->revenue = $revenue;
+  }
+  public function getRevenue()
+  {
+    return $this->revenue;
+  }
+  public function setSpend(Google_Service_AdExchangeBuyer_MoneyDto $spend)
+  {
+    $this->spend = $spend;
+  }
+  public function getSpend()
+  {
+    return $this->spend;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_TargetingValue extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $creativeSizeValueType = 'Google_Service_AdExchangeBuyer_TargetingValueCreativeSize';
+  protected $creativeSizeValueDataType = '';
+  protected $dayPartTargetingValueType = 'Google_Service_AdExchangeBuyer_TargetingValueDayPartTargeting';
+  protected $dayPartTargetingValueDataType = '';
+  public $longValue;
+  public $stringValue;
+
+
+  public function setCreativeSizeValue(Google_Service_AdExchangeBuyer_TargetingValueCreativeSize $creativeSizeValue)
+  {
+    $this->creativeSizeValue = $creativeSizeValue;
+  }
+  public function getCreativeSizeValue()
+  {
+    return $this->creativeSizeValue;
+  }
+  public function setDayPartTargetingValue(Google_Service_AdExchangeBuyer_TargetingValueDayPartTargeting $dayPartTargetingValue)
+  {
+    $this->dayPartTargetingValue = $dayPartTargetingValue;
+  }
+  public function getDayPartTargetingValue()
+  {
+    return $this->dayPartTargetingValue;
+  }
+  public function setLongValue($longValue)
+  {
+    $this->longValue = $longValue;
+  }
+  public function getLongValue()
+  {
+    return $this->longValue;
+  }
+  public function setStringValue($stringValue)
+  {
+    $this->stringValue = $stringValue;
+  }
+  public function getStringValue()
+  {
+    return $this->stringValue;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_TargetingValueCreativeSize extends Google_Collection
+{
+  protected $collection_key = 'companionSizes';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $companionSizesType = 'Google_Service_AdExchangeBuyer_TargetingValueSize';
+  protected $companionSizesDataType = 'array';
+  public $creativeSizeType;
+  protected $sizeType = 'Google_Service_AdExchangeBuyer_TargetingValueSize';
+  protected $sizeDataType = '';
+
+
+  public function setCompanionSizes($companionSizes)
+  {
+    $this->companionSizes = $companionSizes;
+  }
+  public function getCompanionSizes()
+  {
+    return $this->companionSizes;
+  }
+  public function setCreativeSizeType($creativeSizeType)
+  {
+    $this->creativeSizeType = $creativeSizeType;
+  }
+  public function getCreativeSizeType()
+  {
+    return $this->creativeSizeType;
+  }
+  public function setSize(Google_Service_AdExchangeBuyer_TargetingValueSize $size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_TargetingValueDayPartTargeting extends Google_Collection
+{
+  protected $collection_key = 'dayParts';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $dayPartsType = 'Google_Service_AdExchangeBuyer_TargetingValueDayPartTargetingDayPart';
+  protected $dayPartsDataType = 'array';
+  public $timeZoneType;
+
+
+  public function setDayParts($dayParts)
+  {
+    $this->dayParts = $dayParts;
+  }
+  public function getDayParts()
+  {
+    return $this->dayParts;
+  }
+  public function setTimeZoneType($timeZoneType)
+  {
+    $this->timeZoneType = $timeZoneType;
+  }
+  public function getTimeZoneType()
+  {
+    return $this->timeZoneType;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_TargetingValueDayPartTargetingDayPart extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $dayOfWeek;
+  public $endHour;
+  public $endMinute;
+  public $startHour;
+  public $startMinute;
+
+
+  public function setDayOfWeek($dayOfWeek)
+  {
+    $this->dayOfWeek = $dayOfWeek;
+  }
+  public function getDayOfWeek()
+  {
+    return $this->dayOfWeek;
+  }
+  public function setEndHour($endHour)
+  {
+    $this->endHour = $endHour;
+  }
+  public function getEndHour()
+  {
+    return $this->endHour;
+  }
+  public function setEndMinute($endMinute)
+  {
+    $this->endMinute = $endMinute;
+  }
+  public function getEndMinute()
+  {
+    return $this->endMinute;
+  }
+  public function setStartHour($startHour)
+  {
+    $this->startHour = $startHour;
+  }
+  public function getStartHour()
+  {
+    return $this->startHour;
+  }
+  public function setStartMinute($startMinute)
+  {
+    $this->startMinute = $startMinute;
+  }
+  public function getStartMinute()
+  {
+    return $this->startMinute;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_TargetingValueSize extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_TermsDto extends Google_Collection
+{
+  protected $collection_key = 'urls';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $adSlotsType = 'Google_Service_AdExchangeBuyer_AdSlotDto';
+  protected $adSlotsDataType = 'array';
+  protected $advertisersType = 'Google_Service_AdExchangeBuyer_AdvertiserDto';
+  protected $advertisersDataType = 'array';
+  protected $audienceSegmentType = 'Google_Service_AdExchangeBuyer_AudienceSegment';
+  protected $audienceSegmentDataType = '';
+  public $audienceSegmentDescription;
+  public $billingTerms;
+  public $buyerBillingType;
+  protected $cpmType = 'Google_Service_AdExchangeBuyer_MoneyDto';
+  protected $cpmDataType = '';
+  public $creativeBlockingLevel;
+  public $creativeReviewPolicy;
+  protected $dealPremiumType = 'Google_Service_AdExchangeBuyer_MoneyDto';
+  protected $dealPremiumDataType = '';
+  public $description;
+  public $descriptiveName;
+  protected $endDateType = 'Google_Service_AdExchangeBuyer_DateTime';
+  protected $endDateDataType = '';
+  public $estimatedImpressionsPerDay;
+  protected $estimatedSpendType = 'Google_Service_AdExchangeBuyer_MoneyDto';
+  protected $estimatedSpendDataType = '';
+  public $finalizeAutomatically;
+  protected $inventorySegmentTargetingType = 'Google_Service_AdExchangeBuyer_InventorySegmentTargeting';
+  protected $inventorySegmentTargetingDataType = '';
+  public $isReservation;
+  public $minimumSpendMicros;
+  public $minimumTrueLooks;
+  public $monetizerType;
+  public $semiTransparent;
+  protected $startDateType = 'Google_Service_AdExchangeBuyer_DateTime';
+  protected $startDateDataType = '';
+  public $targetByDealId;
+  public $targetingAllAdSlots;
+  public $termsAttributes;
+  public $urls;
+
+
+  public function setAdSlots($adSlots)
+  {
+    $this->adSlots = $adSlots;
+  }
+  public function getAdSlots()
+  {
+    return $this->adSlots;
+  }
+  public function setAdvertisers($advertisers)
+  {
+    $this->advertisers = $advertisers;
+  }
+  public function getAdvertisers()
+  {
+    return $this->advertisers;
+  }
+  public function setAudienceSegment(Google_Service_AdExchangeBuyer_AudienceSegment $audienceSegment)
+  {
+    $this->audienceSegment = $audienceSegment;
+  }
+  public function getAudienceSegment()
+  {
+    return $this->audienceSegment;
+  }
+  public function setAudienceSegmentDescription($audienceSegmentDescription)
+  {
+    $this->audienceSegmentDescription = $audienceSegmentDescription;
+  }
+  public function getAudienceSegmentDescription()
+  {
+    return $this->audienceSegmentDescription;
+  }
+  public function setBillingTerms($billingTerms)
+  {
+    $this->billingTerms = $billingTerms;
+  }
+  public function getBillingTerms()
+  {
+    return $this->billingTerms;
+  }
+  public function setBuyerBillingType($buyerBillingType)
+  {
+    $this->buyerBillingType = $buyerBillingType;
+  }
+  public function getBuyerBillingType()
+  {
+    return $this->buyerBillingType;
+  }
+  public function setCpm(Google_Service_AdExchangeBuyer_MoneyDto $cpm)
+  {
+    $this->cpm = $cpm;
+  }
+  public function getCpm()
+  {
+    return $this->cpm;
+  }
+  public function setCreativeBlockingLevel($creativeBlockingLevel)
+  {
+    $this->creativeBlockingLevel = $creativeBlockingLevel;
+  }
+  public function getCreativeBlockingLevel()
+  {
+    return $this->creativeBlockingLevel;
+  }
+  public function setCreativeReviewPolicy($creativeReviewPolicy)
+  {
+    $this->creativeReviewPolicy = $creativeReviewPolicy;
+  }
+  public function getCreativeReviewPolicy()
+  {
+    return $this->creativeReviewPolicy;
+  }
+  public function setDealPremium(Google_Service_AdExchangeBuyer_MoneyDto $dealPremium)
+  {
+    $this->dealPremium = $dealPremium;
+  }
+  public function getDealPremium()
+  {
+    return $this->dealPremium;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDescriptiveName($descriptiveName)
+  {
+    $this->descriptiveName = $descriptiveName;
+  }
+  public function getDescriptiveName()
+  {
+    return $this->descriptiveName;
+  }
+  public function setEndDate(Google_Service_AdExchangeBuyer_DateTime $endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setEstimatedImpressionsPerDay($estimatedImpressionsPerDay)
+  {
+    $this->estimatedImpressionsPerDay = $estimatedImpressionsPerDay;
+  }
+  public function getEstimatedImpressionsPerDay()
+  {
+    return $this->estimatedImpressionsPerDay;
+  }
+  public function setEstimatedSpend(Google_Service_AdExchangeBuyer_MoneyDto $estimatedSpend)
+  {
+    $this->estimatedSpend = $estimatedSpend;
+  }
+  public function getEstimatedSpend()
+  {
+    return $this->estimatedSpend;
+  }
+  public function setFinalizeAutomatically($finalizeAutomatically)
+  {
+    $this->finalizeAutomatically = $finalizeAutomatically;
+  }
+  public function getFinalizeAutomatically()
+  {
+    return $this->finalizeAutomatically;
+  }
+  public function setInventorySegmentTargeting(Google_Service_AdExchangeBuyer_InventorySegmentTargeting $inventorySegmentTargeting)
+  {
+    $this->inventorySegmentTargeting = $inventorySegmentTargeting;
+  }
+  public function getInventorySegmentTargeting()
+  {
+    return $this->inventorySegmentTargeting;
+  }
+  public function setIsReservation($isReservation)
+  {
+    $this->isReservation = $isReservation;
+  }
+  public function getIsReservation()
+  {
+    return $this->isReservation;
+  }
+  public function setMinimumSpendMicros($minimumSpendMicros)
+  {
+    $this->minimumSpendMicros = $minimumSpendMicros;
+  }
+  public function getMinimumSpendMicros()
+  {
+    return $this->minimumSpendMicros;
+  }
+  public function setMinimumTrueLooks($minimumTrueLooks)
+  {
+    $this->minimumTrueLooks = $minimumTrueLooks;
+  }
+  public function getMinimumTrueLooks()
+  {
+    return $this->minimumTrueLooks;
+  }
+  public function setMonetizerType($monetizerType)
+  {
+    $this->monetizerType = $monetizerType;
+  }
+  public function getMonetizerType()
+  {
+    return $this->monetizerType;
+  }
+  public function setSemiTransparent($semiTransparent)
+  {
+    $this->semiTransparent = $semiTransparent;
+  }
+  public function getSemiTransparent()
+  {
+    return $this->semiTransparent;
+  }
+  public function setStartDate(Google_Service_AdExchangeBuyer_DateTime $startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+  public function setTargetByDealId($targetByDealId)
+  {
+    $this->targetByDealId = $targetByDealId;
+  }
+  public function getTargetByDealId()
+  {
+    return $this->targetByDealId;
+  }
+  public function setTargetingAllAdSlots($targetingAllAdSlots)
+  {
+    $this->targetingAllAdSlots = $targetingAllAdSlots;
+  }
+  public function getTargetingAllAdSlots()
+  {
+    return $this->targetingAllAdSlots;
+  }
+  public function setTermsAttributes($termsAttributes)
+  {
+    $this->termsAttributes = $termsAttributes;
+  }
+  public function getTermsAttributes()
+  {
+    return $this->termsAttributes;
+  }
+  public function setUrls($urls)
+  {
+    $this->urls = $urls;
+  }
+  public function getUrls()
+  {
+    return $this->urls;
+  }
+}
+
+class Google_Service_AdExchangeBuyer_WebPropertyDto extends Google_Collection
+{
+  protected $collection_key = 'siteUrls';
+  protected $internal_gapi_mappings = array(
+  );
+  public $allowInterestTargetedAds;
+  public $enabledForPreferredDeals;
+  public $id;
+  public $name;
+  public $propertyCode;
+  public $siteUrls;
+  public $syndicationProduct;
+
+
+  public function setAllowInterestTargetedAds($allowInterestTargetedAds)
+  {
+    $this->allowInterestTargetedAds = $allowInterestTargetedAds;
+  }
+  public function getAllowInterestTargetedAds()
+  {
+    return $this->allowInterestTargetedAds;
+  }
+  public function setEnabledForPreferredDeals($enabledForPreferredDeals)
+  {
+    $this->enabledForPreferredDeals = $enabledForPreferredDeals;
+  }
+  public function getEnabledForPreferredDeals()
+  {
+    return $this->enabledForPreferredDeals;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPropertyCode($propertyCode)
+  {
+    $this->propertyCode = $propertyCode;
+  }
+  public function getPropertyCode()
+  {
+    return $this->propertyCode;
+  }
+  public function setSiteUrls($siteUrls)
+  {
+    $this->siteUrls = $siteUrls;
+  }
+  public function getSiteUrls()
+  {
+    return $this->siteUrls;
+  }
+  public function setSyndicationProduct($syndicationProduct)
+  {
+    $this->syndicationProduct = $syndicationProduct;
+  }
+  public function getSyndicationProduct()
+  {
+    return $this->syndicationProduct;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/AdExchangeSeller.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/AdExchangeSeller.php
@@ -1,0 +1,1713 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for AdExchangeSeller (v2.0).
+ *
+ * <p>
+ * Gives Ad Exchange seller users access to their inventory and the ability to
+ * generate reports</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/ad-exchange/seller-rest/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_AdExchangeSeller extends Google_Service
+{
+  /** View and manage your Ad Exchange data. */
+  const ADEXCHANGE_SELLER =
+      "https://www.googleapis.com/auth/adexchange.seller";
+  /** View your Ad Exchange data. */
+  const ADEXCHANGE_SELLER_READONLY =
+      "https://www.googleapis.com/auth/adexchange.seller.readonly";
+
+  public $accounts;
+  public $accounts_adclients;
+  public $accounts_alerts;
+  public $accounts_customchannels;
+  public $accounts_metadata_dimensions;
+  public $accounts_metadata_metrics;
+  public $accounts_preferreddeals;
+  public $accounts_reports;
+  public $accounts_reports_saved;
+  public $accounts_urlchannels;
+  
+
+  /**
+   * Constructs the internal representation of the AdExchangeSeller service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'adexchangeseller/v2.0/';
+    $this->version = 'v2.0';
+    $this->serviceName = 'adexchangeseller';
+
+    $this->accounts = new Google_Service_AdExchangeSeller_Accounts_Resource(
+        $this,
+        $this->serviceName,
+        'accounts',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'accounts/{accountId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_adclients = new Google_Service_AdExchangeSeller_AccountsAdclients_Resource(
+        $this,
+        $this->serviceName,
+        'adclients',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'accounts/{accountId}/adclients',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_alerts = new Google_Service_AdExchangeSeller_AccountsAlerts_Resource(
+        $this,
+        $this->serviceName,
+        'alerts',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'accounts/{accountId}/alerts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_customchannels = new Google_Service_AdExchangeSeller_AccountsCustomchannels_Resource(
+        $this,
+        $this->serviceName,
+        'customchannels',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}/customchannels/{customChannelId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customChannelId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}/customchannels',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_metadata_dimensions = new Google_Service_AdExchangeSeller_AccountsMetadataDimensions_Resource(
+        $this,
+        $this->serviceName,
+        'dimensions',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'accounts/{accountId}/metadata/dimensions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_metadata_metrics = new Google_Service_AdExchangeSeller_AccountsMetadataMetrics_Resource(
+        $this,
+        $this->serviceName,
+        'metrics',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'accounts/{accountId}/metadata/metrics',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_preferreddeals = new Google_Service_AdExchangeSeller_AccountsPreferreddeals_Resource(
+        $this,
+        $this->serviceName,
+        'preferreddeals',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'accounts/{accountId}/preferreddeals/{dealId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dealId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts/{accountId}/preferreddeals',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_reports = new Google_Service_AdExchangeSeller_AccountsReports_Resource(
+        $this,
+        $this->serviceName,
+        'reports',
+        array(
+          'methods' => array(
+            'generate' => array(
+              'path' => 'accounts/{accountId}/reports',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'startDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'endDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sort' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'metric' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'startIndex' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'dimension' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_reports_saved = new Google_Service_AdExchangeSeller_AccountsReportsSaved_Resource(
+        $this,
+        $this->serviceName,
+        'saved',
+        array(
+          'methods' => array(
+            'generate' => array(
+              'path' => 'accounts/{accountId}/reports/{savedReportId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'savedReportId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startIndex' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts/{accountId}/reports/saved',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_urlchannels = new Google_Service_AdExchangeSeller_AccountsUrlchannels_Resource(
+        $this,
+        $this->serviceName,
+        'urlchannels',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}/urlchannels',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "accounts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangesellerService = new Google_Service_AdExchangeSeller(...);
+ *   $accounts = $adexchangesellerService->accounts;
+ *  </code>
+ */
+class Google_Service_AdExchangeSeller_Accounts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get information about the selected Ad Exchange account. (accounts.get)
+   *
+   * @param string $accountId Account to get information about. Tip: 'myaccount'
+   * is a valid ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeSeller_Account
+   */
+  public function get($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdExchangeSeller_Account");
+  }
+
+  /**
+   * List all accounts available to this Ad Exchange account.
+   * (accounts.listAccounts)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through
+   * accounts. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param int maxResults The maximum number of accounts to include in the
+   * response, used for paging.
+   * @return Google_Service_AdExchangeSeller_Accounts
+   */
+  public function listAccounts($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeSeller_Accounts");
+  }
+}
+
+/**
+ * The "adclients" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangesellerService = new Google_Service_AdExchangeSeller(...);
+ *   $adclients = $adexchangesellerService->adclients;
+ *  </code>
+ */
+class Google_Service_AdExchangeSeller_AccountsAdclients_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List all ad clients in this Ad Exchange account.
+   * (adclients.listAccountsAdclients)
+   *
+   * @param string $accountId Account to which the ad client belongs.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through ad
+   * clients. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param string maxResults The maximum number of ad clients to include in
+   * the response, used for paging.
+   * @return Google_Service_AdExchangeSeller_AdClients
+   */
+  public function listAccountsAdclients($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeSeller_AdClients");
+  }
+}
+/**
+ * The "alerts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangesellerService = new Google_Service_AdExchangeSeller(...);
+ *   $alerts = $adexchangesellerService->alerts;
+ *  </code>
+ */
+class Google_Service_AdExchangeSeller_AccountsAlerts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List the alerts for this Ad Exchange account. (alerts.listAccountsAlerts)
+   *
+   * @param string $accountId Account owning the alerts.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string locale The locale to use for translating alert messages.
+   * The account locale will be used if this is not supplied. The AdSense default
+   * (English) will be used if the supplied locale is invalid or unsupported.
+   * @return Google_Service_AdExchangeSeller_Alerts
+   */
+  public function listAccountsAlerts($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeSeller_Alerts");
+  }
+}
+/**
+ * The "customchannels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangesellerService = new Google_Service_AdExchangeSeller(...);
+ *   $customchannels = $adexchangesellerService->customchannels;
+ *  </code>
+ */
+class Google_Service_AdExchangeSeller_AccountsCustomchannels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get the specified custom channel from the specified ad client.
+   * (customchannels.get)
+   *
+   * @param string $accountId Account to which the ad client belongs.
+   * @param string $adClientId Ad client which contains the custom channel.
+   * @param string $customChannelId Custom channel to retrieve.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeSeller_CustomChannel
+   */
+  public function get($accountId, $adClientId, $customChannelId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId, 'customChannelId' => $customChannelId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdExchangeSeller_CustomChannel");
+  }
+
+  /**
+   * List all custom channels in the specified ad client for this Ad Exchange
+   * account. (customchannels.listAccountsCustomchannels)
+   *
+   * @param string $accountId Account to which the ad client belongs.
+   * @param string $adClientId Ad client for which to list custom channels.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through custom
+   * channels. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param string maxResults The maximum number of custom channels to include
+   * in the response, used for paging.
+   * @return Google_Service_AdExchangeSeller_CustomChannels
+   */
+  public function listAccountsCustomchannels($accountId, $adClientId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeSeller_CustomChannels");
+  }
+}
+/**
+ * The "metadata" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangesellerService = new Google_Service_AdExchangeSeller(...);
+ *   $metadata = $adexchangesellerService->metadata;
+ *  </code>
+ */
+class Google_Service_AdExchangeSeller_AccountsMetadata_Resource extends Google_Service_Resource
+{
+}
+
+/**
+ * The "dimensions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangesellerService = new Google_Service_AdExchangeSeller(...);
+ *   $dimensions = $adexchangesellerService->dimensions;
+ *  </code>
+ */
+class Google_Service_AdExchangeSeller_AccountsMetadataDimensions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List the metadata for the dimensions available to this AdExchange account.
+   * (dimensions.listAccountsMetadataDimensions)
+   *
+   * @param string $accountId Account with visibility to the dimensions.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeSeller_Metadata
+   */
+  public function listAccountsMetadataDimensions($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeSeller_Metadata");
+  }
+}
+/**
+ * The "metrics" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangesellerService = new Google_Service_AdExchangeSeller(...);
+ *   $metrics = $adexchangesellerService->metrics;
+ *  </code>
+ */
+class Google_Service_AdExchangeSeller_AccountsMetadataMetrics_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List the metadata for the metrics available to this AdExchange account.
+   * (metrics.listAccountsMetadataMetrics)
+   *
+   * @param string $accountId Account with visibility to the metrics.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeSeller_Metadata
+   */
+  public function listAccountsMetadataMetrics($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeSeller_Metadata");
+  }
+}
+/**
+ * The "preferreddeals" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangesellerService = new Google_Service_AdExchangeSeller(...);
+ *   $preferreddeals = $adexchangesellerService->preferreddeals;
+ *  </code>
+ */
+class Google_Service_AdExchangeSeller_AccountsPreferreddeals_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get information about the selected Ad Exchange Preferred Deal.
+   * (preferreddeals.get)
+   *
+   * @param string $accountId Account owning the deal.
+   * @param string $dealId Preferred deal to get information about.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeSeller_PreferredDeal
+   */
+  public function get($accountId, $dealId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'dealId' => $dealId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdExchangeSeller_PreferredDeal");
+  }
+
+  /**
+   * List the preferred deals for this Ad Exchange account.
+   * (preferreddeals.listAccountsPreferreddeals)
+   *
+   * @param string $accountId Account owning the deals.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdExchangeSeller_PreferredDeals
+   */
+  public function listAccountsPreferreddeals($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeSeller_PreferredDeals");
+  }
+}
+/**
+ * The "reports" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangesellerService = new Google_Service_AdExchangeSeller(...);
+ *   $reports = $adexchangesellerService->reports;
+ *  </code>
+ */
+class Google_Service_AdExchangeSeller_AccountsReports_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Generate an Ad Exchange report based on the report request sent in the query
+   * parameters. Returns the result as JSON; to retrieve output in CSV format
+   * specify "alt=csv" as a query parameter. (reports.generate)
+   *
+   * @param string $accountId Account which owns the generated report.
+   * @param string $startDate Start of the date range to report on in "YYYY-MM-DD"
+   * format, inclusive.
+   * @param string $endDate End of the date range to report on in "YYYY-MM-DD"
+   * format, inclusive.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string sort The name of a dimension or metric to sort the
+   * resulting report on, optionally prefixed with "+" to sort ascending or "-" to
+   * sort descending. If no prefix is specified, the column is sorted ascending.
+   * @opt_param string locale Optional locale to use for translating report output
+   * to a local language. Defaults to "en_US" if not specified.
+   * @opt_param string metric Numeric columns to include in the report.
+   * @opt_param string maxResults The maximum number of rows of report data to
+   * return.
+   * @opt_param string filter Filters to be run on the report.
+   * @opt_param string startIndex Index of the first row of report data to return.
+   * @opt_param string dimension Dimensions to base the report on.
+   * @return Google_Service_AdExchangeSeller_Report
+   */
+  public function generate($accountId, $startDate, $endDate, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'startDate' => $startDate, 'endDate' => $endDate);
+    $params = array_merge($params, $optParams);
+    return $this->call('generate', array($params), "Google_Service_AdExchangeSeller_Report");
+  }
+}
+
+/**
+ * The "saved" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangesellerService = new Google_Service_AdExchangeSeller(...);
+ *   $saved = $adexchangesellerService->saved;
+ *  </code>
+ */
+class Google_Service_AdExchangeSeller_AccountsReportsSaved_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Generate an Ad Exchange report based on the saved report ID sent in the query
+   * parameters. (saved.generate)
+   *
+   * @param string $accountId Account owning the saved report.
+   * @param string $savedReportId The saved report to retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string locale Optional locale to use for translating report output
+   * to a local language. Defaults to "en_US" if not specified.
+   * @opt_param int startIndex Index of the first row of report data to return.
+   * @opt_param int maxResults The maximum number of rows of report data to
+   * return.
+   * @return Google_Service_AdExchangeSeller_Report
+   */
+  public function generate($accountId, $savedReportId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'savedReportId' => $savedReportId);
+    $params = array_merge($params, $optParams);
+    return $this->call('generate', array($params), "Google_Service_AdExchangeSeller_Report");
+  }
+
+  /**
+   * List all saved reports in this Ad Exchange account.
+   * (saved.listAccountsReportsSaved)
+   *
+   * @param string $accountId Account owning the saved reports.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through saved
+   * reports. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param int maxResults The maximum number of saved reports to include in
+   * the response, used for paging.
+   * @return Google_Service_AdExchangeSeller_SavedReports
+   */
+  public function listAccountsReportsSaved($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeSeller_SavedReports");
+  }
+}
+/**
+ * The "urlchannels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adexchangesellerService = new Google_Service_AdExchangeSeller(...);
+ *   $urlchannels = $adexchangesellerService->urlchannels;
+ *  </code>
+ */
+class Google_Service_AdExchangeSeller_AccountsUrlchannels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List all URL channels in the specified ad client for this Ad Exchange
+   * account. (urlchannels.listAccountsUrlchannels)
+   *
+   * @param string $accountId Account to which the ad client belongs.
+   * @param string $adClientId Ad client for which to list URL channels.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through URL
+   * channels. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param string maxResults The maximum number of URL channels to include in
+   * the response, used for paging.
+   * @return Google_Service_AdExchangeSeller_UrlChannels
+   */
+  public function listAccountsUrlchannels($accountId, $adClientId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdExchangeSeller_UrlChannels");
+  }
+}
+
+
+
+
+class Google_Service_AdExchangeSeller_Account extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_AdExchangeSeller_Accounts extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_AdExchangeSeller_Account';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_AdExchangeSeller_AdClient extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $arcOptIn;
+  public $id;
+  public $kind;
+  public $productCode;
+  public $supportsReporting;
+
+
+  public function setArcOptIn($arcOptIn)
+  {
+    $this->arcOptIn = $arcOptIn;
+  }
+  public function getArcOptIn()
+  {
+    return $this->arcOptIn;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProductCode($productCode)
+  {
+    $this->productCode = $productCode;
+  }
+  public function getProductCode()
+  {
+    return $this->productCode;
+  }
+  public function setSupportsReporting($supportsReporting)
+  {
+    $this->supportsReporting = $supportsReporting;
+  }
+  public function getSupportsReporting()
+  {
+    return $this->supportsReporting;
+  }
+}
+
+class Google_Service_AdExchangeSeller_AdClients extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_AdExchangeSeller_AdClient';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_AdExchangeSeller_Alert extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $message;
+  public $severity;
+  public $type;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+  public function setSeverity($severity)
+  {
+    $this->severity = $severity;
+  }
+  public function getSeverity()
+  {
+    return $this->severity;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_AdExchangeSeller_Alerts extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_AdExchangeSeller_Alert';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AdExchangeSeller_CustomChannel extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $id;
+  public $kind;
+  public $name;
+  protected $targetingInfoType = 'Google_Service_AdExchangeSeller_CustomChannelTargetingInfo';
+  protected $targetingInfoDataType = '';
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setTargetingInfo(Google_Service_AdExchangeSeller_CustomChannelTargetingInfo $targetingInfo)
+  {
+    $this->targetingInfo = $targetingInfo;
+  }
+  public function getTargetingInfo()
+  {
+    return $this->targetingInfo;
+  }
+}
+
+class Google_Service_AdExchangeSeller_CustomChannelTargetingInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $adsAppearOn;
+  public $description;
+  public $location;
+  public $siteLanguage;
+
+
+  public function setAdsAppearOn($adsAppearOn)
+  {
+    $this->adsAppearOn = $adsAppearOn;
+  }
+  public function getAdsAppearOn()
+  {
+    return $this->adsAppearOn;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setSiteLanguage($siteLanguage)
+  {
+    $this->siteLanguage = $siteLanguage;
+  }
+  public function getSiteLanguage()
+  {
+    return $this->siteLanguage;
+  }
+}
+
+class Google_Service_AdExchangeSeller_CustomChannels extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_AdExchangeSeller_CustomChannel';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_AdExchangeSeller_Metadata extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_AdExchangeSeller_ReportingMetadataEntry';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AdExchangeSeller_PreferredDeal extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $advertiserName;
+  public $buyerNetworkName;
+  public $currencyCode;
+  public $endTime;
+  public $fixedCpm;
+  public $id;
+  public $kind;
+  public $startTime;
+
+
+  public function setAdvertiserName($advertiserName)
+  {
+    $this->advertiserName = $advertiserName;
+  }
+  public function getAdvertiserName()
+  {
+    return $this->advertiserName;
+  }
+  public function setBuyerNetworkName($buyerNetworkName)
+  {
+    $this->buyerNetworkName = $buyerNetworkName;
+  }
+  public function getBuyerNetworkName()
+  {
+    return $this->buyerNetworkName;
+  }
+  public function setCurrencyCode($currencyCode)
+  {
+    $this->currencyCode = $currencyCode;
+  }
+  public function getCurrencyCode()
+  {
+    return $this->currencyCode;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setFixedCpm($fixedCpm)
+  {
+    $this->fixedCpm = $fixedCpm;
+  }
+  public function getFixedCpm()
+  {
+    return $this->fixedCpm;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+}
+
+class Google_Service_AdExchangeSeller_PreferredDeals extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_AdExchangeSeller_PreferredDeal';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AdExchangeSeller_Report extends Google_Collection
+{
+  protected $collection_key = 'warnings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $averages;
+  protected $headersType = 'Google_Service_AdExchangeSeller_ReportHeaders';
+  protected $headersDataType = 'array';
+  public $kind;
+  public $rows;
+  public $totalMatchedRows;
+  public $totals;
+  public $warnings;
+
+
+  public function setAverages($averages)
+  {
+    $this->averages = $averages;
+  }
+  public function getAverages()
+  {
+    return $this->averages;
+  }
+  public function setHeaders($headers)
+  {
+    $this->headers = $headers;
+  }
+  public function getHeaders()
+  {
+    return $this->headers;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRows($rows)
+  {
+    $this->rows = $rows;
+  }
+  public function getRows()
+  {
+    return $this->rows;
+  }
+  public function setTotalMatchedRows($totalMatchedRows)
+  {
+    $this->totalMatchedRows = $totalMatchedRows;
+  }
+  public function getTotalMatchedRows()
+  {
+    return $this->totalMatchedRows;
+  }
+  public function setTotals($totals)
+  {
+    $this->totals = $totals;
+  }
+  public function getTotals()
+  {
+    return $this->totals;
+  }
+  public function setWarnings($warnings)
+  {
+    $this->warnings = $warnings;
+  }
+  public function getWarnings()
+  {
+    return $this->warnings;
+  }
+}
+
+class Google_Service_AdExchangeSeller_ReportHeaders extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $currency;
+  public $name;
+  public $type;
+
+
+  public function setCurrency($currency)
+  {
+    $this->currency = $currency;
+  }
+  public function getCurrency()
+  {
+    return $this->currency;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_AdExchangeSeller_ReportingMetadataEntry extends Google_Collection
+{
+  protected $collection_key = 'supportedProducts';
+  protected $internal_gapi_mappings = array(
+  );
+  public $compatibleDimensions;
+  public $compatibleMetrics;
+  public $id;
+  public $kind;
+  public $requiredDimensions;
+  public $requiredMetrics;
+  public $supportedProducts;
+
+
+  public function setCompatibleDimensions($compatibleDimensions)
+  {
+    $this->compatibleDimensions = $compatibleDimensions;
+  }
+  public function getCompatibleDimensions()
+  {
+    return $this->compatibleDimensions;
+  }
+  public function setCompatibleMetrics($compatibleMetrics)
+  {
+    $this->compatibleMetrics = $compatibleMetrics;
+  }
+  public function getCompatibleMetrics()
+  {
+    return $this->compatibleMetrics;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRequiredDimensions($requiredDimensions)
+  {
+    $this->requiredDimensions = $requiredDimensions;
+  }
+  public function getRequiredDimensions()
+  {
+    return $this->requiredDimensions;
+  }
+  public function setRequiredMetrics($requiredMetrics)
+  {
+    $this->requiredMetrics = $requiredMetrics;
+  }
+  public function getRequiredMetrics()
+  {
+    return $this->requiredMetrics;
+  }
+  public function setSupportedProducts($supportedProducts)
+  {
+    $this->supportedProducts = $supportedProducts;
+  }
+  public function getSupportedProducts()
+  {
+    return $this->supportedProducts;
+  }
+}
+
+class Google_Service_AdExchangeSeller_SavedReport extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_AdExchangeSeller_SavedReports extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_AdExchangeSeller_SavedReport';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_AdExchangeSeller_UrlChannel extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $urlPattern;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUrlPattern($urlPattern)
+  {
+    $this->urlPattern = $urlPattern;
+  }
+  public function getUrlPattern()
+  {
+    return $this->urlPattern;
+  }
+}
+
+class Google_Service_AdExchangeSeller_UrlChannels extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_AdExchangeSeller_UrlChannel';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/AdSense.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/AdSense.php
@@ -1,0 +1,3596 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for AdSense (v1.4).
+ *
+ * <p>
+ * Gives AdSense publishers access to their inventory and the ability to
+ * generate reports</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/adsense/management/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_AdSense extends Google_Service
+{
+  /** View and manage your AdSense data. */
+  const ADSENSE =
+      "https://www.googleapis.com/auth/adsense";
+  /** View your AdSense data. */
+  const ADSENSE_READONLY =
+      "https://www.googleapis.com/auth/adsense.readonly";
+
+  public $accounts;
+  public $accounts_adclients;
+  public $accounts_adunits;
+  public $accounts_adunits_customchannels;
+  public $accounts_alerts;
+  public $accounts_customchannels;
+  public $accounts_customchannels_adunits;
+  public $accounts_payments;
+  public $accounts_reports;
+  public $accounts_reports_saved;
+  public $accounts_savedadstyles;
+  public $accounts_urlchannels;
+  public $adclients;
+  public $adunits;
+  public $adunits_customchannels;
+  public $alerts;
+  public $customchannels;
+  public $customchannels_adunits;
+  public $metadata_dimensions;
+  public $metadata_metrics;
+  public $payments;
+  public $reports;
+  public $reports_saved;
+  public $savedadstyles;
+  public $urlchannels;
+  
+
+  /**
+   * Constructs the internal representation of the AdSense service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'adsense/v1.4/';
+    $this->version = 'v1.4';
+    $this->serviceName = 'adsense';
+
+    $this->accounts = new Google_Service_AdSense_Accounts_Resource(
+        $this,
+        $this->serviceName,
+        'accounts',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'accounts/{accountId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'tree' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_adclients = new Google_Service_AdSense_AccountsAdclients_Resource(
+        $this,
+        $this->serviceName,
+        'adclients',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'accounts/{accountId}/adclients',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_adunits = new Google_Service_AdSense_AccountsAdunits_Resource(
+        $this,
+        $this->serviceName,
+        'adunits',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}/adunits/{adUnitId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adUnitId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getAdCode' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}/adunits/{adUnitId}/adcode',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adUnitId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}/adunits',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'includeInactive' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_adunits_customchannels = new Google_Service_AdSense_AccountsAdunitsCustomchannels_Resource(
+        $this,
+        $this->serviceName,
+        'customchannels',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}/adunits/{adUnitId}/customchannels',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adUnitId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_alerts = new Google_Service_AdSense_AccountsAlerts_Resource(
+        $this,
+        $this->serviceName,
+        'alerts',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'accounts/{accountId}/alerts/{alertId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'alertId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts/{accountId}/alerts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_customchannels = new Google_Service_AdSense_AccountsCustomchannels_Resource(
+        $this,
+        $this->serviceName,
+        'customchannels',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}/customchannels/{customChannelId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customChannelId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}/customchannels',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_customchannels_adunits = new Google_Service_AdSense_AccountsCustomchannelsAdunits_Resource(
+        $this,
+        $this->serviceName,
+        'adunits',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}/customchannels/{customChannelId}/adunits',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customChannelId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'includeInactive' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_payments = new Google_Service_AdSense_AccountsPayments_Resource(
+        $this,
+        $this->serviceName,
+        'payments',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'accounts/{accountId}/payments',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_reports = new Google_Service_AdSense_AccountsReports_Resource(
+        $this,
+        $this->serviceName,
+        'reports',
+        array(
+          'methods' => array(
+            'generate' => array(
+              'path' => 'accounts/{accountId}/reports',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'startDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'endDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sort' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'metric' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'currency' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startIndex' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'useTimezoneReporting' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'dimension' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_reports_saved = new Google_Service_AdSense_AccountsReportsSaved_Resource(
+        $this,
+        $this->serviceName,
+        'saved',
+        array(
+          'methods' => array(
+            'generate' => array(
+              'path' => 'accounts/{accountId}/reports/{savedReportId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'savedReportId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startIndex' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts/{accountId}/reports/saved',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_savedadstyles = new Google_Service_AdSense_AccountsSavedadstyles_Resource(
+        $this,
+        $this->serviceName,
+        'savedadstyles',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'accounts/{accountId}/savedadstyles/{savedAdStyleId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'savedAdStyleId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts/{accountId}/savedadstyles',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_urlchannels = new Google_Service_AdSense_AccountsUrlchannels_Resource(
+        $this,
+        $this->serviceName,
+        'urlchannels',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}/urlchannels',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->adclients = new Google_Service_AdSense_Adclients_Resource(
+        $this,
+        $this->serviceName,
+        'adclients',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'adclients',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->adunits = new Google_Service_AdSense_Adunits_Resource(
+        $this,
+        $this->serviceName,
+        'adunits',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'adclients/{adClientId}/adunits/{adUnitId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adUnitId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getAdCode' => array(
+              'path' => 'adclients/{adClientId}/adunits/{adUnitId}/adcode',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adUnitId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'adclients/{adClientId}/adunits',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'includeInactive' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->adunits_customchannels = new Google_Service_AdSense_AdunitsCustomchannels_Resource(
+        $this,
+        $this->serviceName,
+        'customchannels',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'adclients/{adClientId}/adunits/{adUnitId}/customchannels',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adUnitId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->alerts = new Google_Service_AdSense_Alerts_Resource(
+        $this,
+        $this->serviceName,
+        'alerts',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'alerts/{alertId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'alertId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'alerts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->customchannels = new Google_Service_AdSense_Customchannels_Resource(
+        $this,
+        $this->serviceName,
+        'customchannels',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'adclients/{adClientId}/customchannels/{customChannelId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customChannelId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'adclients/{adClientId}/customchannels',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->customchannels_adunits = new Google_Service_AdSense_CustomchannelsAdunits_Resource(
+        $this,
+        $this->serviceName,
+        'adunits',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'adclients/{adClientId}/customchannels/{customChannelId}/adunits',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customChannelId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'includeInactive' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->metadata_dimensions = new Google_Service_AdSense_MetadataDimensions_Resource(
+        $this,
+        $this->serviceName,
+        'dimensions',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'metadata/dimensions',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->metadata_metrics = new Google_Service_AdSense_MetadataMetrics_Resource(
+        $this,
+        $this->serviceName,
+        'metrics',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'metadata/metrics',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->payments = new Google_Service_AdSense_Payments_Resource(
+        $this,
+        $this->serviceName,
+        'payments',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'payments',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->reports = new Google_Service_AdSense_Reports_Resource(
+        $this,
+        $this->serviceName,
+        'reports',
+        array(
+          'methods' => array(
+            'generate' => array(
+              'path' => 'reports',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'startDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'endDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sort' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'metric' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'currency' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startIndex' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'useTimezoneReporting' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'dimension' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'accountId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->reports_saved = new Google_Service_AdSense_ReportsSaved_Resource(
+        $this,
+        $this->serviceName,
+        'saved',
+        array(
+          'methods' => array(
+            'generate' => array(
+              'path' => 'reports/{savedReportId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'savedReportId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startIndex' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'reports/saved',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->savedadstyles = new Google_Service_AdSense_Savedadstyles_Resource(
+        $this,
+        $this->serviceName,
+        'savedadstyles',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'savedadstyles/{savedAdStyleId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'savedAdStyleId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'savedadstyles',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->urlchannels = new Google_Service_AdSense_Urlchannels_Resource(
+        $this,
+        $this->serviceName,
+        'urlchannels',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'adclients/{adClientId}/urlchannels',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "accounts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $accounts = $adsenseService->accounts;
+ *  </code>
+ */
+class Google_Service_AdSense_Accounts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get information about the selected AdSense account. (accounts.get)
+   *
+   * @param string $accountId Account to get information about.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool tree Whether the tree of sub accounts should be returned.
+   * @return Google_Service_AdSense_Account
+   */
+  public function get($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdSense_Account");
+  }
+
+  /**
+   * List all accounts available to this AdSense account. (accounts.listAccounts)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through
+   * accounts. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param int maxResults The maximum number of accounts to include in the
+   * response, used for paging.
+   * @return Google_Service_AdSense_Accounts
+   */
+  public function listAccounts($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_Accounts");
+  }
+}
+
+/**
+ * The "adclients" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $adclients = $adsenseService->adclients;
+ *  </code>
+ */
+class Google_Service_AdSense_AccountsAdclients_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List all ad clients in the specified account.
+   * (adclients.listAccountsAdclients)
+   *
+   * @param string $accountId Account for which to list ad clients.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through ad
+   * clients. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param int maxResults The maximum number of ad clients to include in the
+   * response, used for paging.
+   * @return Google_Service_AdSense_AdClients
+   */
+  public function listAccountsAdclients($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_AdClients");
+  }
+}
+/**
+ * The "adunits" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $adunits = $adsenseService->adunits;
+ *  </code>
+ */
+class Google_Service_AdSense_AccountsAdunits_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the specified ad unit in the specified ad client for the specified
+   * account. (adunits.get)
+   *
+   * @param string $accountId Account to which the ad client belongs.
+   * @param string $adClientId Ad client for which to get the ad unit.
+   * @param string $adUnitId Ad unit to retrieve.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSense_AdUnit
+   */
+  public function get($accountId, $adClientId, $adUnitId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId, 'adUnitId' => $adUnitId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdSense_AdUnit");
+  }
+
+  /**
+   * Get ad code for the specified ad unit. (adunits.getAdCode)
+   *
+   * @param string $accountId Account which contains the ad client.
+   * @param string $adClientId Ad client with contains the ad unit.
+   * @param string $adUnitId Ad unit to get the code for.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSense_AdCode
+   */
+  public function getAdCode($accountId, $adClientId, $adUnitId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId, 'adUnitId' => $adUnitId);
+    $params = array_merge($params, $optParams);
+    return $this->call('getAdCode', array($params), "Google_Service_AdSense_AdCode");
+  }
+
+  /**
+   * List all ad units in the specified ad client for the specified account.
+   * (adunits.listAccountsAdunits)
+   *
+   * @param string $accountId Account to which the ad client belongs.
+   * @param string $adClientId Ad client for which to list ad units.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool includeInactive Whether to include inactive ad units.
+   * Default: true.
+   * @opt_param string pageToken A continuation token, used to page through ad
+   * units. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param int maxResults The maximum number of ad units to include in the
+   * response, used for paging.
+   * @return Google_Service_AdSense_AdUnits
+   */
+  public function listAccountsAdunits($accountId, $adClientId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_AdUnits");
+  }
+}
+
+/**
+ * The "customchannels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $customchannels = $adsenseService->customchannels;
+ *  </code>
+ */
+class Google_Service_AdSense_AccountsAdunitsCustomchannels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List all custom channels which the specified ad unit belongs to.
+   * (customchannels.listAccountsAdunitsCustomchannels)
+   *
+   * @param string $accountId Account to which the ad client belongs.
+   * @param string $adClientId Ad client which contains the ad unit.
+   * @param string $adUnitId Ad unit for which to list custom channels.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through custom
+   * channels. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param int maxResults The maximum number of custom channels to include in
+   * the response, used for paging.
+   * @return Google_Service_AdSense_CustomChannels
+   */
+  public function listAccountsAdunitsCustomchannels($accountId, $adClientId, $adUnitId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId, 'adUnitId' => $adUnitId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_CustomChannels");
+  }
+}
+/**
+ * The "alerts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $alerts = $adsenseService->alerts;
+ *  </code>
+ */
+class Google_Service_AdSense_AccountsAlerts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Dismiss (delete) the specified alert from the specified publisher AdSense
+   * account. (alerts.delete)
+   *
+   * @param string $accountId Account which contains the ad unit.
+   * @param string $alertId Alert to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($accountId, $alertId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'alertId' => $alertId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * List the alerts for the specified AdSense account.
+   * (alerts.listAccountsAlerts)
+   *
+   * @param string $accountId Account for which to retrieve the alerts.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string locale The locale to use for translating alert messages.
+   * The account locale will be used if this is not supplied. The AdSense default
+   * (English) will be used if the supplied locale is invalid or unsupported.
+   * @return Google_Service_AdSense_Alerts
+   */
+  public function listAccountsAlerts($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_Alerts");
+  }
+}
+/**
+ * The "customchannels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $customchannels = $adsenseService->customchannels;
+ *  </code>
+ */
+class Google_Service_AdSense_AccountsCustomchannels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get the specified custom channel from the specified ad client for the
+   * specified account. (customchannels.get)
+   *
+   * @param string $accountId Account to which the ad client belongs.
+   * @param string $adClientId Ad client which contains the custom channel.
+   * @param string $customChannelId Custom channel to retrieve.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSense_CustomChannel
+   */
+  public function get($accountId, $adClientId, $customChannelId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId, 'customChannelId' => $customChannelId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdSense_CustomChannel");
+  }
+
+  /**
+   * List all custom channels in the specified ad client for the specified
+   * account. (customchannels.listAccountsCustomchannels)
+   *
+   * @param string $accountId Account to which the ad client belongs.
+   * @param string $adClientId Ad client for which to list custom channels.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through custom
+   * channels. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param int maxResults The maximum number of custom channels to include in
+   * the response, used for paging.
+   * @return Google_Service_AdSense_CustomChannels
+   */
+  public function listAccountsCustomchannels($accountId, $adClientId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_CustomChannels");
+  }
+}
+
+/**
+ * The "adunits" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $adunits = $adsenseService->adunits;
+ *  </code>
+ */
+class Google_Service_AdSense_AccountsCustomchannelsAdunits_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List all ad units in the specified custom channel.
+   * (adunits.listAccountsCustomchannelsAdunits)
+   *
+   * @param string $accountId Account to which the ad client belongs.
+   * @param string $adClientId Ad client which contains the custom channel.
+   * @param string $customChannelId Custom channel for which to list ad units.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool includeInactive Whether to include inactive ad units.
+   * Default: true.
+   * @opt_param int maxResults The maximum number of ad units to include in the
+   * response, used for paging.
+   * @opt_param string pageToken A continuation token, used to page through ad
+   * units. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @return Google_Service_AdSense_AdUnits
+   */
+  public function listAccountsCustomchannelsAdunits($accountId, $adClientId, $customChannelId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId, 'customChannelId' => $customChannelId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_AdUnits");
+  }
+}
+/**
+ * The "payments" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $payments = $adsenseService->payments;
+ *  </code>
+ */
+class Google_Service_AdSense_AccountsPayments_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List the payments for the specified AdSense account.
+   * (payments.listAccountsPayments)
+   *
+   * @param string $accountId Account for which to retrieve the payments.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSense_Payments
+   */
+  public function listAccountsPayments($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_Payments");
+  }
+}
+/**
+ * The "reports" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $reports = $adsenseService->reports;
+ *  </code>
+ */
+class Google_Service_AdSense_AccountsReports_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Generate an AdSense report based on the report request sent in the query
+   * parameters. Returns the result as JSON; to retrieve output in CSV format
+   * specify "alt=csv" as a query parameter. (reports.generate)
+   *
+   * @param string $accountId Account upon which to report.
+   * @param string $startDate Start of the date range to report on in "YYYY-MM-DD"
+   * format, inclusive.
+   * @param string $endDate End of the date range to report on in "YYYY-MM-DD"
+   * format, inclusive.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string sort The name of a dimension or metric to sort the
+   * resulting report on, optionally prefixed with "+" to sort ascending or "-" to
+   * sort descending. If no prefix is specified, the column is sorted ascending.
+   * @opt_param string locale Optional locale to use for translating report output
+   * to a local language. Defaults to "en_US" if not specified.
+   * @opt_param string metric Numeric columns to include in the report.
+   * @opt_param int maxResults The maximum number of rows of report data to
+   * return.
+   * @opt_param string filter Filters to be run on the report.
+   * @opt_param string currency Optional currency to use when reporting on
+   * monetary metrics. Defaults to the account's currency if not set.
+   * @opt_param int startIndex Index of the first row of report data to return.
+   * @opt_param bool useTimezoneReporting Whether the report should be generated
+   * in the AdSense account's local timezone. If false default PST/PDT timezone
+   * will be used.
+   * @opt_param string dimension Dimensions to base the report on.
+   * @return Google_Service_AdSense_AdsenseReportsGenerateResponse
+   */
+  public function generate($accountId, $startDate, $endDate, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'startDate' => $startDate, 'endDate' => $endDate);
+    $params = array_merge($params, $optParams);
+    return $this->call('generate', array($params), "Google_Service_AdSense_AdsenseReportsGenerateResponse");
+  }
+}
+
+/**
+ * The "saved" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $saved = $adsenseService->saved;
+ *  </code>
+ */
+class Google_Service_AdSense_AccountsReportsSaved_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Generate an AdSense report based on the saved report ID sent in the query
+   * parameters. (saved.generate)
+   *
+   * @param string $accountId Account to which the saved reports belong.
+   * @param string $savedReportId The saved report to retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string locale Optional locale to use for translating report output
+   * to a local language. Defaults to "en_US" if not specified.
+   * @opt_param int startIndex Index of the first row of report data to return.
+   * @opt_param int maxResults The maximum number of rows of report data to
+   * return.
+   * @return Google_Service_AdSense_AdsenseReportsGenerateResponse
+   */
+  public function generate($accountId, $savedReportId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'savedReportId' => $savedReportId);
+    $params = array_merge($params, $optParams);
+    return $this->call('generate', array($params), "Google_Service_AdSense_AdsenseReportsGenerateResponse");
+  }
+
+  /**
+   * List all saved reports in the specified AdSense account.
+   * (saved.listAccountsReportsSaved)
+   *
+   * @param string $accountId Account to which the saved reports belong.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through saved
+   * reports. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param int maxResults The maximum number of saved reports to include in
+   * the response, used for paging.
+   * @return Google_Service_AdSense_SavedReports
+   */
+  public function listAccountsReportsSaved($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_SavedReports");
+  }
+}
+/**
+ * The "savedadstyles" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $savedadstyles = $adsenseService->savedadstyles;
+ *  </code>
+ */
+class Google_Service_AdSense_AccountsSavedadstyles_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List a specific saved ad style for the specified account. (savedadstyles.get)
+   *
+   * @param string $accountId Account for which to get the saved ad style.
+   * @param string $savedAdStyleId Saved ad style to retrieve.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSense_SavedAdStyle
+   */
+  public function get($accountId, $savedAdStyleId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'savedAdStyleId' => $savedAdStyleId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdSense_SavedAdStyle");
+  }
+
+  /**
+   * List all saved ad styles in the specified account.
+   * (savedadstyles.listAccountsSavedadstyles)
+   *
+   * @param string $accountId Account for which to list saved ad styles.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through saved
+   * ad styles. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param int maxResults The maximum number of saved ad styles to include in
+   * the response, used for paging.
+   * @return Google_Service_AdSense_SavedAdStyles
+   */
+  public function listAccountsSavedadstyles($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_SavedAdStyles");
+  }
+}
+/**
+ * The "urlchannels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $urlchannels = $adsenseService->urlchannels;
+ *  </code>
+ */
+class Google_Service_AdSense_AccountsUrlchannels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List all URL channels in the specified ad client for the specified account.
+   * (urlchannels.listAccountsUrlchannels)
+   *
+   * @param string $accountId Account to which the ad client belongs.
+   * @param string $adClientId Ad client for which to list URL channels.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through URL
+   * channels. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param int maxResults The maximum number of URL channels to include in
+   * the response, used for paging.
+   * @return Google_Service_AdSense_UrlChannels
+   */
+  public function listAccountsUrlchannels($accountId, $adClientId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_UrlChannels");
+  }
+}
+
+/**
+ * The "adclients" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $adclients = $adsenseService->adclients;
+ *  </code>
+ */
+class Google_Service_AdSense_Adclients_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List all ad clients in this AdSense account. (adclients.listAdclients)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through ad
+   * clients. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param int maxResults The maximum number of ad clients to include in the
+   * response, used for paging.
+   * @return Google_Service_AdSense_AdClients
+   */
+  public function listAdclients($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_AdClients");
+  }
+}
+
+/**
+ * The "adunits" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $adunits = $adsenseService->adunits;
+ *  </code>
+ */
+class Google_Service_AdSense_Adunits_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the specified ad unit in the specified ad client. (adunits.get)
+   *
+   * @param string $adClientId Ad client for which to get the ad unit.
+   * @param string $adUnitId Ad unit to retrieve.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSense_AdUnit
+   */
+  public function get($adClientId, $adUnitId, $optParams = array())
+  {
+    $params = array('adClientId' => $adClientId, 'adUnitId' => $adUnitId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdSense_AdUnit");
+  }
+
+  /**
+   * Get ad code for the specified ad unit. (adunits.getAdCode)
+   *
+   * @param string $adClientId Ad client with contains the ad unit.
+   * @param string $adUnitId Ad unit to get the code for.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSense_AdCode
+   */
+  public function getAdCode($adClientId, $adUnitId, $optParams = array())
+  {
+    $params = array('adClientId' => $adClientId, 'adUnitId' => $adUnitId);
+    $params = array_merge($params, $optParams);
+    return $this->call('getAdCode', array($params), "Google_Service_AdSense_AdCode");
+  }
+
+  /**
+   * List all ad units in the specified ad client for this AdSense account.
+   * (adunits.listAdunits)
+   *
+   * @param string $adClientId Ad client for which to list ad units.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool includeInactive Whether to include inactive ad units.
+   * Default: true.
+   * @opt_param string pageToken A continuation token, used to page through ad
+   * units. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param int maxResults The maximum number of ad units to include in the
+   * response, used for paging.
+   * @return Google_Service_AdSense_AdUnits
+   */
+  public function listAdunits($adClientId, $optParams = array())
+  {
+    $params = array('adClientId' => $adClientId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_AdUnits");
+  }
+}
+
+/**
+ * The "customchannels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $customchannels = $adsenseService->customchannels;
+ *  </code>
+ */
+class Google_Service_AdSense_AdunitsCustomchannels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List all custom channels which the specified ad unit belongs to.
+   * (customchannels.listAdunitsCustomchannels)
+   *
+   * @param string $adClientId Ad client which contains the ad unit.
+   * @param string $adUnitId Ad unit for which to list custom channels.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through custom
+   * channels. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param int maxResults The maximum number of custom channels to include in
+   * the response, used for paging.
+   * @return Google_Service_AdSense_CustomChannels
+   */
+  public function listAdunitsCustomchannels($adClientId, $adUnitId, $optParams = array())
+  {
+    $params = array('adClientId' => $adClientId, 'adUnitId' => $adUnitId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_CustomChannels");
+  }
+}
+
+/**
+ * The "alerts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $alerts = $adsenseService->alerts;
+ *  </code>
+ */
+class Google_Service_AdSense_Alerts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Dismiss (delete) the specified alert from the publisher's AdSense account.
+   * (alerts.delete)
+   *
+   * @param string $alertId Alert to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($alertId, $optParams = array())
+  {
+    $params = array('alertId' => $alertId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * List the alerts for this AdSense account. (alerts.listAlerts)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string locale The locale to use for translating alert messages.
+   * The account locale will be used if this is not supplied. The AdSense default
+   * (English) will be used if the supplied locale is invalid or unsupported.
+   * @return Google_Service_AdSense_Alerts
+   */
+  public function listAlerts($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_Alerts");
+  }
+}
+
+/**
+ * The "customchannels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $customchannels = $adsenseService->customchannels;
+ *  </code>
+ */
+class Google_Service_AdSense_Customchannels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get the specified custom channel from the specified ad client.
+   * (customchannels.get)
+   *
+   * @param string $adClientId Ad client which contains the custom channel.
+   * @param string $customChannelId Custom channel to retrieve.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSense_CustomChannel
+   */
+  public function get($adClientId, $customChannelId, $optParams = array())
+  {
+    $params = array('adClientId' => $adClientId, 'customChannelId' => $customChannelId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdSense_CustomChannel");
+  }
+
+  /**
+   * List all custom channels in the specified ad client for this AdSense account.
+   * (customchannels.listCustomchannels)
+   *
+   * @param string $adClientId Ad client for which to list custom channels.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through custom
+   * channels. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param int maxResults The maximum number of custom channels to include in
+   * the response, used for paging.
+   * @return Google_Service_AdSense_CustomChannels
+   */
+  public function listCustomchannels($adClientId, $optParams = array())
+  {
+    $params = array('adClientId' => $adClientId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_CustomChannels");
+  }
+}
+
+/**
+ * The "adunits" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $adunits = $adsenseService->adunits;
+ *  </code>
+ */
+class Google_Service_AdSense_CustomchannelsAdunits_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List all ad units in the specified custom channel.
+   * (adunits.listCustomchannelsAdunits)
+   *
+   * @param string $adClientId Ad client which contains the custom channel.
+   * @param string $customChannelId Custom channel for which to list ad units.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool includeInactive Whether to include inactive ad units.
+   * Default: true.
+   * @opt_param string pageToken A continuation token, used to page through ad
+   * units. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param int maxResults The maximum number of ad units to include in the
+   * response, used for paging.
+   * @return Google_Service_AdSense_AdUnits
+   */
+  public function listCustomchannelsAdunits($adClientId, $customChannelId, $optParams = array())
+  {
+    $params = array('adClientId' => $adClientId, 'customChannelId' => $customChannelId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_AdUnits");
+  }
+}
+
+/**
+ * The "metadata" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $metadata = $adsenseService->metadata;
+ *  </code>
+ */
+class Google_Service_AdSense_Metadata_Resource extends Google_Service_Resource
+{
+}
+
+/**
+ * The "dimensions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $dimensions = $adsenseService->dimensions;
+ *  </code>
+ */
+class Google_Service_AdSense_MetadataDimensions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List the metadata for the dimensions available to this AdSense account.
+   * (dimensions.listMetadataDimensions)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSense_Metadata
+   */
+  public function listMetadataDimensions($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_Metadata");
+  }
+}
+/**
+ * The "metrics" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $metrics = $adsenseService->metrics;
+ *  </code>
+ */
+class Google_Service_AdSense_MetadataMetrics_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List the metadata for the metrics available to this AdSense account.
+   * (metrics.listMetadataMetrics)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSense_Metadata
+   */
+  public function listMetadataMetrics($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_Metadata");
+  }
+}
+
+/**
+ * The "payments" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $payments = $adsenseService->payments;
+ *  </code>
+ */
+class Google_Service_AdSense_Payments_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List the payments for this AdSense account. (payments.listPayments)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSense_Payments
+   */
+  public function listPayments($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_Payments");
+  }
+}
+
+/**
+ * The "reports" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $reports = $adsenseService->reports;
+ *  </code>
+ */
+class Google_Service_AdSense_Reports_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Generate an AdSense report based on the report request sent in the query
+   * parameters. Returns the result as JSON; to retrieve output in CSV format
+   * specify "alt=csv" as a query parameter. (reports.generate)
+   *
+   * @param string $startDate Start of the date range to report on in "YYYY-MM-DD"
+   * format, inclusive.
+   * @param string $endDate End of the date range to report on in "YYYY-MM-DD"
+   * format, inclusive.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string sort The name of a dimension or metric to sort the
+   * resulting report on, optionally prefixed with "+" to sort ascending or "-" to
+   * sort descending. If no prefix is specified, the column is sorted ascending.
+   * @opt_param string locale Optional locale to use for translating report output
+   * to a local language. Defaults to "en_US" if not specified.
+   * @opt_param string metric Numeric columns to include in the report.
+   * @opt_param int maxResults The maximum number of rows of report data to
+   * return.
+   * @opt_param string filter Filters to be run on the report.
+   * @opt_param string currency Optional currency to use when reporting on
+   * monetary metrics. Defaults to the account's currency if not set.
+   * @opt_param int startIndex Index of the first row of report data to return.
+   * @opt_param bool useTimezoneReporting Whether the report should be generated
+   * in the AdSense account's local timezone. If false default PST/PDT timezone
+   * will be used.
+   * @opt_param string dimension Dimensions to base the report on.
+   * @opt_param string accountId Accounts upon which to report.
+   * @return Google_Service_AdSense_AdsenseReportsGenerateResponse
+   */
+  public function generate($startDate, $endDate, $optParams = array())
+  {
+    $params = array('startDate' => $startDate, 'endDate' => $endDate);
+    $params = array_merge($params, $optParams);
+    return $this->call('generate', array($params), "Google_Service_AdSense_AdsenseReportsGenerateResponse");
+  }
+}
+
+/**
+ * The "saved" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $saved = $adsenseService->saved;
+ *  </code>
+ */
+class Google_Service_AdSense_ReportsSaved_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Generate an AdSense report based on the saved report ID sent in the query
+   * parameters. (saved.generate)
+   *
+   * @param string $savedReportId The saved report to retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string locale Optional locale to use for translating report output
+   * to a local language. Defaults to "en_US" if not specified.
+   * @opt_param int startIndex Index of the first row of report data to return.
+   * @opt_param int maxResults The maximum number of rows of report data to
+   * return.
+   * @return Google_Service_AdSense_AdsenseReportsGenerateResponse
+   */
+  public function generate($savedReportId, $optParams = array())
+  {
+    $params = array('savedReportId' => $savedReportId);
+    $params = array_merge($params, $optParams);
+    return $this->call('generate', array($params), "Google_Service_AdSense_AdsenseReportsGenerateResponse");
+  }
+
+  /**
+   * List all saved reports in this AdSense account. (saved.listReportsSaved)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through saved
+   * reports. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param int maxResults The maximum number of saved reports to include in
+   * the response, used for paging.
+   * @return Google_Service_AdSense_SavedReports
+   */
+  public function listReportsSaved($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_SavedReports");
+  }
+}
+
+/**
+ * The "savedadstyles" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $savedadstyles = $adsenseService->savedadstyles;
+ *  </code>
+ */
+class Google_Service_AdSense_Savedadstyles_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get a specific saved ad style from the user's account. (savedadstyles.get)
+   *
+   * @param string $savedAdStyleId Saved ad style to retrieve.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSense_SavedAdStyle
+   */
+  public function get($savedAdStyleId, $optParams = array())
+  {
+    $params = array('savedAdStyleId' => $savedAdStyleId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdSense_SavedAdStyle");
+  }
+
+  /**
+   * List all saved ad styles in the user's account.
+   * (savedadstyles.listSavedadstyles)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through saved
+   * ad styles. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param int maxResults The maximum number of saved ad styles to include in
+   * the response, used for paging.
+   * @return Google_Service_AdSense_SavedAdStyles
+   */
+  public function listSavedadstyles($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_SavedAdStyles");
+  }
+}
+
+/**
+ * The "urlchannels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsenseService = new Google_Service_AdSense(...);
+ *   $urlchannels = $adsenseService->urlchannels;
+ *  </code>
+ */
+class Google_Service_AdSense_Urlchannels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List all URL channels in the specified ad client for this AdSense account.
+   * (urlchannels.listUrlchannels)
+   *
+   * @param string $adClientId Ad client for which to list URL channels.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through URL
+   * channels. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param int maxResults The maximum number of URL channels to include in
+   * the response, used for paging.
+   * @return Google_Service_AdSense_UrlChannels
+   */
+  public function listUrlchannels($adClientId, $optParams = array())
+  {
+    $params = array('adClientId' => $adClientId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSense_UrlChannels");
+  }
+}
+
+
+
+
+class Google_Service_AdSense_Account extends Google_Collection
+{
+  protected $collection_key = 'subAccounts';
+  protected $internal_gapi_mappings = array(
+        "creationTime" => "creation_time",
+  );
+  public $creationTime;
+  public $id;
+  public $kind;
+  public $name;
+  public $premium;
+  protected $subAccountsType = 'Google_Service_AdSense_Account';
+  protected $subAccountsDataType = 'array';
+  public $timezone;
+
+
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPremium($premium)
+  {
+    $this->premium = $premium;
+  }
+  public function getPremium()
+  {
+    return $this->premium;
+  }
+  public function setSubAccounts($subAccounts)
+  {
+    $this->subAccounts = $subAccounts;
+  }
+  public function getSubAccounts()
+  {
+    return $this->subAccounts;
+  }
+  public function setTimezone($timezone)
+  {
+    $this->timezone = $timezone;
+  }
+  public function getTimezone()
+  {
+    return $this->timezone;
+  }
+}
+
+class Google_Service_AdSense_Accounts extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_AdSense_Account';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_AdSense_AdClient extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $arcOptIn;
+  public $arcReviewMode;
+  public $id;
+  public $kind;
+  public $productCode;
+  public $supportsReporting;
+
+
+  public function setArcOptIn($arcOptIn)
+  {
+    $this->arcOptIn = $arcOptIn;
+  }
+  public function getArcOptIn()
+  {
+    return $this->arcOptIn;
+  }
+  public function setArcReviewMode($arcReviewMode)
+  {
+    $this->arcReviewMode = $arcReviewMode;
+  }
+  public function getArcReviewMode()
+  {
+    return $this->arcReviewMode;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProductCode($productCode)
+  {
+    $this->productCode = $productCode;
+  }
+  public function getProductCode()
+  {
+    return $this->productCode;
+  }
+  public function setSupportsReporting($supportsReporting)
+  {
+    $this->supportsReporting = $supportsReporting;
+  }
+  public function getSupportsReporting()
+  {
+    return $this->supportsReporting;
+  }
+}
+
+class Google_Service_AdSense_AdClients extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_AdSense_AdClient';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_AdSense_AdCode extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $adCode;
+  public $kind;
+
+
+  public function setAdCode($adCode)
+  {
+    $this->adCode = $adCode;
+  }
+  public function getAdCode()
+  {
+    return $this->adCode;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AdSense_AdStyle extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $colorsType = 'Google_Service_AdSense_AdStyleColors';
+  protected $colorsDataType = '';
+  public $corners;
+  protected $fontType = 'Google_Service_AdSense_AdStyleFont';
+  protected $fontDataType = '';
+  public $kind;
+
+
+  public function setColors(Google_Service_AdSense_AdStyleColors $colors)
+  {
+    $this->colors = $colors;
+  }
+  public function getColors()
+  {
+    return $this->colors;
+  }
+  public function setCorners($corners)
+  {
+    $this->corners = $corners;
+  }
+  public function getCorners()
+  {
+    return $this->corners;
+  }
+  public function setFont(Google_Service_AdSense_AdStyleFont $font)
+  {
+    $this->font = $font;
+  }
+  public function getFont()
+  {
+    return $this->font;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AdSense_AdStyleColors extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $background;
+  public $border;
+  public $text;
+  public $title;
+  public $url;
+
+
+  public function setBackground($background)
+  {
+    $this->background = $background;
+  }
+  public function getBackground()
+  {
+    return $this->background;
+  }
+  public function setBorder($border)
+  {
+    $this->border = $border;
+  }
+  public function getBorder()
+  {
+    return $this->border;
+  }
+  public function setText($text)
+  {
+    $this->text = $text;
+  }
+  public function getText()
+  {
+    return $this->text;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_AdSense_AdStyleFont extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $family;
+  public $size;
+
+
+  public function setFamily($family)
+  {
+    $this->family = $family;
+  }
+  public function getFamily()
+  {
+    return $this->family;
+  }
+  public function setSize($size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+}
+
+class Google_Service_AdSense_AdUnit extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $contentAdsSettingsType = 'Google_Service_AdSense_AdUnitContentAdsSettings';
+  protected $contentAdsSettingsDataType = '';
+  protected $customStyleType = 'Google_Service_AdSense_AdStyle';
+  protected $customStyleDataType = '';
+  protected $feedAdsSettingsType = 'Google_Service_AdSense_AdUnitFeedAdsSettings';
+  protected $feedAdsSettingsDataType = '';
+  public $id;
+  public $kind;
+  protected $mobileContentAdsSettingsType = 'Google_Service_AdSense_AdUnitMobileContentAdsSettings';
+  protected $mobileContentAdsSettingsDataType = '';
+  public $name;
+  public $savedStyleId;
+  public $status;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setContentAdsSettings(Google_Service_AdSense_AdUnitContentAdsSettings $contentAdsSettings)
+  {
+    $this->contentAdsSettings = $contentAdsSettings;
+  }
+  public function getContentAdsSettings()
+  {
+    return $this->contentAdsSettings;
+  }
+  public function setCustomStyle(Google_Service_AdSense_AdStyle $customStyle)
+  {
+    $this->customStyle = $customStyle;
+  }
+  public function getCustomStyle()
+  {
+    return $this->customStyle;
+  }
+  public function setFeedAdsSettings(Google_Service_AdSense_AdUnitFeedAdsSettings $feedAdsSettings)
+  {
+    $this->feedAdsSettings = $feedAdsSettings;
+  }
+  public function getFeedAdsSettings()
+  {
+    return $this->feedAdsSettings;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMobileContentAdsSettings(Google_Service_AdSense_AdUnitMobileContentAdsSettings $mobileContentAdsSettings)
+  {
+    $this->mobileContentAdsSettings = $mobileContentAdsSettings;
+  }
+  public function getMobileContentAdsSettings()
+  {
+    return $this->mobileContentAdsSettings;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSavedStyleId($savedStyleId)
+  {
+    $this->savedStyleId = $savedStyleId;
+  }
+  public function getSavedStyleId()
+  {
+    return $this->savedStyleId;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_AdSense_AdUnitContentAdsSettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $backupOptionType = 'Google_Service_AdSense_AdUnitContentAdsSettingsBackupOption';
+  protected $backupOptionDataType = '';
+  public $size;
+  public $type;
+
+
+  public function setBackupOption(Google_Service_AdSense_AdUnitContentAdsSettingsBackupOption $backupOption)
+  {
+    $this->backupOption = $backupOption;
+  }
+  public function getBackupOption()
+  {
+    return $this->backupOption;
+  }
+  public function setSize($size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_AdSense_AdUnitContentAdsSettingsBackupOption extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $color;
+  public $type;
+  public $url;
+
+
+  public function setColor($color)
+  {
+    $this->color = $color;
+  }
+  public function getColor()
+  {
+    return $this->color;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_AdSense_AdUnitFeedAdsSettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $adPosition;
+  public $frequency;
+  public $minimumWordCount;
+  public $type;
+
+
+  public function setAdPosition($adPosition)
+  {
+    $this->adPosition = $adPosition;
+  }
+  public function getAdPosition()
+  {
+    return $this->adPosition;
+  }
+  public function setFrequency($frequency)
+  {
+    $this->frequency = $frequency;
+  }
+  public function getFrequency()
+  {
+    return $this->frequency;
+  }
+  public function setMinimumWordCount($minimumWordCount)
+  {
+    $this->minimumWordCount = $minimumWordCount;
+  }
+  public function getMinimumWordCount()
+  {
+    return $this->minimumWordCount;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_AdSense_AdUnitMobileContentAdsSettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $markupLanguage;
+  public $scriptingLanguage;
+  public $size;
+  public $type;
+
+
+  public function setMarkupLanguage($markupLanguage)
+  {
+    $this->markupLanguage = $markupLanguage;
+  }
+  public function getMarkupLanguage()
+  {
+    return $this->markupLanguage;
+  }
+  public function setScriptingLanguage($scriptingLanguage)
+  {
+    $this->scriptingLanguage = $scriptingLanguage;
+  }
+  public function getScriptingLanguage()
+  {
+    return $this->scriptingLanguage;
+  }
+  public function setSize($size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_AdSense_AdUnits extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_AdSense_AdUnit';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_AdSense_AdsenseReportsGenerateResponse extends Google_Collection
+{
+  protected $collection_key = 'warnings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $averages;
+  public $endDate;
+  protected $headersType = 'Google_Service_AdSense_AdsenseReportsGenerateResponseHeaders';
+  protected $headersDataType = 'array';
+  public $kind;
+  public $rows;
+  public $startDate;
+  public $totalMatchedRows;
+  public $totals;
+  public $warnings;
+
+
+  public function setAverages($averages)
+  {
+    $this->averages = $averages;
+  }
+  public function getAverages()
+  {
+    return $this->averages;
+  }
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setHeaders($headers)
+  {
+    $this->headers = $headers;
+  }
+  public function getHeaders()
+  {
+    return $this->headers;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRows($rows)
+  {
+    $this->rows = $rows;
+  }
+  public function getRows()
+  {
+    return $this->rows;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+  public function setTotalMatchedRows($totalMatchedRows)
+  {
+    $this->totalMatchedRows = $totalMatchedRows;
+  }
+  public function getTotalMatchedRows()
+  {
+    return $this->totalMatchedRows;
+  }
+  public function setTotals($totals)
+  {
+    $this->totals = $totals;
+  }
+  public function getTotals()
+  {
+    return $this->totals;
+  }
+  public function setWarnings($warnings)
+  {
+    $this->warnings = $warnings;
+  }
+  public function getWarnings()
+  {
+    return $this->warnings;
+  }
+}
+
+class Google_Service_AdSense_AdsenseReportsGenerateResponseHeaders extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $currency;
+  public $name;
+  public $type;
+
+
+  public function setCurrency($currency)
+  {
+    $this->currency = $currency;
+  }
+  public function getCurrency()
+  {
+    return $this->currency;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_AdSense_Alert extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $isDismissible;
+  public $kind;
+  public $message;
+  public $severity;
+  public $type;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIsDismissible($isDismissible)
+  {
+    $this->isDismissible = $isDismissible;
+  }
+  public function getIsDismissible()
+  {
+    return $this->isDismissible;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+  public function setSeverity($severity)
+  {
+    $this->severity = $severity;
+  }
+  public function getSeverity()
+  {
+    return $this->severity;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_AdSense_Alerts extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_AdSense_Alert';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AdSense_CustomChannel extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $id;
+  public $kind;
+  public $name;
+  protected $targetingInfoType = 'Google_Service_AdSense_CustomChannelTargetingInfo';
+  protected $targetingInfoDataType = '';
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setTargetingInfo(Google_Service_AdSense_CustomChannelTargetingInfo $targetingInfo)
+  {
+    $this->targetingInfo = $targetingInfo;
+  }
+  public function getTargetingInfo()
+  {
+    return $this->targetingInfo;
+  }
+}
+
+class Google_Service_AdSense_CustomChannelTargetingInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $adsAppearOn;
+  public $description;
+  public $location;
+  public $siteLanguage;
+
+
+  public function setAdsAppearOn($adsAppearOn)
+  {
+    $this->adsAppearOn = $adsAppearOn;
+  }
+  public function getAdsAppearOn()
+  {
+    return $this->adsAppearOn;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setSiteLanguage($siteLanguage)
+  {
+    $this->siteLanguage = $siteLanguage;
+  }
+  public function getSiteLanguage()
+  {
+    return $this->siteLanguage;
+  }
+}
+
+class Google_Service_AdSense_CustomChannels extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_AdSense_CustomChannel';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_AdSense_Metadata extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_AdSense_ReportingMetadataEntry';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AdSense_Payment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $paymentAmount;
+  public $paymentAmountCurrencyCode;
+  public $paymentDate;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPaymentAmount($paymentAmount)
+  {
+    $this->paymentAmount = $paymentAmount;
+  }
+  public function getPaymentAmount()
+  {
+    return $this->paymentAmount;
+  }
+  public function setPaymentAmountCurrencyCode($paymentAmountCurrencyCode)
+  {
+    $this->paymentAmountCurrencyCode = $paymentAmountCurrencyCode;
+  }
+  public function getPaymentAmountCurrencyCode()
+  {
+    return $this->paymentAmountCurrencyCode;
+  }
+  public function setPaymentDate($paymentDate)
+  {
+    $this->paymentDate = $paymentDate;
+  }
+  public function getPaymentDate()
+  {
+    return $this->paymentDate;
+  }
+}
+
+class Google_Service_AdSense_Payments extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_AdSense_Payment';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AdSense_ReportingMetadataEntry extends Google_Collection
+{
+  protected $collection_key = 'supportedProducts';
+  protected $internal_gapi_mappings = array(
+  );
+  public $compatibleDimensions;
+  public $compatibleMetrics;
+  public $id;
+  public $kind;
+  public $requiredDimensions;
+  public $requiredMetrics;
+  public $supportedProducts;
+
+
+  public function setCompatibleDimensions($compatibleDimensions)
+  {
+    $this->compatibleDimensions = $compatibleDimensions;
+  }
+  public function getCompatibleDimensions()
+  {
+    return $this->compatibleDimensions;
+  }
+  public function setCompatibleMetrics($compatibleMetrics)
+  {
+    $this->compatibleMetrics = $compatibleMetrics;
+  }
+  public function getCompatibleMetrics()
+  {
+    return $this->compatibleMetrics;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRequiredDimensions($requiredDimensions)
+  {
+    $this->requiredDimensions = $requiredDimensions;
+  }
+  public function getRequiredDimensions()
+  {
+    return $this->requiredDimensions;
+  }
+  public function setRequiredMetrics($requiredMetrics)
+  {
+    $this->requiredMetrics = $requiredMetrics;
+  }
+  public function getRequiredMetrics()
+  {
+    return $this->requiredMetrics;
+  }
+  public function setSupportedProducts($supportedProducts)
+  {
+    $this->supportedProducts = $supportedProducts;
+  }
+  public function getSupportedProducts()
+  {
+    return $this->supportedProducts;
+  }
+}
+
+class Google_Service_AdSense_SavedAdStyle extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $adStyleType = 'Google_Service_AdSense_AdStyle';
+  protected $adStyleDataType = '';
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setAdStyle(Google_Service_AdSense_AdStyle $adStyle)
+  {
+    $this->adStyle = $adStyle;
+  }
+  public function getAdStyle()
+  {
+    return $this->adStyle;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_AdSense_SavedAdStyles extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_AdSense_SavedAdStyle';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_AdSense_SavedReport extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_AdSense_SavedReports extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_AdSense_SavedReport';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_AdSense_UrlChannel extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $urlPattern;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUrlPattern($urlPattern)
+  {
+    $this->urlPattern = $urlPattern;
+  }
+  public function getUrlPattern()
+  {
+    return $this->urlPattern;
+  }
+}
+
+class Google_Service_AdSense_UrlChannels extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_AdSense_UrlChannel';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/AdSenseHost.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/AdSenseHost.php
@@ -1,0 +1,2166 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for AdSenseHost (v4.1).
+ *
+ * <p>
+ * Gives AdSense Hosts access to report generation, ad code generation, and
+ * publisher management capabilities.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/adsense/host/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_AdSenseHost extends Google_Service
+{
+  /** View and manage your AdSense host data and associated accounts. */
+  const ADSENSEHOST =
+      "https://www.googleapis.com/auth/adsensehost";
+
+  public $accounts;
+  public $accounts_adclients;
+  public $accounts_adunits;
+  public $accounts_reports;
+  public $adclients;
+  public $associationsessions;
+  public $customchannels;
+  public $reports;
+  public $urlchannels;
+  
+
+  /**
+   * Constructs the internal representation of the AdSenseHost service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'adsensehost/v4.1/';
+    $this->version = 'v4.1';
+    $this->serviceName = 'adsensehost';
+
+    $this->accounts = new Google_Service_AdSenseHost_Accounts_Resource(
+        $this,
+        $this->serviceName,
+        'accounts',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'accounts/{accountId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'filterAdClientId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_adclients = new Google_Service_AdSenseHost_AccountsAdclients_Resource(
+        $this,
+        $this->serviceName,
+        'adclients',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts/{accountId}/adclients',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_adunits = new Google_Service_AdSenseHost_AccountsAdunits_Resource(
+        $this,
+        $this->serviceName,
+        'adunits',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}/adunits/{adUnitId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adUnitId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}/adunits/{adUnitId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adUnitId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getAdCode' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}/adunits/{adUnitId}/adcode',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adUnitId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'hostCustomChannelId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}/adunits',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}/adunits',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'includeInactive' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}/adunits',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adUnitId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'accounts/{accountId}/adclients/{adClientId}/adunits',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_reports = new Google_Service_AdSenseHost_AccountsReports_Resource(
+        $this,
+        $this->serviceName,
+        'reports',
+        array(
+          'methods' => array(
+            'generate' => array(
+              'path' => 'accounts/{accountId}/reports',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'startDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'endDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sort' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'metric' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'startIndex' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'dimension' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->adclients = new Google_Service_AdSenseHost_Adclients_Resource(
+        $this,
+        $this->serviceName,
+        'adclients',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'adclients/{adClientId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'adclients',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->associationsessions = new Google_Service_AdSenseHost_Associationsessions_Resource(
+        $this,
+        $this->serviceName,
+        'associationsessions',
+        array(
+          'methods' => array(
+            'start' => array(
+              'path' => 'associationsessions/start',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'productCode' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                  'required' => true,
+                ),
+                'websiteUrl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'websiteLocale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'userLocale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'verify' => array(
+              'path' => 'associationsessions/verify',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'token' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->customchannels = new Google_Service_AdSenseHost_Customchannels_Resource(
+        $this,
+        $this->serviceName,
+        'customchannels',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'adclients/{adClientId}/customchannels/{customChannelId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customChannelId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'adclients/{adClientId}/customchannels/{customChannelId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customChannelId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'adclients/{adClientId}/customchannels',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'adclients/{adClientId}/customchannels',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'adclients/{adClientId}/customchannels',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customChannelId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'adclients/{adClientId}/customchannels',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->reports = new Google_Service_AdSenseHost_Reports_Resource(
+        $this,
+        $this->serviceName,
+        'reports',
+        array(
+          'methods' => array(
+            'generate' => array(
+              'path' => 'reports',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'startDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'endDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sort' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'metric' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'startIndex' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'dimension' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->urlchannels = new Google_Service_AdSenseHost_Urlchannels_Resource(
+        $this,
+        $this->serviceName,
+        'urlchannels',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'adclients/{adClientId}/urlchannels/{urlChannelId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'urlChannelId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'adclients/{adClientId}/urlchannels',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'adclients/{adClientId}/urlchannels',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'adClientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "accounts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsensehostService = new Google_Service_AdSenseHost(...);
+ *   $accounts = $adsensehostService->accounts;
+ *  </code>
+ */
+class Google_Service_AdSenseHost_Accounts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get information about the selected associated AdSense account. (accounts.get)
+   *
+   * @param string $accountId Account to get information about.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSenseHost_Account
+   */
+  public function get($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdSenseHost_Account");
+  }
+
+  /**
+   * List hosted accounts associated with this AdSense account by ad client id.
+   * (accounts.listAccounts)
+   *
+   * @param string $filterAdClientId Ad clients to list accounts for.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSenseHost_Accounts
+   */
+  public function listAccounts($filterAdClientId, $optParams = array())
+  {
+    $params = array('filterAdClientId' => $filterAdClientId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSenseHost_Accounts");
+  }
+}
+
+/**
+ * The "adclients" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsensehostService = new Google_Service_AdSenseHost(...);
+ *   $adclients = $adsensehostService->adclients;
+ *  </code>
+ */
+class Google_Service_AdSenseHost_AccountsAdclients_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get information about one of the ad clients in the specified publisher's
+   * AdSense account. (adclients.get)
+   *
+   * @param string $accountId Account which contains the ad client.
+   * @param string $adClientId Ad client to get.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSenseHost_AdClient
+   */
+  public function get($accountId, $adClientId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdSenseHost_AdClient");
+  }
+
+  /**
+   * List all hosted ad clients in the specified hosted account.
+   * (adclients.listAccountsAdclients)
+   *
+   * @param string $accountId Account for which to list ad clients.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through ad
+   * clients. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param string maxResults The maximum number of ad clients to include in
+   * the response, used for paging.
+   * @return Google_Service_AdSenseHost_AdClients
+   */
+  public function listAccountsAdclients($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSenseHost_AdClients");
+  }
+}
+/**
+ * The "adunits" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsensehostService = new Google_Service_AdSenseHost(...);
+ *   $adunits = $adsensehostService->adunits;
+ *  </code>
+ */
+class Google_Service_AdSenseHost_AccountsAdunits_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete the specified ad unit from the specified publisher AdSense account.
+   * (adunits.delete)
+   *
+   * @param string $accountId Account which contains the ad unit.
+   * @param string $adClientId Ad client for which to get ad unit.
+   * @param string $adUnitId Ad unit to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSenseHost_AdUnit
+   */
+  public function delete($accountId, $adClientId, $adUnitId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId, 'adUnitId' => $adUnitId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_AdSenseHost_AdUnit");
+  }
+
+  /**
+   * Get the specified host ad unit in this AdSense account. (adunits.get)
+   *
+   * @param string $accountId Account which contains the ad unit.
+   * @param string $adClientId Ad client for which to get ad unit.
+   * @param string $adUnitId Ad unit to get.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSenseHost_AdUnit
+   */
+  public function get($accountId, $adClientId, $adUnitId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId, 'adUnitId' => $adUnitId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdSenseHost_AdUnit");
+  }
+
+  /**
+   * Get ad code for the specified ad unit, attaching the specified host custom
+   * channels. (adunits.getAdCode)
+   *
+   * @param string $accountId Account which contains the ad client.
+   * @param string $adClientId Ad client with contains the ad unit.
+   * @param string $adUnitId Ad unit to get the code for.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string hostCustomChannelId Host custom channel to attach to the ad
+   * code.
+   * @return Google_Service_AdSenseHost_AdCode
+   */
+  public function getAdCode($accountId, $adClientId, $adUnitId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId, 'adUnitId' => $adUnitId);
+    $params = array_merge($params, $optParams);
+    return $this->call('getAdCode', array($params), "Google_Service_AdSenseHost_AdCode");
+  }
+
+  /**
+   * Insert the supplied ad unit into the specified publisher AdSense account.
+   * (adunits.insert)
+   *
+   * @param string $accountId Account which will contain the ad unit.
+   * @param string $adClientId Ad client into which to insert the ad unit.
+   * @param Google_AdUnit $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSenseHost_AdUnit
+   */
+  public function insert($accountId, $adClientId, Google_Service_AdSenseHost_AdUnit $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_AdSenseHost_AdUnit");
+  }
+
+  /**
+   * List all ad units in the specified publisher's AdSense account.
+   * (adunits.listAccountsAdunits)
+   *
+   * @param string $accountId Account which contains the ad client.
+   * @param string $adClientId Ad client for which to list ad units.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool includeInactive Whether to include inactive ad units.
+   * Default: true.
+   * @opt_param string pageToken A continuation token, used to page through ad
+   * units. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param string maxResults The maximum number of ad units to include in the
+   * response, used for paging.
+   * @return Google_Service_AdSenseHost_AdUnits
+   */
+  public function listAccountsAdunits($accountId, $adClientId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSenseHost_AdUnits");
+  }
+
+  /**
+   * Update the supplied ad unit in the specified publisher AdSense account. This
+   * method supports patch semantics. (adunits.patch)
+   *
+   * @param string $accountId Account which contains the ad client.
+   * @param string $adClientId Ad client which contains the ad unit.
+   * @param string $adUnitId Ad unit to get.
+   * @param Google_AdUnit $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSenseHost_AdUnit
+   */
+  public function patch($accountId, $adClientId, $adUnitId, Google_Service_AdSenseHost_AdUnit $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId, 'adUnitId' => $adUnitId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_AdSenseHost_AdUnit");
+  }
+
+  /**
+   * Update the supplied ad unit in the specified publisher AdSense account.
+   * (adunits.update)
+   *
+   * @param string $accountId Account which contains the ad client.
+   * @param string $adClientId Ad client which contains the ad unit.
+   * @param Google_AdUnit $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSenseHost_AdUnit
+   */
+  public function update($accountId, $adClientId, Google_Service_AdSenseHost_AdUnit $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'adClientId' => $adClientId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AdSenseHost_AdUnit");
+  }
+}
+/**
+ * The "reports" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsensehostService = new Google_Service_AdSenseHost(...);
+ *   $reports = $adsensehostService->reports;
+ *  </code>
+ */
+class Google_Service_AdSenseHost_AccountsReports_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Generate an AdSense report based on the report request sent in the query
+   * parameters. Returns the result as JSON; to retrieve output in CSV format
+   * specify "alt=csv" as a query parameter. (reports.generate)
+   *
+   * @param string $accountId Hosted account upon which to report.
+   * @param string $startDate Start of the date range to report on in "YYYY-MM-DD"
+   * format, inclusive.
+   * @param string $endDate End of the date range to report on in "YYYY-MM-DD"
+   * format, inclusive.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string sort The name of a dimension or metric to sort the
+   * resulting report on, optionally prefixed with "+" to sort ascending or "-" to
+   * sort descending. If no prefix is specified, the column is sorted ascending.
+   * @opt_param string locale Optional locale to use for translating report output
+   * to a local language. Defaults to "en_US" if not specified.
+   * @opt_param string metric Numeric columns to include in the report.
+   * @opt_param string maxResults The maximum number of rows of report data to
+   * return.
+   * @opt_param string filter Filters to be run on the report.
+   * @opt_param string startIndex Index of the first row of report data to return.
+   * @opt_param string dimension Dimensions to base the report on.
+   * @return Google_Service_AdSenseHost_Report
+   */
+  public function generate($accountId, $startDate, $endDate, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'startDate' => $startDate, 'endDate' => $endDate);
+    $params = array_merge($params, $optParams);
+    return $this->call('generate', array($params), "Google_Service_AdSenseHost_Report");
+  }
+}
+
+/**
+ * The "adclients" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsensehostService = new Google_Service_AdSenseHost(...);
+ *   $adclients = $adsensehostService->adclients;
+ *  </code>
+ */
+class Google_Service_AdSenseHost_Adclients_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get information about one of the ad clients in the Host AdSense account.
+   * (adclients.get)
+   *
+   * @param string $adClientId Ad client to get.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSenseHost_AdClient
+   */
+  public function get($adClientId, $optParams = array())
+  {
+    $params = array('adClientId' => $adClientId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdSenseHost_AdClient");
+  }
+
+  /**
+   * List all host ad clients in this AdSense account. (adclients.listAdclients)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through ad
+   * clients. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param string maxResults The maximum number of ad clients to include in
+   * the response, used for paging.
+   * @return Google_Service_AdSenseHost_AdClients
+   */
+  public function listAdclients($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSenseHost_AdClients");
+  }
+}
+
+/**
+ * The "associationsessions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsensehostService = new Google_Service_AdSenseHost(...);
+ *   $associationsessions = $adsensehostService->associationsessions;
+ *  </code>
+ */
+class Google_Service_AdSenseHost_Associationsessions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Create an association session for initiating an association with an AdSense
+   * user. (associationsessions.start)
+   *
+   * @param string $productCode Products to associate with the user.
+   * @param string $websiteUrl The URL of the user's hosted website.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string websiteLocale The locale of the user's hosted website.
+   * @opt_param string userLocale The preferred locale of the user.
+   * @return Google_Service_AdSenseHost_AssociationSession
+   */
+  public function start($productCode, $websiteUrl, $optParams = array())
+  {
+    $params = array('productCode' => $productCode, 'websiteUrl' => $websiteUrl);
+    $params = array_merge($params, $optParams);
+    return $this->call('start', array($params), "Google_Service_AdSenseHost_AssociationSession");
+  }
+
+  /**
+   * Verify an association session after the association callback returns from
+   * AdSense signup. (associationsessions.verify)
+   *
+   * @param string $token The token returned to the association callback URL.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSenseHost_AssociationSession
+   */
+  public function verify($token, $optParams = array())
+  {
+    $params = array('token' => $token);
+    $params = array_merge($params, $optParams);
+    return $this->call('verify', array($params), "Google_Service_AdSenseHost_AssociationSession");
+  }
+}
+
+/**
+ * The "customchannels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsensehostService = new Google_Service_AdSenseHost(...);
+ *   $customchannels = $adsensehostService->customchannels;
+ *  </code>
+ */
+class Google_Service_AdSenseHost_Customchannels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete a specific custom channel from the host AdSense account.
+   * (customchannels.delete)
+   *
+   * @param string $adClientId Ad client from which to delete the custom channel.
+   * @param string $customChannelId Custom channel to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSenseHost_CustomChannel
+   */
+  public function delete($adClientId, $customChannelId, $optParams = array())
+  {
+    $params = array('adClientId' => $adClientId, 'customChannelId' => $customChannelId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_AdSenseHost_CustomChannel");
+  }
+
+  /**
+   * Get a specific custom channel from the host AdSense account.
+   * (customchannels.get)
+   *
+   * @param string $adClientId Ad client from which to get the custom channel.
+   * @param string $customChannelId Custom channel to get.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSenseHost_CustomChannel
+   */
+  public function get($adClientId, $customChannelId, $optParams = array())
+  {
+    $params = array('adClientId' => $adClientId, 'customChannelId' => $customChannelId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AdSenseHost_CustomChannel");
+  }
+
+  /**
+   * Add a new custom channel to the host AdSense account. (customchannels.insert)
+   *
+   * @param string $adClientId Ad client to which the new custom channel will be
+   * added.
+   * @param Google_CustomChannel $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSenseHost_CustomChannel
+   */
+  public function insert($adClientId, Google_Service_AdSenseHost_CustomChannel $postBody, $optParams = array())
+  {
+    $params = array('adClientId' => $adClientId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_AdSenseHost_CustomChannel");
+  }
+
+  /**
+   * List all host custom channels in this AdSense account.
+   * (customchannels.listCustomchannels)
+   *
+   * @param string $adClientId Ad client for which to list custom channels.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through custom
+   * channels. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param string maxResults The maximum number of custom channels to include
+   * in the response, used for paging.
+   * @return Google_Service_AdSenseHost_CustomChannels
+   */
+  public function listCustomchannels($adClientId, $optParams = array())
+  {
+    $params = array('adClientId' => $adClientId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSenseHost_CustomChannels");
+  }
+
+  /**
+   * Update a custom channel in the host AdSense account. This method supports
+   * patch semantics. (customchannels.patch)
+   *
+   * @param string $adClientId Ad client in which the custom channel will be
+   * updated.
+   * @param string $customChannelId Custom channel to get.
+   * @param Google_CustomChannel $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSenseHost_CustomChannel
+   */
+  public function patch($adClientId, $customChannelId, Google_Service_AdSenseHost_CustomChannel $postBody, $optParams = array())
+  {
+    $params = array('adClientId' => $adClientId, 'customChannelId' => $customChannelId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_AdSenseHost_CustomChannel");
+  }
+
+  /**
+   * Update a custom channel in the host AdSense account. (customchannels.update)
+   *
+   * @param string $adClientId Ad client in which the custom channel will be
+   * updated.
+   * @param Google_CustomChannel $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSenseHost_CustomChannel
+   */
+  public function update($adClientId, Google_Service_AdSenseHost_CustomChannel $postBody, $optParams = array())
+  {
+    $params = array('adClientId' => $adClientId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AdSenseHost_CustomChannel");
+  }
+}
+
+/**
+ * The "reports" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsensehostService = new Google_Service_AdSenseHost(...);
+ *   $reports = $adsensehostService->reports;
+ *  </code>
+ */
+class Google_Service_AdSenseHost_Reports_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Generate an AdSense report based on the report request sent in the query
+   * parameters. Returns the result as JSON; to retrieve output in CSV format
+   * specify "alt=csv" as a query parameter. (reports.generate)
+   *
+   * @param string $startDate Start of the date range to report on in "YYYY-MM-DD"
+   * format, inclusive.
+   * @param string $endDate End of the date range to report on in "YYYY-MM-DD"
+   * format, inclusive.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string sort The name of a dimension or metric to sort the
+   * resulting report on, optionally prefixed with "+" to sort ascending or "-" to
+   * sort descending. If no prefix is specified, the column is sorted ascending.
+   * @opt_param string locale Optional locale to use for translating report output
+   * to a local language. Defaults to "en_US" if not specified.
+   * @opt_param string metric Numeric columns to include in the report.
+   * @opt_param string maxResults The maximum number of rows of report data to
+   * return.
+   * @opt_param string filter Filters to be run on the report.
+   * @opt_param string startIndex Index of the first row of report data to return.
+   * @opt_param string dimension Dimensions to base the report on.
+   * @return Google_Service_AdSenseHost_Report
+   */
+  public function generate($startDate, $endDate, $optParams = array())
+  {
+    $params = array('startDate' => $startDate, 'endDate' => $endDate);
+    $params = array_merge($params, $optParams);
+    return $this->call('generate', array($params), "Google_Service_AdSenseHost_Report");
+  }
+}
+
+/**
+ * The "urlchannels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adsensehostService = new Google_Service_AdSenseHost(...);
+ *   $urlchannels = $adsensehostService->urlchannels;
+ *  </code>
+ */
+class Google_Service_AdSenseHost_Urlchannels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete a URL channel from the host AdSense account. (urlchannels.delete)
+   *
+   * @param string $adClientId Ad client from which to delete the URL channel.
+   * @param string $urlChannelId URL channel to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSenseHost_UrlChannel
+   */
+  public function delete($adClientId, $urlChannelId, $optParams = array())
+  {
+    $params = array('adClientId' => $adClientId, 'urlChannelId' => $urlChannelId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_AdSenseHost_UrlChannel");
+  }
+
+  /**
+   * Add a new URL channel to the host AdSense account. (urlchannels.insert)
+   *
+   * @param string $adClientId Ad client to which the new URL channel will be
+   * added.
+   * @param Google_UrlChannel $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AdSenseHost_UrlChannel
+   */
+  public function insert($adClientId, Google_Service_AdSenseHost_UrlChannel $postBody, $optParams = array())
+  {
+    $params = array('adClientId' => $adClientId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_AdSenseHost_UrlChannel");
+  }
+
+  /**
+   * List all host URL channels in the host AdSense account.
+   * (urlchannels.listUrlchannels)
+   *
+   * @param string $adClientId Ad client for which to list URL channels.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A continuation token, used to page through URL
+   * channels. To retrieve the next page, set this parameter to the value of
+   * "nextPageToken" from the previous response.
+   * @opt_param string maxResults The maximum number of URL channels to include in
+   * the response, used for paging.
+   * @return Google_Service_AdSenseHost_UrlChannels
+   */
+  public function listUrlchannels($adClientId, $optParams = array())
+  {
+    $params = array('adClientId' => $adClientId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AdSenseHost_UrlChannels");
+  }
+}
+
+
+
+
+class Google_Service_AdSenseHost_Account extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $name;
+  public $status;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_AdSenseHost_Accounts extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_AdSenseHost_Account';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AdSenseHost_AdClient extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $arcOptIn;
+  public $id;
+  public $kind;
+  public $productCode;
+  public $supportsReporting;
+
+
+  public function setArcOptIn($arcOptIn)
+  {
+    $this->arcOptIn = $arcOptIn;
+  }
+  public function getArcOptIn()
+  {
+    return $this->arcOptIn;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProductCode($productCode)
+  {
+    $this->productCode = $productCode;
+  }
+  public function getProductCode()
+  {
+    return $this->productCode;
+  }
+  public function setSupportsReporting($supportsReporting)
+  {
+    $this->supportsReporting = $supportsReporting;
+  }
+  public function getSupportsReporting()
+  {
+    return $this->supportsReporting;
+  }
+}
+
+class Google_Service_AdSenseHost_AdClients extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_AdSenseHost_AdClient';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_AdSenseHost_AdCode extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $adCode;
+  public $kind;
+
+
+  public function setAdCode($adCode)
+  {
+    $this->adCode = $adCode;
+  }
+  public function getAdCode()
+  {
+    return $this->adCode;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AdSenseHost_AdStyle extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $colorsType = 'Google_Service_AdSenseHost_AdStyleColors';
+  protected $colorsDataType = '';
+  public $corners;
+  protected $fontType = 'Google_Service_AdSenseHost_AdStyleFont';
+  protected $fontDataType = '';
+  public $kind;
+
+
+  public function setColors(Google_Service_AdSenseHost_AdStyleColors $colors)
+  {
+    $this->colors = $colors;
+  }
+  public function getColors()
+  {
+    return $this->colors;
+  }
+  public function setCorners($corners)
+  {
+    $this->corners = $corners;
+  }
+  public function getCorners()
+  {
+    return $this->corners;
+  }
+  public function setFont(Google_Service_AdSenseHost_AdStyleFont $font)
+  {
+    $this->font = $font;
+  }
+  public function getFont()
+  {
+    return $this->font;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AdSenseHost_AdStyleColors extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $background;
+  public $border;
+  public $text;
+  public $title;
+  public $url;
+
+
+  public function setBackground($background)
+  {
+    $this->background = $background;
+  }
+  public function getBackground()
+  {
+    return $this->background;
+  }
+  public function setBorder($border)
+  {
+    $this->border = $border;
+  }
+  public function getBorder()
+  {
+    return $this->border;
+  }
+  public function setText($text)
+  {
+    $this->text = $text;
+  }
+  public function getText()
+  {
+    return $this->text;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_AdSenseHost_AdStyleFont extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $family;
+  public $size;
+
+
+  public function setFamily($family)
+  {
+    $this->family = $family;
+  }
+  public function getFamily()
+  {
+    return $this->family;
+  }
+  public function setSize($size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+}
+
+class Google_Service_AdSenseHost_AdUnit extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $contentAdsSettingsType = 'Google_Service_AdSenseHost_AdUnitContentAdsSettings';
+  protected $contentAdsSettingsDataType = '';
+  protected $customStyleType = 'Google_Service_AdSenseHost_AdStyle';
+  protected $customStyleDataType = '';
+  public $id;
+  public $kind;
+  protected $mobileContentAdsSettingsType = 'Google_Service_AdSenseHost_AdUnitMobileContentAdsSettings';
+  protected $mobileContentAdsSettingsDataType = '';
+  public $name;
+  public $status;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setContentAdsSettings(Google_Service_AdSenseHost_AdUnitContentAdsSettings $contentAdsSettings)
+  {
+    $this->contentAdsSettings = $contentAdsSettings;
+  }
+  public function getContentAdsSettings()
+  {
+    return $this->contentAdsSettings;
+  }
+  public function setCustomStyle(Google_Service_AdSenseHost_AdStyle $customStyle)
+  {
+    $this->customStyle = $customStyle;
+  }
+  public function getCustomStyle()
+  {
+    return $this->customStyle;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMobileContentAdsSettings(Google_Service_AdSenseHost_AdUnitMobileContentAdsSettings $mobileContentAdsSettings)
+  {
+    $this->mobileContentAdsSettings = $mobileContentAdsSettings;
+  }
+  public function getMobileContentAdsSettings()
+  {
+    return $this->mobileContentAdsSettings;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_AdSenseHost_AdUnitContentAdsSettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $backupOptionType = 'Google_Service_AdSenseHost_AdUnitContentAdsSettingsBackupOption';
+  protected $backupOptionDataType = '';
+  public $size;
+  public $type;
+
+
+  public function setBackupOption(Google_Service_AdSenseHost_AdUnitContentAdsSettingsBackupOption $backupOption)
+  {
+    $this->backupOption = $backupOption;
+  }
+  public function getBackupOption()
+  {
+    return $this->backupOption;
+  }
+  public function setSize($size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_AdSenseHost_AdUnitContentAdsSettingsBackupOption extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $color;
+  public $type;
+  public $url;
+
+
+  public function setColor($color)
+  {
+    $this->color = $color;
+  }
+  public function getColor()
+  {
+    return $this->color;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_AdSenseHost_AdUnitMobileContentAdsSettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $markupLanguage;
+  public $scriptingLanguage;
+  public $size;
+  public $type;
+
+
+  public function setMarkupLanguage($markupLanguage)
+  {
+    $this->markupLanguage = $markupLanguage;
+  }
+  public function getMarkupLanguage()
+  {
+    return $this->markupLanguage;
+  }
+  public function setScriptingLanguage($scriptingLanguage)
+  {
+    $this->scriptingLanguage = $scriptingLanguage;
+  }
+  public function getScriptingLanguage()
+  {
+    return $this->scriptingLanguage;
+  }
+  public function setSize($size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_AdSenseHost_AdUnits extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_AdSenseHost_AdUnit';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_AdSenseHost_AssociationSession extends Google_Collection
+{
+  protected $collection_key = 'productCodes';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $id;
+  public $kind;
+  public $productCodes;
+  public $redirectUrl;
+  public $status;
+  public $userLocale;
+  public $websiteLocale;
+  public $websiteUrl;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProductCodes($productCodes)
+  {
+    $this->productCodes = $productCodes;
+  }
+  public function getProductCodes()
+  {
+    return $this->productCodes;
+  }
+  public function setRedirectUrl($redirectUrl)
+  {
+    $this->redirectUrl = $redirectUrl;
+  }
+  public function getRedirectUrl()
+  {
+    return $this->redirectUrl;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setUserLocale($userLocale)
+  {
+    $this->userLocale = $userLocale;
+  }
+  public function getUserLocale()
+  {
+    return $this->userLocale;
+  }
+  public function setWebsiteLocale($websiteLocale)
+  {
+    $this->websiteLocale = $websiteLocale;
+  }
+  public function getWebsiteLocale()
+  {
+    return $this->websiteLocale;
+  }
+  public function setWebsiteUrl($websiteUrl)
+  {
+    $this->websiteUrl = $websiteUrl;
+  }
+  public function getWebsiteUrl()
+  {
+    return $this->websiteUrl;
+  }
+}
+
+class Google_Service_AdSenseHost_CustomChannel extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_AdSenseHost_CustomChannels extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_AdSenseHost_CustomChannel';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_AdSenseHost_Report extends Google_Collection
+{
+  protected $collection_key = 'warnings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $averages;
+  protected $headersType = 'Google_Service_AdSenseHost_ReportHeaders';
+  protected $headersDataType = 'array';
+  public $kind;
+  public $rows;
+  public $totalMatchedRows;
+  public $totals;
+  public $warnings;
+
+
+  public function setAverages($averages)
+  {
+    $this->averages = $averages;
+  }
+  public function getAverages()
+  {
+    return $this->averages;
+  }
+  public function setHeaders($headers)
+  {
+    $this->headers = $headers;
+  }
+  public function getHeaders()
+  {
+    return $this->headers;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRows($rows)
+  {
+    $this->rows = $rows;
+  }
+  public function getRows()
+  {
+    return $this->rows;
+  }
+  public function setTotalMatchedRows($totalMatchedRows)
+  {
+    $this->totalMatchedRows = $totalMatchedRows;
+  }
+  public function getTotalMatchedRows()
+  {
+    return $this->totalMatchedRows;
+  }
+  public function setTotals($totals)
+  {
+    $this->totals = $totals;
+  }
+  public function getTotals()
+  {
+    return $this->totals;
+  }
+  public function setWarnings($warnings)
+  {
+    $this->warnings = $warnings;
+  }
+  public function getWarnings()
+  {
+    return $this->warnings;
+  }
+}
+
+class Google_Service_AdSenseHost_ReportHeaders extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $currency;
+  public $name;
+  public $type;
+
+
+  public function setCurrency($currency)
+  {
+    $this->currency = $currency;
+  }
+  public function getCurrency()
+  {
+    return $this->currency;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_AdSenseHost_UrlChannel extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $urlPattern;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUrlPattern($urlPattern)
+  {
+    $this->urlPattern = $urlPattern;
+  }
+  public function getUrlPattern()
+  {
+    return $this->urlPattern;
+  }
+}
+
+class Google_Service_AdSenseHost_UrlChannels extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_AdSenseHost_UrlChannel';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Admin.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Admin.php
@@ -1,0 +1,194 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Admin (email_migration_v2).
+ *
+ * <p>
+ * Email Migration API lets you migrate emails of users to Google backends.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/admin-sdk/email-migration/v2/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Admin extends Google_Service
+{
+  /** Manage email messages of users on your domain. */
+  const EMAIL_MIGRATION =
+      "https://www.googleapis.com/auth/email.migration";
+
+  public $mail;
+  
+
+  /**
+   * Constructs the internal representation of the Admin service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'email/v2/users/';
+    $this->version = 'email_migration_v2';
+    $this->serviceName = 'admin';
+
+    $this->mail = new Google_Service_Admin_Mail_Resource(
+        $this,
+        $this->serviceName,
+        'mail',
+        array(
+          'methods' => array(
+            'insert' => array(
+              'path' => '{userKey}/mail',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "mail" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Admin(...);
+ *   $mail = $adminService->mail;
+ *  </code>
+ */
+class Google_Service_Admin_Mail_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Insert Mail into Google's Gmail backends (mail.insert)
+   *
+   * @param string $userKey The email or immutable id of the user
+   * @param Google_MailItem $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function insert($userKey, Google_Service_Admin_MailItem $postBody, $optParams = array())
+  {
+    $params = array('userKey' => $userKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params));
+  }
+}
+
+
+
+
+class Google_Service_Admin_MailItem extends Google_Collection
+{
+  protected $collection_key = 'labels';
+  protected $internal_gapi_mappings = array(
+  );
+  public $isDeleted;
+  public $isDraft;
+  public $isInbox;
+  public $isSent;
+  public $isStarred;
+  public $isTrash;
+  public $isUnread;
+  public $kind;
+  public $labels;
+
+
+  public function setIsDeleted($isDeleted)
+  {
+    $this->isDeleted = $isDeleted;
+  }
+  public function getIsDeleted()
+  {
+    return $this->isDeleted;
+  }
+  public function setIsDraft($isDraft)
+  {
+    $this->isDraft = $isDraft;
+  }
+  public function getIsDraft()
+  {
+    return $this->isDraft;
+  }
+  public function setIsInbox($isInbox)
+  {
+    $this->isInbox = $isInbox;
+  }
+  public function getIsInbox()
+  {
+    return $this->isInbox;
+  }
+  public function setIsSent($isSent)
+  {
+    $this->isSent = $isSent;
+  }
+  public function getIsSent()
+  {
+    return $this->isSent;
+  }
+  public function setIsStarred($isStarred)
+  {
+    $this->isStarred = $isStarred;
+  }
+  public function getIsStarred()
+  {
+    return $this->isStarred;
+  }
+  public function setIsTrash($isTrash)
+  {
+    $this->isTrash = $isTrash;
+  }
+  public function getIsTrash()
+  {
+    return $this->isTrash;
+  }
+  public function setIsUnread($isUnread)
+  {
+    $this->isUnread = $isUnread;
+  }
+  public function getIsUnread()
+  {
+    return $this->isUnread;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLabels($labels)
+  {
+    $this->labels = $labels;
+  }
+  public function getLabels()
+  {
+    return $this->labels;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Analytics.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Analytics.php
@@ -1,0 +1,9899 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Analytics (v3).
+ *
+ * <p>
+ * View and manage your Google Analytics data</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/analytics/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Analytics extends Google_Service
+{
+  /** View and manage your Google Analytics data. */
+  const ANALYTICS =
+      "https://www.googleapis.com/auth/analytics";
+  /** Edit Google Analytics management entities. */
+  const ANALYTICS_EDIT =
+      "https://www.googleapis.com/auth/analytics.edit";
+  /** Manage Google Analytics Account users by email address. */
+  const ANALYTICS_MANAGE_USERS =
+      "https://www.googleapis.com/auth/analytics.manage.users";
+  /** View Google Analytics user permissions. */
+  const ANALYTICS_MANAGE_USERS_READONLY =
+      "https://www.googleapis.com/auth/analytics.manage.users.readonly";
+  /** Create a new Google Analytics account along with its default property and view. */
+  const ANALYTICS_PROVISION =
+      "https://www.googleapis.com/auth/analytics.provision";
+  /** View your Google Analytics data. */
+  const ANALYTICS_READONLY =
+      "https://www.googleapis.com/auth/analytics.readonly";
+
+  public $data_ga;
+  public $data_mcf;
+  public $data_realtime;
+  public $management_accountSummaries;
+  public $management_accountUserLinks;
+  public $management_accounts;
+  public $management_customDataSources;
+  public $management_customDimensions;
+  public $management_customMetrics;
+  public $management_experiments;
+  public $management_filters;
+  public $management_goals;
+  public $management_profileFilterLinks;
+  public $management_profileUserLinks;
+  public $management_profiles;
+  public $management_segments;
+  public $management_unsampledReports;
+  public $management_uploads;
+  public $management_webPropertyAdWordsLinks;
+  public $management_webproperties;
+  public $management_webpropertyUserLinks;
+  public $metadata_columns;
+  public $provisioning;
+  
+
+  /**
+   * Constructs the internal representation of the Analytics service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'analytics/v3/';
+    $this->version = 'v3';
+    $this->serviceName = 'analytics';
+
+    $this->data_ga = new Google_Service_Analytics_DataGa_Resource(
+        $this,
+        $this->serviceName,
+        'ga',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'data/ga',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'start-date' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'end-date' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'metrics' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'sort' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'dimensions' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'segment' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'samplingLevel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'filters' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'output' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->data_mcf = new Google_Service_Analytics_DataMcf_Resource(
+        $this,
+        $this->serviceName,
+        'mcf',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'data/mcf',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'start-date' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'end-date' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'metrics' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'sort' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'dimensions' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'samplingLevel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'filters' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->data_realtime = new Google_Service_Analytics_DataRealtime_Resource(
+        $this,
+        $this->serviceName,
+        'realtime',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'data/realtime',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'metrics' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'sort' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'dimensions' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'filters' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->management_accountSummaries = new Google_Service_Analytics_ManagementAccountSummaries_Resource(
+        $this,
+        $this->serviceName,
+        'accountSummaries',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'management/accountSummaries',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->management_accountUserLinks = new Google_Service_Analytics_ManagementAccountUserLinks_Resource(
+        $this,
+        $this->serviceName,
+        'accountUserLinks',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'management/accounts/{accountId}/entityUserLinks/{linkId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'linkId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'management/accounts/{accountId}/entityUserLinks',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'management/accounts/{accountId}/entityUserLinks',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'management/accounts/{accountId}/entityUserLinks/{linkId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'linkId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->management_accounts = new Google_Service_Analytics_ManagementAccounts_Resource(
+        $this,
+        $this->serviceName,
+        'accounts',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'management/accounts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->management_customDataSources = new Google_Service_Analytics_ManagementCustomDataSources_Resource(
+        $this,
+        $this->serviceName,
+        'customDataSources',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/customDataSources',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->management_customDimensions = new Google_Service_Analytics_ManagementCustomDimensions_Resource(
+        $this,
+        $this->serviceName,
+        'customDimensions',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/customDimensions/{customDimensionId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customDimensionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/customDimensions',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/customDimensions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/customDimensions/{customDimensionId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customDimensionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ignoreCustomDataSourceLinks' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/customDimensions/{customDimensionId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customDimensionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ignoreCustomDataSourceLinks' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->management_customMetrics = new Google_Service_Analytics_ManagementCustomMetrics_Resource(
+        $this,
+        $this->serviceName,
+        'customMetrics',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/customMetrics/{customMetricId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customMetricId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/customMetrics',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/customMetrics',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/customMetrics/{customMetricId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customMetricId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ignoreCustomDataSourceLinks' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/customMetrics/{customMetricId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customMetricId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ignoreCustomDataSourceLinks' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->management_experiments = new Google_Service_Analytics_ManagementExperiments_Resource(
+        $this,
+        $this->serviceName,
+        'experiments',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/experiments/{experimentId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'experimentId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/experiments/{experimentId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'experimentId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/experiments',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/experiments',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/experiments/{experimentId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'experimentId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/experiments/{experimentId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'experimentId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->management_filters = new Google_Service_Analytics_ManagementFilters_Resource(
+        $this,
+        $this->serviceName,
+        'filters',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'management/accounts/{accountId}/filters/{filterId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filterId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'management/accounts/{accountId}/filters/{filterId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filterId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'management/accounts/{accountId}/filters',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'management/accounts/{accountId}/filters',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'management/accounts/{accountId}/filters/{filterId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filterId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'management/accounts/{accountId}/filters/{filterId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filterId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->management_goals = new Google_Service_Analytics_ManagementGoals_Resource(
+        $this,
+        $this->serviceName,
+        'goals',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/goals/{goalId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'goalId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/goals',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/goals',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/goals/{goalId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'goalId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/goals/{goalId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'goalId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->management_profileFilterLinks = new Google_Service_Analytics_ManagementProfileFilterLinks_Resource(
+        $this,
+        $this->serviceName,
+        'profileFilterLinks',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/profileFilterLinks/{linkId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'linkId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/profileFilterLinks/{linkId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'linkId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/profileFilterLinks',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/profileFilterLinks',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/profileFilterLinks/{linkId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'linkId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/profileFilterLinks/{linkId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'linkId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->management_profileUserLinks = new Google_Service_Analytics_ManagementProfileUserLinks_Resource(
+        $this,
+        $this->serviceName,
+        'profileUserLinks',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/entityUserLinks/{linkId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'linkId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/entityUserLinks',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/entityUserLinks',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/entityUserLinks/{linkId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'linkId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->management_profiles = new Google_Service_Analytics_ManagementProfiles_Resource(
+        $this,
+        $this->serviceName,
+        'profiles',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->management_segments = new Google_Service_Analytics_ManagementSegments_Resource(
+        $this,
+        $this->serviceName,
+        'segments',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'management/segments',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->management_unsampledReports = new Google_Service_Analytics_ManagementUnsampledReports_Resource(
+        $this,
+        $this->serviceName,
+        'unsampledReports',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/unsampledReports/{unsampledReportId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'unsampledReportId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/unsampledReports',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/unsampledReports',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->management_uploads = new Google_Service_Analytics_ManagementUploads_Resource(
+        $this,
+        $this->serviceName,
+        'uploads',
+        array(
+          'methods' => array(
+            'deleteUploadData' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/customDataSources/{customDataSourceId}/deleteUploadData',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customDataSourceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/customDataSources/{customDataSourceId}/uploads/{uploadId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customDataSourceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'uploadId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/customDataSources/{customDataSourceId}/uploads',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customDataSourceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'uploadData' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/customDataSources/{customDataSourceId}/uploads',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customDataSourceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->management_webPropertyAdWordsLinks = new Google_Service_Analytics_ManagementWebPropertyAdWordsLinks_Resource(
+        $this,
+        $this->serviceName,
+        'webPropertyAdWordsLinks',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/entityAdWordsLinks/{webPropertyAdWordsLinkId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyAdWordsLinkId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/entityAdWordsLinks/{webPropertyAdWordsLinkId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyAdWordsLinkId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/entityAdWordsLinks',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/entityAdWordsLinks',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/entityAdWordsLinks/{webPropertyAdWordsLinkId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyAdWordsLinkId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/entityAdWordsLinks/{webPropertyAdWordsLinkId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyAdWordsLinkId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->management_webproperties = new Google_Service_Analytics_ManagementWebproperties_Resource(
+        $this,
+        $this->serviceName,
+        'webproperties',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'management/accounts/{accountId}/webproperties',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'management/accounts/{accountId}/webproperties',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->management_webpropertyUserLinks = new Google_Service_Analytics_ManagementWebpropertyUserLinks_Resource(
+        $this,
+        $this->serviceName,
+        'webpropertyUserLinks',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/entityUserLinks/{linkId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'linkId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/entityUserLinks',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/entityUserLinks',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'management/accounts/{accountId}/webproperties/{webPropertyId}/entityUserLinks/{linkId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'webPropertyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'linkId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->metadata_columns = new Google_Service_Analytics_MetadataColumns_Resource(
+        $this,
+        $this->serviceName,
+        'columns',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'metadata/{reportType}/columns',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'reportType' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->provisioning = new Google_Service_Analytics_Provisioning_Resource(
+        $this,
+        $this->serviceName,
+        'provisioning',
+        array(
+          'methods' => array(
+            'createAccountTicket' => array(
+              'path' => 'provisioning/createAccountTicket',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "data" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $data = $analyticsService->data;
+ *  </code>
+ */
+class Google_Service_Analytics_Data_Resource extends Google_Service_Resource
+{
+}
+
+/**
+ * The "ga" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $ga = $analyticsService->ga;
+ *  </code>
+ */
+class Google_Service_Analytics_DataGa_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns Analytics data for a view (profile). (ga.get)
+   *
+   * @param string $ids Unique table ID for retrieving Analytics data. Table ID is
+   * of the form ga:XXXX, where XXXX is the Analytics view (profile) ID.
+   * @param string $startDate Start date for fetching Analytics data. Requests can
+   * specify a start date formatted as YYYY-MM-DD, or as a relative date (e.g.,
+   * today, yesterday, or 7daysAgo). The default value is 7daysAgo.
+   * @param string $endDate End date for fetching Analytics data. Request can
+   * should specify an end date formatted as YYYY-MM-DD, or as a relative date
+   * (e.g., today, yesterday, or 7daysAgo). The default value is yesterday.
+   * @param string $metrics A comma-separated list of Analytics metrics. E.g.,
+   * 'ga:sessions,ga:pageviews'. At least one metric must be specified.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of entries to include in this
+   * feed.
+   * @opt_param string sort A comma-separated list of dimensions or metrics that
+   * determine the sort order for Analytics data.
+   * @opt_param string dimensions A comma-separated list of Analytics dimensions.
+   * E.g., 'ga:browser,ga:city'.
+   * @opt_param int start-index An index of the first entity to retrieve. Use this
+   * parameter as a pagination mechanism along with the max-results parameter.
+   * @opt_param string segment An Analytics segment to be applied to data.
+   * @opt_param string samplingLevel The desired sampling level.
+   * @opt_param string filters A comma-separated list of dimension or metric
+   * filters to be applied to Analytics data.
+   * @opt_param string output The selected format for the response. Default format
+   * is JSON.
+   * @return Google_Service_Analytics_GaData
+   */
+  public function get($ids, $startDate, $endDate, $metrics, $optParams = array())
+  {
+    $params = array('ids' => $ids, 'start-date' => $startDate, 'end-date' => $endDate, 'metrics' => $metrics);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Analytics_GaData");
+  }
+}
+/**
+ * The "mcf" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $mcf = $analyticsService->mcf;
+ *  </code>
+ */
+class Google_Service_Analytics_DataMcf_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns Analytics Multi-Channel Funnels data for a view (profile). (mcf.get)
+   *
+   * @param string $ids Unique table ID for retrieving Analytics data. Table ID is
+   * of the form ga:XXXX, where XXXX is the Analytics view (profile) ID.
+   * @param string $startDate Start date for fetching Analytics data. Requests can
+   * specify a start date formatted as YYYY-MM-DD, or as a relative date (e.g.,
+   * today, yesterday, or 7daysAgo). The default value is 7daysAgo.
+   * @param string $endDate End date for fetching Analytics data. Requests can
+   * specify a start date formatted as YYYY-MM-DD, or as a relative date (e.g.,
+   * today, yesterday, or 7daysAgo). The default value is 7daysAgo.
+   * @param string $metrics A comma-separated list of Multi-Channel Funnels
+   * metrics. E.g., 'mcf:totalConversions,mcf:totalConversionValue'. At least one
+   * metric must be specified.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of entries to include in this
+   * feed.
+   * @opt_param string sort A comma-separated list of dimensions or metrics that
+   * determine the sort order for the Analytics data.
+   * @opt_param string dimensions A comma-separated list of Multi-Channel Funnels
+   * dimensions. E.g., 'mcf:source,mcf:medium'.
+   * @opt_param int start-index An index of the first entity to retrieve. Use this
+   * parameter as a pagination mechanism along with the max-results parameter.
+   * @opt_param string samplingLevel The desired sampling level.
+   * @opt_param string filters A comma-separated list of dimension or metric
+   * filters to be applied to the Analytics data.
+   * @return Google_Service_Analytics_McfData
+   */
+  public function get($ids, $startDate, $endDate, $metrics, $optParams = array())
+  {
+    $params = array('ids' => $ids, 'start-date' => $startDate, 'end-date' => $endDate, 'metrics' => $metrics);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Analytics_McfData");
+  }
+}
+/**
+ * The "realtime" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $realtime = $analyticsService->realtime;
+ *  </code>
+ */
+class Google_Service_Analytics_DataRealtime_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns real time data for a view (profile). (realtime.get)
+   *
+   * @param string $ids Unique table ID for retrieving real time data. Table ID is
+   * of the form ga:XXXX, where XXXX is the Analytics view (profile) ID.
+   * @param string $metrics A comma-separated list of real time metrics. E.g.,
+   * 'rt:activeUsers'. At least one metric must be specified.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of entries to include in this
+   * feed.
+   * @opt_param string sort A comma-separated list of dimensions or metrics that
+   * determine the sort order for real time data.
+   * @opt_param string dimensions A comma-separated list of real time dimensions.
+   * E.g., 'rt:medium,rt:city'.
+   * @opt_param string filters A comma-separated list of dimension or metric
+   * filters to be applied to real time data.
+   * @return Google_Service_Analytics_RealtimeData
+   */
+  public function get($ids, $metrics, $optParams = array())
+  {
+    $params = array('ids' => $ids, 'metrics' => $metrics);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Analytics_RealtimeData");
+  }
+}
+
+/**
+ * The "management" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $management = $analyticsService->management;
+ *  </code>
+ */
+class Google_Service_Analytics_Management_Resource extends Google_Service_Resource
+{
+}
+
+/**
+ * The "accountSummaries" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $accountSummaries = $analyticsService->accountSummaries;
+ *  </code>
+ */
+class Google_Service_Analytics_ManagementAccountSummaries_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Lists account summaries (lightweight tree comprised of
+   * accounts/properties/profiles) to which the user has access.
+   * (accountSummaries.listManagementAccountSummaries)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of account summaries to include
+   * in this response, where the largest acceptable value is 1000.
+   * @opt_param int start-index An index of the first entity to retrieve. Use this
+   * parameter as a pagination mechanism along with the max-results parameter.
+   * @return Google_Service_Analytics_AccountSummaries
+   */
+  public function listManagementAccountSummaries($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_AccountSummaries");
+  }
+}
+/**
+ * The "accountUserLinks" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $accountUserLinks = $analyticsService->accountUserLinks;
+ *  </code>
+ */
+class Google_Service_Analytics_ManagementAccountUserLinks_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Removes a user from the given account. (accountUserLinks.delete)
+   *
+   * @param string $accountId Account ID to delete the user link for.
+   * @param string $linkId Link ID to delete the user link for.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($accountId, $linkId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'linkId' => $linkId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Adds a new user to the given account. (accountUserLinks.insert)
+   *
+   * @param string $accountId Account ID to create the user link for.
+   * @param Google_EntityUserLink $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_EntityUserLink
+   */
+  public function insert($accountId, Google_Service_Analytics_EntityUserLink $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Analytics_EntityUserLink");
+  }
+
+  /**
+   * Lists account-user links for a given account.
+   * (accountUserLinks.listManagementAccountUserLinks)
+   *
+   * @param string $accountId Account ID to retrieve the user links for.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of account-user links to
+   * include in this response.
+   * @opt_param int start-index An index of the first account-user link to
+   * retrieve. Use this parameter as a pagination mechanism along with the max-
+   * results parameter.
+   * @return Google_Service_Analytics_EntityUserLinks
+   */
+  public function listManagementAccountUserLinks($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_EntityUserLinks");
+  }
+
+  /**
+   * Updates permissions for an existing user on the given account.
+   * (accountUserLinks.update)
+   *
+   * @param string $accountId Account ID to update the account-user link for.
+   * @param string $linkId Link ID to update the account-user link for.
+   * @param Google_EntityUserLink $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_EntityUserLink
+   */
+  public function update($accountId, $linkId, Google_Service_Analytics_EntityUserLink $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'linkId' => $linkId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Analytics_EntityUserLink");
+  }
+}
+/**
+ * The "accounts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $accounts = $analyticsService->accounts;
+ *  </code>
+ */
+class Google_Service_Analytics_ManagementAccounts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Lists all accounts to which the user has access.
+   * (accounts.listManagementAccounts)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of accounts to include in this
+   * response.
+   * @opt_param int start-index An index of the first account to retrieve. Use
+   * this parameter as a pagination mechanism along with the max-results
+   * parameter.
+   * @return Google_Service_Analytics_Accounts
+   */
+  public function listManagementAccounts($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_Accounts");
+  }
+}
+/**
+ * The "customDataSources" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $customDataSources = $analyticsService->customDataSources;
+ *  </code>
+ */
+class Google_Service_Analytics_ManagementCustomDataSources_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List custom data sources to which the user has access.
+   * (customDataSources.listManagementCustomDataSources)
+   *
+   * @param string $accountId Account Id for the custom data sources to retrieve.
+   * @param string $webPropertyId Web property Id for the custom data sources to
+   * retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of custom data sources to
+   * include in this response.
+   * @opt_param int start-index A 1-based index of the first custom data source to
+   * retrieve. Use this parameter as a pagination mechanism along with the max-
+   * results parameter.
+   * @return Google_Service_Analytics_CustomDataSources
+   */
+  public function listManagementCustomDataSources($accountId, $webPropertyId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_CustomDataSources");
+  }
+}
+/**
+ * The "customDimensions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $customDimensions = $analyticsService->customDimensions;
+ *  </code>
+ */
+class Google_Service_Analytics_ManagementCustomDimensions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get a custom dimension to which the user has access. (customDimensions.get)
+   *
+   * @param string $accountId Account ID for the custom dimension to retrieve.
+   * @param string $webPropertyId Web property ID for the custom dimension to
+   * retrieve.
+   * @param string $customDimensionId The ID of the custom dimension to retrieve.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_CustomDimension
+   */
+  public function get($accountId, $webPropertyId, $customDimensionId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'customDimensionId' => $customDimensionId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Analytics_CustomDimension");
+  }
+
+  /**
+   * Create a new custom dimension. (customDimensions.insert)
+   *
+   * @param string $accountId Account ID for the custom dimension to create.
+   * @param string $webPropertyId Web property ID for the custom dimension to
+   * create.
+   * @param Google_CustomDimension $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_CustomDimension
+   */
+  public function insert($accountId, $webPropertyId, Google_Service_Analytics_CustomDimension $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Analytics_CustomDimension");
+  }
+
+  /**
+   * Lists custom dimensions to which the user has access.
+   * (customDimensions.listManagementCustomDimensions)
+   *
+   * @param string $accountId Account ID for the custom dimensions to retrieve.
+   * @param string $webPropertyId Web property ID for the custom dimensions to
+   * retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of custom dimensions to include
+   * in this response.
+   * @opt_param int start-index An index of the first entity to retrieve. Use this
+   * parameter as a pagination mechanism along with the max-results parameter.
+   * @return Google_Service_Analytics_CustomDimensions
+   */
+  public function listManagementCustomDimensions($accountId, $webPropertyId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_CustomDimensions");
+  }
+
+  /**
+   * Updates an existing custom dimension. This method supports patch semantics.
+   * (customDimensions.patch)
+   *
+   * @param string $accountId Account ID for the custom dimension to update.
+   * @param string $webPropertyId Web property ID for the custom dimension to
+   * update.
+   * @param string $customDimensionId Custom dimension ID for the custom dimension
+   * to update.
+   * @param Google_CustomDimension $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool ignoreCustomDataSourceLinks Force the update and ignore any
+   * warnings related to the custom dimension being linked to a custom data source
+   * / data set.
+   * @return Google_Service_Analytics_CustomDimension
+   */
+  public function patch($accountId, $webPropertyId, $customDimensionId, Google_Service_Analytics_CustomDimension $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'customDimensionId' => $customDimensionId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Analytics_CustomDimension");
+  }
+
+  /**
+   * Updates an existing custom dimension. (customDimensions.update)
+   *
+   * @param string $accountId Account ID for the custom dimension to update.
+   * @param string $webPropertyId Web property ID for the custom dimension to
+   * update.
+   * @param string $customDimensionId Custom dimension ID for the custom dimension
+   * to update.
+   * @param Google_CustomDimension $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool ignoreCustomDataSourceLinks Force the update and ignore any
+   * warnings related to the custom dimension being linked to a custom data source
+   * / data set.
+   * @return Google_Service_Analytics_CustomDimension
+   */
+  public function update($accountId, $webPropertyId, $customDimensionId, Google_Service_Analytics_CustomDimension $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'customDimensionId' => $customDimensionId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Analytics_CustomDimension");
+  }
+}
+/**
+ * The "customMetrics" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $customMetrics = $analyticsService->customMetrics;
+ *  </code>
+ */
+class Google_Service_Analytics_ManagementCustomMetrics_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get a custom metric to which the user has access. (customMetrics.get)
+   *
+   * @param string $accountId Account ID for the custom metric to retrieve.
+   * @param string $webPropertyId Web property ID for the custom metric to
+   * retrieve.
+   * @param string $customMetricId The ID of the custom metric to retrieve.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_CustomMetric
+   */
+  public function get($accountId, $webPropertyId, $customMetricId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'customMetricId' => $customMetricId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Analytics_CustomMetric");
+  }
+
+  /**
+   * Create a new custom metric. (customMetrics.insert)
+   *
+   * @param string $accountId Account ID for the custom metric to create.
+   * @param string $webPropertyId Web property ID for the custom dimension to
+   * create.
+   * @param Google_CustomMetric $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_CustomMetric
+   */
+  public function insert($accountId, $webPropertyId, Google_Service_Analytics_CustomMetric $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Analytics_CustomMetric");
+  }
+
+  /**
+   * Lists custom metrics to which the user has access.
+   * (customMetrics.listManagementCustomMetrics)
+   *
+   * @param string $accountId Account ID for the custom metrics to retrieve.
+   * @param string $webPropertyId Web property ID for the custom metrics to
+   * retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of custom metrics to include in
+   * this response.
+   * @opt_param int start-index An index of the first entity to retrieve. Use this
+   * parameter as a pagination mechanism along with the max-results parameter.
+   * @return Google_Service_Analytics_CustomMetrics
+   */
+  public function listManagementCustomMetrics($accountId, $webPropertyId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_CustomMetrics");
+  }
+
+  /**
+   * Updates an existing custom metric. This method supports patch semantics.
+   * (customMetrics.patch)
+   *
+   * @param string $accountId Account ID for the custom metric to update.
+   * @param string $webPropertyId Web property ID for the custom metric to update.
+   * @param string $customMetricId Custom metric ID for the custom metric to
+   * update.
+   * @param Google_CustomMetric $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool ignoreCustomDataSourceLinks Force the update and ignore any
+   * warnings related to the custom metric being linked to a custom data source /
+   * data set.
+   * @return Google_Service_Analytics_CustomMetric
+   */
+  public function patch($accountId, $webPropertyId, $customMetricId, Google_Service_Analytics_CustomMetric $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'customMetricId' => $customMetricId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Analytics_CustomMetric");
+  }
+
+  /**
+   * Updates an existing custom metric. (customMetrics.update)
+   *
+   * @param string $accountId Account ID for the custom metric to update.
+   * @param string $webPropertyId Web property ID for the custom metric to update.
+   * @param string $customMetricId Custom metric ID for the custom metric to
+   * update.
+   * @param Google_CustomMetric $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool ignoreCustomDataSourceLinks Force the update and ignore any
+   * warnings related to the custom metric being linked to a custom data source /
+   * data set.
+   * @return Google_Service_Analytics_CustomMetric
+   */
+  public function update($accountId, $webPropertyId, $customMetricId, Google_Service_Analytics_CustomMetric $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'customMetricId' => $customMetricId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Analytics_CustomMetric");
+  }
+}
+/**
+ * The "experiments" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $experiments = $analyticsService->experiments;
+ *  </code>
+ */
+class Google_Service_Analytics_ManagementExperiments_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete an experiment. (experiments.delete)
+   *
+   * @param string $accountId Account ID to which the experiment belongs
+   * @param string $webPropertyId Web property ID to which the experiment belongs
+   * @param string $profileId View (Profile) ID to which the experiment belongs
+   * @param string $experimentId ID of the experiment to delete
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($accountId, $webPropertyId, $profileId, $experimentId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'experimentId' => $experimentId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Returns an experiment to which the user has access. (experiments.get)
+   *
+   * @param string $accountId Account ID to retrieve the experiment for.
+   * @param string $webPropertyId Web property ID to retrieve the experiment for.
+   * @param string $profileId View (Profile) ID to retrieve the experiment for.
+   * @param string $experimentId Experiment ID to retrieve the experiment for.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Experiment
+   */
+  public function get($accountId, $webPropertyId, $profileId, $experimentId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'experimentId' => $experimentId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Analytics_Experiment");
+  }
+
+  /**
+   * Create a new experiment. (experiments.insert)
+   *
+   * @param string $accountId Account ID to create the experiment for.
+   * @param string $webPropertyId Web property ID to create the experiment for.
+   * @param string $profileId View (Profile) ID to create the experiment for.
+   * @param Google_Experiment $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Experiment
+   */
+  public function insert($accountId, $webPropertyId, $profileId, Google_Service_Analytics_Experiment $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Analytics_Experiment");
+  }
+
+  /**
+   * Lists experiments to which the user has access.
+   * (experiments.listManagementExperiments)
+   *
+   * @param string $accountId Account ID to retrieve experiments for.
+   * @param string $webPropertyId Web property ID to retrieve experiments for.
+   * @param string $profileId View (Profile) ID to retrieve experiments for.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of experiments to include in
+   * this response.
+   * @opt_param int start-index An index of the first experiment to retrieve. Use
+   * this parameter as a pagination mechanism along with the max-results
+   * parameter.
+   * @return Google_Service_Analytics_Experiments
+   */
+  public function listManagementExperiments($accountId, $webPropertyId, $profileId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_Experiments");
+  }
+
+  /**
+   * Update an existing experiment. This method supports patch semantics.
+   * (experiments.patch)
+   *
+   * @param string $accountId Account ID of the experiment to update.
+   * @param string $webPropertyId Web property ID of the experiment to update.
+   * @param string $profileId View (Profile) ID of the experiment to update.
+   * @param string $experimentId Experiment ID of the experiment to update.
+   * @param Google_Experiment $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Experiment
+   */
+  public function patch($accountId, $webPropertyId, $profileId, $experimentId, Google_Service_Analytics_Experiment $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'experimentId' => $experimentId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Analytics_Experiment");
+  }
+
+  /**
+   * Update an existing experiment. (experiments.update)
+   *
+   * @param string $accountId Account ID of the experiment to update.
+   * @param string $webPropertyId Web property ID of the experiment to update.
+   * @param string $profileId View (Profile) ID of the experiment to update.
+   * @param string $experimentId Experiment ID of the experiment to update.
+   * @param Google_Experiment $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Experiment
+   */
+  public function update($accountId, $webPropertyId, $profileId, $experimentId, Google_Service_Analytics_Experiment $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'experimentId' => $experimentId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Analytics_Experiment");
+  }
+}
+/**
+ * The "filters" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $filters = $analyticsService->filters;
+ *  </code>
+ */
+class Google_Service_Analytics_ManagementFilters_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete a filter. (filters.delete)
+   *
+   * @param string $accountId Account ID to delete the filter for.
+   * @param string $filterId ID of the filter to be deleted.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Filter
+   */
+  public function delete($accountId, $filterId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'filterId' => $filterId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Analytics_Filter");
+  }
+
+  /**
+   * Returns a filters to which the user has access. (filters.get)
+   *
+   * @param string $accountId Account ID to retrieve filters for.
+   * @param string $filterId Filter ID to retrieve filters for.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Filter
+   */
+  public function get($accountId, $filterId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'filterId' => $filterId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Analytics_Filter");
+  }
+
+  /**
+   * Create a new filter. (filters.insert)
+   *
+   * @param string $accountId Account ID to create filter for.
+   * @param Google_Filter $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Filter
+   */
+  public function insert($accountId, Google_Service_Analytics_Filter $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Analytics_Filter");
+  }
+
+  /**
+   * Lists all filters for an account (filters.listManagementFilters)
+   *
+   * @param string $accountId Account ID to retrieve filters for.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of filters to include in this
+   * response.
+   * @opt_param int start-index An index of the first entity to retrieve. Use this
+   * parameter as a pagination mechanism along with the max-results parameter.
+   * @return Google_Service_Analytics_Filters
+   */
+  public function listManagementFilters($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_Filters");
+  }
+
+  /**
+   * Updates an existing filter. This method supports patch semantics.
+   * (filters.patch)
+   *
+   * @param string $accountId Account ID to which the filter belongs.
+   * @param string $filterId ID of the filter to be updated.
+   * @param Google_Filter $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Filter
+   */
+  public function patch($accountId, $filterId, Google_Service_Analytics_Filter $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'filterId' => $filterId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Analytics_Filter");
+  }
+
+  /**
+   * Updates an existing filter. (filters.update)
+   *
+   * @param string $accountId Account ID to which the filter belongs.
+   * @param string $filterId ID of the filter to be updated.
+   * @param Google_Filter $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Filter
+   */
+  public function update($accountId, $filterId, Google_Service_Analytics_Filter $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'filterId' => $filterId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Analytics_Filter");
+  }
+}
+/**
+ * The "goals" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $goals = $analyticsService->goals;
+ *  </code>
+ */
+class Google_Service_Analytics_ManagementGoals_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets a goal to which the user has access. (goals.get)
+   *
+   * @param string $accountId Account ID to retrieve the goal for.
+   * @param string $webPropertyId Web property ID to retrieve the goal for.
+   * @param string $profileId View (Profile) ID to retrieve the goal for.
+   * @param string $goalId Goal ID to retrieve the goal for.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Goal
+   */
+  public function get($accountId, $webPropertyId, $profileId, $goalId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'goalId' => $goalId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Analytics_Goal");
+  }
+
+  /**
+   * Create a new goal. (goals.insert)
+   *
+   * @param string $accountId Account ID to create the goal for.
+   * @param string $webPropertyId Web property ID to create the goal for.
+   * @param string $profileId View (Profile) ID to create the goal for.
+   * @param Google_Goal $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Goal
+   */
+  public function insert($accountId, $webPropertyId, $profileId, Google_Service_Analytics_Goal $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Analytics_Goal");
+  }
+
+  /**
+   * Lists goals to which the user has access. (goals.listManagementGoals)
+   *
+   * @param string $accountId Account ID to retrieve goals for. Can either be a
+   * specific account ID or '~all', which refers to all the accounts that user has
+   * access to.
+   * @param string $webPropertyId Web property ID to retrieve goals for. Can
+   * either be a specific web property ID or '~all', which refers to all the web
+   * properties that user has access to.
+   * @param string $profileId View (Profile) ID to retrieve goals for. Can either
+   * be a specific view (profile) ID or '~all', which refers to all the views
+   * (profiles) that user has access to.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of goals to include in this
+   * response.
+   * @opt_param int start-index An index of the first goal to retrieve. Use this
+   * parameter as a pagination mechanism along with the max-results parameter.
+   * @return Google_Service_Analytics_Goals
+   */
+  public function listManagementGoals($accountId, $webPropertyId, $profileId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_Goals");
+  }
+
+  /**
+   * Updates an existing view (profile). This method supports patch semantics.
+   * (goals.patch)
+   *
+   * @param string $accountId Account ID to update the goal.
+   * @param string $webPropertyId Web property ID to update the goal.
+   * @param string $profileId View (Profile) ID to update the goal.
+   * @param string $goalId Index of the goal to be updated.
+   * @param Google_Goal $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Goal
+   */
+  public function patch($accountId, $webPropertyId, $profileId, $goalId, Google_Service_Analytics_Goal $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'goalId' => $goalId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Analytics_Goal");
+  }
+
+  /**
+   * Updates an existing view (profile). (goals.update)
+   *
+   * @param string $accountId Account ID to update the goal.
+   * @param string $webPropertyId Web property ID to update the goal.
+   * @param string $profileId View (Profile) ID to update the goal.
+   * @param string $goalId Index of the goal to be updated.
+   * @param Google_Goal $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Goal
+   */
+  public function update($accountId, $webPropertyId, $profileId, $goalId, Google_Service_Analytics_Goal $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'goalId' => $goalId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Analytics_Goal");
+  }
+}
+/**
+ * The "profileFilterLinks" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $profileFilterLinks = $analyticsService->profileFilterLinks;
+ *  </code>
+ */
+class Google_Service_Analytics_ManagementProfileFilterLinks_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete a profile filter link. (profileFilterLinks.delete)
+   *
+   * @param string $accountId Account ID to which the profile filter link belongs.
+   * @param string $webPropertyId Web property Id to which the profile filter link
+   * belongs.
+   * @param string $profileId Profile ID to which the filter link belongs.
+   * @param string $linkId ID of the profile filter link to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($accountId, $webPropertyId, $profileId, $linkId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'linkId' => $linkId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Returns a single profile filter link. (profileFilterLinks.get)
+   *
+   * @param string $accountId Account ID to retrieve profile filter link for.
+   * @param string $webPropertyId Web property Id to retrieve profile filter link
+   * for.
+   * @param string $profileId Profile ID to retrieve filter link for.
+   * @param string $linkId ID of the profile filter link.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_ProfileFilterLink
+   */
+  public function get($accountId, $webPropertyId, $profileId, $linkId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'linkId' => $linkId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Analytics_ProfileFilterLink");
+  }
+
+  /**
+   * Create a new profile filter link. (profileFilterLinks.insert)
+   *
+   * @param string $accountId Account ID to create profile filter link for.
+   * @param string $webPropertyId Web property Id to create profile filter link
+   * for.
+   * @param string $profileId Profile ID to create filter link for.
+   * @param Google_ProfileFilterLink $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_ProfileFilterLink
+   */
+  public function insert($accountId, $webPropertyId, $profileId, Google_Service_Analytics_ProfileFilterLink $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Analytics_ProfileFilterLink");
+  }
+
+  /**
+   * Lists all profile filter links for a profile.
+   * (profileFilterLinks.listManagementProfileFilterLinks)
+   *
+   * @param string $accountId Account ID to retrieve profile filter links for.
+   * @param string $webPropertyId Web property Id for profile filter links for.
+   * Can either be a specific web property ID or '~all', which refers to all the
+   * web properties that user has access to.
+   * @param string $profileId Profile ID to retrieve filter links for. Can either
+   * be a specific profile ID or '~all', which refers to all the profiles that
+   * user has access to.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of profile filter links to
+   * include in this response.
+   * @opt_param int start-index An index of the first entity to retrieve. Use this
+   * parameter as a pagination mechanism along with the max-results parameter.
+   * @return Google_Service_Analytics_ProfileFilterLinks
+   */
+  public function listManagementProfileFilterLinks($accountId, $webPropertyId, $profileId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_ProfileFilterLinks");
+  }
+
+  /**
+   * Update an existing profile filter link. This method supports patch semantics.
+   * (profileFilterLinks.patch)
+   *
+   * @param string $accountId Account ID to which profile filter link belongs.
+   * @param string $webPropertyId Web property Id to which profile filter link
+   * belongs
+   * @param string $profileId Profile ID to which filter link belongs
+   * @param string $linkId ID of the profile filter link to be updated.
+   * @param Google_ProfileFilterLink $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_ProfileFilterLink
+   */
+  public function patch($accountId, $webPropertyId, $profileId, $linkId, Google_Service_Analytics_ProfileFilterLink $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'linkId' => $linkId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Analytics_ProfileFilterLink");
+  }
+
+  /**
+   * Update an existing profile filter link. (profileFilterLinks.update)
+   *
+   * @param string $accountId Account ID to which profile filter link belongs.
+   * @param string $webPropertyId Web property Id to which profile filter link
+   * belongs
+   * @param string $profileId Profile ID to which filter link belongs
+   * @param string $linkId ID of the profile filter link to be updated.
+   * @param Google_ProfileFilterLink $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_ProfileFilterLink
+   */
+  public function update($accountId, $webPropertyId, $profileId, $linkId, Google_Service_Analytics_ProfileFilterLink $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'linkId' => $linkId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Analytics_ProfileFilterLink");
+  }
+}
+/**
+ * The "profileUserLinks" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $profileUserLinks = $analyticsService->profileUserLinks;
+ *  </code>
+ */
+class Google_Service_Analytics_ManagementProfileUserLinks_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Removes a user from the given view (profile). (profileUserLinks.delete)
+   *
+   * @param string $accountId Account ID to delete the user link for.
+   * @param string $webPropertyId Web Property ID to delete the user link for.
+   * @param string $profileId View (Profile) ID to delete the user link for.
+   * @param string $linkId Link ID to delete the user link for.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($accountId, $webPropertyId, $profileId, $linkId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'linkId' => $linkId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Adds a new user to the given view (profile). (profileUserLinks.insert)
+   *
+   * @param string $accountId Account ID to create the user link for.
+   * @param string $webPropertyId Web Property ID to create the user link for.
+   * @param string $profileId View (Profile) ID to create the user link for.
+   * @param Google_EntityUserLink $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_EntityUserLink
+   */
+  public function insert($accountId, $webPropertyId, $profileId, Google_Service_Analytics_EntityUserLink $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Analytics_EntityUserLink");
+  }
+
+  /**
+   * Lists profile-user links for a given view (profile).
+   * (profileUserLinks.listManagementProfileUserLinks)
+   *
+   * @param string $accountId Account ID which the given view (profile) belongs
+   * to.
+   * @param string $webPropertyId Web Property ID which the given view (profile)
+   * belongs to. Can either be a specific web property ID or '~all', which refers
+   * to all the web properties that user has access to.
+   * @param string $profileId View (Profile) ID to retrieve the profile-user links
+   * for. Can either be a specific profile ID or '~all', which refers to all the
+   * profiles that user has access to.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of profile-user links to
+   * include in this response.
+   * @opt_param int start-index An index of the first profile-user link to
+   * retrieve. Use this parameter as a pagination mechanism along with the max-
+   * results parameter.
+   * @return Google_Service_Analytics_EntityUserLinks
+   */
+  public function listManagementProfileUserLinks($accountId, $webPropertyId, $profileId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_EntityUserLinks");
+  }
+
+  /**
+   * Updates permissions for an existing user on the given view (profile).
+   * (profileUserLinks.update)
+   *
+   * @param string $accountId Account ID to update the user link for.
+   * @param string $webPropertyId Web Property ID to update the user link for.
+   * @param string $profileId View (Profile ID) to update the user link for.
+   * @param string $linkId Link ID to update the user link for.
+   * @param Google_EntityUserLink $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_EntityUserLink
+   */
+  public function update($accountId, $webPropertyId, $profileId, $linkId, Google_Service_Analytics_EntityUserLink $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'linkId' => $linkId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Analytics_EntityUserLink");
+  }
+}
+/**
+ * The "profiles" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $profiles = $analyticsService->profiles;
+ *  </code>
+ */
+class Google_Service_Analytics_ManagementProfiles_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a view (profile). (profiles.delete)
+   *
+   * @param string $accountId Account ID to delete the view (profile) for.
+   * @param string $webPropertyId Web property ID to delete the view (profile)
+   * for.
+   * @param string $profileId ID of the view (profile) to be deleted.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($accountId, $webPropertyId, $profileId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets a view (profile) to which the user has access. (profiles.get)
+   *
+   * @param string $accountId Account ID to retrieve the goal for.
+   * @param string $webPropertyId Web property ID to retrieve the goal for.
+   * @param string $profileId View (Profile) ID to retrieve the goal for.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Profile
+   */
+  public function get($accountId, $webPropertyId, $profileId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Analytics_Profile");
+  }
+
+  /**
+   * Create a new view (profile). (profiles.insert)
+   *
+   * @param string $accountId Account ID to create the view (profile) for.
+   * @param string $webPropertyId Web property ID to create the view (profile)
+   * for.
+   * @param Google_Profile $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Profile
+   */
+  public function insert($accountId, $webPropertyId, Google_Service_Analytics_Profile $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Analytics_Profile");
+  }
+
+  /**
+   * Lists views (profiles) to which the user has access.
+   * (profiles.listManagementProfiles)
+   *
+   * @param string $accountId Account ID for the view (profiles) to retrieve. Can
+   * either be a specific account ID or '~all', which refers to all the accounts
+   * to which the user has access.
+   * @param string $webPropertyId Web property ID for the views (profiles) to
+   * retrieve. Can either be a specific web property ID or '~all', which refers to
+   * all the web properties to which the user has access.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of views (profiles) to include
+   * in this response.
+   * @opt_param int start-index An index of the first entity to retrieve. Use this
+   * parameter as a pagination mechanism along with the max-results parameter.
+   * @return Google_Service_Analytics_Profiles
+   */
+  public function listManagementProfiles($accountId, $webPropertyId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_Profiles");
+  }
+
+  /**
+   * Updates an existing view (profile). This method supports patch semantics.
+   * (profiles.patch)
+   *
+   * @param string $accountId Account ID to which the view (profile) belongs
+   * @param string $webPropertyId Web property ID to which the view (profile)
+   * belongs
+   * @param string $profileId ID of the view (profile) to be updated.
+   * @param Google_Profile $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Profile
+   */
+  public function patch($accountId, $webPropertyId, $profileId, Google_Service_Analytics_Profile $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Analytics_Profile");
+  }
+
+  /**
+   * Updates an existing view (profile). (profiles.update)
+   *
+   * @param string $accountId Account ID to which the view (profile) belongs
+   * @param string $webPropertyId Web property ID to which the view (profile)
+   * belongs
+   * @param string $profileId ID of the view (profile) to be updated.
+   * @param Google_Profile $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Profile
+   */
+  public function update($accountId, $webPropertyId, $profileId, Google_Service_Analytics_Profile $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Analytics_Profile");
+  }
+}
+/**
+ * The "segments" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $segments = $analyticsService->segments;
+ *  </code>
+ */
+class Google_Service_Analytics_ManagementSegments_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Lists segments to which the user has access.
+   * (segments.listManagementSegments)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of segments to include in this
+   * response.
+   * @opt_param int start-index An index of the first segment to retrieve. Use
+   * this parameter as a pagination mechanism along with the max-results
+   * parameter.
+   * @return Google_Service_Analytics_Segments
+   */
+  public function listManagementSegments($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_Segments");
+  }
+}
+/**
+ * The "unsampledReports" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $unsampledReports = $analyticsService->unsampledReports;
+ *  </code>
+ */
+class Google_Service_Analytics_ManagementUnsampledReports_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns a single unsampled report. (unsampledReports.get)
+   *
+   * @param string $accountId Account ID to retrieve unsampled report for.
+   * @param string $webPropertyId Web property ID to retrieve unsampled reports
+   * for.
+   * @param string $profileId View (Profile) ID to retrieve unsampled report for.
+   * @param string $unsampledReportId ID of the unsampled report to retrieve.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_UnsampledReport
+   */
+  public function get($accountId, $webPropertyId, $profileId, $unsampledReportId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'unsampledReportId' => $unsampledReportId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Analytics_UnsampledReport");
+  }
+
+  /**
+   * Create a new unsampled report. (unsampledReports.insert)
+   *
+   * @param string $accountId Account ID to create the unsampled report for.
+   * @param string $webPropertyId Web property ID to create the unsampled report
+   * for.
+   * @param string $profileId View (Profile) ID to create the unsampled report
+   * for.
+   * @param Google_UnsampledReport $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_UnsampledReport
+   */
+  public function insert($accountId, $webPropertyId, $profileId, Google_Service_Analytics_UnsampledReport $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Analytics_UnsampledReport");
+  }
+
+  /**
+   * Lists unsampled reports to which the user has access.
+   * (unsampledReports.listManagementUnsampledReports)
+   *
+   * @param string $accountId Account ID to retrieve unsampled reports for. Must
+   * be a specific account ID, ~all is not supported.
+   * @param string $webPropertyId Web property ID to retrieve unsampled reports
+   * for. Must be a specific web property ID, ~all is not supported.
+   * @param string $profileId View (Profile) ID to retrieve unsampled reports for.
+   * Must be a specific view (profile) ID, ~all is not supported.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of unsampled reports to include
+   * in this response.
+   * @opt_param int start-index An index of the first unsampled report to
+   * retrieve. Use this parameter as a pagination mechanism along with the max-
+   * results parameter.
+   * @return Google_Service_Analytics_UnsampledReports
+   */
+  public function listManagementUnsampledReports($accountId, $webPropertyId, $profileId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_UnsampledReports");
+  }
+}
+/**
+ * The "uploads" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $uploads = $analyticsService->uploads;
+ *  </code>
+ */
+class Google_Service_Analytics_ManagementUploads_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete data associated with a previous upload. (uploads.deleteUploadData)
+   *
+   * @param string $accountId Account Id for the uploads to be deleted.
+   * @param string $webPropertyId Web property Id for the uploads to be deleted.
+   * @param string $customDataSourceId Custom data source Id for the uploads to be
+   * deleted.
+   * @param Google_AnalyticsDataimportDeleteUploadDataRequest $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function deleteUploadData($accountId, $webPropertyId, $customDataSourceId, Google_Service_Analytics_AnalyticsDataimportDeleteUploadDataRequest $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'customDataSourceId' => $customDataSourceId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('deleteUploadData', array($params));
+  }
+
+  /**
+   * List uploads to which the user has access. (uploads.get)
+   *
+   * @param string $accountId Account Id for the upload to retrieve.
+   * @param string $webPropertyId Web property Id for the upload to retrieve.
+   * @param string $customDataSourceId Custom data source Id for upload to
+   * retrieve.
+   * @param string $uploadId Upload Id to retrieve.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Upload
+   */
+  public function get($accountId, $webPropertyId, $customDataSourceId, $uploadId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'customDataSourceId' => $customDataSourceId, 'uploadId' => $uploadId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Analytics_Upload");
+  }
+
+  /**
+   * List uploads to which the user has access. (uploads.listManagementUploads)
+   *
+   * @param string $accountId Account Id for the uploads to retrieve.
+   * @param string $webPropertyId Web property Id for the uploads to retrieve.
+   * @param string $customDataSourceId Custom data source Id for uploads to
+   * retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of uploads to include in this
+   * response.
+   * @opt_param int start-index A 1-based index of the first upload to retrieve.
+   * Use this parameter as a pagination mechanism along with the max-results
+   * parameter.
+   * @return Google_Service_Analytics_Uploads
+   */
+  public function listManagementUploads($accountId, $webPropertyId, $customDataSourceId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'customDataSourceId' => $customDataSourceId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_Uploads");
+  }
+
+  /**
+   * Upload data for a custom data source. (uploads.uploadData)
+   *
+   * @param string $accountId Account Id associated with the upload.
+   * @param string $webPropertyId Web property UA-string associated with the
+   * upload.
+   * @param string $customDataSourceId Custom data source Id to which the data
+   * being uploaded belongs.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Upload
+   */
+  public function uploadData($accountId, $webPropertyId, $customDataSourceId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'customDataSourceId' => $customDataSourceId);
+    $params = array_merge($params, $optParams);
+    return $this->call('uploadData', array($params), "Google_Service_Analytics_Upload");
+  }
+}
+/**
+ * The "webPropertyAdWordsLinks" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $webPropertyAdWordsLinks = $analyticsService->webPropertyAdWordsLinks;
+ *  </code>
+ */
+class Google_Service_Analytics_ManagementWebPropertyAdWordsLinks_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a web property-AdWords link. (webPropertyAdWordsLinks.delete)
+   *
+   * @param string $accountId ID of the account which the given web property
+   * belongs to.
+   * @param string $webPropertyId Web property ID to delete the AdWords link for.
+   * @param string $webPropertyAdWordsLinkId Web property AdWords link ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($accountId, $webPropertyId, $webPropertyAdWordsLinkId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'webPropertyAdWordsLinkId' => $webPropertyAdWordsLinkId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Returns a web property-AdWords link to which the user has access.
+   * (webPropertyAdWordsLinks.get)
+   *
+   * @param string $accountId ID of the account which the given web property
+   * belongs to.
+   * @param string $webPropertyId Web property ID to retrieve the AdWords link
+   * for.
+   * @param string $webPropertyAdWordsLinkId Web property-AdWords link ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_EntityAdWordsLink
+   */
+  public function get($accountId, $webPropertyId, $webPropertyAdWordsLinkId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'webPropertyAdWordsLinkId' => $webPropertyAdWordsLinkId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Analytics_EntityAdWordsLink");
+  }
+
+  /**
+   * Creates a webProperty-AdWords link. (webPropertyAdWordsLinks.insert)
+   *
+   * @param string $accountId ID of the Google Analytics account to create the
+   * link for.
+   * @param string $webPropertyId Web property ID to create the link for.
+   * @param Google_EntityAdWordsLink $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_EntityAdWordsLink
+   */
+  public function insert($accountId, $webPropertyId, Google_Service_Analytics_EntityAdWordsLink $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Analytics_EntityAdWordsLink");
+  }
+
+  /**
+   * Lists webProperty-AdWords links for a given web property.
+   * (webPropertyAdWordsLinks.listManagementWebPropertyAdWordsLinks)
+   *
+   * @param string $accountId ID of the account which the given web property
+   * belongs to.
+   * @param string $webPropertyId Web property ID to retrieve the AdWords links
+   * for.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of webProperty-AdWords links to
+   * include in this response.
+   * @opt_param int start-index An index of the first webProperty-AdWords link to
+   * retrieve. Use this parameter as a pagination mechanism along with the max-
+   * results parameter.
+   * @return Google_Service_Analytics_EntityAdWordsLinks
+   */
+  public function listManagementWebPropertyAdWordsLinks($accountId, $webPropertyId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_EntityAdWordsLinks");
+  }
+
+  /**
+   * Updates an existing webProperty-AdWords link. This method supports patch
+   * semantics. (webPropertyAdWordsLinks.patch)
+   *
+   * @param string $accountId ID of the account which the given web property
+   * belongs to.
+   * @param string $webPropertyId Web property ID to retrieve the AdWords link
+   * for.
+   * @param string $webPropertyAdWordsLinkId Web property-AdWords link ID.
+   * @param Google_EntityAdWordsLink $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_EntityAdWordsLink
+   */
+  public function patch($accountId, $webPropertyId, $webPropertyAdWordsLinkId, Google_Service_Analytics_EntityAdWordsLink $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'webPropertyAdWordsLinkId' => $webPropertyAdWordsLinkId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Analytics_EntityAdWordsLink");
+  }
+
+  /**
+   * Updates an existing webProperty-AdWords link.
+   * (webPropertyAdWordsLinks.update)
+   *
+   * @param string $accountId ID of the account which the given web property
+   * belongs to.
+   * @param string $webPropertyId Web property ID to retrieve the AdWords link
+   * for.
+   * @param string $webPropertyAdWordsLinkId Web property-AdWords link ID.
+   * @param Google_EntityAdWordsLink $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_EntityAdWordsLink
+   */
+  public function update($accountId, $webPropertyId, $webPropertyAdWordsLinkId, Google_Service_Analytics_EntityAdWordsLink $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'webPropertyAdWordsLinkId' => $webPropertyAdWordsLinkId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Analytics_EntityAdWordsLink");
+  }
+}
+/**
+ * The "webproperties" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $webproperties = $analyticsService->webproperties;
+ *  </code>
+ */
+class Google_Service_Analytics_ManagementWebproperties_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets a web property to which the user has access. (webproperties.get)
+   *
+   * @param string $accountId Account ID to retrieve the web property for.
+   * @param string $webPropertyId ID to retrieve the web property for.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Webproperty
+   */
+  public function get($accountId, $webPropertyId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Analytics_Webproperty");
+  }
+
+  /**
+   * Create a new property if the account has fewer than 20 properties. Web
+   * properties are visible in the Google Analytics interface only if they have at
+   * least one profile. (webproperties.insert)
+   *
+   * @param string $accountId Account ID to create the web property for.
+   * @param Google_Webproperty $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Webproperty
+   */
+  public function insert($accountId, Google_Service_Analytics_Webproperty $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Analytics_Webproperty");
+  }
+
+  /**
+   * Lists web properties to which the user has access.
+   * (webproperties.listManagementWebproperties)
+   *
+   * @param string $accountId Account ID to retrieve web properties for. Can
+   * either be a specific account ID or '~all', which refers to all the accounts
+   * that user has access to.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of web properties to include in
+   * this response.
+   * @opt_param int start-index An index of the first entity to retrieve. Use this
+   * parameter as a pagination mechanism along with the max-results parameter.
+   * @return Google_Service_Analytics_Webproperties
+   */
+  public function listManagementWebproperties($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_Webproperties");
+  }
+
+  /**
+   * Updates an existing web property. This method supports patch semantics.
+   * (webproperties.patch)
+   *
+   * @param string $accountId Account ID to which the web property belongs
+   * @param string $webPropertyId Web property ID
+   * @param Google_Webproperty $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Webproperty
+   */
+  public function patch($accountId, $webPropertyId, Google_Service_Analytics_Webproperty $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Analytics_Webproperty");
+  }
+
+  /**
+   * Updates an existing web property. (webproperties.update)
+   *
+   * @param string $accountId Account ID to which the web property belongs
+   * @param string $webPropertyId Web property ID
+   * @param Google_Webproperty $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Webproperty
+   */
+  public function update($accountId, $webPropertyId, Google_Service_Analytics_Webproperty $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Analytics_Webproperty");
+  }
+}
+/**
+ * The "webpropertyUserLinks" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $webpropertyUserLinks = $analyticsService->webpropertyUserLinks;
+ *  </code>
+ */
+class Google_Service_Analytics_ManagementWebpropertyUserLinks_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Removes a user from the given web property. (webpropertyUserLinks.delete)
+   *
+   * @param string $accountId Account ID to delete the user link for.
+   * @param string $webPropertyId Web Property ID to delete the user link for.
+   * @param string $linkId Link ID to delete the user link for.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($accountId, $webPropertyId, $linkId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'linkId' => $linkId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Adds a new user to the given web property. (webpropertyUserLinks.insert)
+   *
+   * @param string $accountId Account ID to create the user link for.
+   * @param string $webPropertyId Web Property ID to create the user link for.
+   * @param Google_EntityUserLink $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_EntityUserLink
+   */
+  public function insert($accountId, $webPropertyId, Google_Service_Analytics_EntityUserLink $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Analytics_EntityUserLink");
+  }
+
+  /**
+   * Lists webProperty-user links for a given web property.
+   * (webpropertyUserLinks.listManagementWebpropertyUserLinks)
+   *
+   * @param string $accountId Account ID which the given web property belongs to.
+   * @param string $webPropertyId Web Property ID for the webProperty-user links
+   * to retrieve. Can either be a specific web property ID or '~all', which refers
+   * to all the web properties that user has access to.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of webProperty-user Links to
+   * include in this response.
+   * @opt_param int start-index An index of the first webProperty-user link to
+   * retrieve. Use this parameter as a pagination mechanism along with the max-
+   * results parameter.
+   * @return Google_Service_Analytics_EntityUserLinks
+   */
+  public function listManagementWebpropertyUserLinks($accountId, $webPropertyId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_EntityUserLinks");
+  }
+
+  /**
+   * Updates permissions for an existing user on the given web property.
+   * (webpropertyUserLinks.update)
+   *
+   * @param string $accountId Account ID to update the account-user link for.
+   * @param string $webPropertyId Web property ID to update the account-user link
+   * for.
+   * @param string $linkId Link ID to update the account-user link for.
+   * @param Google_EntityUserLink $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_EntityUserLink
+   */
+  public function update($accountId, $webPropertyId, $linkId, Google_Service_Analytics_EntityUserLink $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'webPropertyId' => $webPropertyId, 'linkId' => $linkId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Analytics_EntityUserLink");
+  }
+}
+
+/**
+ * The "metadata" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $metadata = $analyticsService->metadata;
+ *  </code>
+ */
+class Google_Service_Analytics_Metadata_Resource extends Google_Service_Resource
+{
+}
+
+/**
+ * The "columns" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $columns = $analyticsService->columns;
+ *  </code>
+ */
+class Google_Service_Analytics_MetadataColumns_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Lists all columns for a report type (columns.listMetadataColumns)
+   *
+   * @param string $reportType Report type. Allowed Values: 'ga'. Where 'ga'
+   * corresponds to the Core Reporting API
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_Columns
+   */
+  public function listMetadataColumns($reportType, $optParams = array())
+  {
+    $params = array('reportType' => $reportType);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Analytics_Columns");
+  }
+}
+
+/**
+ * The "provisioning" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $analyticsService = new Google_Service_Analytics(...);
+ *   $provisioning = $analyticsService->provisioning;
+ *  </code>
+ */
+class Google_Service_Analytics_Provisioning_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates an account ticket. (provisioning.createAccountTicket)
+   *
+   * @param Google_AccountTicket $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Analytics_AccountTicket
+   */
+  public function createAccountTicket(Google_Service_Analytics_AccountTicket $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('createAccountTicket', array($params), "Google_Service_Analytics_AccountTicket");
+  }
+}
+
+
+
+
+class Google_Service_Analytics_Account extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $childLinkType = 'Google_Service_Analytics_AccountChildLink';
+  protected $childLinkDataType = '';
+  public $created;
+  public $id;
+  public $kind;
+  public $name;
+  protected $permissionsType = 'Google_Service_Analytics_AccountPermissions';
+  protected $permissionsDataType = '';
+  public $selfLink;
+  public $updated;
+
+
+  public function setChildLink(Google_Service_Analytics_AccountChildLink $childLink)
+  {
+    $this->childLink = $childLink;
+  }
+  public function getChildLink()
+  {
+    return $this->childLink;
+  }
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPermissions(Google_Service_Analytics_AccountPermissions $permissions)
+  {
+    $this->permissions = $permissions;
+  }
+  public function getPermissions()
+  {
+    return $this->permissions;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+}
+
+class Google_Service_Analytics_AccountChildLink extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $href;
+  public $type;
+
+
+  public function setHref($href)
+  {
+    $this->href = $href;
+  }
+  public function getHref()
+  {
+    return $this->href;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Analytics_AccountPermissions extends Google_Collection
+{
+  protected $collection_key = 'effective';
+  protected $internal_gapi_mappings = array(
+  );
+  public $effective;
+
+
+  public function setEffective($effective)
+  {
+    $this->effective = $effective;
+  }
+  public function getEffective()
+  {
+    return $this->effective;
+  }
+}
+
+class Google_Service_Analytics_AccountRef extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $href;
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setHref($href)
+  {
+    $this->href = $href;
+  }
+  public function getHref()
+  {
+    return $this->href;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Analytics_AccountSummaries extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Analytics_AccountSummary';
+  protected $itemsDataType = 'array';
+  public $itemsPerPage;
+  public $kind;
+  public $nextLink;
+  public $previousLink;
+  public $startIndex;
+  public $totalResults;
+  public $username;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setPreviousLink($previousLink)
+  {
+    $this->previousLink = $previousLink;
+  }
+  public function getPreviousLink()
+  {
+    return $this->previousLink;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+  public function setUsername($username)
+  {
+    $this->username = $username;
+  }
+  public function getUsername()
+  {
+    return $this->username;
+  }
+}
+
+class Google_Service_Analytics_AccountSummary extends Google_Collection
+{
+  protected $collection_key = 'webProperties';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $name;
+  protected $webPropertiesType = 'Google_Service_Analytics_WebPropertySummary';
+  protected $webPropertiesDataType = 'array';
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setWebProperties($webProperties)
+  {
+    $this->webProperties = $webProperties;
+  }
+  public function getWebProperties()
+  {
+    return $this->webProperties;
+  }
+}
+
+class Google_Service_Analytics_AccountTicket extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accountType = 'Google_Service_Analytics_Account';
+  protected $accountDataType = '';
+  public $id;
+  public $kind;
+  protected $profileType = 'Google_Service_Analytics_Profile';
+  protected $profileDataType = '';
+  public $redirectUri;
+  protected $webpropertyType = 'Google_Service_Analytics_Webproperty';
+  protected $webpropertyDataType = '';
+
+
+  public function setAccount(Google_Service_Analytics_Account $account)
+  {
+    $this->account = $account;
+  }
+  public function getAccount()
+  {
+    return $this->account;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProfile(Google_Service_Analytics_Profile $profile)
+  {
+    $this->profile = $profile;
+  }
+  public function getProfile()
+  {
+    return $this->profile;
+  }
+  public function setRedirectUri($redirectUri)
+  {
+    $this->redirectUri = $redirectUri;
+  }
+  public function getRedirectUri()
+  {
+    return $this->redirectUri;
+  }
+  public function setWebproperty(Google_Service_Analytics_Webproperty $webproperty)
+  {
+    $this->webproperty = $webproperty;
+  }
+  public function getWebproperty()
+  {
+    return $this->webproperty;
+  }
+}
+
+class Google_Service_Analytics_Accounts extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Analytics_Account';
+  protected $itemsDataType = 'array';
+  public $itemsPerPage;
+  public $kind;
+  public $nextLink;
+  public $previousLink;
+  public $startIndex;
+  public $totalResults;
+  public $username;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setPreviousLink($previousLink)
+  {
+    $this->previousLink = $previousLink;
+  }
+  public function getPreviousLink()
+  {
+    return $this->previousLink;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+  public function setUsername($username)
+  {
+    $this->username = $username;
+  }
+  public function getUsername()
+  {
+    return $this->username;
+  }
+}
+
+class Google_Service_Analytics_AdWordsAccount extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $autoTaggingEnabled;
+  public $customerId;
+  public $kind;
+
+
+  public function setAutoTaggingEnabled($autoTaggingEnabled)
+  {
+    $this->autoTaggingEnabled = $autoTaggingEnabled;
+  }
+  public function getAutoTaggingEnabled()
+  {
+    return $this->autoTaggingEnabled;
+  }
+  public function setCustomerId($customerId)
+  {
+    $this->customerId = $customerId;
+  }
+  public function getCustomerId()
+  {
+    return $this->customerId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Analytics_AnalyticsDataimportDeleteUploadDataRequest extends Google_Collection
+{
+  protected $collection_key = 'customDataImportUids';
+  protected $internal_gapi_mappings = array(
+  );
+  public $customDataImportUids;
+
+
+  public function setCustomDataImportUids($customDataImportUids)
+  {
+    $this->customDataImportUids = $customDataImportUids;
+  }
+  public function getCustomDataImportUids()
+  {
+    return $this->customDataImportUids;
+  }
+}
+
+class Google_Service_Analytics_Column extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $attributes;
+  public $id;
+  public $kind;
+
+
+  public function setAttributes($attributes)
+  {
+    $this->attributes = $attributes;
+  }
+  public function getAttributes()
+  {
+    return $this->attributes;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Analytics_ColumnAttributes extends Google_Model
+{
+}
+
+class Google_Service_Analytics_Columns extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $attributeNames;
+  public $etag;
+  protected $itemsType = 'Google_Service_Analytics_Column';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $totalResults;
+
+
+  public function setAttributeNames($attributeNames)
+  {
+    $this->attributeNames = $attributeNames;
+  }
+  public function getAttributeNames()
+  {
+    return $this->attributeNames;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+}
+
+class Google_Service_Analytics_CustomDataSource extends Google_Collection
+{
+  protected $collection_key = 'profilesLinked';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  protected $childLinkType = 'Google_Service_Analytics_CustomDataSourceChildLink';
+  protected $childLinkDataType = '';
+  public $created;
+  public $description;
+  public $id;
+  public $importBehavior;
+  public $kind;
+  public $name;
+  protected $parentLinkType = 'Google_Service_Analytics_CustomDataSourceParentLink';
+  protected $parentLinkDataType = '';
+  public $profilesLinked;
+  public $selfLink;
+  public $type;
+  public $updated;
+  public $uploadType;
+  public $webPropertyId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setChildLink(Google_Service_Analytics_CustomDataSourceChildLink $childLink)
+  {
+    $this->childLink = $childLink;
+  }
+  public function getChildLink()
+  {
+    return $this->childLink;
+  }
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImportBehavior($importBehavior)
+  {
+    $this->importBehavior = $importBehavior;
+  }
+  public function getImportBehavior()
+  {
+    return $this->importBehavior;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setParentLink(Google_Service_Analytics_CustomDataSourceParentLink $parentLink)
+  {
+    $this->parentLink = $parentLink;
+  }
+  public function getParentLink()
+  {
+    return $this->parentLink;
+  }
+  public function setProfilesLinked($profilesLinked)
+  {
+    $this->profilesLinked = $profilesLinked;
+  }
+  public function getProfilesLinked()
+  {
+    return $this->profilesLinked;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setUploadType($uploadType)
+  {
+    $this->uploadType = $uploadType;
+  }
+  public function getUploadType()
+  {
+    return $this->uploadType;
+  }
+  public function setWebPropertyId($webPropertyId)
+  {
+    $this->webPropertyId = $webPropertyId;
+  }
+  public function getWebPropertyId()
+  {
+    return $this->webPropertyId;
+  }
+}
+
+class Google_Service_Analytics_CustomDataSourceChildLink extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $href;
+  public $type;
+
+
+  public function setHref($href)
+  {
+    $this->href = $href;
+  }
+  public function getHref()
+  {
+    return $this->href;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Analytics_CustomDataSourceParentLink extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $href;
+  public $type;
+
+
+  public function setHref($href)
+  {
+    $this->href = $href;
+  }
+  public function getHref()
+  {
+    return $this->href;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Analytics_CustomDataSources extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Analytics_CustomDataSource';
+  protected $itemsDataType = 'array';
+  public $itemsPerPage;
+  public $kind;
+  public $nextLink;
+  public $previousLink;
+  public $startIndex;
+  public $totalResults;
+  public $username;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setPreviousLink($previousLink)
+  {
+    $this->previousLink = $previousLink;
+  }
+  public function getPreviousLink()
+  {
+    return $this->previousLink;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+  public function setUsername($username)
+  {
+    $this->username = $username;
+  }
+  public function getUsername()
+  {
+    return $this->username;
+  }
+}
+
+class Google_Service_Analytics_CustomDimension extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $active;
+  public $created;
+  public $id;
+  public $index;
+  public $kind;
+  public $name;
+  protected $parentLinkType = 'Google_Service_Analytics_CustomDimensionParentLink';
+  protected $parentLinkDataType = '';
+  public $scope;
+  public $selfLink;
+  public $updated;
+  public $webPropertyId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setActive($active)
+  {
+    $this->active = $active;
+  }
+  public function getActive()
+  {
+    return $this->active;
+  }
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIndex($index)
+  {
+    $this->index = $index;
+  }
+  public function getIndex()
+  {
+    return $this->index;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setParentLink(Google_Service_Analytics_CustomDimensionParentLink $parentLink)
+  {
+    $this->parentLink = $parentLink;
+  }
+  public function getParentLink()
+  {
+    return $this->parentLink;
+  }
+  public function setScope($scope)
+  {
+    $this->scope = $scope;
+  }
+  public function getScope()
+  {
+    return $this->scope;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setWebPropertyId($webPropertyId)
+  {
+    $this->webPropertyId = $webPropertyId;
+  }
+  public function getWebPropertyId()
+  {
+    return $this->webPropertyId;
+  }
+}
+
+class Google_Service_Analytics_CustomDimensionParentLink extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $href;
+  public $type;
+
+
+  public function setHref($href)
+  {
+    $this->href = $href;
+  }
+  public function getHref()
+  {
+    return $this->href;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Analytics_CustomDimensions extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Analytics_CustomDimension';
+  protected $itemsDataType = 'array';
+  public $itemsPerPage;
+  public $kind;
+  public $nextLink;
+  public $previousLink;
+  public $startIndex;
+  public $totalResults;
+  public $username;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setPreviousLink($previousLink)
+  {
+    $this->previousLink = $previousLink;
+  }
+  public function getPreviousLink()
+  {
+    return $this->previousLink;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+  public function setUsername($username)
+  {
+    $this->username = $username;
+  }
+  public function getUsername()
+  {
+    return $this->username;
+  }
+}
+
+class Google_Service_Analytics_CustomMetric extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "maxValue" => "max_value",
+        "minValue" => "min_value",
+  );
+  public $accountId;
+  public $active;
+  public $created;
+  public $id;
+  public $index;
+  public $kind;
+  public $maxValue;
+  public $minValue;
+  public $name;
+  protected $parentLinkType = 'Google_Service_Analytics_CustomMetricParentLink';
+  protected $parentLinkDataType = '';
+  public $scope;
+  public $selfLink;
+  public $type;
+  public $updated;
+  public $webPropertyId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setActive($active)
+  {
+    $this->active = $active;
+  }
+  public function getActive()
+  {
+    return $this->active;
+  }
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIndex($index)
+  {
+    $this->index = $index;
+  }
+  public function getIndex()
+  {
+    return $this->index;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMaxValue($maxValue)
+  {
+    $this->maxValue = $maxValue;
+  }
+  public function getMaxValue()
+  {
+    return $this->maxValue;
+  }
+  public function setMinValue($minValue)
+  {
+    $this->minValue = $minValue;
+  }
+  public function getMinValue()
+  {
+    return $this->minValue;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setParentLink(Google_Service_Analytics_CustomMetricParentLink $parentLink)
+  {
+    $this->parentLink = $parentLink;
+  }
+  public function getParentLink()
+  {
+    return $this->parentLink;
+  }
+  public function setScope($scope)
+  {
+    $this->scope = $scope;
+  }
+  public function getScope()
+  {
+    return $this->scope;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setWebPropertyId($webPropertyId)
+  {
+    $this->webPropertyId = $webPropertyId;
+  }
+  public function getWebPropertyId()
+  {
+    return $this->webPropertyId;
+  }
+}
+
+class Google_Service_Analytics_CustomMetricParentLink extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $href;
+  public $type;
+
+
+  public function setHref($href)
+  {
+    $this->href = $href;
+  }
+  public function getHref()
+  {
+    return $this->href;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Analytics_CustomMetrics extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Analytics_CustomMetric';
+  protected $itemsDataType = 'array';
+  public $itemsPerPage;
+  public $kind;
+  public $nextLink;
+  public $previousLink;
+  public $startIndex;
+  public $totalResults;
+  public $username;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setPreviousLink($previousLink)
+  {
+    $this->previousLink = $previousLink;
+  }
+  public function getPreviousLink()
+  {
+    return $this->previousLink;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+  public function setUsername($username)
+  {
+    $this->username = $username;
+  }
+  public function getUsername()
+  {
+    return $this->username;
+  }
+}
+
+class Google_Service_Analytics_EntityAdWordsLink extends Google_Collection
+{
+  protected $collection_key = 'profileIds';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $adWordsAccountsType = 'Google_Service_Analytics_AdWordsAccount';
+  protected $adWordsAccountsDataType = 'array';
+  protected $entityType = 'Google_Service_Analytics_EntityAdWordsLinkEntity';
+  protected $entityDataType = '';
+  public $id;
+  public $kind;
+  public $name;
+  public $profileIds;
+  public $selfLink;
+
+
+  public function setAdWordsAccounts($adWordsAccounts)
+  {
+    $this->adWordsAccounts = $adWordsAccounts;
+  }
+  public function getAdWordsAccounts()
+  {
+    return $this->adWordsAccounts;
+  }
+  public function setEntity(Google_Service_Analytics_EntityAdWordsLinkEntity $entity)
+  {
+    $this->entity = $entity;
+  }
+  public function getEntity()
+  {
+    return $this->entity;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProfileIds($profileIds)
+  {
+    $this->profileIds = $profileIds;
+  }
+  public function getProfileIds()
+  {
+    return $this->profileIds;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Analytics_EntityAdWordsLinkEntity extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $webPropertyRefType = 'Google_Service_Analytics_WebPropertyRef';
+  protected $webPropertyRefDataType = '';
+
+
+  public function setWebPropertyRef(Google_Service_Analytics_WebPropertyRef $webPropertyRef)
+  {
+    $this->webPropertyRef = $webPropertyRef;
+  }
+  public function getWebPropertyRef()
+  {
+    return $this->webPropertyRef;
+  }
+}
+
+class Google_Service_Analytics_EntityAdWordsLinks extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Analytics_EntityAdWordsLink';
+  protected $itemsDataType = 'array';
+  public $itemsPerPage;
+  public $kind;
+  public $nextLink;
+  public $previousLink;
+  public $startIndex;
+  public $totalResults;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setPreviousLink($previousLink)
+  {
+    $this->previousLink = $previousLink;
+  }
+  public function getPreviousLink()
+  {
+    return $this->previousLink;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+}
+
+class Google_Service_Analytics_EntityUserLink extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entityType = 'Google_Service_Analytics_EntityUserLinkEntity';
+  protected $entityDataType = '';
+  public $id;
+  public $kind;
+  protected $permissionsType = 'Google_Service_Analytics_EntityUserLinkPermissions';
+  protected $permissionsDataType = '';
+  public $selfLink;
+  protected $userRefType = 'Google_Service_Analytics_UserRef';
+  protected $userRefDataType = '';
+
+
+  public function setEntity(Google_Service_Analytics_EntityUserLinkEntity $entity)
+  {
+    $this->entity = $entity;
+  }
+  public function getEntity()
+  {
+    return $this->entity;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPermissions(Google_Service_Analytics_EntityUserLinkPermissions $permissions)
+  {
+    $this->permissions = $permissions;
+  }
+  public function getPermissions()
+  {
+    return $this->permissions;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setUserRef(Google_Service_Analytics_UserRef $userRef)
+  {
+    $this->userRef = $userRef;
+  }
+  public function getUserRef()
+  {
+    return $this->userRef;
+  }
+}
+
+class Google_Service_Analytics_EntityUserLinkEntity extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accountRefType = 'Google_Service_Analytics_AccountRef';
+  protected $accountRefDataType = '';
+  protected $profileRefType = 'Google_Service_Analytics_ProfileRef';
+  protected $profileRefDataType = '';
+  protected $webPropertyRefType = 'Google_Service_Analytics_WebPropertyRef';
+  protected $webPropertyRefDataType = '';
+
+
+  public function setAccountRef(Google_Service_Analytics_AccountRef $accountRef)
+  {
+    $this->accountRef = $accountRef;
+  }
+  public function getAccountRef()
+  {
+    return $this->accountRef;
+  }
+  public function setProfileRef(Google_Service_Analytics_ProfileRef $profileRef)
+  {
+    $this->profileRef = $profileRef;
+  }
+  public function getProfileRef()
+  {
+    return $this->profileRef;
+  }
+  public function setWebPropertyRef(Google_Service_Analytics_WebPropertyRef $webPropertyRef)
+  {
+    $this->webPropertyRef = $webPropertyRef;
+  }
+  public function getWebPropertyRef()
+  {
+    return $this->webPropertyRef;
+  }
+}
+
+class Google_Service_Analytics_EntityUserLinkPermissions extends Google_Collection
+{
+  protected $collection_key = 'local';
+  protected $internal_gapi_mappings = array(
+  );
+  public $effective;
+  public $local;
+
+
+  public function setEffective($effective)
+  {
+    $this->effective = $effective;
+  }
+  public function getEffective()
+  {
+    return $this->effective;
+  }
+  public function setLocal($local)
+  {
+    $this->local = $local;
+  }
+  public function getLocal()
+  {
+    return $this->local;
+  }
+}
+
+class Google_Service_Analytics_EntityUserLinks extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Analytics_EntityUserLink';
+  protected $itemsDataType = 'array';
+  public $itemsPerPage;
+  public $kind;
+  public $nextLink;
+  public $previousLink;
+  public $startIndex;
+  public $totalResults;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setPreviousLink($previousLink)
+  {
+    $this->previousLink = $previousLink;
+  }
+  public function getPreviousLink()
+  {
+    return $this->previousLink;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+}
+
+class Google_Service_Analytics_Experiment extends Google_Collection
+{
+  protected $collection_key = 'variations';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $created;
+  public $description;
+  public $editableInGaUi;
+  public $endTime;
+  public $equalWeighting;
+  public $id;
+  public $internalWebPropertyId;
+  public $kind;
+  public $minimumExperimentLengthInDays;
+  public $name;
+  public $objectiveMetric;
+  public $optimizationType;
+  protected $parentLinkType = 'Google_Service_Analytics_ExperimentParentLink';
+  protected $parentLinkDataType = '';
+  public $profileId;
+  public $reasonExperimentEnded;
+  public $rewriteVariationUrlsAsOriginal;
+  public $selfLink;
+  public $servingFramework;
+  public $snippet;
+  public $startTime;
+  public $status;
+  public $trafficCoverage;
+  public $updated;
+  protected $variationsType = 'Google_Service_Analytics_ExperimentVariations';
+  protected $variationsDataType = 'array';
+  public $webPropertyId;
+  public $winnerConfidenceLevel;
+  public $winnerFound;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEditableInGaUi($editableInGaUi)
+  {
+    $this->editableInGaUi = $editableInGaUi;
+  }
+  public function getEditableInGaUi()
+  {
+    return $this->editableInGaUi;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setEqualWeighting($equalWeighting)
+  {
+    $this->equalWeighting = $equalWeighting;
+  }
+  public function getEqualWeighting()
+  {
+    return $this->equalWeighting;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInternalWebPropertyId($internalWebPropertyId)
+  {
+    $this->internalWebPropertyId = $internalWebPropertyId;
+  }
+  public function getInternalWebPropertyId()
+  {
+    return $this->internalWebPropertyId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMinimumExperimentLengthInDays($minimumExperimentLengthInDays)
+  {
+    $this->minimumExperimentLengthInDays = $minimumExperimentLengthInDays;
+  }
+  public function getMinimumExperimentLengthInDays()
+  {
+    return $this->minimumExperimentLengthInDays;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setObjectiveMetric($objectiveMetric)
+  {
+    $this->objectiveMetric = $objectiveMetric;
+  }
+  public function getObjectiveMetric()
+  {
+    return $this->objectiveMetric;
+  }
+  public function setOptimizationType($optimizationType)
+  {
+    $this->optimizationType = $optimizationType;
+  }
+  public function getOptimizationType()
+  {
+    return $this->optimizationType;
+  }
+  public function setParentLink(Google_Service_Analytics_ExperimentParentLink $parentLink)
+  {
+    $this->parentLink = $parentLink;
+  }
+  public function getParentLink()
+  {
+    return $this->parentLink;
+  }
+  public function setProfileId($profileId)
+  {
+    $this->profileId = $profileId;
+  }
+  public function getProfileId()
+  {
+    return $this->profileId;
+  }
+  public function setReasonExperimentEnded($reasonExperimentEnded)
+  {
+    $this->reasonExperimentEnded = $reasonExperimentEnded;
+  }
+  public function getReasonExperimentEnded()
+  {
+    return $this->reasonExperimentEnded;
+  }
+  public function setRewriteVariationUrlsAsOriginal($rewriteVariationUrlsAsOriginal)
+  {
+    $this->rewriteVariationUrlsAsOriginal = $rewriteVariationUrlsAsOriginal;
+  }
+  public function getRewriteVariationUrlsAsOriginal()
+  {
+    return $this->rewriteVariationUrlsAsOriginal;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setServingFramework($servingFramework)
+  {
+    $this->servingFramework = $servingFramework;
+  }
+  public function getServingFramework()
+  {
+    return $this->servingFramework;
+  }
+  public function setSnippet($snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setTrafficCoverage($trafficCoverage)
+  {
+    $this->trafficCoverage = $trafficCoverage;
+  }
+  public function getTrafficCoverage()
+  {
+    return $this->trafficCoverage;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setVariations($variations)
+  {
+    $this->variations = $variations;
+  }
+  public function getVariations()
+  {
+    return $this->variations;
+  }
+  public function setWebPropertyId($webPropertyId)
+  {
+    $this->webPropertyId = $webPropertyId;
+  }
+  public function getWebPropertyId()
+  {
+    return $this->webPropertyId;
+  }
+  public function setWinnerConfidenceLevel($winnerConfidenceLevel)
+  {
+    $this->winnerConfidenceLevel = $winnerConfidenceLevel;
+  }
+  public function getWinnerConfidenceLevel()
+  {
+    return $this->winnerConfidenceLevel;
+  }
+  public function setWinnerFound($winnerFound)
+  {
+    $this->winnerFound = $winnerFound;
+  }
+  public function getWinnerFound()
+  {
+    return $this->winnerFound;
+  }
+}
+
+class Google_Service_Analytics_ExperimentParentLink extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $href;
+  public $type;
+
+
+  public function setHref($href)
+  {
+    $this->href = $href;
+  }
+  public function getHref()
+  {
+    return $this->href;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Analytics_ExperimentVariations extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $status;
+  public $url;
+  public $weight;
+  public $won;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setWeight($weight)
+  {
+    $this->weight = $weight;
+  }
+  public function getWeight()
+  {
+    return $this->weight;
+  }
+  public function setWon($won)
+  {
+    $this->won = $won;
+  }
+  public function getWon()
+  {
+    return $this->won;
+  }
+}
+
+class Google_Service_Analytics_Experiments extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Analytics_Experiment';
+  protected $itemsDataType = 'array';
+  public $itemsPerPage;
+  public $kind;
+  public $nextLink;
+  public $previousLink;
+  public $startIndex;
+  public $totalResults;
+  public $username;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setPreviousLink($previousLink)
+  {
+    $this->previousLink = $previousLink;
+  }
+  public function getPreviousLink()
+  {
+    return $this->previousLink;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+  public function setUsername($username)
+  {
+    $this->username = $username;
+  }
+  public function getUsername()
+  {
+    return $this->username;
+  }
+}
+
+class Google_Service_Analytics_Filter extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  protected $advancedDetailsType = 'Google_Service_Analytics_FilterAdvancedDetails';
+  protected $advancedDetailsDataType = '';
+  public $created;
+  protected $excludeDetailsType = 'Google_Service_Analytics_FilterExpression';
+  protected $excludeDetailsDataType = '';
+  public $id;
+  protected $includeDetailsType = 'Google_Service_Analytics_FilterExpression';
+  protected $includeDetailsDataType = '';
+  public $kind;
+  protected $lowercaseDetailsType = 'Google_Service_Analytics_FilterLowercaseDetails';
+  protected $lowercaseDetailsDataType = '';
+  public $name;
+  protected $parentLinkType = 'Google_Service_Analytics_FilterParentLink';
+  protected $parentLinkDataType = '';
+  protected $searchAndReplaceDetailsType = 'Google_Service_Analytics_FilterSearchAndReplaceDetails';
+  protected $searchAndReplaceDetailsDataType = '';
+  public $selfLink;
+  public $type;
+  public $updated;
+  protected $uppercaseDetailsType = 'Google_Service_Analytics_FilterUppercaseDetails';
+  protected $uppercaseDetailsDataType = '';
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAdvancedDetails(Google_Service_Analytics_FilterAdvancedDetails $advancedDetails)
+  {
+    $this->advancedDetails = $advancedDetails;
+  }
+  public function getAdvancedDetails()
+  {
+    return $this->advancedDetails;
+  }
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setExcludeDetails(Google_Service_Analytics_FilterExpression $excludeDetails)
+  {
+    $this->excludeDetails = $excludeDetails;
+  }
+  public function getExcludeDetails()
+  {
+    return $this->excludeDetails;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIncludeDetails(Google_Service_Analytics_FilterExpression $includeDetails)
+  {
+    $this->includeDetails = $includeDetails;
+  }
+  public function getIncludeDetails()
+  {
+    return $this->includeDetails;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLowercaseDetails(Google_Service_Analytics_FilterLowercaseDetails $lowercaseDetails)
+  {
+    $this->lowercaseDetails = $lowercaseDetails;
+  }
+  public function getLowercaseDetails()
+  {
+    return $this->lowercaseDetails;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setParentLink(Google_Service_Analytics_FilterParentLink $parentLink)
+  {
+    $this->parentLink = $parentLink;
+  }
+  public function getParentLink()
+  {
+    return $this->parentLink;
+  }
+  public function setSearchAndReplaceDetails(Google_Service_Analytics_FilterSearchAndReplaceDetails $searchAndReplaceDetails)
+  {
+    $this->searchAndReplaceDetails = $searchAndReplaceDetails;
+  }
+  public function getSearchAndReplaceDetails()
+  {
+    return $this->searchAndReplaceDetails;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setUppercaseDetails(Google_Service_Analytics_FilterUppercaseDetails $uppercaseDetails)
+  {
+    $this->uppercaseDetails = $uppercaseDetails;
+  }
+  public function getUppercaseDetails()
+  {
+    return $this->uppercaseDetails;
+  }
+}
+
+class Google_Service_Analytics_FilterAdvancedDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $caseSensitive;
+  public $extractA;
+  public $extractB;
+  public $fieldA;
+  public $fieldAIndex;
+  public $fieldARequired;
+  public $fieldB;
+  public $fieldBIndex;
+  public $fieldBRequired;
+  public $outputConstructor;
+  public $outputToField;
+  public $outputToFieldIndex;
+  public $overrideOutputField;
+
+
+  public function setCaseSensitive($caseSensitive)
+  {
+    $this->caseSensitive = $caseSensitive;
+  }
+  public function getCaseSensitive()
+  {
+    return $this->caseSensitive;
+  }
+  public function setExtractA($extractA)
+  {
+    $this->extractA = $extractA;
+  }
+  public function getExtractA()
+  {
+    return $this->extractA;
+  }
+  public function setExtractB($extractB)
+  {
+    $this->extractB = $extractB;
+  }
+  public function getExtractB()
+  {
+    return $this->extractB;
+  }
+  public function setFieldA($fieldA)
+  {
+    $this->fieldA = $fieldA;
+  }
+  public function getFieldA()
+  {
+    return $this->fieldA;
+  }
+  public function setFieldAIndex($fieldAIndex)
+  {
+    $this->fieldAIndex = $fieldAIndex;
+  }
+  public function getFieldAIndex()
+  {
+    return $this->fieldAIndex;
+  }
+  public function setFieldARequired($fieldARequired)
+  {
+    $this->fieldARequired = $fieldARequired;
+  }
+  public function getFieldARequired()
+  {
+    return $this->fieldARequired;
+  }
+  public function setFieldB($fieldB)
+  {
+    $this->fieldB = $fieldB;
+  }
+  public function getFieldB()
+  {
+    return $this->fieldB;
+  }
+  public function setFieldBIndex($fieldBIndex)
+  {
+    $this->fieldBIndex = $fieldBIndex;
+  }
+  public function getFieldBIndex()
+  {
+    return $this->fieldBIndex;
+  }
+  public function setFieldBRequired($fieldBRequired)
+  {
+    $this->fieldBRequired = $fieldBRequired;
+  }
+  public function getFieldBRequired()
+  {
+    return $this->fieldBRequired;
+  }
+  public function setOutputConstructor($outputConstructor)
+  {
+    $this->outputConstructor = $outputConstructor;
+  }
+  public function getOutputConstructor()
+  {
+    return $this->outputConstructor;
+  }
+  public function setOutputToField($outputToField)
+  {
+    $this->outputToField = $outputToField;
+  }
+  public function getOutputToField()
+  {
+    return $this->outputToField;
+  }
+  public function setOutputToFieldIndex($outputToFieldIndex)
+  {
+    $this->outputToFieldIndex = $outputToFieldIndex;
+  }
+  public function getOutputToFieldIndex()
+  {
+    return $this->outputToFieldIndex;
+  }
+  public function setOverrideOutputField($overrideOutputField)
+  {
+    $this->overrideOutputField = $overrideOutputField;
+  }
+  public function getOverrideOutputField()
+  {
+    return $this->overrideOutputField;
+  }
+}
+
+class Google_Service_Analytics_FilterExpression extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $caseSensitive;
+  public $expressionValue;
+  public $field;
+  public $fieldIndex;
+  public $kind;
+  public $matchType;
+
+
+  public function setCaseSensitive($caseSensitive)
+  {
+    $this->caseSensitive = $caseSensitive;
+  }
+  public function getCaseSensitive()
+  {
+    return $this->caseSensitive;
+  }
+  public function setExpressionValue($expressionValue)
+  {
+    $this->expressionValue = $expressionValue;
+  }
+  public function getExpressionValue()
+  {
+    return $this->expressionValue;
+  }
+  public function setField($field)
+  {
+    $this->field = $field;
+  }
+  public function getField()
+  {
+    return $this->field;
+  }
+  public function setFieldIndex($fieldIndex)
+  {
+    $this->fieldIndex = $fieldIndex;
+  }
+  public function getFieldIndex()
+  {
+    return $this->fieldIndex;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMatchType($matchType)
+  {
+    $this->matchType = $matchType;
+  }
+  public function getMatchType()
+  {
+    return $this->matchType;
+  }
+}
+
+class Google_Service_Analytics_FilterLowercaseDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $field;
+  public $fieldIndex;
+
+
+  public function setField($field)
+  {
+    $this->field = $field;
+  }
+  public function getField()
+  {
+    return $this->field;
+  }
+  public function setFieldIndex($fieldIndex)
+  {
+    $this->fieldIndex = $fieldIndex;
+  }
+  public function getFieldIndex()
+  {
+    return $this->fieldIndex;
+  }
+}
+
+class Google_Service_Analytics_FilterParentLink extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $href;
+  public $type;
+
+
+  public function setHref($href)
+  {
+    $this->href = $href;
+  }
+  public function getHref()
+  {
+    return $this->href;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Analytics_FilterRef extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $href;
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setHref($href)
+  {
+    $this->href = $href;
+  }
+  public function getHref()
+  {
+    return $this->href;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Analytics_FilterSearchAndReplaceDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $caseSensitive;
+  public $field;
+  public $fieldIndex;
+  public $replaceString;
+  public $searchString;
+
+
+  public function setCaseSensitive($caseSensitive)
+  {
+    $this->caseSensitive = $caseSensitive;
+  }
+  public function getCaseSensitive()
+  {
+    return $this->caseSensitive;
+  }
+  public function setField($field)
+  {
+    $this->field = $field;
+  }
+  public function getField()
+  {
+    return $this->field;
+  }
+  public function setFieldIndex($fieldIndex)
+  {
+    $this->fieldIndex = $fieldIndex;
+  }
+  public function getFieldIndex()
+  {
+    return $this->fieldIndex;
+  }
+  public function setReplaceString($replaceString)
+  {
+    $this->replaceString = $replaceString;
+  }
+  public function getReplaceString()
+  {
+    return $this->replaceString;
+  }
+  public function setSearchString($searchString)
+  {
+    $this->searchString = $searchString;
+  }
+  public function getSearchString()
+  {
+    return $this->searchString;
+  }
+}
+
+class Google_Service_Analytics_FilterUppercaseDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $field;
+  public $fieldIndex;
+
+
+  public function setField($field)
+  {
+    $this->field = $field;
+  }
+  public function getField()
+  {
+    return $this->field;
+  }
+  public function setFieldIndex($fieldIndex)
+  {
+    $this->fieldIndex = $fieldIndex;
+  }
+  public function getFieldIndex()
+  {
+    return $this->fieldIndex;
+  }
+}
+
+class Google_Service_Analytics_Filters extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Analytics_Filter';
+  protected $itemsDataType = 'array';
+  public $itemsPerPage;
+  public $kind;
+  public $nextLink;
+  public $previousLink;
+  public $startIndex;
+  public $totalResults;
+  public $username;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setPreviousLink($previousLink)
+  {
+    $this->previousLink = $previousLink;
+  }
+  public function getPreviousLink()
+  {
+    return $this->previousLink;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+  public function setUsername($username)
+  {
+    $this->username = $username;
+  }
+  public function getUsername()
+  {
+    return $this->username;
+  }
+}
+
+class Google_Service_Analytics_GaData extends Google_Collection
+{
+  protected $collection_key = 'rows';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $columnHeadersType = 'Google_Service_Analytics_GaDataColumnHeaders';
+  protected $columnHeadersDataType = 'array';
+  public $containsSampledData;
+  protected $dataTableType = 'Google_Service_Analytics_GaDataDataTable';
+  protected $dataTableDataType = '';
+  public $id;
+  public $itemsPerPage;
+  public $kind;
+  public $nextLink;
+  public $previousLink;
+  protected $profileInfoType = 'Google_Service_Analytics_GaDataProfileInfo';
+  protected $profileInfoDataType = '';
+  protected $queryType = 'Google_Service_Analytics_GaDataQuery';
+  protected $queryDataType = '';
+  public $rows;
+  public $sampleSize;
+  public $sampleSpace;
+  public $selfLink;
+  public $totalResults;
+  public $totalsForAllResults;
+
+
+  public function setColumnHeaders($columnHeaders)
+  {
+    $this->columnHeaders = $columnHeaders;
+  }
+  public function getColumnHeaders()
+  {
+    return $this->columnHeaders;
+  }
+  public function setContainsSampledData($containsSampledData)
+  {
+    $this->containsSampledData = $containsSampledData;
+  }
+  public function getContainsSampledData()
+  {
+    return $this->containsSampledData;
+  }
+  public function setDataTable(Google_Service_Analytics_GaDataDataTable $dataTable)
+  {
+    $this->dataTable = $dataTable;
+  }
+  public function getDataTable()
+  {
+    return $this->dataTable;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setPreviousLink($previousLink)
+  {
+    $this->previousLink = $previousLink;
+  }
+  public function getPreviousLink()
+  {
+    return $this->previousLink;
+  }
+  public function setProfileInfo(Google_Service_Analytics_GaDataProfileInfo $profileInfo)
+  {
+    $this->profileInfo = $profileInfo;
+  }
+  public function getProfileInfo()
+  {
+    return $this->profileInfo;
+  }
+  public function setQuery(Google_Service_Analytics_GaDataQuery $query)
+  {
+    $this->query = $query;
+  }
+  public function getQuery()
+  {
+    return $this->query;
+  }
+  public function setRows($rows)
+  {
+    $this->rows = $rows;
+  }
+  public function getRows()
+  {
+    return $this->rows;
+  }
+  public function setSampleSize($sampleSize)
+  {
+    $this->sampleSize = $sampleSize;
+  }
+  public function getSampleSize()
+  {
+    return $this->sampleSize;
+  }
+  public function setSampleSpace($sampleSpace)
+  {
+    $this->sampleSpace = $sampleSpace;
+  }
+  public function getSampleSpace()
+  {
+    return $this->sampleSpace;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+  public function setTotalsForAllResults($totalsForAllResults)
+  {
+    $this->totalsForAllResults = $totalsForAllResults;
+  }
+  public function getTotalsForAllResults()
+  {
+    return $this->totalsForAllResults;
+  }
+}
+
+class Google_Service_Analytics_GaDataColumnHeaders extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $columnType;
+  public $dataType;
+  public $name;
+
+
+  public function setColumnType($columnType)
+  {
+    $this->columnType = $columnType;
+  }
+  public function getColumnType()
+  {
+    return $this->columnType;
+  }
+  public function setDataType($dataType)
+  {
+    $this->dataType = $dataType;
+  }
+  public function getDataType()
+  {
+    return $this->dataType;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Analytics_GaDataDataTable extends Google_Collection
+{
+  protected $collection_key = 'rows';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $colsType = 'Google_Service_Analytics_GaDataDataTableCols';
+  protected $colsDataType = 'array';
+  protected $rowsType = 'Google_Service_Analytics_GaDataDataTableRows';
+  protected $rowsDataType = 'array';
+
+
+  public function setCols($cols)
+  {
+    $this->cols = $cols;
+  }
+  public function getCols()
+  {
+    return $this->cols;
+  }
+  public function setRows($rows)
+  {
+    $this->rows = $rows;
+  }
+  public function getRows()
+  {
+    return $this->rows;
+  }
+}
+
+class Google_Service_Analytics_GaDataDataTableCols extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $label;
+  public $type;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLabel($label)
+  {
+    $this->label = $label;
+  }
+  public function getLabel()
+  {
+    return $this->label;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Analytics_GaDataDataTableRows extends Google_Collection
+{
+  protected $collection_key = 'c';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $cType = 'Google_Service_Analytics_GaDataDataTableRowsC';
+  protected $cDataType = 'array';
+
+
+  public function setC($c)
+  {
+    $this->c = $c;
+  }
+  public function getC()
+  {
+    return $this->c;
+  }
+}
+
+class Google_Service_Analytics_GaDataDataTableRowsC extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $v;
+
+
+  public function setV($v)
+  {
+    $this->v = $v;
+  }
+  public function getV()
+  {
+    return $this->v;
+  }
+}
+
+class Google_Service_Analytics_GaDataProfileInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $internalWebPropertyId;
+  public $profileId;
+  public $profileName;
+  public $tableId;
+  public $webPropertyId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setInternalWebPropertyId($internalWebPropertyId)
+  {
+    $this->internalWebPropertyId = $internalWebPropertyId;
+  }
+  public function getInternalWebPropertyId()
+  {
+    return $this->internalWebPropertyId;
+  }
+  public function setProfileId($profileId)
+  {
+    $this->profileId = $profileId;
+  }
+  public function getProfileId()
+  {
+    return $this->profileId;
+  }
+  public function setProfileName($profileName)
+  {
+    $this->profileName = $profileName;
+  }
+  public function getProfileName()
+  {
+    return $this->profileName;
+  }
+  public function setTableId($tableId)
+  {
+    $this->tableId = $tableId;
+  }
+  public function getTableId()
+  {
+    return $this->tableId;
+  }
+  public function setWebPropertyId($webPropertyId)
+  {
+    $this->webPropertyId = $webPropertyId;
+  }
+  public function getWebPropertyId()
+  {
+    return $this->webPropertyId;
+  }
+}
+
+class Google_Service_Analytics_GaDataQuery extends Google_Collection
+{
+  protected $collection_key = 'sort';
+  protected $internal_gapi_mappings = array(
+        "endDate" => "end-date",
+        "maxResults" => "max-results",
+        "startDate" => "start-date",
+        "startIndex" => "start-index",
+  );
+  public $dimensions;
+  public $endDate;
+  public $filters;
+  public $ids;
+  public $maxResults;
+  public $metrics;
+  public $samplingLevel;
+  public $segment;
+  public $sort;
+  public $startDate;
+  public $startIndex;
+
+
+  public function setDimensions($dimensions)
+  {
+    $this->dimensions = $dimensions;
+  }
+  public function getDimensions()
+  {
+    return $this->dimensions;
+  }
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setFilters($filters)
+  {
+    $this->filters = $filters;
+  }
+  public function getFilters()
+  {
+    return $this->filters;
+  }
+  public function setIds($ids)
+  {
+    $this->ids = $ids;
+  }
+  public function getIds()
+  {
+    return $this->ids;
+  }
+  public function setMaxResults($maxResults)
+  {
+    $this->maxResults = $maxResults;
+  }
+  public function getMaxResults()
+  {
+    return $this->maxResults;
+  }
+  public function setMetrics($metrics)
+  {
+    $this->metrics = $metrics;
+  }
+  public function getMetrics()
+  {
+    return $this->metrics;
+  }
+  public function setSamplingLevel($samplingLevel)
+  {
+    $this->samplingLevel = $samplingLevel;
+  }
+  public function getSamplingLevel()
+  {
+    return $this->samplingLevel;
+  }
+  public function setSegment($segment)
+  {
+    $this->segment = $segment;
+  }
+  public function getSegment()
+  {
+    return $this->segment;
+  }
+  public function setSort($sort)
+  {
+    $this->sort = $sort;
+  }
+  public function getSort()
+  {
+    return $this->sort;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+}
+
+class Google_Service_Analytics_GaDataTotalsForAllResults extends Google_Model
+{
+}
+
+class Google_Service_Analytics_Goal extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $active;
+  public $created;
+  protected $eventDetailsType = 'Google_Service_Analytics_GoalEventDetails';
+  protected $eventDetailsDataType = '';
+  public $id;
+  public $internalWebPropertyId;
+  public $kind;
+  public $name;
+  protected $parentLinkType = 'Google_Service_Analytics_GoalParentLink';
+  protected $parentLinkDataType = '';
+  public $profileId;
+  public $selfLink;
+  public $type;
+  public $updated;
+  protected $urlDestinationDetailsType = 'Google_Service_Analytics_GoalUrlDestinationDetails';
+  protected $urlDestinationDetailsDataType = '';
+  public $value;
+  protected $visitNumPagesDetailsType = 'Google_Service_Analytics_GoalVisitNumPagesDetails';
+  protected $visitNumPagesDetailsDataType = '';
+  protected $visitTimeOnSiteDetailsType = 'Google_Service_Analytics_GoalVisitTimeOnSiteDetails';
+  protected $visitTimeOnSiteDetailsDataType = '';
+  public $webPropertyId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setActive($active)
+  {
+    $this->active = $active;
+  }
+  public function getActive()
+  {
+    return $this->active;
+  }
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setEventDetails(Google_Service_Analytics_GoalEventDetails $eventDetails)
+  {
+    $this->eventDetails = $eventDetails;
+  }
+  public function getEventDetails()
+  {
+    return $this->eventDetails;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInternalWebPropertyId($internalWebPropertyId)
+  {
+    $this->internalWebPropertyId = $internalWebPropertyId;
+  }
+  public function getInternalWebPropertyId()
+  {
+    return $this->internalWebPropertyId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setParentLink(Google_Service_Analytics_GoalParentLink $parentLink)
+  {
+    $this->parentLink = $parentLink;
+  }
+  public function getParentLink()
+  {
+    return $this->parentLink;
+  }
+  public function setProfileId($profileId)
+  {
+    $this->profileId = $profileId;
+  }
+  public function getProfileId()
+  {
+    return $this->profileId;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setUrlDestinationDetails(Google_Service_Analytics_GoalUrlDestinationDetails $urlDestinationDetails)
+  {
+    $this->urlDestinationDetails = $urlDestinationDetails;
+  }
+  public function getUrlDestinationDetails()
+  {
+    return $this->urlDestinationDetails;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+  public function setVisitNumPagesDetails(Google_Service_Analytics_GoalVisitNumPagesDetails $visitNumPagesDetails)
+  {
+    $this->visitNumPagesDetails = $visitNumPagesDetails;
+  }
+  public function getVisitNumPagesDetails()
+  {
+    return $this->visitNumPagesDetails;
+  }
+  public function setVisitTimeOnSiteDetails(Google_Service_Analytics_GoalVisitTimeOnSiteDetails $visitTimeOnSiteDetails)
+  {
+    $this->visitTimeOnSiteDetails = $visitTimeOnSiteDetails;
+  }
+  public function getVisitTimeOnSiteDetails()
+  {
+    return $this->visitTimeOnSiteDetails;
+  }
+  public function setWebPropertyId($webPropertyId)
+  {
+    $this->webPropertyId = $webPropertyId;
+  }
+  public function getWebPropertyId()
+  {
+    return $this->webPropertyId;
+  }
+}
+
+class Google_Service_Analytics_GoalEventDetails extends Google_Collection
+{
+  protected $collection_key = 'eventConditions';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $eventConditionsType = 'Google_Service_Analytics_GoalEventDetailsEventConditions';
+  protected $eventConditionsDataType = 'array';
+  public $useEventValue;
+
+
+  public function setEventConditions($eventConditions)
+  {
+    $this->eventConditions = $eventConditions;
+  }
+  public function getEventConditions()
+  {
+    return $this->eventConditions;
+  }
+  public function setUseEventValue($useEventValue)
+  {
+    $this->useEventValue = $useEventValue;
+  }
+  public function getUseEventValue()
+  {
+    return $this->useEventValue;
+  }
+}
+
+class Google_Service_Analytics_GoalEventDetailsEventConditions extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $comparisonType;
+  public $comparisonValue;
+  public $expression;
+  public $matchType;
+  public $type;
+
+
+  public function setComparisonType($comparisonType)
+  {
+    $this->comparisonType = $comparisonType;
+  }
+  public function getComparisonType()
+  {
+    return $this->comparisonType;
+  }
+  public function setComparisonValue($comparisonValue)
+  {
+    $this->comparisonValue = $comparisonValue;
+  }
+  public function getComparisonValue()
+  {
+    return $this->comparisonValue;
+  }
+  public function setExpression($expression)
+  {
+    $this->expression = $expression;
+  }
+  public function getExpression()
+  {
+    return $this->expression;
+  }
+  public function setMatchType($matchType)
+  {
+    $this->matchType = $matchType;
+  }
+  public function getMatchType()
+  {
+    return $this->matchType;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Analytics_GoalParentLink extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $href;
+  public $type;
+
+
+  public function setHref($href)
+  {
+    $this->href = $href;
+  }
+  public function getHref()
+  {
+    return $this->href;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Analytics_GoalUrlDestinationDetails extends Google_Collection
+{
+  protected $collection_key = 'steps';
+  protected $internal_gapi_mappings = array(
+  );
+  public $caseSensitive;
+  public $firstStepRequired;
+  public $matchType;
+  protected $stepsType = 'Google_Service_Analytics_GoalUrlDestinationDetailsSteps';
+  protected $stepsDataType = 'array';
+  public $url;
+
+
+  public function setCaseSensitive($caseSensitive)
+  {
+    $this->caseSensitive = $caseSensitive;
+  }
+  public function getCaseSensitive()
+  {
+    return $this->caseSensitive;
+  }
+  public function setFirstStepRequired($firstStepRequired)
+  {
+    $this->firstStepRequired = $firstStepRequired;
+  }
+  public function getFirstStepRequired()
+  {
+    return $this->firstStepRequired;
+  }
+  public function setMatchType($matchType)
+  {
+    $this->matchType = $matchType;
+  }
+  public function getMatchType()
+  {
+    return $this->matchType;
+  }
+  public function setSteps($steps)
+  {
+    $this->steps = $steps;
+  }
+  public function getSteps()
+  {
+    return $this->steps;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Analytics_GoalUrlDestinationDetailsSteps extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $number;
+  public $url;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNumber($number)
+  {
+    $this->number = $number;
+  }
+  public function getNumber()
+  {
+    return $this->number;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Analytics_GoalVisitNumPagesDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $comparisonType;
+  public $comparisonValue;
+
+
+  public function setComparisonType($comparisonType)
+  {
+    $this->comparisonType = $comparisonType;
+  }
+  public function getComparisonType()
+  {
+    return $this->comparisonType;
+  }
+  public function setComparisonValue($comparisonValue)
+  {
+    $this->comparisonValue = $comparisonValue;
+  }
+  public function getComparisonValue()
+  {
+    return $this->comparisonValue;
+  }
+}
+
+class Google_Service_Analytics_GoalVisitTimeOnSiteDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $comparisonType;
+  public $comparisonValue;
+
+
+  public function setComparisonType($comparisonType)
+  {
+    $this->comparisonType = $comparisonType;
+  }
+  public function getComparisonType()
+  {
+    return $this->comparisonType;
+  }
+  public function setComparisonValue($comparisonValue)
+  {
+    $this->comparisonValue = $comparisonValue;
+  }
+  public function getComparisonValue()
+  {
+    return $this->comparisonValue;
+  }
+}
+
+class Google_Service_Analytics_Goals extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Analytics_Goal';
+  protected $itemsDataType = 'array';
+  public $itemsPerPage;
+  public $kind;
+  public $nextLink;
+  public $previousLink;
+  public $startIndex;
+  public $totalResults;
+  public $username;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setPreviousLink($previousLink)
+  {
+    $this->previousLink = $previousLink;
+  }
+  public function getPreviousLink()
+  {
+    return $this->previousLink;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+  public function setUsername($username)
+  {
+    $this->username = $username;
+  }
+  public function getUsername()
+  {
+    return $this->username;
+  }
+}
+
+class Google_Service_Analytics_McfData extends Google_Collection
+{
+  protected $collection_key = 'rows';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $columnHeadersType = 'Google_Service_Analytics_McfDataColumnHeaders';
+  protected $columnHeadersDataType = 'array';
+  public $containsSampledData;
+  public $id;
+  public $itemsPerPage;
+  public $kind;
+  public $nextLink;
+  public $previousLink;
+  protected $profileInfoType = 'Google_Service_Analytics_McfDataProfileInfo';
+  protected $profileInfoDataType = '';
+  protected $queryType = 'Google_Service_Analytics_McfDataQuery';
+  protected $queryDataType = '';
+  protected $rowsType = 'Google_Service_Analytics_McfDataRows';
+  protected $rowsDataType = 'array';
+  public $sampleSize;
+  public $sampleSpace;
+  public $selfLink;
+  public $totalResults;
+  public $totalsForAllResults;
+
+
+  public function setColumnHeaders($columnHeaders)
+  {
+    $this->columnHeaders = $columnHeaders;
+  }
+  public function getColumnHeaders()
+  {
+    return $this->columnHeaders;
+  }
+  public function setContainsSampledData($containsSampledData)
+  {
+    $this->containsSampledData = $containsSampledData;
+  }
+  public function getContainsSampledData()
+  {
+    return $this->containsSampledData;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setPreviousLink($previousLink)
+  {
+    $this->previousLink = $previousLink;
+  }
+  public function getPreviousLink()
+  {
+    return $this->previousLink;
+  }
+  public function setProfileInfo(Google_Service_Analytics_McfDataProfileInfo $profileInfo)
+  {
+    $this->profileInfo = $profileInfo;
+  }
+  public function getProfileInfo()
+  {
+    return $this->profileInfo;
+  }
+  public function setQuery(Google_Service_Analytics_McfDataQuery $query)
+  {
+    $this->query = $query;
+  }
+  public function getQuery()
+  {
+    return $this->query;
+  }
+  public function setRows($rows)
+  {
+    $this->rows = $rows;
+  }
+  public function getRows()
+  {
+    return $this->rows;
+  }
+  public function setSampleSize($sampleSize)
+  {
+    $this->sampleSize = $sampleSize;
+  }
+  public function getSampleSize()
+  {
+    return $this->sampleSize;
+  }
+  public function setSampleSpace($sampleSpace)
+  {
+    $this->sampleSpace = $sampleSpace;
+  }
+  public function getSampleSpace()
+  {
+    return $this->sampleSpace;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+  public function setTotalsForAllResults($totalsForAllResults)
+  {
+    $this->totalsForAllResults = $totalsForAllResults;
+  }
+  public function getTotalsForAllResults()
+  {
+    return $this->totalsForAllResults;
+  }
+}
+
+class Google_Service_Analytics_McfDataColumnHeaders extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $columnType;
+  public $dataType;
+  public $name;
+
+
+  public function setColumnType($columnType)
+  {
+    $this->columnType = $columnType;
+  }
+  public function getColumnType()
+  {
+    return $this->columnType;
+  }
+  public function setDataType($dataType)
+  {
+    $this->dataType = $dataType;
+  }
+  public function getDataType()
+  {
+    return $this->dataType;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Analytics_McfDataProfileInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $internalWebPropertyId;
+  public $profileId;
+  public $profileName;
+  public $tableId;
+  public $webPropertyId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setInternalWebPropertyId($internalWebPropertyId)
+  {
+    $this->internalWebPropertyId = $internalWebPropertyId;
+  }
+  public function getInternalWebPropertyId()
+  {
+    return $this->internalWebPropertyId;
+  }
+  public function setProfileId($profileId)
+  {
+    $this->profileId = $profileId;
+  }
+  public function getProfileId()
+  {
+    return $this->profileId;
+  }
+  public function setProfileName($profileName)
+  {
+    $this->profileName = $profileName;
+  }
+  public function getProfileName()
+  {
+    return $this->profileName;
+  }
+  public function setTableId($tableId)
+  {
+    $this->tableId = $tableId;
+  }
+  public function getTableId()
+  {
+    return $this->tableId;
+  }
+  public function setWebPropertyId($webPropertyId)
+  {
+    $this->webPropertyId = $webPropertyId;
+  }
+  public function getWebPropertyId()
+  {
+    return $this->webPropertyId;
+  }
+}
+
+class Google_Service_Analytics_McfDataQuery extends Google_Collection
+{
+  protected $collection_key = 'sort';
+  protected $internal_gapi_mappings = array(
+        "endDate" => "end-date",
+        "maxResults" => "max-results",
+        "startDate" => "start-date",
+        "startIndex" => "start-index",
+  );
+  public $dimensions;
+  public $endDate;
+  public $filters;
+  public $ids;
+  public $maxResults;
+  public $metrics;
+  public $samplingLevel;
+  public $segment;
+  public $sort;
+  public $startDate;
+  public $startIndex;
+
+
+  public function setDimensions($dimensions)
+  {
+    $this->dimensions = $dimensions;
+  }
+  public function getDimensions()
+  {
+    return $this->dimensions;
+  }
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setFilters($filters)
+  {
+    $this->filters = $filters;
+  }
+  public function getFilters()
+  {
+    return $this->filters;
+  }
+  public function setIds($ids)
+  {
+    $this->ids = $ids;
+  }
+  public function getIds()
+  {
+    return $this->ids;
+  }
+  public function setMaxResults($maxResults)
+  {
+    $this->maxResults = $maxResults;
+  }
+  public function getMaxResults()
+  {
+    return $this->maxResults;
+  }
+  public function setMetrics($metrics)
+  {
+    $this->metrics = $metrics;
+  }
+  public function getMetrics()
+  {
+    return $this->metrics;
+  }
+  public function setSamplingLevel($samplingLevel)
+  {
+    $this->samplingLevel = $samplingLevel;
+  }
+  public function getSamplingLevel()
+  {
+    return $this->samplingLevel;
+  }
+  public function setSegment($segment)
+  {
+    $this->segment = $segment;
+  }
+  public function getSegment()
+  {
+    return $this->segment;
+  }
+  public function setSort($sort)
+  {
+    $this->sort = $sort;
+  }
+  public function getSort()
+  {
+    return $this->sort;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+}
+
+class Google_Service_Analytics_McfDataRows extends Google_Collection
+{
+  protected $collection_key = 'conversionPathValue';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $conversionPathValueType = 'Google_Service_Analytics_McfDataRowsConversionPathValue';
+  protected $conversionPathValueDataType = 'array';
+  public $primitiveValue;
+
+
+  public function setConversionPathValue($conversionPathValue)
+  {
+    $this->conversionPathValue = $conversionPathValue;
+  }
+  public function getConversionPathValue()
+  {
+    return $this->conversionPathValue;
+  }
+  public function setPrimitiveValue($primitiveValue)
+  {
+    $this->primitiveValue = $primitiveValue;
+  }
+  public function getPrimitiveValue()
+  {
+    return $this->primitiveValue;
+  }
+}
+
+class Google_Service_Analytics_McfDataRowsConversionPathValue extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $interactionType;
+  public $nodeValue;
+
+
+  public function setInteractionType($interactionType)
+  {
+    $this->interactionType = $interactionType;
+  }
+  public function getInteractionType()
+  {
+    return $this->interactionType;
+  }
+  public function setNodeValue($nodeValue)
+  {
+    $this->nodeValue = $nodeValue;
+  }
+  public function getNodeValue()
+  {
+    return $this->nodeValue;
+  }
+}
+
+class Google_Service_Analytics_McfDataTotalsForAllResults extends Google_Model
+{
+}
+
+class Google_Service_Analytics_Profile extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  protected $childLinkType = 'Google_Service_Analytics_ProfileChildLink';
+  protected $childLinkDataType = '';
+  public $created;
+  public $currency;
+  public $defaultPage;
+  public $eCommerceTracking;
+  public $enhancedECommerceTracking;
+  public $excludeQueryParameters;
+  public $id;
+  public $internalWebPropertyId;
+  public $kind;
+  public $name;
+  protected $parentLinkType = 'Google_Service_Analytics_ProfileParentLink';
+  protected $parentLinkDataType = '';
+  protected $permissionsType = 'Google_Service_Analytics_ProfilePermissions';
+  protected $permissionsDataType = '';
+  public $selfLink;
+  public $siteSearchCategoryParameters;
+  public $siteSearchQueryParameters;
+  public $stripSiteSearchCategoryParameters;
+  public $stripSiteSearchQueryParameters;
+  public $timezone;
+  public $type;
+  public $updated;
+  public $webPropertyId;
+  public $websiteUrl;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setChildLink(Google_Service_Analytics_ProfileChildLink $childLink)
+  {
+    $this->childLink = $childLink;
+  }
+  public function getChildLink()
+  {
+    return $this->childLink;
+  }
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setCurrency($currency)
+  {
+    $this->currency = $currency;
+  }
+  public function getCurrency()
+  {
+    return $this->currency;
+  }
+  public function setDefaultPage($defaultPage)
+  {
+    $this->defaultPage = $defaultPage;
+  }
+  public function getDefaultPage()
+  {
+    return $this->defaultPage;
+  }
+  public function setECommerceTracking($eCommerceTracking)
+  {
+    $this->eCommerceTracking = $eCommerceTracking;
+  }
+  public function getECommerceTracking()
+  {
+    return $this->eCommerceTracking;
+  }
+  public function setEnhancedECommerceTracking($enhancedECommerceTracking)
+  {
+    $this->enhancedECommerceTracking = $enhancedECommerceTracking;
+  }
+  public function getEnhancedECommerceTracking()
+  {
+    return $this->enhancedECommerceTracking;
+  }
+  public function setExcludeQueryParameters($excludeQueryParameters)
+  {
+    $this->excludeQueryParameters = $excludeQueryParameters;
+  }
+  public function getExcludeQueryParameters()
+  {
+    return $this->excludeQueryParameters;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInternalWebPropertyId($internalWebPropertyId)
+  {
+    $this->internalWebPropertyId = $internalWebPropertyId;
+  }
+  public function getInternalWebPropertyId()
+  {
+    return $this->internalWebPropertyId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setParentLink(Google_Service_Analytics_ProfileParentLink $parentLink)
+  {
+    $this->parentLink = $parentLink;
+  }
+  public function getParentLink()
+  {
+    return $this->parentLink;
+  }
+  public function setPermissions(Google_Service_Analytics_ProfilePermissions $permissions)
+  {
+    $this->permissions = $permissions;
+  }
+  public function getPermissions()
+  {
+    return $this->permissions;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setSiteSearchCategoryParameters($siteSearchCategoryParameters)
+  {
+    $this->siteSearchCategoryParameters = $siteSearchCategoryParameters;
+  }
+  public function getSiteSearchCategoryParameters()
+  {
+    return $this->siteSearchCategoryParameters;
+  }
+  public function setSiteSearchQueryParameters($siteSearchQueryParameters)
+  {
+    $this->siteSearchQueryParameters = $siteSearchQueryParameters;
+  }
+  public function getSiteSearchQueryParameters()
+  {
+    return $this->siteSearchQueryParameters;
+  }
+  public function setStripSiteSearchCategoryParameters($stripSiteSearchCategoryParameters)
+  {
+    $this->stripSiteSearchCategoryParameters = $stripSiteSearchCategoryParameters;
+  }
+  public function getStripSiteSearchCategoryParameters()
+  {
+    return $this->stripSiteSearchCategoryParameters;
+  }
+  public function setStripSiteSearchQueryParameters($stripSiteSearchQueryParameters)
+  {
+    $this->stripSiteSearchQueryParameters = $stripSiteSearchQueryParameters;
+  }
+  public function getStripSiteSearchQueryParameters()
+  {
+    return $this->stripSiteSearchQueryParameters;
+  }
+  public function setTimezone($timezone)
+  {
+    $this->timezone = $timezone;
+  }
+  public function getTimezone()
+  {
+    return $this->timezone;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setWebPropertyId($webPropertyId)
+  {
+    $this->webPropertyId = $webPropertyId;
+  }
+  public function getWebPropertyId()
+  {
+    return $this->webPropertyId;
+  }
+  public function setWebsiteUrl($websiteUrl)
+  {
+    $this->websiteUrl = $websiteUrl;
+  }
+  public function getWebsiteUrl()
+  {
+    return $this->websiteUrl;
+  }
+}
+
+class Google_Service_Analytics_ProfileChildLink extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $href;
+  public $type;
+
+
+  public function setHref($href)
+  {
+    $this->href = $href;
+  }
+  public function getHref()
+  {
+    return $this->href;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Analytics_ProfileFilterLink extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $filterRefType = 'Google_Service_Analytics_FilterRef';
+  protected $filterRefDataType = '';
+  public $id;
+  public $kind;
+  protected $profileRefType = 'Google_Service_Analytics_ProfileRef';
+  protected $profileRefDataType = '';
+  public $rank;
+  public $selfLink;
+
+
+  public function setFilterRef(Google_Service_Analytics_FilterRef $filterRef)
+  {
+    $this->filterRef = $filterRef;
+  }
+  public function getFilterRef()
+  {
+    return $this->filterRef;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProfileRef(Google_Service_Analytics_ProfileRef $profileRef)
+  {
+    $this->profileRef = $profileRef;
+  }
+  public function getProfileRef()
+  {
+    return $this->profileRef;
+  }
+  public function setRank($rank)
+  {
+    $this->rank = $rank;
+  }
+  public function getRank()
+  {
+    return $this->rank;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Analytics_ProfileFilterLinks extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Analytics_ProfileFilterLink';
+  protected $itemsDataType = 'array';
+  public $itemsPerPage;
+  public $kind;
+  public $nextLink;
+  public $previousLink;
+  public $startIndex;
+  public $totalResults;
+  public $username;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setPreviousLink($previousLink)
+  {
+    $this->previousLink = $previousLink;
+  }
+  public function getPreviousLink()
+  {
+    return $this->previousLink;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+  public function setUsername($username)
+  {
+    $this->username = $username;
+  }
+  public function getUsername()
+  {
+    return $this->username;
+  }
+}
+
+class Google_Service_Analytics_ProfileParentLink extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $href;
+  public $type;
+
+
+  public function setHref($href)
+  {
+    $this->href = $href;
+  }
+  public function getHref()
+  {
+    return $this->href;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Analytics_ProfilePermissions extends Google_Collection
+{
+  protected $collection_key = 'effective';
+  protected $internal_gapi_mappings = array(
+  );
+  public $effective;
+
+
+  public function setEffective($effective)
+  {
+    $this->effective = $effective;
+  }
+  public function getEffective()
+  {
+    return $this->effective;
+  }
+}
+
+class Google_Service_Analytics_ProfileRef extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $href;
+  public $id;
+  public $internalWebPropertyId;
+  public $kind;
+  public $name;
+  public $webPropertyId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setHref($href)
+  {
+    $this->href = $href;
+  }
+  public function getHref()
+  {
+    return $this->href;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInternalWebPropertyId($internalWebPropertyId)
+  {
+    $this->internalWebPropertyId = $internalWebPropertyId;
+  }
+  public function getInternalWebPropertyId()
+  {
+    return $this->internalWebPropertyId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setWebPropertyId($webPropertyId)
+  {
+    $this->webPropertyId = $webPropertyId;
+  }
+  public function getWebPropertyId()
+  {
+    return $this->webPropertyId;
+  }
+}
+
+class Google_Service_Analytics_ProfileSummary extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $name;
+  public $type;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Analytics_Profiles extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Analytics_Profile';
+  protected $itemsDataType = 'array';
+  public $itemsPerPage;
+  public $kind;
+  public $nextLink;
+  public $previousLink;
+  public $startIndex;
+  public $totalResults;
+  public $username;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setPreviousLink($previousLink)
+  {
+    $this->previousLink = $previousLink;
+  }
+  public function getPreviousLink()
+  {
+    return $this->previousLink;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+  public function setUsername($username)
+  {
+    $this->username = $username;
+  }
+  public function getUsername()
+  {
+    return $this->username;
+  }
+}
+
+class Google_Service_Analytics_RealtimeData extends Google_Collection
+{
+  protected $collection_key = 'rows';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $columnHeadersType = 'Google_Service_Analytics_RealtimeDataColumnHeaders';
+  protected $columnHeadersDataType = 'array';
+  public $id;
+  public $kind;
+  protected $profileInfoType = 'Google_Service_Analytics_RealtimeDataProfileInfo';
+  protected $profileInfoDataType = '';
+  protected $queryType = 'Google_Service_Analytics_RealtimeDataQuery';
+  protected $queryDataType = '';
+  public $rows;
+  public $selfLink;
+  public $totalResults;
+  public $totalsForAllResults;
+
+
+  public function setColumnHeaders($columnHeaders)
+  {
+    $this->columnHeaders = $columnHeaders;
+  }
+  public function getColumnHeaders()
+  {
+    return $this->columnHeaders;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProfileInfo(Google_Service_Analytics_RealtimeDataProfileInfo $profileInfo)
+  {
+    $this->profileInfo = $profileInfo;
+  }
+  public function getProfileInfo()
+  {
+    return $this->profileInfo;
+  }
+  public function setQuery(Google_Service_Analytics_RealtimeDataQuery $query)
+  {
+    $this->query = $query;
+  }
+  public function getQuery()
+  {
+    return $this->query;
+  }
+  public function setRows($rows)
+  {
+    $this->rows = $rows;
+  }
+  public function getRows()
+  {
+    return $this->rows;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+  public function setTotalsForAllResults($totalsForAllResults)
+  {
+    $this->totalsForAllResults = $totalsForAllResults;
+  }
+  public function getTotalsForAllResults()
+  {
+    return $this->totalsForAllResults;
+  }
+}
+
+class Google_Service_Analytics_RealtimeDataColumnHeaders extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $columnType;
+  public $dataType;
+  public $name;
+
+
+  public function setColumnType($columnType)
+  {
+    $this->columnType = $columnType;
+  }
+  public function getColumnType()
+  {
+    return $this->columnType;
+  }
+  public function setDataType($dataType)
+  {
+    $this->dataType = $dataType;
+  }
+  public function getDataType()
+  {
+    return $this->dataType;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Analytics_RealtimeDataProfileInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $internalWebPropertyId;
+  public $profileId;
+  public $profileName;
+  public $tableId;
+  public $webPropertyId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setInternalWebPropertyId($internalWebPropertyId)
+  {
+    $this->internalWebPropertyId = $internalWebPropertyId;
+  }
+  public function getInternalWebPropertyId()
+  {
+    return $this->internalWebPropertyId;
+  }
+  public function setProfileId($profileId)
+  {
+    $this->profileId = $profileId;
+  }
+  public function getProfileId()
+  {
+    return $this->profileId;
+  }
+  public function setProfileName($profileName)
+  {
+    $this->profileName = $profileName;
+  }
+  public function getProfileName()
+  {
+    return $this->profileName;
+  }
+  public function setTableId($tableId)
+  {
+    $this->tableId = $tableId;
+  }
+  public function getTableId()
+  {
+    return $this->tableId;
+  }
+  public function setWebPropertyId($webPropertyId)
+  {
+    $this->webPropertyId = $webPropertyId;
+  }
+  public function getWebPropertyId()
+  {
+    return $this->webPropertyId;
+  }
+}
+
+class Google_Service_Analytics_RealtimeDataQuery extends Google_Collection
+{
+  protected $collection_key = 'sort';
+  protected $internal_gapi_mappings = array(
+        "maxResults" => "max-results",
+  );
+  public $dimensions;
+  public $filters;
+  public $ids;
+  public $maxResults;
+  public $metrics;
+  public $sort;
+
+
+  public function setDimensions($dimensions)
+  {
+    $this->dimensions = $dimensions;
+  }
+  public function getDimensions()
+  {
+    return $this->dimensions;
+  }
+  public function setFilters($filters)
+  {
+    $this->filters = $filters;
+  }
+  public function getFilters()
+  {
+    return $this->filters;
+  }
+  public function setIds($ids)
+  {
+    $this->ids = $ids;
+  }
+  public function getIds()
+  {
+    return $this->ids;
+  }
+  public function setMaxResults($maxResults)
+  {
+    $this->maxResults = $maxResults;
+  }
+  public function getMaxResults()
+  {
+    return $this->maxResults;
+  }
+  public function setMetrics($metrics)
+  {
+    $this->metrics = $metrics;
+  }
+  public function getMetrics()
+  {
+    return $this->metrics;
+  }
+  public function setSort($sort)
+  {
+    $this->sort = $sort;
+  }
+  public function getSort()
+  {
+    return $this->sort;
+  }
+}
+
+class Google_Service_Analytics_RealtimeDataTotalsForAllResults extends Google_Model
+{
+}
+
+class Google_Service_Analytics_Segment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $created;
+  public $definition;
+  public $id;
+  public $kind;
+  public $name;
+  public $segmentId;
+  public $selfLink;
+  public $type;
+  public $updated;
+
+
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setDefinition($definition)
+  {
+    $this->definition = $definition;
+  }
+  public function getDefinition()
+  {
+    return $this->definition;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSegmentId($segmentId)
+  {
+    $this->segmentId = $segmentId;
+  }
+  public function getSegmentId()
+  {
+    return $this->segmentId;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+}
+
+class Google_Service_Analytics_Segments extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Analytics_Segment';
+  protected $itemsDataType = 'array';
+  public $itemsPerPage;
+  public $kind;
+  public $nextLink;
+  public $previousLink;
+  public $startIndex;
+  public $totalResults;
+  public $username;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setPreviousLink($previousLink)
+  {
+    $this->previousLink = $previousLink;
+  }
+  public function getPreviousLink()
+  {
+    return $this->previousLink;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+  public function setUsername($username)
+  {
+    $this->username = $username;
+  }
+  public function getUsername()
+  {
+    return $this->username;
+  }
+}
+
+class Google_Service_Analytics_UnsampledReport extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "endDate" => "end-date",
+        "startDate" => "start-date",
+  );
+  public $accountId;
+  protected $cloudStorageDownloadDetailsType = 'Google_Service_Analytics_UnsampledReportCloudStorageDownloadDetails';
+  protected $cloudStorageDownloadDetailsDataType = '';
+  public $created;
+  public $dimensions;
+  public $downloadType;
+  protected $driveDownloadDetailsType = 'Google_Service_Analytics_UnsampledReportDriveDownloadDetails';
+  protected $driveDownloadDetailsDataType = '';
+  public $endDate;
+  public $filters;
+  public $id;
+  public $kind;
+  public $metrics;
+  public $profileId;
+  public $segment;
+  public $selfLink;
+  public $startDate;
+  public $status;
+  public $title;
+  public $updated;
+  public $webPropertyId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setCloudStorageDownloadDetails(Google_Service_Analytics_UnsampledReportCloudStorageDownloadDetails $cloudStorageDownloadDetails)
+  {
+    $this->cloudStorageDownloadDetails = $cloudStorageDownloadDetails;
+  }
+  public function getCloudStorageDownloadDetails()
+  {
+    return $this->cloudStorageDownloadDetails;
+  }
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setDimensions($dimensions)
+  {
+    $this->dimensions = $dimensions;
+  }
+  public function getDimensions()
+  {
+    return $this->dimensions;
+  }
+  public function setDownloadType($downloadType)
+  {
+    $this->downloadType = $downloadType;
+  }
+  public function getDownloadType()
+  {
+    return $this->downloadType;
+  }
+  public function setDriveDownloadDetails(Google_Service_Analytics_UnsampledReportDriveDownloadDetails $driveDownloadDetails)
+  {
+    $this->driveDownloadDetails = $driveDownloadDetails;
+  }
+  public function getDriveDownloadDetails()
+  {
+    return $this->driveDownloadDetails;
+  }
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setFilters($filters)
+  {
+    $this->filters = $filters;
+  }
+  public function getFilters()
+  {
+    return $this->filters;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMetrics($metrics)
+  {
+    $this->metrics = $metrics;
+  }
+  public function getMetrics()
+  {
+    return $this->metrics;
+  }
+  public function setProfileId($profileId)
+  {
+    $this->profileId = $profileId;
+  }
+  public function getProfileId()
+  {
+    return $this->profileId;
+  }
+  public function setSegment($segment)
+  {
+    $this->segment = $segment;
+  }
+  public function getSegment()
+  {
+    return $this->segment;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setWebPropertyId($webPropertyId)
+  {
+    $this->webPropertyId = $webPropertyId;
+  }
+  public function getWebPropertyId()
+  {
+    return $this->webPropertyId;
+  }
+}
+
+class Google_Service_Analytics_UnsampledReportCloudStorageDownloadDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $bucketId;
+  public $objectId;
+
+
+  public function setBucketId($bucketId)
+  {
+    $this->bucketId = $bucketId;
+  }
+  public function getBucketId()
+  {
+    return $this->bucketId;
+  }
+  public function setObjectId($objectId)
+  {
+    $this->objectId = $objectId;
+  }
+  public function getObjectId()
+  {
+    return $this->objectId;
+  }
+}
+
+class Google_Service_Analytics_UnsampledReportDriveDownloadDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $documentId;
+
+
+  public function setDocumentId($documentId)
+  {
+    $this->documentId = $documentId;
+  }
+  public function getDocumentId()
+  {
+    return $this->documentId;
+  }
+}
+
+class Google_Service_Analytics_UnsampledReports extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Analytics_UnsampledReport';
+  protected $itemsDataType = 'array';
+  public $itemsPerPage;
+  public $kind;
+  public $nextLink;
+  public $previousLink;
+  public $startIndex;
+  public $totalResults;
+  public $username;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setPreviousLink($previousLink)
+  {
+    $this->previousLink = $previousLink;
+  }
+  public function getPreviousLink()
+  {
+    return $this->previousLink;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+  public function setUsername($username)
+  {
+    $this->username = $username;
+  }
+  public function getUsername()
+  {
+    return $this->username;
+  }
+}
+
+class Google_Service_Analytics_Upload extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $customDataSourceId;
+  public $errors;
+  public $id;
+  public $kind;
+  public $status;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setCustomDataSourceId($customDataSourceId)
+  {
+    $this->customDataSourceId = $customDataSourceId;
+  }
+  public function getCustomDataSourceId()
+  {
+    return $this->customDataSourceId;
+  }
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_Analytics_Uploads extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Analytics_Upload';
+  protected $itemsDataType = 'array';
+  public $itemsPerPage;
+  public $kind;
+  public $nextLink;
+  public $previousLink;
+  public $startIndex;
+  public $totalResults;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setPreviousLink($previousLink)
+  {
+    $this->previousLink = $previousLink;
+  }
+  public function getPreviousLink()
+  {
+    return $this->previousLink;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+}
+
+class Google_Service_Analytics_UserRef extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $email;
+  public $id;
+  public $kind;
+
+
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Analytics_WebPropertyRef extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $href;
+  public $id;
+  public $internalWebPropertyId;
+  public $kind;
+  public $name;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setHref($href)
+  {
+    $this->href = $href;
+  }
+  public function getHref()
+  {
+    return $this->href;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInternalWebPropertyId($internalWebPropertyId)
+  {
+    $this->internalWebPropertyId = $internalWebPropertyId;
+  }
+  public function getInternalWebPropertyId()
+  {
+    return $this->internalWebPropertyId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Analytics_WebPropertySummary extends Google_Collection
+{
+  protected $collection_key = 'profiles';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $internalWebPropertyId;
+  public $kind;
+  public $level;
+  public $name;
+  protected $profilesType = 'Google_Service_Analytics_ProfileSummary';
+  protected $profilesDataType = 'array';
+  public $websiteUrl;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInternalWebPropertyId($internalWebPropertyId)
+  {
+    $this->internalWebPropertyId = $internalWebPropertyId;
+  }
+  public function getInternalWebPropertyId()
+  {
+    return $this->internalWebPropertyId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLevel($level)
+  {
+    $this->level = $level;
+  }
+  public function getLevel()
+  {
+    return $this->level;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProfiles($profiles)
+  {
+    $this->profiles = $profiles;
+  }
+  public function getProfiles()
+  {
+    return $this->profiles;
+  }
+  public function setWebsiteUrl($websiteUrl)
+  {
+    $this->websiteUrl = $websiteUrl;
+  }
+  public function getWebsiteUrl()
+  {
+    return $this->websiteUrl;
+  }
+}
+
+class Google_Service_Analytics_Webproperties extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Analytics_Webproperty';
+  protected $itemsDataType = 'array';
+  public $itemsPerPage;
+  public $kind;
+  public $nextLink;
+  public $previousLink;
+  public $startIndex;
+  public $totalResults;
+  public $username;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setPreviousLink($previousLink)
+  {
+    $this->previousLink = $previousLink;
+  }
+  public function getPreviousLink()
+  {
+    return $this->previousLink;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+  public function setUsername($username)
+  {
+    $this->username = $username;
+  }
+  public function getUsername()
+  {
+    return $this->username;
+  }
+}
+
+class Google_Service_Analytics_Webproperty extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  protected $childLinkType = 'Google_Service_Analytics_WebpropertyChildLink';
+  protected $childLinkDataType = '';
+  public $created;
+  public $defaultProfileId;
+  public $id;
+  public $industryVertical;
+  public $internalWebPropertyId;
+  public $kind;
+  public $level;
+  public $name;
+  protected $parentLinkType = 'Google_Service_Analytics_WebpropertyParentLink';
+  protected $parentLinkDataType = '';
+  protected $permissionsType = 'Google_Service_Analytics_WebpropertyPermissions';
+  protected $permissionsDataType = '';
+  public $profileCount;
+  public $selfLink;
+  public $updated;
+  public $websiteUrl;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setChildLink(Google_Service_Analytics_WebpropertyChildLink $childLink)
+  {
+    $this->childLink = $childLink;
+  }
+  public function getChildLink()
+  {
+    return $this->childLink;
+  }
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setDefaultProfileId($defaultProfileId)
+  {
+    $this->defaultProfileId = $defaultProfileId;
+  }
+  public function getDefaultProfileId()
+  {
+    return $this->defaultProfileId;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIndustryVertical($industryVertical)
+  {
+    $this->industryVertical = $industryVertical;
+  }
+  public function getIndustryVertical()
+  {
+    return $this->industryVertical;
+  }
+  public function setInternalWebPropertyId($internalWebPropertyId)
+  {
+    $this->internalWebPropertyId = $internalWebPropertyId;
+  }
+  public function getInternalWebPropertyId()
+  {
+    return $this->internalWebPropertyId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLevel($level)
+  {
+    $this->level = $level;
+  }
+  public function getLevel()
+  {
+    return $this->level;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setParentLink(Google_Service_Analytics_WebpropertyParentLink $parentLink)
+  {
+    $this->parentLink = $parentLink;
+  }
+  public function getParentLink()
+  {
+    return $this->parentLink;
+  }
+  public function setPermissions(Google_Service_Analytics_WebpropertyPermissions $permissions)
+  {
+    $this->permissions = $permissions;
+  }
+  public function getPermissions()
+  {
+    return $this->permissions;
+  }
+  public function setProfileCount($profileCount)
+  {
+    $this->profileCount = $profileCount;
+  }
+  public function getProfileCount()
+  {
+    return $this->profileCount;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setWebsiteUrl($websiteUrl)
+  {
+    $this->websiteUrl = $websiteUrl;
+  }
+  public function getWebsiteUrl()
+  {
+    return $this->websiteUrl;
+  }
+}
+
+class Google_Service_Analytics_WebpropertyChildLink extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $href;
+  public $type;
+
+
+  public function setHref($href)
+  {
+    $this->href = $href;
+  }
+  public function getHref()
+  {
+    return $this->href;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Analytics_WebpropertyParentLink extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $href;
+  public $type;
+
+
+  public function setHref($href)
+  {
+    $this->href = $href;
+  }
+  public function getHref()
+  {
+    return $this->href;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Analytics_WebpropertyPermissions extends Google_Collection
+{
+  protected $collection_key = 'effective';
+  protected $internal_gapi_mappings = array(
+  );
+  public $effective;
+
+
+  public function setEffective($effective)
+  {
+    $this->effective = $effective;
+  }
+  public function getEffective()
+  {
+    return $this->effective;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/AndroidEnterprise.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/AndroidEnterprise.php
@@ -1,0 +1,3109 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for AndroidEnterprise (v1).
+ *
+ * <p>
+ * Allows MDMs/EMMs and enterprises to manage the deployment of apps to Android
+ * for Work users.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/play/enterprise" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_AndroidEnterprise extends Google_Service
+{
+  /** Manage corporate Android devices. */
+  const ANDROIDENTERPRISE =
+      "https://www.googleapis.com/auth/androidenterprise";
+
+  public $collections;
+  public $collectionviewers;
+  public $devices;
+  public $enterprises;
+  public $entitlements;
+  public $grouplicenses;
+  public $grouplicenseusers;
+  public $installs;
+  public $permissions;
+  public $products;
+  public $users;
+  
+
+  /**
+   * Constructs the internal representation of the AndroidEnterprise service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'androidenterprise/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'androidenterprise';
+
+    $this->collections = new Google_Service_AndroidEnterprise_Collections_Resource(
+        $this,
+        $this->serviceName,
+        'collections',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'enterprises/{enterpriseId}/collections/{collectionId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collectionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'enterprises/{enterpriseId}/collections/{collectionId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collectionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'enterprises/{enterpriseId}/collections',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'enterprises/{enterpriseId}/collections',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'enterprises/{enterpriseId}/collections/{collectionId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collectionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'enterprises/{enterpriseId}/collections/{collectionId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collectionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->collectionviewers = new Google_Service_AndroidEnterprise_Collectionviewers_Resource(
+        $this,
+        $this->serviceName,
+        'collectionviewers',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'enterprises/{enterpriseId}/collections/{collectionId}/users/{userId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collectionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'enterprises/{enterpriseId}/collections/{collectionId}/users/{userId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collectionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'enterprises/{enterpriseId}/collections/{collectionId}/users',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collectionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'enterprises/{enterpriseId}/collections/{collectionId}/users/{userId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collectionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'enterprises/{enterpriseId}/collections/{collectionId}/users/{userId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collectionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->devices = new Google_Service_AndroidEnterprise_Devices_Resource(
+        $this,
+        $this->serviceName,
+        'devices',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}/devices/{deviceId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deviceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getState' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}/devices/{deviceId}/state',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deviceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}/devices',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setState' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}/devices/{deviceId}/state',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deviceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->enterprises = new Google_Service_AndroidEnterprise_Enterprises_Resource(
+        $this,
+        $this->serviceName,
+        'enterprises',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'enterprises/{enterpriseId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'enroll' => array(
+              'path' => 'enterprises/enroll',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'token' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'enterprises/{enterpriseId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'enterprises',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'token' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'enterprises',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'domain' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'sendTestPushNotification' => array(
+              'path' => 'enterprises/{enterpriseId}/sendTestPushNotification',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setAccount' => array(
+              'path' => 'enterprises/{enterpriseId}/account',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'unenroll' => array(
+              'path' => 'enterprises/{enterpriseId}/unenroll',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->entitlements = new Google_Service_AndroidEnterprise_Entitlements_Resource(
+        $this,
+        $this->serviceName,
+        'entitlements',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}/entitlements/{entitlementId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'entitlementId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}/entitlements/{entitlementId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'entitlementId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}/entitlements',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}/entitlements/{entitlementId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'entitlementId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'install' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}/entitlements/{entitlementId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'entitlementId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'install' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->grouplicenses = new Google_Service_AndroidEnterprise_Grouplicenses_Resource(
+        $this,
+        $this->serviceName,
+        'grouplicenses',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'enterprises/{enterpriseId}/groupLicenses/{groupLicenseId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'groupLicenseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'enterprises/{enterpriseId}/groupLicenses',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->grouplicenseusers = new Google_Service_AndroidEnterprise_Grouplicenseusers_Resource(
+        $this,
+        $this->serviceName,
+        'grouplicenseusers',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'enterprises/{enterpriseId}/groupLicenses/{groupLicenseId}/users',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'groupLicenseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->installs = new Google_Service_AndroidEnterprise_Installs_Resource(
+        $this,
+        $this->serviceName,
+        'installs',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}/devices/{deviceId}/installs/{installId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deviceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'installId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}/devices/{deviceId}/installs/{installId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deviceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'installId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}/devices/{deviceId}/installs',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deviceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}/devices/{deviceId}/installs/{installId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deviceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'installId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}/devices/{deviceId}/installs/{installId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deviceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'installId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->permissions = new Google_Service_AndroidEnterprise_Permissions_Resource(
+        $this,
+        $this->serviceName,
+        'permissions',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'permissions/{permissionId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'permissionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->products = new Google_Service_AndroidEnterprise_Products_Resource(
+        $this,
+        $this->serviceName,
+        'products',
+        array(
+          'methods' => array(
+            'approve' => array(
+              'path' => 'enterprises/{enterpriseId}/products/{productId}/approve',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'productId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'generateApprovalUrl' => array(
+              'path' => 'enterprises/{enterpriseId}/products/{productId}/generateApprovalUrl',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'productId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'languageCode' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'enterprises/{enterpriseId}/products/{productId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'productId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'getAppRestrictionsSchema' => array(
+              'path' => 'enterprises/{enterpriseId}/products/{productId}/appRestrictionsSchema',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'productId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'getPermissions' => array(
+              'path' => 'enterprises/{enterpriseId}/products/{productId}/permissions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'productId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'updatePermissions' => array(
+              'path' => 'enterprises/{enterpriseId}/products/{productId}/permissions',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'productId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->users = new Google_Service_AndroidEnterprise_Users_Resource(
+        $this,
+        $this->serviceName,
+        'users',
+        array(
+          'methods' => array(
+            'generateToken' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}/token',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getAvailableProductSet' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}/availableProductSet',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'enterprises/{enterpriseId}/users',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'email' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'revokeToken' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}/token',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setAvailableProductSet' => array(
+              'path' => 'enterprises/{enterpriseId}/users/{userId}/availableProductSet',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'enterpriseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "collections" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidenterpriseService = new Google_Service_AndroidEnterprise(...);
+ *   $collections = $androidenterpriseService->collections;
+ *  </code>
+ */
+class Google_Service_AndroidEnterprise_Collections_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a collection. (collections.delete)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $collectionId The ID of the collection.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($enterpriseId, $collectionId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'collectionId' => $collectionId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves the details of a collection. (collections.get)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $collectionId The ID of the collection.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_Collection
+   */
+  public function get($enterpriseId, $collectionId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'collectionId' => $collectionId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidEnterprise_Collection");
+  }
+
+  /**
+   * Creates a new collection. (collections.insert)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param Google_Collection $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_Collection
+   */
+  public function insert($enterpriseId, Google_Service_AndroidEnterprise_Collection $postBody, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_AndroidEnterprise_Collection");
+  }
+
+  /**
+   * Retrieves the IDs of all the collections for an enterprise.
+   * (collections.listCollections)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_CollectionsListResponse
+   */
+  public function listCollections($enterpriseId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AndroidEnterprise_CollectionsListResponse");
+  }
+
+  /**
+   * Updates a collection. This method supports patch semantics.
+   * (collections.patch)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $collectionId The ID of the collection.
+   * @param Google_Collection $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_Collection
+   */
+  public function patch($enterpriseId, $collectionId, Google_Service_AndroidEnterprise_Collection $postBody, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'collectionId' => $collectionId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_AndroidEnterprise_Collection");
+  }
+
+  /**
+   * Updates a collection. (collections.update)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $collectionId The ID of the collection.
+   * @param Google_Collection $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_Collection
+   */
+  public function update($enterpriseId, $collectionId, Google_Service_AndroidEnterprise_Collection $postBody, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'collectionId' => $collectionId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AndroidEnterprise_Collection");
+  }
+}
+
+/**
+ * The "collectionviewers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidenterpriseService = new Google_Service_AndroidEnterprise(...);
+ *   $collectionviewers = $androidenterpriseService->collectionviewers;
+ *  </code>
+ */
+class Google_Service_AndroidEnterprise_Collectionviewers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Removes the user from the list of those specifically allowed to see the
+   * collection. If the collection's visibility is set to viewersOnly then only
+   * such users will see the collection. (collectionviewers.delete)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $collectionId The ID of the collection.
+   * @param string $userId The ID of the user.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($enterpriseId, $collectionId, $userId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'collectionId' => $collectionId, 'userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves the ID of the user if they have been specifically allowed to see
+   * the collection. If the collection's visibility is set to viewersOnly then
+   * only these users will see the collection. (collectionviewers.get)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $collectionId The ID of the collection.
+   * @param string $userId The ID of the user.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_User
+   */
+  public function get($enterpriseId, $collectionId, $userId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'collectionId' => $collectionId, 'userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidEnterprise_User");
+  }
+
+  /**
+   * Retrieves the IDs of the users who have been specifically allowed to see the
+   * collection. If the collection's visibility is set to viewersOnly then only
+   * these users will see the collection.
+   * (collectionviewers.listCollectionviewers)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $collectionId The ID of the collection.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_CollectionViewersListResponse
+   */
+  public function listCollectionviewers($enterpriseId, $collectionId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'collectionId' => $collectionId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AndroidEnterprise_CollectionViewersListResponse");
+  }
+
+  /**
+   * Adds the user to the list of those specifically allowed to see the
+   * collection. If the collection's visibility is set to viewersOnly then only
+   * such users will see the collection. This method supports patch semantics.
+   * (collectionviewers.patch)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $collectionId The ID of the collection.
+   * @param string $userId The ID of the user.
+   * @param Google_User $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_User
+   */
+  public function patch($enterpriseId, $collectionId, $userId, Google_Service_AndroidEnterprise_User $postBody, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'collectionId' => $collectionId, 'userId' => $userId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_AndroidEnterprise_User");
+  }
+
+  /**
+   * Adds the user to the list of those specifically allowed to see the
+   * collection. If the collection's visibility is set to viewersOnly then only
+   * such users will see the collection. (collectionviewers.update)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $collectionId The ID of the collection.
+   * @param string $userId The ID of the user.
+   * @param Google_User $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_User
+   */
+  public function update($enterpriseId, $collectionId, $userId, Google_Service_AndroidEnterprise_User $postBody, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'collectionId' => $collectionId, 'userId' => $userId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AndroidEnterprise_User");
+  }
+}
+
+/**
+ * The "devices" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidenterpriseService = new Google_Service_AndroidEnterprise(...);
+ *   $devices = $androidenterpriseService->devices;
+ *  </code>
+ */
+class Google_Service_AndroidEnterprise_Devices_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the details of a device. (devices.get)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param string $deviceId The ID of the device.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_Device
+   */
+  public function get($enterpriseId, $userId, $deviceId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId, 'deviceId' => $deviceId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidEnterprise_Device");
+  }
+
+  /**
+   * Retrieves whether a device is enabled or disabled for access by the user to
+   * Google services. The device state takes effect only if enforcing EMM policies
+   * on Android devices is enabled in the Google Admin Console. Otherwise, the
+   * device state is ignored and all devices are allowed access to Google
+   * services. (devices.getState)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param string $deviceId The ID of the device.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_DeviceState
+   */
+  public function getState($enterpriseId, $userId, $deviceId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId, 'deviceId' => $deviceId);
+    $params = array_merge($params, $optParams);
+    return $this->call('getState', array($params), "Google_Service_AndroidEnterprise_DeviceState");
+  }
+
+  /**
+   * Retrieves the IDs of all of a user's devices. (devices.listDevices)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_DevicesListResponse
+   */
+  public function listDevices($enterpriseId, $userId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AndroidEnterprise_DevicesListResponse");
+  }
+
+  /**
+   * Sets whether a device is enabled or disabled for access by the user to Google
+   * services. The device state takes effect only if enforcing EMM policies on
+   * Android devices is enabled in the Google Admin Console. Otherwise, the device
+   * state is ignored and all devices are allowed access to Google services.
+   * (devices.setState)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param string $deviceId The ID of the device.
+   * @param Google_DeviceState $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_DeviceState
+   */
+  public function setState($enterpriseId, $userId, $deviceId, Google_Service_AndroidEnterprise_DeviceState $postBody, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId, 'deviceId' => $deviceId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setState', array($params), "Google_Service_AndroidEnterprise_DeviceState");
+  }
+}
+
+/**
+ * The "enterprises" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidenterpriseService = new Google_Service_AndroidEnterprise(...);
+ *   $enterprises = $androidenterpriseService->enterprises;
+ *  </code>
+ */
+class Google_Service_AndroidEnterprise_Enterprises_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the binding between the MDM and enterprise. This is now deprecated;
+   * use this to unenroll customers that were previously enrolled with the
+   * 'insert' call, then enroll them again with the 'enroll' call.
+   * (enterprises.delete)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($enterpriseId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Enrolls an enterprise with the calling MDM. (enterprises.enroll)
+   *
+   * @param string $token The token provided by the enterprise to register the
+   * MDM.
+   * @param Google_Enterprise $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_Enterprise
+   */
+  public function enroll($token, Google_Service_AndroidEnterprise_Enterprise $postBody, $optParams = array())
+  {
+    $params = array('token' => $token, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('enroll', array($params), "Google_Service_AndroidEnterprise_Enterprise");
+  }
+
+  /**
+   * Retrieves the name and domain of an enterprise. (enterprises.get)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_Enterprise
+   */
+  public function get($enterpriseId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidEnterprise_Enterprise");
+  }
+
+  /**
+   * Establishes the binding between the MDM and an enterprise. This is now
+   * deprecated; use enroll instead. (enterprises.insert)
+   *
+   * @param string $token The token provided by the enterprise to register the
+   * MDM.
+   * @param Google_Enterprise $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_Enterprise
+   */
+  public function insert($token, Google_Service_AndroidEnterprise_Enterprise $postBody, $optParams = array())
+  {
+    $params = array('token' => $token, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_AndroidEnterprise_Enterprise");
+  }
+
+  /**
+   * Looks up an enterprise by domain name. (enterprises.listEnterprises)
+   *
+   * @param string $domain The exact primary domain name of the enterprise to look
+   * up.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_EnterprisesListResponse
+   */
+  public function listEnterprises($domain, $optParams = array())
+  {
+    $params = array('domain' => $domain);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AndroidEnterprise_EnterprisesListResponse");
+  }
+
+  /**
+   * Sends a test push notification to validate the MDM integration with the
+   * Google Cloud Pub/Sub service for this enterprise.
+   * (enterprises.sendTestPushNotification)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_EnterprisesSendTestPushNotificationResponse
+   */
+  public function sendTestPushNotification($enterpriseId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId);
+    $params = array_merge($params, $optParams);
+    return $this->call('sendTestPushNotification', array($params), "Google_Service_AndroidEnterprise_EnterprisesSendTestPushNotificationResponse");
+  }
+
+  /**
+   * Set the account that will be used to authenticate to the API as the
+   * enterprise. (enterprises.setAccount)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param Google_EnterpriseAccount $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_EnterpriseAccount
+   */
+  public function setAccount($enterpriseId, Google_Service_AndroidEnterprise_EnterpriseAccount $postBody, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setAccount', array($params), "Google_Service_AndroidEnterprise_EnterpriseAccount");
+  }
+
+  /**
+   * Unenrolls an enterprise from the calling MDM. (enterprises.unenroll)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param array $optParams Optional parameters.
+   */
+  public function unenroll($enterpriseId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId);
+    $params = array_merge($params, $optParams);
+    return $this->call('unenroll', array($params));
+  }
+}
+
+/**
+ * The "entitlements" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidenterpriseService = new Google_Service_AndroidEnterprise(...);
+ *   $entitlements = $androidenterpriseService->entitlements;
+ *  </code>
+ */
+class Google_Service_AndroidEnterprise_Entitlements_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Removes an entitlement to an app for a user and uninstalls it.
+   * (entitlements.delete)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param string $entitlementId The ID of the entitlement, e.g.
+   * "app:com.google.android.gm".
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($enterpriseId, $userId, $entitlementId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId, 'entitlementId' => $entitlementId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves details of an entitlement. (entitlements.get)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param string $entitlementId The ID of the entitlement, e.g.
+   * "app:com.google.android.gm".
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_Entitlement
+   */
+  public function get($enterpriseId, $userId, $entitlementId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId, 'entitlementId' => $entitlementId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidEnterprise_Entitlement");
+  }
+
+  /**
+   * List of all entitlements for the specified user. Only the ID is set.
+   * (entitlements.listEntitlements)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_EntitlementsListResponse
+   */
+  public function listEntitlements($enterpriseId, $userId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AndroidEnterprise_EntitlementsListResponse");
+  }
+
+  /**
+   * Adds or updates an entitlement to an app for a user. This method supports
+   * patch semantics. (entitlements.patch)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param string $entitlementId The ID of the entitlement, e.g.
+   * "app:com.google.android.gm".
+   * @param Google_Entitlement $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool install Set to true to also install the product on all the
+   * user's devices where possible. Failure to install on one or more devices will
+   * not prevent this operation from returning successfully, as long as the
+   * entitlement was successfully assigned to the user.
+   * @return Google_Service_AndroidEnterprise_Entitlement
+   */
+  public function patch($enterpriseId, $userId, $entitlementId, Google_Service_AndroidEnterprise_Entitlement $postBody, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId, 'entitlementId' => $entitlementId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_AndroidEnterprise_Entitlement");
+  }
+
+  /**
+   * Adds or updates an entitlement to an app for a user. (entitlements.update)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param string $entitlementId The ID of the entitlement, e.g.
+   * "app:com.google.android.gm".
+   * @param Google_Entitlement $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool install Set to true to also install the product on all the
+   * user's devices where possible. Failure to install on one or more devices will
+   * not prevent this operation from returning successfully, as long as the
+   * entitlement was successfully assigned to the user.
+   * @return Google_Service_AndroidEnterprise_Entitlement
+   */
+  public function update($enterpriseId, $userId, $entitlementId, Google_Service_AndroidEnterprise_Entitlement $postBody, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId, 'entitlementId' => $entitlementId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AndroidEnterprise_Entitlement");
+  }
+}
+
+/**
+ * The "grouplicenses" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidenterpriseService = new Google_Service_AndroidEnterprise(...);
+ *   $grouplicenses = $androidenterpriseService->grouplicenses;
+ *  </code>
+ */
+class Google_Service_AndroidEnterprise_Grouplicenses_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves details of an enterprise's group license for a product.
+   * (grouplicenses.get)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $groupLicenseId The ID of the product the group license is for,
+   * e.g. "app:com.google.android.gm".
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_GroupLicense
+   */
+  public function get($enterpriseId, $groupLicenseId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'groupLicenseId' => $groupLicenseId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidEnterprise_GroupLicense");
+  }
+
+  /**
+   * Retrieves IDs of all products for which the enterprise has a group license.
+   * (grouplicenses.listGrouplicenses)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_GroupLicensesListResponse
+   */
+  public function listGrouplicenses($enterpriseId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AndroidEnterprise_GroupLicensesListResponse");
+  }
+}
+
+/**
+ * The "grouplicenseusers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidenterpriseService = new Google_Service_AndroidEnterprise(...);
+ *   $grouplicenseusers = $androidenterpriseService->grouplicenseusers;
+ *  </code>
+ */
+class Google_Service_AndroidEnterprise_Grouplicenseusers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the IDs of the users who have been granted entitlements under the
+   * license. (grouplicenseusers.listGrouplicenseusers)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $groupLicenseId The ID of the product the group license is for,
+   * e.g. "app:com.google.android.gm".
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_GroupLicenseUsersListResponse
+   */
+  public function listGrouplicenseusers($enterpriseId, $groupLicenseId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'groupLicenseId' => $groupLicenseId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AndroidEnterprise_GroupLicenseUsersListResponse");
+  }
+}
+
+/**
+ * The "installs" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidenterpriseService = new Google_Service_AndroidEnterprise(...);
+ *   $installs = $androidenterpriseService->installs;
+ *  </code>
+ */
+class Google_Service_AndroidEnterprise_Installs_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Requests to remove an app from a device. A call to get or list will still
+   * show the app as installed on the device until it is actually removed.
+   * (installs.delete)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param string $deviceId The Android ID of the device.
+   * @param string $installId The ID of the product represented by the install,
+   * e.g. "app:com.google.android.gm".
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($enterpriseId, $userId, $deviceId, $installId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId, 'deviceId' => $deviceId, 'installId' => $installId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves details of an installation of an app on a device. (installs.get)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param string $deviceId The Android ID of the device.
+   * @param string $installId The ID of the product represented by the install,
+   * e.g. "app:com.google.android.gm".
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_Install
+   */
+  public function get($enterpriseId, $userId, $deviceId, $installId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId, 'deviceId' => $deviceId, 'installId' => $installId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidEnterprise_Install");
+  }
+
+  /**
+   * Retrieves the details of all apps installed on the specified device.
+   * (installs.listInstalls)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param string $deviceId The Android ID of the device.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_InstallsListResponse
+   */
+  public function listInstalls($enterpriseId, $userId, $deviceId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId, 'deviceId' => $deviceId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AndroidEnterprise_InstallsListResponse");
+  }
+
+  /**
+   * Requests to install the latest version of an app to a device. If the app is
+   * already installed then it is updated to the latest version if necessary. This
+   * method supports patch semantics. (installs.patch)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param string $deviceId The Android ID of the device.
+   * @param string $installId The ID of the product represented by the install,
+   * e.g. "app:com.google.android.gm".
+   * @param Google_Install $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_Install
+   */
+  public function patch($enterpriseId, $userId, $deviceId, $installId, Google_Service_AndroidEnterprise_Install $postBody, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId, 'deviceId' => $deviceId, 'installId' => $installId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_AndroidEnterprise_Install");
+  }
+
+  /**
+   * Requests to install the latest version of an app to a device. If the app is
+   * already installed then it is updated to the latest version if necessary.
+   * (installs.update)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param string $deviceId The Android ID of the device.
+   * @param string $installId The ID of the product represented by the install,
+   * e.g. "app:com.google.android.gm".
+   * @param Google_Install $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_Install
+   */
+  public function update($enterpriseId, $userId, $deviceId, $installId, Google_Service_AndroidEnterprise_Install $postBody, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId, 'deviceId' => $deviceId, 'installId' => $installId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AndroidEnterprise_Install");
+  }
+}
+
+/**
+ * The "permissions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidenterpriseService = new Google_Service_AndroidEnterprise(...);
+ *   $permissions = $androidenterpriseService->permissions;
+ *  </code>
+ */
+class Google_Service_AndroidEnterprise_Permissions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves details of an Android app permission for display to an enterprise
+   * admin. (permissions.get)
+   *
+   * @param string $permissionId The ID of the permission.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The BCP47 tag for the user's preferred language
+   * (e.g. "en-US", "de")
+   * @return Google_Service_AndroidEnterprise_Permission
+   */
+  public function get($permissionId, $optParams = array())
+  {
+    $params = array('permissionId' => $permissionId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidEnterprise_Permission");
+  }
+}
+
+/**
+ * The "products" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidenterpriseService = new Google_Service_AndroidEnterprise(...);
+ *   $products = $androidenterpriseService->products;
+ *  </code>
+ */
+class Google_Service_AndroidEnterprise_Products_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Approves the specified product (and the relevant app permissions, if any).
+   * (products.approve)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $productId The ID of the product.
+   * @param Google_ProductsApproveRequest $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function approve($enterpriseId, $productId, Google_Service_AndroidEnterprise_ProductsApproveRequest $postBody, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'productId' => $productId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('approve', array($params));
+  }
+
+  /**
+   * Generates a URL that can be rendered in an iframe to display the permissions
+   * (if any) of a product. An enterprise admin must view these permissions and
+   * accept them on behalf of their organization in order to approve that product.
+   *
+   * Admins should accept the displayed permissions by interacting with a separate
+   * UI element in the EMM console, which in turn should trigger the use of this
+   * URL as the approvalUrlInfo.approvalUrl property in a Products.approve call to
+   * approve the product. This URL can only be used to display permissions for up
+   * to 1 day. (products.generateApprovalUrl)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $productId The ID of the product.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string languageCode The BCP 47 language code used for permission
+   * names and descriptions in the returned iframe, for instance "en-US".
+   * @return Google_Service_AndroidEnterprise_ProductsGenerateApprovalUrlResponse
+   */
+  public function generateApprovalUrl($enterpriseId, $productId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'productId' => $productId);
+    $params = array_merge($params, $optParams);
+    return $this->call('generateApprovalUrl', array($params), "Google_Service_AndroidEnterprise_ProductsGenerateApprovalUrlResponse");
+  }
+
+  /**
+   * Retrieves details of a product for display to an enterprise admin.
+   * (products.get)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $productId The ID of the product, e.g.
+   * "app:com.google.android.gm".
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The BCP47 tag for the user's preferred language
+   * (e.g. "en-US", "de").
+   * @return Google_Service_AndroidEnterprise_Product
+   */
+  public function get($enterpriseId, $productId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'productId' => $productId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidEnterprise_Product");
+  }
+
+  /**
+   * Retrieves the schema defining app restrictions configurable for this product.
+   * All products have a schema, but this may be empty if no app restrictions are
+   * defined. (products.getAppRestrictionsSchema)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $productId The ID of the product.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The BCP47 tag for the user's preferred language
+   * (e.g. "en-US", "de").
+   * @return Google_Service_AndroidEnterprise_AppRestrictionsSchema
+   */
+  public function getAppRestrictionsSchema($enterpriseId, $productId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'productId' => $productId);
+    $params = array_merge($params, $optParams);
+    return $this->call('getAppRestrictionsSchema', array($params), "Google_Service_AndroidEnterprise_AppRestrictionsSchema");
+  }
+
+  /**
+   * Retrieves the Android app permissions required by this app.
+   * (products.getPermissions)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $productId The ID of the product.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_ProductPermissions
+   */
+  public function getPermissions($enterpriseId, $productId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'productId' => $productId);
+    $params = array_merge($params, $optParams);
+    return $this->call('getPermissions', array($params), "Google_Service_AndroidEnterprise_ProductPermissions");
+  }
+
+  /**
+   * Updates the set of Android app permissions for this app that have been
+   * accepted by the enterprise. (products.updatePermissions)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $productId The ID of the product.
+   * @param Google_ProductPermissions $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_ProductPermissions
+   */
+  public function updatePermissions($enterpriseId, $productId, Google_Service_AndroidEnterprise_ProductPermissions $postBody, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'productId' => $productId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('updatePermissions', array($params), "Google_Service_AndroidEnterprise_ProductPermissions");
+  }
+}
+
+/**
+ * The "users" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidenterpriseService = new Google_Service_AndroidEnterprise(...);
+ *   $users = $androidenterpriseService->users;
+ *  </code>
+ */
+class Google_Service_AndroidEnterprise_Users_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Generates a token (activation code) to allow this user to configure their
+   * work account in the Android Setup Wizard. Revokes any previously generated
+   * token. (users.generateToken)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_UserToken
+   */
+  public function generateToken($enterpriseId, $userId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('generateToken', array($params), "Google_Service_AndroidEnterprise_UserToken");
+  }
+
+  /**
+   * Retrieves a user's details. (users.get)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_User
+   */
+  public function get($enterpriseId, $userId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidEnterprise_User");
+  }
+
+  /**
+   * Retrieves the set of products a user is entitled to access.
+   * (users.getAvailableProductSet)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_ProductSet
+   */
+  public function getAvailableProductSet($enterpriseId, $userId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('getAvailableProductSet', array($params), "Google_Service_AndroidEnterprise_ProductSet");
+  }
+
+  /**
+   * Looks up a user by email address. (users.listUsers)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $email The exact primary email address of the user to look up.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_UsersListResponse
+   */
+  public function listUsers($enterpriseId, $email, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'email' => $email);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AndroidEnterprise_UsersListResponse");
+  }
+
+  /**
+   * Revokes a previously generated token (activation code) for the user.
+   * (users.revokeToken)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param array $optParams Optional parameters.
+   */
+  public function revokeToken($enterpriseId, $userId, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('revokeToken', array($params));
+  }
+
+  /**
+   * Modifies the set of products a user is entitled to access.
+   * (users.setAvailableProductSet)
+   *
+   * @param string $enterpriseId The ID of the enterprise.
+   * @param string $userId The ID of the user.
+   * @param Google_ProductSet $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidEnterprise_ProductSet
+   */
+  public function setAvailableProductSet($enterpriseId, $userId, Google_Service_AndroidEnterprise_ProductSet $postBody, $optParams = array())
+  {
+    $params = array('enterpriseId' => $enterpriseId, 'userId' => $userId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setAvailableProductSet', array($params), "Google_Service_AndroidEnterprise_ProductSet");
+  }
+}
+
+
+
+
+class Google_Service_AndroidEnterprise_AppRestrictionsSchema extends Google_Collection
+{
+  protected $collection_key = 'restrictions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $restrictionsType = 'Google_Service_AndroidEnterprise_AppRestrictionsSchemaRestriction';
+  protected $restrictionsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRestrictions($restrictions)
+  {
+    $this->restrictions = $restrictions;
+  }
+  public function getRestrictions()
+  {
+    return $this->restrictions;
+  }
+}
+
+class Google_Service_AndroidEnterprise_AppRestrictionsSchemaRestriction extends Google_Collection
+{
+  protected $collection_key = 'entryValue';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $defaultValueType = 'Google_Service_AndroidEnterprise_AppRestrictionsSchemaRestrictionRestrictionValue';
+  protected $defaultValueDataType = '';
+  public $description;
+  public $entry;
+  public $entryValue;
+  public $key;
+  public $restrictionType;
+  public $title;
+
+
+  public function setDefaultValue(Google_Service_AndroidEnterprise_AppRestrictionsSchemaRestrictionRestrictionValue $defaultValue)
+  {
+    $this->defaultValue = $defaultValue;
+  }
+  public function getDefaultValue()
+  {
+    return $this->defaultValue;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEntry($entry)
+  {
+    $this->entry = $entry;
+  }
+  public function getEntry()
+  {
+    return $this->entry;
+  }
+  public function setEntryValue($entryValue)
+  {
+    $this->entryValue = $entryValue;
+  }
+  public function getEntryValue()
+  {
+    return $this->entryValue;
+  }
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setRestrictionType($restrictionType)
+  {
+    $this->restrictionType = $restrictionType;
+  }
+  public function getRestrictionType()
+  {
+    return $this->restrictionType;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_AndroidEnterprise_AppRestrictionsSchemaRestrictionRestrictionValue extends Google_Collection
+{
+  protected $collection_key = 'valueMultiselect';
+  protected $internal_gapi_mappings = array(
+  );
+  public $type;
+  public $valueBool;
+  public $valueInteger;
+  public $valueMultiselect;
+  public $valueString;
+
+
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setValueBool($valueBool)
+  {
+    $this->valueBool = $valueBool;
+  }
+  public function getValueBool()
+  {
+    return $this->valueBool;
+  }
+  public function setValueInteger($valueInteger)
+  {
+    $this->valueInteger = $valueInteger;
+  }
+  public function getValueInteger()
+  {
+    return $this->valueInteger;
+  }
+  public function setValueMultiselect($valueMultiselect)
+  {
+    $this->valueMultiselect = $valueMultiselect;
+  }
+  public function getValueMultiselect()
+  {
+    return $this->valueMultiselect;
+  }
+  public function setValueString($valueString)
+  {
+    $this->valueString = $valueString;
+  }
+  public function getValueString()
+  {
+    return $this->valueString;
+  }
+}
+
+class Google_Service_AndroidEnterprise_AppVersion extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $versionCode;
+  public $versionString;
+
+
+  public function setVersionCode($versionCode)
+  {
+    $this->versionCode = $versionCode;
+  }
+  public function getVersionCode()
+  {
+    return $this->versionCode;
+  }
+  public function setVersionString($versionString)
+  {
+    $this->versionString = $versionString;
+  }
+  public function getVersionString()
+  {
+    return $this->versionString;
+  }
+}
+
+class Google_Service_AndroidEnterprise_ApprovalUrlInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $approvalUrl;
+  public $kind;
+
+
+  public function setApprovalUrl($approvalUrl)
+  {
+    $this->approvalUrl = $approvalUrl;
+  }
+  public function getApprovalUrl()
+  {
+    return $this->approvalUrl;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AndroidEnterprise_Collection extends Google_Collection
+{
+  protected $collection_key = 'productId';
+  protected $internal_gapi_mappings = array(
+  );
+  public $collectionId;
+  public $kind;
+  public $name;
+  public $productId;
+  public $visibility;
+
+
+  public function setCollectionId($collectionId)
+  {
+    $this->collectionId = $collectionId;
+  }
+  public function getCollectionId()
+  {
+    return $this->collectionId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProductId($productId)
+  {
+    $this->productId = $productId;
+  }
+  public function getProductId()
+  {
+    return $this->productId;
+  }
+  public function setVisibility($visibility)
+  {
+    $this->visibility = $visibility;
+  }
+  public function getVisibility()
+  {
+    return $this->visibility;
+  }
+}
+
+class Google_Service_AndroidEnterprise_CollectionViewersListResponse extends Google_Collection
+{
+  protected $collection_key = 'user';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $userType = 'Google_Service_AndroidEnterprise_User';
+  protected $userDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUser($user)
+  {
+    $this->user = $user;
+  }
+  public function getUser()
+  {
+    return $this->user;
+  }
+}
+
+class Google_Service_AndroidEnterprise_CollectionsListResponse extends Google_Collection
+{
+  protected $collection_key = 'collection';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $collectionType = 'Google_Service_AndroidEnterprise_Collection';
+  protected $collectionDataType = 'array';
+  public $kind;
+
+
+  public function setCollection($collection)
+  {
+    $this->collection = $collection;
+  }
+  public function getCollection()
+  {
+    return $this->collection;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AndroidEnterprise_Device extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $androidId;
+  public $kind;
+  public $managementType;
+
+
+  public function setAndroidId($androidId)
+  {
+    $this->androidId = $androidId;
+  }
+  public function getAndroidId()
+  {
+    return $this->androidId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setManagementType($managementType)
+  {
+    $this->managementType = $managementType;
+  }
+  public function getManagementType()
+  {
+    return $this->managementType;
+  }
+}
+
+class Google_Service_AndroidEnterprise_DeviceState extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountState;
+  public $kind;
+
+
+  public function setAccountState($accountState)
+  {
+    $this->accountState = $accountState;
+  }
+  public function getAccountState()
+  {
+    return $this->accountState;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AndroidEnterprise_DevicesListResponse extends Google_Collection
+{
+  protected $collection_key = 'device';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $deviceType = 'Google_Service_AndroidEnterprise_Device';
+  protected $deviceDataType = 'array';
+  public $kind;
+
+
+  public function setDevice($device)
+  {
+    $this->device = $device;
+  }
+  public function getDevice()
+  {
+    return $this->device;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AndroidEnterprise_Enterprise extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $name;
+  public $primaryDomain;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPrimaryDomain($primaryDomain)
+  {
+    $this->primaryDomain = $primaryDomain;
+  }
+  public function getPrimaryDomain()
+  {
+    return $this->primaryDomain;
+  }
+}
+
+class Google_Service_AndroidEnterprise_EnterpriseAccount extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountEmail;
+  public $kind;
+
+
+  public function setAccountEmail($accountEmail)
+  {
+    $this->accountEmail = $accountEmail;
+  }
+  public function getAccountEmail()
+  {
+    return $this->accountEmail;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AndroidEnterprise_EnterprisesListResponse extends Google_Collection
+{
+  protected $collection_key = 'enterprise';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $enterpriseType = 'Google_Service_AndroidEnterprise_Enterprise';
+  protected $enterpriseDataType = 'array';
+  public $kind;
+
+
+  public function setEnterprise($enterprise)
+  {
+    $this->enterprise = $enterprise;
+  }
+  public function getEnterprise()
+  {
+    return $this->enterprise;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AndroidEnterprise_EnterprisesSendTestPushNotificationResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $messageId;
+  public $topicName;
+
+
+  public function setMessageId($messageId)
+  {
+    $this->messageId = $messageId;
+  }
+  public function getMessageId()
+  {
+    return $this->messageId;
+  }
+  public function setTopicName($topicName)
+  {
+    $this->topicName = $topicName;
+  }
+  public function getTopicName()
+  {
+    return $this->topicName;
+  }
+}
+
+class Google_Service_AndroidEnterprise_Entitlement extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $productId;
+  public $reason;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProductId($productId)
+  {
+    $this->productId = $productId;
+  }
+  public function getProductId()
+  {
+    return $this->productId;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+}
+
+class Google_Service_AndroidEnterprise_EntitlementsListResponse extends Google_Collection
+{
+  protected $collection_key = 'entitlement';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entitlementType = 'Google_Service_AndroidEnterprise_Entitlement';
+  protected $entitlementDataType = 'array';
+  public $kind;
+
+
+  public function setEntitlement($entitlement)
+  {
+    $this->entitlement = $entitlement;
+  }
+  public function getEntitlement()
+  {
+    return $this->entitlement;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AndroidEnterprise_GroupLicense extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $acquisitionKind;
+  public $approval;
+  public $kind;
+  public $numProvisioned;
+  public $numPurchased;
+  public $productId;
+
+
+  public function setAcquisitionKind($acquisitionKind)
+  {
+    $this->acquisitionKind = $acquisitionKind;
+  }
+  public function getAcquisitionKind()
+  {
+    return $this->acquisitionKind;
+  }
+  public function setApproval($approval)
+  {
+    $this->approval = $approval;
+  }
+  public function getApproval()
+  {
+    return $this->approval;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNumProvisioned($numProvisioned)
+  {
+    $this->numProvisioned = $numProvisioned;
+  }
+  public function getNumProvisioned()
+  {
+    return $this->numProvisioned;
+  }
+  public function setNumPurchased($numPurchased)
+  {
+    $this->numPurchased = $numPurchased;
+  }
+  public function getNumPurchased()
+  {
+    return $this->numPurchased;
+  }
+  public function setProductId($productId)
+  {
+    $this->productId = $productId;
+  }
+  public function getProductId()
+  {
+    return $this->productId;
+  }
+}
+
+class Google_Service_AndroidEnterprise_GroupLicenseUsersListResponse extends Google_Collection
+{
+  protected $collection_key = 'user';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $userType = 'Google_Service_AndroidEnterprise_User';
+  protected $userDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUser($user)
+  {
+    $this->user = $user;
+  }
+  public function getUser()
+  {
+    return $this->user;
+  }
+}
+
+class Google_Service_AndroidEnterprise_GroupLicensesListResponse extends Google_Collection
+{
+  protected $collection_key = 'groupLicense';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $groupLicenseType = 'Google_Service_AndroidEnterprise_GroupLicense';
+  protected $groupLicenseDataType = 'array';
+  public $kind;
+
+
+  public function setGroupLicense($groupLicense)
+  {
+    $this->groupLicense = $groupLicense;
+  }
+  public function getGroupLicense()
+  {
+    return $this->groupLicense;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AndroidEnterprise_Install extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $installState;
+  public $kind;
+  public $productId;
+  public $versionCode;
+
+
+  public function setInstallState($installState)
+  {
+    $this->installState = $installState;
+  }
+  public function getInstallState()
+  {
+    return $this->installState;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProductId($productId)
+  {
+    $this->productId = $productId;
+  }
+  public function getProductId()
+  {
+    return $this->productId;
+  }
+  public function setVersionCode($versionCode)
+  {
+    $this->versionCode = $versionCode;
+  }
+  public function getVersionCode()
+  {
+    return $this->versionCode;
+  }
+}
+
+class Google_Service_AndroidEnterprise_InstallsListResponse extends Google_Collection
+{
+  protected $collection_key = 'install';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $installType = 'Google_Service_AndroidEnterprise_Install';
+  protected $installDataType = 'array';
+  public $kind;
+
+
+  public function setInstall($install)
+  {
+    $this->install = $install;
+  }
+  public function getInstall()
+  {
+    return $this->install;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AndroidEnterprise_Permission extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $kind;
+  public $name;
+  public $permissionId;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPermissionId($permissionId)
+  {
+    $this->permissionId = $permissionId;
+  }
+  public function getPermissionId()
+  {
+    return $this->permissionId;
+  }
+}
+
+class Google_Service_AndroidEnterprise_Product extends Google_Collection
+{
+  protected $collection_key = 'appVersion';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $appVersionType = 'Google_Service_AndroidEnterprise_AppVersion';
+  protected $appVersionDataType = 'array';
+  public $authorName;
+  public $detailsUrl;
+  public $distributionChannel;
+  public $iconUrl;
+  public $kind;
+  public $productId;
+  public $requiresContainerApp;
+  public $title;
+  public $workDetailsUrl;
+
+
+  public function setAppVersion($appVersion)
+  {
+    $this->appVersion = $appVersion;
+  }
+  public function getAppVersion()
+  {
+    return $this->appVersion;
+  }
+  public function setAuthorName($authorName)
+  {
+    $this->authorName = $authorName;
+  }
+  public function getAuthorName()
+  {
+    return $this->authorName;
+  }
+  public function setDetailsUrl($detailsUrl)
+  {
+    $this->detailsUrl = $detailsUrl;
+  }
+  public function getDetailsUrl()
+  {
+    return $this->detailsUrl;
+  }
+  public function setDistributionChannel($distributionChannel)
+  {
+    $this->distributionChannel = $distributionChannel;
+  }
+  public function getDistributionChannel()
+  {
+    return $this->distributionChannel;
+  }
+  public function setIconUrl($iconUrl)
+  {
+    $this->iconUrl = $iconUrl;
+  }
+  public function getIconUrl()
+  {
+    return $this->iconUrl;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProductId($productId)
+  {
+    $this->productId = $productId;
+  }
+  public function getProductId()
+  {
+    return $this->productId;
+  }
+  public function setRequiresContainerApp($requiresContainerApp)
+  {
+    $this->requiresContainerApp = $requiresContainerApp;
+  }
+  public function getRequiresContainerApp()
+  {
+    return $this->requiresContainerApp;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setWorkDetailsUrl($workDetailsUrl)
+  {
+    $this->workDetailsUrl = $workDetailsUrl;
+  }
+  public function getWorkDetailsUrl()
+  {
+    return $this->workDetailsUrl;
+  }
+}
+
+class Google_Service_AndroidEnterprise_ProductPermission extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $permissionId;
+  public $state;
+
+
+  public function setPermissionId($permissionId)
+  {
+    $this->permissionId = $permissionId;
+  }
+  public function getPermissionId()
+  {
+    return $this->permissionId;
+  }
+  public function setState($state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+}
+
+class Google_Service_AndroidEnterprise_ProductPermissions extends Google_Collection
+{
+  protected $collection_key = 'permission';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $permissionType = 'Google_Service_AndroidEnterprise_ProductPermission';
+  protected $permissionDataType = 'array';
+  public $productId;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPermission($permission)
+  {
+    $this->permission = $permission;
+  }
+  public function getPermission()
+  {
+    return $this->permission;
+  }
+  public function setProductId($productId)
+  {
+    $this->productId = $productId;
+  }
+  public function getProductId()
+  {
+    return $this->productId;
+  }
+}
+
+class Google_Service_AndroidEnterprise_ProductSet extends Google_Collection
+{
+  protected $collection_key = 'productId';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $productId;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProductId($productId)
+  {
+    $this->productId = $productId;
+  }
+  public function getProductId()
+  {
+    return $this->productId;
+  }
+}
+
+class Google_Service_AndroidEnterprise_ProductsApproveRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $approvalUrlInfoType = 'Google_Service_AndroidEnterprise_ApprovalUrlInfo';
+  protected $approvalUrlInfoDataType = '';
+
+
+  public function setApprovalUrlInfo(Google_Service_AndroidEnterprise_ApprovalUrlInfo $approvalUrlInfo)
+  {
+    $this->approvalUrlInfo = $approvalUrlInfo;
+  }
+  public function getApprovalUrlInfo()
+  {
+    return $this->approvalUrlInfo;
+  }
+}
+
+class Google_Service_AndroidEnterprise_ProductsGenerateApprovalUrlResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $url;
+
+
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_AndroidEnterprise_User extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $primaryEmail;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPrimaryEmail($primaryEmail)
+  {
+    $this->primaryEmail = $primaryEmail;
+  }
+  public function getPrimaryEmail()
+  {
+    return $this->primaryEmail;
+  }
+}
+
+class Google_Service_AndroidEnterprise_UserToken extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $token;
+  public $userId;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setToken($token)
+  {
+    $this->token = $token;
+  }
+  public function getToken()
+  {
+    return $this->token;
+  }
+  public function setUserId($userId)
+  {
+    $this->userId = $userId;
+  }
+  public function getUserId()
+  {
+    return $this->userId;
+  }
+}
+
+class Google_Service_AndroidEnterprise_UsersListResponse extends Google_Collection
+{
+  protected $collection_key = 'user';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $userType = 'Google_Service_AndroidEnterprise_User';
+  protected $userDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUser($user)
+  {
+    $this->user = $user;
+  }
+  public function getUser()
+  {
+    return $this->user;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/AndroidPublisher.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/AndroidPublisher.php
@@ -1,0 +1,3842 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for AndroidPublisher (v2).
+ *
+ * <p>
+ * Lets Android application developers access their Google Play accounts.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/android-publisher" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_AndroidPublisher extends Google_Service
+{
+  /** View and manage your Google Play Developer account. */
+  const ANDROIDPUBLISHER =
+      "https://www.googleapis.com/auth/androidpublisher";
+
+  public $edits;
+  public $edits_apklistings;
+  public $edits_apks;
+  public $edits_details;
+  public $edits_expansionfiles;
+  public $edits_images;
+  public $edits_listings;
+  public $edits_testers;
+  public $edits_tracks;
+  public $entitlements;
+  public $inappproducts;
+  public $purchases_products;
+  public $purchases_subscriptions;
+  
+
+  /**
+   * Constructs the internal representation of the AndroidPublisher service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'androidpublisher/v2/applications/';
+    $this->version = 'v2';
+    $this->serviceName = 'androidpublisher';
+
+    $this->edits = new Google_Service_AndroidPublisher_Edits_Resource(
+        $this,
+        $this->serviceName,
+        'edits',
+        array(
+          'methods' => array(
+            'commit' => array(
+              'path' => '{packageName}/edits/{editId}:commit',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{packageName}/edits/{editId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{packageName}/edits/{editId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{packageName}/edits',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'validate' => array(
+              'path' => '{packageName}/edits/{editId}:validate',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->edits_apklistings = new Google_Service_AndroidPublisher_EditsApklistings_Resource(
+        $this,
+        $this->serviceName,
+        'apklistings',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{packageName}/edits/{editId}/apks/{apkVersionCode}/listings/{language}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'apkVersionCode' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'deleteall' => array(
+              'path' => '{packageName}/edits/{editId}/apks/{apkVersionCode}/listings',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'apkVersionCode' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{packageName}/edits/{editId}/apks/{apkVersionCode}/listings/{language}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'apkVersionCode' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{packageName}/edits/{editId}/apks/{apkVersionCode}/listings',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'apkVersionCode' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{packageName}/edits/{editId}/apks/{apkVersionCode}/listings/{language}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'apkVersionCode' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{packageName}/edits/{editId}/apks/{apkVersionCode}/listings/{language}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'apkVersionCode' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->edits_apks = new Google_Service_AndroidPublisher_EditsApks_Resource(
+        $this,
+        $this->serviceName,
+        'apks',
+        array(
+          'methods' => array(
+            'addexternallyhosted' => array(
+              'path' => '{packageName}/edits/{editId}/apks/externallyHosted',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{packageName}/edits/{editId}/apks',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'upload' => array(
+              'path' => '{packageName}/edits/{editId}/apks',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->edits_details = new Google_Service_AndroidPublisher_EditsDetails_Resource(
+        $this,
+        $this->serviceName,
+        'details',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{packageName}/edits/{editId}/details',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{packageName}/edits/{editId}/details',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{packageName}/edits/{editId}/details',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->edits_expansionfiles = new Google_Service_AndroidPublisher_EditsExpansionfiles_Resource(
+        $this,
+        $this->serviceName,
+        'expansionfiles',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{packageName}/edits/{editId}/apks/{apkVersionCode}/expansionFiles/{expansionFileType}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'apkVersionCode' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'expansionFileType' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{packageName}/edits/{editId}/apks/{apkVersionCode}/expansionFiles/{expansionFileType}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'apkVersionCode' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'expansionFileType' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{packageName}/edits/{editId}/apks/{apkVersionCode}/expansionFiles/{expansionFileType}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'apkVersionCode' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'expansionFileType' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'upload' => array(
+              'path' => '{packageName}/edits/{editId}/apks/{apkVersionCode}/expansionFiles/{expansionFileType}',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'apkVersionCode' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'expansionFileType' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->edits_images = new Google_Service_AndroidPublisher_EditsImages_Resource(
+        $this,
+        $this->serviceName,
+        'images',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{packageName}/edits/{editId}/listings/{language}/{imageType}/{imageId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'imageType' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'imageId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'deleteall' => array(
+              'path' => '{packageName}/edits/{editId}/listings/{language}/{imageType}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'imageType' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{packageName}/edits/{editId}/listings/{language}/{imageType}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'imageType' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'upload' => array(
+              'path' => '{packageName}/edits/{editId}/listings/{language}/{imageType}',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'imageType' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->edits_listings = new Google_Service_AndroidPublisher_EditsListings_Resource(
+        $this,
+        $this->serviceName,
+        'listings',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{packageName}/edits/{editId}/listings/{language}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'deleteall' => array(
+              'path' => '{packageName}/edits/{editId}/listings',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{packageName}/edits/{editId}/listings/{language}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{packageName}/edits/{editId}/listings',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{packageName}/edits/{editId}/listings/{language}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{packageName}/edits/{editId}/listings/{language}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->edits_testers = new Google_Service_AndroidPublisher_EditsTesters_Resource(
+        $this,
+        $this->serviceName,
+        'testers',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{packageName}/edits/{editId}/testers/{track}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'track' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{packageName}/edits/{editId}/testers/{track}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'track' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{packageName}/edits/{editId}/testers/{track}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'track' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->edits_tracks = new Google_Service_AndroidPublisher_EditsTracks_Resource(
+        $this,
+        $this->serviceName,
+        'tracks',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{packageName}/edits/{editId}/tracks/{track}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'track' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{packageName}/edits/{editId}/tracks',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{packageName}/edits/{editId}/tracks/{track}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'track' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{packageName}/edits/{editId}/tracks/{track}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'editId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'track' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->entitlements = new Google_Service_AndroidPublisher_Entitlements_Resource(
+        $this,
+        $this->serviceName,
+        'entitlements',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => '{packageName}/entitlements',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'token' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startIndex' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'productId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->inappproducts = new Google_Service_AndroidPublisher_Inappproducts_Resource(
+        $this,
+        $this->serviceName,
+        'inappproducts',
+        array(
+          'methods' => array(
+            'batch' => array(
+              'path' => 'inappproducts/batch',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'delete' => array(
+              'path' => '{packageName}/inappproducts/{sku}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sku' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{packageName}/inappproducts/{sku}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sku' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{packageName}/inappproducts',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'autoConvertMissingPrices' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{packageName}/inappproducts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'token' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startIndex' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{packageName}/inappproducts/{sku}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sku' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'autoConvertMissingPrices' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{packageName}/inappproducts/{sku}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sku' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'autoConvertMissingPrices' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->purchases_products = new Google_Service_AndroidPublisher_PurchasesProducts_Resource(
+        $this,
+        $this->serviceName,
+        'products',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{packageName}/purchases/products/{productId}/tokens/{token}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'productId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'token' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->purchases_subscriptions = new Google_Service_AndroidPublisher_PurchasesSubscriptions_Resource(
+        $this,
+        $this->serviceName,
+        'subscriptions',
+        array(
+          'methods' => array(
+            'cancel' => array(
+              'path' => '{packageName}/purchases/subscriptions/{subscriptionId}/tokens/{token}:cancel',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'subscriptionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'token' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'defer' => array(
+              'path' => '{packageName}/purchases/subscriptions/{subscriptionId}/tokens/{token}:defer',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'subscriptionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'token' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{packageName}/purchases/subscriptions/{subscriptionId}/tokens/{token}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'subscriptionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'token' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'refund' => array(
+              'path' => '{packageName}/purchases/subscriptions/{subscriptionId}/tokens/{token}:refund',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'subscriptionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'token' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'revoke' => array(
+              'path' => '{packageName}/purchases/subscriptions/{subscriptionId}/tokens/{token}:revoke',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'packageName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'subscriptionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'token' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "edits" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidpublisherService = new Google_Service_AndroidPublisher(...);
+ *   $edits = $androidpublisherService->edits;
+ *  </code>
+ */
+class Google_Service_AndroidPublisher_Edits_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Commits/applies the changes made in this edit back to the app. (edits.commit)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_AppEdit
+   */
+  public function commit($packageName, $editId, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId);
+    $params = array_merge($params, $optParams);
+    return $this->call('commit', array($params), "Google_Service_AndroidPublisher_AppEdit");
+  }
+
+  /**
+   * Deletes an edit for an app. Creating a new edit will automatically delete any
+   * of your previous edits so this method need only be called if you want to
+   * preemptively abandon an edit. (edits.delete)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($packageName, $editId, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Returns information about the edit specified. Calls will fail if the edit is
+   * no long active (e.g. has been deleted, superseded or expired). (edits.get)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_AppEdit
+   */
+  public function get($packageName, $editId, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidPublisher_AppEdit");
+  }
+
+  /**
+   * Creates a new edit for an app, populated with the app's current state.
+   * (edits.insert)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param Google_AppEdit $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_AppEdit
+   */
+  public function insert($packageName, Google_Service_AndroidPublisher_AppEdit $postBody, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_AndroidPublisher_AppEdit");
+  }
+
+  /**
+   * Checks that the edit can be successfully committed. The edit's changes are
+   * not applied to the live app. (edits.validate)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_AppEdit
+   */
+  public function validate($packageName, $editId, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId);
+    $params = array_merge($params, $optParams);
+    return $this->call('validate', array($params), "Google_Service_AndroidPublisher_AppEdit");
+  }
+}
+
+/**
+ * The "apklistings" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidpublisherService = new Google_Service_AndroidPublisher(...);
+ *   $apklistings = $androidpublisherService->apklistings;
+ *  </code>
+ */
+class Google_Service_AndroidPublisher_EditsApklistings_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the APK-specific localized listing for a specified APK and language
+   * code. (apklistings.delete)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param int $apkVersionCode The APK version code whose APK-specific listings
+   * should be read or modified.
+   * @param string $language The language code (a BCP-47 language tag) of the APK-
+   * specific localized listing to read or modify. For example, to select Austrian
+   * German, pass "de-AT".
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($packageName, $editId, $apkVersionCode, $language, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'apkVersionCode' => $apkVersionCode, 'language' => $language);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Deletes all the APK-specific localized listings for a specified APK.
+   * (apklistings.deleteall)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param int $apkVersionCode The APK version code whose APK-specific listings
+   * should be read or modified.
+   * @param array $optParams Optional parameters.
+   */
+  public function deleteall($packageName, $editId, $apkVersionCode, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'apkVersionCode' => $apkVersionCode);
+    $params = array_merge($params, $optParams);
+    return $this->call('deleteall', array($params));
+  }
+
+  /**
+   * Fetches the APK-specific localized listing for a specified APK and language
+   * code. (apklistings.get)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param int $apkVersionCode The APK version code whose APK-specific listings
+   * should be read or modified.
+   * @param string $language The language code (a BCP-47 language tag) of the APK-
+   * specific localized listing to read or modify. For example, to select Austrian
+   * German, pass "de-AT".
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_ApkListing
+   */
+  public function get($packageName, $editId, $apkVersionCode, $language, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'apkVersionCode' => $apkVersionCode, 'language' => $language);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidPublisher_ApkListing");
+  }
+
+  /**
+   * Lists all the APK-specific localized listings for a specified APK.
+   * (apklistings.listEditsApklistings)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param int $apkVersionCode The APK version code whose APK-specific listings
+   * should be read or modified.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_ApkListingsListResponse
+   */
+  public function listEditsApklistings($packageName, $editId, $apkVersionCode, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'apkVersionCode' => $apkVersionCode);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AndroidPublisher_ApkListingsListResponse");
+  }
+
+  /**
+   * Updates or creates the APK-specific localized listing for a specified APK and
+   * language code. This method supports patch semantics. (apklistings.patch)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param int $apkVersionCode The APK version code whose APK-specific listings
+   * should be read or modified.
+   * @param string $language The language code (a BCP-47 language tag) of the APK-
+   * specific localized listing to read or modify. For example, to select Austrian
+   * German, pass "de-AT".
+   * @param Google_ApkListing $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_ApkListing
+   */
+  public function patch($packageName, $editId, $apkVersionCode, $language, Google_Service_AndroidPublisher_ApkListing $postBody, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'apkVersionCode' => $apkVersionCode, 'language' => $language, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_AndroidPublisher_ApkListing");
+  }
+
+  /**
+   * Updates or creates the APK-specific localized listing for a specified APK and
+   * language code. (apklistings.update)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param int $apkVersionCode The APK version code whose APK-specific listings
+   * should be read or modified.
+   * @param string $language The language code (a BCP-47 language tag) of the APK-
+   * specific localized listing to read or modify. For example, to select Austrian
+   * German, pass "de-AT".
+   * @param Google_ApkListing $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_ApkListing
+   */
+  public function update($packageName, $editId, $apkVersionCode, $language, Google_Service_AndroidPublisher_ApkListing $postBody, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'apkVersionCode' => $apkVersionCode, 'language' => $language, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AndroidPublisher_ApkListing");
+  }
+}
+/**
+ * The "apks" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidpublisherService = new Google_Service_AndroidPublisher(...);
+ *   $apks = $androidpublisherService->apks;
+ *  </code>
+ */
+class Google_Service_AndroidPublisher_EditsApks_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a new APK without uploading the APK itself to Google Play, instead
+   * hosting the APK at a specified URL. This function is only available to
+   * enterprises using Google Play for Work whose application is configured to
+   * restrict distribution to the enterprise domain. (apks.addexternallyhosted)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param Google_ApksAddExternallyHostedRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_ApksAddExternallyHostedResponse
+   */
+  public function addexternallyhosted($packageName, $editId, Google_Service_AndroidPublisher_ApksAddExternallyHostedRequest $postBody, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('addexternallyhosted', array($params), "Google_Service_AndroidPublisher_ApksAddExternallyHostedResponse");
+  }
+
+  /**
+   * (apks.listEditsApks)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_ApksListResponse
+   */
+  public function listEditsApks($packageName, $editId, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AndroidPublisher_ApksListResponse");
+  }
+
+  /**
+   * (apks.upload)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_Apk
+   */
+  public function upload($packageName, $editId, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId);
+    $params = array_merge($params, $optParams);
+    return $this->call('upload', array($params), "Google_Service_AndroidPublisher_Apk");
+  }
+}
+/**
+ * The "details" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidpublisherService = new Google_Service_AndroidPublisher(...);
+ *   $details = $androidpublisherService->details;
+ *  </code>
+ */
+class Google_Service_AndroidPublisher_EditsDetails_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Fetches app details for this edit. This includes the default language and
+   * developer support contact information. (details.get)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_AppDetails
+   */
+  public function get($packageName, $editId, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidPublisher_AppDetails");
+  }
+
+  /**
+   * Updates app details for this edit. This method supports patch semantics.
+   * (details.patch)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param Google_AppDetails $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_AppDetails
+   */
+  public function patch($packageName, $editId, Google_Service_AndroidPublisher_AppDetails $postBody, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_AndroidPublisher_AppDetails");
+  }
+
+  /**
+   * Updates app details for this edit. (details.update)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param Google_AppDetails $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_AppDetails
+   */
+  public function update($packageName, $editId, Google_Service_AndroidPublisher_AppDetails $postBody, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AndroidPublisher_AppDetails");
+  }
+}
+/**
+ * The "expansionfiles" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidpublisherService = new Google_Service_AndroidPublisher(...);
+ *   $expansionfiles = $androidpublisherService->expansionfiles;
+ *  </code>
+ */
+class Google_Service_AndroidPublisher_EditsExpansionfiles_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Fetches the Expansion File configuration for the APK specified.
+   * (expansionfiles.get)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param int $apkVersionCode The version code of the APK whose Expansion File
+   * configuration is being read or modified.
+   * @param string $expansionFileType
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_ExpansionFile
+   */
+  public function get($packageName, $editId, $apkVersionCode, $expansionFileType, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'apkVersionCode' => $apkVersionCode, 'expansionFileType' => $expansionFileType);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidPublisher_ExpansionFile");
+  }
+
+  /**
+   * Updates the APK's Expansion File configuration to reference another APK's
+   * Expansion Files. To add a new Expansion File use the Upload method. This
+   * method supports patch semantics. (expansionfiles.patch)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param int $apkVersionCode The version code of the APK whose Expansion File
+   * configuration is being read or modified.
+   * @param string $expansionFileType
+   * @param Google_ExpansionFile $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_ExpansionFile
+   */
+  public function patch($packageName, $editId, $apkVersionCode, $expansionFileType, Google_Service_AndroidPublisher_ExpansionFile $postBody, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'apkVersionCode' => $apkVersionCode, 'expansionFileType' => $expansionFileType, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_AndroidPublisher_ExpansionFile");
+  }
+
+  /**
+   * Updates the APK's Expansion File configuration to reference another APK's
+   * Expansion Files. To add a new Expansion File use the Upload method.
+   * (expansionfiles.update)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param int $apkVersionCode The version code of the APK whose Expansion File
+   * configuration is being read or modified.
+   * @param string $expansionFileType
+   * @param Google_ExpansionFile $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_ExpansionFile
+   */
+  public function update($packageName, $editId, $apkVersionCode, $expansionFileType, Google_Service_AndroidPublisher_ExpansionFile $postBody, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'apkVersionCode' => $apkVersionCode, 'expansionFileType' => $expansionFileType, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AndroidPublisher_ExpansionFile");
+  }
+
+  /**
+   * Uploads and attaches a new Expansion File to the APK specified.
+   * (expansionfiles.upload)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param int $apkVersionCode The version code of the APK whose Expansion File
+   * configuration is being read or modified.
+   * @param string $expansionFileType
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_ExpansionFilesUploadResponse
+   */
+  public function upload($packageName, $editId, $apkVersionCode, $expansionFileType, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'apkVersionCode' => $apkVersionCode, 'expansionFileType' => $expansionFileType);
+    $params = array_merge($params, $optParams);
+    return $this->call('upload', array($params), "Google_Service_AndroidPublisher_ExpansionFilesUploadResponse");
+  }
+}
+/**
+ * The "images" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidpublisherService = new Google_Service_AndroidPublisher(...);
+ *   $images = $androidpublisherService->images;
+ *  </code>
+ */
+class Google_Service_AndroidPublisher_EditsImages_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the image (specified by id) from the edit. (images.delete)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param string $language The language code (a BCP-47 language tag) of the
+   * localized listing whose images are to read or modified. For example, to
+   * select Austrian German, pass "de-AT".
+   * @param string $imageType
+   * @param string $imageId Unique identifier an image within the set of images
+   * attached to this edit.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($packageName, $editId, $language, $imageType, $imageId, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'language' => $language, 'imageType' => $imageType, 'imageId' => $imageId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Deletes all images for the specified language and image type.
+   * (images.deleteall)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param string $language The language code (a BCP-47 language tag) of the
+   * localized listing whose images are to read or modified. For example, to
+   * select Austrian German, pass "de-AT".
+   * @param string $imageType
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_ImagesDeleteAllResponse
+   */
+  public function deleteall($packageName, $editId, $language, $imageType, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'language' => $language, 'imageType' => $imageType);
+    $params = array_merge($params, $optParams);
+    return $this->call('deleteall', array($params), "Google_Service_AndroidPublisher_ImagesDeleteAllResponse");
+  }
+
+  /**
+   * Lists all images for the specified language and image type.
+   * (images.listEditsImages)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param string $language The language code (a BCP-47 language tag) of the
+   * localized listing whose images are to read or modified. For example, to
+   * select Austrian German, pass "de-AT".
+   * @param string $imageType
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_ImagesListResponse
+   */
+  public function listEditsImages($packageName, $editId, $language, $imageType, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'language' => $language, 'imageType' => $imageType);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AndroidPublisher_ImagesListResponse");
+  }
+
+  /**
+   * Uploads a new image and adds it to the list of images for the specified
+   * language and image type. (images.upload)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param string $language The language code (a BCP-47 language tag) of the
+   * localized listing whose images are to read or modified. For example, to
+   * select Austrian German, pass "de-AT".
+   * @param string $imageType
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_ImagesUploadResponse
+   */
+  public function upload($packageName, $editId, $language, $imageType, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'language' => $language, 'imageType' => $imageType);
+    $params = array_merge($params, $optParams);
+    return $this->call('upload', array($params), "Google_Service_AndroidPublisher_ImagesUploadResponse");
+  }
+}
+/**
+ * The "listings" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidpublisherService = new Google_Service_AndroidPublisher(...);
+ *   $listings = $androidpublisherService->listings;
+ *  </code>
+ */
+class Google_Service_AndroidPublisher_EditsListings_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified localized store listing from an edit. (listings.delete)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param string $language The language code (a BCP-47 language tag) of the
+   * localized listing to read or modify. For example, to select Austrian German,
+   * pass "de-AT".
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($packageName, $editId, $language, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'language' => $language);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Deletes all localized listings from an edit. (listings.deleteall)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param array $optParams Optional parameters.
+   */
+  public function deleteall($packageName, $editId, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId);
+    $params = array_merge($params, $optParams);
+    return $this->call('deleteall', array($params));
+  }
+
+  /**
+   * Fetches information about a localized store listing. (listings.get)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param string $language The language code (a BCP-47 language tag) of the
+   * localized listing to read or modify. For example, to select Austrian German,
+   * pass "de-AT".
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_Listing
+   */
+  public function get($packageName, $editId, $language, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'language' => $language);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidPublisher_Listing");
+  }
+
+  /**
+   * Returns all of the localized store listings attached to this edit.
+   * (listings.listEditsListings)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_ListingsListResponse
+   */
+  public function listEditsListings($packageName, $editId, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AndroidPublisher_ListingsListResponse");
+  }
+
+  /**
+   * Creates or updates a localized store listing. This method supports patch
+   * semantics. (listings.patch)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param string $language The language code (a BCP-47 language tag) of the
+   * localized listing to read or modify. For example, to select Austrian German,
+   * pass "de-AT".
+   * @param Google_Listing $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_Listing
+   */
+  public function patch($packageName, $editId, $language, Google_Service_AndroidPublisher_Listing $postBody, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'language' => $language, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_AndroidPublisher_Listing");
+  }
+
+  /**
+   * Creates or updates a localized store listing. (listings.update)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param string $language The language code (a BCP-47 language tag) of the
+   * localized listing to read or modify. For example, to select Austrian German,
+   * pass "de-AT".
+   * @param Google_Listing $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_Listing
+   */
+  public function update($packageName, $editId, $language, Google_Service_AndroidPublisher_Listing $postBody, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'language' => $language, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AndroidPublisher_Listing");
+  }
+}
+/**
+ * The "testers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidpublisherService = new Google_Service_AndroidPublisher(...);
+ *   $testers = $androidpublisherService->testers;
+ *  </code>
+ */
+class Google_Service_AndroidPublisher_EditsTesters_Resource extends Google_Service_Resource
+{
+
+  /**
+   * (testers.get)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param string $track
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_Testers
+   */
+  public function get($packageName, $editId, $track, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'track' => $track);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidPublisher_Testers");
+  }
+
+  /**
+   * (testers.patch)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param string $track
+   * @param Google_Testers $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_Testers
+   */
+  public function patch($packageName, $editId, $track, Google_Service_AndroidPublisher_Testers $postBody, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'track' => $track, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_AndroidPublisher_Testers");
+  }
+
+  /**
+   * (testers.update)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param string $track
+   * @param Google_Testers $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_Testers
+   */
+  public function update($packageName, $editId, $track, Google_Service_AndroidPublisher_Testers $postBody, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'track' => $track, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AndroidPublisher_Testers");
+  }
+}
+/**
+ * The "tracks" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidpublisherService = new Google_Service_AndroidPublisher(...);
+ *   $tracks = $androidpublisherService->tracks;
+ *  </code>
+ */
+class Google_Service_AndroidPublisher_EditsTracks_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Fetches the track configuration for the specified track type. Includes the
+   * APK version codes that are in this track. (tracks.get)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param string $track The track type to read or modify.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_Track
+   */
+  public function get($packageName, $editId, $track, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'track' => $track);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidPublisher_Track");
+  }
+
+  /**
+   * Lists all the track configurations for this edit. (tracks.listEditsTracks)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_TracksListResponse
+   */
+  public function listEditsTracks($packageName, $editId, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AndroidPublisher_TracksListResponse");
+  }
+
+  /**
+   * Updates the track configuration for the specified track type. When halted,
+   * the rollout track cannot be updated without adding new APKs, and adding new
+   * APKs will cause it to resume. This method supports patch semantics.
+   * (tracks.patch)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param string $track The track type to read or modify.
+   * @param Google_Track $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_Track
+   */
+  public function patch($packageName, $editId, $track, Google_Service_AndroidPublisher_Track $postBody, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'track' => $track, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_AndroidPublisher_Track");
+  }
+
+  /**
+   * Updates the track configuration for the specified track type. When halted,
+   * the rollout track cannot be updated without adding new APKs, and adding new
+   * APKs will cause it to resume. (tracks.update)
+   *
+   * @param string $packageName Unique identifier for the Android app that is
+   * being updated; for example, "com.spiffygame".
+   * @param string $editId Unique identifier for this edit.
+   * @param string $track The track type to read or modify.
+   * @param Google_Track $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_Track
+   */
+  public function update($packageName, $editId, $track, Google_Service_AndroidPublisher_Track $postBody, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'editId' => $editId, 'track' => $track, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AndroidPublisher_Track");
+  }
+}
+
+/**
+ * The "entitlements" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidpublisherService = new Google_Service_AndroidPublisher(...);
+ *   $entitlements = $androidpublisherService->entitlements;
+ *  </code>
+ */
+class Google_Service_AndroidPublisher_Entitlements_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Lists the user's current inapp item or subscription entitlements
+   * (entitlements.listEntitlements)
+   *
+   * @param string $packageName The package name of the application the inapp
+   * product was sold in (for example, 'com.some.thing').
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string token
+   * @opt_param string startIndex
+   * @opt_param string maxResults
+   * @opt_param string productId The product id of the inapp product (for example,
+   * 'sku1'). This can be used to restrict the result set.
+   * @return Google_Service_AndroidPublisher_EntitlementsListResponse
+   */
+  public function listEntitlements($packageName, $optParams = array())
+  {
+    $params = array('packageName' => $packageName);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AndroidPublisher_EntitlementsListResponse");
+  }
+}
+
+/**
+ * The "inappproducts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidpublisherService = new Google_Service_AndroidPublisher(...);
+ *   $inappproducts = $androidpublisherService->inappproducts;
+ *  </code>
+ */
+class Google_Service_AndroidPublisher_Inappproducts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * (inappproducts.batch)
+   *
+   * @param Google_InappproductsBatchRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_InappproductsBatchResponse
+   */
+  public function batch(Google_Service_AndroidPublisher_InappproductsBatchRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('batch', array($params), "Google_Service_AndroidPublisher_InappproductsBatchResponse");
+  }
+
+  /**
+   * Delete an in-app product for an app. (inappproducts.delete)
+   *
+   * @param string $packageName Unique identifier for the Android app with the in-
+   * app product; for example, "com.spiffygame".
+   * @param string $sku Unique identifier for the in-app product.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($packageName, $sku, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'sku' => $sku);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Returns information about the in-app product specified. (inappproducts.get)
+   *
+   * @param string $packageName
+   * @param string $sku Unique identifier for the in-app product.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_InAppProduct
+   */
+  public function get($packageName, $sku, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'sku' => $sku);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidPublisher_InAppProduct");
+  }
+
+  /**
+   * Creates a new in-app product for an app. (inappproducts.insert)
+   *
+   * @param string $packageName Unique identifier for the Android app; for
+   * example, "com.spiffygame".
+   * @param Google_InAppProduct $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool autoConvertMissingPrices If true the prices for all regions
+   * targeted by the parent app that don't have a price specified for this in-app
+   * product will be auto converted to the target currency based on the default
+   * price. Defaults to false.
+   * @return Google_Service_AndroidPublisher_InAppProduct
+   */
+  public function insert($packageName, Google_Service_AndroidPublisher_InAppProduct $postBody, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_AndroidPublisher_InAppProduct");
+  }
+
+  /**
+   * List all the in-app products for an Android app, both subscriptions and
+   * managed in-app products.. (inappproducts.listInappproducts)
+   *
+   * @param string $packageName Unique identifier for the Android app with in-app
+   * products; for example, "com.spiffygame".
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string token
+   * @opt_param string startIndex
+   * @opt_param string maxResults
+   * @return Google_Service_AndroidPublisher_InappproductsListResponse
+   */
+  public function listInappproducts($packageName, $optParams = array())
+  {
+    $params = array('packageName' => $packageName);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AndroidPublisher_InappproductsListResponse");
+  }
+
+  /**
+   * Updates the details of an in-app product. This method supports patch
+   * semantics. (inappproducts.patch)
+   *
+   * @param string $packageName Unique identifier for the Android app with the in-
+   * app product; for example, "com.spiffygame".
+   * @param string $sku Unique identifier for the in-app product.
+   * @param Google_InAppProduct $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool autoConvertMissingPrices If true the prices for all regions
+   * targeted by the parent app that don't have a price specified for this in-app
+   * product will be auto converted to the target currency based on the default
+   * price. Defaults to false.
+   * @return Google_Service_AndroidPublisher_InAppProduct
+   */
+  public function patch($packageName, $sku, Google_Service_AndroidPublisher_InAppProduct $postBody, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'sku' => $sku, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_AndroidPublisher_InAppProduct");
+  }
+
+  /**
+   * Updates the details of an in-app product. (inappproducts.update)
+   *
+   * @param string $packageName Unique identifier for the Android app with the in-
+   * app product; for example, "com.spiffygame".
+   * @param string $sku Unique identifier for the in-app product.
+   * @param Google_InAppProduct $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool autoConvertMissingPrices If true the prices for all regions
+   * targeted by the parent app that don't have a price specified for this in-app
+   * product will be auto converted to the target currency based on the default
+   * price. Defaults to false.
+   * @return Google_Service_AndroidPublisher_InAppProduct
+   */
+  public function update($packageName, $sku, Google_Service_AndroidPublisher_InAppProduct $postBody, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'sku' => $sku, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AndroidPublisher_InAppProduct");
+  }
+}
+
+/**
+ * The "purchases" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidpublisherService = new Google_Service_AndroidPublisher(...);
+ *   $purchases = $androidpublisherService->purchases;
+ *  </code>
+ */
+class Google_Service_AndroidPublisher_Purchases_Resource extends Google_Service_Resource
+{
+}
+
+/**
+ * The "products" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidpublisherService = new Google_Service_AndroidPublisher(...);
+ *   $products = $androidpublisherService->products;
+ *  </code>
+ */
+class Google_Service_AndroidPublisher_PurchasesProducts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Checks the purchase and consumption status of an inapp item. (products.get)
+   *
+   * @param string $packageName The package name of the application the inapp
+   * product was sold in (for example, 'com.some.thing').
+   * @param string $productId The inapp product SKU (for example,
+   * 'com.some.thing.inapp1').
+   * @param string $token The token provided to the user's device when the inapp
+   * product was purchased.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_ProductPurchase
+   */
+  public function get($packageName, $productId, $token, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'productId' => $productId, 'token' => $token);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidPublisher_ProductPurchase");
+  }
+}
+/**
+ * The "subscriptions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $androidpublisherService = new Google_Service_AndroidPublisher(...);
+ *   $subscriptions = $androidpublisherService->subscriptions;
+ *  </code>
+ */
+class Google_Service_AndroidPublisher_PurchasesSubscriptions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Cancels a user's subscription purchase. The subscription remains valid until
+   * its expiration time. (subscriptions.cancel)
+   *
+   * @param string $packageName The package name of the application for which this
+   * subscription was purchased (for example, 'com.some.thing').
+   * @param string $subscriptionId The purchased subscription ID (for example,
+   * 'monthly001').
+   * @param string $token The token provided to the user's device when the
+   * subscription was purchased.
+   * @param array $optParams Optional parameters.
+   */
+  public function cancel($packageName, $subscriptionId, $token, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'subscriptionId' => $subscriptionId, 'token' => $token);
+    $params = array_merge($params, $optParams);
+    return $this->call('cancel', array($params));
+  }
+
+  /**
+   * Defers a user's subscription purchase until a specified future expiration
+   * time. (subscriptions.defer)
+   *
+   * @param string $packageName The package name of the application for which this
+   * subscription was purchased (for example, 'com.some.thing').
+   * @param string $subscriptionId The purchased subscription ID (for example,
+   * 'monthly001').
+   * @param string $token The token provided to the user's device when the
+   * subscription was purchased.
+   * @param Google_SubscriptionPurchasesDeferRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_SubscriptionPurchasesDeferResponse
+   */
+  public function defer($packageName, $subscriptionId, $token, Google_Service_AndroidPublisher_SubscriptionPurchasesDeferRequest $postBody, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'subscriptionId' => $subscriptionId, 'token' => $token, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('defer', array($params), "Google_Service_AndroidPublisher_SubscriptionPurchasesDeferResponse");
+  }
+
+  /**
+   * Checks whether a user's subscription purchase is valid and returns its expiry
+   * time. (subscriptions.get)
+   *
+   * @param string $packageName The package name of the application for which this
+   * subscription was purchased (for example, 'com.some.thing').
+   * @param string $subscriptionId The purchased subscription ID (for example,
+   * 'monthly001').
+   * @param string $token The token provided to the user's device when the
+   * subscription was purchased.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AndroidPublisher_SubscriptionPurchase
+   */
+  public function get($packageName, $subscriptionId, $token, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'subscriptionId' => $subscriptionId, 'token' => $token);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AndroidPublisher_SubscriptionPurchase");
+  }
+
+  /**
+   * Refunds a user's subscription purchase, but the subscription remains valid
+   * until its expiration time and it will continue to recur.
+   * (subscriptions.refund)
+   *
+   * @param string $packageName The package name of the application for which this
+   * subscription was purchased (for example, 'com.some.thing').
+   * @param string $subscriptionId The purchased subscription ID (for example,
+   * 'monthly001').
+   * @param string $token The token provided to the user's device when the
+   * subscription was purchased.
+   * @param array $optParams Optional parameters.
+   */
+  public function refund($packageName, $subscriptionId, $token, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'subscriptionId' => $subscriptionId, 'token' => $token);
+    $params = array_merge($params, $optParams);
+    return $this->call('refund', array($params));
+  }
+
+  /**
+   * Refunds and immediately revokes a user's subscription purchase. Access to the
+   * subscription will be terminated immediately and it will stop recurring.
+   * (subscriptions.revoke)
+   *
+   * @param string $packageName The package name of the application for which this
+   * subscription was purchased (for example, 'com.some.thing').
+   * @param string $subscriptionId The purchased subscription ID (for example,
+   * 'monthly001').
+   * @param string $token The token provided to the user's device when the
+   * subscription was purchased.
+   * @param array $optParams Optional parameters.
+   */
+  public function revoke($packageName, $subscriptionId, $token, $optParams = array())
+  {
+    $params = array('packageName' => $packageName, 'subscriptionId' => $subscriptionId, 'token' => $token);
+    $params = array_merge($params, $optParams);
+    return $this->call('revoke', array($params));
+  }
+}
+
+
+
+
+class Google_Service_AndroidPublisher_Apk extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $binaryType = 'Google_Service_AndroidPublisher_ApkBinary';
+  protected $binaryDataType = '';
+  public $versionCode;
+
+
+  public function setBinary(Google_Service_AndroidPublisher_ApkBinary $binary)
+  {
+    $this->binary = $binary;
+  }
+  public function getBinary()
+  {
+    return $this->binary;
+  }
+  public function setVersionCode($versionCode)
+  {
+    $this->versionCode = $versionCode;
+  }
+  public function getVersionCode()
+  {
+    return $this->versionCode;
+  }
+}
+
+class Google_Service_AndroidPublisher_ApkBinary extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $sha1;
+
+
+  public function setSha1($sha1)
+  {
+    $this->sha1 = $sha1;
+  }
+  public function getSha1()
+  {
+    return $this->sha1;
+  }
+}
+
+class Google_Service_AndroidPublisher_ApkListing extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $language;
+  public $recentChanges;
+
+
+  public function setLanguage($language)
+  {
+    $this->language = $language;
+  }
+  public function getLanguage()
+  {
+    return $this->language;
+  }
+  public function setRecentChanges($recentChanges)
+  {
+    $this->recentChanges = $recentChanges;
+  }
+  public function getRecentChanges()
+  {
+    return $this->recentChanges;
+  }
+}
+
+class Google_Service_AndroidPublisher_ApkListingsListResponse extends Google_Collection
+{
+  protected $collection_key = 'listings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $listingsType = 'Google_Service_AndroidPublisher_ApkListing';
+  protected $listingsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setListings($listings)
+  {
+    $this->listings = $listings;
+  }
+  public function getListings()
+  {
+    return $this->listings;
+  }
+}
+
+class Google_Service_AndroidPublisher_ApksAddExternallyHostedRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $externallyHostedApkType = 'Google_Service_AndroidPublisher_ExternallyHostedApk';
+  protected $externallyHostedApkDataType = '';
+
+
+  public function setExternallyHostedApk(Google_Service_AndroidPublisher_ExternallyHostedApk $externallyHostedApk)
+  {
+    $this->externallyHostedApk = $externallyHostedApk;
+  }
+  public function getExternallyHostedApk()
+  {
+    return $this->externallyHostedApk;
+  }
+}
+
+class Google_Service_AndroidPublisher_ApksAddExternallyHostedResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $externallyHostedApkType = 'Google_Service_AndroidPublisher_ExternallyHostedApk';
+  protected $externallyHostedApkDataType = '';
+
+
+  public function setExternallyHostedApk(Google_Service_AndroidPublisher_ExternallyHostedApk $externallyHostedApk)
+  {
+    $this->externallyHostedApk = $externallyHostedApk;
+  }
+  public function getExternallyHostedApk()
+  {
+    return $this->externallyHostedApk;
+  }
+}
+
+class Google_Service_AndroidPublisher_ApksListResponse extends Google_Collection
+{
+  protected $collection_key = 'apks';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $apksType = 'Google_Service_AndroidPublisher_Apk';
+  protected $apksDataType = 'array';
+  public $kind;
+
+
+  public function setApks($apks)
+  {
+    $this->apks = $apks;
+  }
+  public function getApks()
+  {
+    return $this->apks;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AndroidPublisher_AppDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $contactEmail;
+  public $contactPhone;
+  public $contactWebsite;
+  public $defaultLanguage;
+
+
+  public function setContactEmail($contactEmail)
+  {
+    $this->contactEmail = $contactEmail;
+  }
+  public function getContactEmail()
+  {
+    return $this->contactEmail;
+  }
+  public function setContactPhone($contactPhone)
+  {
+    $this->contactPhone = $contactPhone;
+  }
+  public function getContactPhone()
+  {
+    return $this->contactPhone;
+  }
+  public function setContactWebsite($contactWebsite)
+  {
+    $this->contactWebsite = $contactWebsite;
+  }
+  public function getContactWebsite()
+  {
+    return $this->contactWebsite;
+  }
+  public function setDefaultLanguage($defaultLanguage)
+  {
+    $this->defaultLanguage = $defaultLanguage;
+  }
+  public function getDefaultLanguage()
+  {
+    return $this->defaultLanguage;
+  }
+}
+
+class Google_Service_AndroidPublisher_AppEdit extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $expiryTimeSeconds;
+  public $id;
+
+
+  public function setExpiryTimeSeconds($expiryTimeSeconds)
+  {
+    $this->expiryTimeSeconds = $expiryTimeSeconds;
+  }
+  public function getExpiryTimeSeconds()
+  {
+    return $this->expiryTimeSeconds;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+}
+
+class Google_Service_AndroidPublisher_Entitlement extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $productId;
+  public $productType;
+  public $token;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProductId($productId)
+  {
+    $this->productId = $productId;
+  }
+  public function getProductId()
+  {
+    return $this->productId;
+  }
+  public function setProductType($productType)
+  {
+    $this->productType = $productType;
+  }
+  public function getProductType()
+  {
+    return $this->productType;
+  }
+  public function setToken($token)
+  {
+    $this->token = $token;
+  }
+  public function getToken()
+  {
+    return $this->token;
+  }
+}
+
+class Google_Service_AndroidPublisher_EntitlementsListResponse extends Google_Collection
+{
+  protected $collection_key = 'resources';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $pageInfoType = 'Google_Service_AndroidPublisher_PageInfo';
+  protected $pageInfoDataType = '';
+  protected $resourcesType = 'Google_Service_AndroidPublisher_Entitlement';
+  protected $resourcesDataType = 'array';
+  protected $tokenPaginationType = 'Google_Service_AndroidPublisher_TokenPagination';
+  protected $tokenPaginationDataType = '';
+
+
+  public function setPageInfo(Google_Service_AndroidPublisher_PageInfo $pageInfo)
+  {
+    $this->pageInfo = $pageInfo;
+  }
+  public function getPageInfo()
+  {
+    return $this->pageInfo;
+  }
+  public function setResources($resources)
+  {
+    $this->resources = $resources;
+  }
+  public function getResources()
+  {
+    return $this->resources;
+  }
+  public function setTokenPagination(Google_Service_AndroidPublisher_TokenPagination $tokenPagination)
+  {
+    $this->tokenPagination = $tokenPagination;
+  }
+  public function getTokenPagination()
+  {
+    return $this->tokenPagination;
+  }
+}
+
+class Google_Service_AndroidPublisher_ExpansionFile extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $fileSize;
+  public $referencesVersion;
+
+
+  public function setFileSize($fileSize)
+  {
+    $this->fileSize = $fileSize;
+  }
+  public function getFileSize()
+  {
+    return $this->fileSize;
+  }
+  public function setReferencesVersion($referencesVersion)
+  {
+    $this->referencesVersion = $referencesVersion;
+  }
+  public function getReferencesVersion()
+  {
+    return $this->referencesVersion;
+  }
+}
+
+class Google_Service_AndroidPublisher_ExpansionFilesUploadResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $expansionFileType = 'Google_Service_AndroidPublisher_ExpansionFile';
+  protected $expansionFileDataType = '';
+
+
+  public function setExpansionFile(Google_Service_AndroidPublisher_ExpansionFile $expansionFile)
+  {
+    $this->expansionFile = $expansionFile;
+  }
+  public function getExpansionFile()
+  {
+    return $this->expansionFile;
+  }
+}
+
+class Google_Service_AndroidPublisher_ExternallyHostedApk extends Google_Collection
+{
+  protected $collection_key = 'usesPermissions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $applicationLabel;
+  public $certificateBase64s;
+  public $externallyHostedUrl;
+  public $fileSha1Base64;
+  public $fileSha256Base64;
+  public $fileSize;
+  public $iconBase64;
+  public $maximumSdk;
+  public $minimumSdk;
+  public $nativeCodes;
+  public $packageName;
+  public $usesFeatures;
+  protected $usesPermissionsType = 'Google_Service_AndroidPublisher_ExternallyHostedApkUsesPermission';
+  protected $usesPermissionsDataType = 'array';
+  public $versionCode;
+  public $versionName;
+
+
+  public function setApplicationLabel($applicationLabel)
+  {
+    $this->applicationLabel = $applicationLabel;
+  }
+  public function getApplicationLabel()
+  {
+    return $this->applicationLabel;
+  }
+  public function setCertificateBase64s($certificateBase64s)
+  {
+    $this->certificateBase64s = $certificateBase64s;
+  }
+  public function getCertificateBase64s()
+  {
+    return $this->certificateBase64s;
+  }
+  public function setExternallyHostedUrl($externallyHostedUrl)
+  {
+    $this->externallyHostedUrl = $externallyHostedUrl;
+  }
+  public function getExternallyHostedUrl()
+  {
+    return $this->externallyHostedUrl;
+  }
+  public function setFileSha1Base64($fileSha1Base64)
+  {
+    $this->fileSha1Base64 = $fileSha1Base64;
+  }
+  public function getFileSha1Base64()
+  {
+    return $this->fileSha1Base64;
+  }
+  public function setFileSha256Base64($fileSha256Base64)
+  {
+    $this->fileSha256Base64 = $fileSha256Base64;
+  }
+  public function getFileSha256Base64()
+  {
+    return $this->fileSha256Base64;
+  }
+  public function setFileSize($fileSize)
+  {
+    $this->fileSize = $fileSize;
+  }
+  public function getFileSize()
+  {
+    return $this->fileSize;
+  }
+  public function setIconBase64($iconBase64)
+  {
+    $this->iconBase64 = $iconBase64;
+  }
+  public function getIconBase64()
+  {
+    return $this->iconBase64;
+  }
+  public function setMaximumSdk($maximumSdk)
+  {
+    $this->maximumSdk = $maximumSdk;
+  }
+  public function getMaximumSdk()
+  {
+    return $this->maximumSdk;
+  }
+  public function setMinimumSdk($minimumSdk)
+  {
+    $this->minimumSdk = $minimumSdk;
+  }
+  public function getMinimumSdk()
+  {
+    return $this->minimumSdk;
+  }
+  public function setNativeCodes($nativeCodes)
+  {
+    $this->nativeCodes = $nativeCodes;
+  }
+  public function getNativeCodes()
+  {
+    return $this->nativeCodes;
+  }
+  public function setPackageName($packageName)
+  {
+    $this->packageName = $packageName;
+  }
+  public function getPackageName()
+  {
+    return $this->packageName;
+  }
+  public function setUsesFeatures($usesFeatures)
+  {
+    $this->usesFeatures = $usesFeatures;
+  }
+  public function getUsesFeatures()
+  {
+    return $this->usesFeatures;
+  }
+  public function setUsesPermissions($usesPermissions)
+  {
+    $this->usesPermissions = $usesPermissions;
+  }
+  public function getUsesPermissions()
+  {
+    return $this->usesPermissions;
+  }
+  public function setVersionCode($versionCode)
+  {
+    $this->versionCode = $versionCode;
+  }
+  public function getVersionCode()
+  {
+    return $this->versionCode;
+  }
+  public function setVersionName($versionName)
+  {
+    $this->versionName = $versionName;
+  }
+  public function getVersionName()
+  {
+    return $this->versionName;
+  }
+}
+
+class Google_Service_AndroidPublisher_ExternallyHostedApkUsesPermission extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $maxSdkVersion;
+  public $name;
+
+
+  public function setMaxSdkVersion($maxSdkVersion)
+  {
+    $this->maxSdkVersion = $maxSdkVersion;
+  }
+  public function getMaxSdkVersion()
+  {
+    return $this->maxSdkVersion;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_AndroidPublisher_Image extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $sha1;
+  public $url;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setSha1($sha1)
+  {
+    $this->sha1 = $sha1;
+  }
+  public function getSha1()
+  {
+    return $this->sha1;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_AndroidPublisher_ImagesDeleteAllResponse extends Google_Collection
+{
+  protected $collection_key = 'deleted';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $deletedType = 'Google_Service_AndroidPublisher_Image';
+  protected $deletedDataType = 'array';
+
+
+  public function setDeleted($deleted)
+  {
+    $this->deleted = $deleted;
+  }
+  public function getDeleted()
+  {
+    return $this->deleted;
+  }
+}
+
+class Google_Service_AndroidPublisher_ImagesListResponse extends Google_Collection
+{
+  protected $collection_key = 'images';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $imagesType = 'Google_Service_AndroidPublisher_Image';
+  protected $imagesDataType = 'array';
+
+
+  public function setImages($images)
+  {
+    $this->images = $images;
+  }
+  public function getImages()
+  {
+    return $this->images;
+  }
+}
+
+class Google_Service_AndroidPublisher_ImagesUploadResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $imageType = 'Google_Service_AndroidPublisher_Image';
+  protected $imageDataType = '';
+
+
+  public function setImage(Google_Service_AndroidPublisher_Image $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+}
+
+class Google_Service_AndroidPublisher_InAppProduct extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $defaultLanguage;
+  protected $defaultPriceType = 'Google_Service_AndroidPublisher_Price';
+  protected $defaultPriceDataType = '';
+  protected $listingsType = 'Google_Service_AndroidPublisher_InAppProductListing';
+  protected $listingsDataType = 'map';
+  public $packageName;
+  protected $pricesType = 'Google_Service_AndroidPublisher_Price';
+  protected $pricesDataType = 'map';
+  public $purchaseType;
+  protected $seasonType = 'Google_Service_AndroidPublisher_Season';
+  protected $seasonDataType = '';
+  public $sku;
+  public $status;
+  public $subscriptionPeriod;
+  public $trialPeriod;
+
+
+  public function setDefaultLanguage($defaultLanguage)
+  {
+    $this->defaultLanguage = $defaultLanguage;
+  }
+  public function getDefaultLanguage()
+  {
+    return $this->defaultLanguage;
+  }
+  public function setDefaultPrice(Google_Service_AndroidPublisher_Price $defaultPrice)
+  {
+    $this->defaultPrice = $defaultPrice;
+  }
+  public function getDefaultPrice()
+  {
+    return $this->defaultPrice;
+  }
+  public function setListings($listings)
+  {
+    $this->listings = $listings;
+  }
+  public function getListings()
+  {
+    return $this->listings;
+  }
+  public function setPackageName($packageName)
+  {
+    $this->packageName = $packageName;
+  }
+  public function getPackageName()
+  {
+    return $this->packageName;
+  }
+  public function setPrices($prices)
+  {
+    $this->prices = $prices;
+  }
+  public function getPrices()
+  {
+    return $this->prices;
+  }
+  public function setPurchaseType($purchaseType)
+  {
+    $this->purchaseType = $purchaseType;
+  }
+  public function getPurchaseType()
+  {
+    return $this->purchaseType;
+  }
+  public function setSeason(Google_Service_AndroidPublisher_Season $season)
+  {
+    $this->season = $season;
+  }
+  public function getSeason()
+  {
+    return $this->season;
+  }
+  public function setSku($sku)
+  {
+    $this->sku = $sku;
+  }
+  public function getSku()
+  {
+    return $this->sku;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setSubscriptionPeriod($subscriptionPeriod)
+  {
+    $this->subscriptionPeriod = $subscriptionPeriod;
+  }
+  public function getSubscriptionPeriod()
+  {
+    return $this->subscriptionPeriod;
+  }
+  public function setTrialPeriod($trialPeriod)
+  {
+    $this->trialPeriod = $trialPeriod;
+  }
+  public function getTrialPeriod()
+  {
+    return $this->trialPeriod;
+  }
+}
+
+class Google_Service_AndroidPublisher_InAppProductListing extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $title;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_AndroidPublisher_InAppProductListings extends Google_Model
+{
+}
+
+class Google_Service_AndroidPublisher_InAppProductPrices extends Google_Model
+{
+}
+
+class Google_Service_AndroidPublisher_InappproductsBatchRequest extends Google_Collection
+{
+  protected $collection_key = 'entrys';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entrysType = 'Google_Service_AndroidPublisher_InappproductsBatchRequestEntry';
+  protected $entrysDataType = 'array';
+
+
+  public function setEntrys($entrys)
+  {
+    $this->entrys = $entrys;
+  }
+  public function getEntrys()
+  {
+    return $this->entrys;
+  }
+}
+
+class Google_Service_AndroidPublisher_InappproductsBatchRequestEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $batchId;
+  protected $inappproductsinsertrequestType = 'Google_Service_AndroidPublisher_InappproductsInsertRequest';
+  protected $inappproductsinsertrequestDataType = '';
+  protected $inappproductsupdaterequestType = 'Google_Service_AndroidPublisher_InappproductsUpdateRequest';
+  protected $inappproductsupdaterequestDataType = '';
+  public $methodName;
+
+
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setInappproductsinsertrequest(Google_Service_AndroidPublisher_InappproductsInsertRequest $inappproductsinsertrequest)
+  {
+    $this->inappproductsinsertrequest = $inappproductsinsertrequest;
+  }
+  public function getInappproductsinsertrequest()
+  {
+    return $this->inappproductsinsertrequest;
+  }
+  public function setInappproductsupdaterequest(Google_Service_AndroidPublisher_InappproductsUpdateRequest $inappproductsupdaterequest)
+  {
+    $this->inappproductsupdaterequest = $inappproductsupdaterequest;
+  }
+  public function getInappproductsupdaterequest()
+  {
+    return $this->inappproductsupdaterequest;
+  }
+  public function setMethodName($methodName)
+  {
+    $this->methodName = $methodName;
+  }
+  public function getMethodName()
+  {
+    return $this->methodName;
+  }
+}
+
+class Google_Service_AndroidPublisher_InappproductsBatchResponse extends Google_Collection
+{
+  protected $collection_key = 'entrys';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entrysType = 'Google_Service_AndroidPublisher_InappproductsBatchResponseEntry';
+  protected $entrysDataType = 'array';
+  public $kind;
+
+
+  public function setEntrys($entrys)
+  {
+    $this->entrys = $entrys;
+  }
+  public function getEntrys()
+  {
+    return $this->entrys;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AndroidPublisher_InappproductsBatchResponseEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $batchId;
+  protected $inappproductsinsertresponseType = 'Google_Service_AndroidPublisher_InappproductsInsertResponse';
+  protected $inappproductsinsertresponseDataType = '';
+  protected $inappproductsupdateresponseType = 'Google_Service_AndroidPublisher_InappproductsUpdateResponse';
+  protected $inappproductsupdateresponseDataType = '';
+
+
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setInappproductsinsertresponse(Google_Service_AndroidPublisher_InappproductsInsertResponse $inappproductsinsertresponse)
+  {
+    $this->inappproductsinsertresponse = $inappproductsinsertresponse;
+  }
+  public function getInappproductsinsertresponse()
+  {
+    return $this->inappproductsinsertresponse;
+  }
+  public function setInappproductsupdateresponse(Google_Service_AndroidPublisher_InappproductsUpdateResponse $inappproductsupdateresponse)
+  {
+    $this->inappproductsupdateresponse = $inappproductsupdateresponse;
+  }
+  public function getInappproductsupdateresponse()
+  {
+    return $this->inappproductsupdateresponse;
+  }
+}
+
+class Google_Service_AndroidPublisher_InappproductsInsertRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $inappproductType = 'Google_Service_AndroidPublisher_InAppProduct';
+  protected $inappproductDataType = '';
+
+
+  public function setInappproduct(Google_Service_AndroidPublisher_InAppProduct $inappproduct)
+  {
+    $this->inappproduct = $inappproduct;
+  }
+  public function getInappproduct()
+  {
+    return $this->inappproduct;
+  }
+}
+
+class Google_Service_AndroidPublisher_InappproductsInsertResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $inappproductType = 'Google_Service_AndroidPublisher_InAppProduct';
+  protected $inappproductDataType = '';
+
+
+  public function setInappproduct(Google_Service_AndroidPublisher_InAppProduct $inappproduct)
+  {
+    $this->inappproduct = $inappproduct;
+  }
+  public function getInappproduct()
+  {
+    return $this->inappproduct;
+  }
+}
+
+class Google_Service_AndroidPublisher_InappproductsListResponse extends Google_Collection
+{
+  protected $collection_key = 'inappproduct';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $inappproductType = 'Google_Service_AndroidPublisher_InAppProduct';
+  protected $inappproductDataType = 'array';
+  public $kind;
+  protected $pageInfoType = 'Google_Service_AndroidPublisher_PageInfo';
+  protected $pageInfoDataType = '';
+  protected $tokenPaginationType = 'Google_Service_AndroidPublisher_TokenPagination';
+  protected $tokenPaginationDataType = '';
+
+
+  public function setInappproduct($inappproduct)
+  {
+    $this->inappproduct = $inappproduct;
+  }
+  public function getInappproduct()
+  {
+    return $this->inappproduct;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPageInfo(Google_Service_AndroidPublisher_PageInfo $pageInfo)
+  {
+    $this->pageInfo = $pageInfo;
+  }
+  public function getPageInfo()
+  {
+    return $this->pageInfo;
+  }
+  public function setTokenPagination(Google_Service_AndroidPublisher_TokenPagination $tokenPagination)
+  {
+    $this->tokenPagination = $tokenPagination;
+  }
+  public function getTokenPagination()
+  {
+    return $this->tokenPagination;
+  }
+}
+
+class Google_Service_AndroidPublisher_InappproductsUpdateRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $inappproductType = 'Google_Service_AndroidPublisher_InAppProduct';
+  protected $inappproductDataType = '';
+
+
+  public function setInappproduct(Google_Service_AndroidPublisher_InAppProduct $inappproduct)
+  {
+    $this->inappproduct = $inappproduct;
+  }
+  public function getInappproduct()
+  {
+    return $this->inappproduct;
+  }
+}
+
+class Google_Service_AndroidPublisher_InappproductsUpdateResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $inappproductType = 'Google_Service_AndroidPublisher_InAppProduct';
+  protected $inappproductDataType = '';
+
+
+  public function setInappproduct(Google_Service_AndroidPublisher_InAppProduct $inappproduct)
+  {
+    $this->inappproduct = $inappproduct;
+  }
+  public function getInappproduct()
+  {
+    return $this->inappproduct;
+  }
+}
+
+class Google_Service_AndroidPublisher_Listing extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $fullDescription;
+  public $language;
+  public $shortDescription;
+  public $title;
+  public $video;
+
+
+  public function setFullDescription($fullDescription)
+  {
+    $this->fullDescription = $fullDescription;
+  }
+  public function getFullDescription()
+  {
+    return $this->fullDescription;
+  }
+  public function setLanguage($language)
+  {
+    $this->language = $language;
+  }
+  public function getLanguage()
+  {
+    return $this->language;
+  }
+  public function setShortDescription($shortDescription)
+  {
+    $this->shortDescription = $shortDescription;
+  }
+  public function getShortDescription()
+  {
+    return $this->shortDescription;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setVideo($video)
+  {
+    $this->video = $video;
+  }
+  public function getVideo()
+  {
+    return $this->video;
+  }
+}
+
+class Google_Service_AndroidPublisher_ListingsListResponse extends Google_Collection
+{
+  protected $collection_key = 'listings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $listingsType = 'Google_Service_AndroidPublisher_Listing';
+  protected $listingsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setListings($listings)
+  {
+    $this->listings = $listings;
+  }
+  public function getListings()
+  {
+    return $this->listings;
+  }
+}
+
+class Google_Service_AndroidPublisher_MonthDay extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $day;
+  public $month;
+
+
+  public function setDay($day)
+  {
+    $this->day = $day;
+  }
+  public function getDay()
+  {
+    return $this->day;
+  }
+  public function setMonth($month)
+  {
+    $this->month = $month;
+  }
+  public function getMonth()
+  {
+    return $this->month;
+  }
+}
+
+class Google_Service_AndroidPublisher_PageInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $resultPerPage;
+  public $startIndex;
+  public $totalResults;
+
+
+  public function setResultPerPage($resultPerPage)
+  {
+    $this->resultPerPage = $resultPerPage;
+  }
+  public function getResultPerPage()
+  {
+    return $this->resultPerPage;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+}
+
+class Google_Service_AndroidPublisher_Price extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $currency;
+  public $priceMicros;
+
+
+  public function setCurrency($currency)
+  {
+    $this->currency = $currency;
+  }
+  public function getCurrency()
+  {
+    return $this->currency;
+  }
+  public function setPriceMicros($priceMicros)
+  {
+    $this->priceMicros = $priceMicros;
+  }
+  public function getPriceMicros()
+  {
+    return $this->priceMicros;
+  }
+}
+
+class Google_Service_AndroidPublisher_ProductPurchase extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $consumptionState;
+  public $developerPayload;
+  public $kind;
+  public $purchaseState;
+  public $purchaseTimeMillis;
+
+
+  public function setConsumptionState($consumptionState)
+  {
+    $this->consumptionState = $consumptionState;
+  }
+  public function getConsumptionState()
+  {
+    return $this->consumptionState;
+  }
+  public function setDeveloperPayload($developerPayload)
+  {
+    $this->developerPayload = $developerPayload;
+  }
+  public function getDeveloperPayload()
+  {
+    return $this->developerPayload;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPurchaseState($purchaseState)
+  {
+    $this->purchaseState = $purchaseState;
+  }
+  public function getPurchaseState()
+  {
+    return $this->purchaseState;
+  }
+  public function setPurchaseTimeMillis($purchaseTimeMillis)
+  {
+    $this->purchaseTimeMillis = $purchaseTimeMillis;
+  }
+  public function getPurchaseTimeMillis()
+  {
+    return $this->purchaseTimeMillis;
+  }
+}
+
+class Google_Service_AndroidPublisher_Season extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $endType = 'Google_Service_AndroidPublisher_MonthDay';
+  protected $endDataType = '';
+  protected $startType = 'Google_Service_AndroidPublisher_MonthDay';
+  protected $startDataType = '';
+
+
+  public function setEnd(Google_Service_AndroidPublisher_MonthDay $end)
+  {
+    $this->end = $end;
+  }
+  public function getEnd()
+  {
+    return $this->end;
+  }
+  public function setStart(Google_Service_AndroidPublisher_MonthDay $start)
+  {
+    $this->start = $start;
+  }
+  public function getStart()
+  {
+    return $this->start;
+  }
+}
+
+class Google_Service_AndroidPublisher_SubscriptionDeferralInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $desiredExpiryTimeMillis;
+  public $expectedExpiryTimeMillis;
+
+
+  public function setDesiredExpiryTimeMillis($desiredExpiryTimeMillis)
+  {
+    $this->desiredExpiryTimeMillis = $desiredExpiryTimeMillis;
+  }
+  public function getDesiredExpiryTimeMillis()
+  {
+    return $this->desiredExpiryTimeMillis;
+  }
+  public function setExpectedExpiryTimeMillis($expectedExpiryTimeMillis)
+  {
+    $this->expectedExpiryTimeMillis = $expectedExpiryTimeMillis;
+  }
+  public function getExpectedExpiryTimeMillis()
+  {
+    return $this->expectedExpiryTimeMillis;
+  }
+}
+
+class Google_Service_AndroidPublisher_SubscriptionPurchase extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $autoRenewing;
+  public $expiryTimeMillis;
+  public $kind;
+  public $startTimeMillis;
+
+
+  public function setAutoRenewing($autoRenewing)
+  {
+    $this->autoRenewing = $autoRenewing;
+  }
+  public function getAutoRenewing()
+  {
+    return $this->autoRenewing;
+  }
+  public function setExpiryTimeMillis($expiryTimeMillis)
+  {
+    $this->expiryTimeMillis = $expiryTimeMillis;
+  }
+  public function getExpiryTimeMillis()
+  {
+    return $this->expiryTimeMillis;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setStartTimeMillis($startTimeMillis)
+  {
+    $this->startTimeMillis = $startTimeMillis;
+  }
+  public function getStartTimeMillis()
+  {
+    return $this->startTimeMillis;
+  }
+}
+
+class Google_Service_AndroidPublisher_SubscriptionPurchasesDeferRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $deferralInfoType = 'Google_Service_AndroidPublisher_SubscriptionDeferralInfo';
+  protected $deferralInfoDataType = '';
+
+
+  public function setDeferralInfo(Google_Service_AndroidPublisher_SubscriptionDeferralInfo $deferralInfo)
+  {
+    $this->deferralInfo = $deferralInfo;
+  }
+  public function getDeferralInfo()
+  {
+    return $this->deferralInfo;
+  }
+}
+
+class Google_Service_AndroidPublisher_SubscriptionPurchasesDeferResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $newExpiryTimeMillis;
+
+
+  public function setNewExpiryTimeMillis($newExpiryTimeMillis)
+  {
+    $this->newExpiryTimeMillis = $newExpiryTimeMillis;
+  }
+  public function getNewExpiryTimeMillis()
+  {
+    return $this->newExpiryTimeMillis;
+  }
+}
+
+class Google_Service_AndroidPublisher_Testers extends Google_Collection
+{
+  protected $collection_key = 'googlePlusCommunities';
+  protected $internal_gapi_mappings = array(
+  );
+  public $googleGroups;
+  public $googlePlusCommunities;
+
+
+  public function setGoogleGroups($googleGroups)
+  {
+    $this->googleGroups = $googleGroups;
+  }
+  public function getGoogleGroups()
+  {
+    return $this->googleGroups;
+  }
+  public function setGooglePlusCommunities($googlePlusCommunities)
+  {
+    $this->googlePlusCommunities = $googlePlusCommunities;
+  }
+  public function getGooglePlusCommunities()
+  {
+    return $this->googlePlusCommunities;
+  }
+}
+
+class Google_Service_AndroidPublisher_TokenPagination extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  public $previousPageToken;
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPreviousPageToken($previousPageToken)
+  {
+    $this->previousPageToken = $previousPageToken;
+  }
+  public function getPreviousPageToken()
+  {
+    return $this->previousPageToken;
+  }
+}
+
+class Google_Service_AndroidPublisher_Track extends Google_Collection
+{
+  protected $collection_key = 'versionCodes';
+  protected $internal_gapi_mappings = array(
+  );
+  public $track;
+  public $userFraction;
+  public $versionCodes;
+
+
+  public function setTrack($track)
+  {
+    $this->track = $track;
+  }
+  public function getTrack()
+  {
+    return $this->track;
+  }
+  public function setUserFraction($userFraction)
+  {
+    $this->userFraction = $userFraction;
+  }
+  public function getUserFraction()
+  {
+    return $this->userFraction;
+  }
+  public function setVersionCodes($versionCodes)
+  {
+    $this->versionCodes = $versionCodes;
+  }
+  public function getVersionCodes()
+  {
+    return $this->versionCodes;
+  }
+}
+
+class Google_Service_AndroidPublisher_TracksListResponse extends Google_Collection
+{
+  protected $collection_key = 'tracks';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $tracksType = 'Google_Service_AndroidPublisher_Track';
+  protected $tracksDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setTracks($tracks)
+  {
+    $this->tracks = $tracks;
+  }
+  public function getTracks()
+  {
+    return $this->tracks;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/AppState.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/AppState.php
@@ -1,0 +1,369 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for AppState (v1).
+ *
+ * <p>
+ * The Google App State API.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/games/services/web/api/states" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_AppState extends Google_Service
+{
+  /** View and manage your data for this application. */
+  const APPSTATE =
+      "https://www.googleapis.com/auth/appstate";
+
+  public $states;
+  
+
+  /**
+   * Constructs the internal representation of the AppState service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'appstate/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'appstate';
+
+    $this->states = new Google_Service_AppState_States_Resource(
+        $this,
+        $this->serviceName,
+        'states',
+        array(
+          'methods' => array(
+            'clear' => array(
+              'path' => 'states/{stateKey}/clear',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'stateKey' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'currentDataVersion' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'states/{stateKey}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'stateKey' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'states/{stateKey}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'stateKey' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'states',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'includeData' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'states/{stateKey}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'stateKey' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'currentStateVersion' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "states" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $appstateService = new Google_Service_AppState(...);
+ *   $states = $appstateService->states;
+ *  </code>
+ */
+class Google_Service_AppState_States_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Clears (sets to empty) the data for the passed key if and only if the passed
+   * version matches the currently stored version. This method results in a
+   * conflict error on version mismatch. (states.clear)
+   *
+   * @param int $stateKey The key for the data to be retrieved.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string currentDataVersion The version of the data to be cleared.
+   * Version strings are returned by the server.
+   * @return Google_Service_AppState_WriteResult
+   */
+  public function clear($stateKey, $optParams = array())
+  {
+    $params = array('stateKey' => $stateKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('clear', array($params), "Google_Service_AppState_WriteResult");
+  }
+
+  /**
+   * Deletes a key and the data associated with it. The key is removed and no
+   * longer counts against the key quota. Note that since this method is not safe
+   * in the face of concurrent modifications, it should only be used for
+   * development and testing purposes. Invoking this method in shipping code can
+   * result in data loss and data corruption. (states.delete)
+   *
+   * @param int $stateKey The key for the data to be retrieved.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($stateKey, $optParams = array())
+  {
+    $params = array('stateKey' => $stateKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves the data corresponding to the passed key. If the key does not exist
+   * on the server, an HTTP 404 will be returned. (states.get)
+   *
+   * @param int $stateKey The key for the data to be retrieved.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_AppState_GetResponse
+   */
+  public function get($stateKey, $optParams = array())
+  {
+    $params = array('stateKey' => $stateKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_AppState_GetResponse");
+  }
+
+  /**
+   * Lists all the states keys, and optionally the state data. (states.listStates)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool includeData Whether to include the full data in addition to
+   * the version number
+   * @return Google_Service_AppState_ListResponse
+   */
+  public function listStates($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_AppState_ListResponse");
+  }
+
+  /**
+   * Update the data associated with the input key if and only if the passed
+   * version matches the currently stored version. This method is safe in the face
+   * of concurrent writes. Maximum per-key size is 128KB. (states.update)
+   *
+   * @param int $stateKey The key for the data to be retrieved.
+   * @param Google_UpdateRequest $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string currentStateVersion The version of the app state your
+   * application is attempting to update. If this does not match the current
+   * version, this method will return a conflict error. If there is no data stored
+   * on the server for this key, the update will succeed irrespective of the value
+   * of this parameter.
+   * @return Google_Service_AppState_WriteResult
+   */
+  public function update($stateKey, Google_Service_AppState_UpdateRequest $postBody, $optParams = array())
+  {
+    $params = array('stateKey' => $stateKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_AppState_WriteResult");
+  }
+}
+
+
+
+
+class Google_Service_AppState_GetResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $currentStateVersion;
+  public $data;
+  public $kind;
+  public $stateKey;
+
+
+  public function setCurrentStateVersion($currentStateVersion)
+  {
+    $this->currentStateVersion = $currentStateVersion;
+  }
+  public function getCurrentStateVersion()
+  {
+    return $this->currentStateVersion;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setStateKey($stateKey)
+  {
+    $this->stateKey = $stateKey;
+  }
+  public function getStateKey()
+  {
+    return $this->stateKey;
+  }
+}
+
+class Google_Service_AppState_ListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_AppState_GetResponse';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $maximumKeyCount;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMaximumKeyCount($maximumKeyCount)
+  {
+    $this->maximumKeyCount = $maximumKeyCount;
+  }
+  public function getMaximumKeyCount()
+  {
+    return $this->maximumKeyCount;
+  }
+}
+
+class Google_Service_AppState_UpdateRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $data;
+  public $kind;
+
+
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_AppState_WriteResult extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $currentStateVersion;
+  public $kind;
+  public $stateKey;
+
+
+  public function setCurrentStateVersion($currentStateVersion)
+  {
+    $this->currentStateVersion = $currentStateVersion;
+  }
+  public function getCurrentStateVersion()
+  {
+    return $this->currentStateVersion;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setStateKey($stateKey)
+  {
+    $this->stateKey = $stateKey;
+  }
+  public function getStateKey()
+  {
+    return $this->stateKey;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Appengine.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Appengine.php
@@ -1,0 +1,2032 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Appengine (v1beta4).
+ *
+ * <p>
+ * The Google App Engine Admin API enables developers to provision and manage
+ * their App Engine applications.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/appengine/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Appengine extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+
+  public $apps;
+  public $apps_modules;
+  public $apps_modules_versions;
+  public $apps_operations;
+
+
+  /**
+   * Constructs the internal representation of the Appengine service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://appengine.googleapis.com/';
+    $this->servicePath = '';
+    $this->version = 'v1beta4';
+    $this->serviceName = 'appengine';
+
+    $this->apps = new Google_Service_Appengine_Apps_Resource(
+        $this,
+        $this->serviceName,
+        'apps',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'v1beta4/apps/{appsId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'appsId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ensureResourcesExist' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->apps_modules = new Google_Service_Appengine_AppsModules_Resource(
+        $this,
+        $this->serviceName,
+        'modules',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'v1beta4/apps/{appsId}/modules/{modulesId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'appsId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'modulesId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v1beta4/apps/{appsId}/modules/{modulesId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'appsId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'modulesId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1beta4/apps/{appsId}/modules',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'appsId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'v1beta4/apps/{appsId}/modules/{modulesId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'appsId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'modulesId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'migrateTraffic' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'mask' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->apps_modules_versions = new Google_Service_Appengine_AppsModulesVersions_Resource(
+        $this,
+        $this->serviceName,
+        'versions',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'v1beta4/apps/{appsId}/modules/{modulesId}/versions',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'appsId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'modulesId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'v1beta4/apps/{appsId}/modules/{modulesId}/versions/{versionsId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'appsId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'modulesId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'versionsId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v1beta4/apps/{appsId}/modules/{modulesId}/versions/{versionsId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'appsId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'modulesId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'versionsId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1beta4/apps/{appsId}/modules/{modulesId}/versions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'appsId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'modulesId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->apps_operations = new Google_Service_Appengine_AppsOperations_Resource(
+        $this,
+        $this->serviceName,
+        'operations',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'v1beta4/apps/{appsId}/operations/{operationsId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'appsId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operationsId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1beta4/apps/{appsId}/operations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'appsId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "apps" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $appengineService = new Google_Service_Appengine(...);
+ *   $apps = $appengineService->apps;
+ *  </code>
+ */
+class Google_Service_Appengine_Apps_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets information about an application. (apps.get)
+   *
+   * @param string $appsId Part of `name`. Name of the application to get. For
+   * example: "apps/myapp".
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool ensureResourcesExist Certain resources associated with an
+   * application are created on-demand. Controls whether these resources should be
+   * created when performing the `GET` operation. If specified and any resources
+   * cloud not be created, the request will fail with an error code.
+   * @return Google_Service_Appengine_Application
+   */
+  public function get($appsId, $optParams = array())
+  {
+    $params = array('appsId' => $appsId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Appengine_Application");
+  }
+}
+
+/**
+ * The "modules" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $appengineService = new Google_Service_Appengine(...);
+ *   $modules = $appengineService->modules;
+ *  </code>
+ */
+class Google_Service_Appengine_AppsModules_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a module and all enclosed versions. (modules.delete)
+   *
+   * @param string $appsId Part of `name`. Name of the resource requested. For
+   * example: "apps/myapp/modules/default".
+   * @param string $modulesId Part of `name`. See documentation of `appsId`.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Appengine_Operation
+   */
+  public function delete($appsId, $modulesId, $optParams = array())
+  {
+    $params = array('appsId' => $appsId, 'modulesId' => $modulesId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Appengine_Operation");
+  }
+
+  /**
+   * Gets the current configuration of the module. (modules.get)
+   *
+   * @param string $appsId Part of `name`. Name of the resource requested. For
+   * example: "apps/myapp/modules/default".
+   * @param string $modulesId Part of `name`. See documentation of `appsId`.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Appengine_Module
+   */
+  public function get($appsId, $modulesId, $optParams = array())
+  {
+    $params = array('appsId' => $appsId, 'modulesId' => $modulesId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Appengine_Module");
+  }
+
+  /**
+   * Lists all the modules in the application. (modules.listAppsModules)
+   *
+   * @param string $appsId Part of `name`. Name of the resource requested. For
+   * example: "apps/myapp".
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int pageSize Maximum results to return per page.
+   * @opt_param string pageToken Continuation token for fetching the next page of
+   * results.
+   * @return Google_Service_Appengine_ListModulesResponse
+   */
+  public function listAppsModules($appsId, $optParams = array())
+  {
+    $params = array('appsId' => $appsId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Appengine_ListModulesResponse");
+  }
+
+  /**
+   * Updates the configuration of the specified module. (modules.patch)
+   *
+   * @param string $appsId Part of `name`. Name of the resource to update. For
+   * example: "apps/myapp/modules/default".
+   * @param string $modulesId Part of `name`. See documentation of `appsId`.
+   * @param Google_Module $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool migrateTraffic Whether to use Traffic Migration to shift
+   * traffic gradually. Traffic can only be migrated from a single version to
+   * another single version.
+   * @opt_param string mask Standard field mask for the set of fields to be
+   * updated.
+   * @return Google_Service_Appengine_Operation
+   */
+  public function patch($appsId, $modulesId, Google_Service_Appengine_Module $postBody, $optParams = array())
+  {
+    $params = array('appsId' => $appsId, 'modulesId' => $modulesId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Appengine_Operation");
+  }
+}
+
+/**
+ * The "versions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $appengineService = new Google_Service_Appengine(...);
+ *   $versions = $appengineService->versions;
+ *  </code>
+ */
+class Google_Service_Appengine_AppsModulesVersions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deploys new code and resource files to a version. (versions.create)
+   *
+   * @param string $appsId Part of `name`. Name of the resource to update. For
+   * example: "apps/myapp/modules/default".
+   * @param string $modulesId Part of `name`. See documentation of `appsId`.
+   * @param Google_Version $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Appengine_Operation
+   */
+  public function create($appsId, $modulesId, Google_Service_Appengine_Version $postBody, $optParams = array())
+  {
+    $params = array('appsId' => $appsId, 'modulesId' => $modulesId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Appengine_Operation");
+  }
+
+  /**
+   * Deletes an existing version. (versions.delete)
+   *
+   * @param string $appsId Part of `name`. Name of the resource requested. For
+   * example: "apps/myapp/modules/default/versions/v1".
+   * @param string $modulesId Part of `name`. See documentation of `appsId`.
+   * @param string $versionsId Part of `name`. See documentation of `appsId`.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Appengine_Operation
+   */
+  public function delete($appsId, $modulesId, $versionsId, $optParams = array())
+  {
+    $params = array('appsId' => $appsId, 'modulesId' => $modulesId, 'versionsId' => $versionsId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Appengine_Operation");
+  }
+
+  /**
+   * Gets application deployment information. (versions.get)
+   *
+   * @param string $appsId Part of `name`. Name of the resource requested. For
+   * example: "apps/myapp/modules/default/versions/v1".
+   * @param string $modulesId Part of `name`. See documentation of `appsId`.
+   * @param string $versionsId Part of `name`. See documentation of `appsId`.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string view Controls the set of fields returned in the `Get`
+   * response.
+   * @return Google_Service_Appengine_Version
+   */
+  public function get($appsId, $modulesId, $versionsId, $optParams = array())
+  {
+    $params = array('appsId' => $appsId, 'modulesId' => $modulesId, 'versionsId' => $versionsId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Appengine_Version");
+  }
+
+  /**
+   * Lists the versions of a module. (versions.listAppsModulesVersions)
+   *
+   * @param string $appsId Part of `name`. Name of the resource requested. For
+   * example: "apps/myapp/modules/default".
+   * @param string $modulesId Part of `name`. See documentation of `appsId`.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Continuation token for fetching the next page of
+   * results.
+   * @opt_param int pageSize Maximum results to return per page.
+   * @opt_param string view Controls the set of fields returned in the `List`
+   * response.
+   * @return Google_Service_Appengine_ListVersionsResponse
+   */
+  public function listAppsModulesVersions($appsId, $modulesId, $optParams = array())
+  {
+    $params = array('appsId' => $appsId, 'modulesId' => $modulesId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Appengine_ListVersionsResponse");
+  }
+}
+/**
+ * The "operations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $appengineService = new Google_Service_Appengine(...);
+ *   $operations = $appengineService->operations;
+ *  </code>
+ */
+class Google_Service_Appengine_AppsOperations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the latest state of a long-running operation. Clients can use this
+   * method to poll the operation result at intervals as recommended by the API
+   * service. (operations.get)
+   *
+   * @param string $appsId Part of `name`. The name of the operation resource.
+   * @param string $operationsId Part of `name`. See documentation of `appsId`.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Appengine_Operation
+   */
+  public function get($appsId, $operationsId, $optParams = array())
+  {
+    $params = array('appsId' => $appsId, 'operationsId' => $operationsId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Appengine_Operation");
+  }
+
+  /**
+   * Lists operations that match the specified filter in the request. If the
+   * server doesn't support this method, it returns `UNIMPLEMENTED`. NOTE: the
+   * `name` binding below allows API services to override the binding to use
+   * different resource name schemes, such as `users/operations`.
+   * (operations.listAppsOperations)
+   *
+   * @param string $appsId Part of `name`. The name of the operation collection.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter The standard list filter.
+   * @opt_param int pageSize The standard list page size.
+   * @opt_param string pageToken The standard list page token.
+   * @return Google_Service_Appengine_ListOperationsResponse
+   */
+  public function listAppsOperations($appsId, $optParams = array())
+  {
+    $params = array('appsId' => $appsId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Appengine_ListOperationsResponse");
+  }
+}
+
+
+
+
+class Google_Service_Appengine_ApiConfigHandler extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $authFailAction;
+  public $login;
+  public $script;
+  public $securityLevel;
+  public $url;
+
+
+  public function setAuthFailAction($authFailAction)
+  {
+    $this->authFailAction = $authFailAction;
+  }
+  public function getAuthFailAction()
+  {
+    return $this->authFailAction;
+  }
+  public function setLogin($login)
+  {
+    $this->login = $login;
+  }
+  public function getLogin()
+  {
+    return $this->login;
+  }
+  public function setScript($script)
+  {
+    $this->script = $script;
+  }
+  public function getScript()
+  {
+    return $this->script;
+  }
+  public function setSecurityLevel($securityLevel)
+  {
+    $this->securityLevel = $securityLevel;
+  }
+  public function getSecurityLevel()
+  {
+    return $this->securityLevel;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Appengine_ApiEndpointHandler extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $scriptPath;
+
+
+  public function setScriptPath($scriptPath)
+  {
+    $this->scriptPath = $scriptPath;
+  }
+  public function getScriptPath()
+  {
+    return $this->scriptPath;
+  }
+}
+
+class Google_Service_Appengine_Application extends Google_Collection
+{
+  protected $collection_key = 'dispatchRules';
+  protected $internal_gapi_mappings = array(
+  );
+  public $codeBucket;
+  protected $dispatchRulesType = 'Google_Service_Appengine_UrlDispatchRule';
+  protected $dispatchRulesDataType = 'array';
+  public $id;
+  public $location;
+  public $name;
+
+
+  public function setCodeBucket($codeBucket)
+  {
+    $this->codeBucket = $codeBucket;
+  }
+  public function getCodeBucket()
+  {
+    return $this->codeBucket;
+  }
+  public function setDispatchRules($dispatchRules)
+  {
+    $this->dispatchRules = $dispatchRules;
+  }
+  public function getDispatchRules()
+  {
+    return $this->dispatchRules;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Appengine_AutomaticScaling extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $coolDownPeriod;
+  protected $cpuUtilizationType = 'Google_Service_Appengine_CpuUtilization';
+  protected $cpuUtilizationDataType = '';
+  public $maxConcurrentRequests;
+  public $maxIdleInstances;
+  public $maxPendingLatency;
+  public $maxTotalInstances;
+  public $minIdleInstances;
+  public $minPendingLatency;
+  public $minTotalInstances;
+
+
+  public function setCoolDownPeriod($coolDownPeriod)
+  {
+    $this->coolDownPeriod = $coolDownPeriod;
+  }
+  public function getCoolDownPeriod()
+  {
+    return $this->coolDownPeriod;
+  }
+  public function setCpuUtilization(Google_Service_Appengine_CpuUtilization $cpuUtilization)
+  {
+    $this->cpuUtilization = $cpuUtilization;
+  }
+  public function getCpuUtilization()
+  {
+    return $this->cpuUtilization;
+  }
+  public function setMaxConcurrentRequests($maxConcurrentRequests)
+  {
+    $this->maxConcurrentRequests = $maxConcurrentRequests;
+  }
+  public function getMaxConcurrentRequests()
+  {
+    return $this->maxConcurrentRequests;
+  }
+  public function setMaxIdleInstances($maxIdleInstances)
+  {
+    $this->maxIdleInstances = $maxIdleInstances;
+  }
+  public function getMaxIdleInstances()
+  {
+    return $this->maxIdleInstances;
+  }
+  public function setMaxPendingLatency($maxPendingLatency)
+  {
+    $this->maxPendingLatency = $maxPendingLatency;
+  }
+  public function getMaxPendingLatency()
+  {
+    return $this->maxPendingLatency;
+  }
+  public function setMaxTotalInstances($maxTotalInstances)
+  {
+    $this->maxTotalInstances = $maxTotalInstances;
+  }
+  public function getMaxTotalInstances()
+  {
+    return $this->maxTotalInstances;
+  }
+  public function setMinIdleInstances($minIdleInstances)
+  {
+    $this->minIdleInstances = $minIdleInstances;
+  }
+  public function getMinIdleInstances()
+  {
+    return $this->minIdleInstances;
+  }
+  public function setMinPendingLatency($minPendingLatency)
+  {
+    $this->minPendingLatency = $minPendingLatency;
+  }
+  public function getMinPendingLatency()
+  {
+    return $this->minPendingLatency;
+  }
+  public function setMinTotalInstances($minTotalInstances)
+  {
+    $this->minTotalInstances = $minTotalInstances;
+  }
+  public function getMinTotalInstances()
+  {
+    return $this->minTotalInstances;
+  }
+}
+
+class Google_Service_Appengine_BasicScaling extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $idleTimeout;
+  public $maxInstances;
+
+
+  public function setIdleTimeout($idleTimeout)
+  {
+    $this->idleTimeout = $idleTimeout;
+  }
+  public function getIdleTimeout()
+  {
+    return $this->idleTimeout;
+  }
+  public function setMaxInstances($maxInstances)
+  {
+    $this->maxInstances = $maxInstances;
+  }
+  public function getMaxInstances()
+  {
+    return $this->maxInstances;
+  }
+}
+
+class Google_Service_Appengine_ContainerInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $image;
+
+
+  public function setImage($image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+}
+
+class Google_Service_Appengine_CpuUtilization extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $aggregationWindowLength;
+  public $targetUtilization;
+
+
+  public function setAggregationWindowLength($aggregationWindowLength)
+  {
+    $this->aggregationWindowLength = $aggregationWindowLength;
+  }
+  public function getAggregationWindowLength()
+  {
+    return $this->aggregationWindowLength;
+  }
+  public function setTargetUtilization($targetUtilization)
+  {
+    $this->targetUtilization = $targetUtilization;
+  }
+  public function getTargetUtilization()
+  {
+    return $this->targetUtilization;
+  }
+}
+
+class Google_Service_Appengine_Deployment extends Google_Collection
+{
+  protected $collection_key = 'sourceReferences';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $containerType = 'Google_Service_Appengine_ContainerInfo';
+  protected $containerDataType = '';
+  protected $filesType = 'Google_Service_Appengine_FileInfo';
+  protected $filesDataType = 'map';
+  protected $sourceReferencesType = 'Google_Service_Appengine_SourceReference';
+  protected $sourceReferencesDataType = 'array';
+
+
+  public function setContainer(Google_Service_Appengine_ContainerInfo $container)
+  {
+    $this->container = $container;
+  }
+  public function getContainer()
+  {
+    return $this->container;
+  }
+  public function setFiles($files)
+  {
+    $this->files = $files;
+  }
+  public function getFiles()
+  {
+    return $this->files;
+  }
+  public function setSourceReferences($sourceReferences)
+  {
+    $this->sourceReferences = $sourceReferences;
+  }
+  public function getSourceReferences()
+  {
+    return $this->sourceReferences;
+  }
+}
+
+class Google_Service_Appengine_DeploymentFiles extends Google_Model
+{
+}
+
+class Google_Service_Appengine_ErrorHandler extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $errorCode;
+  public $mimeType;
+  public $staticFile;
+
+
+  public function setErrorCode($errorCode)
+  {
+    $this->errorCode = $errorCode;
+  }
+  public function getErrorCode()
+  {
+    return $this->errorCode;
+  }
+  public function setMimeType($mimeType)
+  {
+    $this->mimeType = $mimeType;
+  }
+  public function getMimeType()
+  {
+    return $this->mimeType;
+  }
+  public function setStaticFile($staticFile)
+  {
+    $this->staticFile = $staticFile;
+  }
+  public function getStaticFile()
+  {
+    return $this->staticFile;
+  }
+}
+
+class Google_Service_Appengine_FileInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $mimeType;
+  public $sha1Sum;
+  public $sourceUrl;
+
+
+  public function setMimeType($mimeType)
+  {
+    $this->mimeType = $mimeType;
+  }
+  public function getMimeType()
+  {
+    return $this->mimeType;
+  }
+  public function setSha1Sum($sha1Sum)
+  {
+    $this->sha1Sum = $sha1Sum;
+  }
+  public function getSha1Sum()
+  {
+    return $this->sha1Sum;
+  }
+  public function setSourceUrl($sourceUrl)
+  {
+    $this->sourceUrl = $sourceUrl;
+  }
+  public function getSourceUrl()
+  {
+    return $this->sourceUrl;
+  }
+}
+
+class Google_Service_Appengine_HealthCheck extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $checkInterval;
+  public $disableHealthCheck;
+  public $healthyThreshold;
+  public $host;
+  public $restartThreshold;
+  public $timeout;
+  public $unhealthyThreshold;
+
+
+  public function setCheckInterval($checkInterval)
+  {
+    $this->checkInterval = $checkInterval;
+  }
+  public function getCheckInterval()
+  {
+    return $this->checkInterval;
+  }
+  public function setDisableHealthCheck($disableHealthCheck)
+  {
+    $this->disableHealthCheck = $disableHealthCheck;
+  }
+  public function getDisableHealthCheck()
+  {
+    return $this->disableHealthCheck;
+  }
+  public function setHealthyThreshold($healthyThreshold)
+  {
+    $this->healthyThreshold = $healthyThreshold;
+  }
+  public function getHealthyThreshold()
+  {
+    return $this->healthyThreshold;
+  }
+  public function setHost($host)
+  {
+    $this->host = $host;
+  }
+  public function getHost()
+  {
+    return $this->host;
+  }
+  public function setRestartThreshold($restartThreshold)
+  {
+    $this->restartThreshold = $restartThreshold;
+  }
+  public function getRestartThreshold()
+  {
+    return $this->restartThreshold;
+  }
+  public function setTimeout($timeout)
+  {
+    $this->timeout = $timeout;
+  }
+  public function getTimeout()
+  {
+    return $this->timeout;
+  }
+  public function setUnhealthyThreshold($unhealthyThreshold)
+  {
+    $this->unhealthyThreshold = $unhealthyThreshold;
+  }
+  public function getUnhealthyThreshold()
+  {
+    return $this->unhealthyThreshold;
+  }
+}
+
+class Google_Service_Appengine_Library extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $version;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Appengine_ListModulesResponse extends Google_Collection
+{
+  protected $collection_key = 'modules';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $modulesType = 'Google_Service_Appengine_Module';
+  protected $modulesDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setModules($modules)
+  {
+    $this->modules = $modules;
+  }
+  public function getModules()
+  {
+    return $this->modules;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Appengine_ListOperationsResponse extends Google_Collection
+{
+  protected $collection_key = 'operations';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $operationsType = 'Google_Service_Appengine_Operation';
+  protected $operationsDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setOperations($operations)
+  {
+    $this->operations = $operations;
+  }
+  public function getOperations()
+  {
+    return $this->operations;
+  }
+}
+
+class Google_Service_Appengine_ListVersionsResponse extends Google_Collection
+{
+  protected $collection_key = 'versions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $versionsType = 'Google_Service_Appengine_Version';
+  protected $versionsDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setVersions($versions)
+  {
+    $this->versions = $versions;
+  }
+  public function getVersions()
+  {
+    return $this->versions;
+  }
+}
+
+class Google_Service_Appengine_ManualScaling extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $instances;
+
+
+  public function setInstances($instances)
+  {
+    $this->instances = $instances;
+  }
+  public function getInstances()
+  {
+    return $this->instances;
+  }
+}
+
+class Google_Service_Appengine_Module extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $name;
+  protected $splitType = 'Google_Service_Appengine_TrafficSplit';
+  protected $splitDataType = '';
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSplit(Google_Service_Appengine_TrafficSplit $split)
+  {
+    $this->split = $split;
+  }
+  public function getSplit()
+  {
+    return $this->split;
+  }
+}
+
+class Google_Service_Appengine_Network extends Google_Collection
+{
+  protected $collection_key = 'forwardedPorts';
+  protected $internal_gapi_mappings = array(
+  );
+  public $forwardedPorts;
+  public $instanceTag;
+  public $name;
+
+
+  public function setForwardedPorts($forwardedPorts)
+  {
+    $this->forwardedPorts = $forwardedPorts;
+  }
+  public function getForwardedPorts()
+  {
+    return $this->forwardedPorts;
+  }
+  public function setInstanceTag($instanceTag)
+  {
+    $this->instanceTag = $instanceTag;
+  }
+  public function getInstanceTag()
+  {
+    return $this->instanceTag;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Appengine_Operation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $done;
+  protected $errorType = 'Google_Service_Appengine_Status';
+  protected $errorDataType = '';
+  public $metadata;
+  public $name;
+  public $response;
+
+
+  public function setDone($done)
+  {
+    $this->done = $done;
+  }
+  public function getDone()
+  {
+    return $this->done;
+  }
+  public function setError(Google_Service_Appengine_Status $error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setMetadata($metadata)
+  {
+    $this->metadata = $metadata;
+  }
+  public function getMetadata()
+  {
+    return $this->metadata;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setResponse($response)
+  {
+    $this->response = $response;
+  }
+  public function getResponse()
+  {
+    return $this->response;
+  }
+}
+
+class Google_Service_Appengine_OperationMetadata extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $endTime;
+  public $insertTime;
+  public $method;
+  public $operationType;
+  public $target;
+  public $user;
+
+
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setInsertTime($insertTime)
+  {
+    $this->insertTime = $insertTime;
+  }
+  public function getInsertTime()
+  {
+    return $this->insertTime;
+  }
+  public function setMethod($method)
+  {
+    $this->method = $method;
+  }
+  public function getMethod()
+  {
+    return $this->method;
+  }
+  public function setOperationType($operationType)
+  {
+    $this->operationType = $operationType;
+  }
+  public function getOperationType()
+  {
+    return $this->operationType;
+  }
+  public function setTarget($target)
+  {
+    $this->target = $target;
+  }
+  public function getTarget()
+  {
+    return $this->target;
+  }
+  public function setUser($user)
+  {
+    $this->user = $user;
+  }
+  public function getUser()
+  {
+    return $this->user;
+  }
+}
+
+class Google_Service_Appengine_OperationResponse extends Google_Model
+{
+}
+
+class Google_Service_Appengine_Resources extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $cpu;
+  public $diskGb;
+  public $memoryGb;
+
+
+  public function setCpu($cpu)
+  {
+    $this->cpu = $cpu;
+  }
+  public function getCpu()
+  {
+    return $this->cpu;
+  }
+  public function setDiskGb($diskGb)
+  {
+    $this->diskGb = $diskGb;
+  }
+  public function getDiskGb()
+  {
+    return $this->diskGb;
+  }
+  public function setMemoryGb($memoryGb)
+  {
+    $this->memoryGb = $memoryGb;
+  }
+  public function getMemoryGb()
+  {
+    return $this->memoryGb;
+  }
+}
+
+class Google_Service_Appengine_ScriptHandler extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $scriptPath;
+
+
+  public function setScriptPath($scriptPath)
+  {
+    $this->scriptPath = $scriptPath;
+  }
+  public function getScriptPath()
+  {
+    return $this->scriptPath;
+  }
+}
+
+class Google_Service_Appengine_SourceReference extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $repository;
+  public $revisionId;
+
+
+  public function setRepository($repository)
+  {
+    $this->repository = $repository;
+  }
+  public function getRepository()
+  {
+    return $this->repository;
+  }
+  public function setRevisionId($revisionId)
+  {
+    $this->revisionId = $revisionId;
+  }
+  public function getRevisionId()
+  {
+    return $this->revisionId;
+  }
+}
+
+class Google_Service_Appengine_StaticDirectoryHandler extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $applicationReadable;
+  public $directory;
+  public $expiration;
+  public $httpHeaders;
+  public $mimeType;
+  public $requireMatchingFile;
+
+
+  public function setApplicationReadable($applicationReadable)
+  {
+    $this->applicationReadable = $applicationReadable;
+  }
+  public function getApplicationReadable()
+  {
+    return $this->applicationReadable;
+  }
+  public function setDirectory($directory)
+  {
+    $this->directory = $directory;
+  }
+  public function getDirectory()
+  {
+    return $this->directory;
+  }
+  public function setExpiration($expiration)
+  {
+    $this->expiration = $expiration;
+  }
+  public function getExpiration()
+  {
+    return $this->expiration;
+  }
+  public function setHttpHeaders($httpHeaders)
+  {
+    $this->httpHeaders = $httpHeaders;
+  }
+  public function getHttpHeaders()
+  {
+    return $this->httpHeaders;
+  }
+  public function setMimeType($mimeType)
+  {
+    $this->mimeType = $mimeType;
+  }
+  public function getMimeType()
+  {
+    return $this->mimeType;
+  }
+  public function setRequireMatchingFile($requireMatchingFile)
+  {
+    $this->requireMatchingFile = $requireMatchingFile;
+  }
+  public function getRequireMatchingFile()
+  {
+    return $this->requireMatchingFile;
+  }
+}
+
+class Google_Service_Appengine_StaticDirectoryHandlerHttpHeaders extends Google_Model
+{
+}
+
+class Google_Service_Appengine_StaticFilesHandler extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $applicationReadable;
+  public $expiration;
+  public $httpHeaders;
+  public $mimeType;
+  public $path;
+  public $requireMatchingFile;
+  public $uploadPathRegex;
+
+
+  public function setApplicationReadable($applicationReadable)
+  {
+    $this->applicationReadable = $applicationReadable;
+  }
+  public function getApplicationReadable()
+  {
+    return $this->applicationReadable;
+  }
+  public function setExpiration($expiration)
+  {
+    $this->expiration = $expiration;
+  }
+  public function getExpiration()
+  {
+    return $this->expiration;
+  }
+  public function setHttpHeaders($httpHeaders)
+  {
+    $this->httpHeaders = $httpHeaders;
+  }
+  public function getHttpHeaders()
+  {
+    return $this->httpHeaders;
+  }
+  public function setMimeType($mimeType)
+  {
+    $this->mimeType = $mimeType;
+  }
+  public function getMimeType()
+  {
+    return $this->mimeType;
+  }
+  public function setPath($path)
+  {
+    $this->path = $path;
+  }
+  public function getPath()
+  {
+    return $this->path;
+  }
+  public function setRequireMatchingFile($requireMatchingFile)
+  {
+    $this->requireMatchingFile = $requireMatchingFile;
+  }
+  public function getRequireMatchingFile()
+  {
+    return $this->requireMatchingFile;
+  }
+  public function setUploadPathRegex($uploadPathRegex)
+  {
+    $this->uploadPathRegex = $uploadPathRegex;
+  }
+  public function getUploadPathRegex()
+  {
+    return $this->uploadPathRegex;
+  }
+}
+
+class Google_Service_Appengine_StaticFilesHandlerHttpHeaders extends Google_Model
+{
+}
+
+class Google_Service_Appengine_Status extends Google_Collection
+{
+  protected $collection_key = 'details';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $details;
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setDetails($details)
+  {
+    $this->details = $details;
+  }
+  public function getDetails()
+  {
+    return $this->details;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Appengine_StatusDetails extends Google_Model
+{
+}
+
+class Google_Service_Appengine_TrafficSplit extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $allocations;
+  public $shardBy;
+
+
+  public function setAllocations($allocations)
+  {
+    $this->allocations = $allocations;
+  }
+  public function getAllocations()
+  {
+    return $this->allocations;
+  }
+  public function setShardBy($shardBy)
+  {
+    $this->shardBy = $shardBy;
+  }
+  public function getShardBy()
+  {
+    return $this->shardBy;
+  }
+}
+
+class Google_Service_Appengine_TrafficSplitAllocations extends Google_Model
+{
+}
+
+class Google_Service_Appengine_UrlDispatchRule extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $domain;
+  public $module;
+  public $path;
+
+
+  public function setDomain($domain)
+  {
+    $this->domain = $domain;
+  }
+  public function getDomain()
+  {
+    return $this->domain;
+  }
+  public function setModule($module)
+  {
+    $this->module = $module;
+  }
+  public function getModule()
+  {
+    return $this->module;
+  }
+  public function setPath($path)
+  {
+    $this->path = $path;
+  }
+  public function getPath()
+  {
+    return $this->path;
+  }
+}
+
+class Google_Service_Appengine_UrlMap extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $apiEndpointType = 'Google_Service_Appengine_ApiEndpointHandler';
+  protected $apiEndpointDataType = '';
+  public $authFailAction;
+  public $login;
+  public $redirectHttpResponseCode;
+  protected $scriptType = 'Google_Service_Appengine_ScriptHandler';
+  protected $scriptDataType = '';
+  public $securityLevel;
+  protected $staticDirectoryType = 'Google_Service_Appengine_StaticDirectoryHandler';
+  protected $staticDirectoryDataType = '';
+  protected $staticFilesType = 'Google_Service_Appengine_StaticFilesHandler';
+  protected $staticFilesDataType = '';
+  public $urlRegex;
+
+
+  public function setApiEndpoint(Google_Service_Appengine_ApiEndpointHandler $apiEndpoint)
+  {
+    $this->apiEndpoint = $apiEndpoint;
+  }
+  public function getApiEndpoint()
+  {
+    return $this->apiEndpoint;
+  }
+  public function setAuthFailAction($authFailAction)
+  {
+    $this->authFailAction = $authFailAction;
+  }
+  public function getAuthFailAction()
+  {
+    return $this->authFailAction;
+  }
+  public function setLogin($login)
+  {
+    $this->login = $login;
+  }
+  public function getLogin()
+  {
+    return $this->login;
+  }
+  public function setRedirectHttpResponseCode($redirectHttpResponseCode)
+  {
+    $this->redirectHttpResponseCode = $redirectHttpResponseCode;
+  }
+  public function getRedirectHttpResponseCode()
+  {
+    return $this->redirectHttpResponseCode;
+  }
+  public function setScript(Google_Service_Appengine_ScriptHandler $script)
+  {
+    $this->script = $script;
+  }
+  public function getScript()
+  {
+    return $this->script;
+  }
+  public function setSecurityLevel($securityLevel)
+  {
+    $this->securityLevel = $securityLevel;
+  }
+  public function getSecurityLevel()
+  {
+    return $this->securityLevel;
+  }
+  public function setStaticDirectory(Google_Service_Appengine_StaticDirectoryHandler $staticDirectory)
+  {
+    $this->staticDirectory = $staticDirectory;
+  }
+  public function getStaticDirectory()
+  {
+    return $this->staticDirectory;
+  }
+  public function setStaticFiles(Google_Service_Appengine_StaticFilesHandler $staticFiles)
+  {
+    $this->staticFiles = $staticFiles;
+  }
+  public function getStaticFiles()
+  {
+    return $this->staticFiles;
+  }
+  public function setUrlRegex($urlRegex)
+  {
+    $this->urlRegex = $urlRegex;
+  }
+  public function getUrlRegex()
+  {
+    return $this->urlRegex;
+  }
+}
+
+class Google_Service_Appengine_Version extends Google_Collection
+{
+  protected $collection_key = 'libraries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $apiConfigType = 'Google_Service_Appengine_ApiConfigHandler';
+  protected $apiConfigDataType = '';
+  protected $automaticScalingType = 'Google_Service_Appengine_AutomaticScaling';
+  protected $automaticScalingDataType = '';
+  protected $basicScalingType = 'Google_Service_Appengine_BasicScaling';
+  protected $basicScalingDataType = '';
+  public $betaSettings;
+  public $creationTime;
+  public $defaultExpiration;
+  public $deployer;
+  protected $deploymentType = 'Google_Service_Appengine_Deployment';
+  protected $deploymentDataType = '';
+  public $env;
+  public $envVariables;
+  protected $errorHandlersType = 'Google_Service_Appengine_ErrorHandler';
+  protected $errorHandlersDataType = 'array';
+  protected $handlersType = 'Google_Service_Appengine_UrlMap';
+  protected $handlersDataType = 'array';
+  protected $healthCheckType = 'Google_Service_Appengine_HealthCheck';
+  protected $healthCheckDataType = '';
+  public $id;
+  public $inboundServices;
+  public $instanceClass;
+  protected $librariesType = 'Google_Service_Appengine_Library';
+  protected $librariesDataType = 'array';
+  protected $manualScalingType = 'Google_Service_Appengine_ManualScaling';
+  protected $manualScalingDataType = '';
+  public $name;
+  protected $networkType = 'Google_Service_Appengine_Network';
+  protected $networkDataType = '';
+  public $nobuildFilesRegex;
+  protected $resourcesType = 'Google_Service_Appengine_Resources';
+  protected $resourcesDataType = '';
+  public $runtime;
+  public $servingStatus;
+  public $threadsafe;
+  public $vm;
+
+
+  public function setApiConfig(Google_Service_Appengine_ApiConfigHandler $apiConfig)
+  {
+    $this->apiConfig = $apiConfig;
+  }
+  public function getApiConfig()
+  {
+    return $this->apiConfig;
+  }
+  public function setAutomaticScaling(Google_Service_Appengine_AutomaticScaling $automaticScaling)
+  {
+    $this->automaticScaling = $automaticScaling;
+  }
+  public function getAutomaticScaling()
+  {
+    return $this->automaticScaling;
+  }
+  public function setBasicScaling(Google_Service_Appengine_BasicScaling $basicScaling)
+  {
+    $this->basicScaling = $basicScaling;
+  }
+  public function getBasicScaling()
+  {
+    return $this->basicScaling;
+  }
+  public function setBetaSettings($betaSettings)
+  {
+    $this->betaSettings = $betaSettings;
+  }
+  public function getBetaSettings()
+  {
+    return $this->betaSettings;
+  }
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setDefaultExpiration($defaultExpiration)
+  {
+    $this->defaultExpiration = $defaultExpiration;
+  }
+  public function getDefaultExpiration()
+  {
+    return $this->defaultExpiration;
+  }
+  public function setDeployer($deployer)
+  {
+    $this->deployer = $deployer;
+  }
+  public function getDeployer()
+  {
+    return $this->deployer;
+  }
+  public function setDeployment(Google_Service_Appengine_Deployment $deployment)
+  {
+    $this->deployment = $deployment;
+  }
+  public function getDeployment()
+  {
+    return $this->deployment;
+  }
+  public function setEnv($env)
+  {
+    $this->env = $env;
+  }
+  public function getEnv()
+  {
+    return $this->env;
+  }
+  public function setEnvVariables($envVariables)
+  {
+    $this->envVariables = $envVariables;
+  }
+  public function getEnvVariables()
+  {
+    return $this->envVariables;
+  }
+  public function setErrorHandlers($errorHandlers)
+  {
+    $this->errorHandlers = $errorHandlers;
+  }
+  public function getErrorHandlers()
+  {
+    return $this->errorHandlers;
+  }
+  public function setHandlers($handlers)
+  {
+    $this->handlers = $handlers;
+  }
+  public function getHandlers()
+  {
+    return $this->handlers;
+  }
+  public function setHealthCheck(Google_Service_Appengine_HealthCheck $healthCheck)
+  {
+    $this->healthCheck = $healthCheck;
+  }
+  public function getHealthCheck()
+  {
+    return $this->healthCheck;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInboundServices($inboundServices)
+  {
+    $this->inboundServices = $inboundServices;
+  }
+  public function getInboundServices()
+  {
+    return $this->inboundServices;
+  }
+  public function setInstanceClass($instanceClass)
+  {
+    $this->instanceClass = $instanceClass;
+  }
+  public function getInstanceClass()
+  {
+    return $this->instanceClass;
+  }
+  public function setLibraries($libraries)
+  {
+    $this->libraries = $libraries;
+  }
+  public function getLibraries()
+  {
+    return $this->libraries;
+  }
+  public function setManualScaling(Google_Service_Appengine_ManualScaling $manualScaling)
+  {
+    $this->manualScaling = $manualScaling;
+  }
+  public function getManualScaling()
+  {
+    return $this->manualScaling;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNetwork(Google_Service_Appengine_Network $network)
+  {
+    $this->network = $network;
+  }
+  public function getNetwork()
+  {
+    return $this->network;
+  }
+  public function setNobuildFilesRegex($nobuildFilesRegex)
+  {
+    $this->nobuildFilesRegex = $nobuildFilesRegex;
+  }
+  public function getNobuildFilesRegex()
+  {
+    return $this->nobuildFilesRegex;
+  }
+  public function setResources(Google_Service_Appengine_Resources $resources)
+  {
+    $this->resources = $resources;
+  }
+  public function getResources()
+  {
+    return $this->resources;
+  }
+  public function setRuntime($runtime)
+  {
+    $this->runtime = $runtime;
+  }
+  public function getRuntime()
+  {
+    return $this->runtime;
+  }
+  public function setServingStatus($servingStatus)
+  {
+    $this->servingStatus = $servingStatus;
+  }
+  public function getServingStatus()
+  {
+    return $this->servingStatus;
+  }
+  public function setThreadsafe($threadsafe)
+  {
+    $this->threadsafe = $threadsafe;
+  }
+  public function getThreadsafe()
+  {
+    return $this->threadsafe;
+  }
+  public function setVm($vm)
+  {
+    $this->vm = $vm;
+  }
+  public function getVm()
+  {
+    return $this->vm;
+  }
+}
+
+class Google_Service_Appengine_VersionBetaSettings extends Google_Model
+{
+}
+
+class Google_Service_Appengine_VersionEnvVariables extends Google_Model
+{
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Appsactivity.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Appsactivity.php
@@ -1,0 +1,570 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Appsactivity (v1).
+ *
+ * <p>
+ * Provides a historical view of activity.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/google-apps/activity/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Appsactivity extends Google_Service
+{
+  /** View the activity history of your Google Apps. */
+  const ACTIVITY =
+      "https://www.googleapis.com/auth/activity";
+  /** View and manage the files in your Google Drive. */
+  const DRIVE =
+      "https://www.googleapis.com/auth/drive";
+  /** View and manage metadata of files in your Google Drive. */
+  const DRIVE_METADATA =
+      "https://www.googleapis.com/auth/drive.metadata";
+  /** View metadata for files in your Google Drive. */
+  const DRIVE_METADATA_READONLY =
+      "https://www.googleapis.com/auth/drive.metadata.readonly";
+  /** View the files in your Google Drive. */
+  const DRIVE_READONLY =
+      "https://www.googleapis.com/auth/drive.readonly";
+
+  public $activities;
+  
+
+  /**
+   * Constructs the internal representation of the Appsactivity service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'appsactivity/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'appsactivity';
+
+    $this->activities = new Google_Service_Appsactivity_Activities_Resource(
+        $this,
+        $this->serviceName,
+        'activities',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'activities',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'drive.ancestorId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'userId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'groupingStrategy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'drive.fileId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "activities" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $appsactivityService = new Google_Service_Appsactivity(...);
+ *   $activities = $appsactivityService->activities;
+ *  </code>
+ */
+class Google_Service_Appsactivity_Activities_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns a list of activities visible to the current logged in user. Visible
+   * activities are determined by the visiblity settings of the object that was
+   * acted on, e.g. Drive files a user can see. An activity is a record of past
+   * events. Multiple events may be merged if they are similar. A request is
+   * scoped to activities from a given Google service using the source parameter.
+   * (activities.listActivities)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string drive.ancestorId Identifies the Drive folder containing the
+   * items for which to return activities.
+   * @opt_param int pageSize The maximum number of events to return on a page. The
+   * response includes a continuation token if there are more events.
+   * @opt_param string pageToken A token to retrieve a specific page of results.
+   * @opt_param string userId Indicates the user to return activity for. Use the
+   * special value me to indicate the currently authenticated user.
+   * @opt_param string groupingStrategy Indicates the strategy to use when
+   * grouping singleEvents items in the associated combinedEvent object.
+   * @opt_param string drive.fileId Identifies the Drive item to return activities
+   * for.
+   * @opt_param string source The Google service from which to return activities.
+   * Possible values of source are: - drive.google.com
+   * @return Google_Service_Appsactivity_ListActivitiesResponse
+   */
+  public function listActivities($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Appsactivity_ListActivitiesResponse");
+  }
+}
+
+
+
+
+class Google_Service_Appsactivity_Activity extends Google_Collection
+{
+  protected $collection_key = 'singleEvents';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $combinedEventType = 'Google_Service_Appsactivity_Event';
+  protected $combinedEventDataType = '';
+  protected $singleEventsType = 'Google_Service_Appsactivity_Event';
+  protected $singleEventsDataType = 'array';
+
+
+  public function setCombinedEvent(Google_Service_Appsactivity_Event $combinedEvent)
+  {
+    $this->combinedEvent = $combinedEvent;
+  }
+  public function getCombinedEvent()
+  {
+    return $this->combinedEvent;
+  }
+  public function setSingleEvents($singleEvents)
+  {
+    $this->singleEvents = $singleEvents;
+  }
+  public function getSingleEvents()
+  {
+    return $this->singleEvents;
+  }
+}
+
+class Google_Service_Appsactivity_Event extends Google_Collection
+{
+  protected $collection_key = 'permissionChanges';
+  protected $internal_gapi_mappings = array(
+  );
+  public $additionalEventTypes;
+  public $eventTimeMillis;
+  public $fromUserDeletion;
+  protected $moveType = 'Google_Service_Appsactivity_Move';
+  protected $moveDataType = '';
+  protected $permissionChangesType = 'Google_Service_Appsactivity_PermissionChange';
+  protected $permissionChangesDataType = 'array';
+  public $primaryEventType;
+  protected $renameType = 'Google_Service_Appsactivity_Rename';
+  protected $renameDataType = '';
+  protected $targetType = 'Google_Service_Appsactivity_Target';
+  protected $targetDataType = '';
+  protected $userType = 'Google_Service_Appsactivity_User';
+  protected $userDataType = '';
+
+
+  public function setAdditionalEventTypes($additionalEventTypes)
+  {
+    $this->additionalEventTypes = $additionalEventTypes;
+  }
+  public function getAdditionalEventTypes()
+  {
+    return $this->additionalEventTypes;
+  }
+  public function setEventTimeMillis($eventTimeMillis)
+  {
+    $this->eventTimeMillis = $eventTimeMillis;
+  }
+  public function getEventTimeMillis()
+  {
+    return $this->eventTimeMillis;
+  }
+  public function setFromUserDeletion($fromUserDeletion)
+  {
+    $this->fromUserDeletion = $fromUserDeletion;
+  }
+  public function getFromUserDeletion()
+  {
+    return $this->fromUserDeletion;
+  }
+  public function setMove(Google_Service_Appsactivity_Move $move)
+  {
+    $this->move = $move;
+  }
+  public function getMove()
+  {
+    return $this->move;
+  }
+  public function setPermissionChanges($permissionChanges)
+  {
+    $this->permissionChanges = $permissionChanges;
+  }
+  public function getPermissionChanges()
+  {
+    return $this->permissionChanges;
+  }
+  public function setPrimaryEventType($primaryEventType)
+  {
+    $this->primaryEventType = $primaryEventType;
+  }
+  public function getPrimaryEventType()
+  {
+    return $this->primaryEventType;
+  }
+  public function setRename(Google_Service_Appsactivity_Rename $rename)
+  {
+    $this->rename = $rename;
+  }
+  public function getRename()
+  {
+    return $this->rename;
+  }
+  public function setTarget(Google_Service_Appsactivity_Target $target)
+  {
+    $this->target = $target;
+  }
+  public function getTarget()
+  {
+    return $this->target;
+  }
+  public function setUser(Google_Service_Appsactivity_User $user)
+  {
+    $this->user = $user;
+  }
+  public function getUser()
+  {
+    return $this->user;
+  }
+}
+
+class Google_Service_Appsactivity_ListActivitiesResponse extends Google_Collection
+{
+  protected $collection_key = 'activities';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $activitiesType = 'Google_Service_Appsactivity_Activity';
+  protected $activitiesDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setActivities($activities)
+  {
+    $this->activities = $activities;
+  }
+  public function getActivities()
+  {
+    return $this->activities;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Appsactivity_Move extends Google_Collection
+{
+  protected $collection_key = 'removedParents';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $addedParentsType = 'Google_Service_Appsactivity_Parent';
+  protected $addedParentsDataType = 'array';
+  protected $removedParentsType = 'Google_Service_Appsactivity_Parent';
+  protected $removedParentsDataType = 'array';
+
+
+  public function setAddedParents($addedParents)
+  {
+    $this->addedParents = $addedParents;
+  }
+  public function getAddedParents()
+  {
+    return $this->addedParents;
+  }
+  public function setRemovedParents($removedParents)
+  {
+    $this->removedParents = $removedParents;
+  }
+  public function getRemovedParents()
+  {
+    return $this->removedParents;
+  }
+}
+
+class Google_Service_Appsactivity_Parent extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $isRoot;
+  public $title;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIsRoot($isRoot)
+  {
+    $this->isRoot = $isRoot;
+  }
+  public function getIsRoot()
+  {
+    return $this->isRoot;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_Appsactivity_Permission extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $permissionId;
+  public $role;
+  public $type;
+  protected $userType = 'Google_Service_Appsactivity_User';
+  protected $userDataType = '';
+  public $withLink;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPermissionId($permissionId)
+  {
+    $this->permissionId = $permissionId;
+  }
+  public function getPermissionId()
+  {
+    return $this->permissionId;
+  }
+  public function setRole($role)
+  {
+    $this->role = $role;
+  }
+  public function getRole()
+  {
+    return $this->role;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUser(Google_Service_Appsactivity_User $user)
+  {
+    $this->user = $user;
+  }
+  public function getUser()
+  {
+    return $this->user;
+  }
+  public function setWithLink($withLink)
+  {
+    $this->withLink = $withLink;
+  }
+  public function getWithLink()
+  {
+    return $this->withLink;
+  }
+}
+
+class Google_Service_Appsactivity_PermissionChange extends Google_Collection
+{
+  protected $collection_key = 'removedPermissions';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $addedPermissionsType = 'Google_Service_Appsactivity_Permission';
+  protected $addedPermissionsDataType = 'array';
+  protected $removedPermissionsType = 'Google_Service_Appsactivity_Permission';
+  protected $removedPermissionsDataType = 'array';
+
+
+  public function setAddedPermissions($addedPermissions)
+  {
+    $this->addedPermissions = $addedPermissions;
+  }
+  public function getAddedPermissions()
+  {
+    return $this->addedPermissions;
+  }
+  public function setRemovedPermissions($removedPermissions)
+  {
+    $this->removedPermissions = $removedPermissions;
+  }
+  public function getRemovedPermissions()
+  {
+    return $this->removedPermissions;
+  }
+}
+
+class Google_Service_Appsactivity_Photo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $url;
+
+
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Appsactivity_Rename extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $newTitle;
+  public $oldTitle;
+
+
+  public function setNewTitle($newTitle)
+  {
+    $this->newTitle = $newTitle;
+  }
+  public function getNewTitle()
+  {
+    return $this->newTitle;
+  }
+  public function setOldTitle($oldTitle)
+  {
+    $this->oldTitle = $oldTitle;
+  }
+  public function getOldTitle()
+  {
+    return $this->oldTitle;
+  }
+}
+
+class Google_Service_Appsactivity_Target extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $mimeType;
+  public $name;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setMimeType($mimeType)
+  {
+    $this->mimeType = $mimeType;
+  }
+  public function getMimeType()
+  {
+    return $this->mimeType;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Appsactivity_User extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  protected $photoType = 'Google_Service_Appsactivity_Photo';
+  protected $photoDataType = '';
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPhoto(Google_Service_Appsactivity_Photo $photo)
+  {
+    $this->photo = $photo;
+  }
+  public function getPhoto()
+  {
+    return $this->photo;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Audit.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Audit.php
@@ -1,0 +1,416 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Audit (v1).
+ *
+ * <p>
+ * Lets you access user activities in your enterprise made through various
+ * applications.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/google-apps/admin-audit/get_started" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Audit extends Google_Service
+{
+
+
+  public $activities;
+  
+
+  /**
+   * Constructs the internal representation of the Audit service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->servicePath = 'apps/reporting/audit/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'audit';
+
+    $this->activities = new Google_Service_Audit_Activities_Resource(
+        $this,
+        $this->serviceName,
+        'activities',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => '{customerId}/{applicationId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'applicationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'actorEmail' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'actorApplicationId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'actorIpAddress' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'caller' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'eventName' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'endTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'continuationToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "activities" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $auditService = new Google_Service_Audit(...);
+ *   $activities = $auditService->activities;
+ *  </code>
+ */
+class Google_Service_Audit_Activities_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a list of activities for a specific customer and application.
+   * (activities.listActivities)
+   *
+   * @param string $customerId Represents the customer who is the owner of target
+   * object on which action was performed.
+   * @param string $applicationId Application ID of the application on which the
+   * event was performed.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string actorEmail Email address of the user who performed the
+   * action.
+   * @opt_param string actorApplicationId Application ID of the application which
+   * interacted on behalf of the user while performing the event.
+   * @opt_param string actorIpAddress IP Address of host where the event was
+   * performed. Supports both IPv4 and IPv6 addresses.
+   * @opt_param string caller Type of the caller.
+   * @opt_param int maxResults Number of activity records to be shown in each
+   * page.
+   * @opt_param string eventName Name of the event being queried.
+   * @opt_param string startTime Return events which occured at or after this
+   * time.
+   * @opt_param string endTime Return events which occured at or before this time.
+   * @opt_param string continuationToken Next page URL.
+   * @return Google_Service_Audit_Activities
+   */
+  public function listActivities($customerId, $applicationId, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'applicationId' => $applicationId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Audit_Activities");
+  }
+}
+
+
+
+
+class Google_Service_Audit_Activities extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Audit_Activity';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $next;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNext($next)
+  {
+    $this->next = $next;
+  }
+  public function getNext()
+  {
+    return $this->next;
+  }
+}
+
+class Google_Service_Audit_Activity extends Google_Collection
+{
+  protected $collection_key = 'events';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $actorType = 'Google_Service_Audit_ActivityActor';
+  protected $actorDataType = '';
+  protected $eventsType = 'Google_Service_Audit_ActivityEvents';
+  protected $eventsDataType = 'array';
+  protected $idType = 'Google_Service_Audit_ActivityId';
+  protected $idDataType = '';
+  public $ipAddress;
+  public $kind;
+  public $ownerDomain;
+
+
+  public function setActor(Google_Service_Audit_ActivityActor $actor)
+  {
+    $this->actor = $actor;
+  }
+  public function getActor()
+  {
+    return $this->actor;
+  }
+  public function setEvents($events)
+  {
+    $this->events = $events;
+  }
+  public function getEvents()
+  {
+    return $this->events;
+  }
+  public function setId(Google_Service_Audit_ActivityId $id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIpAddress($ipAddress)
+  {
+    $this->ipAddress = $ipAddress;
+  }
+  public function getIpAddress()
+  {
+    return $this->ipAddress;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setOwnerDomain($ownerDomain)
+  {
+    $this->ownerDomain = $ownerDomain;
+  }
+  public function getOwnerDomain()
+  {
+    return $this->ownerDomain;
+  }
+}
+
+class Google_Service_Audit_ActivityActor extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $applicationId;
+  public $callerType;
+  public $email;
+  public $key;
+
+
+  public function setApplicationId($applicationId)
+  {
+    $this->applicationId = $applicationId;
+  }
+  public function getApplicationId()
+  {
+    return $this->applicationId;
+  }
+  public function setCallerType($callerType)
+  {
+    $this->callerType = $callerType;
+  }
+  public function getCallerType()
+  {
+    return $this->callerType;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+}
+
+class Google_Service_Audit_ActivityEvents extends Google_Collection
+{
+  protected $collection_key = 'parameters';
+  protected $internal_gapi_mappings = array(
+  );
+  public $eventType;
+  public $name;
+  protected $parametersType = 'Google_Service_Audit_ActivityEventsParameters';
+  protected $parametersDataType = 'array';
+
+
+  public function setEventType($eventType)
+  {
+    $this->eventType = $eventType;
+  }
+  public function getEventType()
+  {
+    return $this->eventType;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setParameters($parameters)
+  {
+    $this->parameters = $parameters;
+  }
+  public function getParameters()
+  {
+    return $this->parameters;
+  }
+}
+
+class Google_Service_Audit_ActivityEventsParameters extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $value;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Audit_ActivityId extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $applicationId;
+  public $customerId;
+  public $time;
+  public $uniqQualifier;
+
+
+  public function setApplicationId($applicationId)
+  {
+    $this->applicationId = $applicationId;
+  }
+  public function getApplicationId()
+  {
+    return $this->applicationId;
+  }
+  public function setCustomerId($customerId)
+  {
+    $this->customerId = $customerId;
+  }
+  public function getCustomerId()
+  {
+    return $this->customerId;
+  }
+  public function setTime($time)
+  {
+    $this->time = $time;
+  }
+  public function getTime()
+  {
+    return $this->time;
+  }
+  public function setUniqQualifier($uniqQualifier)
+  {
+    $this->uniqQualifier = $uniqQualifier;
+  }
+  public function getUniqQualifier()
+  {
+    return $this->uniqQualifier;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Autoscaler.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Autoscaler.php
@@ -1,0 +1,1401 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Autoscaler (v1beta2).
+ *
+ * <p>
+ * The Google Compute Engine Autoscaler API provides autoscaling for groups of
+ * Cloud VMs.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="http://developers.google.com/compute/docs/autoscaler" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Autoscaler extends Google_Service
+{
+  /** View and manage your Google Compute Engine resources. */
+  const COMPUTE =
+      "https://www.googleapis.com/auth/compute";
+  /** View your Google Compute Engine resources. */
+  const COMPUTE_READONLY =
+      "https://www.googleapis.com/auth/compute.readonly";
+
+  public $autoscalers;
+  public $zoneOperations;
+  public $zones;
+  
+
+  /**
+   * Constructs the internal representation of the Autoscaler service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'autoscaler/v1beta2/';
+    $this->version = 'v1beta2';
+    $this->serviceName = 'autoscaler';
+
+    $this->autoscalers = new Google_Service_Autoscaler_Autoscalers_Resource(
+        $this,
+        $this->serviceName,
+        'autoscalers',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'projects/{project}/zones/{zone}/autoscalers/{autoscaler}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'autoscaler' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'projects/{project}/zones/{zone}/autoscalers/{autoscaler}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'autoscaler' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'projects/{project}/zones/{zone}/autoscalers',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'projects/{project}/zones/{zone}/autoscalers',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'projects/{project}/zones/{zone}/autoscalers/{autoscaler}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'autoscaler' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'projects/{project}/zones/{zone}/autoscalers/{autoscaler}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'autoscaler' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->zoneOperations = new Google_Service_Autoscaler_ZoneOperations_Resource(
+        $this,
+        $this->serviceName,
+        'zoneOperations',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/zones/{zone}/operations/{operation}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operation' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/zones/{zone}/operations/{operation}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operation' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/zones/{zone}/operations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->zones = new Google_Service_Autoscaler_Zones_Resource(
+        $this,
+        $this->serviceName,
+        'zones',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => '{project}/zones',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "autoscalers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $autoscalerService = new Google_Service_Autoscaler(...);
+ *   $autoscalers = $autoscalerService->autoscalers;
+ *  </code>
+ */
+class Google_Service_Autoscaler_Autoscalers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified Autoscaler resource. (autoscalers.delete)
+   *
+   * @param string $project Project ID of Autoscaler resource.
+   * @param string $zone Zone name of Autoscaler resource.
+   * @param string $autoscaler Name of the Autoscaler resource.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Autoscaler_Operation
+   */
+  public function delete($project, $zone, $autoscaler, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'autoscaler' => $autoscaler);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Autoscaler_Operation");
+  }
+
+  /**
+   * Gets the specified Autoscaler resource. (autoscalers.get)
+   *
+   * @param string $project Project ID of Autoscaler resource.
+   * @param string $zone Zone name of Autoscaler resource.
+   * @param string $autoscaler Name of the Autoscaler resource.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Autoscaler_Autoscaler
+   */
+  public function get($project, $zone, $autoscaler, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'autoscaler' => $autoscaler);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Autoscaler_Autoscaler");
+  }
+
+  /**
+   * Adds new Autoscaler resource. (autoscalers.insert)
+   *
+   * @param string $project Project ID of Autoscaler resource.
+   * @param string $zone Zone name of Autoscaler resource.
+   * @param Google_Autoscaler $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Autoscaler_Operation
+   */
+  public function insert($project, $zone, Google_Service_Autoscaler_Autoscaler $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Autoscaler_Operation");
+  }
+
+  /**
+   * Lists all Autoscaler resources in this zone. (autoscalers.listAutoscalers)
+   *
+   * @param string $project Project ID of Autoscaler resource.
+   * @param string $zone Zone name of Autoscaler resource.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter
+   * @opt_param string pageToken
+   * @opt_param string maxResults
+   * @return Google_Service_Autoscaler_AutoscalerListResponse
+   */
+  public function listAutoscalers($project, $zone, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Autoscaler_AutoscalerListResponse");
+  }
+
+  /**
+   * Update the entire content of the Autoscaler resource. This method supports
+   * patch semantics. (autoscalers.patch)
+   *
+   * @param string $project Project ID of Autoscaler resource.
+   * @param string $zone Zone name of Autoscaler resource.
+   * @param string $autoscaler Name of the Autoscaler resource.
+   * @param Google_Autoscaler $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Autoscaler_Operation
+   */
+  public function patch($project, $zone, $autoscaler, Google_Service_Autoscaler_Autoscaler $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'autoscaler' => $autoscaler, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Autoscaler_Operation");
+  }
+
+  /**
+   * Update the entire content of the Autoscaler resource. (autoscalers.update)
+   *
+   * @param string $project Project ID of Autoscaler resource.
+   * @param string $zone Zone name of Autoscaler resource.
+   * @param string $autoscaler Name of the Autoscaler resource.
+   * @param Google_Autoscaler $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Autoscaler_Operation
+   */
+  public function update($project, $zone, $autoscaler, Google_Service_Autoscaler_Autoscaler $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'autoscaler' => $autoscaler, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Autoscaler_Operation");
+  }
+}
+
+/**
+ * The "zoneOperations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $autoscalerService = new Google_Service_Autoscaler(...);
+ *   $zoneOperations = $autoscalerService->zoneOperations;
+ *  </code>
+ */
+class Google_Service_Autoscaler_ZoneOperations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified zone-specific operation resource.
+   * (zoneOperations.delete)
+   *
+   * @param string $project
+   * @param string $zone
+   * @param string $operation
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($project, $zone, $operation, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'operation' => $operation);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves the specified zone-specific operation resource.
+   * (zoneOperations.get)
+   *
+   * @param string $project
+   * @param string $zone
+   * @param string $operation
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Autoscaler_Operation
+   */
+  public function get($project, $zone, $operation, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'operation' => $operation);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Autoscaler_Operation");
+  }
+
+  /**
+   * Retrieves the list of operation resources contained within the specified
+   * zone. (zoneOperations.listZoneOperations)
+   *
+   * @param string $project
+   * @param string $zone
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter
+   * @opt_param string pageToken
+   * @opt_param string maxResults
+   * @return Google_Service_Autoscaler_OperationList
+   */
+  public function listZoneOperations($project, $zone, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Autoscaler_OperationList");
+  }
+}
+
+/**
+ * The "zones" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $autoscalerService = new Google_Service_Autoscaler(...);
+ *   $zones = $autoscalerService->zones;
+ *  </code>
+ */
+class Google_Service_Autoscaler_Zones_Resource extends Google_Service_Resource
+{
+
+  /**
+   * (zones.listZones)
+   *
+   * @param string $project
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter
+   * @opt_param string pageToken
+   * @opt_param string maxResults
+   * @return Google_Service_Autoscaler_ZoneList
+   */
+  public function listZones($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Autoscaler_ZoneList");
+  }
+}
+
+
+
+
+class Google_Service_Autoscaler_Autoscaler extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $autoscalingPolicyType = 'Google_Service_Autoscaler_AutoscalingPolicy';
+  protected $autoscalingPolicyDataType = '';
+  public $creationTimestamp;
+  public $description;
+  public $id;
+  public $kind;
+  public $name;
+  public $selfLink;
+  public $target;
+
+
+  public function setAutoscalingPolicy(Google_Service_Autoscaler_AutoscalingPolicy $autoscalingPolicy)
+  {
+    $this->autoscalingPolicy = $autoscalingPolicy;
+  }
+  public function getAutoscalingPolicy()
+  {
+    return $this->autoscalingPolicy;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTarget($target)
+  {
+    $this->target = $target;
+  }
+  public function getTarget()
+  {
+    return $this->target;
+  }
+}
+
+class Google_Service_Autoscaler_AutoscalerListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Autoscaler_Autoscaler';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Autoscaler_AutoscalingPolicy extends Google_Collection
+{
+  protected $collection_key = 'customMetricUtilizations';
+  protected $internal_gapi_mappings = array(
+  );
+  public $coolDownPeriodSec;
+  protected $cpuUtilizationType = 'Google_Service_Autoscaler_AutoscalingPolicyCpuUtilization';
+  protected $cpuUtilizationDataType = '';
+  protected $customMetricUtilizationsType = 'Google_Service_Autoscaler_AutoscalingPolicyCustomMetricUtilization';
+  protected $customMetricUtilizationsDataType = 'array';
+  protected $loadBalancingUtilizationType = 'Google_Service_Autoscaler_AutoscalingPolicyLoadBalancingUtilization';
+  protected $loadBalancingUtilizationDataType = '';
+  public $maxNumReplicas;
+  public $minNumReplicas;
+
+
+  public function setCoolDownPeriodSec($coolDownPeriodSec)
+  {
+    $this->coolDownPeriodSec = $coolDownPeriodSec;
+  }
+  public function getCoolDownPeriodSec()
+  {
+    return $this->coolDownPeriodSec;
+  }
+  public function setCpuUtilization(Google_Service_Autoscaler_AutoscalingPolicyCpuUtilization $cpuUtilization)
+  {
+    $this->cpuUtilization = $cpuUtilization;
+  }
+  public function getCpuUtilization()
+  {
+    return $this->cpuUtilization;
+  }
+  public function setCustomMetricUtilizations($customMetricUtilizations)
+  {
+    $this->customMetricUtilizations = $customMetricUtilizations;
+  }
+  public function getCustomMetricUtilizations()
+  {
+    return $this->customMetricUtilizations;
+  }
+  public function setLoadBalancingUtilization(Google_Service_Autoscaler_AutoscalingPolicyLoadBalancingUtilization $loadBalancingUtilization)
+  {
+    $this->loadBalancingUtilization = $loadBalancingUtilization;
+  }
+  public function getLoadBalancingUtilization()
+  {
+    return $this->loadBalancingUtilization;
+  }
+  public function setMaxNumReplicas($maxNumReplicas)
+  {
+    $this->maxNumReplicas = $maxNumReplicas;
+  }
+  public function getMaxNumReplicas()
+  {
+    return $this->maxNumReplicas;
+  }
+  public function setMinNumReplicas($minNumReplicas)
+  {
+    $this->minNumReplicas = $minNumReplicas;
+  }
+  public function getMinNumReplicas()
+  {
+    return $this->minNumReplicas;
+  }
+}
+
+class Google_Service_Autoscaler_AutoscalingPolicyCpuUtilization extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $utilizationTarget;
+
+
+  public function setUtilizationTarget($utilizationTarget)
+  {
+    $this->utilizationTarget = $utilizationTarget;
+  }
+  public function getUtilizationTarget()
+  {
+    return $this->utilizationTarget;
+  }
+}
+
+class Google_Service_Autoscaler_AutoscalingPolicyCustomMetricUtilization extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $metric;
+  public $utilizationTarget;
+  public $utilizationTargetType;
+
+
+  public function setMetric($metric)
+  {
+    $this->metric = $metric;
+  }
+  public function getMetric()
+  {
+    return $this->metric;
+  }
+  public function setUtilizationTarget($utilizationTarget)
+  {
+    $this->utilizationTarget = $utilizationTarget;
+  }
+  public function getUtilizationTarget()
+  {
+    return $this->utilizationTarget;
+  }
+  public function setUtilizationTargetType($utilizationTargetType)
+  {
+    $this->utilizationTargetType = $utilizationTargetType;
+  }
+  public function getUtilizationTargetType()
+  {
+    return $this->utilizationTargetType;
+  }
+}
+
+class Google_Service_Autoscaler_AutoscalingPolicyLoadBalancingUtilization extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $utilizationTarget;
+
+
+  public function setUtilizationTarget($utilizationTarget)
+  {
+    $this->utilizationTarget = $utilizationTarget;
+  }
+  public function getUtilizationTarget()
+  {
+    return $this->utilizationTarget;
+  }
+}
+
+class Google_Service_Autoscaler_DeprecationStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $deleted;
+  public $deprecated;
+  public $obsolete;
+  public $replacement;
+  public $state;
+
+
+  public function setDeleted($deleted)
+  {
+    $this->deleted = $deleted;
+  }
+  public function getDeleted()
+  {
+    return $this->deleted;
+  }
+  public function setDeprecated($deprecated)
+  {
+    $this->deprecated = $deprecated;
+  }
+  public function getDeprecated()
+  {
+    return $this->deprecated;
+  }
+  public function setObsolete($obsolete)
+  {
+    $this->obsolete = $obsolete;
+  }
+  public function getObsolete()
+  {
+    return $this->obsolete;
+  }
+  public function setReplacement($replacement)
+  {
+    $this->replacement = $replacement;
+  }
+  public function getReplacement()
+  {
+    return $this->replacement;
+  }
+  public function setState($state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+}
+
+class Google_Service_Autoscaler_Operation extends Google_Collection
+{
+  protected $collection_key = 'warnings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $clientOperationId;
+  public $creationTimestamp;
+  public $endTime;
+  protected $errorType = 'Google_Service_Autoscaler_OperationError';
+  protected $errorDataType = '';
+  public $httpErrorMessage;
+  public $httpErrorStatusCode;
+  public $id;
+  public $insertTime;
+  public $kind;
+  public $name;
+  public $operationType;
+  public $progress;
+  public $region;
+  public $selfLink;
+  public $startTime;
+  public $status;
+  public $statusMessage;
+  public $targetId;
+  public $targetLink;
+  public $user;
+  protected $warningsType = 'Google_Service_Autoscaler_OperationWarnings';
+  protected $warningsDataType = 'array';
+  public $zone;
+
+
+  public function setClientOperationId($clientOperationId)
+  {
+    $this->clientOperationId = $clientOperationId;
+  }
+  public function getClientOperationId()
+  {
+    return $this->clientOperationId;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setError(Google_Service_Autoscaler_OperationError $error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setHttpErrorMessage($httpErrorMessage)
+  {
+    $this->httpErrorMessage = $httpErrorMessage;
+  }
+  public function getHttpErrorMessage()
+  {
+    return $this->httpErrorMessage;
+  }
+  public function setHttpErrorStatusCode($httpErrorStatusCode)
+  {
+    $this->httpErrorStatusCode = $httpErrorStatusCode;
+  }
+  public function getHttpErrorStatusCode()
+  {
+    return $this->httpErrorStatusCode;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInsertTime($insertTime)
+  {
+    $this->insertTime = $insertTime;
+  }
+  public function getInsertTime()
+  {
+    return $this->insertTime;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOperationType($operationType)
+  {
+    $this->operationType = $operationType;
+  }
+  public function getOperationType()
+  {
+    return $this->operationType;
+  }
+  public function setProgress($progress)
+  {
+    $this->progress = $progress;
+  }
+  public function getProgress()
+  {
+    return $this->progress;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setStatusMessage($statusMessage)
+  {
+    $this->statusMessage = $statusMessage;
+  }
+  public function getStatusMessage()
+  {
+    return $this->statusMessage;
+  }
+  public function setTargetId($targetId)
+  {
+    $this->targetId = $targetId;
+  }
+  public function getTargetId()
+  {
+    return $this->targetId;
+  }
+  public function setTargetLink($targetLink)
+  {
+    $this->targetLink = $targetLink;
+  }
+  public function getTargetLink()
+  {
+    return $this->targetLink;
+  }
+  public function setUser($user)
+  {
+    $this->user = $user;
+  }
+  public function getUser()
+  {
+    return $this->user;
+  }
+  public function setWarnings($warnings)
+  {
+    $this->warnings = $warnings;
+  }
+  public function getWarnings()
+  {
+    return $this->warnings;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_Autoscaler_OperationError extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorsType = 'Google_Service_Autoscaler_OperationErrorErrors';
+  protected $errorsDataType = 'array';
+
+
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+}
+
+class Google_Service_Autoscaler_OperationErrorErrors extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $location;
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Autoscaler_OperationList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Autoscaler_Operation';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Autoscaler_OperationWarnings extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Autoscaler_OperationWarningsData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Autoscaler_OperationWarningsData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Autoscaler_Zone extends Google_Collection
+{
+  protected $collection_key = 'maintenanceWindows';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  protected $deprecatedType = 'Google_Service_Autoscaler_DeprecationStatus';
+  protected $deprecatedDataType = '';
+  public $description;
+  public $id;
+  public $kind;
+  protected $maintenanceWindowsType = 'Google_Service_Autoscaler_ZoneMaintenanceWindows';
+  protected $maintenanceWindowsDataType = 'array';
+  public $name;
+  public $region;
+  public $selfLink;
+  public $status;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDeprecated(Google_Service_Autoscaler_DeprecationStatus $deprecated)
+  {
+    $this->deprecated = $deprecated;
+  }
+  public function getDeprecated()
+  {
+    return $this->deprecated;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMaintenanceWindows($maintenanceWindows)
+  {
+    $this->maintenanceWindows = $maintenanceWindows;
+  }
+  public function getMaintenanceWindows()
+  {
+    return $this->maintenanceWindows;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_Autoscaler_ZoneList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Autoscaler_Zone';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Autoscaler_ZoneMaintenanceWindows extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $beginTime;
+  public $description;
+  public $endTime;
+  public $name;
+
+
+  public function setBeginTime($beginTime)
+  {
+    $this->beginTime = $beginTime;
+  }
+  public function getBeginTime()
+  {
+    return $this->beginTime;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Bigquery.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Bigquery.php
@@ -1,0 +1,3607 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Bigquery (v2).
+ *
+ * <p>
+ * A data platform for customers to create, manage, share and query data.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://cloud.google.com/bigquery/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Bigquery extends Google_Service
+{
+  /** View and manage your data in Google BigQuery. */
+  const BIGQUERY =
+      "https://www.googleapis.com/auth/bigquery";
+  /** Insert data into Google BigQuery. */
+  const BIGQUERY_INSERTDATA =
+      "https://www.googleapis.com/auth/bigquery.insertdata";
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+  /** View your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM_READ_ONLY =
+      "https://www.googleapis.com/auth/cloud-platform.read-only";
+  /** Manage your data and permissions in Google Cloud Storage. */
+  const DEVSTORAGE_FULL_CONTROL =
+      "https://www.googleapis.com/auth/devstorage.full_control";
+  /** View your data in Google Cloud Storage. */
+  const DEVSTORAGE_READ_ONLY =
+      "https://www.googleapis.com/auth/devstorage.read_only";
+  /** Manage your data in Google Cloud Storage. */
+  const DEVSTORAGE_READ_WRITE =
+      "https://www.googleapis.com/auth/devstorage.read_write";
+
+  public $datasets;
+  public $jobs;
+  public $projects;
+  public $tabledata;
+  public $tables;
+  
+
+  /**
+   * Constructs the internal representation of the Bigquery service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'bigquery/v2/';
+    $this->version = 'v2';
+    $this->serviceName = 'bigquery';
+
+    $this->datasets = new Google_Service_Bigquery_Datasets_Resource(
+        $this,
+        $this->serviceName,
+        'datasets',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'projects/{projectId}/datasets/{datasetId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deleteContents' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'projects/{projectId}/datasets/{datasetId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'projects/{projectId}/datasets',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'projects/{projectId}/datasets',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'all' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'projects/{projectId}/datasets/{datasetId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'projects/{projectId}/datasets/{datasetId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->jobs = new Google_Service_Bigquery_Jobs_Resource(
+        $this,
+        $this->serviceName,
+        'jobs',
+        array(
+          'methods' => array(
+            'cancel' => array(
+              'path' => 'project/{projectId}/jobs/{jobId}/cancel',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'projects/{projectId}/jobs/{jobId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getQueryResults' => array(
+              'path' => 'projects/{projectId}/queries/{jobId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'timeoutMs' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startIndex' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'projects/{projectId}/jobs',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'projects/{projectId}/jobs',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'stateFilter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'allUsers' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'query' => array(
+              'path' => 'projects/{projectId}/queries',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->projects = new Google_Service_Bigquery_Projects_Resource(
+        $this,
+        $this->serviceName,
+        'projects',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'projects',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->tabledata = new Google_Service_Bigquery_Tabledata_Resource(
+        $this,
+        $this->serviceName,
+        'tabledata',
+        array(
+          'methods' => array(
+            'insertAll' => array(
+              'path' => 'projects/{projectId}/datasets/{datasetId}/tables/{tableId}/insertAll',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'projects/{projectId}/datasets/{datasetId}/tables/{tableId}/data',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startIndex' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->tables = new Google_Service_Bigquery_Tables_Resource(
+        $this,
+        $this->serviceName,
+        'tables',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'projects/{projectId}/datasets/{datasetId}/tables/{tableId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'projects/{projectId}/datasets/{datasetId}/tables/{tableId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'projects/{projectId}/datasets/{datasetId}/tables',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'projects/{projectId}/datasets/{datasetId}/tables',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'projects/{projectId}/datasets/{datasetId}/tables/{tableId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'projects/{projectId}/datasets/{datasetId}/tables/{tableId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "datasets" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $bigqueryService = new Google_Service_Bigquery(...);
+ *   $datasets = $bigqueryService->datasets;
+ *  </code>
+ */
+class Google_Service_Bigquery_Datasets_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the dataset specified by the datasetId value. Before you can delete a
+   * dataset, you must delete all its tables, either manually or by specifying
+   * deleteContents. Immediately after deletion, you can create another dataset
+   * with the same name. (datasets.delete)
+   *
+   * @param string $projectId Project ID of the dataset being deleted
+   * @param string $datasetId Dataset ID of dataset being deleted
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool deleteContents If True, delete all the tables in the dataset.
+   * If False and the dataset contains tables, the request will fail. Default is
+   * False
+   */
+  public function delete($projectId, $datasetId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'datasetId' => $datasetId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Returns the dataset specified by datasetID. (datasets.get)
+   *
+   * @param string $projectId Project ID of the requested dataset
+   * @param string $datasetId Dataset ID of the requested dataset
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Bigquery_Dataset
+   */
+  public function get($projectId, $datasetId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'datasetId' => $datasetId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Bigquery_Dataset");
+  }
+
+  /**
+   * Creates a new empty dataset. (datasets.insert)
+   *
+   * @param string $projectId Project ID of the new dataset
+   * @param Google_Dataset $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Bigquery_Dataset
+   */
+  public function insert($projectId, Google_Service_Bigquery_Dataset $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Bigquery_Dataset");
+  }
+
+  /**
+   * Lists all datasets in the specified project to which you have been granted
+   * the READER dataset role. (datasets.listDatasets)
+   *
+   * @param string $projectId Project ID of the datasets to be listed
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Page token, returned by a previous call, to
+   * request the next page of results
+   * @opt_param bool all Whether to list all datasets, including hidden ones
+   * @opt_param string maxResults The maximum number of results to return
+   * @return Google_Service_Bigquery_DatasetList
+   */
+  public function listDatasets($projectId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Bigquery_DatasetList");
+  }
+
+  /**
+   * Updates information in an existing dataset. The update method replaces the
+   * entire dataset resource, whereas the patch method only replaces fields that
+   * are provided in the submitted dataset resource. This method supports patch
+   * semantics. (datasets.patch)
+   *
+   * @param string $projectId Project ID of the dataset being updated
+   * @param string $datasetId Dataset ID of the dataset being updated
+   * @param Google_Dataset $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Bigquery_Dataset
+   */
+  public function patch($projectId, $datasetId, Google_Service_Bigquery_Dataset $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'datasetId' => $datasetId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Bigquery_Dataset");
+  }
+
+  /**
+   * Updates information in an existing dataset. The update method replaces the
+   * entire dataset resource, whereas the patch method only replaces fields that
+   * are provided in the submitted dataset resource. (datasets.update)
+   *
+   * @param string $projectId Project ID of the dataset being updated
+   * @param string $datasetId Dataset ID of the dataset being updated
+   * @param Google_Dataset $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Bigquery_Dataset
+   */
+  public function update($projectId, $datasetId, Google_Service_Bigquery_Dataset $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'datasetId' => $datasetId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Bigquery_Dataset");
+  }
+}
+
+/**
+ * The "jobs" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $bigqueryService = new Google_Service_Bigquery(...);
+ *   $jobs = $bigqueryService->jobs;
+ *  </code>
+ */
+class Google_Service_Bigquery_Jobs_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Requests that a job be cancelled. This call will return immediately, and the
+   * client will need to poll for the job status to see if the cancel completed
+   * successfully. Cancelled jobs may still incur costs. (jobs.cancel)
+   *
+   * @param string $projectId Project ID of the job to cancel
+   * @param string $jobId Job ID of the job to cancel
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Bigquery_JobCancelResponse
+   */
+  public function cancel($projectId, $jobId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'jobId' => $jobId);
+    $params = array_merge($params, $optParams);
+    return $this->call('cancel', array($params), "Google_Service_Bigquery_JobCancelResponse");
+  }
+
+  /**
+   * Returns information about a specific job. Job information is available for a
+   * six month period after creation. Requires that you're the person who ran the
+   * job, or have the Is Owner project role. (jobs.get)
+   *
+   * @param string $projectId Project ID of the requested job
+   * @param string $jobId Job ID of the requested job
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Bigquery_Job
+   */
+  public function get($projectId, $jobId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'jobId' => $jobId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Bigquery_Job");
+  }
+
+  /**
+   * Retrieves the results of a query job. (jobs.getQueryResults)
+   *
+   * @param string $projectId Project ID of the query job
+   * @param string $jobId Job ID of the query job
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string timeoutMs How long to wait for the query to complete, in
+   * milliseconds, before returning. Default is 10 seconds. If the timeout passes
+   * before the job completes, the 'jobComplete' field in the response will be
+   * false
+   * @opt_param string maxResults Maximum number of results to read
+   * @opt_param string pageToken Page token, returned by a previous call, to
+   * request the next page of results
+   * @opt_param string startIndex Zero-based index of the starting row
+   * @return Google_Service_Bigquery_GetQueryResultsResponse
+   */
+  public function getQueryResults($projectId, $jobId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'jobId' => $jobId);
+    $params = array_merge($params, $optParams);
+    return $this->call('getQueryResults', array($params), "Google_Service_Bigquery_GetQueryResultsResponse");
+  }
+
+  /**
+   * Starts a new asynchronous job. Requires the Can View project role.
+   * (jobs.insert)
+   *
+   * @param string $projectId Project ID of the project that will be billed for
+   * the job
+   * @param Google_Job $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Bigquery_Job
+   */
+  public function insert($projectId, Google_Service_Bigquery_Job $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Bigquery_Job");
+  }
+
+  /**
+   * Lists all jobs that you started in the specified project. Job information is
+   * available for a six month period after creation. The job list is sorted in
+   * reverse chronological order, by job creation time. Requires the Can View
+   * project role, or the Is Owner project role if you set the allUsers property.
+   * (jobs.listJobs)
+   *
+   * @param string $projectId Project ID of the jobs to list
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string projection Restrict information returned to a set of
+   * selected fields
+   * @opt_param string stateFilter Filter for job state
+   * @opt_param bool allUsers Whether to display jobs owned by all users in the
+   * project. Default false
+   * @opt_param string maxResults Maximum number of results to return
+   * @opt_param string pageToken Page token, returned by a previous call, to
+   * request the next page of results
+   * @return Google_Service_Bigquery_JobList
+   */
+  public function listJobs($projectId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Bigquery_JobList");
+  }
+
+  /**
+   * Runs a BigQuery SQL query synchronously and returns query results if the
+   * query completes within a specified timeout. (jobs.query)
+   *
+   * @param string $projectId Project ID of the project billed for the query
+   * @param Google_QueryRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Bigquery_QueryResponse
+   */
+  public function query($projectId, Google_Service_Bigquery_QueryRequest $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('query', array($params), "Google_Service_Bigquery_QueryResponse");
+  }
+}
+
+/**
+ * The "projects" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $bigqueryService = new Google_Service_Bigquery(...);
+ *   $projects = $bigqueryService->projects;
+ *  </code>
+ */
+class Google_Service_Bigquery_Projects_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Lists all projects to which you have been granted any project role.
+   * (projects.listProjects)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Page token, returned by a previous call, to
+   * request the next page of results
+   * @opt_param string maxResults Maximum number of results to return
+   * @return Google_Service_Bigquery_ProjectList
+   */
+  public function listProjects($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Bigquery_ProjectList");
+  }
+}
+
+/**
+ * The "tabledata" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $bigqueryService = new Google_Service_Bigquery(...);
+ *   $tabledata = $bigqueryService->tabledata;
+ *  </code>
+ */
+class Google_Service_Bigquery_Tabledata_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Streams data into BigQuery one record at a time without needing to run a load
+   * job. Requires the WRITER dataset role. (tabledata.insertAll)
+   *
+   * @param string $projectId Project ID of the destination table.
+   * @param string $datasetId Dataset ID of the destination table.
+   * @param string $tableId Table ID of the destination table.
+   * @param Google_TableDataInsertAllRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Bigquery_TableDataInsertAllResponse
+   */
+  public function insertAll($projectId, $datasetId, $tableId, Google_Service_Bigquery_TableDataInsertAllRequest $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'datasetId' => $datasetId, 'tableId' => $tableId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insertAll', array($params), "Google_Service_Bigquery_TableDataInsertAllResponse");
+  }
+
+  /**
+   * Retrieves table data from a specified set of rows. Requires the READER
+   * dataset role. (tabledata.listTabledata)
+   *
+   * @param string $projectId Project ID of the table to read
+   * @param string $datasetId Dataset ID of the table to read
+   * @param string $tableId Table ID of the table to read
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string maxResults Maximum number of results to return
+   * @opt_param string pageToken Page token, returned by a previous call,
+   * identifying the result set
+   * @opt_param string startIndex Zero-based index of the starting row to read
+   * @return Google_Service_Bigquery_TableDataList
+   */
+  public function listTabledata($projectId, $datasetId, $tableId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'datasetId' => $datasetId, 'tableId' => $tableId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Bigquery_TableDataList");
+  }
+}
+
+/**
+ * The "tables" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $bigqueryService = new Google_Service_Bigquery(...);
+ *   $tables = $bigqueryService->tables;
+ *  </code>
+ */
+class Google_Service_Bigquery_Tables_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the table specified by tableId from the dataset. If the table
+   * contains data, all the data will be deleted. (tables.delete)
+   *
+   * @param string $projectId Project ID of the table to delete
+   * @param string $datasetId Dataset ID of the table to delete
+   * @param string $tableId Table ID of the table to delete
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($projectId, $datasetId, $tableId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'datasetId' => $datasetId, 'tableId' => $tableId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets the specified table resource by table ID. This method does not return
+   * the data in the table, it only returns the table resource, which describes
+   * the structure of this table. (tables.get)
+   *
+   * @param string $projectId Project ID of the requested table
+   * @param string $datasetId Dataset ID of the requested table
+   * @param string $tableId Table ID of the requested table
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Bigquery_Table
+   */
+  public function get($projectId, $datasetId, $tableId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'datasetId' => $datasetId, 'tableId' => $tableId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Bigquery_Table");
+  }
+
+  /**
+   * Creates a new, empty table in the dataset. (tables.insert)
+   *
+   * @param string $projectId Project ID of the new table
+   * @param string $datasetId Dataset ID of the new table
+   * @param Google_Table $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Bigquery_Table
+   */
+  public function insert($projectId, $datasetId, Google_Service_Bigquery_Table $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'datasetId' => $datasetId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Bigquery_Table");
+  }
+
+  /**
+   * Lists all tables in the specified dataset. Requires the READER dataset role.
+   * (tables.listTables)
+   *
+   * @param string $projectId Project ID of the tables to list
+   * @param string $datasetId Dataset ID of the tables to list
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Page token, returned by a previous call, to
+   * request the next page of results
+   * @opt_param string maxResults Maximum number of results to return
+   * @return Google_Service_Bigquery_TableList
+   */
+  public function listTables($projectId, $datasetId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'datasetId' => $datasetId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Bigquery_TableList");
+  }
+
+  /**
+   * Updates information in an existing table. The update method replaces the
+   * entire table resource, whereas the patch method only replaces fields that are
+   * provided in the submitted table resource. This method supports patch
+   * semantics. (tables.patch)
+   *
+   * @param string $projectId Project ID of the table to update
+   * @param string $datasetId Dataset ID of the table to update
+   * @param string $tableId Table ID of the table to update
+   * @param Google_Table $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Bigquery_Table
+   */
+  public function patch($projectId, $datasetId, $tableId, Google_Service_Bigquery_Table $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'datasetId' => $datasetId, 'tableId' => $tableId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Bigquery_Table");
+  }
+
+  /**
+   * Updates information in an existing table. The update method replaces the
+   * entire table resource, whereas the patch method only replaces fields that are
+   * provided in the submitted table resource. (tables.update)
+   *
+   * @param string $projectId Project ID of the table to update
+   * @param string $datasetId Dataset ID of the table to update
+   * @param string $tableId Table ID of the table to update
+   * @param Google_Table $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Bigquery_Table
+   */
+  public function update($projectId, $datasetId, $tableId, Google_Service_Bigquery_Table $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'datasetId' => $datasetId, 'tableId' => $tableId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Bigquery_Table");
+  }
+}
+
+
+
+
+class Google_Service_Bigquery_CsvOptions extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $allowJaggedRows;
+  public $allowQuotedNewlines;
+  public $encoding;
+  public $fieldDelimiter;
+  public $quote;
+  public $skipLeadingRows;
+
+
+  public function setAllowJaggedRows($allowJaggedRows)
+  {
+    $this->allowJaggedRows = $allowJaggedRows;
+  }
+  public function getAllowJaggedRows()
+  {
+    return $this->allowJaggedRows;
+  }
+  public function setAllowQuotedNewlines($allowQuotedNewlines)
+  {
+    $this->allowQuotedNewlines = $allowQuotedNewlines;
+  }
+  public function getAllowQuotedNewlines()
+  {
+    return $this->allowQuotedNewlines;
+  }
+  public function setEncoding($encoding)
+  {
+    $this->encoding = $encoding;
+  }
+  public function getEncoding()
+  {
+    return $this->encoding;
+  }
+  public function setFieldDelimiter($fieldDelimiter)
+  {
+    $this->fieldDelimiter = $fieldDelimiter;
+  }
+  public function getFieldDelimiter()
+  {
+    return $this->fieldDelimiter;
+  }
+  public function setQuote($quote)
+  {
+    $this->quote = $quote;
+  }
+  public function getQuote()
+  {
+    return $this->quote;
+  }
+  public function setSkipLeadingRows($skipLeadingRows)
+  {
+    $this->skipLeadingRows = $skipLeadingRows;
+  }
+  public function getSkipLeadingRows()
+  {
+    return $this->skipLeadingRows;
+  }
+}
+
+class Google_Service_Bigquery_Dataset extends Google_Collection
+{
+  protected $collection_key = 'access';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accessType = 'Google_Service_Bigquery_DatasetAccess';
+  protected $accessDataType = 'array';
+  public $creationTime;
+  protected $datasetReferenceType = 'Google_Service_Bigquery_DatasetReference';
+  protected $datasetReferenceDataType = '';
+  public $defaultTableExpirationMs;
+  public $description;
+  public $etag;
+  public $friendlyName;
+  public $id;
+  public $kind;
+  public $lastModifiedTime;
+  public $location;
+  public $selfLink;
+
+
+  public function setAccess($access)
+  {
+    $this->access = $access;
+  }
+  public function getAccess()
+  {
+    return $this->access;
+  }
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setDatasetReference(Google_Service_Bigquery_DatasetReference $datasetReference)
+  {
+    $this->datasetReference = $datasetReference;
+  }
+  public function getDatasetReference()
+  {
+    return $this->datasetReference;
+  }
+  public function setDefaultTableExpirationMs($defaultTableExpirationMs)
+  {
+    $this->defaultTableExpirationMs = $defaultTableExpirationMs;
+  }
+  public function getDefaultTableExpirationMs()
+  {
+    return $this->defaultTableExpirationMs;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setFriendlyName($friendlyName)
+  {
+    $this->friendlyName = $friendlyName;
+  }
+  public function getFriendlyName()
+  {
+    return $this->friendlyName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastModifiedTime($lastModifiedTime)
+  {
+    $this->lastModifiedTime = $lastModifiedTime;
+  }
+  public function getLastModifiedTime()
+  {
+    return $this->lastModifiedTime;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Bigquery_DatasetAccess extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $domain;
+  public $groupByEmail;
+  public $role;
+  public $specialGroup;
+  public $userByEmail;
+  protected $viewType = 'Google_Service_Bigquery_TableReference';
+  protected $viewDataType = '';
+
+
+  public function setDomain($domain)
+  {
+    $this->domain = $domain;
+  }
+  public function getDomain()
+  {
+    return $this->domain;
+  }
+  public function setGroupByEmail($groupByEmail)
+  {
+    $this->groupByEmail = $groupByEmail;
+  }
+  public function getGroupByEmail()
+  {
+    return $this->groupByEmail;
+  }
+  public function setRole($role)
+  {
+    $this->role = $role;
+  }
+  public function getRole()
+  {
+    return $this->role;
+  }
+  public function setSpecialGroup($specialGroup)
+  {
+    $this->specialGroup = $specialGroup;
+  }
+  public function getSpecialGroup()
+  {
+    return $this->specialGroup;
+  }
+  public function setUserByEmail($userByEmail)
+  {
+    $this->userByEmail = $userByEmail;
+  }
+  public function getUserByEmail()
+  {
+    return $this->userByEmail;
+  }
+  public function setView(Google_Service_Bigquery_TableReference $view)
+  {
+    $this->view = $view;
+  }
+  public function getView()
+  {
+    return $this->view;
+  }
+}
+
+class Google_Service_Bigquery_DatasetList extends Google_Collection
+{
+  protected $collection_key = 'datasets';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $datasetsType = 'Google_Service_Bigquery_DatasetListDatasets';
+  protected $datasetsDataType = 'array';
+  public $etag;
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setDatasets($datasets)
+  {
+    $this->datasets = $datasets;
+  }
+  public function getDatasets()
+  {
+    return $this->datasets;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Bigquery_DatasetListDatasets extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $datasetReferenceType = 'Google_Service_Bigquery_DatasetReference';
+  protected $datasetReferenceDataType = '';
+  public $friendlyName;
+  public $id;
+  public $kind;
+
+
+  public function setDatasetReference(Google_Service_Bigquery_DatasetReference $datasetReference)
+  {
+    $this->datasetReference = $datasetReference;
+  }
+  public function getDatasetReference()
+  {
+    return $this->datasetReference;
+  }
+  public function setFriendlyName($friendlyName)
+  {
+    $this->friendlyName = $friendlyName;
+  }
+  public function getFriendlyName()
+  {
+    return $this->friendlyName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Bigquery_DatasetReference extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $datasetId;
+  public $projectId;
+
+
+  public function setDatasetId($datasetId)
+  {
+    $this->datasetId = $datasetId;
+  }
+  public function getDatasetId()
+  {
+    return $this->datasetId;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+}
+
+class Google_Service_Bigquery_ErrorProto extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $debugInfo;
+  public $location;
+  public $message;
+  public $reason;
+
+
+  public function setDebugInfo($debugInfo)
+  {
+    $this->debugInfo = $debugInfo;
+  }
+  public function getDebugInfo()
+  {
+    return $this->debugInfo;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+}
+
+class Google_Service_Bigquery_ExternalDataConfiguration extends Google_Collection
+{
+  protected $collection_key = 'sourceUris';
+  protected $internal_gapi_mappings = array(
+  );
+  public $compression;
+  protected $csvOptionsType = 'Google_Service_Bigquery_CsvOptions';
+  protected $csvOptionsDataType = '';
+  public $ignoreUnknownValues;
+  public $maxBadRecords;
+  protected $schemaType = 'Google_Service_Bigquery_TableSchema';
+  protected $schemaDataType = '';
+  public $sourceFormat;
+  public $sourceUris;
+
+
+  public function setCompression($compression)
+  {
+    $this->compression = $compression;
+  }
+  public function getCompression()
+  {
+    return $this->compression;
+  }
+  public function setCsvOptions(Google_Service_Bigquery_CsvOptions $csvOptions)
+  {
+    $this->csvOptions = $csvOptions;
+  }
+  public function getCsvOptions()
+  {
+    return $this->csvOptions;
+  }
+  public function setIgnoreUnknownValues($ignoreUnknownValues)
+  {
+    $this->ignoreUnknownValues = $ignoreUnknownValues;
+  }
+  public function getIgnoreUnknownValues()
+  {
+    return $this->ignoreUnknownValues;
+  }
+  public function setMaxBadRecords($maxBadRecords)
+  {
+    $this->maxBadRecords = $maxBadRecords;
+  }
+  public function getMaxBadRecords()
+  {
+    return $this->maxBadRecords;
+  }
+  public function setSchema(Google_Service_Bigquery_TableSchema $schema)
+  {
+    $this->schema = $schema;
+  }
+  public function getSchema()
+  {
+    return $this->schema;
+  }
+  public function setSourceFormat($sourceFormat)
+  {
+    $this->sourceFormat = $sourceFormat;
+  }
+  public function getSourceFormat()
+  {
+    return $this->sourceFormat;
+  }
+  public function setSourceUris($sourceUris)
+  {
+    $this->sourceUris = $sourceUris;
+  }
+  public function getSourceUris()
+  {
+    return $this->sourceUris;
+  }
+}
+
+class Google_Service_Bigquery_GetQueryResultsResponse extends Google_Collection
+{
+  protected $collection_key = 'rows';
+  protected $internal_gapi_mappings = array(
+  );
+  public $cacheHit;
+  protected $errorsType = 'Google_Service_Bigquery_ErrorProto';
+  protected $errorsDataType = 'array';
+  public $etag;
+  public $jobComplete;
+  protected $jobReferenceType = 'Google_Service_Bigquery_JobReference';
+  protected $jobReferenceDataType = '';
+  public $kind;
+  public $pageToken;
+  protected $rowsType = 'Google_Service_Bigquery_TableRow';
+  protected $rowsDataType = 'array';
+  protected $schemaType = 'Google_Service_Bigquery_TableSchema';
+  protected $schemaDataType = '';
+  public $totalBytesProcessed;
+  public $totalRows;
+
+
+  public function setCacheHit($cacheHit)
+  {
+    $this->cacheHit = $cacheHit;
+  }
+  public function getCacheHit()
+  {
+    return $this->cacheHit;
+  }
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setJobComplete($jobComplete)
+  {
+    $this->jobComplete = $jobComplete;
+  }
+  public function getJobComplete()
+  {
+    return $this->jobComplete;
+  }
+  public function setJobReference(Google_Service_Bigquery_JobReference $jobReference)
+  {
+    $this->jobReference = $jobReference;
+  }
+  public function getJobReference()
+  {
+    return $this->jobReference;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPageToken($pageToken)
+  {
+    $this->pageToken = $pageToken;
+  }
+  public function getPageToken()
+  {
+    return $this->pageToken;
+  }
+  public function setRows($rows)
+  {
+    $this->rows = $rows;
+  }
+  public function getRows()
+  {
+    return $this->rows;
+  }
+  public function setSchema(Google_Service_Bigquery_TableSchema $schema)
+  {
+    $this->schema = $schema;
+  }
+  public function getSchema()
+  {
+    return $this->schema;
+  }
+  public function setTotalBytesProcessed($totalBytesProcessed)
+  {
+    $this->totalBytesProcessed = $totalBytesProcessed;
+  }
+  public function getTotalBytesProcessed()
+  {
+    return $this->totalBytesProcessed;
+  }
+  public function setTotalRows($totalRows)
+  {
+    $this->totalRows = $totalRows;
+  }
+  public function getTotalRows()
+  {
+    return $this->totalRows;
+  }
+}
+
+class Google_Service_Bigquery_Job extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "userEmail" => "user_email",
+  );
+  protected $configurationType = 'Google_Service_Bigquery_JobConfiguration';
+  protected $configurationDataType = '';
+  public $etag;
+  public $id;
+  protected $jobReferenceType = 'Google_Service_Bigquery_JobReference';
+  protected $jobReferenceDataType = '';
+  public $kind;
+  public $selfLink;
+  protected $statisticsType = 'Google_Service_Bigquery_JobStatistics';
+  protected $statisticsDataType = '';
+  protected $statusType = 'Google_Service_Bigquery_JobStatus';
+  protected $statusDataType = '';
+  public $userEmail;
+
+
+  public function setConfiguration(Google_Service_Bigquery_JobConfiguration $configuration)
+  {
+    $this->configuration = $configuration;
+  }
+  public function getConfiguration()
+  {
+    return $this->configuration;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setJobReference(Google_Service_Bigquery_JobReference $jobReference)
+  {
+    $this->jobReference = $jobReference;
+  }
+  public function getJobReference()
+  {
+    return $this->jobReference;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStatistics(Google_Service_Bigquery_JobStatistics $statistics)
+  {
+    $this->statistics = $statistics;
+  }
+  public function getStatistics()
+  {
+    return $this->statistics;
+  }
+  public function setStatus(Google_Service_Bigquery_JobStatus $status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setUserEmail($userEmail)
+  {
+    $this->userEmail = $userEmail;
+  }
+  public function getUserEmail()
+  {
+    return $this->userEmail;
+  }
+}
+
+class Google_Service_Bigquery_JobCancelResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $jobType = 'Google_Service_Bigquery_Job';
+  protected $jobDataType = '';
+  public $kind;
+
+
+  public function setJob(Google_Service_Bigquery_Job $job)
+  {
+    $this->job = $job;
+  }
+  public function getJob()
+  {
+    return $this->job;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Bigquery_JobConfiguration extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $copyType = 'Google_Service_Bigquery_JobConfigurationTableCopy';
+  protected $copyDataType = '';
+  public $dryRun;
+  protected $extractType = 'Google_Service_Bigquery_JobConfigurationExtract';
+  protected $extractDataType = '';
+  protected $linkType = 'Google_Service_Bigquery_JobConfigurationLink';
+  protected $linkDataType = '';
+  protected $loadType = 'Google_Service_Bigquery_JobConfigurationLoad';
+  protected $loadDataType = '';
+  protected $queryType = 'Google_Service_Bigquery_JobConfigurationQuery';
+  protected $queryDataType = '';
+
+
+  public function setCopy(Google_Service_Bigquery_JobConfigurationTableCopy $copy)
+  {
+    $this->copy = $copy;
+  }
+  public function getCopy()
+  {
+    return $this->copy;
+  }
+  public function setDryRun($dryRun)
+  {
+    $this->dryRun = $dryRun;
+  }
+  public function getDryRun()
+  {
+    return $this->dryRun;
+  }
+  public function setExtract(Google_Service_Bigquery_JobConfigurationExtract $extract)
+  {
+    $this->extract = $extract;
+  }
+  public function getExtract()
+  {
+    return $this->extract;
+  }
+  public function setLink(Google_Service_Bigquery_JobConfigurationLink $link)
+  {
+    $this->link = $link;
+  }
+  public function getLink()
+  {
+    return $this->link;
+  }
+  public function setLoad(Google_Service_Bigquery_JobConfigurationLoad $load)
+  {
+    $this->load = $load;
+  }
+  public function getLoad()
+  {
+    return $this->load;
+  }
+  public function setQuery(Google_Service_Bigquery_JobConfigurationQuery $query)
+  {
+    $this->query = $query;
+  }
+  public function getQuery()
+  {
+    return $this->query;
+  }
+}
+
+class Google_Service_Bigquery_JobConfigurationExtract extends Google_Collection
+{
+  protected $collection_key = 'destinationUris';
+  protected $internal_gapi_mappings = array(
+  );
+  public $compression;
+  public $destinationFormat;
+  public $destinationUri;
+  public $destinationUris;
+  public $fieldDelimiter;
+  public $printHeader;
+  protected $sourceTableType = 'Google_Service_Bigquery_TableReference';
+  protected $sourceTableDataType = '';
+
+
+  public function setCompression($compression)
+  {
+    $this->compression = $compression;
+  }
+  public function getCompression()
+  {
+    return $this->compression;
+  }
+  public function setDestinationFormat($destinationFormat)
+  {
+    $this->destinationFormat = $destinationFormat;
+  }
+  public function getDestinationFormat()
+  {
+    return $this->destinationFormat;
+  }
+  public function setDestinationUri($destinationUri)
+  {
+    $this->destinationUri = $destinationUri;
+  }
+  public function getDestinationUri()
+  {
+    return $this->destinationUri;
+  }
+  public function setDestinationUris($destinationUris)
+  {
+    $this->destinationUris = $destinationUris;
+  }
+  public function getDestinationUris()
+  {
+    return $this->destinationUris;
+  }
+  public function setFieldDelimiter($fieldDelimiter)
+  {
+    $this->fieldDelimiter = $fieldDelimiter;
+  }
+  public function getFieldDelimiter()
+  {
+    return $this->fieldDelimiter;
+  }
+  public function setPrintHeader($printHeader)
+  {
+    $this->printHeader = $printHeader;
+  }
+  public function getPrintHeader()
+  {
+    return $this->printHeader;
+  }
+  public function setSourceTable(Google_Service_Bigquery_TableReference $sourceTable)
+  {
+    $this->sourceTable = $sourceTable;
+  }
+  public function getSourceTable()
+  {
+    return $this->sourceTable;
+  }
+}
+
+class Google_Service_Bigquery_JobConfigurationLink extends Google_Collection
+{
+  protected $collection_key = 'sourceUri';
+  protected $internal_gapi_mappings = array(
+  );
+  public $createDisposition;
+  protected $destinationTableType = 'Google_Service_Bigquery_TableReference';
+  protected $destinationTableDataType = '';
+  public $sourceUri;
+  public $writeDisposition;
+
+
+  public function setCreateDisposition($createDisposition)
+  {
+    $this->createDisposition = $createDisposition;
+  }
+  public function getCreateDisposition()
+  {
+    return $this->createDisposition;
+  }
+  public function setDestinationTable(Google_Service_Bigquery_TableReference $destinationTable)
+  {
+    $this->destinationTable = $destinationTable;
+  }
+  public function getDestinationTable()
+  {
+    return $this->destinationTable;
+  }
+  public function setSourceUri($sourceUri)
+  {
+    $this->sourceUri = $sourceUri;
+  }
+  public function getSourceUri()
+  {
+    return $this->sourceUri;
+  }
+  public function setWriteDisposition($writeDisposition)
+  {
+    $this->writeDisposition = $writeDisposition;
+  }
+  public function getWriteDisposition()
+  {
+    return $this->writeDisposition;
+  }
+}
+
+class Google_Service_Bigquery_JobConfigurationLoad extends Google_Collection
+{
+  protected $collection_key = 'sourceUris';
+  protected $internal_gapi_mappings = array(
+  );
+  public $allowJaggedRows;
+  public $allowQuotedNewlines;
+  public $createDisposition;
+  protected $destinationTableType = 'Google_Service_Bigquery_TableReference';
+  protected $destinationTableDataType = '';
+  public $encoding;
+  public $fieldDelimiter;
+  public $ignoreUnknownValues;
+  public $maxBadRecords;
+  public $projectionFields;
+  public $quote;
+  protected $schemaType = 'Google_Service_Bigquery_TableSchema';
+  protected $schemaDataType = '';
+  public $schemaInline;
+  public $schemaInlineFormat;
+  public $skipLeadingRows;
+  public $sourceFormat;
+  public $sourceUris;
+  public $writeDisposition;
+
+
+  public function setAllowJaggedRows($allowJaggedRows)
+  {
+    $this->allowJaggedRows = $allowJaggedRows;
+  }
+  public function getAllowJaggedRows()
+  {
+    return $this->allowJaggedRows;
+  }
+  public function setAllowQuotedNewlines($allowQuotedNewlines)
+  {
+    $this->allowQuotedNewlines = $allowQuotedNewlines;
+  }
+  public function getAllowQuotedNewlines()
+  {
+    return $this->allowQuotedNewlines;
+  }
+  public function setCreateDisposition($createDisposition)
+  {
+    $this->createDisposition = $createDisposition;
+  }
+  public function getCreateDisposition()
+  {
+    return $this->createDisposition;
+  }
+  public function setDestinationTable(Google_Service_Bigquery_TableReference $destinationTable)
+  {
+    $this->destinationTable = $destinationTable;
+  }
+  public function getDestinationTable()
+  {
+    return $this->destinationTable;
+  }
+  public function setEncoding($encoding)
+  {
+    $this->encoding = $encoding;
+  }
+  public function getEncoding()
+  {
+    return $this->encoding;
+  }
+  public function setFieldDelimiter($fieldDelimiter)
+  {
+    $this->fieldDelimiter = $fieldDelimiter;
+  }
+  public function getFieldDelimiter()
+  {
+    return $this->fieldDelimiter;
+  }
+  public function setIgnoreUnknownValues($ignoreUnknownValues)
+  {
+    $this->ignoreUnknownValues = $ignoreUnknownValues;
+  }
+  public function getIgnoreUnknownValues()
+  {
+    return $this->ignoreUnknownValues;
+  }
+  public function setMaxBadRecords($maxBadRecords)
+  {
+    $this->maxBadRecords = $maxBadRecords;
+  }
+  public function getMaxBadRecords()
+  {
+    return $this->maxBadRecords;
+  }
+  public function setProjectionFields($projectionFields)
+  {
+    $this->projectionFields = $projectionFields;
+  }
+  public function getProjectionFields()
+  {
+    return $this->projectionFields;
+  }
+  public function setQuote($quote)
+  {
+    $this->quote = $quote;
+  }
+  public function getQuote()
+  {
+    return $this->quote;
+  }
+  public function setSchema(Google_Service_Bigquery_TableSchema $schema)
+  {
+    $this->schema = $schema;
+  }
+  public function getSchema()
+  {
+    return $this->schema;
+  }
+  public function setSchemaInline($schemaInline)
+  {
+    $this->schemaInline = $schemaInline;
+  }
+  public function getSchemaInline()
+  {
+    return $this->schemaInline;
+  }
+  public function setSchemaInlineFormat($schemaInlineFormat)
+  {
+    $this->schemaInlineFormat = $schemaInlineFormat;
+  }
+  public function getSchemaInlineFormat()
+  {
+    return $this->schemaInlineFormat;
+  }
+  public function setSkipLeadingRows($skipLeadingRows)
+  {
+    $this->skipLeadingRows = $skipLeadingRows;
+  }
+  public function getSkipLeadingRows()
+  {
+    return $this->skipLeadingRows;
+  }
+  public function setSourceFormat($sourceFormat)
+  {
+    $this->sourceFormat = $sourceFormat;
+  }
+  public function getSourceFormat()
+  {
+    return $this->sourceFormat;
+  }
+  public function setSourceUris($sourceUris)
+  {
+    $this->sourceUris = $sourceUris;
+  }
+  public function getSourceUris()
+  {
+    return $this->sourceUris;
+  }
+  public function setWriteDisposition($writeDisposition)
+  {
+    $this->writeDisposition = $writeDisposition;
+  }
+  public function getWriteDisposition()
+  {
+    return $this->writeDisposition;
+  }
+}
+
+class Google_Service_Bigquery_JobConfigurationQuery extends Google_Collection
+{
+  protected $collection_key = 'userDefinedFunctionResources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $allowLargeResults;
+  public $createDisposition;
+  protected $defaultDatasetType = 'Google_Service_Bigquery_DatasetReference';
+  protected $defaultDatasetDataType = '';
+  protected $destinationTableType = 'Google_Service_Bigquery_TableReference';
+  protected $destinationTableDataType = '';
+  public $flattenResults;
+  public $preserveNulls;
+  public $priority;
+  public $query;
+  protected $tableDefinitionsType = 'Google_Service_Bigquery_ExternalDataConfiguration';
+  protected $tableDefinitionsDataType = 'map';
+  public $useQueryCache;
+  protected $userDefinedFunctionResourcesType = 'Google_Service_Bigquery_UserDefinedFunctionResource';
+  protected $userDefinedFunctionResourcesDataType = 'array';
+  public $writeDisposition;
+
+
+  public function setAllowLargeResults($allowLargeResults)
+  {
+    $this->allowLargeResults = $allowLargeResults;
+  }
+  public function getAllowLargeResults()
+  {
+    return $this->allowLargeResults;
+  }
+  public function setCreateDisposition($createDisposition)
+  {
+    $this->createDisposition = $createDisposition;
+  }
+  public function getCreateDisposition()
+  {
+    return $this->createDisposition;
+  }
+  public function setDefaultDataset(Google_Service_Bigquery_DatasetReference $defaultDataset)
+  {
+    $this->defaultDataset = $defaultDataset;
+  }
+  public function getDefaultDataset()
+  {
+    return $this->defaultDataset;
+  }
+  public function setDestinationTable(Google_Service_Bigquery_TableReference $destinationTable)
+  {
+    $this->destinationTable = $destinationTable;
+  }
+  public function getDestinationTable()
+  {
+    return $this->destinationTable;
+  }
+  public function setFlattenResults($flattenResults)
+  {
+    $this->flattenResults = $flattenResults;
+  }
+  public function getFlattenResults()
+  {
+    return $this->flattenResults;
+  }
+  public function setPreserveNulls($preserveNulls)
+  {
+    $this->preserveNulls = $preserveNulls;
+  }
+  public function getPreserveNulls()
+  {
+    return $this->preserveNulls;
+  }
+  public function setPriority($priority)
+  {
+    $this->priority = $priority;
+  }
+  public function getPriority()
+  {
+    return $this->priority;
+  }
+  public function setQuery($query)
+  {
+    $this->query = $query;
+  }
+  public function getQuery()
+  {
+    return $this->query;
+  }
+  public function setTableDefinitions($tableDefinitions)
+  {
+    $this->tableDefinitions = $tableDefinitions;
+  }
+  public function getTableDefinitions()
+  {
+    return $this->tableDefinitions;
+  }
+  public function setUseQueryCache($useQueryCache)
+  {
+    $this->useQueryCache = $useQueryCache;
+  }
+  public function getUseQueryCache()
+  {
+    return $this->useQueryCache;
+  }
+  public function setUserDefinedFunctionResources($userDefinedFunctionResources)
+  {
+    $this->userDefinedFunctionResources = $userDefinedFunctionResources;
+  }
+  public function getUserDefinedFunctionResources()
+  {
+    return $this->userDefinedFunctionResources;
+  }
+  public function setWriteDisposition($writeDisposition)
+  {
+    $this->writeDisposition = $writeDisposition;
+  }
+  public function getWriteDisposition()
+  {
+    return $this->writeDisposition;
+  }
+}
+
+class Google_Service_Bigquery_JobConfigurationQueryTableDefinitions extends Google_Model
+{
+}
+
+class Google_Service_Bigquery_JobConfigurationTableCopy extends Google_Collection
+{
+  protected $collection_key = 'sourceTables';
+  protected $internal_gapi_mappings = array(
+  );
+  public $createDisposition;
+  protected $destinationTableType = 'Google_Service_Bigquery_TableReference';
+  protected $destinationTableDataType = '';
+  protected $sourceTableType = 'Google_Service_Bigquery_TableReference';
+  protected $sourceTableDataType = '';
+  protected $sourceTablesType = 'Google_Service_Bigquery_TableReference';
+  protected $sourceTablesDataType = 'array';
+  public $writeDisposition;
+
+
+  public function setCreateDisposition($createDisposition)
+  {
+    $this->createDisposition = $createDisposition;
+  }
+  public function getCreateDisposition()
+  {
+    return $this->createDisposition;
+  }
+  public function setDestinationTable(Google_Service_Bigquery_TableReference $destinationTable)
+  {
+    $this->destinationTable = $destinationTable;
+  }
+  public function getDestinationTable()
+  {
+    return $this->destinationTable;
+  }
+  public function setSourceTable(Google_Service_Bigquery_TableReference $sourceTable)
+  {
+    $this->sourceTable = $sourceTable;
+  }
+  public function getSourceTable()
+  {
+    return $this->sourceTable;
+  }
+  public function setSourceTables($sourceTables)
+  {
+    $this->sourceTables = $sourceTables;
+  }
+  public function getSourceTables()
+  {
+    return $this->sourceTables;
+  }
+  public function setWriteDisposition($writeDisposition)
+  {
+    $this->writeDisposition = $writeDisposition;
+  }
+  public function getWriteDisposition()
+  {
+    return $this->writeDisposition;
+  }
+}
+
+class Google_Service_Bigquery_JobList extends Google_Collection
+{
+  protected $collection_key = 'jobs';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $jobsType = 'Google_Service_Bigquery_JobListJobs';
+  protected $jobsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setJobs($jobs)
+  {
+    $this->jobs = $jobs;
+  }
+  public function getJobs()
+  {
+    return $this->jobs;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Bigquery_JobListJobs extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "userEmail" => "user_email",
+  );
+  protected $configurationType = 'Google_Service_Bigquery_JobConfiguration';
+  protected $configurationDataType = '';
+  protected $errorResultType = 'Google_Service_Bigquery_ErrorProto';
+  protected $errorResultDataType = '';
+  public $id;
+  protected $jobReferenceType = 'Google_Service_Bigquery_JobReference';
+  protected $jobReferenceDataType = '';
+  public $kind;
+  public $state;
+  protected $statisticsType = 'Google_Service_Bigquery_JobStatistics';
+  protected $statisticsDataType = '';
+  protected $statusType = 'Google_Service_Bigquery_JobStatus';
+  protected $statusDataType = '';
+  public $userEmail;
+
+
+  public function setConfiguration(Google_Service_Bigquery_JobConfiguration $configuration)
+  {
+    $this->configuration = $configuration;
+  }
+  public function getConfiguration()
+  {
+    return $this->configuration;
+  }
+  public function setErrorResult(Google_Service_Bigquery_ErrorProto $errorResult)
+  {
+    $this->errorResult = $errorResult;
+  }
+  public function getErrorResult()
+  {
+    return $this->errorResult;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setJobReference(Google_Service_Bigquery_JobReference $jobReference)
+  {
+    $this->jobReference = $jobReference;
+  }
+  public function getJobReference()
+  {
+    return $this->jobReference;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setState($state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+  public function setStatistics(Google_Service_Bigquery_JobStatistics $statistics)
+  {
+    $this->statistics = $statistics;
+  }
+  public function getStatistics()
+  {
+    return $this->statistics;
+  }
+  public function setStatus(Google_Service_Bigquery_JobStatus $status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setUserEmail($userEmail)
+  {
+    $this->userEmail = $userEmail;
+  }
+  public function getUserEmail()
+  {
+    return $this->userEmail;
+  }
+}
+
+class Google_Service_Bigquery_JobReference extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $jobId;
+  public $projectId;
+
+
+  public function setJobId($jobId)
+  {
+    $this->jobId = $jobId;
+  }
+  public function getJobId()
+  {
+    return $this->jobId;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+}
+
+class Google_Service_Bigquery_JobStatistics extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTime;
+  public $endTime;
+  protected $extractType = 'Google_Service_Bigquery_JobStatistics4';
+  protected $extractDataType = '';
+  protected $loadType = 'Google_Service_Bigquery_JobStatistics3';
+  protected $loadDataType = '';
+  protected $queryType = 'Google_Service_Bigquery_JobStatistics2';
+  protected $queryDataType = '';
+  public $startTime;
+  public $totalBytesProcessed;
+
+
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setExtract(Google_Service_Bigquery_JobStatistics4 $extract)
+  {
+    $this->extract = $extract;
+  }
+  public function getExtract()
+  {
+    return $this->extract;
+  }
+  public function setLoad(Google_Service_Bigquery_JobStatistics3 $load)
+  {
+    $this->load = $load;
+  }
+  public function getLoad()
+  {
+    return $this->load;
+  }
+  public function setQuery(Google_Service_Bigquery_JobStatistics2 $query)
+  {
+    $this->query = $query;
+  }
+  public function getQuery()
+  {
+    return $this->query;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+  public function setTotalBytesProcessed($totalBytesProcessed)
+  {
+    $this->totalBytesProcessed = $totalBytesProcessed;
+  }
+  public function getTotalBytesProcessed()
+  {
+    return $this->totalBytesProcessed;
+  }
+}
+
+class Google_Service_Bigquery_JobStatistics2 extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $billingTier;
+  public $cacheHit;
+  public $totalBytesBilled;
+  public $totalBytesProcessed;
+
+
+  public function setBillingTier($billingTier)
+  {
+    $this->billingTier = $billingTier;
+  }
+  public function getBillingTier()
+  {
+    return $this->billingTier;
+  }
+  public function setCacheHit($cacheHit)
+  {
+    $this->cacheHit = $cacheHit;
+  }
+  public function getCacheHit()
+  {
+    return $this->cacheHit;
+  }
+  public function setTotalBytesBilled($totalBytesBilled)
+  {
+    $this->totalBytesBilled = $totalBytesBilled;
+  }
+  public function getTotalBytesBilled()
+  {
+    return $this->totalBytesBilled;
+  }
+  public function setTotalBytesProcessed($totalBytesProcessed)
+  {
+    $this->totalBytesProcessed = $totalBytesProcessed;
+  }
+  public function getTotalBytesProcessed()
+  {
+    return $this->totalBytesProcessed;
+  }
+}
+
+class Google_Service_Bigquery_JobStatistics3 extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $inputFileBytes;
+  public $inputFiles;
+  public $outputBytes;
+  public $outputRows;
+
+
+  public function setInputFileBytes($inputFileBytes)
+  {
+    $this->inputFileBytes = $inputFileBytes;
+  }
+  public function getInputFileBytes()
+  {
+    return $this->inputFileBytes;
+  }
+  public function setInputFiles($inputFiles)
+  {
+    $this->inputFiles = $inputFiles;
+  }
+  public function getInputFiles()
+  {
+    return $this->inputFiles;
+  }
+  public function setOutputBytes($outputBytes)
+  {
+    $this->outputBytes = $outputBytes;
+  }
+  public function getOutputBytes()
+  {
+    return $this->outputBytes;
+  }
+  public function setOutputRows($outputRows)
+  {
+    $this->outputRows = $outputRows;
+  }
+  public function getOutputRows()
+  {
+    return $this->outputRows;
+  }
+}
+
+class Google_Service_Bigquery_JobStatistics4 extends Google_Collection
+{
+  protected $collection_key = 'destinationUriFileCounts';
+  protected $internal_gapi_mappings = array(
+  );
+  public $destinationUriFileCounts;
+
+
+  public function setDestinationUriFileCounts($destinationUriFileCounts)
+  {
+    $this->destinationUriFileCounts = $destinationUriFileCounts;
+  }
+  public function getDestinationUriFileCounts()
+  {
+    return $this->destinationUriFileCounts;
+  }
+}
+
+class Google_Service_Bigquery_JobStatus extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorResultType = 'Google_Service_Bigquery_ErrorProto';
+  protected $errorResultDataType = '';
+  protected $errorsType = 'Google_Service_Bigquery_ErrorProto';
+  protected $errorsDataType = 'array';
+  public $state;
+
+
+  public function setErrorResult(Google_Service_Bigquery_ErrorProto $errorResult)
+  {
+    $this->errorResult = $errorResult;
+  }
+  public function getErrorResult()
+  {
+    return $this->errorResult;
+  }
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setState($state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+}
+
+class Google_Service_Bigquery_JsonObject extends Google_Model
+{
+}
+
+class Google_Service_Bigquery_ProjectList extends Google_Collection
+{
+  protected $collection_key = 'projects';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $kind;
+  public $nextPageToken;
+  protected $projectsType = 'Google_Service_Bigquery_ProjectListProjects';
+  protected $projectsDataType = 'array';
+  public $totalItems;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setProjects($projects)
+  {
+    $this->projects = $projects;
+  }
+  public function getProjects()
+  {
+    return $this->projects;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_Bigquery_ProjectListProjects extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $friendlyName;
+  public $id;
+  public $kind;
+  public $numericId;
+  protected $projectReferenceType = 'Google_Service_Bigquery_ProjectReference';
+  protected $projectReferenceDataType = '';
+
+
+  public function setFriendlyName($friendlyName)
+  {
+    $this->friendlyName = $friendlyName;
+  }
+  public function getFriendlyName()
+  {
+    return $this->friendlyName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNumericId($numericId)
+  {
+    $this->numericId = $numericId;
+  }
+  public function getNumericId()
+  {
+    return $this->numericId;
+  }
+  public function setProjectReference(Google_Service_Bigquery_ProjectReference $projectReference)
+  {
+    $this->projectReference = $projectReference;
+  }
+  public function getProjectReference()
+  {
+    return $this->projectReference;
+  }
+}
+
+class Google_Service_Bigquery_ProjectReference extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $projectId;
+
+
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+}
+
+class Google_Service_Bigquery_QueryRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $defaultDatasetType = 'Google_Service_Bigquery_DatasetReference';
+  protected $defaultDatasetDataType = '';
+  public $dryRun;
+  public $kind;
+  public $maxResults;
+  public $preserveNulls;
+  public $query;
+  public $timeoutMs;
+  public $useQueryCache;
+
+
+  public function setDefaultDataset(Google_Service_Bigquery_DatasetReference $defaultDataset)
+  {
+    $this->defaultDataset = $defaultDataset;
+  }
+  public function getDefaultDataset()
+  {
+    return $this->defaultDataset;
+  }
+  public function setDryRun($dryRun)
+  {
+    $this->dryRun = $dryRun;
+  }
+  public function getDryRun()
+  {
+    return $this->dryRun;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMaxResults($maxResults)
+  {
+    $this->maxResults = $maxResults;
+  }
+  public function getMaxResults()
+  {
+    return $this->maxResults;
+  }
+  public function setPreserveNulls($preserveNulls)
+  {
+    $this->preserveNulls = $preserveNulls;
+  }
+  public function getPreserveNulls()
+  {
+    return $this->preserveNulls;
+  }
+  public function setQuery($query)
+  {
+    $this->query = $query;
+  }
+  public function getQuery()
+  {
+    return $this->query;
+  }
+  public function setTimeoutMs($timeoutMs)
+  {
+    $this->timeoutMs = $timeoutMs;
+  }
+  public function getTimeoutMs()
+  {
+    return $this->timeoutMs;
+  }
+  public function setUseQueryCache($useQueryCache)
+  {
+    $this->useQueryCache = $useQueryCache;
+  }
+  public function getUseQueryCache()
+  {
+    return $this->useQueryCache;
+  }
+}
+
+class Google_Service_Bigquery_QueryResponse extends Google_Collection
+{
+  protected $collection_key = 'rows';
+  protected $internal_gapi_mappings = array(
+  );
+  public $cacheHit;
+  protected $errorsType = 'Google_Service_Bigquery_ErrorProto';
+  protected $errorsDataType = 'array';
+  public $jobComplete;
+  protected $jobReferenceType = 'Google_Service_Bigquery_JobReference';
+  protected $jobReferenceDataType = '';
+  public $kind;
+  public $pageToken;
+  protected $rowsType = 'Google_Service_Bigquery_TableRow';
+  protected $rowsDataType = 'array';
+  protected $schemaType = 'Google_Service_Bigquery_TableSchema';
+  protected $schemaDataType = '';
+  public $totalBytesProcessed;
+  public $totalRows;
+
+
+  public function setCacheHit($cacheHit)
+  {
+    $this->cacheHit = $cacheHit;
+  }
+  public function getCacheHit()
+  {
+    return $this->cacheHit;
+  }
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setJobComplete($jobComplete)
+  {
+    $this->jobComplete = $jobComplete;
+  }
+  public function getJobComplete()
+  {
+    return $this->jobComplete;
+  }
+  public function setJobReference(Google_Service_Bigquery_JobReference $jobReference)
+  {
+    $this->jobReference = $jobReference;
+  }
+  public function getJobReference()
+  {
+    return $this->jobReference;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPageToken($pageToken)
+  {
+    $this->pageToken = $pageToken;
+  }
+  public function getPageToken()
+  {
+    return $this->pageToken;
+  }
+  public function setRows($rows)
+  {
+    $this->rows = $rows;
+  }
+  public function getRows()
+  {
+    return $this->rows;
+  }
+  public function setSchema(Google_Service_Bigquery_TableSchema $schema)
+  {
+    $this->schema = $schema;
+  }
+  public function getSchema()
+  {
+    return $this->schema;
+  }
+  public function setTotalBytesProcessed($totalBytesProcessed)
+  {
+    $this->totalBytesProcessed = $totalBytesProcessed;
+  }
+  public function getTotalBytesProcessed()
+  {
+    return $this->totalBytesProcessed;
+  }
+  public function setTotalRows($totalRows)
+  {
+    $this->totalRows = $totalRows;
+  }
+  public function getTotalRows()
+  {
+    return $this->totalRows;
+  }
+}
+
+class Google_Service_Bigquery_Streamingbuffer extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $estimatedBytes;
+  public $estimatedRows;
+  public $oldestEntryTime;
+
+
+  public function setEstimatedBytes($estimatedBytes)
+  {
+    $this->estimatedBytes = $estimatedBytes;
+  }
+  public function getEstimatedBytes()
+  {
+    return $this->estimatedBytes;
+  }
+  public function setEstimatedRows($estimatedRows)
+  {
+    $this->estimatedRows = $estimatedRows;
+  }
+  public function getEstimatedRows()
+  {
+    return $this->estimatedRows;
+  }
+  public function setOldestEntryTime($oldestEntryTime)
+  {
+    $this->oldestEntryTime = $oldestEntryTime;
+  }
+  public function getOldestEntryTime()
+  {
+    return $this->oldestEntryTime;
+  }
+}
+
+class Google_Service_Bigquery_Table extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTime;
+  public $description;
+  public $etag;
+  public $expirationTime;
+  protected $externalDataConfigurationType = 'Google_Service_Bigquery_ExternalDataConfiguration';
+  protected $externalDataConfigurationDataType = '';
+  public $friendlyName;
+  public $id;
+  public $kind;
+  public $lastModifiedTime;
+  public $location;
+  public $numBytes;
+  public $numRows;
+  protected $schemaType = 'Google_Service_Bigquery_TableSchema';
+  protected $schemaDataType = '';
+  public $selfLink;
+  protected $streamingBufferType = 'Google_Service_Bigquery_Streamingbuffer';
+  protected $streamingBufferDataType = '';
+  protected $tableReferenceType = 'Google_Service_Bigquery_TableReference';
+  protected $tableReferenceDataType = '';
+  public $type;
+  protected $viewType = 'Google_Service_Bigquery_ViewDefinition';
+  protected $viewDataType = '';
+
+
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setExpirationTime($expirationTime)
+  {
+    $this->expirationTime = $expirationTime;
+  }
+  public function getExpirationTime()
+  {
+    return $this->expirationTime;
+  }
+  public function setExternalDataConfiguration(Google_Service_Bigquery_ExternalDataConfiguration $externalDataConfiguration)
+  {
+    $this->externalDataConfiguration = $externalDataConfiguration;
+  }
+  public function getExternalDataConfiguration()
+  {
+    return $this->externalDataConfiguration;
+  }
+  public function setFriendlyName($friendlyName)
+  {
+    $this->friendlyName = $friendlyName;
+  }
+  public function getFriendlyName()
+  {
+    return $this->friendlyName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastModifiedTime($lastModifiedTime)
+  {
+    $this->lastModifiedTime = $lastModifiedTime;
+  }
+  public function getLastModifiedTime()
+  {
+    return $this->lastModifiedTime;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setNumBytes($numBytes)
+  {
+    $this->numBytes = $numBytes;
+  }
+  public function getNumBytes()
+  {
+    return $this->numBytes;
+  }
+  public function setNumRows($numRows)
+  {
+    $this->numRows = $numRows;
+  }
+  public function getNumRows()
+  {
+    return $this->numRows;
+  }
+  public function setSchema(Google_Service_Bigquery_TableSchema $schema)
+  {
+    $this->schema = $schema;
+  }
+  public function getSchema()
+  {
+    return $this->schema;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStreamingBuffer(Google_Service_Bigquery_Streamingbuffer $streamingBuffer)
+  {
+    $this->streamingBuffer = $streamingBuffer;
+  }
+  public function getStreamingBuffer()
+  {
+    return $this->streamingBuffer;
+  }
+  public function setTableReference(Google_Service_Bigquery_TableReference $tableReference)
+  {
+    $this->tableReference = $tableReference;
+  }
+  public function getTableReference()
+  {
+    return $this->tableReference;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setView(Google_Service_Bigquery_ViewDefinition $view)
+  {
+    $this->view = $view;
+  }
+  public function getView()
+  {
+    return $this->view;
+  }
+}
+
+class Google_Service_Bigquery_TableCell extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $v;
+
+
+  public function setV($v)
+  {
+    $this->v = $v;
+  }
+  public function getV()
+  {
+    return $this->v;
+  }
+}
+
+class Google_Service_Bigquery_TableDataInsertAllRequest extends Google_Collection
+{
+  protected $collection_key = 'rows';
+  protected $internal_gapi_mappings = array(
+  );
+  public $ignoreUnknownValues;
+  public $kind;
+  protected $rowsType = 'Google_Service_Bigquery_TableDataInsertAllRequestRows';
+  protected $rowsDataType = 'array';
+  public $skipInvalidRows;
+
+
+  public function setIgnoreUnknownValues($ignoreUnknownValues)
+  {
+    $this->ignoreUnknownValues = $ignoreUnknownValues;
+  }
+  public function getIgnoreUnknownValues()
+  {
+    return $this->ignoreUnknownValues;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRows($rows)
+  {
+    $this->rows = $rows;
+  }
+  public function getRows()
+  {
+    return $this->rows;
+  }
+  public function setSkipInvalidRows($skipInvalidRows)
+  {
+    $this->skipInvalidRows = $skipInvalidRows;
+  }
+  public function getSkipInvalidRows()
+  {
+    return $this->skipInvalidRows;
+  }
+}
+
+class Google_Service_Bigquery_TableDataInsertAllRequestRows extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $insertId;
+  public $json;
+
+
+  public function setInsertId($insertId)
+  {
+    $this->insertId = $insertId;
+  }
+  public function getInsertId()
+  {
+    return $this->insertId;
+  }
+  public function setJson($json)
+  {
+    $this->json = $json;
+  }
+  public function getJson()
+  {
+    return $this->json;
+  }
+}
+
+class Google_Service_Bigquery_TableDataInsertAllResponse extends Google_Collection
+{
+  protected $collection_key = 'insertErrors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $insertErrorsType = 'Google_Service_Bigquery_TableDataInsertAllResponseInsertErrors';
+  protected $insertErrorsDataType = 'array';
+  public $kind;
+
+
+  public function setInsertErrors($insertErrors)
+  {
+    $this->insertErrors = $insertErrors;
+  }
+  public function getInsertErrors()
+  {
+    return $this->insertErrors;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Bigquery_TableDataInsertAllResponseInsertErrors extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorsType = 'Google_Service_Bigquery_ErrorProto';
+  protected $errorsDataType = 'array';
+  public $index;
+
+
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setIndex($index)
+  {
+    $this->index = $index;
+  }
+  public function getIndex()
+  {
+    return $this->index;
+  }
+}
+
+class Google_Service_Bigquery_TableDataList extends Google_Collection
+{
+  protected $collection_key = 'rows';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $kind;
+  public $pageToken;
+  protected $rowsType = 'Google_Service_Bigquery_TableRow';
+  protected $rowsDataType = 'array';
+  public $totalRows;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPageToken($pageToken)
+  {
+    $this->pageToken = $pageToken;
+  }
+  public function getPageToken()
+  {
+    return $this->pageToken;
+  }
+  public function setRows($rows)
+  {
+    $this->rows = $rows;
+  }
+  public function getRows()
+  {
+    return $this->rows;
+  }
+  public function setTotalRows($totalRows)
+  {
+    $this->totalRows = $totalRows;
+  }
+  public function getTotalRows()
+  {
+    return $this->totalRows;
+  }
+}
+
+class Google_Service_Bigquery_TableFieldSchema extends Google_Collection
+{
+  protected $collection_key = 'fields';
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  protected $fieldsType = 'Google_Service_Bigquery_TableFieldSchema';
+  protected $fieldsDataType = 'array';
+  public $mode;
+  public $name;
+  public $type;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setFields($fields)
+  {
+    $this->fields = $fields;
+  }
+  public function getFields()
+  {
+    return $this->fields;
+  }
+  public function setMode($mode)
+  {
+    $this->mode = $mode;
+  }
+  public function getMode()
+  {
+    return $this->mode;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Bigquery_TableList extends Google_Collection
+{
+  protected $collection_key = 'tables';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $kind;
+  public $nextPageToken;
+  protected $tablesType = 'Google_Service_Bigquery_TableListTables';
+  protected $tablesDataType = 'array';
+  public $totalItems;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTables($tables)
+  {
+    $this->tables = $tables;
+  }
+  public function getTables()
+  {
+    return $this->tables;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_Bigquery_TableListTables extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $friendlyName;
+  public $id;
+  public $kind;
+  protected $tableReferenceType = 'Google_Service_Bigquery_TableReference';
+  protected $tableReferenceDataType = '';
+  public $type;
+
+
+  public function setFriendlyName($friendlyName)
+  {
+    $this->friendlyName = $friendlyName;
+  }
+  public function getFriendlyName()
+  {
+    return $this->friendlyName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setTableReference(Google_Service_Bigquery_TableReference $tableReference)
+  {
+    $this->tableReference = $tableReference;
+  }
+  public function getTableReference()
+  {
+    return $this->tableReference;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Bigquery_TableReference extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $datasetId;
+  public $projectId;
+  public $tableId;
+
+
+  public function setDatasetId($datasetId)
+  {
+    $this->datasetId = $datasetId;
+  }
+  public function getDatasetId()
+  {
+    return $this->datasetId;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setTableId($tableId)
+  {
+    $this->tableId = $tableId;
+  }
+  public function getTableId()
+  {
+    return $this->tableId;
+  }
+}
+
+class Google_Service_Bigquery_TableRow extends Google_Collection
+{
+  protected $collection_key = 'f';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $fType = 'Google_Service_Bigquery_TableCell';
+  protected $fDataType = 'array';
+
+
+  public function setF($f)
+  {
+    $this->f = $f;
+  }
+  public function getF()
+  {
+    return $this->f;
+  }
+}
+
+class Google_Service_Bigquery_TableSchema extends Google_Collection
+{
+  protected $collection_key = 'fields';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $fieldsType = 'Google_Service_Bigquery_TableFieldSchema';
+  protected $fieldsDataType = 'array';
+
+
+  public function setFields($fields)
+  {
+    $this->fields = $fields;
+  }
+  public function getFields()
+  {
+    return $this->fields;
+  }
+}
+
+class Google_Service_Bigquery_UserDefinedFunctionResource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $inlineCode;
+  public $resourceUri;
+
+
+  public function setInlineCode($inlineCode)
+  {
+    $this->inlineCode = $inlineCode;
+  }
+  public function getInlineCode()
+  {
+    return $this->inlineCode;
+  }
+  public function setResourceUri($resourceUri)
+  {
+    $this->resourceUri = $resourceUri;
+  }
+  public function getResourceUri()
+  {
+    return $this->resourceUri;
+  }
+}
+
+class Google_Service_Bigquery_ViewDefinition extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $query;
+
+
+  public function setQuery($query)
+  {
+    $this->query = $query;
+  }
+  public function getQuery()
+  {
+    return $this->query;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Blogger.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Blogger.php
@@ -1,0 +1,3330 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Blogger (v3).
+ *
+ * <p>
+ * API for access to the data within Blogger.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/blogger/docs/3.0/getting_started" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Blogger extends Google_Service
+{
+  /** Manage your Blogger account. */
+  const BLOGGER =
+      "https://www.googleapis.com/auth/blogger";
+  /** View your Blogger account. */
+  const BLOGGER_READONLY =
+      "https://www.googleapis.com/auth/blogger.readonly";
+
+  public $blogUserInfos;
+  public $blogs;
+  public $comments;
+  public $pageViews;
+  public $pages;
+  public $postUserInfos;
+  public $posts;
+  public $users;
+  
+
+  /**
+   * Constructs the internal representation of the Blogger service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'blogger/v3/';
+    $this->version = 'v3';
+    $this->serviceName = 'blogger';
+
+    $this->blogUserInfos = new Google_Service_Blogger_BlogUserInfos_Resource(
+        $this,
+        $this->serviceName,
+        'blogUserInfos',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'users/{userId}/blogs/{blogId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'maxPosts' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->blogs = new Google_Service_Blogger_Blogs_Resource(
+        $this,
+        $this->serviceName,
+        'blogs',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'blogs/{blogId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'maxPosts' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'getByUrl' => array(
+              'path' => 'blogs/byurl',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'url' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'listByUser' => array(
+              'path' => 'users/{userId}/blogs',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'fetchUserInfo' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'status' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'role' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->comments = new Google_Service_Blogger_Comments_Resource(
+        $this,
+        $this->serviceName,
+        'comments',
+        array(
+          'methods' => array(
+            'approve' => array(
+              'path' => 'blogs/{blogId}/posts/{postId}/comments/{commentId}/approve',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'postId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'commentId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'blogs/{blogId}/posts/{postId}/comments/{commentId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'postId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'commentId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'blogs/{blogId}/posts/{postId}/comments/{commentId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'postId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'commentId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'blogs/{blogId}/posts/{postId}/comments',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'postId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'status' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'startDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'endDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'fetchBodies' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'listByBlog' => array(
+              'path' => 'blogs/{blogId}/comments',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'status' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'startDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'endDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'fetchBodies' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'markAsSpam' => array(
+              'path' => 'blogs/{blogId}/posts/{postId}/comments/{commentId}/spam',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'postId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'commentId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'removeContent' => array(
+              'path' => 'blogs/{blogId}/posts/{postId}/comments/{commentId}/removecontent',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'postId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'commentId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->pageViews = new Google_Service_Blogger_PageViews_Resource(
+        $this,
+        $this->serviceName,
+        'pageViews',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'blogs/{blogId}/pageviews',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'range' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->pages = new Google_Service_Blogger_Pages_Resource(
+        $this,
+        $this->serviceName,
+        'pages',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'blogs/{blogId}/pages/{pageId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'blogs/{blogId}/pages/{pageId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'blogs/{blogId}/pages',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'isDraft' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'blogs/{blogId}/pages',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'status' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'fetchBodies' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'blogs/{blogId}/pages/{pageId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'revert' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'publish' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'publish' => array(
+              'path' => 'blogs/{blogId}/pages/{pageId}/publish',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'revert' => array(
+              'path' => 'blogs/{blogId}/pages/{pageId}/revert',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'blogs/{blogId}/pages/{pageId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'revert' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'publish' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->postUserInfos = new Google_Service_Blogger_PostUserInfos_Resource(
+        $this,
+        $this->serviceName,
+        'postUserInfos',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'users/{userId}/blogs/{blogId}/posts/{postId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'postId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'maxComments' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'users/{userId}/blogs/{blogId}/posts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'endDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'labels' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'status' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'fetchBodies' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->posts = new Google_Service_Blogger_Posts_Resource(
+        $this,
+        $this->serviceName,
+        'posts',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'blogs/{blogId}/posts/{postId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'postId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'blogs/{blogId}/posts/{postId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'postId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'fetchBody' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxComments' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'fetchImages' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'getByPath' => array(
+              'path' => 'blogs/{blogId}/posts/bypath',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'path' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'maxComments' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'blogs/{blogId}/posts',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'fetchImages' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'isDraft' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'fetchBody' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'blogs/{blogId}/posts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'endDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'labels' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'fetchImages' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'status' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'fetchBodies' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'blogs/{blogId}/posts/{postId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'postId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'revert' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'publish' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'fetchBody' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxComments' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'fetchImages' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'publish' => array(
+              'path' => 'blogs/{blogId}/posts/{postId}/publish',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'postId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'publishDate' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'revert' => array(
+              'path' => 'blogs/{blogId}/posts/{postId}/revert',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'postId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'search' => array(
+              'path' => 'blogs/{blogId}/posts/search',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'q' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'fetchBodies' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'blogs/{blogId}/posts/{postId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'blogId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'postId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'revert' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'publish' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'fetchBody' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxComments' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'fetchImages' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->users = new Google_Service_Blogger_Users_Resource(
+        $this,
+        $this->serviceName,
+        'users',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'users/{userId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "blogUserInfos" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $bloggerService = new Google_Service_Blogger(...);
+ *   $blogUserInfos = $bloggerService->blogUserInfos;
+ *  </code>
+ */
+class Google_Service_Blogger_BlogUserInfos_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one blog and user info pair by blogId and userId. (blogUserInfos.get)
+   *
+   * @param string $userId ID of the user whose blogs are to be fetched. Either
+   * the word 'self' (sans quote marks) or the user's profile identifier.
+   * @param string $blogId The ID of the blog to get.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string maxPosts Maximum number of posts to pull back with the
+   * blog.
+   * @return Google_Service_Blogger_BlogUserInfo
+   */
+  public function get($userId, $blogId, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'blogId' => $blogId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Blogger_BlogUserInfo");
+  }
+}
+
+/**
+ * The "blogs" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $bloggerService = new Google_Service_Blogger(...);
+ *   $blogs = $bloggerService->blogs;
+ *  </code>
+ */
+class Google_Service_Blogger_Blogs_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one blog by ID. (blogs.get)
+   *
+   * @param string $blogId The ID of the blog to get.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string maxPosts Maximum number of posts to pull back with the
+   * blog.
+   * @opt_param string view Access level with which to view the blog. Note that
+   * some fields require elevated access.
+   * @return Google_Service_Blogger_Blog
+   */
+  public function get($blogId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Blogger_Blog");
+  }
+
+  /**
+   * Retrieve a Blog by URL. (blogs.getByUrl)
+   *
+   * @param string $url The URL of the blog to retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string view Access level with which to view the blog. Note that
+   * some fields require elevated access.
+   * @return Google_Service_Blogger_Blog
+   */
+  public function getByUrl($url, $optParams = array())
+  {
+    $params = array('url' => $url);
+    $params = array_merge($params, $optParams);
+    return $this->call('getByUrl', array($params), "Google_Service_Blogger_Blog");
+  }
+
+  /**
+   * Retrieves a list of blogs, possibly filtered. (blogs.listByUser)
+   *
+   * @param string $userId ID of the user whose blogs are to be fetched. Either
+   * the word 'self' (sans quote marks) or the user's profile identifier.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool fetchUserInfo Whether the response is a list of blogs with
+   * per-user information instead of just blogs.
+   * @opt_param string status Blog statuses to include in the result (default:
+   * Live blogs only). Note that ADMIN access is required to view deleted blogs.
+   * @opt_param string role User access types for blogs to include in the results,
+   * e.g. AUTHOR will return blogs where the user has author level access. If no
+   * roles are specified, defaults to ADMIN and AUTHOR roles.
+   * @opt_param string view Access level with which to view the blogs. Note that
+   * some fields require elevated access.
+   * @return Google_Service_Blogger_BlogList
+   */
+  public function listByUser($userId, $optParams = array())
+  {
+    $params = array('userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('listByUser', array($params), "Google_Service_Blogger_BlogList");
+  }
+}
+
+/**
+ * The "comments" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $bloggerService = new Google_Service_Blogger(...);
+ *   $comments = $bloggerService->comments;
+ *  </code>
+ */
+class Google_Service_Blogger_Comments_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Marks a comment as not spam. (comments.approve)
+   *
+   * @param string $blogId The ID of the Blog.
+   * @param string $postId The ID of the Post.
+   * @param string $commentId The ID of the comment to mark as not spam.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Blogger_Comment
+   */
+  public function approve($blogId, $postId, $commentId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'postId' => $postId, 'commentId' => $commentId);
+    $params = array_merge($params, $optParams);
+    return $this->call('approve', array($params), "Google_Service_Blogger_Comment");
+  }
+
+  /**
+   * Delete a comment by ID. (comments.delete)
+   *
+   * @param string $blogId The ID of the Blog.
+   * @param string $postId The ID of the Post.
+   * @param string $commentId The ID of the comment to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($blogId, $postId, $commentId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'postId' => $postId, 'commentId' => $commentId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets one comment by ID. (comments.get)
+   *
+   * @param string $blogId ID of the blog to containing the comment.
+   * @param string $postId ID of the post to fetch posts from.
+   * @param string $commentId The ID of the comment to get.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string view Access level for the requested comment (default:
+   * READER). Note that some comments will require elevated permissions, for
+   * example comments where the parent posts which is in a draft state, or
+   * comments that are pending moderation.
+   * @return Google_Service_Blogger_Comment
+   */
+  public function get($blogId, $postId, $commentId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'postId' => $postId, 'commentId' => $commentId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Blogger_Comment");
+  }
+
+  /**
+   * Retrieves the comments for a post, possibly filtered. (comments.listComments)
+   *
+   * @param string $blogId ID of the blog to fetch comments from.
+   * @param string $postId ID of the post to fetch posts from.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string status
+   * @opt_param string startDate Earliest date of comment to fetch, a date-time
+   * with RFC 3339 formatting.
+   * @opt_param string endDate Latest date of comment to fetch, a date-time with
+   * RFC 3339 formatting.
+   * @opt_param string maxResults Maximum number of comments to include in the
+   * result.
+   * @opt_param string pageToken Continuation token if request is paged.
+   * @opt_param bool fetchBodies Whether the body content of the comments is
+   * included.
+   * @opt_param string view Access level with which to view the returned result.
+   * Note that some fields require elevated access.
+   * @return Google_Service_Blogger_CommentList
+   */
+  public function listComments($blogId, $postId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'postId' => $postId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Blogger_CommentList");
+  }
+
+  /**
+   * Retrieves the comments for a blog, across all posts, possibly filtered.
+   * (comments.listByBlog)
+   *
+   * @param string $blogId ID of the blog to fetch comments from.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string status
+   * @opt_param string startDate Earliest date of comment to fetch, a date-time
+   * with RFC 3339 formatting.
+   * @opt_param string endDate Latest date of comment to fetch, a date-time with
+   * RFC 3339 formatting.
+   * @opt_param string maxResults Maximum number of comments to include in the
+   * result.
+   * @opt_param string pageToken Continuation token if request is paged.
+   * @opt_param bool fetchBodies Whether the body content of the comments is
+   * included.
+   * @return Google_Service_Blogger_CommentList
+   */
+  public function listByBlog($blogId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId);
+    $params = array_merge($params, $optParams);
+    return $this->call('listByBlog', array($params), "Google_Service_Blogger_CommentList");
+  }
+
+  /**
+   * Marks a comment as spam. (comments.markAsSpam)
+   *
+   * @param string $blogId The ID of the Blog.
+   * @param string $postId The ID of the Post.
+   * @param string $commentId The ID of the comment to mark as spam.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Blogger_Comment
+   */
+  public function markAsSpam($blogId, $postId, $commentId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'postId' => $postId, 'commentId' => $commentId);
+    $params = array_merge($params, $optParams);
+    return $this->call('markAsSpam', array($params), "Google_Service_Blogger_Comment");
+  }
+
+  /**
+   * Removes the content of a comment. (comments.removeContent)
+   *
+   * @param string $blogId The ID of the Blog.
+   * @param string $postId The ID of the Post.
+   * @param string $commentId The ID of the comment to delete content from.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Blogger_Comment
+   */
+  public function removeContent($blogId, $postId, $commentId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'postId' => $postId, 'commentId' => $commentId);
+    $params = array_merge($params, $optParams);
+    return $this->call('removeContent', array($params), "Google_Service_Blogger_Comment");
+  }
+}
+
+/**
+ * The "pageViews" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $bloggerService = new Google_Service_Blogger(...);
+ *   $pageViews = $bloggerService->pageViews;
+ *  </code>
+ */
+class Google_Service_Blogger_PageViews_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieve pageview stats for a Blog. (pageViews.get)
+   *
+   * @param string $blogId The ID of the blog to get.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string range
+   * @return Google_Service_Blogger_Pageviews
+   */
+  public function get($blogId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Blogger_Pageviews");
+  }
+}
+
+/**
+ * The "pages" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $bloggerService = new Google_Service_Blogger(...);
+ *   $pages = $bloggerService->pages;
+ *  </code>
+ */
+class Google_Service_Blogger_Pages_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete a page by ID. (pages.delete)
+   *
+   * @param string $blogId The ID of the Blog.
+   * @param string $pageId The ID of the Page.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($blogId, $pageId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'pageId' => $pageId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets one blog page by ID. (pages.get)
+   *
+   * @param string $blogId ID of the blog containing the page.
+   * @param string $pageId The ID of the page to get.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string view
+   * @return Google_Service_Blogger_Page
+   */
+  public function get($blogId, $pageId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'pageId' => $pageId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Blogger_Page");
+  }
+
+  /**
+   * Add a page. (pages.insert)
+   *
+   * @param string $blogId ID of the blog to add the page to.
+   * @param Google_Page $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool isDraft Whether to create the page as a draft (default:
+   * false).
+   * @return Google_Service_Blogger_Page
+   */
+  public function insert($blogId, Google_Service_Blogger_Page $postBody, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Blogger_Page");
+  }
+
+  /**
+   * Retrieves the pages for a blog, optionally including non-LIVE statuses.
+   * (pages.listPages)
+   *
+   * @param string $blogId ID of the blog to fetch Pages from.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string status
+   * @opt_param string maxResults Maximum number of Pages to fetch.
+   * @opt_param string pageToken Continuation token if the request is paged.
+   * @opt_param bool fetchBodies Whether to retrieve the Page bodies.
+   * @opt_param string view Access level with which to view the returned result.
+   * Note that some fields require elevated access.
+   * @return Google_Service_Blogger_PageList
+   */
+  public function listPages($blogId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Blogger_PageList");
+  }
+
+  /**
+   * Update a page. This method supports patch semantics. (pages.patch)
+   *
+   * @param string $blogId The ID of the Blog.
+   * @param string $pageId The ID of the Page.
+   * @param Google_Page $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool revert Whether a revert action should be performed when the
+   * page is updated (default: false).
+   * @opt_param bool publish Whether a publish action should be performed when the
+   * page is updated (default: false).
+   * @return Google_Service_Blogger_Page
+   */
+  public function patch($blogId, $pageId, Google_Service_Blogger_Page $postBody, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'pageId' => $pageId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Blogger_Page");
+  }
+
+  /**
+   * Publishes a draft page. (pages.publish)
+   *
+   * @param string $blogId The ID of the blog.
+   * @param string $pageId The ID of the page.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Blogger_Page
+   */
+  public function publish($blogId, $pageId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'pageId' => $pageId);
+    $params = array_merge($params, $optParams);
+    return $this->call('publish', array($params), "Google_Service_Blogger_Page");
+  }
+
+  /**
+   * Revert a published or scheduled page to draft state. (pages.revert)
+   *
+   * @param string $blogId The ID of the blog.
+   * @param string $pageId The ID of the page.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Blogger_Page
+   */
+  public function revert($blogId, $pageId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'pageId' => $pageId);
+    $params = array_merge($params, $optParams);
+    return $this->call('revert', array($params), "Google_Service_Blogger_Page");
+  }
+
+  /**
+   * Update a page. (pages.update)
+   *
+   * @param string $blogId The ID of the Blog.
+   * @param string $pageId The ID of the Page.
+   * @param Google_Page $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool revert Whether a revert action should be performed when the
+   * page is updated (default: false).
+   * @opt_param bool publish Whether a publish action should be performed when the
+   * page is updated (default: false).
+   * @return Google_Service_Blogger_Page
+   */
+  public function update($blogId, $pageId, Google_Service_Blogger_Page $postBody, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'pageId' => $pageId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Blogger_Page");
+  }
+}
+
+/**
+ * The "postUserInfos" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $bloggerService = new Google_Service_Blogger(...);
+ *   $postUserInfos = $bloggerService->postUserInfos;
+ *  </code>
+ */
+class Google_Service_Blogger_PostUserInfos_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one post and user info pair, by post ID and user ID. The post user info
+   * contains per-user information about the post, such as access rights, specific
+   * to the user. (postUserInfos.get)
+   *
+   * @param string $userId ID of the user for the per-user information to be
+   * fetched. Either the word 'self' (sans quote marks) or the user's profile
+   * identifier.
+   * @param string $blogId The ID of the blog.
+   * @param string $postId The ID of the post to get.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string maxComments Maximum number of comments to pull back on a
+   * post.
+   * @return Google_Service_Blogger_PostUserInfo
+   */
+  public function get($userId, $blogId, $postId, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'blogId' => $blogId, 'postId' => $postId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Blogger_PostUserInfo");
+  }
+
+  /**
+   * Retrieves a list of post and post user info pairs, possibly filtered. The
+   * post user info contains per-user information about the post, such as access
+   * rights, specific to the user. (postUserInfos.listPostUserInfos)
+   *
+   * @param string $userId ID of the user for the per-user information to be
+   * fetched. Either the word 'self' (sans quote marks) or the user's profile
+   * identifier.
+   * @param string $blogId ID of the blog to fetch posts from.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderBy Sort order applied to search results. Default is
+   * published.
+   * @opt_param string startDate Earliest post date to fetch, a date-time with RFC
+   * 3339 formatting.
+   * @opt_param string endDate Latest post date to fetch, a date-time with RFC
+   * 3339 formatting.
+   * @opt_param string labels Comma-separated list of labels to search for.
+   * @opt_param string maxResults Maximum number of posts to fetch.
+   * @opt_param string pageToken Continuation token if the request is paged.
+   * @opt_param string status
+   * @opt_param bool fetchBodies Whether the body content of posts is included.
+   * Default is false.
+   * @opt_param string view Access level with which to view the returned result.
+   * Note that some fields require elevated access.
+   * @return Google_Service_Blogger_PostUserInfosList
+   */
+  public function listPostUserInfos($userId, $blogId, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'blogId' => $blogId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Blogger_PostUserInfosList");
+  }
+}
+
+/**
+ * The "posts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $bloggerService = new Google_Service_Blogger(...);
+ *   $posts = $bloggerService->posts;
+ *  </code>
+ */
+class Google_Service_Blogger_Posts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete a post by ID. (posts.delete)
+   *
+   * @param string $blogId The ID of the Blog.
+   * @param string $postId The ID of the Post.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($blogId, $postId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'postId' => $postId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Get a post by ID. (posts.get)
+   *
+   * @param string $blogId ID of the blog to fetch the post from.
+   * @param string $postId The ID of the post
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool fetchBody Whether the body content of the post is included
+   * (default: true). This should be set to false when the post bodies are not
+   * required, to help minimize traffic.
+   * @opt_param string maxComments Maximum number of comments to pull back on a
+   * post.
+   * @opt_param bool fetchImages Whether image URL metadata for each post is
+   * included (default: false).
+   * @opt_param string view Access level with which to view the returned result.
+   * Note that some fields require elevated access.
+   * @return Google_Service_Blogger_Post
+   */
+  public function get($blogId, $postId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'postId' => $postId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Blogger_Post");
+  }
+
+  /**
+   * Retrieve a Post by Path. (posts.getByPath)
+   *
+   * @param string $blogId ID of the blog to fetch the post from.
+   * @param string $path Path of the Post to retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string maxComments Maximum number of comments to pull back on a
+   * post.
+   * @opt_param string view Access level with which to view the returned result.
+   * Note that some fields require elevated access.
+   * @return Google_Service_Blogger_Post
+   */
+  public function getByPath($blogId, $path, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'path' => $path);
+    $params = array_merge($params, $optParams);
+    return $this->call('getByPath', array($params), "Google_Service_Blogger_Post");
+  }
+
+  /**
+   * Add a post. (posts.insert)
+   *
+   * @param string $blogId ID of the blog to add the post to.
+   * @param Google_Post $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool fetchImages Whether image URL metadata for each post is
+   * included in the returned result (default: false).
+   * @opt_param bool isDraft Whether to create the post as a draft (default:
+   * false).
+   * @opt_param bool fetchBody Whether the body content of the post is included
+   * with the result (default: true).
+   * @return Google_Service_Blogger_Post
+   */
+  public function insert($blogId, Google_Service_Blogger_Post $postBody, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Blogger_Post");
+  }
+
+  /**
+   * Retrieves a list of posts, possibly filtered. (posts.listPosts)
+   *
+   * @param string $blogId ID of the blog to fetch posts from.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderBy Sort search results
+   * @opt_param string startDate Earliest post date to fetch, a date-time with RFC
+   * 3339 formatting.
+   * @opt_param string endDate Latest post date to fetch, a date-time with RFC
+   * 3339 formatting.
+   * @opt_param string labels Comma-separated list of labels to search for.
+   * @opt_param string maxResults Maximum number of posts to fetch.
+   * @opt_param bool fetchImages Whether image URL metadata for each post is
+   * included.
+   * @opt_param string pageToken Continuation token if the request is paged.
+   * @opt_param string status Statuses to include in the results.
+   * @opt_param bool fetchBodies Whether the body content of posts is included
+   * (default: true). This should be set to false when the post bodies are not
+   * required, to help minimize traffic.
+   * @opt_param string view Access level with which to view the returned result.
+   * Note that some fields require escalated access.
+   * @return Google_Service_Blogger_PostList
+   */
+  public function listPosts($blogId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Blogger_PostList");
+  }
+
+  /**
+   * Update a post. This method supports patch semantics. (posts.patch)
+   *
+   * @param string $blogId The ID of the Blog.
+   * @param string $postId The ID of the Post.
+   * @param Google_Post $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool revert Whether a revert action should be performed when the
+   * post is updated (default: false).
+   * @opt_param bool publish Whether a publish action should be performed when the
+   * post is updated (default: false).
+   * @opt_param bool fetchBody Whether the body content of the post is included
+   * with the result (default: true).
+   * @opt_param string maxComments Maximum number of comments to retrieve with the
+   * returned post.
+   * @opt_param bool fetchImages Whether image URL metadata for each post is
+   * included in the returned result (default: false).
+   * @return Google_Service_Blogger_Post
+   */
+  public function patch($blogId, $postId, Google_Service_Blogger_Post $postBody, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'postId' => $postId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Blogger_Post");
+  }
+
+  /**
+   * Publishes a draft post, optionally at the specific time of the given
+   * publishDate parameter. (posts.publish)
+   *
+   * @param string $blogId The ID of the Blog.
+   * @param string $postId The ID of the Post.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string publishDate Optional date and time to schedule the
+   * publishing of the Blog. If no publishDate parameter is given, the post is
+   * either published at the a previously saved schedule date (if present), or the
+   * current time. If a future date is given, the post will be scheduled to be
+   * published.
+   * @return Google_Service_Blogger_Post
+   */
+  public function publish($blogId, $postId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'postId' => $postId);
+    $params = array_merge($params, $optParams);
+    return $this->call('publish', array($params), "Google_Service_Blogger_Post");
+  }
+
+  /**
+   * Revert a published or scheduled post to draft state. (posts.revert)
+   *
+   * @param string $blogId The ID of the Blog.
+   * @param string $postId The ID of the Post.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Blogger_Post
+   */
+  public function revert($blogId, $postId, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'postId' => $postId);
+    $params = array_merge($params, $optParams);
+    return $this->call('revert', array($params), "Google_Service_Blogger_Post");
+  }
+
+  /**
+   * Search for a post. (posts.search)
+   *
+   * @param string $blogId ID of the blog to fetch the post from.
+   * @param string $q Query terms to search this blog for matching posts.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderBy Sort search results
+   * @opt_param bool fetchBodies Whether the body content of posts is included
+   * (default: true). This should be set to false when the post bodies are not
+   * required, to help minimize traffic.
+   * @return Google_Service_Blogger_PostList
+   */
+  public function search($blogId, $q, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'q' => $q);
+    $params = array_merge($params, $optParams);
+    return $this->call('search', array($params), "Google_Service_Blogger_PostList");
+  }
+
+  /**
+   * Update a post. (posts.update)
+   *
+   * @param string $blogId The ID of the Blog.
+   * @param string $postId The ID of the Post.
+   * @param Google_Post $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool revert Whether a revert action should be performed when the
+   * post is updated (default: false).
+   * @opt_param bool publish Whether a publish action should be performed when the
+   * post is updated (default: false).
+   * @opt_param bool fetchBody Whether the body content of the post is included
+   * with the result (default: true).
+   * @opt_param string maxComments Maximum number of comments to retrieve with the
+   * returned post.
+   * @opt_param bool fetchImages Whether image URL metadata for each post is
+   * included in the returned result (default: false).
+   * @return Google_Service_Blogger_Post
+   */
+  public function update($blogId, $postId, Google_Service_Blogger_Post $postBody, $optParams = array())
+  {
+    $params = array('blogId' => $blogId, 'postId' => $postId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Blogger_Post");
+  }
+}
+
+/**
+ * The "users" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $bloggerService = new Google_Service_Blogger(...);
+ *   $users = $bloggerService->users;
+ *  </code>
+ */
+class Google_Service_Blogger_Users_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one user by ID. (users.get)
+   *
+   * @param string $userId The ID of the user to get.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Blogger_User
+   */
+  public function get($userId, $optParams = array())
+  {
+    $params = array('userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Blogger_User");
+  }
+}
+
+
+
+
+class Google_Service_Blogger_Blog extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $customMetaData;
+  public $description;
+  public $id;
+  public $kind;
+  protected $localeType = 'Google_Service_Blogger_BlogLocale';
+  protected $localeDataType = '';
+  public $name;
+  protected $pagesType = 'Google_Service_Blogger_BlogPages';
+  protected $pagesDataType = '';
+  protected $postsType = 'Google_Service_Blogger_BlogPosts';
+  protected $postsDataType = '';
+  public $published;
+  public $selfLink;
+  public $status;
+  public $updated;
+  public $url;
+
+
+  public function setCustomMetaData($customMetaData)
+  {
+    $this->customMetaData = $customMetaData;
+  }
+  public function getCustomMetaData()
+  {
+    return $this->customMetaData;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocale(Google_Service_Blogger_BlogLocale $locale)
+  {
+    $this->locale = $locale;
+  }
+  public function getLocale()
+  {
+    return $this->locale;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPages(Google_Service_Blogger_BlogPages $pages)
+  {
+    $this->pages = $pages;
+  }
+  public function getPages()
+  {
+    return $this->pages;
+  }
+  public function setPosts(Google_Service_Blogger_BlogPosts $posts)
+  {
+    $this->posts = $posts;
+  }
+  public function getPosts()
+  {
+    return $this->posts;
+  }
+  public function setPublished($published)
+  {
+    $this->published = $published;
+  }
+  public function getPublished()
+  {
+    return $this->published;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Blogger_BlogList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $blogUserInfosType = 'Google_Service_Blogger_BlogUserInfo';
+  protected $blogUserInfosDataType = 'array';
+  protected $itemsType = 'Google_Service_Blogger_Blog';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setBlogUserInfos($blogUserInfos)
+  {
+    $this->blogUserInfos = $blogUserInfos;
+  }
+  public function getBlogUserInfos()
+  {
+    return $this->blogUserInfos;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Blogger_BlogLocale extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $country;
+  public $language;
+  public $variant;
+
+
+  public function setCountry($country)
+  {
+    $this->country = $country;
+  }
+  public function getCountry()
+  {
+    return $this->country;
+  }
+  public function setLanguage($language)
+  {
+    $this->language = $language;
+  }
+  public function getLanguage()
+  {
+    return $this->language;
+  }
+  public function setVariant($variant)
+  {
+    $this->variant = $variant;
+  }
+  public function getVariant()
+  {
+    return $this->variant;
+  }
+}
+
+class Google_Service_Blogger_BlogPages extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $selfLink;
+  public $totalItems;
+
+
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_Blogger_BlogPerUserInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $blogId;
+  public $hasAdminAccess;
+  public $kind;
+  public $photosAlbumKey;
+  public $role;
+  public $userId;
+
+
+  public function setBlogId($blogId)
+  {
+    $this->blogId = $blogId;
+  }
+  public function getBlogId()
+  {
+    return $this->blogId;
+  }
+  public function setHasAdminAccess($hasAdminAccess)
+  {
+    $this->hasAdminAccess = $hasAdminAccess;
+  }
+  public function getHasAdminAccess()
+  {
+    return $this->hasAdminAccess;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPhotosAlbumKey($photosAlbumKey)
+  {
+    $this->photosAlbumKey = $photosAlbumKey;
+  }
+  public function getPhotosAlbumKey()
+  {
+    return $this->photosAlbumKey;
+  }
+  public function setRole($role)
+  {
+    $this->role = $role;
+  }
+  public function getRole()
+  {
+    return $this->role;
+  }
+  public function setUserId($userId)
+  {
+    $this->userId = $userId;
+  }
+  public function getUserId()
+  {
+    return $this->userId;
+  }
+}
+
+class Google_Service_Blogger_BlogPosts extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Blogger_Post';
+  protected $itemsDataType = 'array';
+  public $selfLink;
+  public $totalItems;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_Blogger_BlogUserInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "blogUserInfo" => "blog_user_info",
+  );
+  protected $blogType = 'Google_Service_Blogger_Blog';
+  protected $blogDataType = '';
+  protected $blogUserInfoType = 'Google_Service_Blogger_BlogPerUserInfo';
+  protected $blogUserInfoDataType = '';
+  public $kind;
+
+
+  public function setBlog(Google_Service_Blogger_Blog $blog)
+  {
+    $this->blog = $blog;
+  }
+  public function getBlog()
+  {
+    return $this->blog;
+  }
+  public function setBlogUserInfo(Google_Service_Blogger_BlogPerUserInfo $blogUserInfo)
+  {
+    $this->blogUserInfo = $blogUserInfo;
+  }
+  public function getBlogUserInfo()
+  {
+    return $this->blogUserInfo;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Blogger_Comment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $authorType = 'Google_Service_Blogger_CommentAuthor';
+  protected $authorDataType = '';
+  protected $blogType = 'Google_Service_Blogger_CommentBlog';
+  protected $blogDataType = '';
+  public $content;
+  public $id;
+  protected $inReplyToType = 'Google_Service_Blogger_CommentInReplyTo';
+  protected $inReplyToDataType = '';
+  public $kind;
+  protected $postType = 'Google_Service_Blogger_CommentPost';
+  protected $postDataType = '';
+  public $published;
+  public $selfLink;
+  public $status;
+  public $updated;
+
+
+  public function setAuthor(Google_Service_Blogger_CommentAuthor $author)
+  {
+    $this->author = $author;
+  }
+  public function getAuthor()
+  {
+    return $this->author;
+  }
+  public function setBlog(Google_Service_Blogger_CommentBlog $blog)
+  {
+    $this->blog = $blog;
+  }
+  public function getBlog()
+  {
+    return $this->blog;
+  }
+  public function setContent($content)
+  {
+    $this->content = $content;
+  }
+  public function getContent()
+  {
+    return $this->content;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInReplyTo(Google_Service_Blogger_CommentInReplyTo $inReplyTo)
+  {
+    $this->inReplyTo = $inReplyTo;
+  }
+  public function getInReplyTo()
+  {
+    return $this->inReplyTo;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPost(Google_Service_Blogger_CommentPost $post)
+  {
+    $this->post = $post;
+  }
+  public function getPost()
+  {
+    return $this->post;
+  }
+  public function setPublished($published)
+  {
+    $this->published = $published;
+  }
+  public function getPublished()
+  {
+    return $this->published;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+}
+
+class Google_Service_Blogger_CommentAuthor extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $displayName;
+  public $id;
+  protected $imageType = 'Google_Service_Blogger_CommentAuthorImage';
+  protected $imageDataType = '';
+  public $url;
+
+
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImage(Google_Service_Blogger_CommentAuthorImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Blogger_CommentAuthorImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $url;
+
+
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Blogger_CommentBlog extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+}
+
+class Google_Service_Blogger_CommentInReplyTo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+}
+
+class Google_Service_Blogger_CommentList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Blogger_Comment';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $prevPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPrevPageToken($prevPageToken)
+  {
+    $this->prevPageToken = $prevPageToken;
+  }
+  public function getPrevPageToken()
+  {
+    return $this->prevPageToken;
+  }
+}
+
+class Google_Service_Blogger_CommentPost extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+}
+
+class Google_Service_Blogger_Page extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $authorType = 'Google_Service_Blogger_PageAuthor';
+  protected $authorDataType = '';
+  protected $blogType = 'Google_Service_Blogger_PageBlog';
+  protected $blogDataType = '';
+  public $content;
+  public $etag;
+  public $id;
+  public $kind;
+  public $published;
+  public $selfLink;
+  public $status;
+  public $title;
+  public $updated;
+  public $url;
+
+
+  public function setAuthor(Google_Service_Blogger_PageAuthor $author)
+  {
+    $this->author = $author;
+  }
+  public function getAuthor()
+  {
+    return $this->author;
+  }
+  public function setBlog(Google_Service_Blogger_PageBlog $blog)
+  {
+    $this->blog = $blog;
+  }
+  public function getBlog()
+  {
+    return $this->blog;
+  }
+  public function setContent($content)
+  {
+    $this->content = $content;
+  }
+  public function getContent()
+  {
+    return $this->content;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPublished($published)
+  {
+    $this->published = $published;
+  }
+  public function getPublished()
+  {
+    return $this->published;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Blogger_PageAuthor extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $displayName;
+  public $id;
+  protected $imageType = 'Google_Service_Blogger_PageAuthorImage';
+  protected $imageDataType = '';
+  public $url;
+
+
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImage(Google_Service_Blogger_PageAuthorImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Blogger_PageAuthorImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $url;
+
+
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Blogger_PageBlog extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+}
+
+class Google_Service_Blogger_PageList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Blogger_Page';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Blogger_Pageviews extends Google_Collection
+{
+  protected $collection_key = 'counts';
+  protected $internal_gapi_mappings = array(
+  );
+  public $blogId;
+  protected $countsType = 'Google_Service_Blogger_PageviewsCounts';
+  protected $countsDataType = 'array';
+  public $kind;
+
+
+  public function setBlogId($blogId)
+  {
+    $this->blogId = $blogId;
+  }
+  public function getBlogId()
+  {
+    return $this->blogId;
+  }
+  public function setCounts($counts)
+  {
+    $this->counts = $counts;
+  }
+  public function getCounts()
+  {
+    return $this->counts;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Blogger_PageviewsCounts extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $count;
+  public $timeRange;
+
+
+  public function setCount($count)
+  {
+    $this->count = $count;
+  }
+  public function getCount()
+  {
+    return $this->count;
+  }
+  public function setTimeRange($timeRange)
+  {
+    $this->timeRange = $timeRange;
+  }
+  public function getTimeRange()
+  {
+    return $this->timeRange;
+  }
+}
+
+class Google_Service_Blogger_Post extends Google_Collection
+{
+  protected $collection_key = 'labels';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $authorType = 'Google_Service_Blogger_PostAuthor';
+  protected $authorDataType = '';
+  protected $blogType = 'Google_Service_Blogger_PostBlog';
+  protected $blogDataType = '';
+  public $content;
+  public $customMetaData;
+  public $etag;
+  public $id;
+  protected $imagesType = 'Google_Service_Blogger_PostImages';
+  protected $imagesDataType = 'array';
+  public $kind;
+  public $labels;
+  protected $locationType = 'Google_Service_Blogger_PostLocation';
+  protected $locationDataType = '';
+  public $published;
+  public $readerComments;
+  protected $repliesType = 'Google_Service_Blogger_PostReplies';
+  protected $repliesDataType = '';
+  public $selfLink;
+  public $status;
+  public $title;
+  public $titleLink;
+  public $updated;
+  public $url;
+
+
+  public function setAuthor(Google_Service_Blogger_PostAuthor $author)
+  {
+    $this->author = $author;
+  }
+  public function getAuthor()
+  {
+    return $this->author;
+  }
+  public function setBlog(Google_Service_Blogger_PostBlog $blog)
+  {
+    $this->blog = $blog;
+  }
+  public function getBlog()
+  {
+    return $this->blog;
+  }
+  public function setContent($content)
+  {
+    $this->content = $content;
+  }
+  public function getContent()
+  {
+    return $this->content;
+  }
+  public function setCustomMetaData($customMetaData)
+  {
+    $this->customMetaData = $customMetaData;
+  }
+  public function getCustomMetaData()
+  {
+    return $this->customMetaData;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImages($images)
+  {
+    $this->images = $images;
+  }
+  public function getImages()
+  {
+    return $this->images;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLabels($labels)
+  {
+    $this->labels = $labels;
+  }
+  public function getLabels()
+  {
+    return $this->labels;
+  }
+  public function setLocation(Google_Service_Blogger_PostLocation $location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setPublished($published)
+  {
+    $this->published = $published;
+  }
+  public function getPublished()
+  {
+    return $this->published;
+  }
+  public function setReaderComments($readerComments)
+  {
+    $this->readerComments = $readerComments;
+  }
+  public function getReaderComments()
+  {
+    return $this->readerComments;
+  }
+  public function setReplies(Google_Service_Blogger_PostReplies $replies)
+  {
+    $this->replies = $replies;
+  }
+  public function getReplies()
+  {
+    return $this->replies;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setTitleLink($titleLink)
+  {
+    $this->titleLink = $titleLink;
+  }
+  public function getTitleLink()
+  {
+    return $this->titleLink;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Blogger_PostAuthor extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $displayName;
+  public $id;
+  protected $imageType = 'Google_Service_Blogger_PostAuthorImage';
+  protected $imageDataType = '';
+  public $url;
+
+
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImage(Google_Service_Blogger_PostAuthorImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Blogger_PostAuthorImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $url;
+
+
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Blogger_PostBlog extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+}
+
+class Google_Service_Blogger_PostImages extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $url;
+
+
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Blogger_PostList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Blogger_Post';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Blogger_PostLocation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $lat;
+  public $lng;
+  public $name;
+  public $span;
+
+
+  public function setLat($lat)
+  {
+    $this->lat = $lat;
+  }
+  public function getLat()
+  {
+    return $this->lat;
+  }
+  public function setLng($lng)
+  {
+    $this->lng = $lng;
+  }
+  public function getLng()
+  {
+    return $this->lng;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSpan($span)
+  {
+    $this->span = $span;
+  }
+  public function getSpan()
+  {
+    return $this->span;
+  }
+}
+
+class Google_Service_Blogger_PostPerUserInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $blogId;
+  public $hasEditAccess;
+  public $kind;
+  public $postId;
+  public $userId;
+
+
+  public function setBlogId($blogId)
+  {
+    $this->blogId = $blogId;
+  }
+  public function getBlogId()
+  {
+    return $this->blogId;
+  }
+  public function setHasEditAccess($hasEditAccess)
+  {
+    $this->hasEditAccess = $hasEditAccess;
+  }
+  public function getHasEditAccess()
+  {
+    return $this->hasEditAccess;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPostId($postId)
+  {
+    $this->postId = $postId;
+  }
+  public function getPostId()
+  {
+    return $this->postId;
+  }
+  public function setUserId($userId)
+  {
+    $this->userId = $userId;
+  }
+  public function getUserId()
+  {
+    return $this->userId;
+  }
+}
+
+class Google_Service_Blogger_PostReplies extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Blogger_Comment';
+  protected $itemsDataType = 'array';
+  public $selfLink;
+  public $totalItems;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_Blogger_PostUserInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "postUserInfo" => "post_user_info",
+  );
+  public $kind;
+  protected $postType = 'Google_Service_Blogger_Post';
+  protected $postDataType = '';
+  protected $postUserInfoType = 'Google_Service_Blogger_PostPerUserInfo';
+  protected $postUserInfoDataType = '';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPost(Google_Service_Blogger_Post $post)
+  {
+    $this->post = $post;
+  }
+  public function getPost()
+  {
+    return $this->post;
+  }
+  public function setPostUserInfo(Google_Service_Blogger_PostPerUserInfo $postUserInfo)
+  {
+    $this->postUserInfo = $postUserInfo;
+  }
+  public function getPostUserInfo()
+  {
+    return $this->postUserInfo;
+  }
+}
+
+class Google_Service_Blogger_PostUserInfosList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Blogger_PostUserInfo';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Blogger_User extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $about;
+  protected $blogsType = 'Google_Service_Blogger_UserBlogs';
+  protected $blogsDataType = '';
+  public $created;
+  public $displayName;
+  public $id;
+  public $kind;
+  protected $localeType = 'Google_Service_Blogger_UserLocale';
+  protected $localeDataType = '';
+  public $selfLink;
+  public $url;
+
+
+  public function setAbout($about)
+  {
+    $this->about = $about;
+  }
+  public function getAbout()
+  {
+    return $this->about;
+  }
+  public function setBlogs(Google_Service_Blogger_UserBlogs $blogs)
+  {
+    $this->blogs = $blogs;
+  }
+  public function getBlogs()
+  {
+    return $this->blogs;
+  }
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocale(Google_Service_Blogger_UserLocale $locale)
+  {
+    $this->locale = $locale;
+  }
+  public function getLocale()
+  {
+    return $this->locale;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Blogger_UserBlogs extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $selfLink;
+
+
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Blogger_UserLocale extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $country;
+  public $language;
+  public $variant;
+
+
+  public function setCountry($country)
+  {
+    $this->country = $country;
+  }
+  public function getCountry()
+  {
+    return $this->country;
+  }
+  public function setLanguage($language)
+  {
+    $this->language = $language;
+  }
+  public function getLanguage()
+  {
+    return $this->language;
+  }
+  public function setVariant($variant)
+  {
+    $this->variant = $variant;
+  }
+  public function getVariant()
+  {
+    return $this->variant;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Books.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Books.php
@@ -1,0 +1,7132 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Books (v1).
+ *
+ * <p>
+ * Lets you search for books and manage your Google Books library.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/books/docs/v1/getting_started" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Books extends Google_Service
+{
+  /** Manage your books. */
+  const BOOKS =
+      "https://www.googleapis.com/auth/books";
+
+  public $bookshelves;
+  public $bookshelves_volumes;
+  public $cloudloading;
+  public $dictionary;
+  public $layers;
+  public $layers_annotationData;
+  public $layers_volumeAnnotations;
+  public $myconfig;
+  public $mylibrary_annotations;
+  public $mylibrary_bookshelves;
+  public $mylibrary_bookshelves_volumes;
+  public $mylibrary_readingpositions;
+  public $notification;
+  public $onboarding;
+  public $personalizedstream;
+  public $promooffer;
+  public $volumes;
+  public $volumes_associated;
+  public $volumes_mybooks;
+  public $volumes_recommended;
+  public $volumes_useruploaded;
+  
+
+  /**
+   * Constructs the internal representation of the Books service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'books/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'books';
+
+    $this->bookshelves = new Google_Service_Books_Bookshelves_Resource(
+        $this,
+        $this->serviceName,
+        'bookshelves',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'users/{userId}/bookshelves/{shelf}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'shelf' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'users/{userId}/bookshelves',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->bookshelves_volumes = new Google_Service_Books_BookshelvesVolumes_Resource(
+        $this,
+        $this->serviceName,
+        'volumes',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'users/{userId}/bookshelves/{shelf}/volumes',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'shelf' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'showPreorders' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startIndex' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->cloudloading = new Google_Service_Books_Cloudloading_Resource(
+        $this,
+        $this->serviceName,
+        'cloudloading',
+        array(
+          'methods' => array(
+            'addBook' => array(
+              'path' => 'cloudloading/addBook',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'upload_client_token' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'drive_document_id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'mime_type' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'name' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'deleteBook' => array(
+              'path' => 'cloudloading/deleteBook',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'volumeId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'updateBook' => array(
+              'path' => 'cloudloading/updateBook',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->dictionary = new Google_Service_Books_Dictionary_Resource(
+        $this,
+        $this->serviceName,
+        'dictionary',
+        array(
+          'methods' => array(
+            'listOfflineMetadata' => array(
+              'path' => 'dictionary/listOfflineMetadata',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'cpksver' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->layers = new Google_Service_Books_Layers_Resource(
+        $this,
+        $this->serviceName,
+        'layers',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'volumes/{volumeId}/layersummary/{summaryId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'volumeId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'summaryId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'contentVersion' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'volumes/{volumeId}/layersummary',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'volumeId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'contentVersion' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->layers_annotationData = new Google_Service_Books_LayersAnnotationData_Resource(
+        $this,
+        $this->serviceName,
+        'annotationData',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'volumes/{volumeId}/layers/{layerId}/data/{annotationDataId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'volumeId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'layerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'annotationDataId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'contentVersion' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'scale' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'allowWebDefinitions' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'h' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'w' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'volumes/{volumeId}/layers/{layerId}/data',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'volumeId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'layerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'contentVersion' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'scale' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'h' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'updatedMax' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'annotationDataId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'w' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'updatedMin' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->layers_volumeAnnotations = new Google_Service_Books_LayersVolumeAnnotations_Resource(
+        $this,
+        $this->serviceName,
+        'volumeAnnotations',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'volumes/{volumeId}/layers/{layerId}/annotations/{annotationId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'volumeId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'layerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'annotationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'volumes/{volumeId}/layers/{layerId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'volumeId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'layerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'contentVersion' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'showDeleted' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'volumeAnnotationsVersion' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'endPosition' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'endOffset' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'updatedMin' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'updatedMax' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startOffset' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startPosition' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->myconfig = new Google_Service_Books_Myconfig_Resource(
+        $this,
+        $this->serviceName,
+        'myconfig',
+        array(
+          'methods' => array(
+            'getUserSettings' => array(
+              'path' => 'myconfig/getUserSettings',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),'releaseDownloadAccess' => array(
+              'path' => 'myconfig/releaseDownloadAccess',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'volumeIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                  'required' => true,
+                ),
+                'cpksver' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'requestAccess' => array(
+              'path' => 'myconfig/requestAccess',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'volumeId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'nonce' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'cpksver' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'licenseTypes' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'syncVolumeLicenses' => array(
+              'path' => 'myconfig/syncVolumeLicenses',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'nonce' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'cpksver' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'features' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'showPreorders' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'volumeIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),'updateUserSettings' => array(
+              'path' => 'myconfig/updateUserSettings',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->mylibrary_annotations = new Google_Service_Books_MylibraryAnnotations_Resource(
+        $this,
+        $this->serviceName,
+        'annotations',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'mylibrary/annotations/{annotationId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'annotationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'mylibrary/annotations',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'country' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'showOnlySummaryInResponse' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'mylibrary/annotations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'showDeleted' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'updatedMin' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'layerIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'volumeId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'updatedMax' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'contentVersion' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'layerId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'summary' => array(
+              'path' => 'mylibrary/annotations/summary',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'layerIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                  'required' => true,
+                ),
+                'volumeId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'mylibrary/annotations/{annotationId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'annotationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->mylibrary_bookshelves = new Google_Service_Books_MylibraryBookshelves_Resource(
+        $this,
+        $this->serviceName,
+        'bookshelves',
+        array(
+          'methods' => array(
+            'addVolume' => array(
+              'path' => 'mylibrary/bookshelves/{shelf}/addVolume',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'shelf' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'volumeId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'reason' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'clearVolumes' => array(
+              'path' => 'mylibrary/bookshelves/{shelf}/clearVolumes',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'shelf' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'mylibrary/bookshelves/{shelf}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'shelf' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'mylibrary/bookshelves',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'moveVolume' => array(
+              'path' => 'mylibrary/bookshelves/{shelf}/moveVolume',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'shelf' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'volumeId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'volumePosition' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'removeVolume' => array(
+              'path' => 'mylibrary/bookshelves/{shelf}/removeVolume',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'shelf' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'volumeId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'reason' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->mylibrary_bookshelves_volumes = new Google_Service_Books_MylibraryBookshelvesVolumes_Resource(
+        $this,
+        $this->serviceName,
+        'volumes',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'mylibrary/bookshelves/{shelf}/volumes',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'shelf' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'country' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'showPreorders' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'q' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startIndex' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->mylibrary_readingpositions = new Google_Service_Books_MylibraryReadingpositions_Resource(
+        $this,
+        $this->serviceName,
+        'readingpositions',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'mylibrary/readingpositions/{volumeId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'volumeId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'contentVersion' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'setPosition' => array(
+              'path' => 'mylibrary/readingpositions/{volumeId}/setPosition',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'volumeId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'timestamp' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'position' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deviceCookie' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'contentVersion' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'action' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->notification = new Google_Service_Books_Notification_Resource(
+        $this,
+        $this->serviceName,
+        'notification',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'notification/get',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'notification_id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->onboarding = new Google_Service_Books_Onboarding_Resource(
+        $this,
+        $this->serviceName,
+        'onboarding',
+        array(
+          'methods' => array(
+            'listCategories' => array(
+              'path' => 'onboarding/listCategories',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'listCategoryVolumes' => array(
+              'path' => 'onboarding/listCategoryVolumes',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxAllowedMaturityRating' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'categoryId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->personalizedstream = new Google_Service_Books_Personalizedstream_Resource(
+        $this,
+        $this->serviceName,
+        'personalizedstream',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'personalizedstream/get',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxAllowedMaturityRating' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->promooffer = new Google_Service_Books_Promooffer_Resource(
+        $this,
+        $this->serviceName,
+        'promooffer',
+        array(
+          'methods' => array(
+            'accept' => array(
+              'path' => 'promooffer/accept',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'product' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'volumeId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'offerId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'androidId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'device' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'model' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'serial' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'manufacturer' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'dismiss' => array(
+              'path' => 'promooffer/dismiss',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'product' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'offerId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'androidId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'device' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'model' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'serial' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'manufacturer' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'promooffer/get',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'product' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'androidId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'device' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'model' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'serial' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'manufacturer' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->volumes = new Google_Service_Books_Volumes_Resource(
+        $this,
+        $this->serviceName,
+        'volumes',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'volumes/{volumeId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'volumeId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'user_library_consistent_read' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'country' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'partner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'volumes',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'q' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'libraryRestrict' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'langRestrict' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'showPreorders' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'printType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startIndex' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'download' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'partner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->volumes_associated = new Google_Service_Books_VolumesAssociated_Resource(
+        $this,
+        $this->serviceName,
+        'associated',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'volumes/{volumeId}/associated',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'volumeId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxAllowedMaturityRating' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'association' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->volumes_mybooks = new Google_Service_Books_VolumesMybooks_Resource(
+        $this,
+        $this->serviceName,
+        'mybooks',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'volumes/mybooks',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startIndex' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'acquireMethod' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'processingState' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->volumes_recommended = new Google_Service_Books_VolumesRecommended_Resource(
+        $this,
+        $this->serviceName,
+        'recommended',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'volumes/recommended',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxAllowedMaturityRating' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'rate' => array(
+              'path' => 'volumes/recommended/rate',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'rating' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'volumeId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->volumes_useruploaded = new Google_Service_Books_VolumesUseruploaded_Resource(
+        $this,
+        $this->serviceName,
+        'useruploaded',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'volumes/useruploaded',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'volumeId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startIndex' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'processingState' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "bookshelves" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $bookshelves = $booksService->bookshelves;
+ *  </code>
+ */
+class Google_Service_Books_Bookshelves_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves metadata for a specific bookshelf for the specified user.
+   * (bookshelves.get)
+   *
+   * @param string $userId ID of user for whom to retrieve bookshelves.
+   * @param string $shelf ID of bookshelf to retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string source String to identify the originator of this request.
+   * @return Google_Service_Books_Bookshelf
+   */
+  public function get($userId, $shelf, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'shelf' => $shelf);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Books_Bookshelf");
+  }
+
+  /**
+   * Retrieves a list of public bookshelves for the specified user.
+   * (bookshelves.listBookshelves)
+   *
+   * @param string $userId ID of user for whom to retrieve bookshelves.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string source String to identify the originator of this request.
+   * @return Google_Service_Books_Bookshelves
+   */
+  public function listBookshelves($userId, $optParams = array())
+  {
+    $params = array('userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Books_Bookshelves");
+  }
+}
+
+/**
+ * The "volumes" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $volumes = $booksService->volumes;
+ *  </code>
+ */
+class Google_Service_Books_BookshelvesVolumes_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves volumes in a specific bookshelf for the specified user.
+   * (volumes.listBookshelvesVolumes)
+   *
+   * @param string $userId ID of user for whom to retrieve bookshelf volumes.
+   * @param string $shelf ID of bookshelf to retrieve volumes.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool showPreorders Set to true to show pre-ordered books. Defaults
+   * to false.
+   * @opt_param string maxResults Maximum number of results to return
+   * @opt_param string source String to identify the originator of this request.
+   * @opt_param string startIndex Index of the first element to return (starts at
+   * 0)
+   * @return Google_Service_Books_Volumes
+   */
+  public function listBookshelvesVolumes($userId, $shelf, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'shelf' => $shelf);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Books_Volumes");
+  }
+}
+
+/**
+ * The "cloudloading" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $cloudloading = $booksService->cloudloading;
+ *  </code>
+ */
+class Google_Service_Books_Cloudloading_Resource extends Google_Service_Resource
+{
+
+  /**
+   * (cloudloading.addBook)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string upload_client_token
+   * @opt_param string drive_document_id A drive document id. The
+   * upload_client_token must not be set.
+   * @opt_param string mime_type The document MIME type. It can be set only if the
+   * drive_document_id is set.
+   * @opt_param string name The document name. It can be set only if the
+   * drive_document_id is set.
+   * @return Google_Service_Books_BooksCloudloadingResource
+   */
+  public function addBook($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('addBook', array($params), "Google_Service_Books_BooksCloudloadingResource");
+  }
+
+  /**
+   * Remove the book and its contents (cloudloading.deleteBook)
+   *
+   * @param string $volumeId The id of the book to be removed.
+   * @param array $optParams Optional parameters.
+   */
+  public function deleteBook($volumeId, $optParams = array())
+  {
+    $params = array('volumeId' => $volumeId);
+    $params = array_merge($params, $optParams);
+    return $this->call('deleteBook', array($params));
+  }
+
+  /**
+   * (cloudloading.updateBook)
+   *
+   * @param Google_BooksCloudloadingResource $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Books_BooksCloudloadingResource
+   */
+  public function updateBook(Google_Service_Books_BooksCloudloadingResource $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('updateBook', array($params), "Google_Service_Books_BooksCloudloadingResource");
+  }
+}
+
+/**
+ * The "dictionary" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $dictionary = $booksService->dictionary;
+ *  </code>
+ */
+class Google_Service_Books_Dictionary_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns a list of offline dictionary metadata available
+   * (dictionary.listOfflineMetadata)
+   *
+   * @param string $cpksver The device/version ID from which to request the data.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Books_Metadata
+   */
+  public function listOfflineMetadata($cpksver, $optParams = array())
+  {
+    $params = array('cpksver' => $cpksver);
+    $params = array_merge($params, $optParams);
+    return $this->call('listOfflineMetadata', array($params), "Google_Service_Books_Metadata");
+  }
+}
+
+/**
+ * The "layers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $layers = $booksService->layers;
+ *  </code>
+ */
+class Google_Service_Books_Layers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the layer summary for a volume. (layers.get)
+   *
+   * @param string $volumeId The volume to retrieve layers for.
+   * @param string $summaryId The ID for the layer to get the summary for.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string source String to identify the originator of this request.
+   * @opt_param string contentVersion The content version for the requested
+   * volume.
+   * @return Google_Service_Books_Layersummary
+   */
+  public function get($volumeId, $summaryId, $optParams = array())
+  {
+    $params = array('volumeId' => $volumeId, 'summaryId' => $summaryId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Books_Layersummary");
+  }
+
+  /**
+   * List the layer summaries for a volume. (layers.listLayers)
+   *
+   * @param string $volumeId The volume to retrieve layers for.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The value of the nextToken from the previous
+   * page.
+   * @opt_param string contentVersion The content version for the requested
+   * volume.
+   * @opt_param string maxResults Maximum number of results to return
+   * @opt_param string source String to identify the originator of this request.
+   * @return Google_Service_Books_Layersummaries
+   */
+  public function listLayers($volumeId, $optParams = array())
+  {
+    $params = array('volumeId' => $volumeId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Books_Layersummaries");
+  }
+}
+
+/**
+ * The "annotationData" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $annotationData = $booksService->annotationData;
+ *  </code>
+ */
+class Google_Service_Books_LayersAnnotationData_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the annotation data. (annotationData.get)
+   *
+   * @param string $volumeId The volume to retrieve annotations for.
+   * @param string $layerId The ID for the layer to get the annotations.
+   * @param string $annotationDataId The ID of the annotation data to retrieve.
+   * @param string $contentVersion The content version for the volume you are
+   * trying to retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int scale The requested scale for the image.
+   * @opt_param string source String to identify the originator of this request.
+   * @opt_param bool allowWebDefinitions For the dictionary layer. Whether or not
+   * to allow web definitions.
+   * @opt_param int h The requested pixel height for any images. If height is
+   * provided width must also be provided.
+   * @opt_param string locale The locale information for the data. ISO-639-1
+   * language and ISO-3166-1 country code. Ex: 'en_US'.
+   * @opt_param int w The requested pixel width for any images. If width is
+   * provided height must also be provided.
+   * @return Google_Service_Books_Annotationdata
+   */
+  public function get($volumeId, $layerId, $annotationDataId, $contentVersion, $optParams = array())
+  {
+    $params = array('volumeId' => $volumeId, 'layerId' => $layerId, 'annotationDataId' => $annotationDataId, 'contentVersion' => $contentVersion);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Books_Annotationdata");
+  }
+
+  /**
+   * Gets the annotation data for a volume and layer.
+   * (annotationData.listLayersAnnotationData)
+   *
+   * @param string $volumeId The volume to retrieve annotation data for.
+   * @param string $layerId The ID for the layer to get the annotation data.
+   * @param string $contentVersion The content version for the requested volume.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int scale The requested scale for the image.
+   * @opt_param string source String to identify the originator of this request.
+   * @opt_param string locale The locale information for the data. ISO-639-1
+   * language and ISO-3166-1 country code. Ex: 'en_US'.
+   * @opt_param int h The requested pixel height for any images. If height is
+   * provided width must also be provided.
+   * @opt_param string updatedMax RFC 3339 timestamp to restrict to items updated
+   * prior to this timestamp (exclusive).
+   * @opt_param string maxResults Maximum number of results to return
+   * @opt_param string annotationDataId The list of Annotation Data Ids to
+   * retrieve. Pagination is ignored if this is set.
+   * @opt_param string pageToken The value of the nextToken from the previous
+   * page.
+   * @opt_param int w The requested pixel width for any images. If width is
+   * provided height must also be provided.
+   * @opt_param string updatedMin RFC 3339 timestamp to restrict to items updated
+   * since this timestamp (inclusive).
+   * @return Google_Service_Books_Annotationsdata
+   */
+  public function listLayersAnnotationData($volumeId, $layerId, $contentVersion, $optParams = array())
+  {
+    $params = array('volumeId' => $volumeId, 'layerId' => $layerId, 'contentVersion' => $contentVersion);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Books_Annotationsdata");
+  }
+}
+/**
+ * The "volumeAnnotations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $volumeAnnotations = $booksService->volumeAnnotations;
+ *  </code>
+ */
+class Google_Service_Books_LayersVolumeAnnotations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the volume annotation. (volumeAnnotations.get)
+   *
+   * @param string $volumeId The volume to retrieve annotations for.
+   * @param string $layerId The ID for the layer to get the annotations.
+   * @param string $annotationId The ID of the volume annotation to retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string locale The locale information for the data. ISO-639-1
+   * language and ISO-3166-1 country code. Ex: 'en_US'.
+   * @opt_param string source String to identify the originator of this request.
+   * @return Google_Service_Books_Volumeannotation
+   */
+  public function get($volumeId, $layerId, $annotationId, $optParams = array())
+  {
+    $params = array('volumeId' => $volumeId, 'layerId' => $layerId, 'annotationId' => $annotationId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Books_Volumeannotation");
+  }
+
+  /**
+   * Gets the volume annotations for a volume and layer.
+   * (volumeAnnotations.listLayersVolumeAnnotations)
+   *
+   * @param string $volumeId The volume to retrieve annotations for.
+   * @param string $layerId The ID for the layer to get the annotations.
+   * @param string $contentVersion The content version for the requested volume.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool showDeleted Set to true to return deleted annotations.
+   * updatedMin must be in the request to use this. Defaults to false.
+   * @opt_param string volumeAnnotationsVersion The version of the volume
+   * annotations that you are requesting.
+   * @opt_param string endPosition The end position to end retrieving data from.
+   * @opt_param string endOffset The end offset to end retrieving data from.
+   * @opt_param string locale The locale information for the data. ISO-639-1
+   * language and ISO-3166-1 country code. Ex: 'en_US'.
+   * @opt_param string updatedMin RFC 3339 timestamp to restrict to items updated
+   * since this timestamp (inclusive).
+   * @opt_param string updatedMax RFC 3339 timestamp to restrict to items updated
+   * prior to this timestamp (exclusive).
+   * @opt_param string maxResults Maximum number of results to return
+   * @opt_param string pageToken The value of the nextToken from the previous
+   * page.
+   * @opt_param string source String to identify the originator of this request.
+   * @opt_param string startOffset The start offset to start retrieving data from.
+   * @opt_param string startPosition The start position to start retrieving data
+   * from.
+   * @return Google_Service_Books_Volumeannotations
+   */
+  public function listLayersVolumeAnnotations($volumeId, $layerId, $contentVersion, $optParams = array())
+  {
+    $params = array('volumeId' => $volumeId, 'layerId' => $layerId, 'contentVersion' => $contentVersion);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Books_Volumeannotations");
+  }
+}
+
+/**
+ * The "myconfig" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $myconfig = $booksService->myconfig;
+ *  </code>
+ */
+class Google_Service_Books_Myconfig_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the current settings for the user. (myconfig.getUserSettings)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Books_Usersettings
+   */
+  public function getUserSettings($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('getUserSettings', array($params), "Google_Service_Books_Usersettings");
+  }
+
+  /**
+   * Release downloaded content access restriction.
+   * (myconfig.releaseDownloadAccess)
+   *
+   * @param string $volumeIds The volume(s) to release restrictions for.
+   * @param string $cpksver The device/version ID from which to release the
+   * restriction.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string locale ISO-639-1, ISO-3166-1 codes for message
+   * localization, i.e. en_US.
+   * @opt_param string source String to identify the originator of this request.
+   * @return Google_Service_Books_DownloadAccesses
+   */
+  public function releaseDownloadAccess($volumeIds, $cpksver, $optParams = array())
+  {
+    $params = array('volumeIds' => $volumeIds, 'cpksver' => $cpksver);
+    $params = array_merge($params, $optParams);
+    return $this->call('releaseDownloadAccess', array($params), "Google_Service_Books_DownloadAccesses");
+  }
+
+  /**
+   * Request concurrent and download access restrictions. (myconfig.requestAccess)
+   *
+   * @param string $source String to identify the originator of this request.
+   * @param string $volumeId The volume to request concurrent/download
+   * restrictions for.
+   * @param string $nonce The client nonce value.
+   * @param string $cpksver The device/version ID from which to request the
+   * restrictions.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string licenseTypes The type of access license to request. If not
+   * specified, the default is BOTH.
+   * @opt_param string locale ISO-639-1, ISO-3166-1 codes for message
+   * localization, i.e. en_US.
+   * @return Google_Service_Books_RequestAccess
+   */
+  public function requestAccess($source, $volumeId, $nonce, $cpksver, $optParams = array())
+  {
+    $params = array('source' => $source, 'volumeId' => $volumeId, 'nonce' => $nonce, 'cpksver' => $cpksver);
+    $params = array_merge($params, $optParams);
+    return $this->call('requestAccess', array($params), "Google_Service_Books_RequestAccess");
+  }
+
+  /**
+   * Request downloaded content access for specified volumes on the My eBooks
+   * shelf. (myconfig.syncVolumeLicenses)
+   *
+   * @param string $source String to identify the originator of this request.
+   * @param string $nonce The client nonce value.
+   * @param string $cpksver The device/version ID from which to release the
+   * restriction.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string features List of features supported by the client, i.e.,
+   * 'RENTALS'
+   * @opt_param string locale ISO-639-1, ISO-3166-1 codes for message
+   * localization, i.e. en_US.
+   * @opt_param bool showPreorders Set to true to show pre-ordered books. Defaults
+   * to false.
+   * @opt_param string volumeIds The volume(s) to request download restrictions
+   * for.
+   * @return Google_Service_Books_Volumes
+   */
+  public function syncVolumeLicenses($source, $nonce, $cpksver, $optParams = array())
+  {
+    $params = array('source' => $source, 'nonce' => $nonce, 'cpksver' => $cpksver);
+    $params = array_merge($params, $optParams);
+    return $this->call('syncVolumeLicenses', array($params), "Google_Service_Books_Volumes");
+  }
+
+  /**
+   * Sets the settings for the user. If a sub-object is specified, it will
+   * overwrite the existing sub-object stored in the server. Unspecified sub-
+   * objects will retain the existing value. (myconfig.updateUserSettings)
+   *
+   * @param Google_Usersettings $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Books_Usersettings
+   */
+  public function updateUserSettings(Google_Service_Books_Usersettings $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('updateUserSettings', array($params), "Google_Service_Books_Usersettings");
+  }
+}
+
+/**
+ * The "mylibrary" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $mylibrary = $booksService->mylibrary;
+ *  </code>
+ */
+class Google_Service_Books_Mylibrary_Resource extends Google_Service_Resource
+{
+}
+
+/**
+ * The "annotations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $annotations = $booksService->annotations;
+ *  </code>
+ */
+class Google_Service_Books_MylibraryAnnotations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes an annotation. (annotations.delete)
+   *
+   * @param string $annotationId The ID for the annotation to delete.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string source String to identify the originator of this request.
+   */
+  public function delete($annotationId, $optParams = array())
+  {
+    $params = array('annotationId' => $annotationId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Inserts a new annotation. (annotations.insert)
+   *
+   * @param Google_Annotation $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string country ISO-3166-1 code to override the IP-based location.
+   * @opt_param bool showOnlySummaryInResponse Requests that only the summary of
+   * the specified layer be provided in the response.
+   * @opt_param string source String to identify the originator of this request.
+   * @return Google_Service_Books_Annotation
+   */
+  public function insert(Google_Service_Books_Annotation $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Books_Annotation");
+  }
+
+  /**
+   * Retrieves a list of annotations, possibly filtered.
+   * (annotations.listMylibraryAnnotations)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool showDeleted Set to true to return deleted annotations.
+   * updatedMin must be in the request to use this. Defaults to false.
+   * @opt_param string updatedMin RFC 3339 timestamp to restrict to items updated
+   * since this timestamp (inclusive).
+   * @opt_param string layerIds The layer ID(s) to limit annotation by.
+   * @opt_param string volumeId The volume to restrict annotations to.
+   * @opt_param string maxResults Maximum number of results to return
+   * @opt_param string pageToken The value of the nextToken from the previous
+   * page.
+   * @opt_param string updatedMax RFC 3339 timestamp to restrict to items updated
+   * prior to this timestamp (exclusive).
+   * @opt_param string contentVersion The content version for the requested
+   * volume.
+   * @opt_param string source String to identify the originator of this request.
+   * @opt_param string layerId The layer ID to limit annotation by.
+   * @return Google_Service_Books_Annotations
+   */
+  public function listMylibraryAnnotations($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Books_Annotations");
+  }
+
+  /**
+   * Gets the summary of specified layers. (annotations.summary)
+   *
+   * @param string $layerIds Array of layer IDs to get the summary for.
+   * @param string $volumeId Volume id to get the summary for.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Books_AnnotationsSummary
+   */
+  public function summary($layerIds, $volumeId, $optParams = array())
+  {
+    $params = array('layerIds' => $layerIds, 'volumeId' => $volumeId);
+    $params = array_merge($params, $optParams);
+    return $this->call('summary', array($params), "Google_Service_Books_AnnotationsSummary");
+  }
+
+  /**
+   * Updates an existing annotation. (annotations.update)
+   *
+   * @param string $annotationId The ID for the annotation to update.
+   * @param Google_Annotation $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string source String to identify the originator of this request.
+   * @return Google_Service_Books_Annotation
+   */
+  public function update($annotationId, Google_Service_Books_Annotation $postBody, $optParams = array())
+  {
+    $params = array('annotationId' => $annotationId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Books_Annotation");
+  }
+}
+/**
+ * The "bookshelves" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $bookshelves = $booksService->bookshelves;
+ *  </code>
+ */
+class Google_Service_Books_MylibraryBookshelves_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Adds a volume to a bookshelf. (bookshelves.addVolume)
+   *
+   * @param string $shelf ID of bookshelf to which to add a volume.
+   * @param string $volumeId ID of volume to add.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string reason The reason for which the book is added to the
+   * library.
+   * @opt_param string source String to identify the originator of this request.
+   */
+  public function addVolume($shelf, $volumeId, $optParams = array())
+  {
+    $params = array('shelf' => $shelf, 'volumeId' => $volumeId);
+    $params = array_merge($params, $optParams);
+    return $this->call('addVolume', array($params));
+  }
+
+  /**
+   * Clears all volumes from a bookshelf. (bookshelves.clearVolumes)
+   *
+   * @param string $shelf ID of bookshelf from which to remove a volume.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string source String to identify the originator of this request.
+   */
+  public function clearVolumes($shelf, $optParams = array())
+  {
+    $params = array('shelf' => $shelf);
+    $params = array_merge($params, $optParams);
+    return $this->call('clearVolumes', array($params));
+  }
+
+  /**
+   * Retrieves metadata for a specific bookshelf belonging to the authenticated
+   * user. (bookshelves.get)
+   *
+   * @param string $shelf ID of bookshelf to retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string source String to identify the originator of this request.
+   * @return Google_Service_Books_Bookshelf
+   */
+  public function get($shelf, $optParams = array())
+  {
+    $params = array('shelf' => $shelf);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Books_Bookshelf");
+  }
+
+  /**
+   * Retrieves a list of bookshelves belonging to the authenticated user.
+   * (bookshelves.listMylibraryBookshelves)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string source String to identify the originator of this request.
+   * @return Google_Service_Books_Bookshelves
+   */
+  public function listMylibraryBookshelves($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Books_Bookshelves");
+  }
+
+  /**
+   * Moves a volume within a bookshelf. (bookshelves.moveVolume)
+   *
+   * @param string $shelf ID of bookshelf with the volume.
+   * @param string $volumeId ID of volume to move.
+   * @param int $volumePosition Position on shelf to move the item (0 puts the
+   * item before the current first item, 1 puts it between the first and the
+   * second and so on.)
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string source String to identify the originator of this request.
+   */
+  public function moveVolume($shelf, $volumeId, $volumePosition, $optParams = array())
+  {
+    $params = array('shelf' => $shelf, 'volumeId' => $volumeId, 'volumePosition' => $volumePosition);
+    $params = array_merge($params, $optParams);
+    return $this->call('moveVolume', array($params));
+  }
+
+  /**
+   * Removes a volume from a bookshelf. (bookshelves.removeVolume)
+   *
+   * @param string $shelf ID of bookshelf from which to remove a volume.
+   * @param string $volumeId ID of volume to remove.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string reason The reason for which the book is removed from the
+   * library.
+   * @opt_param string source String to identify the originator of this request.
+   */
+  public function removeVolume($shelf, $volumeId, $optParams = array())
+  {
+    $params = array('shelf' => $shelf, 'volumeId' => $volumeId);
+    $params = array_merge($params, $optParams);
+    return $this->call('removeVolume', array($params));
+  }
+}
+
+/**
+ * The "volumes" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $volumes = $booksService->volumes;
+ *  </code>
+ */
+class Google_Service_Books_MylibraryBookshelvesVolumes_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets volume information for volumes on a bookshelf.
+   * (volumes.listMylibraryBookshelvesVolumes)
+   *
+   * @param string $shelf The bookshelf ID or name retrieve volumes for.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string projection Restrict information returned to a set of
+   * selected fields.
+   * @opt_param string country ISO-3166-1 code to override the IP-based location.
+   * @opt_param bool showPreorders Set to true to show pre-ordered books. Defaults
+   * to false.
+   * @opt_param string maxResults Maximum number of results to return
+   * @opt_param string q Full-text search query string in this bookshelf.
+   * @opt_param string source String to identify the originator of this request.
+   * @opt_param string startIndex Index of the first element to return (starts at
+   * 0)
+   * @return Google_Service_Books_Volumes
+   */
+  public function listMylibraryBookshelvesVolumes($shelf, $optParams = array())
+  {
+    $params = array('shelf' => $shelf);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Books_Volumes");
+  }
+}
+/**
+ * The "readingpositions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $readingpositions = $booksService->readingpositions;
+ *  </code>
+ */
+class Google_Service_Books_MylibraryReadingpositions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves my reading position information for a volume.
+   * (readingpositions.get)
+   *
+   * @param string $volumeId ID of volume for which to retrieve a reading
+   * position.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string source String to identify the originator of this request.
+   * @opt_param string contentVersion Volume content version for which this
+   * reading position is requested.
+   * @return Google_Service_Books_ReadingPosition
+   */
+  public function get($volumeId, $optParams = array())
+  {
+    $params = array('volumeId' => $volumeId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Books_ReadingPosition");
+  }
+
+  /**
+   * Sets my reading position information for a volume.
+   * (readingpositions.setPosition)
+   *
+   * @param string $volumeId ID of volume for which to update the reading
+   * position.
+   * @param string $timestamp RFC 3339 UTC format timestamp associated with this
+   * reading position.
+   * @param string $position Position string for the new volume reading position.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string deviceCookie Random persistent device cookie optional on
+   * set position.
+   * @opt_param string source String to identify the originator of this request.
+   * @opt_param string contentVersion Volume content version for which this
+   * reading position applies.
+   * @opt_param string action Action that caused this reading position to be set.
+   */
+  public function setPosition($volumeId, $timestamp, $position, $optParams = array())
+  {
+    $params = array('volumeId' => $volumeId, 'timestamp' => $timestamp, 'position' => $position);
+    $params = array_merge($params, $optParams);
+    return $this->call('setPosition', array($params));
+  }
+}
+
+/**
+ * The "notification" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $notification = $booksService->notification;
+ *  </code>
+ */
+class Google_Service_Books_Notification_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns notification details for a given notification id. (notification.get)
+   *
+   * @param string $notificationId String to identify the notification.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string locale ISO-639-1 language and ISO-3166-1 country code. Ex:
+   * 'en_US'. Used for generating notification title and body.
+   * @opt_param string source String to identify the originator of this request.
+   * @return Google_Service_Books_Notification
+   */
+  public function get($notificationId, $optParams = array())
+  {
+    $params = array('notification_id' => $notificationId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Books_Notification");
+  }
+}
+
+/**
+ * The "onboarding" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $onboarding = $booksService->onboarding;
+ *  </code>
+ */
+class Google_Service_Books_Onboarding_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List categories for onboarding experience. (onboarding.listCategories)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string locale ISO-639-1 language and ISO-3166-1 country code.
+   * Default is en-US if unset.
+   * @return Google_Service_Books_Category
+   */
+  public function listCategories($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('listCategories', array($params), "Google_Service_Books_Category");
+  }
+
+  /**
+   * List available volumes under categories for onboarding experience.
+   * (onboarding.listCategoryVolumes)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string locale ISO-639-1 language and ISO-3166-1 country code.
+   * Default is en-US if unset.
+   * @opt_param string pageToken The value of the nextToken from the previous
+   * page.
+   * @opt_param string maxAllowedMaturityRating The maximum allowed maturity
+   * rating of returned volumes. Books with a higher maturity rating are filtered
+   * out.
+   * @opt_param string categoryId List of category ids requested.
+   * @opt_param string pageSize Number of maximum results per page to be included
+   * in the response.
+   * @return Google_Service_Books_Volume2
+   */
+  public function listCategoryVolumes($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('listCategoryVolumes', array($params), "Google_Service_Books_Volume2");
+  }
+}
+
+/**
+ * The "personalizedstream" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $personalizedstream = $booksService->personalizedstream;
+ *  </code>
+ */
+class Google_Service_Books_Personalizedstream_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns a stream of personalized book clusters (personalizedstream.get)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string locale ISO-639-1 language and ISO-3166-1 country code. Ex:
+   * 'en_US'. Used for generating recommendations.
+   * @opt_param string source String to identify the originator of this request.
+   * @opt_param string maxAllowedMaturityRating The maximum allowed maturity
+   * rating of returned recommendations. Books with a higher maturity rating are
+   * filtered out.
+   * @return Google_Service_Books_Discoveryclusters
+   */
+  public function get($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Books_Discoveryclusters");
+  }
+}
+
+/**
+ * The "promooffer" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $promooffer = $booksService->promooffer;
+ *  </code>
+ */
+class Google_Service_Books_Promooffer_Resource extends Google_Service_Resource
+{
+
+  /**
+   * (promooffer.accept)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string product device product
+   * @opt_param string volumeId Volume id to exercise the offer
+   * @opt_param string offerId
+   * @opt_param string androidId device android_id
+   * @opt_param string device device device
+   * @opt_param string model device model
+   * @opt_param string serial device serial
+   * @opt_param string manufacturer device manufacturer
+   */
+  public function accept($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('accept', array($params));
+  }
+
+  /**
+   * (promooffer.dismiss)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string product device product
+   * @opt_param string offerId Offer to dimiss
+   * @opt_param string androidId device android_id
+   * @opt_param string device device device
+   * @opt_param string model device model
+   * @opt_param string serial device serial
+   * @opt_param string manufacturer device manufacturer
+   */
+  public function dismiss($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('dismiss', array($params));
+  }
+
+  /**
+   * Returns a list of promo offers available to the user (promooffer.get)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string product device product
+   * @opt_param string androidId device android_id
+   * @opt_param string device device device
+   * @opt_param string model device model
+   * @opt_param string serial device serial
+   * @opt_param string manufacturer device manufacturer
+   * @return Google_Service_Books_Offers
+   */
+  public function get($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Books_Offers");
+  }
+}
+
+/**
+ * The "volumes" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $volumes = $booksService->volumes;
+ *  </code>
+ */
+class Google_Service_Books_Volumes_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets volume information for a single volume. (volumes.get)
+   *
+   * @param string $volumeId ID of volume to retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool user_library_consistent_read
+   * @opt_param string projection Restrict information returned to a set of
+   * selected fields.
+   * @opt_param string country ISO-3166-1 code to override the IP-based location.
+   * @opt_param string source String to identify the originator of this request.
+   * @opt_param string partner Brand results for partner ID.
+   * @return Google_Service_Books_Volume
+   */
+  public function get($volumeId, $optParams = array())
+  {
+    $params = array('volumeId' => $volumeId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Books_Volume");
+  }
+
+  /**
+   * Performs a book search. (volumes.listVolumes)
+   *
+   * @param string $q Full-text search query string.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderBy Sort search results.
+   * @opt_param string projection Restrict information returned to a set of
+   * selected fields.
+   * @opt_param string libraryRestrict Restrict search to this user's library.
+   * @opt_param string langRestrict Restrict results to books with this language
+   * code.
+   * @opt_param bool showPreorders Set to true to show books available for
+   * preorder. Defaults to false.
+   * @opt_param string printType Restrict to books or magazines.
+   * @opt_param string maxResults Maximum number of results to return.
+   * @opt_param string filter Filter search results.
+   * @opt_param string source String to identify the originator of this request.
+   * @opt_param string startIndex Index of the first result to return (starts at
+   * 0)
+   * @opt_param string download Restrict to volumes by download availability.
+   * @opt_param string partner Restrict and brand results for partner ID.
+   * @return Google_Service_Books_Volumes
+   */
+  public function listVolumes($q, $optParams = array())
+  {
+    $params = array('q' => $q);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Books_Volumes");
+  }
+}
+
+/**
+ * The "associated" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $associated = $booksService->associated;
+ *  </code>
+ */
+class Google_Service_Books_VolumesAssociated_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Return a list of associated books. (associated.listVolumesAssociated)
+   *
+   * @param string $volumeId ID of the source volume.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string locale ISO-639-1 language and ISO-3166-1 country code. Ex:
+   * 'en_US'. Used for generating recommendations.
+   * @opt_param string source String to identify the originator of this request.
+   * @opt_param string maxAllowedMaturityRating The maximum allowed maturity
+   * rating of returned recommendations. Books with a higher maturity rating are
+   * filtered out.
+   * @opt_param string association Association type.
+   * @return Google_Service_Books_Volumes
+   */
+  public function listVolumesAssociated($volumeId, $optParams = array())
+  {
+    $params = array('volumeId' => $volumeId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Books_Volumes");
+  }
+}
+/**
+ * The "mybooks" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $mybooks = $booksService->mybooks;
+ *  </code>
+ */
+class Google_Service_Books_VolumesMybooks_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Return a list of books in My Library. (mybooks.listVolumesMybooks)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string locale ISO-639-1 language and ISO-3166-1 country code.
+   * Ex:'en_US'. Used for generating recommendations.
+   * @opt_param string startIndex Index of the first result to return (starts at
+   * 0)
+   * @opt_param string maxResults Maximum number of results to return.
+   * @opt_param string source String to identify the originator of this request.
+   * @opt_param string acquireMethod How the book was aquired
+   * @opt_param string processingState The processing state of the user uploaded
+   * volumes to be returned. Applicable only if the UPLOADED is specified in the
+   * acquireMethod.
+   * @return Google_Service_Books_Volumes
+   */
+  public function listVolumesMybooks($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Books_Volumes");
+  }
+}
+/**
+ * The "recommended" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $recommended = $booksService->recommended;
+ *  </code>
+ */
+class Google_Service_Books_VolumesRecommended_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Return a list of recommended books for the current user.
+   * (recommended.listVolumesRecommended)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string locale ISO-639-1 language and ISO-3166-1 country code. Ex:
+   * 'en_US'. Used for generating recommendations.
+   * @opt_param string source String to identify the originator of this request.
+   * @opt_param string maxAllowedMaturityRating The maximum allowed maturity
+   * rating of returned recommendations. Books with a higher maturity rating are
+   * filtered out.
+   * @return Google_Service_Books_Volumes
+   */
+  public function listVolumesRecommended($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Books_Volumes");
+  }
+
+  /**
+   * Rate a recommended book for the current user. (recommended.rate)
+   *
+   * @param string $rating Rating to be given to the volume.
+   * @param string $volumeId ID of the source volume.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string locale ISO-639-1 language and ISO-3166-1 country code. Ex:
+   * 'en_US'. Used for generating recommendations.
+   * @opt_param string source String to identify the originator of this request.
+   * @return Google_Service_Books_BooksVolumesRecommendedRateResponse
+   */
+  public function rate($rating, $volumeId, $optParams = array())
+  {
+    $params = array('rating' => $rating, 'volumeId' => $volumeId);
+    $params = array_merge($params, $optParams);
+    return $this->call('rate', array($params), "Google_Service_Books_BooksVolumesRecommendedRateResponse");
+  }
+}
+/**
+ * The "useruploaded" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $booksService = new Google_Service_Books(...);
+ *   $useruploaded = $booksService->useruploaded;
+ *  </code>
+ */
+class Google_Service_Books_VolumesUseruploaded_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Return a list of books uploaded by the current user.
+   * (useruploaded.listVolumesUseruploaded)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string locale ISO-639-1 language and ISO-3166-1 country code. Ex:
+   * 'en_US'. Used for generating recommendations.
+   * @opt_param string volumeId The ids of the volumes to be returned. If not
+   * specified all that match the processingState are returned.
+   * @opt_param string maxResults Maximum number of results to return.
+   * @opt_param string source String to identify the originator of this request.
+   * @opt_param string startIndex Index of the first result to return (starts at
+   * 0)
+   * @opt_param string processingState The processing state of the user uploaded
+   * volumes to be returned.
+   * @return Google_Service_Books_Volumes
+   */
+  public function listVolumesUseruploaded($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Books_Volumes");
+  }
+}
+
+
+
+
+class Google_Service_Books_Annotation extends Google_Collection
+{
+  protected $collection_key = 'pageIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $afterSelectedText;
+  public $beforeSelectedText;
+  protected $clientVersionRangesType = 'Google_Service_Books_AnnotationClientVersionRanges';
+  protected $clientVersionRangesDataType = '';
+  public $created;
+  protected $currentVersionRangesType = 'Google_Service_Books_AnnotationCurrentVersionRanges';
+  protected $currentVersionRangesDataType = '';
+  public $data;
+  public $deleted;
+  public $highlightStyle;
+  public $id;
+  public $kind;
+  public $layerId;
+  protected $layerSummaryType = 'Google_Service_Books_AnnotationLayerSummary';
+  protected $layerSummaryDataType = '';
+  public $pageIds;
+  public $selectedText;
+  public $selfLink;
+  public $updated;
+  public $volumeId;
+
+
+  public function setAfterSelectedText($afterSelectedText)
+  {
+    $this->afterSelectedText = $afterSelectedText;
+  }
+  public function getAfterSelectedText()
+  {
+    return $this->afterSelectedText;
+  }
+  public function setBeforeSelectedText($beforeSelectedText)
+  {
+    $this->beforeSelectedText = $beforeSelectedText;
+  }
+  public function getBeforeSelectedText()
+  {
+    return $this->beforeSelectedText;
+  }
+  public function setClientVersionRanges(Google_Service_Books_AnnotationClientVersionRanges $clientVersionRanges)
+  {
+    $this->clientVersionRanges = $clientVersionRanges;
+  }
+  public function getClientVersionRanges()
+  {
+    return $this->clientVersionRanges;
+  }
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setCurrentVersionRanges(Google_Service_Books_AnnotationCurrentVersionRanges $currentVersionRanges)
+  {
+    $this->currentVersionRanges = $currentVersionRanges;
+  }
+  public function getCurrentVersionRanges()
+  {
+    return $this->currentVersionRanges;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setDeleted($deleted)
+  {
+    $this->deleted = $deleted;
+  }
+  public function getDeleted()
+  {
+    return $this->deleted;
+  }
+  public function setHighlightStyle($highlightStyle)
+  {
+    $this->highlightStyle = $highlightStyle;
+  }
+  public function getHighlightStyle()
+  {
+    return $this->highlightStyle;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLayerId($layerId)
+  {
+    $this->layerId = $layerId;
+  }
+  public function getLayerId()
+  {
+    return $this->layerId;
+  }
+  public function setLayerSummary(Google_Service_Books_AnnotationLayerSummary $layerSummary)
+  {
+    $this->layerSummary = $layerSummary;
+  }
+  public function getLayerSummary()
+  {
+    return $this->layerSummary;
+  }
+  public function setPageIds($pageIds)
+  {
+    $this->pageIds = $pageIds;
+  }
+  public function getPageIds()
+  {
+    return $this->pageIds;
+  }
+  public function setSelectedText($selectedText)
+  {
+    $this->selectedText = $selectedText;
+  }
+  public function getSelectedText()
+  {
+    return $this->selectedText;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setVolumeId($volumeId)
+  {
+    $this->volumeId = $volumeId;
+  }
+  public function getVolumeId()
+  {
+    return $this->volumeId;
+  }
+}
+
+class Google_Service_Books_AnnotationClientVersionRanges extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $cfiRangeType = 'Google_Service_Books_BooksAnnotationsRange';
+  protected $cfiRangeDataType = '';
+  public $contentVersion;
+  protected $gbImageRangeType = 'Google_Service_Books_BooksAnnotationsRange';
+  protected $gbImageRangeDataType = '';
+  protected $gbTextRangeType = 'Google_Service_Books_BooksAnnotationsRange';
+  protected $gbTextRangeDataType = '';
+  protected $imageCfiRangeType = 'Google_Service_Books_BooksAnnotationsRange';
+  protected $imageCfiRangeDataType = '';
+
+
+  public function setCfiRange(Google_Service_Books_BooksAnnotationsRange $cfiRange)
+  {
+    $this->cfiRange = $cfiRange;
+  }
+  public function getCfiRange()
+  {
+    return $this->cfiRange;
+  }
+  public function setContentVersion($contentVersion)
+  {
+    $this->contentVersion = $contentVersion;
+  }
+  public function getContentVersion()
+  {
+    return $this->contentVersion;
+  }
+  public function setGbImageRange(Google_Service_Books_BooksAnnotationsRange $gbImageRange)
+  {
+    $this->gbImageRange = $gbImageRange;
+  }
+  public function getGbImageRange()
+  {
+    return $this->gbImageRange;
+  }
+  public function setGbTextRange(Google_Service_Books_BooksAnnotationsRange $gbTextRange)
+  {
+    $this->gbTextRange = $gbTextRange;
+  }
+  public function getGbTextRange()
+  {
+    return $this->gbTextRange;
+  }
+  public function setImageCfiRange(Google_Service_Books_BooksAnnotationsRange $imageCfiRange)
+  {
+    $this->imageCfiRange = $imageCfiRange;
+  }
+  public function getImageCfiRange()
+  {
+    return $this->imageCfiRange;
+  }
+}
+
+class Google_Service_Books_AnnotationCurrentVersionRanges extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $cfiRangeType = 'Google_Service_Books_BooksAnnotationsRange';
+  protected $cfiRangeDataType = '';
+  public $contentVersion;
+  protected $gbImageRangeType = 'Google_Service_Books_BooksAnnotationsRange';
+  protected $gbImageRangeDataType = '';
+  protected $gbTextRangeType = 'Google_Service_Books_BooksAnnotationsRange';
+  protected $gbTextRangeDataType = '';
+  protected $imageCfiRangeType = 'Google_Service_Books_BooksAnnotationsRange';
+  protected $imageCfiRangeDataType = '';
+
+
+  public function setCfiRange(Google_Service_Books_BooksAnnotationsRange $cfiRange)
+  {
+    $this->cfiRange = $cfiRange;
+  }
+  public function getCfiRange()
+  {
+    return $this->cfiRange;
+  }
+  public function setContentVersion($contentVersion)
+  {
+    $this->contentVersion = $contentVersion;
+  }
+  public function getContentVersion()
+  {
+    return $this->contentVersion;
+  }
+  public function setGbImageRange(Google_Service_Books_BooksAnnotationsRange $gbImageRange)
+  {
+    $this->gbImageRange = $gbImageRange;
+  }
+  public function getGbImageRange()
+  {
+    return $this->gbImageRange;
+  }
+  public function setGbTextRange(Google_Service_Books_BooksAnnotationsRange $gbTextRange)
+  {
+    $this->gbTextRange = $gbTextRange;
+  }
+  public function getGbTextRange()
+  {
+    return $this->gbTextRange;
+  }
+  public function setImageCfiRange(Google_Service_Books_BooksAnnotationsRange $imageCfiRange)
+  {
+    $this->imageCfiRange = $imageCfiRange;
+  }
+  public function getImageCfiRange()
+  {
+    return $this->imageCfiRange;
+  }
+}
+
+class Google_Service_Books_AnnotationLayerSummary extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $allowedCharacterCount;
+  public $limitType;
+  public $remainingCharacterCount;
+
+
+  public function setAllowedCharacterCount($allowedCharacterCount)
+  {
+    $this->allowedCharacterCount = $allowedCharacterCount;
+  }
+  public function getAllowedCharacterCount()
+  {
+    return $this->allowedCharacterCount;
+  }
+  public function setLimitType($limitType)
+  {
+    $this->limitType = $limitType;
+  }
+  public function getLimitType()
+  {
+    return $this->limitType;
+  }
+  public function setRemainingCharacterCount($remainingCharacterCount)
+  {
+    $this->remainingCharacterCount = $remainingCharacterCount;
+  }
+  public function getRemainingCharacterCount()
+  {
+    return $this->remainingCharacterCount;
+  }
+}
+
+class Google_Service_Books_Annotationdata extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "encodedData" => "encoded_data",
+  );
+  public $annotationType;
+  public $data;
+  public $encodedData;
+  public $id;
+  public $kind;
+  public $layerId;
+  public $selfLink;
+  public $updated;
+  public $volumeId;
+
+
+  public function setAnnotationType($annotationType)
+  {
+    $this->annotationType = $annotationType;
+  }
+  public function getAnnotationType()
+  {
+    return $this->annotationType;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setEncodedData($encodedData)
+  {
+    $this->encodedData = $encodedData;
+  }
+  public function getEncodedData()
+  {
+    return $this->encodedData;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLayerId($layerId)
+  {
+    $this->layerId = $layerId;
+  }
+  public function getLayerId()
+  {
+    return $this->layerId;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setVolumeId($volumeId)
+  {
+    $this->volumeId = $volumeId;
+  }
+  public function getVolumeId()
+  {
+    return $this->volumeId;
+  }
+}
+
+class Google_Service_Books_Annotations extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Books_Annotation';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $totalItems;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_Books_AnnotationsSummary extends Google_Collection
+{
+  protected $collection_key = 'layers';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $layersType = 'Google_Service_Books_AnnotationsSummaryLayers';
+  protected $layersDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLayers($layers)
+  {
+    $this->layers = $layers;
+  }
+  public function getLayers()
+  {
+    return $this->layers;
+  }
+}
+
+class Google_Service_Books_AnnotationsSummaryLayers extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $allowedCharacterCount;
+  public $layerId;
+  public $limitType;
+  public $remainingCharacterCount;
+  public $updated;
+
+
+  public function setAllowedCharacterCount($allowedCharacterCount)
+  {
+    $this->allowedCharacterCount = $allowedCharacterCount;
+  }
+  public function getAllowedCharacterCount()
+  {
+    return $this->allowedCharacterCount;
+  }
+  public function setLayerId($layerId)
+  {
+    $this->layerId = $layerId;
+  }
+  public function getLayerId()
+  {
+    return $this->layerId;
+  }
+  public function setLimitType($limitType)
+  {
+    $this->limitType = $limitType;
+  }
+  public function getLimitType()
+  {
+    return $this->limitType;
+  }
+  public function setRemainingCharacterCount($remainingCharacterCount)
+  {
+    $this->remainingCharacterCount = $remainingCharacterCount;
+  }
+  public function getRemainingCharacterCount()
+  {
+    return $this->remainingCharacterCount;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+}
+
+class Google_Service_Books_Annotationsdata extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Books_Annotationdata';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $totalItems;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_Books_BooksAnnotationsRange extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $endOffset;
+  public $endPosition;
+  public $startOffset;
+  public $startPosition;
+
+
+  public function setEndOffset($endOffset)
+  {
+    $this->endOffset = $endOffset;
+  }
+  public function getEndOffset()
+  {
+    return $this->endOffset;
+  }
+  public function setEndPosition($endPosition)
+  {
+    $this->endPosition = $endPosition;
+  }
+  public function getEndPosition()
+  {
+    return $this->endPosition;
+  }
+  public function setStartOffset($startOffset)
+  {
+    $this->startOffset = $startOffset;
+  }
+  public function getStartOffset()
+  {
+    return $this->startOffset;
+  }
+  public function setStartPosition($startPosition)
+  {
+    $this->startPosition = $startPosition;
+  }
+  public function getStartPosition()
+  {
+    return $this->startPosition;
+  }
+}
+
+class Google_Service_Books_BooksCloudloadingResource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $author;
+  public $processingState;
+  public $title;
+  public $volumeId;
+
+
+  public function setAuthor($author)
+  {
+    $this->author = $author;
+  }
+  public function getAuthor()
+  {
+    return $this->author;
+  }
+  public function setProcessingState($processingState)
+  {
+    $this->processingState = $processingState;
+  }
+  public function getProcessingState()
+  {
+    return $this->processingState;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setVolumeId($volumeId)
+  {
+    $this->volumeId = $volumeId;
+  }
+  public function getVolumeId()
+  {
+    return $this->volumeId;
+  }
+}
+
+class Google_Service_Books_BooksVolumesRecommendedRateResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "consistencyToken" => "consistency_token",
+  );
+  public $consistencyToken;
+
+
+  public function setConsistencyToken($consistencyToken)
+  {
+    $this->consistencyToken = $consistencyToken;
+  }
+  public function getConsistencyToken()
+  {
+    return $this->consistencyToken;
+  }
+}
+
+class Google_Service_Books_Bookshelf extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $access;
+  public $created;
+  public $description;
+  public $id;
+  public $kind;
+  public $selfLink;
+  public $title;
+  public $updated;
+  public $volumeCount;
+  public $volumesLastUpdated;
+
+
+  public function setAccess($access)
+  {
+    $this->access = $access;
+  }
+  public function getAccess()
+  {
+    return $this->access;
+  }
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setVolumeCount($volumeCount)
+  {
+    $this->volumeCount = $volumeCount;
+  }
+  public function getVolumeCount()
+  {
+    return $this->volumeCount;
+  }
+  public function setVolumesLastUpdated($volumesLastUpdated)
+  {
+    $this->volumesLastUpdated = $volumesLastUpdated;
+  }
+  public function getVolumesLastUpdated()
+  {
+    return $this->volumesLastUpdated;
+  }
+}
+
+class Google_Service_Books_Bookshelves extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Books_Bookshelf';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Books_Category extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Books_CategoryItems';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Books_CategoryItems extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $badgeUrl;
+  public $categoryId;
+  public $name;
+
+
+  public function setBadgeUrl($badgeUrl)
+  {
+    $this->badgeUrl = $badgeUrl;
+  }
+  public function getBadgeUrl()
+  {
+    return $this->badgeUrl;
+  }
+  public function setCategoryId($categoryId)
+  {
+    $this->categoryId = $categoryId;
+  }
+  public function getCategoryId()
+  {
+    return $this->categoryId;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Books_ConcurrentAccessRestriction extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $deviceAllowed;
+  public $kind;
+  public $maxConcurrentDevices;
+  public $message;
+  public $nonce;
+  public $reasonCode;
+  public $restricted;
+  public $signature;
+  public $source;
+  public $timeWindowSeconds;
+  public $volumeId;
+
+
+  public function setDeviceAllowed($deviceAllowed)
+  {
+    $this->deviceAllowed = $deviceAllowed;
+  }
+  public function getDeviceAllowed()
+  {
+    return $this->deviceAllowed;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMaxConcurrentDevices($maxConcurrentDevices)
+  {
+    $this->maxConcurrentDevices = $maxConcurrentDevices;
+  }
+  public function getMaxConcurrentDevices()
+  {
+    return $this->maxConcurrentDevices;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+  public function setNonce($nonce)
+  {
+    $this->nonce = $nonce;
+  }
+  public function getNonce()
+  {
+    return $this->nonce;
+  }
+  public function setReasonCode($reasonCode)
+  {
+    $this->reasonCode = $reasonCode;
+  }
+  public function getReasonCode()
+  {
+    return $this->reasonCode;
+  }
+  public function setRestricted($restricted)
+  {
+    $this->restricted = $restricted;
+  }
+  public function getRestricted()
+  {
+    return $this->restricted;
+  }
+  public function setSignature($signature)
+  {
+    $this->signature = $signature;
+  }
+  public function getSignature()
+  {
+    return $this->signature;
+  }
+  public function setSource($source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+  public function setTimeWindowSeconds($timeWindowSeconds)
+  {
+    $this->timeWindowSeconds = $timeWindowSeconds;
+  }
+  public function getTimeWindowSeconds()
+  {
+    return $this->timeWindowSeconds;
+  }
+  public function setVolumeId($volumeId)
+  {
+    $this->volumeId = $volumeId;
+  }
+  public function getVolumeId()
+  {
+    return $this->volumeId;
+  }
+}
+
+class Google_Service_Books_Dictlayerdata extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $commonType = 'Google_Service_Books_DictlayerdataCommon';
+  protected $commonDataType = '';
+  protected $dictType = 'Google_Service_Books_DictlayerdataDict';
+  protected $dictDataType = '';
+  public $kind;
+
+
+  public function setCommon(Google_Service_Books_DictlayerdataCommon $common)
+  {
+    $this->common = $common;
+  }
+  public function getCommon()
+  {
+    return $this->common;
+  }
+  public function setDict(Google_Service_Books_DictlayerdataDict $dict)
+  {
+    $this->dict = $dict;
+  }
+  public function getDict()
+  {
+    return $this->dict;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Books_DictlayerdataCommon extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $title;
+
+
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_Books_DictlayerdataDict extends Google_Collection
+{
+  protected $collection_key = 'words';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $sourceType = 'Google_Service_Books_DictlayerdataDictSource';
+  protected $sourceDataType = '';
+  protected $wordsType = 'Google_Service_Books_DictlayerdataDictWords';
+  protected $wordsDataType = 'array';
+
+
+  public function setSource(Google_Service_Books_DictlayerdataDictSource $source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+  public function setWords($words)
+  {
+    $this->words = $words;
+  }
+  public function getWords()
+  {
+    return $this->words;
+  }
+}
+
+class Google_Service_Books_DictlayerdataDictSource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $attribution;
+  public $url;
+
+
+  public function setAttribution($attribution)
+  {
+    $this->attribution = $attribution;
+  }
+  public function getAttribution()
+  {
+    return $this->attribution;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Books_DictlayerdataDictWords extends Google_Collection
+{
+  protected $collection_key = 'senses';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $derivativesType = 'Google_Service_Books_DictlayerdataDictWordsDerivatives';
+  protected $derivativesDataType = 'array';
+  protected $examplesType = 'Google_Service_Books_DictlayerdataDictWordsExamples';
+  protected $examplesDataType = 'array';
+  protected $sensesType = 'Google_Service_Books_DictlayerdataDictWordsSenses';
+  protected $sensesDataType = 'array';
+  protected $sourceType = 'Google_Service_Books_DictlayerdataDictWordsSource';
+  protected $sourceDataType = '';
+
+
+  public function setDerivatives($derivatives)
+  {
+    $this->derivatives = $derivatives;
+  }
+  public function getDerivatives()
+  {
+    return $this->derivatives;
+  }
+  public function setExamples($examples)
+  {
+    $this->examples = $examples;
+  }
+  public function getExamples()
+  {
+    return $this->examples;
+  }
+  public function setSenses($senses)
+  {
+    $this->senses = $senses;
+  }
+  public function getSenses()
+  {
+    return $this->senses;
+  }
+  public function setSource(Google_Service_Books_DictlayerdataDictWordsSource $source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+}
+
+class Google_Service_Books_DictlayerdataDictWordsDerivatives extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $sourceType = 'Google_Service_Books_DictlayerdataDictWordsDerivativesSource';
+  protected $sourceDataType = '';
+  public $text;
+
+
+  public function setSource(Google_Service_Books_DictlayerdataDictWordsDerivativesSource $source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+  public function setText($text)
+  {
+    $this->text = $text;
+  }
+  public function getText()
+  {
+    return $this->text;
+  }
+}
+
+class Google_Service_Books_DictlayerdataDictWordsDerivativesSource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $attribution;
+  public $url;
+
+
+  public function setAttribution($attribution)
+  {
+    $this->attribution = $attribution;
+  }
+  public function getAttribution()
+  {
+    return $this->attribution;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Books_DictlayerdataDictWordsExamples extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $sourceType = 'Google_Service_Books_DictlayerdataDictWordsExamplesSource';
+  protected $sourceDataType = '';
+  public $text;
+
+
+  public function setSource(Google_Service_Books_DictlayerdataDictWordsExamplesSource $source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+  public function setText($text)
+  {
+    $this->text = $text;
+  }
+  public function getText()
+  {
+    return $this->text;
+  }
+}
+
+class Google_Service_Books_DictlayerdataDictWordsExamplesSource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $attribution;
+  public $url;
+
+
+  public function setAttribution($attribution)
+  {
+    $this->attribution = $attribution;
+  }
+  public function getAttribution()
+  {
+    return $this->attribution;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Books_DictlayerdataDictWordsSenses extends Google_Collection
+{
+  protected $collection_key = 'synonyms';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $conjugationsType = 'Google_Service_Books_DictlayerdataDictWordsSensesConjugations';
+  protected $conjugationsDataType = 'array';
+  protected $definitionsType = 'Google_Service_Books_DictlayerdataDictWordsSensesDefinitions';
+  protected $definitionsDataType = 'array';
+  public $partOfSpeech;
+  public $pronunciation;
+  public $pronunciationUrl;
+  protected $sourceType = 'Google_Service_Books_DictlayerdataDictWordsSensesSource';
+  protected $sourceDataType = '';
+  public $syllabification;
+  protected $synonymsType = 'Google_Service_Books_DictlayerdataDictWordsSensesSynonyms';
+  protected $synonymsDataType = 'array';
+
+
+  public function setConjugations($conjugations)
+  {
+    $this->conjugations = $conjugations;
+  }
+  public function getConjugations()
+  {
+    return $this->conjugations;
+  }
+  public function setDefinitions($definitions)
+  {
+    $this->definitions = $definitions;
+  }
+  public function getDefinitions()
+  {
+    return $this->definitions;
+  }
+  public function setPartOfSpeech($partOfSpeech)
+  {
+    $this->partOfSpeech = $partOfSpeech;
+  }
+  public function getPartOfSpeech()
+  {
+    return $this->partOfSpeech;
+  }
+  public function setPronunciation($pronunciation)
+  {
+    $this->pronunciation = $pronunciation;
+  }
+  public function getPronunciation()
+  {
+    return $this->pronunciation;
+  }
+  public function setPronunciationUrl($pronunciationUrl)
+  {
+    $this->pronunciationUrl = $pronunciationUrl;
+  }
+  public function getPronunciationUrl()
+  {
+    return $this->pronunciationUrl;
+  }
+  public function setSource(Google_Service_Books_DictlayerdataDictWordsSensesSource $source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+  public function setSyllabification($syllabification)
+  {
+    $this->syllabification = $syllabification;
+  }
+  public function getSyllabification()
+  {
+    return $this->syllabification;
+  }
+  public function setSynonyms($synonyms)
+  {
+    $this->synonyms = $synonyms;
+  }
+  public function getSynonyms()
+  {
+    return $this->synonyms;
+  }
+}
+
+class Google_Service_Books_DictlayerdataDictWordsSensesConjugations extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $type;
+  public $value;
+
+
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Books_DictlayerdataDictWordsSensesDefinitions extends Google_Collection
+{
+  protected $collection_key = 'examples';
+  protected $internal_gapi_mappings = array(
+  );
+  public $definition;
+  protected $examplesType = 'Google_Service_Books_DictlayerdataDictWordsSensesDefinitionsExamples';
+  protected $examplesDataType = 'array';
+
+
+  public function setDefinition($definition)
+  {
+    $this->definition = $definition;
+  }
+  public function getDefinition()
+  {
+    return $this->definition;
+  }
+  public function setExamples($examples)
+  {
+    $this->examples = $examples;
+  }
+  public function getExamples()
+  {
+    return $this->examples;
+  }
+}
+
+class Google_Service_Books_DictlayerdataDictWordsSensesDefinitionsExamples extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $sourceType = 'Google_Service_Books_DictlayerdataDictWordsSensesDefinitionsExamplesSource';
+  protected $sourceDataType = '';
+  public $text;
+
+
+  public function setSource(Google_Service_Books_DictlayerdataDictWordsSensesDefinitionsExamplesSource $source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+  public function setText($text)
+  {
+    $this->text = $text;
+  }
+  public function getText()
+  {
+    return $this->text;
+  }
+}
+
+class Google_Service_Books_DictlayerdataDictWordsSensesDefinitionsExamplesSource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $attribution;
+  public $url;
+
+
+  public function setAttribution($attribution)
+  {
+    $this->attribution = $attribution;
+  }
+  public function getAttribution()
+  {
+    return $this->attribution;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Books_DictlayerdataDictWordsSensesSource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $attribution;
+  public $url;
+
+
+  public function setAttribution($attribution)
+  {
+    $this->attribution = $attribution;
+  }
+  public function getAttribution()
+  {
+    return $this->attribution;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Books_DictlayerdataDictWordsSensesSynonyms extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $sourceType = 'Google_Service_Books_DictlayerdataDictWordsSensesSynonymsSource';
+  protected $sourceDataType = '';
+  public $text;
+
+
+  public function setSource(Google_Service_Books_DictlayerdataDictWordsSensesSynonymsSource $source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+  public function setText($text)
+  {
+    $this->text = $text;
+  }
+  public function getText()
+  {
+    return $this->text;
+  }
+}
+
+class Google_Service_Books_DictlayerdataDictWordsSensesSynonymsSource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $attribution;
+  public $url;
+
+
+  public function setAttribution($attribution)
+  {
+    $this->attribution = $attribution;
+  }
+  public function getAttribution()
+  {
+    return $this->attribution;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Books_DictlayerdataDictWordsSource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $attribution;
+  public $url;
+
+
+  public function setAttribution($attribution)
+  {
+    $this->attribution = $attribution;
+  }
+  public function getAttribution()
+  {
+    return $this->attribution;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Books_Discoveryclusters extends Google_Collection
+{
+  protected $collection_key = 'clusters';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $clustersType = 'Google_Service_Books_DiscoveryclustersClusters';
+  protected $clustersDataType = 'array';
+  public $kind;
+  public $totalClusters;
+
+
+  public function setClusters($clusters)
+  {
+    $this->clusters = $clusters;
+  }
+  public function getClusters()
+  {
+    return $this->clusters;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setTotalClusters($totalClusters)
+  {
+    $this->totalClusters = $totalClusters;
+  }
+  public function getTotalClusters()
+  {
+    return $this->totalClusters;
+  }
+}
+
+class Google_Service_Books_DiscoveryclustersClusters extends Google_Collection
+{
+  protected $collection_key = 'volumes';
+  protected $internal_gapi_mappings = array(
+        "bannerWithContentContainer" => "banner_with_content_container",
+  );
+  protected $bannerWithContentContainerType = 'Google_Service_Books_DiscoveryclustersClustersBannerWithContentContainer';
+  protected $bannerWithContentContainerDataType = '';
+  public $subTitle;
+  public $title;
+  public $totalVolumes;
+  public $uid;
+  protected $volumesType = 'Google_Service_Books_Volume';
+  protected $volumesDataType = 'array';
+
+
+  public function setBannerWithContentContainer(Google_Service_Books_DiscoveryclustersClustersBannerWithContentContainer $bannerWithContentContainer)
+  {
+    $this->bannerWithContentContainer = $bannerWithContentContainer;
+  }
+  public function getBannerWithContentContainer()
+  {
+    return $this->bannerWithContentContainer;
+  }
+  public function setSubTitle($subTitle)
+  {
+    $this->subTitle = $subTitle;
+  }
+  public function getSubTitle()
+  {
+    return $this->subTitle;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setTotalVolumes($totalVolumes)
+  {
+    $this->totalVolumes = $totalVolumes;
+  }
+  public function getTotalVolumes()
+  {
+    return $this->totalVolumes;
+  }
+  public function setUid($uid)
+  {
+    $this->uid = $uid;
+  }
+  public function getUid()
+  {
+    return $this->uid;
+  }
+  public function setVolumes($volumes)
+  {
+    $this->volumes = $volumes;
+  }
+  public function getVolumes()
+  {
+    return $this->volumes;
+  }
+}
+
+class Google_Service_Books_DiscoveryclustersClustersBannerWithContentContainer extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $fillColorArgb;
+  public $imageUrl;
+  public $maskColorArgb;
+  public $moreButtonText;
+  public $moreButtonUrl;
+  public $textColorArgb;
+
+
+  public function setFillColorArgb($fillColorArgb)
+  {
+    $this->fillColorArgb = $fillColorArgb;
+  }
+  public function getFillColorArgb()
+  {
+    return $this->fillColorArgb;
+  }
+  public function setImageUrl($imageUrl)
+  {
+    $this->imageUrl = $imageUrl;
+  }
+  public function getImageUrl()
+  {
+    return $this->imageUrl;
+  }
+  public function setMaskColorArgb($maskColorArgb)
+  {
+    $this->maskColorArgb = $maskColorArgb;
+  }
+  public function getMaskColorArgb()
+  {
+    return $this->maskColorArgb;
+  }
+  public function setMoreButtonText($moreButtonText)
+  {
+    $this->moreButtonText = $moreButtonText;
+  }
+  public function getMoreButtonText()
+  {
+    return $this->moreButtonText;
+  }
+  public function setMoreButtonUrl($moreButtonUrl)
+  {
+    $this->moreButtonUrl = $moreButtonUrl;
+  }
+  public function getMoreButtonUrl()
+  {
+    return $this->moreButtonUrl;
+  }
+  public function setTextColorArgb($textColorArgb)
+  {
+    $this->textColorArgb = $textColorArgb;
+  }
+  public function getTextColorArgb()
+  {
+    return $this->textColorArgb;
+  }
+}
+
+class Google_Service_Books_DownloadAccessRestriction extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $deviceAllowed;
+  public $downloadsAcquired;
+  public $justAcquired;
+  public $kind;
+  public $maxDownloadDevices;
+  public $message;
+  public $nonce;
+  public $reasonCode;
+  public $restricted;
+  public $signature;
+  public $source;
+  public $volumeId;
+
+
+  public function setDeviceAllowed($deviceAllowed)
+  {
+    $this->deviceAllowed = $deviceAllowed;
+  }
+  public function getDeviceAllowed()
+  {
+    return $this->deviceAllowed;
+  }
+  public function setDownloadsAcquired($downloadsAcquired)
+  {
+    $this->downloadsAcquired = $downloadsAcquired;
+  }
+  public function getDownloadsAcquired()
+  {
+    return $this->downloadsAcquired;
+  }
+  public function setJustAcquired($justAcquired)
+  {
+    $this->justAcquired = $justAcquired;
+  }
+  public function getJustAcquired()
+  {
+    return $this->justAcquired;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMaxDownloadDevices($maxDownloadDevices)
+  {
+    $this->maxDownloadDevices = $maxDownloadDevices;
+  }
+  public function getMaxDownloadDevices()
+  {
+    return $this->maxDownloadDevices;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+  public function setNonce($nonce)
+  {
+    $this->nonce = $nonce;
+  }
+  public function getNonce()
+  {
+    return $this->nonce;
+  }
+  public function setReasonCode($reasonCode)
+  {
+    $this->reasonCode = $reasonCode;
+  }
+  public function getReasonCode()
+  {
+    return $this->reasonCode;
+  }
+  public function setRestricted($restricted)
+  {
+    $this->restricted = $restricted;
+  }
+  public function getRestricted()
+  {
+    return $this->restricted;
+  }
+  public function setSignature($signature)
+  {
+    $this->signature = $signature;
+  }
+  public function getSignature()
+  {
+    return $this->signature;
+  }
+  public function setSource($source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+  public function setVolumeId($volumeId)
+  {
+    $this->volumeId = $volumeId;
+  }
+  public function getVolumeId()
+  {
+    return $this->volumeId;
+  }
+}
+
+class Google_Service_Books_DownloadAccesses extends Google_Collection
+{
+  protected $collection_key = 'downloadAccessList';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $downloadAccessListType = 'Google_Service_Books_DownloadAccessRestriction';
+  protected $downloadAccessListDataType = 'array';
+  public $kind;
+
+
+  public function setDownloadAccessList($downloadAccessList)
+  {
+    $this->downloadAccessList = $downloadAccessList;
+  }
+  public function getDownloadAccessList()
+  {
+    return $this->downloadAccessList;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Books_Geolayerdata extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $commonType = 'Google_Service_Books_GeolayerdataCommon';
+  protected $commonDataType = '';
+  protected $geoType = 'Google_Service_Books_GeolayerdataGeo';
+  protected $geoDataType = '';
+  public $kind;
+
+
+  public function setCommon(Google_Service_Books_GeolayerdataCommon $common)
+  {
+    $this->common = $common;
+  }
+  public function getCommon()
+  {
+    return $this->common;
+  }
+  public function setGeo(Google_Service_Books_GeolayerdataGeo $geo)
+  {
+    $this->geo = $geo;
+  }
+  public function getGeo()
+  {
+    return $this->geo;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Books_GeolayerdataCommon extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $lang;
+  public $previewImageUrl;
+  public $snippet;
+  public $snippetUrl;
+  public $title;
+
+
+  public function setLang($lang)
+  {
+    $this->lang = $lang;
+  }
+  public function getLang()
+  {
+    return $this->lang;
+  }
+  public function setPreviewImageUrl($previewImageUrl)
+  {
+    $this->previewImageUrl = $previewImageUrl;
+  }
+  public function getPreviewImageUrl()
+  {
+    return $this->previewImageUrl;
+  }
+  public function setSnippet($snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+  public function setSnippetUrl($snippetUrl)
+  {
+    $this->snippetUrl = $snippetUrl;
+  }
+  public function getSnippetUrl()
+  {
+    return $this->snippetUrl;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_Books_GeolayerdataGeo extends Google_Collection
+{
+  protected $collection_key = 'boundary';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $boundaryType = 'Google_Service_Books_GeolayerdataGeoBoundary';
+  protected $boundaryDataType = 'array';
+  public $cachePolicy;
+  public $countryCode;
+  public $latitude;
+  public $longitude;
+  public $mapType;
+  protected $viewportType = 'Google_Service_Books_GeolayerdataGeoViewport';
+  protected $viewportDataType = '';
+  public $zoom;
+
+
+  public function setBoundary($boundary)
+  {
+    $this->boundary = $boundary;
+  }
+  public function getBoundary()
+  {
+    return $this->boundary;
+  }
+  public function setCachePolicy($cachePolicy)
+  {
+    $this->cachePolicy = $cachePolicy;
+  }
+  public function getCachePolicy()
+  {
+    return $this->cachePolicy;
+  }
+  public function setCountryCode($countryCode)
+  {
+    $this->countryCode = $countryCode;
+  }
+  public function getCountryCode()
+  {
+    return $this->countryCode;
+  }
+  public function setLatitude($latitude)
+  {
+    $this->latitude = $latitude;
+  }
+  public function getLatitude()
+  {
+    return $this->latitude;
+  }
+  public function setLongitude($longitude)
+  {
+    $this->longitude = $longitude;
+  }
+  public function getLongitude()
+  {
+    return $this->longitude;
+  }
+  public function setMapType($mapType)
+  {
+    $this->mapType = $mapType;
+  }
+  public function getMapType()
+  {
+    return $this->mapType;
+  }
+  public function setViewport(Google_Service_Books_GeolayerdataGeoViewport $viewport)
+  {
+    $this->viewport = $viewport;
+  }
+  public function getViewport()
+  {
+    return $this->viewport;
+  }
+  public function setZoom($zoom)
+  {
+    $this->zoom = $zoom;
+  }
+  public function getZoom()
+  {
+    return $this->zoom;
+  }
+}
+
+class Google_Service_Books_GeolayerdataGeoBoundary extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $latitude;
+  public $longitude;
+
+
+  public function setLatitude($latitude)
+  {
+    $this->latitude = $latitude;
+  }
+  public function getLatitude()
+  {
+    return $this->latitude;
+  }
+  public function setLongitude($longitude)
+  {
+    $this->longitude = $longitude;
+  }
+  public function getLongitude()
+  {
+    return $this->longitude;
+  }
+}
+
+class Google_Service_Books_GeolayerdataGeoViewport extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $hiType = 'Google_Service_Books_GeolayerdataGeoViewportHi';
+  protected $hiDataType = '';
+  protected $loType = 'Google_Service_Books_GeolayerdataGeoViewportLo';
+  protected $loDataType = '';
+
+
+  public function setHi(Google_Service_Books_GeolayerdataGeoViewportHi $hi)
+  {
+    $this->hi = $hi;
+  }
+  public function getHi()
+  {
+    return $this->hi;
+  }
+  public function setLo(Google_Service_Books_GeolayerdataGeoViewportLo $lo)
+  {
+    $this->lo = $lo;
+  }
+  public function getLo()
+  {
+    return $this->lo;
+  }
+}
+
+class Google_Service_Books_GeolayerdataGeoViewportHi extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $latitude;
+  public $longitude;
+
+
+  public function setLatitude($latitude)
+  {
+    $this->latitude = $latitude;
+  }
+  public function getLatitude()
+  {
+    return $this->latitude;
+  }
+  public function setLongitude($longitude)
+  {
+    $this->longitude = $longitude;
+  }
+  public function getLongitude()
+  {
+    return $this->longitude;
+  }
+}
+
+class Google_Service_Books_GeolayerdataGeoViewportLo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $latitude;
+  public $longitude;
+
+
+  public function setLatitude($latitude)
+  {
+    $this->latitude = $latitude;
+  }
+  public function getLatitude()
+  {
+    return $this->latitude;
+  }
+  public function setLongitude($longitude)
+  {
+    $this->longitude = $longitude;
+  }
+  public function getLongitude()
+  {
+    return $this->longitude;
+  }
+}
+
+class Google_Service_Books_Layersummaries extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Books_Layersummary';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $totalItems;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_Books_Layersummary extends Google_Collection
+{
+  protected $collection_key = 'annotationTypes';
+  protected $internal_gapi_mappings = array(
+  );
+  public $annotationCount;
+  public $annotationTypes;
+  public $annotationsDataLink;
+  public $annotationsLink;
+  public $contentVersion;
+  public $dataCount;
+  public $id;
+  public $kind;
+  public $layerId;
+  public $selfLink;
+  public $updated;
+  public $volumeAnnotationsVersion;
+  public $volumeId;
+
+
+  public function setAnnotationCount($annotationCount)
+  {
+    $this->annotationCount = $annotationCount;
+  }
+  public function getAnnotationCount()
+  {
+    return $this->annotationCount;
+  }
+  public function setAnnotationTypes($annotationTypes)
+  {
+    $this->annotationTypes = $annotationTypes;
+  }
+  public function getAnnotationTypes()
+  {
+    return $this->annotationTypes;
+  }
+  public function setAnnotationsDataLink($annotationsDataLink)
+  {
+    $this->annotationsDataLink = $annotationsDataLink;
+  }
+  public function getAnnotationsDataLink()
+  {
+    return $this->annotationsDataLink;
+  }
+  public function setAnnotationsLink($annotationsLink)
+  {
+    $this->annotationsLink = $annotationsLink;
+  }
+  public function getAnnotationsLink()
+  {
+    return $this->annotationsLink;
+  }
+  public function setContentVersion($contentVersion)
+  {
+    $this->contentVersion = $contentVersion;
+  }
+  public function getContentVersion()
+  {
+    return $this->contentVersion;
+  }
+  public function setDataCount($dataCount)
+  {
+    $this->dataCount = $dataCount;
+  }
+  public function getDataCount()
+  {
+    return $this->dataCount;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLayerId($layerId)
+  {
+    $this->layerId = $layerId;
+  }
+  public function getLayerId()
+  {
+    return $this->layerId;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setVolumeAnnotationsVersion($volumeAnnotationsVersion)
+  {
+    $this->volumeAnnotationsVersion = $volumeAnnotationsVersion;
+  }
+  public function getVolumeAnnotationsVersion()
+  {
+    return $this->volumeAnnotationsVersion;
+  }
+  public function setVolumeId($volumeId)
+  {
+    $this->volumeId = $volumeId;
+  }
+  public function getVolumeId()
+  {
+    return $this->volumeId;
+  }
+}
+
+class Google_Service_Books_Metadata extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Books_MetadataItems';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Books_MetadataItems extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "downloadUrl" => "download_url",
+        "encryptedKey" => "encrypted_key",
+  );
+  public $downloadUrl;
+  public $encryptedKey;
+  public $language;
+  public $size;
+  public $version;
+
+
+  public function setDownloadUrl($downloadUrl)
+  {
+    $this->downloadUrl = $downloadUrl;
+  }
+  public function getDownloadUrl()
+  {
+    return $this->downloadUrl;
+  }
+  public function setEncryptedKey($encryptedKey)
+  {
+    $this->encryptedKey = $encryptedKey;
+  }
+  public function getEncryptedKey()
+  {
+    return $this->encryptedKey;
+  }
+  public function setLanguage($language)
+  {
+    $this->language = $language;
+  }
+  public function getLanguage()
+  {
+    return $this->language;
+  }
+  public function setSize($size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Books_Notification extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $body;
+  public $iconUrl;
+  public $kind;
+  public $linkUrl;
+  public $title;
+
+
+  public function setBody($body)
+  {
+    $this->body = $body;
+  }
+  public function getBody()
+  {
+    return $this->body;
+  }
+  public function setIconUrl($iconUrl)
+  {
+    $this->iconUrl = $iconUrl;
+  }
+  public function getIconUrl()
+  {
+    return $this->iconUrl;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLinkUrl($linkUrl)
+  {
+    $this->linkUrl = $linkUrl;
+  }
+  public function getLinkUrl()
+  {
+    return $this->linkUrl;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_Books_Offers extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Books_OffersItems';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Books_OffersItems extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $artUrl;
+  public $gservicesKey;
+  public $id;
+  protected $itemsType = 'Google_Service_Books_OffersItemsItems';
+  protected $itemsDataType = 'array';
+
+
+  public function setArtUrl($artUrl)
+  {
+    $this->artUrl = $artUrl;
+  }
+  public function getArtUrl()
+  {
+    return $this->artUrl;
+  }
+  public function setGservicesKey($gservicesKey)
+  {
+    $this->gservicesKey = $gservicesKey;
+  }
+  public function getGservicesKey()
+  {
+    return $this->gservicesKey;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+}
+
+class Google_Service_Books_OffersItemsItems extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $author;
+  public $canonicalVolumeLink;
+  public $coverUrl;
+  public $description;
+  public $title;
+  public $volumeId;
+
+
+  public function setAuthor($author)
+  {
+    $this->author = $author;
+  }
+  public function getAuthor()
+  {
+    return $this->author;
+  }
+  public function setCanonicalVolumeLink($canonicalVolumeLink)
+  {
+    $this->canonicalVolumeLink = $canonicalVolumeLink;
+  }
+  public function getCanonicalVolumeLink()
+  {
+    return $this->canonicalVolumeLink;
+  }
+  public function setCoverUrl($coverUrl)
+  {
+    $this->coverUrl = $coverUrl;
+  }
+  public function getCoverUrl()
+  {
+    return $this->coverUrl;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setVolumeId($volumeId)
+  {
+    $this->volumeId = $volumeId;
+  }
+  public function getVolumeId()
+  {
+    return $this->volumeId;
+  }
+}
+
+class Google_Service_Books_ReadingPosition extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $epubCfiPosition;
+  public $gbImagePosition;
+  public $gbTextPosition;
+  public $kind;
+  public $pdfPosition;
+  public $updated;
+  public $volumeId;
+
+
+  public function setEpubCfiPosition($epubCfiPosition)
+  {
+    $this->epubCfiPosition = $epubCfiPosition;
+  }
+  public function getEpubCfiPosition()
+  {
+    return $this->epubCfiPosition;
+  }
+  public function setGbImagePosition($gbImagePosition)
+  {
+    $this->gbImagePosition = $gbImagePosition;
+  }
+  public function getGbImagePosition()
+  {
+    return $this->gbImagePosition;
+  }
+  public function setGbTextPosition($gbTextPosition)
+  {
+    $this->gbTextPosition = $gbTextPosition;
+  }
+  public function getGbTextPosition()
+  {
+    return $this->gbTextPosition;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPdfPosition($pdfPosition)
+  {
+    $this->pdfPosition = $pdfPosition;
+  }
+  public function getPdfPosition()
+  {
+    return $this->pdfPosition;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setVolumeId($volumeId)
+  {
+    $this->volumeId = $volumeId;
+  }
+  public function getVolumeId()
+  {
+    return $this->volumeId;
+  }
+}
+
+class Google_Service_Books_RequestAccess extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $concurrentAccessType = 'Google_Service_Books_ConcurrentAccessRestriction';
+  protected $concurrentAccessDataType = '';
+  protected $downloadAccessType = 'Google_Service_Books_DownloadAccessRestriction';
+  protected $downloadAccessDataType = '';
+  public $kind;
+
+
+  public function setConcurrentAccess(Google_Service_Books_ConcurrentAccessRestriction $concurrentAccess)
+  {
+    $this->concurrentAccess = $concurrentAccess;
+  }
+  public function getConcurrentAccess()
+  {
+    return $this->concurrentAccess;
+  }
+  public function setDownloadAccess(Google_Service_Books_DownloadAccessRestriction $downloadAccess)
+  {
+    $this->downloadAccess = $downloadAccess;
+  }
+  public function getDownloadAccess()
+  {
+    return $this->downloadAccess;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Books_Review extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $authorType = 'Google_Service_Books_ReviewAuthor';
+  protected $authorDataType = '';
+  public $content;
+  public $date;
+  public $fullTextUrl;
+  public $kind;
+  public $rating;
+  protected $sourceType = 'Google_Service_Books_ReviewSource';
+  protected $sourceDataType = '';
+  public $title;
+  public $type;
+  public $volumeId;
+
+
+  public function setAuthor(Google_Service_Books_ReviewAuthor $author)
+  {
+    $this->author = $author;
+  }
+  public function getAuthor()
+  {
+    return $this->author;
+  }
+  public function setContent($content)
+  {
+    $this->content = $content;
+  }
+  public function getContent()
+  {
+    return $this->content;
+  }
+  public function setDate($date)
+  {
+    $this->date = $date;
+  }
+  public function getDate()
+  {
+    return $this->date;
+  }
+  public function setFullTextUrl($fullTextUrl)
+  {
+    $this->fullTextUrl = $fullTextUrl;
+  }
+  public function getFullTextUrl()
+  {
+    return $this->fullTextUrl;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRating($rating)
+  {
+    $this->rating = $rating;
+  }
+  public function getRating()
+  {
+    return $this->rating;
+  }
+  public function setSource(Google_Service_Books_ReviewSource $source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVolumeId($volumeId)
+  {
+    $this->volumeId = $volumeId;
+  }
+  public function getVolumeId()
+  {
+    return $this->volumeId;
+  }
+}
+
+class Google_Service_Books_ReviewAuthor extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $displayName;
+
+
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+}
+
+class Google_Service_Books_ReviewSource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $extraDescription;
+  public $url;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setExtraDescription($extraDescription)
+  {
+    $this->extraDescription = $extraDescription;
+  }
+  public function getExtraDescription()
+  {
+    return $this->extraDescription;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Books_Usersettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $notesExportType = 'Google_Service_Books_UsersettingsNotesExport';
+  protected $notesExportDataType = '';
+  protected $notificationType = 'Google_Service_Books_UsersettingsNotification';
+  protected $notificationDataType = '';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNotesExport(Google_Service_Books_UsersettingsNotesExport $notesExport)
+  {
+    $this->notesExport = $notesExport;
+  }
+  public function getNotesExport()
+  {
+    return $this->notesExport;
+  }
+  public function setNotification(Google_Service_Books_UsersettingsNotification $notification)
+  {
+    $this->notification = $notification;
+  }
+  public function getNotification()
+  {
+    return $this->notification;
+  }
+}
+
+class Google_Service_Books_UsersettingsNotesExport extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $folderName;
+  public $isEnabled;
+
+
+  public function setFolderName($folderName)
+  {
+    $this->folderName = $folderName;
+  }
+  public function getFolderName()
+  {
+    return $this->folderName;
+  }
+  public function setIsEnabled($isEnabled)
+  {
+    $this->isEnabled = $isEnabled;
+  }
+  public function getIsEnabled()
+  {
+    return $this->isEnabled;
+  }
+}
+
+class Google_Service_Books_UsersettingsNotification extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $moreFromAuthorsType = 'Google_Service_Books_UsersettingsNotificationMoreFromAuthors';
+  protected $moreFromAuthorsDataType = '';
+
+
+  public function setMoreFromAuthors(Google_Service_Books_UsersettingsNotificationMoreFromAuthors $moreFromAuthors)
+  {
+    $this->moreFromAuthors = $moreFromAuthors;
+  }
+  public function getMoreFromAuthors()
+  {
+    return $this->moreFromAuthors;
+  }
+}
+
+class Google_Service_Books_UsersettingsNotificationMoreFromAuthors extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "optedState" => "opted_state",
+  );
+  public $optedState;
+
+
+  public function setOptedState($optedState)
+  {
+    $this->optedState = $optedState;
+  }
+  public function getOptedState()
+  {
+    return $this->optedState;
+  }
+}
+
+class Google_Service_Books_Volume extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accessInfoType = 'Google_Service_Books_VolumeAccessInfo';
+  protected $accessInfoDataType = '';
+  public $etag;
+  public $id;
+  public $kind;
+  protected $layerInfoType = 'Google_Service_Books_VolumeLayerInfo';
+  protected $layerInfoDataType = '';
+  protected $recommendedInfoType = 'Google_Service_Books_VolumeRecommendedInfo';
+  protected $recommendedInfoDataType = '';
+  protected $saleInfoType = 'Google_Service_Books_VolumeSaleInfo';
+  protected $saleInfoDataType = '';
+  protected $searchInfoType = 'Google_Service_Books_VolumeSearchInfo';
+  protected $searchInfoDataType = '';
+  public $selfLink;
+  protected $userInfoType = 'Google_Service_Books_VolumeUserInfo';
+  protected $userInfoDataType = '';
+  protected $volumeInfoType = 'Google_Service_Books_VolumeVolumeInfo';
+  protected $volumeInfoDataType = '';
+
+
+  public function setAccessInfo(Google_Service_Books_VolumeAccessInfo $accessInfo)
+  {
+    $this->accessInfo = $accessInfo;
+  }
+  public function getAccessInfo()
+  {
+    return $this->accessInfo;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLayerInfo(Google_Service_Books_VolumeLayerInfo $layerInfo)
+  {
+    $this->layerInfo = $layerInfo;
+  }
+  public function getLayerInfo()
+  {
+    return $this->layerInfo;
+  }
+  public function setRecommendedInfo(Google_Service_Books_VolumeRecommendedInfo $recommendedInfo)
+  {
+    $this->recommendedInfo = $recommendedInfo;
+  }
+  public function getRecommendedInfo()
+  {
+    return $this->recommendedInfo;
+  }
+  public function setSaleInfo(Google_Service_Books_VolumeSaleInfo $saleInfo)
+  {
+    $this->saleInfo = $saleInfo;
+  }
+  public function getSaleInfo()
+  {
+    return $this->saleInfo;
+  }
+  public function setSearchInfo(Google_Service_Books_VolumeSearchInfo $searchInfo)
+  {
+    $this->searchInfo = $searchInfo;
+  }
+  public function getSearchInfo()
+  {
+    return $this->searchInfo;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setUserInfo(Google_Service_Books_VolumeUserInfo $userInfo)
+  {
+    $this->userInfo = $userInfo;
+  }
+  public function getUserInfo()
+  {
+    return $this->userInfo;
+  }
+  public function setVolumeInfo(Google_Service_Books_VolumeVolumeInfo $volumeInfo)
+  {
+    $this->volumeInfo = $volumeInfo;
+  }
+  public function getVolumeInfo()
+  {
+    return $this->volumeInfo;
+  }
+}
+
+class Google_Service_Books_Volume2 extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Books_Volume';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Books_VolumeAccessInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accessViewStatus;
+  public $country;
+  protected $downloadAccessType = 'Google_Service_Books_DownloadAccessRestriction';
+  protected $downloadAccessDataType = '';
+  public $driveImportedContentLink;
+  public $embeddable;
+  protected $epubType = 'Google_Service_Books_VolumeAccessInfoEpub';
+  protected $epubDataType = '';
+  public $explicitOfflineLicenseManagement;
+  protected $pdfType = 'Google_Service_Books_VolumeAccessInfoPdf';
+  protected $pdfDataType = '';
+  public $publicDomain;
+  public $quoteSharingAllowed;
+  public $textToSpeechPermission;
+  public $viewOrderUrl;
+  public $viewability;
+  public $webReaderLink;
+
+
+  public function setAccessViewStatus($accessViewStatus)
+  {
+    $this->accessViewStatus = $accessViewStatus;
+  }
+  public function getAccessViewStatus()
+  {
+    return $this->accessViewStatus;
+  }
+  public function setCountry($country)
+  {
+    $this->country = $country;
+  }
+  public function getCountry()
+  {
+    return $this->country;
+  }
+  public function setDownloadAccess(Google_Service_Books_DownloadAccessRestriction $downloadAccess)
+  {
+    $this->downloadAccess = $downloadAccess;
+  }
+  public function getDownloadAccess()
+  {
+    return $this->downloadAccess;
+  }
+  public function setDriveImportedContentLink($driveImportedContentLink)
+  {
+    $this->driveImportedContentLink = $driveImportedContentLink;
+  }
+  public function getDriveImportedContentLink()
+  {
+    return $this->driveImportedContentLink;
+  }
+  public function setEmbeddable($embeddable)
+  {
+    $this->embeddable = $embeddable;
+  }
+  public function getEmbeddable()
+  {
+    return $this->embeddable;
+  }
+  public function setEpub(Google_Service_Books_VolumeAccessInfoEpub $epub)
+  {
+    $this->epub = $epub;
+  }
+  public function getEpub()
+  {
+    return $this->epub;
+  }
+  public function setExplicitOfflineLicenseManagement($explicitOfflineLicenseManagement)
+  {
+    $this->explicitOfflineLicenseManagement = $explicitOfflineLicenseManagement;
+  }
+  public function getExplicitOfflineLicenseManagement()
+  {
+    return $this->explicitOfflineLicenseManagement;
+  }
+  public function setPdf(Google_Service_Books_VolumeAccessInfoPdf $pdf)
+  {
+    $this->pdf = $pdf;
+  }
+  public function getPdf()
+  {
+    return $this->pdf;
+  }
+  public function setPublicDomain($publicDomain)
+  {
+    $this->publicDomain = $publicDomain;
+  }
+  public function getPublicDomain()
+  {
+    return $this->publicDomain;
+  }
+  public function setQuoteSharingAllowed($quoteSharingAllowed)
+  {
+    $this->quoteSharingAllowed = $quoteSharingAllowed;
+  }
+  public function getQuoteSharingAllowed()
+  {
+    return $this->quoteSharingAllowed;
+  }
+  public function setTextToSpeechPermission($textToSpeechPermission)
+  {
+    $this->textToSpeechPermission = $textToSpeechPermission;
+  }
+  public function getTextToSpeechPermission()
+  {
+    return $this->textToSpeechPermission;
+  }
+  public function setViewOrderUrl($viewOrderUrl)
+  {
+    $this->viewOrderUrl = $viewOrderUrl;
+  }
+  public function getViewOrderUrl()
+  {
+    return $this->viewOrderUrl;
+  }
+  public function setViewability($viewability)
+  {
+    $this->viewability = $viewability;
+  }
+  public function getViewability()
+  {
+    return $this->viewability;
+  }
+  public function setWebReaderLink($webReaderLink)
+  {
+    $this->webReaderLink = $webReaderLink;
+  }
+  public function getWebReaderLink()
+  {
+    return $this->webReaderLink;
+  }
+}
+
+class Google_Service_Books_VolumeAccessInfoEpub extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $acsTokenLink;
+  public $downloadLink;
+  public $isAvailable;
+
+
+  public function setAcsTokenLink($acsTokenLink)
+  {
+    $this->acsTokenLink = $acsTokenLink;
+  }
+  public function getAcsTokenLink()
+  {
+    return $this->acsTokenLink;
+  }
+  public function setDownloadLink($downloadLink)
+  {
+    $this->downloadLink = $downloadLink;
+  }
+  public function getDownloadLink()
+  {
+    return $this->downloadLink;
+  }
+  public function setIsAvailable($isAvailable)
+  {
+    $this->isAvailable = $isAvailable;
+  }
+  public function getIsAvailable()
+  {
+    return $this->isAvailable;
+  }
+}
+
+class Google_Service_Books_VolumeAccessInfoPdf extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $acsTokenLink;
+  public $downloadLink;
+  public $isAvailable;
+
+
+  public function setAcsTokenLink($acsTokenLink)
+  {
+    $this->acsTokenLink = $acsTokenLink;
+  }
+  public function getAcsTokenLink()
+  {
+    return $this->acsTokenLink;
+  }
+  public function setDownloadLink($downloadLink)
+  {
+    $this->downloadLink = $downloadLink;
+  }
+  public function getDownloadLink()
+  {
+    return $this->downloadLink;
+  }
+  public function setIsAvailable($isAvailable)
+  {
+    $this->isAvailable = $isAvailable;
+  }
+  public function getIsAvailable()
+  {
+    return $this->isAvailable;
+  }
+}
+
+class Google_Service_Books_VolumeLayerInfo extends Google_Collection
+{
+  protected $collection_key = 'layers';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $layersType = 'Google_Service_Books_VolumeLayerInfoLayers';
+  protected $layersDataType = 'array';
+
+
+  public function setLayers($layers)
+  {
+    $this->layers = $layers;
+  }
+  public function getLayers()
+  {
+    return $this->layers;
+  }
+}
+
+class Google_Service_Books_VolumeLayerInfoLayers extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $layerId;
+  public $volumeAnnotationsVersion;
+
+
+  public function setLayerId($layerId)
+  {
+    $this->layerId = $layerId;
+  }
+  public function getLayerId()
+  {
+    return $this->layerId;
+  }
+  public function setVolumeAnnotationsVersion($volumeAnnotationsVersion)
+  {
+    $this->volumeAnnotationsVersion = $volumeAnnotationsVersion;
+  }
+  public function getVolumeAnnotationsVersion()
+  {
+    return $this->volumeAnnotationsVersion;
+  }
+}
+
+class Google_Service_Books_VolumeRecommendedInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $explanation;
+
+
+  public function setExplanation($explanation)
+  {
+    $this->explanation = $explanation;
+  }
+  public function getExplanation()
+  {
+    return $this->explanation;
+  }
+}
+
+class Google_Service_Books_VolumeSaleInfo extends Google_Collection
+{
+  protected $collection_key = 'offers';
+  protected $internal_gapi_mappings = array(
+  );
+  public $buyLink;
+  public $country;
+  public $isEbook;
+  protected $listPriceType = 'Google_Service_Books_VolumeSaleInfoListPrice';
+  protected $listPriceDataType = '';
+  protected $offersType = 'Google_Service_Books_VolumeSaleInfoOffers';
+  protected $offersDataType = 'array';
+  public $onSaleDate;
+  protected $retailPriceType = 'Google_Service_Books_VolumeSaleInfoRetailPrice';
+  protected $retailPriceDataType = '';
+  public $saleability;
+
+
+  public function setBuyLink($buyLink)
+  {
+    $this->buyLink = $buyLink;
+  }
+  public function getBuyLink()
+  {
+    return $this->buyLink;
+  }
+  public function setCountry($country)
+  {
+    $this->country = $country;
+  }
+  public function getCountry()
+  {
+    return $this->country;
+  }
+  public function setIsEbook($isEbook)
+  {
+    $this->isEbook = $isEbook;
+  }
+  public function getIsEbook()
+  {
+    return $this->isEbook;
+  }
+  public function setListPrice(Google_Service_Books_VolumeSaleInfoListPrice $listPrice)
+  {
+    $this->listPrice = $listPrice;
+  }
+  public function getListPrice()
+  {
+    return $this->listPrice;
+  }
+  public function setOffers($offers)
+  {
+    $this->offers = $offers;
+  }
+  public function getOffers()
+  {
+    return $this->offers;
+  }
+  public function setOnSaleDate($onSaleDate)
+  {
+    $this->onSaleDate = $onSaleDate;
+  }
+  public function getOnSaleDate()
+  {
+    return $this->onSaleDate;
+  }
+  public function setRetailPrice(Google_Service_Books_VolumeSaleInfoRetailPrice $retailPrice)
+  {
+    $this->retailPrice = $retailPrice;
+  }
+  public function getRetailPrice()
+  {
+    return $this->retailPrice;
+  }
+  public function setSaleability($saleability)
+  {
+    $this->saleability = $saleability;
+  }
+  public function getSaleability()
+  {
+    return $this->saleability;
+  }
+}
+
+class Google_Service_Books_VolumeSaleInfoListPrice extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $amount;
+  public $currencyCode;
+
+
+  public function setAmount($amount)
+  {
+    $this->amount = $amount;
+  }
+  public function getAmount()
+  {
+    return $this->amount;
+  }
+  public function setCurrencyCode($currencyCode)
+  {
+    $this->currencyCode = $currencyCode;
+  }
+  public function getCurrencyCode()
+  {
+    return $this->currencyCode;
+  }
+}
+
+class Google_Service_Books_VolumeSaleInfoOffers extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $finskyOfferType;
+  protected $listPriceType = 'Google_Service_Books_VolumeSaleInfoOffersListPrice';
+  protected $listPriceDataType = '';
+  protected $rentalDurationType = 'Google_Service_Books_VolumeSaleInfoOffersRentalDuration';
+  protected $rentalDurationDataType = '';
+  protected $retailPriceType = 'Google_Service_Books_VolumeSaleInfoOffersRetailPrice';
+  protected $retailPriceDataType = '';
+
+
+  public function setFinskyOfferType($finskyOfferType)
+  {
+    $this->finskyOfferType = $finskyOfferType;
+  }
+  public function getFinskyOfferType()
+  {
+    return $this->finskyOfferType;
+  }
+  public function setListPrice(Google_Service_Books_VolumeSaleInfoOffersListPrice $listPrice)
+  {
+    $this->listPrice = $listPrice;
+  }
+  public function getListPrice()
+  {
+    return $this->listPrice;
+  }
+  public function setRentalDuration(Google_Service_Books_VolumeSaleInfoOffersRentalDuration $rentalDuration)
+  {
+    $this->rentalDuration = $rentalDuration;
+  }
+  public function getRentalDuration()
+  {
+    return $this->rentalDuration;
+  }
+  public function setRetailPrice(Google_Service_Books_VolumeSaleInfoOffersRetailPrice $retailPrice)
+  {
+    $this->retailPrice = $retailPrice;
+  }
+  public function getRetailPrice()
+  {
+    return $this->retailPrice;
+  }
+}
+
+class Google_Service_Books_VolumeSaleInfoOffersListPrice extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $amountInMicros;
+  public $currencyCode;
+
+
+  public function setAmountInMicros($amountInMicros)
+  {
+    $this->amountInMicros = $amountInMicros;
+  }
+  public function getAmountInMicros()
+  {
+    return $this->amountInMicros;
+  }
+  public function setCurrencyCode($currencyCode)
+  {
+    $this->currencyCode = $currencyCode;
+  }
+  public function getCurrencyCode()
+  {
+    return $this->currencyCode;
+  }
+}
+
+class Google_Service_Books_VolumeSaleInfoOffersRentalDuration extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $count;
+  public $unit;
+
+
+  public function setCount($count)
+  {
+    $this->count = $count;
+  }
+  public function getCount()
+  {
+    return $this->count;
+  }
+  public function setUnit($unit)
+  {
+    $this->unit = $unit;
+  }
+  public function getUnit()
+  {
+    return $this->unit;
+  }
+}
+
+class Google_Service_Books_VolumeSaleInfoOffersRetailPrice extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $amountInMicros;
+  public $currencyCode;
+
+
+  public function setAmountInMicros($amountInMicros)
+  {
+    $this->amountInMicros = $amountInMicros;
+  }
+  public function getAmountInMicros()
+  {
+    return $this->amountInMicros;
+  }
+  public function setCurrencyCode($currencyCode)
+  {
+    $this->currencyCode = $currencyCode;
+  }
+  public function getCurrencyCode()
+  {
+    return $this->currencyCode;
+  }
+}
+
+class Google_Service_Books_VolumeSaleInfoRetailPrice extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $amount;
+  public $currencyCode;
+
+
+  public function setAmount($amount)
+  {
+    $this->amount = $amount;
+  }
+  public function getAmount()
+  {
+    return $this->amount;
+  }
+  public function setCurrencyCode($currencyCode)
+  {
+    $this->currencyCode = $currencyCode;
+  }
+  public function getCurrencyCode()
+  {
+    return $this->currencyCode;
+  }
+}
+
+class Google_Service_Books_VolumeSearchInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $textSnippet;
+
+
+  public function setTextSnippet($textSnippet)
+  {
+    $this->textSnippet = $textSnippet;
+  }
+  public function getTextSnippet()
+  {
+    return $this->textSnippet;
+  }
+}
+
+class Google_Service_Books_VolumeUserInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $acquisitionType;
+  protected $copyType = 'Google_Service_Books_VolumeUserInfoCopy';
+  protected $copyDataType = '';
+  public $entitlementType;
+  public $isInMyBooks;
+  public $isPreordered;
+  public $isPurchased;
+  public $isUploaded;
+  protected $readingPositionType = 'Google_Service_Books_ReadingPosition';
+  protected $readingPositionDataType = '';
+  protected $rentalPeriodType = 'Google_Service_Books_VolumeUserInfoRentalPeriod';
+  protected $rentalPeriodDataType = '';
+  public $rentalState;
+  protected $reviewType = 'Google_Service_Books_Review';
+  protected $reviewDataType = '';
+  public $updated;
+  protected $userUploadedVolumeInfoType = 'Google_Service_Books_VolumeUserInfoUserUploadedVolumeInfo';
+  protected $userUploadedVolumeInfoDataType = '';
+
+
+  public function setAcquisitionType($acquisitionType)
+  {
+    $this->acquisitionType = $acquisitionType;
+  }
+  public function getAcquisitionType()
+  {
+    return $this->acquisitionType;
+  }
+  public function setCopy(Google_Service_Books_VolumeUserInfoCopy $copy)
+  {
+    $this->copy = $copy;
+  }
+  public function getCopy()
+  {
+    return $this->copy;
+  }
+  public function setEntitlementType($entitlementType)
+  {
+    $this->entitlementType = $entitlementType;
+  }
+  public function getEntitlementType()
+  {
+    return $this->entitlementType;
+  }
+  public function setIsInMyBooks($isInMyBooks)
+  {
+    $this->isInMyBooks = $isInMyBooks;
+  }
+  public function getIsInMyBooks()
+  {
+    return $this->isInMyBooks;
+  }
+  public function setIsPreordered($isPreordered)
+  {
+    $this->isPreordered = $isPreordered;
+  }
+  public function getIsPreordered()
+  {
+    return $this->isPreordered;
+  }
+  public function setIsPurchased($isPurchased)
+  {
+    $this->isPurchased = $isPurchased;
+  }
+  public function getIsPurchased()
+  {
+    return $this->isPurchased;
+  }
+  public function setIsUploaded($isUploaded)
+  {
+    $this->isUploaded = $isUploaded;
+  }
+  public function getIsUploaded()
+  {
+    return $this->isUploaded;
+  }
+  public function setReadingPosition(Google_Service_Books_ReadingPosition $readingPosition)
+  {
+    $this->readingPosition = $readingPosition;
+  }
+  public function getReadingPosition()
+  {
+    return $this->readingPosition;
+  }
+  public function setRentalPeriod(Google_Service_Books_VolumeUserInfoRentalPeriod $rentalPeriod)
+  {
+    $this->rentalPeriod = $rentalPeriod;
+  }
+  public function getRentalPeriod()
+  {
+    return $this->rentalPeriod;
+  }
+  public function setRentalState($rentalState)
+  {
+    $this->rentalState = $rentalState;
+  }
+  public function getRentalState()
+  {
+    return $this->rentalState;
+  }
+  public function setReview(Google_Service_Books_Review $review)
+  {
+    $this->review = $review;
+  }
+  public function getReview()
+  {
+    return $this->review;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setUserUploadedVolumeInfo(Google_Service_Books_VolumeUserInfoUserUploadedVolumeInfo $userUploadedVolumeInfo)
+  {
+    $this->userUploadedVolumeInfo = $userUploadedVolumeInfo;
+  }
+  public function getUserUploadedVolumeInfo()
+  {
+    return $this->userUploadedVolumeInfo;
+  }
+}
+
+class Google_Service_Books_VolumeUserInfoCopy extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $allowedCharacterCount;
+  public $limitType;
+  public $remainingCharacterCount;
+  public $updated;
+
+
+  public function setAllowedCharacterCount($allowedCharacterCount)
+  {
+    $this->allowedCharacterCount = $allowedCharacterCount;
+  }
+  public function getAllowedCharacterCount()
+  {
+    return $this->allowedCharacterCount;
+  }
+  public function setLimitType($limitType)
+  {
+    $this->limitType = $limitType;
+  }
+  public function getLimitType()
+  {
+    return $this->limitType;
+  }
+  public function setRemainingCharacterCount($remainingCharacterCount)
+  {
+    $this->remainingCharacterCount = $remainingCharacterCount;
+  }
+  public function getRemainingCharacterCount()
+  {
+    return $this->remainingCharacterCount;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+}
+
+class Google_Service_Books_VolumeUserInfoRentalPeriod extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $endUtcSec;
+  public $startUtcSec;
+
+
+  public function setEndUtcSec($endUtcSec)
+  {
+    $this->endUtcSec = $endUtcSec;
+  }
+  public function getEndUtcSec()
+  {
+    return $this->endUtcSec;
+  }
+  public function setStartUtcSec($startUtcSec)
+  {
+    $this->startUtcSec = $startUtcSec;
+  }
+  public function getStartUtcSec()
+  {
+    return $this->startUtcSec;
+  }
+}
+
+class Google_Service_Books_VolumeUserInfoUserUploadedVolumeInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $processingState;
+
+
+  public function setProcessingState($processingState)
+  {
+    $this->processingState = $processingState;
+  }
+  public function getProcessingState()
+  {
+    return $this->processingState;
+  }
+}
+
+class Google_Service_Books_VolumeVolumeInfo extends Google_Collection
+{
+  protected $collection_key = 'industryIdentifiers';
+  protected $internal_gapi_mappings = array(
+  );
+  public $allowAnonLogging;
+  public $authors;
+  public $averageRating;
+  public $canonicalVolumeLink;
+  public $categories;
+  public $contentVersion;
+  public $description;
+  protected $dimensionsType = 'Google_Service_Books_VolumeVolumeInfoDimensions';
+  protected $dimensionsDataType = '';
+  protected $imageLinksType = 'Google_Service_Books_VolumeVolumeInfoImageLinks';
+  protected $imageLinksDataType = '';
+  protected $industryIdentifiersType = 'Google_Service_Books_VolumeVolumeInfoIndustryIdentifiers';
+  protected $industryIdentifiersDataType = 'array';
+  public $infoLink;
+  public $language;
+  public $mainCategory;
+  public $maturityRating;
+  public $pageCount;
+  public $previewLink;
+  public $printType;
+  public $printedPageCount;
+  public $publishedDate;
+  public $publisher;
+  public $ratingsCount;
+  public $readingModes;
+  public $samplePageCount;
+  public $subtitle;
+  public $title;
+
+
+  public function setAllowAnonLogging($allowAnonLogging)
+  {
+    $this->allowAnonLogging = $allowAnonLogging;
+  }
+  public function getAllowAnonLogging()
+  {
+    return $this->allowAnonLogging;
+  }
+  public function setAuthors($authors)
+  {
+    $this->authors = $authors;
+  }
+  public function getAuthors()
+  {
+    return $this->authors;
+  }
+  public function setAverageRating($averageRating)
+  {
+    $this->averageRating = $averageRating;
+  }
+  public function getAverageRating()
+  {
+    return $this->averageRating;
+  }
+  public function setCanonicalVolumeLink($canonicalVolumeLink)
+  {
+    $this->canonicalVolumeLink = $canonicalVolumeLink;
+  }
+  public function getCanonicalVolumeLink()
+  {
+    return $this->canonicalVolumeLink;
+  }
+  public function setCategories($categories)
+  {
+    $this->categories = $categories;
+  }
+  public function getCategories()
+  {
+    return $this->categories;
+  }
+  public function setContentVersion($contentVersion)
+  {
+    $this->contentVersion = $contentVersion;
+  }
+  public function getContentVersion()
+  {
+    return $this->contentVersion;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDimensions(Google_Service_Books_VolumeVolumeInfoDimensions $dimensions)
+  {
+    $this->dimensions = $dimensions;
+  }
+  public function getDimensions()
+  {
+    return $this->dimensions;
+  }
+  public function setImageLinks(Google_Service_Books_VolumeVolumeInfoImageLinks $imageLinks)
+  {
+    $this->imageLinks = $imageLinks;
+  }
+  public function getImageLinks()
+  {
+    return $this->imageLinks;
+  }
+  public function setIndustryIdentifiers($industryIdentifiers)
+  {
+    $this->industryIdentifiers = $industryIdentifiers;
+  }
+  public function getIndustryIdentifiers()
+  {
+    return $this->industryIdentifiers;
+  }
+  public function setInfoLink($infoLink)
+  {
+    $this->infoLink = $infoLink;
+  }
+  public function getInfoLink()
+  {
+    return $this->infoLink;
+  }
+  public function setLanguage($language)
+  {
+    $this->language = $language;
+  }
+  public function getLanguage()
+  {
+    return $this->language;
+  }
+  public function setMainCategory($mainCategory)
+  {
+    $this->mainCategory = $mainCategory;
+  }
+  public function getMainCategory()
+  {
+    return $this->mainCategory;
+  }
+  public function setMaturityRating($maturityRating)
+  {
+    $this->maturityRating = $maturityRating;
+  }
+  public function getMaturityRating()
+  {
+    return $this->maturityRating;
+  }
+  public function setPageCount($pageCount)
+  {
+    $this->pageCount = $pageCount;
+  }
+  public function getPageCount()
+  {
+    return $this->pageCount;
+  }
+  public function setPreviewLink($previewLink)
+  {
+    $this->previewLink = $previewLink;
+  }
+  public function getPreviewLink()
+  {
+    return $this->previewLink;
+  }
+  public function setPrintType($printType)
+  {
+    $this->printType = $printType;
+  }
+  public function getPrintType()
+  {
+    return $this->printType;
+  }
+  public function setPrintedPageCount($printedPageCount)
+  {
+    $this->printedPageCount = $printedPageCount;
+  }
+  public function getPrintedPageCount()
+  {
+    return $this->printedPageCount;
+  }
+  public function setPublishedDate($publishedDate)
+  {
+    $this->publishedDate = $publishedDate;
+  }
+  public function getPublishedDate()
+  {
+    return $this->publishedDate;
+  }
+  public function setPublisher($publisher)
+  {
+    $this->publisher = $publisher;
+  }
+  public function getPublisher()
+  {
+    return $this->publisher;
+  }
+  public function setRatingsCount($ratingsCount)
+  {
+    $this->ratingsCount = $ratingsCount;
+  }
+  public function getRatingsCount()
+  {
+    return $this->ratingsCount;
+  }
+  public function setReadingModes($readingModes)
+  {
+    $this->readingModes = $readingModes;
+  }
+  public function getReadingModes()
+  {
+    return $this->readingModes;
+  }
+  public function setSamplePageCount($samplePageCount)
+  {
+    $this->samplePageCount = $samplePageCount;
+  }
+  public function getSamplePageCount()
+  {
+    return $this->samplePageCount;
+  }
+  public function setSubtitle($subtitle)
+  {
+    $this->subtitle = $subtitle;
+  }
+  public function getSubtitle()
+  {
+    return $this->subtitle;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_Books_VolumeVolumeInfoDimensions extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $thickness;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setThickness($thickness)
+  {
+    $this->thickness = $thickness;
+  }
+  public function getThickness()
+  {
+    return $this->thickness;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_Books_VolumeVolumeInfoImageLinks extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $extraLarge;
+  public $large;
+  public $medium;
+  public $small;
+  public $smallThumbnail;
+  public $thumbnail;
+
+
+  public function setExtraLarge($extraLarge)
+  {
+    $this->extraLarge = $extraLarge;
+  }
+  public function getExtraLarge()
+  {
+    return $this->extraLarge;
+  }
+  public function setLarge($large)
+  {
+    $this->large = $large;
+  }
+  public function getLarge()
+  {
+    return $this->large;
+  }
+  public function setMedium($medium)
+  {
+    $this->medium = $medium;
+  }
+  public function getMedium()
+  {
+    return $this->medium;
+  }
+  public function setSmall($small)
+  {
+    $this->small = $small;
+  }
+  public function getSmall()
+  {
+    return $this->small;
+  }
+  public function setSmallThumbnail($smallThumbnail)
+  {
+    $this->smallThumbnail = $smallThumbnail;
+  }
+  public function getSmallThumbnail()
+  {
+    return $this->smallThumbnail;
+  }
+  public function setThumbnail($thumbnail)
+  {
+    $this->thumbnail = $thumbnail;
+  }
+  public function getThumbnail()
+  {
+    return $this->thumbnail;
+  }
+}
+
+class Google_Service_Books_VolumeVolumeInfoIndustryIdentifiers extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $identifier;
+  public $type;
+
+
+  public function setIdentifier($identifier)
+  {
+    $this->identifier = $identifier;
+  }
+  public function getIdentifier()
+  {
+    return $this->identifier;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Books_Volumeannotation extends Google_Collection
+{
+  protected $collection_key = 'pageIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $annotationDataId;
+  public $annotationDataLink;
+  public $annotationType;
+  protected $contentRangesType = 'Google_Service_Books_VolumeannotationContentRanges';
+  protected $contentRangesDataType = '';
+  public $data;
+  public $deleted;
+  public $id;
+  public $kind;
+  public $layerId;
+  public $pageIds;
+  public $selectedText;
+  public $selfLink;
+  public $updated;
+  public $volumeId;
+
+
+  public function setAnnotationDataId($annotationDataId)
+  {
+    $this->annotationDataId = $annotationDataId;
+  }
+  public function getAnnotationDataId()
+  {
+    return $this->annotationDataId;
+  }
+  public function setAnnotationDataLink($annotationDataLink)
+  {
+    $this->annotationDataLink = $annotationDataLink;
+  }
+  public function getAnnotationDataLink()
+  {
+    return $this->annotationDataLink;
+  }
+  public function setAnnotationType($annotationType)
+  {
+    $this->annotationType = $annotationType;
+  }
+  public function getAnnotationType()
+  {
+    return $this->annotationType;
+  }
+  public function setContentRanges(Google_Service_Books_VolumeannotationContentRanges $contentRanges)
+  {
+    $this->contentRanges = $contentRanges;
+  }
+  public function getContentRanges()
+  {
+    return $this->contentRanges;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setDeleted($deleted)
+  {
+    $this->deleted = $deleted;
+  }
+  public function getDeleted()
+  {
+    return $this->deleted;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLayerId($layerId)
+  {
+    $this->layerId = $layerId;
+  }
+  public function getLayerId()
+  {
+    return $this->layerId;
+  }
+  public function setPageIds($pageIds)
+  {
+    $this->pageIds = $pageIds;
+  }
+  public function getPageIds()
+  {
+    return $this->pageIds;
+  }
+  public function setSelectedText($selectedText)
+  {
+    $this->selectedText = $selectedText;
+  }
+  public function getSelectedText()
+  {
+    return $this->selectedText;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setVolumeId($volumeId)
+  {
+    $this->volumeId = $volumeId;
+  }
+  public function getVolumeId()
+  {
+    return $this->volumeId;
+  }
+}
+
+class Google_Service_Books_VolumeannotationContentRanges extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $cfiRangeType = 'Google_Service_Books_BooksAnnotationsRange';
+  protected $cfiRangeDataType = '';
+  public $contentVersion;
+  protected $gbImageRangeType = 'Google_Service_Books_BooksAnnotationsRange';
+  protected $gbImageRangeDataType = '';
+  protected $gbTextRangeType = 'Google_Service_Books_BooksAnnotationsRange';
+  protected $gbTextRangeDataType = '';
+
+
+  public function setCfiRange(Google_Service_Books_BooksAnnotationsRange $cfiRange)
+  {
+    $this->cfiRange = $cfiRange;
+  }
+  public function getCfiRange()
+  {
+    return $this->cfiRange;
+  }
+  public function setContentVersion($contentVersion)
+  {
+    $this->contentVersion = $contentVersion;
+  }
+  public function getContentVersion()
+  {
+    return $this->contentVersion;
+  }
+  public function setGbImageRange(Google_Service_Books_BooksAnnotationsRange $gbImageRange)
+  {
+    $this->gbImageRange = $gbImageRange;
+  }
+  public function getGbImageRange()
+  {
+    return $this->gbImageRange;
+  }
+  public function setGbTextRange(Google_Service_Books_BooksAnnotationsRange $gbTextRange)
+  {
+    $this->gbTextRange = $gbTextRange;
+  }
+  public function getGbTextRange()
+  {
+    return $this->gbTextRange;
+  }
+}
+
+class Google_Service_Books_Volumeannotations extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Books_Volumeannotation';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $totalItems;
+  public $version;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Books_Volumes extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Books_Volume';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $totalItems;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Calendar.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Calendar.php
@@ -1,0 +1,3890 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Calendar (v3).
+ *
+ * <p>
+ * Lets you manipulate events and other calendar data.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/google-apps/calendar/firstapp" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Calendar extends Google_Service
+{
+  /** Manage your calendars. */
+  const CALENDAR =
+      "https://www.googleapis.com/auth/calendar";
+  /** View your calendars. */
+  const CALENDAR_READONLY =
+      "https://www.googleapis.com/auth/calendar.readonly";
+
+  public $acl;
+  public $calendarList;
+  public $calendars;
+  public $channels;
+  public $colors;
+  public $events;
+  public $freebusy;
+  public $settings;
+  
+
+  /**
+   * Constructs the internal representation of the Calendar service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'calendar/v3/';
+    $this->version = 'v3';
+    $this->serviceName = 'calendar';
+
+    $this->acl = new Google_Service_Calendar_Acl_Resource(
+        $this,
+        $this->serviceName,
+        'acl',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'calendars/{calendarId}/acl/{ruleId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ruleId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'calendars/{calendarId}/acl/{ruleId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ruleId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'calendars/{calendarId}/acl',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'calendars/{calendarId}/acl',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'syncToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'showDeleted' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'calendars/{calendarId}/acl/{ruleId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ruleId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'calendars/{calendarId}/acl/{ruleId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ruleId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'watch' => array(
+              'path' => 'calendars/{calendarId}/acl/watch',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'syncToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'showDeleted' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->calendarList = new Google_Service_Calendar_CalendarList_Resource(
+        $this,
+        $this->serviceName,
+        'calendarList',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'users/me/calendarList/{calendarId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'users/me/calendarList/{calendarId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'users/me/calendarList',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'colorRgbFormat' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'users/me/calendarList',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'syncToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'showDeleted' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'minAccessRole' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'showHidden' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'users/me/calendarList/{calendarId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'colorRgbFormat' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'users/me/calendarList/{calendarId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'colorRgbFormat' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'watch' => array(
+              'path' => 'users/me/calendarList/watch',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'syncToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'showDeleted' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'minAccessRole' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'showHidden' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->calendars = new Google_Service_Calendar_Calendars_Resource(
+        $this,
+        $this->serviceName,
+        'calendars',
+        array(
+          'methods' => array(
+            'clear' => array(
+              'path' => 'calendars/{calendarId}/clear',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'calendars/{calendarId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'calendars/{calendarId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'calendars',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'patch' => array(
+              'path' => 'calendars/{calendarId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'calendars/{calendarId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->channels = new Google_Service_Calendar_Channels_Resource(
+        $this,
+        $this->serviceName,
+        'channels',
+        array(
+          'methods' => array(
+            'stop' => array(
+              'path' => 'channels/stop',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->colors = new Google_Service_Calendar_Colors_Resource(
+        $this,
+        $this->serviceName,
+        'colors',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'colors',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->events = new Google_Service_Calendar_Events_Resource(
+        $this,
+        $this->serviceName,
+        'events',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'calendars/{calendarId}/events/{eventId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'eventId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sendNotifications' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'calendars/{calendarId}/events/{eventId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'eventId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'timeZone' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'alwaysIncludeEmail' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxAttendees' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'import' => array(
+              'path' => 'calendars/{calendarId}/events/import',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'supportsAttachments' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'calendars/{calendarId}/events',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'supportsAttachments' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'sendNotifications' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxAttendees' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'instances' => array(
+              'path' => 'calendars/{calendarId}/events/{eventId}/instances',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'eventId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'showDeleted' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'timeMax' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'alwaysIncludeEmail' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'timeMin' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'timeZone' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'originalStart' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxAttendees' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'calendars/{calendarId}/events',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'showHiddenInvitations' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'syncToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'showDeleted' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'iCalUID' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'updatedMin' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'singleEvents' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'timeMax' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'alwaysIncludeEmail' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'q' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'timeMin' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'timeZone' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'privateExtendedProperty' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'sharedExtendedProperty' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxAttendees' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'move' => array(
+              'path' => 'calendars/{calendarId}/events/{eventId}/move',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'eventId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'destination' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sendNotifications' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'calendars/{calendarId}/events/{eventId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'eventId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sendNotifications' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'alwaysIncludeEmail' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'supportsAttachments' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxAttendees' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'quickAdd' => array(
+              'path' => 'calendars/{calendarId}/events/quickAdd',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'text' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sendNotifications' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'calendars/{calendarId}/events/{eventId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'eventId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sendNotifications' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'alwaysIncludeEmail' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'supportsAttachments' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxAttendees' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'watch' => array(
+              'path' => 'calendars/{calendarId}/events/watch',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'calendarId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'showHiddenInvitations' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'syncToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'showDeleted' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'iCalUID' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'updatedMin' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'singleEvents' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'timeMax' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'alwaysIncludeEmail' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'q' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'timeMin' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'timeZone' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'privateExtendedProperty' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'sharedExtendedProperty' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxAttendees' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->freebusy = new Google_Service_Calendar_Freebusy_Resource(
+        $this,
+        $this->serviceName,
+        'freebusy',
+        array(
+          'methods' => array(
+            'query' => array(
+              'path' => 'freeBusy',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->settings = new Google_Service_Calendar_Settings_Resource(
+        $this,
+        $this->serviceName,
+        'settings',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'users/me/settings/{setting}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'setting' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'users/me/settings',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'syncToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'watch' => array(
+              'path' => 'users/me/settings/watch',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'syncToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "acl" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $calendarService = new Google_Service_Calendar(...);
+ *   $acl = $calendarService->acl;
+ *  </code>
+ */
+class Google_Service_Calendar_Acl_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes an access control rule. (acl.delete)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param string $ruleId ACL rule identifier.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($calendarId, $ruleId, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'ruleId' => $ruleId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Returns an access control rule. (acl.get)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param string $ruleId ACL rule identifier.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Calendar_AclRule
+   */
+  public function get($calendarId, $ruleId, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'ruleId' => $ruleId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Calendar_AclRule");
+  }
+
+  /**
+   * Creates an access control rule. (acl.insert)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param Google_AclRule $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Calendar_AclRule
+   */
+  public function insert($calendarId, Google_Service_Calendar_AclRule $postBody, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Calendar_AclRule");
+  }
+
+  /**
+   * Returns the rules in the access control list for the calendar. (acl.listAcl)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Token specifying which result page to return.
+   * Optional.
+   * @opt_param string syncToken Token obtained from the nextSyncToken field
+   * returned on the last page of results from the previous list request. It makes
+   * the result of this list request contain only entries that have changed since
+   * then. All entries deleted since the previous list request will always be in
+   * the result set and it is not allowed to set showDeleted to False. If the
+   * syncToken expires, the server will respond with a 410 GONE response code and
+   * the client should clear its storage and perform a full synchronization
+   * without any syncToken. Learn more about incremental synchronization.
+   * Optional. The default is to return all entries.
+   * @opt_param int maxResults Maximum number of entries returned on one result
+   * page. By default the value is 100 entries. The page size can never be larger
+   * than 250 entries. Optional.
+   * @opt_param bool showDeleted Whether to include deleted ACLs in the result.
+   * Deleted ACLs are represented by role equal to "none". Deleted ACLs will
+   * always be included if syncToken is provided. Optional. The default is False.
+   * @return Google_Service_Calendar_Acl
+   */
+  public function listAcl($calendarId, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Calendar_Acl");
+  }
+
+  /**
+   * Updates an access control rule. This method supports patch semantics.
+   * (acl.patch)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param string $ruleId ACL rule identifier.
+   * @param Google_AclRule $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Calendar_AclRule
+   */
+  public function patch($calendarId, $ruleId, Google_Service_Calendar_AclRule $postBody, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'ruleId' => $ruleId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Calendar_AclRule");
+  }
+
+  /**
+   * Updates an access control rule. (acl.update)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param string $ruleId ACL rule identifier.
+   * @param Google_AclRule $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Calendar_AclRule
+   */
+  public function update($calendarId, $ruleId, Google_Service_Calendar_AclRule $postBody, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'ruleId' => $ruleId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Calendar_AclRule");
+  }
+
+  /**
+   * Watch for changes to ACL resources. (acl.watch)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param Google_Channel $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Token specifying which result page to return.
+   * Optional.
+   * @opt_param string syncToken Token obtained from the nextSyncToken field
+   * returned on the last page of results from the previous list request. It makes
+   * the result of this list request contain only entries that have changed since
+   * then. All entries deleted since the previous list request will always be in
+   * the result set and it is not allowed to set showDeleted to False. If the
+   * syncToken expires, the server will respond with a 410 GONE response code and
+   * the client should clear its storage and perform a full synchronization
+   * without any syncToken. Learn more about incremental synchronization.
+   * Optional. The default is to return all entries.
+   * @opt_param int maxResults Maximum number of entries returned on one result
+   * page. By default the value is 100 entries. The page size can never be larger
+   * than 250 entries. Optional.
+   * @opt_param bool showDeleted Whether to include deleted ACLs in the result.
+   * Deleted ACLs are represented by role equal to "none". Deleted ACLs will
+   * always be included if syncToken is provided. Optional. The default is False.
+   * @return Google_Service_Calendar_Channel
+   */
+  public function watch($calendarId, Google_Service_Calendar_Channel $postBody, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('watch', array($params), "Google_Service_Calendar_Channel");
+  }
+}
+
+/**
+ * The "calendarList" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $calendarService = new Google_Service_Calendar(...);
+ *   $calendarList = $calendarService->calendarList;
+ *  </code>
+ */
+class Google_Service_Calendar_CalendarList_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes an entry on the user's calendar list. (calendarList.delete)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($calendarId, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Returns an entry on the user's calendar list. (calendarList.get)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Calendar_CalendarListEntry
+   */
+  public function get($calendarId, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Calendar_CalendarListEntry");
+  }
+
+  /**
+   * Adds an entry to the user's calendar list. (calendarList.insert)
+   *
+   * @param Google_CalendarListEntry $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool colorRgbFormat Whether to use the foregroundColor and
+   * backgroundColor fields to write the calendar colors (RGB). If this feature is
+   * used, the index-based colorId field will be set to the best matching option
+   * automatically. Optional. The default is False.
+   * @return Google_Service_Calendar_CalendarListEntry
+   */
+  public function insert(Google_Service_Calendar_CalendarListEntry $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Calendar_CalendarListEntry");
+  }
+
+  /**
+   * Returns entries on the user's calendar list. (calendarList.listCalendarList)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string syncToken Token obtained from the nextSyncToken field
+   * returned on the last page of results from the previous list request. It makes
+   * the result of this list request contain only entries that have changed since
+   * then. If only read-only fields such as calendar properties or ACLs have
+   * changed, the entry won't be returned. All entries deleted and hidden since
+   * the previous list request will always be in the result set and it is not
+   * allowed to set showDeleted neither showHidden to False. To ensure client
+   * state consistency minAccessRole query parameter cannot be specified together
+   * with nextSyncToken. If the syncToken expires, the server will respond with a
+   * 410 GONE response code and the client should clear its storage and perform a
+   * full synchronization without any syncToken. Learn more about incremental
+   * synchronization. Optional. The default is to return all entries.
+   * @opt_param bool showDeleted Whether to include deleted calendar list entries
+   * in the result. Optional. The default is False.
+   * @opt_param string minAccessRole The minimum access role for the user in the
+   * returned entries. Optional. The default is no restriction.
+   * @opt_param int maxResults Maximum number of entries returned on one result
+   * page. By default the value is 100 entries. The page size can never be larger
+   * than 250 entries. Optional.
+   * @opt_param string pageToken Token specifying which result page to return.
+   * Optional.
+   * @opt_param bool showHidden Whether to show hidden entries. Optional. The
+   * default is False.
+   * @return Google_Service_Calendar_CalendarList
+   */
+  public function listCalendarList($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Calendar_CalendarList");
+  }
+
+  /**
+   * Updates an entry on the user's calendar list. This method supports patch
+   * semantics. (calendarList.patch)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param Google_CalendarListEntry $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool colorRgbFormat Whether to use the foregroundColor and
+   * backgroundColor fields to write the calendar colors (RGB). If this feature is
+   * used, the index-based colorId field will be set to the best matching option
+   * automatically. Optional. The default is False.
+   * @return Google_Service_Calendar_CalendarListEntry
+   */
+  public function patch($calendarId, Google_Service_Calendar_CalendarListEntry $postBody, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Calendar_CalendarListEntry");
+  }
+
+  /**
+   * Updates an entry on the user's calendar list. (calendarList.update)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param Google_CalendarListEntry $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool colorRgbFormat Whether to use the foregroundColor and
+   * backgroundColor fields to write the calendar colors (RGB). If this feature is
+   * used, the index-based colorId field will be set to the best matching option
+   * automatically. Optional. The default is False.
+   * @return Google_Service_Calendar_CalendarListEntry
+   */
+  public function update($calendarId, Google_Service_Calendar_CalendarListEntry $postBody, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Calendar_CalendarListEntry");
+  }
+
+  /**
+   * Watch for changes to CalendarList resources. (calendarList.watch)
+   *
+   * @param Google_Channel $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string syncToken Token obtained from the nextSyncToken field
+   * returned on the last page of results from the previous list request. It makes
+   * the result of this list request contain only entries that have changed since
+   * then. If only read-only fields such as calendar properties or ACLs have
+   * changed, the entry won't be returned. All entries deleted and hidden since
+   * the previous list request will always be in the result set and it is not
+   * allowed to set showDeleted neither showHidden to False. To ensure client
+   * state consistency minAccessRole query parameter cannot be specified together
+   * with nextSyncToken. If the syncToken expires, the server will respond with a
+   * 410 GONE response code and the client should clear its storage and perform a
+   * full synchronization without any syncToken. Learn more about incremental
+   * synchronization. Optional. The default is to return all entries.
+   * @opt_param bool showDeleted Whether to include deleted calendar list entries
+   * in the result. Optional. The default is False.
+   * @opt_param string minAccessRole The minimum access role for the user in the
+   * returned entries. Optional. The default is no restriction.
+   * @opt_param int maxResults Maximum number of entries returned on one result
+   * page. By default the value is 100 entries. The page size can never be larger
+   * than 250 entries. Optional.
+   * @opt_param string pageToken Token specifying which result page to return.
+   * Optional.
+   * @opt_param bool showHidden Whether to show hidden entries. Optional. The
+   * default is False.
+   * @return Google_Service_Calendar_Channel
+   */
+  public function watch(Google_Service_Calendar_Channel $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('watch', array($params), "Google_Service_Calendar_Channel");
+  }
+}
+
+/**
+ * The "calendars" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $calendarService = new Google_Service_Calendar(...);
+ *   $calendars = $calendarService->calendars;
+ *  </code>
+ */
+class Google_Service_Calendar_Calendars_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Clears a primary calendar. This operation deletes all events associated with
+   * the primary calendar of an account. (calendars.clear)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param array $optParams Optional parameters.
+   */
+  public function clear($calendarId, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId);
+    $params = array_merge($params, $optParams);
+    return $this->call('clear', array($params));
+  }
+
+  /**
+   * Deletes a secondary calendar. Use calendars.clear for clearing all events on
+   * primary calendars. (calendars.delete)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($calendarId, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Returns metadata for a calendar. (calendars.get)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Calendar_Calendar
+   */
+  public function get($calendarId, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Calendar_Calendar");
+  }
+
+  /**
+   * Creates a secondary calendar. (calendars.insert)
+   *
+   * @param Google_Calendar $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Calendar_Calendar
+   */
+  public function insert(Google_Service_Calendar_Calendar $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Calendar_Calendar");
+  }
+
+  /**
+   * Updates metadata for a calendar. This method supports patch semantics.
+   * (calendars.patch)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param Google_Calendar $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Calendar_Calendar
+   */
+  public function patch($calendarId, Google_Service_Calendar_Calendar $postBody, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Calendar_Calendar");
+  }
+
+  /**
+   * Updates metadata for a calendar. (calendars.update)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param Google_Calendar $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Calendar_Calendar
+   */
+  public function update($calendarId, Google_Service_Calendar_Calendar $postBody, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Calendar_Calendar");
+  }
+}
+
+/**
+ * The "channels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $calendarService = new Google_Service_Calendar(...);
+ *   $channels = $calendarService->channels;
+ *  </code>
+ */
+class Google_Service_Calendar_Channels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Stop watching resources through this channel (channels.stop)
+   *
+   * @param Google_Channel $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function stop(Google_Service_Calendar_Channel $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('stop', array($params));
+  }
+}
+
+/**
+ * The "colors" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $calendarService = new Google_Service_Calendar(...);
+ *   $colors = $calendarService->colors;
+ *  </code>
+ */
+class Google_Service_Calendar_Colors_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns the color definitions for calendars and events. (colors.get)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Calendar_Colors
+   */
+  public function get($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Calendar_Colors");
+  }
+}
+
+/**
+ * The "events" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $calendarService = new Google_Service_Calendar(...);
+ *   $events = $calendarService->events;
+ *  </code>
+ */
+class Google_Service_Calendar_Events_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes an event. (events.delete)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param string $eventId Event identifier.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool sendNotifications Whether to send notifications about the
+   * deletion of the event. Optional. The default is False.
+   */
+  public function delete($calendarId, $eventId, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'eventId' => $eventId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Returns an event. (events.get)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param string $eventId Event identifier.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string timeZone Time zone used in the response. Optional. The
+   * default is the time zone of the calendar.
+   * @opt_param bool alwaysIncludeEmail Whether to always include a value in the
+   * email field for the organizer, creator and attendees, even if no real email
+   * is available (i.e. a generated, non-working value will be provided). The use
+   * of this option is discouraged and should only be used by clients which cannot
+   * handle the absence of an email address value in the mentioned places.
+   * Optional. The default is False.
+   * @opt_param int maxAttendees The maximum number of attendees to include in the
+   * response. If there are more than the specified number of attendees, only the
+   * participant is returned. Optional.
+   * @return Google_Service_Calendar_Event
+   */
+  public function get($calendarId, $eventId, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'eventId' => $eventId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Calendar_Event");
+  }
+
+  /**
+   * Imports an event. This operation is used to add a private copy of an existing
+   * event to a calendar. (events.import)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param Google_Event $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool supportsAttachments Whether API client performing operation
+   * supports event attachments. Optional. The default is False.
+   * @return Google_Service_Calendar_Event
+   */
+  public function import($calendarId, Google_Service_Calendar_Event $postBody, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('import', array($params), "Google_Service_Calendar_Event");
+  }
+
+  /**
+   * Creates an event. (events.insert)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param Google_Event $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool supportsAttachments Whether API client performing operation
+   * supports event attachments. Optional. The default is False.
+   * @opt_param bool sendNotifications Whether to send notifications about the
+   * creation of the new event. Optional. The default is False.
+   * @opt_param int maxAttendees The maximum number of attendees to include in the
+   * response. If there are more than the specified number of attendees, only the
+   * participant is returned. Optional.
+   * @return Google_Service_Calendar_Event
+   */
+  public function insert($calendarId, Google_Service_Calendar_Event $postBody, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Calendar_Event");
+  }
+
+  /**
+   * Returns instances of the specified recurring event. (events.instances)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param string $eventId Recurring event identifier.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool showDeleted Whether to include deleted events (with status
+   * equals "cancelled") in the result. Cancelled instances of recurring events
+   * will still be included if singleEvents is False. Optional. The default is
+   * False.
+   * @opt_param string timeMax Upper bound (exclusive) for an event's start time
+   * to filter by. Optional. The default is not to filter by start time. Must be
+   * an RFC3339 timestamp with mandatory time zone offset.
+   * @opt_param bool alwaysIncludeEmail Whether to always include a value in the
+   * email field for the organizer, creator and attendees, even if no real email
+   * is available (i.e. a generated, non-working value will be provided). The use
+   * of this option is discouraged and should only be used by clients which cannot
+   * handle the absence of an email address value in the mentioned places.
+   * Optional. The default is False.
+   * @opt_param int maxResults Maximum number of events returned on one result
+   * page. By default the value is 250 events. The page size can never be larger
+   * than 2500 events. Optional.
+   * @opt_param string pageToken Token specifying which result page to return.
+   * Optional.
+   * @opt_param string timeMin Lower bound (inclusive) for an event's end time to
+   * filter by. Optional. The default is not to filter by end time. Must be an
+   * RFC3339 timestamp with mandatory time zone offset.
+   * @opt_param string timeZone Time zone used in the response. Optional. The
+   * default is the time zone of the calendar.
+   * @opt_param string originalStart The original start time of the instance in
+   * the result. Optional.
+   * @opt_param int maxAttendees The maximum number of attendees to include in the
+   * response. If there are more than the specified number of attendees, only the
+   * participant is returned. Optional.
+   * @return Google_Service_Calendar_Events
+   */
+  public function instances($calendarId, $eventId, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'eventId' => $eventId);
+    $params = array_merge($params, $optParams);
+    return $this->call('instances', array($params), "Google_Service_Calendar_Events");
+  }
+
+  /**
+   * Returns events on the specified calendar. (events.listEvents)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderBy The order of the events returned in the result.
+   * Optional. The default is an unspecified, stable order.
+   * @opt_param bool showHiddenInvitations Whether to include hidden invitations
+   * in the result. Optional. The default is False.
+   * @opt_param string syncToken Token obtained from the nextSyncToken field
+   * returned on the last page of results from the previous list request. It makes
+   * the result of this list request contain only entries that have changed since
+   * then. All events deleted since the previous list request will always be in
+   * the result set and it is not allowed to set showDeleted to False. There are
+   * several query parameters that cannot be specified together with nextSyncToken
+   * to ensure consistency of the client state.
+   *
+   * These are:  - iCalUID  - orderBy  - privateExtendedProperty  - q  -
+   * sharedExtendedProperty  - timeMin  - timeMax  - updatedMin If the syncToken
+   * expires, the server will respond with a 410 GONE response code and the client
+   * should clear its storage and perform a full synchronization without any
+   * syncToken. Learn more about incremental synchronization. Optional. The
+   * default is to return all entries.
+   * @opt_param bool showDeleted Whether to include deleted events (with status
+   * equals "cancelled") in the result. Cancelled instances of recurring events
+   * (but not the underlying recurring event) will still be included if
+   * showDeleted and singleEvents are both False. If showDeleted and singleEvents
+   * are both True, only single instances of deleted events (but not the
+   * underlying recurring events) are returned. Optional. The default is False.
+   * @opt_param string iCalUID Specifies event ID in the iCalendar format to be
+   * included in the response. Optional.
+   * @opt_param string updatedMin Lower bound for an event's last modification
+   * time (as a RFC3339 timestamp) to filter by. When specified, entries deleted
+   * since this time will always be included regardless of showDeleted. Optional.
+   * The default is not to filter by last modification time.
+   * @opt_param bool singleEvents Whether to expand recurring events into
+   * instances and only return single one-off events and instances of recurring
+   * events, but not the underlying recurring events themselves. Optional. The
+   * default is False.
+   * @opt_param string timeMax Upper bound (exclusive) for an event's start time
+   * to filter by. Optional. The default is not to filter by start time. Must be
+   * an RFC3339 timestamp with mandatory time zone offset, e.g.,
+   * 2011-06-03T10:00:00-07:00, 2011-06-03T10:00:00Z. Milliseconds may be provided
+   * but will be ignored.
+   * @opt_param bool alwaysIncludeEmail Whether to always include a value in the
+   * email field for the organizer, creator and attendees, even if no real email
+   * is available (i.e. a generated, non-working value will be provided). The use
+   * of this option is discouraged and should only be used by clients which cannot
+   * handle the absence of an email address value in the mentioned places.
+   * Optional. The default is False.
+   * @opt_param int maxResults Maximum number of events returned on one result
+   * page. By default the value is 250 events. The page size can never be larger
+   * than 2500 events. Optional.
+   * @opt_param string q Free text search terms to find events that match these
+   * terms in any field, except for extended properties. Optional.
+   * @opt_param string pageToken Token specifying which result page to return.
+   * Optional.
+   * @opt_param string timeMin Lower bound (inclusive) for an event's end time to
+   * filter by. Optional. The default is not to filter by end time. Must be an
+   * RFC3339 timestamp with mandatory time zone offset, e.g.,
+   * 2011-06-03T10:00:00-07:00, 2011-06-03T10:00:00Z. Milliseconds may be provided
+   * but will be ignored.
+   * @opt_param string timeZone Time zone used in the response. Optional. The
+   * default is the time zone of the calendar.
+   * @opt_param string privateExtendedProperty Extended properties constraint
+   * specified as propertyName=value. Matches only private properties. This
+   * parameter might be repeated multiple times to return events that match all
+   * given constraints.
+   * @opt_param string sharedExtendedProperty Extended properties constraint
+   * specified as propertyName=value. Matches only shared properties. This
+   * parameter might be repeated multiple times to return events that match all
+   * given constraints.
+   * @opt_param int maxAttendees The maximum number of attendees to include in the
+   * response. If there are more than the specified number of attendees, only the
+   * participant is returned. Optional.
+   * @return Google_Service_Calendar_Events
+   */
+  public function listEvents($calendarId, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Calendar_Events");
+  }
+
+  /**
+   * Moves an event to another calendar, i.e. changes an event's organizer.
+   * (events.move)
+   *
+   * @param string $calendarId Calendar identifier of the source calendar where
+   * the event currently is on.
+   * @param string $eventId Event identifier.
+   * @param string $destination Calendar identifier of the target calendar where
+   * the event is to be moved to.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool sendNotifications Whether to send notifications about the
+   * change of the event's organizer. Optional. The default is False.
+   * @return Google_Service_Calendar_Event
+   */
+  public function move($calendarId, $eventId, $destination, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'eventId' => $eventId, 'destination' => $destination);
+    $params = array_merge($params, $optParams);
+    return $this->call('move', array($params), "Google_Service_Calendar_Event");
+  }
+
+  /**
+   * Updates an event. This method supports patch semantics. (events.patch)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param string $eventId Event identifier.
+   * @param Google_Event $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool sendNotifications Whether to send notifications about the
+   * event update (e.g. attendee's responses, title changes, etc.). Optional. The
+   * default is False.
+   * @opt_param bool alwaysIncludeEmail Whether to always include a value in the
+   * email field for the organizer, creator and attendees, even if no real email
+   * is available (i.e. a generated, non-working value will be provided). The use
+   * of this option is discouraged and should only be used by clients which cannot
+   * handle the absence of an email address value in the mentioned places.
+   * Optional. The default is False.
+   * @opt_param bool supportsAttachments Whether API client performing operation
+   * supports event attachments. Optional. The default is False.
+   * @opt_param int maxAttendees The maximum number of attendees to include in the
+   * response. If there are more than the specified number of attendees, only the
+   * participant is returned. Optional.
+   * @return Google_Service_Calendar_Event
+   */
+  public function patch($calendarId, $eventId, Google_Service_Calendar_Event $postBody, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'eventId' => $eventId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Calendar_Event");
+  }
+
+  /**
+   * Creates an event based on a simple text string. (events.quickAdd)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param string $text The text describing the event to be created.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool sendNotifications Whether to send notifications about the
+   * creation of the event. Optional. The default is False.
+   * @return Google_Service_Calendar_Event
+   */
+  public function quickAdd($calendarId, $text, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'text' => $text);
+    $params = array_merge($params, $optParams);
+    return $this->call('quickAdd', array($params), "Google_Service_Calendar_Event");
+  }
+
+  /**
+   * Updates an event. (events.update)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param string $eventId Event identifier.
+   * @param Google_Event $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool sendNotifications Whether to send notifications about the
+   * event update (e.g. attendee's responses, title changes, etc.). Optional. The
+   * default is False.
+   * @opt_param bool alwaysIncludeEmail Whether to always include a value in the
+   * email field for the organizer, creator and attendees, even if no real email
+   * is available (i.e. a generated, non-working value will be provided). The use
+   * of this option is discouraged and should only be used by clients which cannot
+   * handle the absence of an email address value in the mentioned places.
+   * Optional. The default is False.
+   * @opt_param bool supportsAttachments Whether API client performing operation
+   * supports event attachments. Optional. The default is False.
+   * @opt_param int maxAttendees The maximum number of attendees to include in the
+   * response. If there are more than the specified number of attendees, only the
+   * participant is returned. Optional.
+   * @return Google_Service_Calendar_Event
+   */
+  public function update($calendarId, $eventId, Google_Service_Calendar_Event $postBody, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'eventId' => $eventId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Calendar_Event");
+  }
+
+  /**
+   * Watch for changes to Events resources. (events.watch)
+   *
+   * @param string $calendarId Calendar identifier. To retrieve calendar IDs call
+   * the calendarList.list method. If you want to access the primary calendar of
+   * the currently logged in user, use the "primary" keyword.
+   * @param Google_Channel $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderBy The order of the events returned in the result.
+   * Optional. The default is an unspecified, stable order.
+   * @opt_param bool showHiddenInvitations Whether to include hidden invitations
+   * in the result. Optional. The default is False.
+   * @opt_param string syncToken Token obtained from the nextSyncToken field
+   * returned on the last page of results from the previous list request. It makes
+   * the result of this list request contain only entries that have changed since
+   * then. All events deleted since the previous list request will always be in
+   * the result set and it is not allowed to set showDeleted to False. There are
+   * several query parameters that cannot be specified together with nextSyncToken
+   * to ensure consistency of the client state.
+   *
+   * These are:  - iCalUID  - orderBy  - privateExtendedProperty  - q  -
+   * sharedExtendedProperty  - timeMin  - timeMax  - updatedMin If the syncToken
+   * expires, the server will respond with a 410 GONE response code and the client
+   * should clear its storage and perform a full synchronization without any
+   * syncToken. Learn more about incremental synchronization. Optional. The
+   * default is to return all entries.
+   * @opt_param bool showDeleted Whether to include deleted events (with status
+   * equals "cancelled") in the result. Cancelled instances of recurring events
+   * (but not the underlying recurring event) will still be included if
+   * showDeleted and singleEvents are both False. If showDeleted and singleEvents
+   * are both True, only single instances of deleted events (but not the
+   * underlying recurring events) are returned. Optional. The default is False.
+   * @opt_param string iCalUID Specifies event ID in the iCalendar format to be
+   * included in the response. Optional.
+   * @opt_param string updatedMin Lower bound for an event's last modification
+   * time (as a RFC3339 timestamp) to filter by. When specified, entries deleted
+   * since this time will always be included regardless of showDeleted. Optional.
+   * The default is not to filter by last modification time.
+   * @opt_param bool singleEvents Whether to expand recurring events into
+   * instances and only return single one-off events and instances of recurring
+   * events, but not the underlying recurring events themselves. Optional. The
+   * default is False.
+   * @opt_param string timeMax Upper bound (exclusive) for an event's start time
+   * to filter by. Optional. The default is not to filter by start time. Must be
+   * an RFC3339 timestamp with mandatory time zone offset, e.g.,
+   * 2011-06-03T10:00:00-07:00, 2011-06-03T10:00:00Z. Milliseconds may be provided
+   * but will be ignored.
+   * @opt_param bool alwaysIncludeEmail Whether to always include a value in the
+   * email field for the organizer, creator and attendees, even if no real email
+   * is available (i.e. a generated, non-working value will be provided). The use
+   * of this option is discouraged and should only be used by clients which cannot
+   * handle the absence of an email address value in the mentioned places.
+   * Optional. The default is False.
+   * @opt_param int maxResults Maximum number of events returned on one result
+   * page. By default the value is 250 events. The page size can never be larger
+   * than 2500 events. Optional.
+   * @opt_param string q Free text search terms to find events that match these
+   * terms in any field, except for extended properties. Optional.
+   * @opt_param string pageToken Token specifying which result page to return.
+   * Optional.
+   * @opt_param string timeMin Lower bound (inclusive) for an event's end time to
+   * filter by. Optional. The default is not to filter by end time. Must be an
+   * RFC3339 timestamp with mandatory time zone offset, e.g.,
+   * 2011-06-03T10:00:00-07:00, 2011-06-03T10:00:00Z. Milliseconds may be provided
+   * but will be ignored.
+   * @opt_param string timeZone Time zone used in the response. Optional. The
+   * default is the time zone of the calendar.
+   * @opt_param string privateExtendedProperty Extended properties constraint
+   * specified as propertyName=value. Matches only private properties. This
+   * parameter might be repeated multiple times to return events that match all
+   * given constraints.
+   * @opt_param string sharedExtendedProperty Extended properties constraint
+   * specified as propertyName=value. Matches only shared properties. This
+   * parameter might be repeated multiple times to return events that match all
+   * given constraints.
+   * @opt_param int maxAttendees The maximum number of attendees to include in the
+   * response. If there are more than the specified number of attendees, only the
+   * participant is returned. Optional.
+   * @return Google_Service_Calendar_Channel
+   */
+  public function watch($calendarId, Google_Service_Calendar_Channel $postBody, $optParams = array())
+  {
+    $params = array('calendarId' => $calendarId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('watch', array($params), "Google_Service_Calendar_Channel");
+  }
+}
+
+/**
+ * The "freebusy" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $calendarService = new Google_Service_Calendar(...);
+ *   $freebusy = $calendarService->freebusy;
+ *  </code>
+ */
+class Google_Service_Calendar_Freebusy_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns free/busy information for a set of calendars. (freebusy.query)
+   *
+   * @param Google_FreeBusyRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Calendar_FreeBusyResponse
+   */
+  public function query(Google_Service_Calendar_FreeBusyRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('query', array($params), "Google_Service_Calendar_FreeBusyResponse");
+  }
+}
+
+/**
+ * The "settings" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $calendarService = new Google_Service_Calendar(...);
+ *   $settings = $calendarService->settings;
+ *  </code>
+ */
+class Google_Service_Calendar_Settings_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns a single user setting. (settings.get)
+   *
+   * @param string $setting The id of the user setting.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Calendar_Setting
+   */
+  public function get($setting, $optParams = array())
+  {
+    $params = array('setting' => $setting);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Calendar_Setting");
+  }
+
+  /**
+   * Returns all user settings for the authenticated user. (settings.listSettings)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Token specifying which result page to return.
+   * Optional.
+   * @opt_param int maxResults Maximum number of entries returned on one result
+   * page. By default the value is 100 entries. The page size can never be larger
+   * than 250 entries. Optional.
+   * @opt_param string syncToken Token obtained from the nextSyncToken field
+   * returned on the last page of results from the previous list request. It makes
+   * the result of this list request contain only entries that have changed since
+   * then. If the syncToken expires, the server will respond with a 410 GONE
+   * response code and the client should clear its storage and perform a full
+   * synchronization without any syncToken. Learn more about incremental
+   * synchronization. Optional. The default is to return all entries.
+   * @return Google_Service_Calendar_Settings
+   */
+  public function listSettings($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Calendar_Settings");
+  }
+
+  /**
+   * Watch for changes to Settings resources. (settings.watch)
+   *
+   * @param Google_Channel $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Token specifying which result page to return.
+   * Optional.
+   * @opt_param int maxResults Maximum number of entries returned on one result
+   * page. By default the value is 100 entries. The page size can never be larger
+   * than 250 entries. Optional.
+   * @opt_param string syncToken Token obtained from the nextSyncToken field
+   * returned on the last page of results from the previous list request. It makes
+   * the result of this list request contain only entries that have changed since
+   * then. If the syncToken expires, the server will respond with a 410 GONE
+   * response code and the client should clear its storage and perform a full
+   * synchronization without any syncToken. Learn more about incremental
+   * synchronization. Optional. The default is to return all entries.
+   * @return Google_Service_Calendar_Channel
+   */
+  public function watch(Google_Service_Calendar_Channel $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('watch', array($params), "Google_Service_Calendar_Channel");
+  }
+}
+
+
+
+
+class Google_Service_Calendar_Acl extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Calendar_AclRule';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $nextSyncToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setNextSyncToken($nextSyncToken)
+  {
+    $this->nextSyncToken = $nextSyncToken;
+  }
+  public function getNextSyncToken()
+  {
+    return $this->nextSyncToken;
+  }
+}
+
+class Google_Service_Calendar_AclRule extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $id;
+  public $kind;
+  public $role;
+  protected $scopeType = 'Google_Service_Calendar_AclRuleScope';
+  protected $scopeDataType = '';
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRole($role)
+  {
+    $this->role = $role;
+  }
+  public function getRole()
+  {
+    return $this->role;
+  }
+  public function setScope(Google_Service_Calendar_AclRuleScope $scope)
+  {
+    $this->scope = $scope;
+  }
+  public function getScope()
+  {
+    return $this->scope;
+  }
+}
+
+class Google_Service_Calendar_AclRuleScope extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $type;
+  public $value;
+
+
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Calendar_Calendar extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $etag;
+  public $id;
+  public $kind;
+  public $location;
+  public $summary;
+  public $timeZone;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setSummary($summary)
+  {
+    $this->summary = $summary;
+  }
+  public function getSummary()
+  {
+    return $this->summary;
+  }
+  public function setTimeZone($timeZone)
+  {
+    $this->timeZone = $timeZone;
+  }
+  public function getTimeZone()
+  {
+    return $this->timeZone;
+  }
+}
+
+class Google_Service_Calendar_CalendarList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Calendar_CalendarListEntry';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $nextSyncToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setNextSyncToken($nextSyncToken)
+  {
+    $this->nextSyncToken = $nextSyncToken;
+  }
+  public function getNextSyncToken()
+  {
+    return $this->nextSyncToken;
+  }
+}
+
+class Google_Service_Calendar_CalendarListEntry extends Google_Collection
+{
+  protected $collection_key = 'defaultReminders';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accessRole;
+  public $backgroundColor;
+  public $colorId;
+  protected $defaultRemindersType = 'Google_Service_Calendar_EventReminder';
+  protected $defaultRemindersDataType = 'array';
+  public $deleted;
+  public $description;
+  public $etag;
+  public $foregroundColor;
+  public $hidden;
+  public $id;
+  public $kind;
+  public $location;
+  protected $notificationSettingsType = 'Google_Service_Calendar_CalendarListEntryNotificationSettings';
+  protected $notificationSettingsDataType = '';
+  public $primary;
+  public $selected;
+  public $summary;
+  public $summaryOverride;
+  public $timeZone;
+
+
+  public function setAccessRole($accessRole)
+  {
+    $this->accessRole = $accessRole;
+  }
+  public function getAccessRole()
+  {
+    return $this->accessRole;
+  }
+  public function setBackgroundColor($backgroundColor)
+  {
+    $this->backgroundColor = $backgroundColor;
+  }
+  public function getBackgroundColor()
+  {
+    return $this->backgroundColor;
+  }
+  public function setColorId($colorId)
+  {
+    $this->colorId = $colorId;
+  }
+  public function getColorId()
+  {
+    return $this->colorId;
+  }
+  public function setDefaultReminders($defaultReminders)
+  {
+    $this->defaultReminders = $defaultReminders;
+  }
+  public function getDefaultReminders()
+  {
+    return $this->defaultReminders;
+  }
+  public function setDeleted($deleted)
+  {
+    $this->deleted = $deleted;
+  }
+  public function getDeleted()
+  {
+    return $this->deleted;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setForegroundColor($foregroundColor)
+  {
+    $this->foregroundColor = $foregroundColor;
+  }
+  public function getForegroundColor()
+  {
+    return $this->foregroundColor;
+  }
+  public function setHidden($hidden)
+  {
+    $this->hidden = $hidden;
+  }
+  public function getHidden()
+  {
+    return $this->hidden;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setNotificationSettings(Google_Service_Calendar_CalendarListEntryNotificationSettings $notificationSettings)
+  {
+    $this->notificationSettings = $notificationSettings;
+  }
+  public function getNotificationSettings()
+  {
+    return $this->notificationSettings;
+  }
+  public function setPrimary($primary)
+  {
+    $this->primary = $primary;
+  }
+  public function getPrimary()
+  {
+    return $this->primary;
+  }
+  public function setSelected($selected)
+  {
+    $this->selected = $selected;
+  }
+  public function getSelected()
+  {
+    return $this->selected;
+  }
+  public function setSummary($summary)
+  {
+    $this->summary = $summary;
+  }
+  public function getSummary()
+  {
+    return $this->summary;
+  }
+  public function setSummaryOverride($summaryOverride)
+  {
+    $this->summaryOverride = $summaryOverride;
+  }
+  public function getSummaryOverride()
+  {
+    return $this->summaryOverride;
+  }
+  public function setTimeZone($timeZone)
+  {
+    $this->timeZone = $timeZone;
+  }
+  public function getTimeZone()
+  {
+    return $this->timeZone;
+  }
+}
+
+class Google_Service_Calendar_CalendarListEntryNotificationSettings extends Google_Collection
+{
+  protected $collection_key = 'notifications';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $notificationsType = 'Google_Service_Calendar_CalendarNotification';
+  protected $notificationsDataType = 'array';
+
+
+  public function setNotifications($notifications)
+  {
+    $this->notifications = $notifications;
+  }
+  public function getNotifications()
+  {
+    return $this->notifications;
+  }
+}
+
+class Google_Service_Calendar_CalendarNotification extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $method;
+  public $type;
+
+
+  public function setMethod($method)
+  {
+    $this->method = $method;
+  }
+  public function getMethod()
+  {
+    return $this->method;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Calendar_Channel extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $address;
+  public $expiration;
+  public $id;
+  public $kind;
+  public $params;
+  public $payload;
+  public $resourceId;
+  public $resourceUri;
+  public $token;
+  public $type;
+
+
+  public function setAddress($address)
+  {
+    $this->address = $address;
+  }
+  public function getAddress()
+  {
+    return $this->address;
+  }
+  public function setExpiration($expiration)
+  {
+    $this->expiration = $expiration;
+  }
+  public function getExpiration()
+  {
+    return $this->expiration;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setParams($params)
+  {
+    $this->params = $params;
+  }
+  public function getParams()
+  {
+    return $this->params;
+  }
+  public function setPayload($payload)
+  {
+    $this->payload = $payload;
+  }
+  public function getPayload()
+  {
+    return $this->payload;
+  }
+  public function setResourceId($resourceId)
+  {
+    $this->resourceId = $resourceId;
+  }
+  public function getResourceId()
+  {
+    return $this->resourceId;
+  }
+  public function setResourceUri($resourceUri)
+  {
+    $this->resourceUri = $resourceUri;
+  }
+  public function getResourceUri()
+  {
+    return $this->resourceUri;
+  }
+  public function setToken($token)
+  {
+    $this->token = $token;
+  }
+  public function getToken()
+  {
+    return $this->token;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Calendar_ChannelParams extends Google_Model
+{
+}
+
+class Google_Service_Calendar_ColorDefinition extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $background;
+  public $foreground;
+
+
+  public function setBackground($background)
+  {
+    $this->background = $background;
+  }
+  public function getBackground()
+  {
+    return $this->background;
+  }
+  public function setForeground($foreground)
+  {
+    $this->foreground = $foreground;
+  }
+  public function getForeground()
+  {
+    return $this->foreground;
+  }
+}
+
+class Google_Service_Calendar_Colors extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $calendarType = 'Google_Service_Calendar_ColorDefinition';
+  protected $calendarDataType = 'map';
+  protected $eventType = 'Google_Service_Calendar_ColorDefinition';
+  protected $eventDataType = 'map';
+  public $kind;
+  public $updated;
+
+
+  public function setCalendar($calendar)
+  {
+    $this->calendar = $calendar;
+  }
+  public function getCalendar()
+  {
+    return $this->calendar;
+  }
+  public function setEvent($event)
+  {
+    $this->event = $event;
+  }
+  public function getEvent()
+  {
+    return $this->event;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+}
+
+class Google_Service_Calendar_ColorsCalendar extends Google_Model
+{
+}
+
+class Google_Service_Calendar_ColorsEvent extends Google_Model
+{
+}
+
+class Google_Service_Calendar_Error extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $domain;
+  public $reason;
+
+
+  public function setDomain($domain)
+  {
+    $this->domain = $domain;
+  }
+  public function getDomain()
+  {
+    return $this->domain;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+}
+
+class Google_Service_Calendar_Event extends Google_Collection
+{
+  protected $collection_key = 'recurrence';
+  protected $internal_gapi_mappings = array(
+  );
+  public $anyoneCanAddSelf;
+  protected $attachmentsType = 'Google_Service_Calendar_EventAttachment';
+  protected $attachmentsDataType = 'array';
+  protected $attendeesType = 'Google_Service_Calendar_EventAttendee';
+  protected $attendeesDataType = 'array';
+  public $attendeesOmitted;
+  public $colorId;
+  public $created;
+  protected $creatorType = 'Google_Service_Calendar_EventCreator';
+  protected $creatorDataType = '';
+  public $description;
+  protected $endType = 'Google_Service_Calendar_EventDateTime';
+  protected $endDataType = '';
+  public $endTimeUnspecified;
+  public $etag;
+  protected $extendedPropertiesType = 'Google_Service_Calendar_EventExtendedProperties';
+  protected $extendedPropertiesDataType = '';
+  protected $gadgetType = 'Google_Service_Calendar_EventGadget';
+  protected $gadgetDataType = '';
+  public $guestsCanInviteOthers;
+  public $guestsCanModify;
+  public $guestsCanSeeOtherGuests;
+  public $hangoutLink;
+  public $htmlLink;
+  public $iCalUID;
+  public $id;
+  public $kind;
+  public $location;
+  public $locked;
+  protected $organizerType = 'Google_Service_Calendar_EventOrganizer';
+  protected $organizerDataType = '';
+  protected $originalStartTimeType = 'Google_Service_Calendar_EventDateTime';
+  protected $originalStartTimeDataType = '';
+  public $privateCopy;
+  public $recurrence;
+  public $recurringEventId;
+  protected $remindersType = 'Google_Service_Calendar_EventReminders';
+  protected $remindersDataType = '';
+  public $sequence;
+  protected $sourceType = 'Google_Service_Calendar_EventSource';
+  protected $sourceDataType = '';
+  protected $startType = 'Google_Service_Calendar_EventDateTime';
+  protected $startDataType = '';
+  public $status;
+  public $summary;
+  public $transparency;
+  public $updated;
+  public $visibility;
+
+
+  public function setAnyoneCanAddSelf($anyoneCanAddSelf)
+  {
+    $this->anyoneCanAddSelf = $anyoneCanAddSelf;
+  }
+  public function getAnyoneCanAddSelf()
+  {
+    return $this->anyoneCanAddSelf;
+  }
+  public function setAttachments($attachments)
+  {
+    $this->attachments = $attachments;
+  }
+  public function getAttachments()
+  {
+    return $this->attachments;
+  }
+  public function setAttendees($attendees)
+  {
+    $this->attendees = $attendees;
+  }
+  public function getAttendees()
+  {
+    return $this->attendees;
+  }
+  public function setAttendeesOmitted($attendeesOmitted)
+  {
+    $this->attendeesOmitted = $attendeesOmitted;
+  }
+  public function getAttendeesOmitted()
+  {
+    return $this->attendeesOmitted;
+  }
+  public function setColorId($colorId)
+  {
+    $this->colorId = $colorId;
+  }
+  public function getColorId()
+  {
+    return $this->colorId;
+  }
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setCreator(Google_Service_Calendar_EventCreator $creator)
+  {
+    $this->creator = $creator;
+  }
+  public function getCreator()
+  {
+    return $this->creator;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEnd(Google_Service_Calendar_EventDateTime $end)
+  {
+    $this->end = $end;
+  }
+  public function getEnd()
+  {
+    return $this->end;
+  }
+  public function setEndTimeUnspecified($endTimeUnspecified)
+  {
+    $this->endTimeUnspecified = $endTimeUnspecified;
+  }
+  public function getEndTimeUnspecified()
+  {
+    return $this->endTimeUnspecified;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setExtendedProperties(Google_Service_Calendar_EventExtendedProperties $extendedProperties)
+  {
+    $this->extendedProperties = $extendedProperties;
+  }
+  public function getExtendedProperties()
+  {
+    return $this->extendedProperties;
+  }
+  public function setGadget(Google_Service_Calendar_EventGadget $gadget)
+  {
+    $this->gadget = $gadget;
+  }
+  public function getGadget()
+  {
+    return $this->gadget;
+  }
+  public function setGuestsCanInviteOthers($guestsCanInviteOthers)
+  {
+    $this->guestsCanInviteOthers = $guestsCanInviteOthers;
+  }
+  public function getGuestsCanInviteOthers()
+  {
+    return $this->guestsCanInviteOthers;
+  }
+  public function setGuestsCanModify($guestsCanModify)
+  {
+    $this->guestsCanModify = $guestsCanModify;
+  }
+  public function getGuestsCanModify()
+  {
+    return $this->guestsCanModify;
+  }
+  public function setGuestsCanSeeOtherGuests($guestsCanSeeOtherGuests)
+  {
+    $this->guestsCanSeeOtherGuests = $guestsCanSeeOtherGuests;
+  }
+  public function getGuestsCanSeeOtherGuests()
+  {
+    return $this->guestsCanSeeOtherGuests;
+  }
+  public function setHangoutLink($hangoutLink)
+  {
+    $this->hangoutLink = $hangoutLink;
+  }
+  public function getHangoutLink()
+  {
+    return $this->hangoutLink;
+  }
+  public function setHtmlLink($htmlLink)
+  {
+    $this->htmlLink = $htmlLink;
+  }
+  public function getHtmlLink()
+  {
+    return $this->htmlLink;
+  }
+  public function setICalUID($iCalUID)
+  {
+    $this->iCalUID = $iCalUID;
+  }
+  public function getICalUID()
+  {
+    return $this->iCalUID;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setLocked($locked)
+  {
+    $this->locked = $locked;
+  }
+  public function getLocked()
+  {
+    return $this->locked;
+  }
+  public function setOrganizer(Google_Service_Calendar_EventOrganizer $organizer)
+  {
+    $this->organizer = $organizer;
+  }
+  public function getOrganizer()
+  {
+    return $this->organizer;
+  }
+  public function setOriginalStartTime(Google_Service_Calendar_EventDateTime $originalStartTime)
+  {
+    $this->originalStartTime = $originalStartTime;
+  }
+  public function getOriginalStartTime()
+  {
+    return $this->originalStartTime;
+  }
+  public function setPrivateCopy($privateCopy)
+  {
+    $this->privateCopy = $privateCopy;
+  }
+  public function getPrivateCopy()
+  {
+    return $this->privateCopy;
+  }
+  public function setRecurrence($recurrence)
+  {
+    $this->recurrence = $recurrence;
+  }
+  public function getRecurrence()
+  {
+    return $this->recurrence;
+  }
+  public function setRecurringEventId($recurringEventId)
+  {
+    $this->recurringEventId = $recurringEventId;
+  }
+  public function getRecurringEventId()
+  {
+    return $this->recurringEventId;
+  }
+  public function setReminders(Google_Service_Calendar_EventReminders $reminders)
+  {
+    $this->reminders = $reminders;
+  }
+  public function getReminders()
+  {
+    return $this->reminders;
+  }
+  public function setSequence($sequence)
+  {
+    $this->sequence = $sequence;
+  }
+  public function getSequence()
+  {
+    return $this->sequence;
+  }
+  public function setSource(Google_Service_Calendar_EventSource $source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+  public function setStart(Google_Service_Calendar_EventDateTime $start)
+  {
+    $this->start = $start;
+  }
+  public function getStart()
+  {
+    return $this->start;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setSummary($summary)
+  {
+    $this->summary = $summary;
+  }
+  public function getSummary()
+  {
+    return $this->summary;
+  }
+  public function setTransparency($transparency)
+  {
+    $this->transparency = $transparency;
+  }
+  public function getTransparency()
+  {
+    return $this->transparency;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setVisibility($visibility)
+  {
+    $this->visibility = $visibility;
+  }
+  public function getVisibility()
+  {
+    return $this->visibility;
+  }
+}
+
+class Google_Service_Calendar_EventAttachment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $fileId;
+  public $fileUrl;
+  public $iconLink;
+  public $mimeType;
+  public $title;
+
+
+  public function setFileId($fileId)
+  {
+    $this->fileId = $fileId;
+  }
+  public function getFileId()
+  {
+    return $this->fileId;
+  }
+  public function setFileUrl($fileUrl)
+  {
+    $this->fileUrl = $fileUrl;
+  }
+  public function getFileUrl()
+  {
+    return $this->fileUrl;
+  }
+  public function setIconLink($iconLink)
+  {
+    $this->iconLink = $iconLink;
+  }
+  public function getIconLink()
+  {
+    return $this->iconLink;
+  }
+  public function setMimeType($mimeType)
+  {
+    $this->mimeType = $mimeType;
+  }
+  public function getMimeType()
+  {
+    return $this->mimeType;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_Calendar_EventAttendee extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $additionalGuests;
+  public $comment;
+  public $displayName;
+  public $email;
+  public $id;
+  public $optional;
+  public $organizer;
+  public $resource;
+  public $responseStatus;
+  public $self;
+
+
+  public function setAdditionalGuests($additionalGuests)
+  {
+    $this->additionalGuests = $additionalGuests;
+  }
+  public function getAdditionalGuests()
+  {
+    return $this->additionalGuests;
+  }
+  public function setComment($comment)
+  {
+    $this->comment = $comment;
+  }
+  public function getComment()
+  {
+    return $this->comment;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setOptional($optional)
+  {
+    $this->optional = $optional;
+  }
+  public function getOptional()
+  {
+    return $this->optional;
+  }
+  public function setOrganizer($organizer)
+  {
+    $this->organizer = $organizer;
+  }
+  public function getOrganizer()
+  {
+    return $this->organizer;
+  }
+  public function setResource($resource)
+  {
+    $this->resource = $resource;
+  }
+  public function getResource()
+  {
+    return $this->resource;
+  }
+  public function setResponseStatus($responseStatus)
+  {
+    $this->responseStatus = $responseStatus;
+  }
+  public function getResponseStatus()
+  {
+    return $this->responseStatus;
+  }
+  public function setSelf($self)
+  {
+    $this->self = $self;
+  }
+  public function getSelf()
+  {
+    return $this->self;
+  }
+}
+
+class Google_Service_Calendar_EventCreator extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $displayName;
+  public $email;
+  public $id;
+  public $self;
+
+
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setSelf($self)
+  {
+    $this->self = $self;
+  }
+  public function getSelf()
+  {
+    return $this->self;
+  }
+}
+
+class Google_Service_Calendar_EventDateTime extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $date;
+  public $dateTime;
+  public $timeZone;
+
+
+  public function setDate($date)
+  {
+    $this->date = $date;
+  }
+  public function getDate()
+  {
+    return $this->date;
+  }
+  public function setDateTime($dateTime)
+  {
+    $this->dateTime = $dateTime;
+  }
+  public function getDateTime()
+  {
+    return $this->dateTime;
+  }
+  public function setTimeZone($timeZone)
+  {
+    $this->timeZone = $timeZone;
+  }
+  public function getTimeZone()
+  {
+    return $this->timeZone;
+  }
+}
+
+class Google_Service_Calendar_EventExtendedProperties extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $private;
+  public $shared;
+
+
+  public function setPrivate($private)
+  {
+    $this->private = $private;
+  }
+  public function getPrivate()
+  {
+    return $this->private;
+  }
+  public function setShared($shared)
+  {
+    $this->shared = $shared;
+  }
+  public function getShared()
+  {
+    return $this->shared;
+  }
+}
+
+class Google_Service_Calendar_EventExtendedPropertiesPrivate extends Google_Model
+{
+}
+
+class Google_Service_Calendar_EventExtendedPropertiesShared extends Google_Model
+{
+}
+
+class Google_Service_Calendar_EventGadget extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $display;
+  public $height;
+  public $iconLink;
+  public $link;
+  public $preferences;
+  public $title;
+  public $type;
+  public $width;
+
+
+  public function setDisplay($display)
+  {
+    $this->display = $display;
+  }
+  public function getDisplay()
+  {
+    return $this->display;
+  }
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setIconLink($iconLink)
+  {
+    $this->iconLink = $iconLink;
+  }
+  public function getIconLink()
+  {
+    return $this->iconLink;
+  }
+  public function setLink($link)
+  {
+    $this->link = $link;
+  }
+  public function getLink()
+  {
+    return $this->link;
+  }
+  public function setPreferences($preferences)
+  {
+    $this->preferences = $preferences;
+  }
+  public function getPreferences()
+  {
+    return $this->preferences;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_Calendar_EventGadgetPreferences extends Google_Model
+{
+}
+
+class Google_Service_Calendar_EventOrganizer extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $displayName;
+  public $email;
+  public $id;
+  public $self;
+
+
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setSelf($self)
+  {
+    $this->self = $self;
+  }
+  public function getSelf()
+  {
+    return $this->self;
+  }
+}
+
+class Google_Service_Calendar_EventReminder extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $method;
+  public $minutes;
+
+
+  public function setMethod($method)
+  {
+    $this->method = $method;
+  }
+  public function getMethod()
+  {
+    return $this->method;
+  }
+  public function setMinutes($minutes)
+  {
+    $this->minutes = $minutes;
+  }
+  public function getMinutes()
+  {
+    return $this->minutes;
+  }
+}
+
+class Google_Service_Calendar_EventReminders extends Google_Collection
+{
+  protected $collection_key = 'overrides';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $overridesType = 'Google_Service_Calendar_EventReminder';
+  protected $overridesDataType = 'array';
+  public $useDefault;
+
+
+  public function setOverrides($overrides)
+  {
+    $this->overrides = $overrides;
+  }
+  public function getOverrides()
+  {
+    return $this->overrides;
+  }
+  public function setUseDefault($useDefault)
+  {
+    $this->useDefault = $useDefault;
+  }
+  public function getUseDefault()
+  {
+    return $this->useDefault;
+  }
+}
+
+class Google_Service_Calendar_EventSource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $title;
+  public $url;
+
+
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Calendar_Events extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accessRole;
+  protected $defaultRemindersType = 'Google_Service_Calendar_EventReminder';
+  protected $defaultRemindersDataType = 'array';
+  public $description;
+  public $etag;
+  protected $itemsType = 'Google_Service_Calendar_Event';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $nextSyncToken;
+  public $summary;
+  public $timeZone;
+  public $updated;
+
+
+  public function setAccessRole($accessRole)
+  {
+    $this->accessRole = $accessRole;
+  }
+  public function getAccessRole()
+  {
+    return $this->accessRole;
+  }
+  public function setDefaultReminders($defaultReminders)
+  {
+    $this->defaultReminders = $defaultReminders;
+  }
+  public function getDefaultReminders()
+  {
+    return $this->defaultReminders;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setNextSyncToken($nextSyncToken)
+  {
+    $this->nextSyncToken = $nextSyncToken;
+  }
+  public function getNextSyncToken()
+  {
+    return $this->nextSyncToken;
+  }
+  public function setSummary($summary)
+  {
+    $this->summary = $summary;
+  }
+  public function getSummary()
+  {
+    return $this->summary;
+  }
+  public function setTimeZone($timeZone)
+  {
+    $this->timeZone = $timeZone;
+  }
+  public function getTimeZone()
+  {
+    return $this->timeZone;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+}
+
+class Google_Service_Calendar_FreeBusyCalendar extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $busyType = 'Google_Service_Calendar_TimePeriod';
+  protected $busyDataType = 'array';
+  protected $errorsType = 'Google_Service_Calendar_Error';
+  protected $errorsDataType = 'array';
+
+
+  public function setBusy($busy)
+  {
+    $this->busy = $busy;
+  }
+  public function getBusy()
+  {
+    return $this->busy;
+  }
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+}
+
+class Google_Service_Calendar_FreeBusyGroup extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  public $calendars;
+  protected $errorsType = 'Google_Service_Calendar_Error';
+  protected $errorsDataType = 'array';
+
+
+  public function setCalendars($calendars)
+  {
+    $this->calendars = $calendars;
+  }
+  public function getCalendars()
+  {
+    return $this->calendars;
+  }
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+}
+
+class Google_Service_Calendar_FreeBusyRequest extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $calendarExpansionMax;
+  public $groupExpansionMax;
+  protected $itemsType = 'Google_Service_Calendar_FreeBusyRequestItem';
+  protected $itemsDataType = 'array';
+  public $timeMax;
+  public $timeMin;
+  public $timeZone;
+
+
+  public function setCalendarExpansionMax($calendarExpansionMax)
+  {
+    $this->calendarExpansionMax = $calendarExpansionMax;
+  }
+  public function getCalendarExpansionMax()
+  {
+    return $this->calendarExpansionMax;
+  }
+  public function setGroupExpansionMax($groupExpansionMax)
+  {
+    $this->groupExpansionMax = $groupExpansionMax;
+  }
+  public function getGroupExpansionMax()
+  {
+    return $this->groupExpansionMax;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setTimeMax($timeMax)
+  {
+    $this->timeMax = $timeMax;
+  }
+  public function getTimeMax()
+  {
+    return $this->timeMax;
+  }
+  public function setTimeMin($timeMin)
+  {
+    $this->timeMin = $timeMin;
+  }
+  public function getTimeMin()
+  {
+    return $this->timeMin;
+  }
+  public function setTimeZone($timeZone)
+  {
+    $this->timeZone = $timeZone;
+  }
+  public function getTimeZone()
+  {
+    return $this->timeZone;
+  }
+}
+
+class Google_Service_Calendar_FreeBusyRequestItem extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+}
+
+class Google_Service_Calendar_FreeBusyResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $calendarsType = 'Google_Service_Calendar_FreeBusyCalendar';
+  protected $calendarsDataType = 'map';
+  protected $groupsType = 'Google_Service_Calendar_FreeBusyGroup';
+  protected $groupsDataType = 'map';
+  public $kind;
+  public $timeMax;
+  public $timeMin;
+
+
+  public function setCalendars($calendars)
+  {
+    $this->calendars = $calendars;
+  }
+  public function getCalendars()
+  {
+    return $this->calendars;
+  }
+  public function setGroups($groups)
+  {
+    $this->groups = $groups;
+  }
+  public function getGroups()
+  {
+    return $this->groups;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setTimeMax($timeMax)
+  {
+    $this->timeMax = $timeMax;
+  }
+  public function getTimeMax()
+  {
+    return $this->timeMax;
+  }
+  public function setTimeMin($timeMin)
+  {
+    $this->timeMin = $timeMin;
+  }
+  public function getTimeMin()
+  {
+    return $this->timeMin;
+  }
+}
+
+class Google_Service_Calendar_FreeBusyResponseCalendars extends Google_Model
+{
+}
+
+class Google_Service_Calendar_FreeBusyResponseGroups extends Google_Model
+{
+}
+
+class Google_Service_Calendar_Setting extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $id;
+  public $kind;
+  public $value;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Calendar_Settings extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Calendar_Setting';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $nextSyncToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setNextSyncToken($nextSyncToken)
+  {
+    $this->nextSyncToken = $nextSyncToken;
+  }
+  public function getNextSyncToken()
+  {
+    return $this->nextSyncToken;
+  }
+}
+
+class Google_Service_Calendar_TimePeriod extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $end;
+  public $start;
+
+
+  public function setEnd($end)
+  {
+    $this->end = $end;
+  }
+  public function getEnd()
+  {
+    return $this->end;
+  }
+  public function setStart($start)
+  {
+    $this->start = $start;
+  }
+  public function getStart()
+  {
+    return $this->start;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/CivicInfo.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/CivicInfo.php
@@ -1,0 +1,1650 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for CivicInfo (v2).
+ *
+ * <p>
+ * An API for accessing civic information.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/civic-information" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_CivicInfo extends Google_Service
+{
+
+
+  public $divisions;
+  public $elections;
+  public $representatives;
+  
+
+  /**
+   * Constructs the internal representation of the CivicInfo service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'civicinfo/v2/';
+    $this->version = 'v2';
+    $this->serviceName = 'civicinfo';
+
+    $this->divisions = new Google_Service_CivicInfo_Divisions_Resource(
+        $this,
+        $this->serviceName,
+        'divisions',
+        array(
+          'methods' => array(
+            'search' => array(
+              'path' => 'divisions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'query' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->elections = new Google_Service_CivicInfo_Elections_Resource(
+        $this,
+        $this->serviceName,
+        'elections',
+        array(
+          'methods' => array(
+            'electionQuery' => array(
+              'path' => 'elections',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),'voterInfoQuery' => array(
+              'path' => 'voterinfo',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'address' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'electionId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'officialOnly' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->representatives = new Google_Service_CivicInfo_Representatives_Resource(
+        $this,
+        $this->serviceName,
+        'representatives',
+        array(
+          'methods' => array(
+            'representativeInfoByAddress' => array(
+              'path' => 'representatives',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'includeOffices' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'levels' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'roles' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'address' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'representativeInfoByDivision' => array(
+              'path' => 'representatives/{ocdId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'ocdId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'levels' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'recursive' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'roles' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "divisions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $civicinfoService = new Google_Service_CivicInfo(...);
+ *   $divisions = $civicinfoService->divisions;
+ *  </code>
+ */
+class Google_Service_CivicInfo_Divisions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Searches for political divisions by their natural name or OCD ID.
+   * (divisions.search)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string query The search query. Queries can cover any parts of a
+   * OCD ID or a human readable division name. All words given in the query are
+   * treated as required patterns. In addition to that, most query operators of
+   * the Apache Lucene library are supported. See
+   * http://lucene.apache.org/core/2_9_4/queryparsersyntax.html
+   * @return Google_Service_CivicInfo_DivisionSearchResponse
+   */
+  public function search($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('search', array($params), "Google_Service_CivicInfo_DivisionSearchResponse");
+  }
+}
+
+/**
+ * The "elections" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $civicinfoService = new Google_Service_CivicInfo(...);
+ *   $elections = $civicinfoService->elections;
+ *  </code>
+ */
+class Google_Service_CivicInfo_Elections_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List of available elections to query. (elections.electionQuery)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CivicInfo_ElectionsQueryResponse
+   */
+  public function electionQuery($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('electionQuery', array($params), "Google_Service_CivicInfo_ElectionsQueryResponse");
+  }
+
+  /**
+   * Looks up information relevant to a voter based on the voter's registered
+   * address. (elections.voterInfoQuery)
+   *
+   * @param string $address The registered address of the voter to look up.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string electionId The unique ID of the election to look up. A list
+   * of election IDs can be obtained at
+   * https://www.googleapis.com/civicinfo/{version}/elections
+   * @opt_param bool officialOnly If set to true, only data from official state
+   * sources will be returned.
+   * @return Google_Service_CivicInfo_VoterInfoResponse
+   */
+  public function voterInfoQuery($address, $optParams = array())
+  {
+    $params = array('address' => $address);
+    $params = array_merge($params, $optParams);
+    return $this->call('voterInfoQuery', array($params), "Google_Service_CivicInfo_VoterInfoResponse");
+  }
+}
+
+/**
+ * The "representatives" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $civicinfoService = new Google_Service_CivicInfo(...);
+ *   $representatives = $civicinfoService->representatives;
+ *  </code>
+ */
+class Google_Service_CivicInfo_Representatives_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Looks up political geography and representative information for a single
+   * address. (representatives.representativeInfoByAddress)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool includeOffices Whether to return information about offices
+   * and officials. If false, only the top-level district information will be
+   * returned.
+   * @opt_param string levels A list of office levels to filter by. Only offices
+   * that serve at least one of these levels will be returned. Divisions that
+   * don't contain a matching office will not be returned.
+   * @opt_param string roles A list of office roles to filter by. Only offices
+   * fulfilling one of these roles will be returned. Divisions that don't contain
+   * a matching office will not be returned.
+   * @opt_param string address The address to look up. May only be specified if
+   * the field ocdId is not given in the URL.
+   * @return Google_Service_CivicInfo_RepresentativeInfoResponse
+   */
+  public function representativeInfoByAddress($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('representativeInfoByAddress', array($params), "Google_Service_CivicInfo_RepresentativeInfoResponse");
+  }
+
+  /**
+   * Looks up representative information for a single geographic division.
+   * (representatives.representativeInfoByDivision)
+   *
+   * @param string $ocdId The Open Civic Data division identifier of the division
+   * to look up.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string levels A list of office levels to filter by. Only offices
+   * that serve at least one of these levels will be returned. Divisions that
+   * don't contain a matching office will not be returned.
+   * @opt_param bool recursive If true, information about all divisions contained
+   * in the division requested will be included as well. For example, if querying
+   * ocd-division/country:us/district:dc, this would also return all DC's wards
+   * and ANCs.
+   * @opt_param string roles A list of office roles to filter by. Only offices
+   * fulfilling one of these roles will be returned. Divisions that don't contain
+   * a matching office will not be returned.
+   * @return Google_Service_CivicInfo_RepresentativeInfoData
+   */
+  public function representativeInfoByDivision($ocdId, $optParams = array())
+  {
+    $params = array('ocdId' => $ocdId);
+    $params = array_merge($params, $optParams);
+    return $this->call('representativeInfoByDivision', array($params), "Google_Service_CivicInfo_RepresentativeInfoData");
+  }
+}
+
+
+
+
+class Google_Service_CivicInfo_AdministrationRegion extends Google_Collection
+{
+  protected $collection_key = 'sources';
+  protected $internal_gapi_mappings = array(
+        "localJurisdiction" => "local_jurisdiction",
+  );
+  protected $electionAdministrationBodyType = 'Google_Service_CivicInfo_AdministrativeBody';
+  protected $electionAdministrationBodyDataType = '';
+  public $id;
+  protected $localJurisdictionType = 'Google_Service_CivicInfo_AdministrationRegion';
+  protected $localJurisdictionDataType = '';
+  public $name;
+  protected $sourcesType = 'Google_Service_CivicInfo_Source';
+  protected $sourcesDataType = 'array';
+
+
+  public function setElectionAdministrationBody(Google_Service_CivicInfo_AdministrativeBody $electionAdministrationBody)
+  {
+    $this->electionAdministrationBody = $electionAdministrationBody;
+  }
+  public function getElectionAdministrationBody()
+  {
+    return $this->electionAdministrationBody;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLocalJurisdiction(Google_Service_CivicInfo_AdministrationRegion $localJurisdiction)
+  {
+    $this->localJurisdiction = $localJurisdiction;
+  }
+  public function getLocalJurisdiction()
+  {
+    return $this->localJurisdiction;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSources($sources)
+  {
+    $this->sources = $sources;
+  }
+  public function getSources()
+  {
+    return $this->sources;
+  }
+}
+
+class Google_Service_CivicInfo_AdministrativeBody extends Google_Collection
+{
+  protected $collection_key = 'voter_services';
+  protected $internal_gapi_mappings = array(
+        "voterServices" => "voter_services",
+  );
+  public $absenteeVotingInfoUrl;
+  public $ballotInfoUrl;
+  protected $correspondenceAddressType = 'Google_Service_CivicInfo_SimpleAddressType';
+  protected $correspondenceAddressDataType = '';
+  public $electionInfoUrl;
+  protected $electionOfficialsType = 'Google_Service_CivicInfo_ElectionOfficial';
+  protected $electionOfficialsDataType = 'array';
+  public $electionRegistrationConfirmationUrl;
+  public $electionRegistrationUrl;
+  public $electionRulesUrl;
+  public $hoursOfOperation;
+  public $name;
+  protected $physicalAddressType = 'Google_Service_CivicInfo_SimpleAddressType';
+  protected $physicalAddressDataType = '';
+  public $voterServices;
+  public $votingLocationFinderUrl;
+
+
+  public function setAbsenteeVotingInfoUrl($absenteeVotingInfoUrl)
+  {
+    $this->absenteeVotingInfoUrl = $absenteeVotingInfoUrl;
+  }
+  public function getAbsenteeVotingInfoUrl()
+  {
+    return $this->absenteeVotingInfoUrl;
+  }
+  public function setBallotInfoUrl($ballotInfoUrl)
+  {
+    $this->ballotInfoUrl = $ballotInfoUrl;
+  }
+  public function getBallotInfoUrl()
+  {
+    return $this->ballotInfoUrl;
+  }
+  public function setCorrespondenceAddress(Google_Service_CivicInfo_SimpleAddressType $correspondenceAddress)
+  {
+    $this->correspondenceAddress = $correspondenceAddress;
+  }
+  public function getCorrespondenceAddress()
+  {
+    return $this->correspondenceAddress;
+  }
+  public function setElectionInfoUrl($electionInfoUrl)
+  {
+    $this->electionInfoUrl = $electionInfoUrl;
+  }
+  public function getElectionInfoUrl()
+  {
+    return $this->electionInfoUrl;
+  }
+  public function setElectionOfficials($electionOfficials)
+  {
+    $this->electionOfficials = $electionOfficials;
+  }
+  public function getElectionOfficials()
+  {
+    return $this->electionOfficials;
+  }
+  public function setElectionRegistrationConfirmationUrl($electionRegistrationConfirmationUrl)
+  {
+    $this->electionRegistrationConfirmationUrl = $electionRegistrationConfirmationUrl;
+  }
+  public function getElectionRegistrationConfirmationUrl()
+  {
+    return $this->electionRegistrationConfirmationUrl;
+  }
+  public function setElectionRegistrationUrl($electionRegistrationUrl)
+  {
+    $this->electionRegistrationUrl = $electionRegistrationUrl;
+  }
+  public function getElectionRegistrationUrl()
+  {
+    return $this->electionRegistrationUrl;
+  }
+  public function setElectionRulesUrl($electionRulesUrl)
+  {
+    $this->electionRulesUrl = $electionRulesUrl;
+  }
+  public function getElectionRulesUrl()
+  {
+    return $this->electionRulesUrl;
+  }
+  public function setHoursOfOperation($hoursOfOperation)
+  {
+    $this->hoursOfOperation = $hoursOfOperation;
+  }
+  public function getHoursOfOperation()
+  {
+    return $this->hoursOfOperation;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPhysicalAddress(Google_Service_CivicInfo_SimpleAddressType $physicalAddress)
+  {
+    $this->physicalAddress = $physicalAddress;
+  }
+  public function getPhysicalAddress()
+  {
+    return $this->physicalAddress;
+  }
+  public function setVoterServices($voterServices)
+  {
+    $this->voterServices = $voterServices;
+  }
+  public function getVoterServices()
+  {
+    return $this->voterServices;
+  }
+  public function setVotingLocationFinderUrl($votingLocationFinderUrl)
+  {
+    $this->votingLocationFinderUrl = $votingLocationFinderUrl;
+  }
+  public function getVotingLocationFinderUrl()
+  {
+    return $this->votingLocationFinderUrl;
+  }
+}
+
+class Google_Service_CivicInfo_Candidate extends Google_Collection
+{
+  protected $collection_key = 'channels';
+  protected $internal_gapi_mappings = array(
+  );
+  public $candidateUrl;
+  protected $channelsType = 'Google_Service_CivicInfo_Channel';
+  protected $channelsDataType = 'array';
+  public $email;
+  public $name;
+  public $orderOnBallot;
+  public $party;
+  public $phone;
+  public $photoUrl;
+
+
+  public function setCandidateUrl($candidateUrl)
+  {
+    $this->candidateUrl = $candidateUrl;
+  }
+  public function getCandidateUrl()
+  {
+    return $this->candidateUrl;
+  }
+  public function setChannels($channels)
+  {
+    $this->channels = $channels;
+  }
+  public function getChannels()
+  {
+    return $this->channels;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOrderOnBallot($orderOnBallot)
+  {
+    $this->orderOnBallot = $orderOnBallot;
+  }
+  public function getOrderOnBallot()
+  {
+    return $this->orderOnBallot;
+  }
+  public function setParty($party)
+  {
+    $this->party = $party;
+  }
+  public function getParty()
+  {
+    return $this->party;
+  }
+  public function setPhone($phone)
+  {
+    $this->phone = $phone;
+  }
+  public function getPhone()
+  {
+    return $this->phone;
+  }
+  public function setPhotoUrl($photoUrl)
+  {
+    $this->photoUrl = $photoUrl;
+  }
+  public function getPhotoUrl()
+  {
+    return $this->photoUrl;
+  }
+}
+
+class Google_Service_CivicInfo_Channel extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $type;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_CivicInfo_Contest extends Google_Collection
+{
+  protected $collection_key = 'sources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $ballotPlacement;
+  protected $candidatesType = 'Google_Service_CivicInfo_Candidate';
+  protected $candidatesDataType = 'array';
+  protected $districtType = 'Google_Service_CivicInfo_ElectoralDistrict';
+  protected $districtDataType = '';
+  public $electorateSpecifications;
+  public $id;
+  public $level;
+  public $numberElected;
+  public $numberVotingFor;
+  public $office;
+  public $primaryParty;
+  public $referendumBallotResponses;
+  public $referendumBrief;
+  public $referendumConStatement;
+  public $referendumEffectOfAbstain;
+  public $referendumPassageThreshold;
+  public $referendumProStatement;
+  public $referendumSubtitle;
+  public $referendumText;
+  public $referendumTitle;
+  public $referendumUrl;
+  public $roles;
+  protected $sourcesType = 'Google_Service_CivicInfo_Source';
+  protected $sourcesDataType = 'array';
+  public $special;
+  public $type;
+
+
+  public function setBallotPlacement($ballotPlacement)
+  {
+    $this->ballotPlacement = $ballotPlacement;
+  }
+  public function getBallotPlacement()
+  {
+    return $this->ballotPlacement;
+  }
+  public function setCandidates($candidates)
+  {
+    $this->candidates = $candidates;
+  }
+  public function getCandidates()
+  {
+    return $this->candidates;
+  }
+  public function setDistrict(Google_Service_CivicInfo_ElectoralDistrict $district)
+  {
+    $this->district = $district;
+  }
+  public function getDistrict()
+  {
+    return $this->district;
+  }
+  public function setElectorateSpecifications($electorateSpecifications)
+  {
+    $this->electorateSpecifications = $electorateSpecifications;
+  }
+  public function getElectorateSpecifications()
+  {
+    return $this->electorateSpecifications;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLevel($level)
+  {
+    $this->level = $level;
+  }
+  public function getLevel()
+  {
+    return $this->level;
+  }
+  public function setNumberElected($numberElected)
+  {
+    $this->numberElected = $numberElected;
+  }
+  public function getNumberElected()
+  {
+    return $this->numberElected;
+  }
+  public function setNumberVotingFor($numberVotingFor)
+  {
+    $this->numberVotingFor = $numberVotingFor;
+  }
+  public function getNumberVotingFor()
+  {
+    return $this->numberVotingFor;
+  }
+  public function setOffice($office)
+  {
+    $this->office = $office;
+  }
+  public function getOffice()
+  {
+    return $this->office;
+  }
+  public function setPrimaryParty($primaryParty)
+  {
+    $this->primaryParty = $primaryParty;
+  }
+  public function getPrimaryParty()
+  {
+    return $this->primaryParty;
+  }
+  public function setReferendumBallotResponses($referendumBallotResponses)
+  {
+    $this->referendumBallotResponses = $referendumBallotResponses;
+  }
+  public function getReferendumBallotResponses()
+  {
+    return $this->referendumBallotResponses;
+  }
+  public function setReferendumBrief($referendumBrief)
+  {
+    $this->referendumBrief = $referendumBrief;
+  }
+  public function getReferendumBrief()
+  {
+    return $this->referendumBrief;
+  }
+  public function setReferendumConStatement($referendumConStatement)
+  {
+    $this->referendumConStatement = $referendumConStatement;
+  }
+  public function getReferendumConStatement()
+  {
+    return $this->referendumConStatement;
+  }
+  public function setReferendumEffectOfAbstain($referendumEffectOfAbstain)
+  {
+    $this->referendumEffectOfAbstain = $referendumEffectOfAbstain;
+  }
+  public function getReferendumEffectOfAbstain()
+  {
+    return $this->referendumEffectOfAbstain;
+  }
+  public function setReferendumPassageThreshold($referendumPassageThreshold)
+  {
+    $this->referendumPassageThreshold = $referendumPassageThreshold;
+  }
+  public function getReferendumPassageThreshold()
+  {
+    return $this->referendumPassageThreshold;
+  }
+  public function setReferendumProStatement($referendumProStatement)
+  {
+    $this->referendumProStatement = $referendumProStatement;
+  }
+  public function getReferendumProStatement()
+  {
+    return $this->referendumProStatement;
+  }
+  public function setReferendumSubtitle($referendumSubtitle)
+  {
+    $this->referendumSubtitle = $referendumSubtitle;
+  }
+  public function getReferendumSubtitle()
+  {
+    return $this->referendumSubtitle;
+  }
+  public function setReferendumText($referendumText)
+  {
+    $this->referendumText = $referendumText;
+  }
+  public function getReferendumText()
+  {
+    return $this->referendumText;
+  }
+  public function setReferendumTitle($referendumTitle)
+  {
+    $this->referendumTitle = $referendumTitle;
+  }
+  public function getReferendumTitle()
+  {
+    return $this->referendumTitle;
+  }
+  public function setReferendumUrl($referendumUrl)
+  {
+    $this->referendumUrl = $referendumUrl;
+  }
+  public function getReferendumUrl()
+  {
+    return $this->referendumUrl;
+  }
+  public function setRoles($roles)
+  {
+    $this->roles = $roles;
+  }
+  public function getRoles()
+  {
+    return $this->roles;
+  }
+  public function setSources($sources)
+  {
+    $this->sources = $sources;
+  }
+  public function getSources()
+  {
+    return $this->sources;
+  }
+  public function setSpecial($special)
+  {
+    $this->special = $special;
+  }
+  public function getSpecial()
+  {
+    return $this->special;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_CivicInfo_DivisionSearchResponse extends Google_Collection
+{
+  protected $collection_key = 'results';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $resultsType = 'Google_Service_CivicInfo_DivisionSearchResult';
+  protected $resultsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setResults($results)
+  {
+    $this->results = $results;
+  }
+  public function getResults()
+  {
+    return $this->results;
+  }
+}
+
+class Google_Service_CivicInfo_DivisionSearchResult extends Google_Collection
+{
+  protected $collection_key = 'aliases';
+  protected $internal_gapi_mappings = array(
+  );
+  public $aliases;
+  public $name;
+  public $ocdId;
+
+
+  public function setAliases($aliases)
+  {
+    $this->aliases = $aliases;
+  }
+  public function getAliases()
+  {
+    return $this->aliases;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOcdId($ocdId)
+  {
+    $this->ocdId = $ocdId;
+  }
+  public function getOcdId()
+  {
+    return $this->ocdId;
+  }
+}
+
+class Google_Service_CivicInfo_Election extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $electionDay;
+  public $id;
+  public $name;
+  public $ocdDivisionId;
+
+
+  public function setElectionDay($electionDay)
+  {
+    $this->electionDay = $electionDay;
+  }
+  public function getElectionDay()
+  {
+    return $this->electionDay;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOcdDivisionId($ocdDivisionId)
+  {
+    $this->ocdDivisionId = $ocdDivisionId;
+  }
+  public function getOcdDivisionId()
+  {
+    return $this->ocdDivisionId;
+  }
+}
+
+class Google_Service_CivicInfo_ElectionOfficial extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $emailAddress;
+  public $faxNumber;
+  public $name;
+  public $officePhoneNumber;
+  public $title;
+
+
+  public function setEmailAddress($emailAddress)
+  {
+    $this->emailAddress = $emailAddress;
+  }
+  public function getEmailAddress()
+  {
+    return $this->emailAddress;
+  }
+  public function setFaxNumber($faxNumber)
+  {
+    $this->faxNumber = $faxNumber;
+  }
+  public function getFaxNumber()
+  {
+    return $this->faxNumber;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOfficePhoneNumber($officePhoneNumber)
+  {
+    $this->officePhoneNumber = $officePhoneNumber;
+  }
+  public function getOfficePhoneNumber()
+  {
+    return $this->officePhoneNumber;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_CivicInfo_ElectionsQueryResponse extends Google_Collection
+{
+  protected $collection_key = 'elections';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $electionsType = 'Google_Service_CivicInfo_Election';
+  protected $electionsDataType = 'array';
+  public $kind;
+
+
+  public function setElections($elections)
+  {
+    $this->elections = $elections;
+  }
+  public function getElections()
+  {
+    return $this->elections;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_CivicInfo_ElectoralDistrict extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $name;
+  public $scope;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setScope($scope)
+  {
+    $this->scope = $scope;
+  }
+  public function getScope()
+  {
+    return $this->scope;
+  }
+}
+
+class Google_Service_CivicInfo_GeographicDivision extends Google_Collection
+{
+  protected $collection_key = 'officeIndices';
+  protected $internal_gapi_mappings = array(
+  );
+  public $alsoKnownAs;
+  public $name;
+  public $officeIndices;
+
+
+  public function setAlsoKnownAs($alsoKnownAs)
+  {
+    $this->alsoKnownAs = $alsoKnownAs;
+  }
+  public function getAlsoKnownAs()
+  {
+    return $this->alsoKnownAs;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOfficeIndices($officeIndices)
+  {
+    $this->officeIndices = $officeIndices;
+  }
+  public function getOfficeIndices()
+  {
+    return $this->officeIndices;
+  }
+}
+
+class Google_Service_CivicInfo_Office extends Google_Collection
+{
+  protected $collection_key = 'sources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $divisionId;
+  public $levels;
+  public $name;
+  public $officialIndices;
+  public $roles;
+  protected $sourcesType = 'Google_Service_CivicInfo_Source';
+  protected $sourcesDataType = 'array';
+
+
+  public function setDivisionId($divisionId)
+  {
+    $this->divisionId = $divisionId;
+  }
+  public function getDivisionId()
+  {
+    return $this->divisionId;
+  }
+  public function setLevels($levels)
+  {
+    $this->levels = $levels;
+  }
+  public function getLevels()
+  {
+    return $this->levels;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOfficialIndices($officialIndices)
+  {
+    $this->officialIndices = $officialIndices;
+  }
+  public function getOfficialIndices()
+  {
+    return $this->officialIndices;
+  }
+  public function setRoles($roles)
+  {
+    $this->roles = $roles;
+  }
+  public function getRoles()
+  {
+    return $this->roles;
+  }
+  public function setSources($sources)
+  {
+    $this->sources = $sources;
+  }
+  public function getSources()
+  {
+    return $this->sources;
+  }
+}
+
+class Google_Service_CivicInfo_Official extends Google_Collection
+{
+  protected $collection_key = 'urls';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $addressType = 'Google_Service_CivicInfo_SimpleAddressType';
+  protected $addressDataType = 'array';
+  protected $channelsType = 'Google_Service_CivicInfo_Channel';
+  protected $channelsDataType = 'array';
+  public $emails;
+  public $name;
+  public $party;
+  public $phones;
+  public $photoUrl;
+  public $urls;
+
+
+  public function setAddress($address)
+  {
+    $this->address = $address;
+  }
+  public function getAddress()
+  {
+    return $this->address;
+  }
+  public function setChannels($channels)
+  {
+    $this->channels = $channels;
+  }
+  public function getChannels()
+  {
+    return $this->channels;
+  }
+  public function setEmails($emails)
+  {
+    $this->emails = $emails;
+  }
+  public function getEmails()
+  {
+    return $this->emails;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setParty($party)
+  {
+    $this->party = $party;
+  }
+  public function getParty()
+  {
+    return $this->party;
+  }
+  public function setPhones($phones)
+  {
+    $this->phones = $phones;
+  }
+  public function getPhones()
+  {
+    return $this->phones;
+  }
+  public function setPhotoUrl($photoUrl)
+  {
+    $this->photoUrl = $photoUrl;
+  }
+  public function getPhotoUrl()
+  {
+    return $this->photoUrl;
+  }
+  public function setUrls($urls)
+  {
+    $this->urls = $urls;
+  }
+  public function getUrls()
+  {
+    return $this->urls;
+  }
+}
+
+class Google_Service_CivicInfo_PollingLocation extends Google_Collection
+{
+  protected $collection_key = 'sources';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $addressType = 'Google_Service_CivicInfo_SimpleAddressType';
+  protected $addressDataType = '';
+  public $endDate;
+  public $id;
+  public $name;
+  public $notes;
+  public $pollingHours;
+  protected $sourcesType = 'Google_Service_CivicInfo_Source';
+  protected $sourcesDataType = 'array';
+  public $startDate;
+  public $voterServices;
+
+
+  public function setAddress(Google_Service_CivicInfo_SimpleAddressType $address)
+  {
+    $this->address = $address;
+  }
+  public function getAddress()
+  {
+    return $this->address;
+  }
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNotes($notes)
+  {
+    $this->notes = $notes;
+  }
+  public function getNotes()
+  {
+    return $this->notes;
+  }
+  public function setPollingHours($pollingHours)
+  {
+    $this->pollingHours = $pollingHours;
+  }
+  public function getPollingHours()
+  {
+    return $this->pollingHours;
+  }
+  public function setSources($sources)
+  {
+    $this->sources = $sources;
+  }
+  public function getSources()
+  {
+    return $this->sources;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+  public function setVoterServices($voterServices)
+  {
+    $this->voterServices = $voterServices;
+  }
+  public function getVoterServices()
+  {
+    return $this->voterServices;
+  }
+}
+
+class Google_Service_CivicInfo_RepresentativeInfoData extends Google_Collection
+{
+  protected $collection_key = 'officials';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $divisionsType = 'Google_Service_CivicInfo_GeographicDivision';
+  protected $divisionsDataType = 'map';
+  protected $officesType = 'Google_Service_CivicInfo_Office';
+  protected $officesDataType = 'array';
+  protected $officialsType = 'Google_Service_CivicInfo_Official';
+  protected $officialsDataType = 'array';
+
+
+  public function setDivisions($divisions)
+  {
+    $this->divisions = $divisions;
+  }
+  public function getDivisions()
+  {
+    return $this->divisions;
+  }
+  public function setOffices($offices)
+  {
+    $this->offices = $offices;
+  }
+  public function getOffices()
+  {
+    return $this->offices;
+  }
+  public function setOfficials($officials)
+  {
+    $this->officials = $officials;
+  }
+  public function getOfficials()
+  {
+    return $this->officials;
+  }
+}
+
+class Google_Service_CivicInfo_RepresentativeInfoDataDivisions extends Google_Model
+{
+}
+
+class Google_Service_CivicInfo_RepresentativeInfoResponse extends Google_Collection
+{
+  protected $collection_key = 'officials';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $divisionsType = 'Google_Service_CivicInfo_GeographicDivision';
+  protected $divisionsDataType = 'map';
+  public $kind;
+  protected $normalizedInputType = 'Google_Service_CivicInfo_SimpleAddressType';
+  protected $normalizedInputDataType = '';
+  protected $officesType = 'Google_Service_CivicInfo_Office';
+  protected $officesDataType = 'array';
+  protected $officialsType = 'Google_Service_CivicInfo_Official';
+  protected $officialsDataType = 'array';
+
+
+  public function setDivisions($divisions)
+  {
+    $this->divisions = $divisions;
+  }
+  public function getDivisions()
+  {
+    return $this->divisions;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNormalizedInput(Google_Service_CivicInfo_SimpleAddressType $normalizedInput)
+  {
+    $this->normalizedInput = $normalizedInput;
+  }
+  public function getNormalizedInput()
+  {
+    return $this->normalizedInput;
+  }
+  public function setOffices($offices)
+  {
+    $this->offices = $offices;
+  }
+  public function getOffices()
+  {
+    return $this->offices;
+  }
+  public function setOfficials($officials)
+  {
+    $this->officials = $officials;
+  }
+  public function getOfficials()
+  {
+    return $this->officials;
+  }
+}
+
+class Google_Service_CivicInfo_RepresentativeInfoResponseDivisions extends Google_Model
+{
+}
+
+class Google_Service_CivicInfo_SimpleAddressType extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $city;
+  public $line1;
+  public $line2;
+  public $line3;
+  public $locationName;
+  public $state;
+  public $zip;
+
+
+  public function setCity($city)
+  {
+    $this->city = $city;
+  }
+  public function getCity()
+  {
+    return $this->city;
+  }
+  public function setLine1($line1)
+  {
+    $this->line1 = $line1;
+  }
+  public function getLine1()
+  {
+    return $this->line1;
+  }
+  public function setLine2($line2)
+  {
+    $this->line2 = $line2;
+  }
+  public function getLine2()
+  {
+    return $this->line2;
+  }
+  public function setLine3($line3)
+  {
+    $this->line3 = $line3;
+  }
+  public function getLine3()
+  {
+    return $this->line3;
+  }
+  public function setLocationName($locationName)
+  {
+    $this->locationName = $locationName;
+  }
+  public function getLocationName()
+  {
+    return $this->locationName;
+  }
+  public function setState($state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+  public function setZip($zip)
+  {
+    $this->zip = $zip;
+  }
+  public function getZip()
+  {
+    return $this->zip;
+  }
+}
+
+class Google_Service_CivicInfo_Source extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $official;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOfficial($official)
+  {
+    $this->official = $official;
+  }
+  public function getOfficial()
+  {
+    return $this->official;
+  }
+}
+
+class Google_Service_CivicInfo_VoterInfoResponse extends Google_Collection
+{
+  protected $collection_key = 'state';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $contestsType = 'Google_Service_CivicInfo_Contest';
+  protected $contestsDataType = 'array';
+  protected $dropOffLocationsType = 'Google_Service_CivicInfo_PollingLocation';
+  protected $dropOffLocationsDataType = 'array';
+  protected $earlyVoteSitesType = 'Google_Service_CivicInfo_PollingLocation';
+  protected $earlyVoteSitesDataType = 'array';
+  protected $electionType = 'Google_Service_CivicInfo_Election';
+  protected $electionDataType = '';
+  public $kind;
+  public $mailOnly;
+  protected $normalizedInputType = 'Google_Service_CivicInfo_SimpleAddressType';
+  protected $normalizedInputDataType = '';
+  protected $otherElectionsType = 'Google_Service_CivicInfo_Election';
+  protected $otherElectionsDataType = 'array';
+  protected $pollingLocationsType = 'Google_Service_CivicInfo_PollingLocation';
+  protected $pollingLocationsDataType = 'array';
+  public $precinctId;
+  protected $stateType = 'Google_Service_CivicInfo_AdministrationRegion';
+  protected $stateDataType = 'array';
+
+
+  public function setContests($contests)
+  {
+    $this->contests = $contests;
+  }
+  public function getContests()
+  {
+    return $this->contests;
+  }
+  public function setDropOffLocations($dropOffLocations)
+  {
+    $this->dropOffLocations = $dropOffLocations;
+  }
+  public function getDropOffLocations()
+  {
+    return $this->dropOffLocations;
+  }
+  public function setEarlyVoteSites($earlyVoteSites)
+  {
+    $this->earlyVoteSites = $earlyVoteSites;
+  }
+  public function getEarlyVoteSites()
+  {
+    return $this->earlyVoteSites;
+  }
+  public function setElection(Google_Service_CivicInfo_Election $election)
+  {
+    $this->election = $election;
+  }
+  public function getElection()
+  {
+    return $this->election;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMailOnly($mailOnly)
+  {
+    $this->mailOnly = $mailOnly;
+  }
+  public function getMailOnly()
+  {
+    return $this->mailOnly;
+  }
+  public function setNormalizedInput(Google_Service_CivicInfo_SimpleAddressType $normalizedInput)
+  {
+    $this->normalizedInput = $normalizedInput;
+  }
+  public function getNormalizedInput()
+  {
+    return $this->normalizedInput;
+  }
+  public function setOtherElections($otherElections)
+  {
+    $this->otherElections = $otherElections;
+  }
+  public function getOtherElections()
+  {
+    return $this->otherElections;
+  }
+  public function setPollingLocations($pollingLocations)
+  {
+    $this->pollingLocations = $pollingLocations;
+  }
+  public function getPollingLocations()
+  {
+    return $this->pollingLocations;
+  }
+  public function setPrecinctId($precinctId)
+  {
+    $this->precinctId = $precinctId;
+  }
+  public function getPrecinctId()
+  {
+    return $this->precinctId;
+  }
+  public function setState($state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Classroom.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Classroom.php
@@ -1,0 +1,1533 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Classroom (v1).
+ *
+ * <p>
+ * Google Classroom API</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/classroom/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Classroom extends Google_Service
+{
+  /** Manage your Google Classroom classes. */
+  const CLASSROOM_COURSES =
+      "https://www.googleapis.com/auth/classroom.courses";
+  /** View your Google Classroom classes. */
+  const CLASSROOM_COURSES_READONLY =
+      "https://www.googleapis.com/auth/classroom.courses.readonly";
+  /** View the email addresses of people in your classes. */
+  const CLASSROOM_PROFILE_EMAILS =
+      "https://www.googleapis.com/auth/classroom.profile.emails";
+  /** View the profile photos of people in your classes. */
+  const CLASSROOM_PROFILE_PHOTOS =
+      "https://www.googleapis.com/auth/classroom.profile.photos";
+  /** Manage your Google Classroom class rosters. */
+  const CLASSROOM_ROSTERS =
+      "https://www.googleapis.com/auth/classroom.rosters";
+  /** View your Google Classroom class rosters. */
+  const CLASSROOM_ROSTERS_READONLY =
+      "https://www.googleapis.com/auth/classroom.rosters.readonly";
+
+  public $courses;
+  public $courses_aliases;
+  public $courses_students;
+  public $courses_teachers;
+  public $invitations;
+  public $userProfiles;
+  
+
+  /**
+   * Constructs the internal representation of the Classroom service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://classroom.googleapis.com/';
+    $this->servicePath = '';
+    $this->version = 'v1';
+    $this->serviceName = 'classroom';
+
+    $this->courses = new Google_Service_Classroom_Courses_Resource(
+        $this,
+        $this->serviceName,
+        'courses',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'v1/courses',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'delete' => array(
+              'path' => 'v1/courses/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v1/courses/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1/courses',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'teacherId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'studentId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'v1/courses/{id}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'updateMask' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'v1/courses/{id}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->courses_aliases = new Google_Service_Classroom_CoursesAliases_Resource(
+        $this,
+        $this->serviceName,
+        'aliases',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'v1/courses/{courseId}/aliases',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'courseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'v1/courses/{courseId}/aliases/{alias}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'courseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'alias' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1/courses/{courseId}/aliases',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'courseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->courses_students = new Google_Service_Classroom_CoursesStudents_Resource(
+        $this,
+        $this->serviceName,
+        'students',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'v1/courses/{courseId}/students',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'courseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'enrollmentCode' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'v1/courses/{courseId}/students/{userId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'courseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v1/courses/{courseId}/students/{userId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'courseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1/courses/{courseId}/students',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'courseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->courses_teachers = new Google_Service_Classroom_CoursesTeachers_Resource(
+        $this,
+        $this->serviceName,
+        'teachers',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'v1/courses/{courseId}/teachers',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'courseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'v1/courses/{courseId}/teachers/{userId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'courseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v1/courses/{courseId}/teachers/{userId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'courseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1/courses/{courseId}/teachers',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'courseId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->invitations = new Google_Service_Classroom_Invitations_Resource(
+        $this,
+        $this->serviceName,
+        'invitations',
+        array(
+          'methods' => array(
+            'accept' => array(
+              'path' => 'v1/invitations/{id}:accept',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'create' => array(
+              'path' => 'v1/invitations',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'delete' => array(
+              'path' => 'v1/invitations/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v1/invitations/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1/invitations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'courseId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'userId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->userProfiles = new Google_Service_Classroom_UserProfiles_Resource(
+        $this,
+        $this->serviceName,
+        'userProfiles',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'v1/userProfiles/{userId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "courses" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $classroomService = new Google_Service_Classroom(...);
+ *   $courses = $classroomService->courses;
+ *  </code>
+ */
+class Google_Service_Classroom_Courses_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a course. The user specified in `ownerId` is the owner of the created
+   * course and added as a teacher. This method returns the following error codes:
+   * * `PERMISSION_DENIED` if the requesting user is not permitted to create
+   * courses or for access errors. * `NOT_FOUND` if the primary teacher is not a
+   * valid user. * `FAILED_PRECONDITION` if the course owner's account is disabled
+   * or for the following request errors: * UserGroupsMembershipLimitReached *
+   * `ALREADY_EXISTS` if an alias was specified in the `id` and already exists.
+   * (courses.create)
+   *
+   * @param Google_Course $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Classroom_Course
+   */
+  public function create(Google_Service_Classroom_Course $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Classroom_Course");
+  }
+
+  /**
+   * Deletes a course. This method returns the following error codes: *
+   * `PERMISSION_DENIED` if the requesting user is not permitted to delete the
+   * requested course or for access errors. * `NOT_FOUND` if no course exists with
+   * the requested ID. (courses.delete)
+   *
+   * @param string $id Identifier of the course to delete. This identifier can be
+   * either the Classroom-assigned identifier or an alias.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Classroom_Empty
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Classroom_Empty");
+  }
+
+  /**
+   * Returns a course. This method returns the following error codes: *
+   * `PERMISSION_DENIED` if the requesting user is not permitted to access the
+   * requested course or for access errors. * `NOT_FOUND` if no course exists with
+   * the requested ID. (courses.get)
+   *
+   * @param string $id Identifier of the course to return. This identifier can be
+   * either the Classroom-assigned identifier or an alias.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Classroom_Course
+   */
+  public function get($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Classroom_Course");
+  }
+
+  /**
+   * Returns a list of courses that the requesting user is permitted to view,
+   * restricted to those that match the request. This method returns the following
+   * error codes: * `PERMISSION_DENIED` for access errors. * `INVALID_ARGUMENT` if
+   * the query argument is malformed. * `NOT_FOUND` if any users specified in the
+   * query arguments do not exist. (courses.listCourses)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string teacherId Restricts returned courses to those having a
+   * teacher with the specified identifier. The identifier can be one of the
+   * following: * the numeric identifier for the user * the email address of the
+   * user * the string literal `"me"`, indicating the requesting user
+   * @opt_param string pageToken nextPageToken value returned from a previous list
+   * call, indicating that the subsequent page of results should be returned. The
+   * list request must be otherwise identical to the one that resulted in this
+   * token.
+   * @opt_param string studentId Restricts returned courses to those having a
+   * student with the specified identifier. The identifier can be one of the
+   * following: * the numeric identifier for the user * the email address of the
+   * user * the string literal `"me"`, indicating the requesting user
+   * @opt_param int pageSize Maximum number of items to return. Zero or
+   * unspecified indicates that the server may assign a maximum. The server may
+   * return fewer than the specified number of results.
+   * @return Google_Service_Classroom_ListCoursesResponse
+   */
+  public function listCourses($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Classroom_ListCoursesResponse");
+  }
+
+  /**
+   * Updates one or more fields in a course. This method returns the following
+   * error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to
+   * modify the requested course or for access errors. * `NOT_FOUND` if no course
+   * exists with the requested ID. * `INVALID_ARGUMENT` if invalid fields are
+   * specified in the update mask or if no update mask is supplied. *
+   * `FAILED_PRECONDITION` for the following request errors: * CourseNotModifiable
+   * (courses.patch)
+   *
+   * @param string $id Identifier of the course to update. This identifier can be
+   * either the Classroom-assigned identifier or an alias.
+   * @param Google_Course $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string updateMask Mask that identifies which fields on the course
+   * to update. This field is required to do an update. The update will fail if
+   * invalid fields are specified. The following fields are valid: * `name` *
+   * `section` * `descriptionHeading` * `description` * `room` * `courseState`
+   * When set in a query parameter, this field should be specified as
+   * `updateMask=,,...`
+   * @return Google_Service_Classroom_Course
+   */
+  public function patch($id, Google_Service_Classroom_Course $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Classroom_Course");
+  }
+
+  /**
+   * Updates a course. This method returns the following error codes: *
+   * `PERMISSION_DENIED` if the requesting user is not permitted to modify the
+   * requested course or for access errors. * `NOT_FOUND` if no course exists with
+   * the requested ID. * `FAILED_PRECONDITION` for the following request errors: *
+   * CourseNotModifiable (courses.update)
+   *
+   * @param string $id Identifier of the course to update. This identifier can be
+   * either the Classroom-assigned identifier or an alias.
+   * @param Google_Course $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Classroom_Course
+   */
+  public function update($id, Google_Service_Classroom_Course $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Classroom_Course");
+  }
+}
+
+/**
+ * The "aliases" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $classroomService = new Google_Service_Classroom(...);
+ *   $aliases = $classroomService->aliases;
+ *  </code>
+ */
+class Google_Service_Classroom_CoursesAliases_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates an alias for a course. This method returns the following error codes:
+   * * `PERMISSION_DENIED` if the requesting user is not permitted to create the
+   * alias or for access errors. * `NOT_FOUND` if the course does not exist. *
+   * `ALREADY_EXISTS` if the alias already exists. (aliases.create)
+   *
+   * @param string $courseId Identifier of the course to alias. This identifier
+   * can be either the Classroom-assigned identifier or an alias.
+   * @param Google_CourseAlias $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Classroom_CourseAlias
+   */
+  public function create($courseId, Google_Service_Classroom_CourseAlias $postBody, $optParams = array())
+  {
+    $params = array('courseId' => $courseId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Classroom_CourseAlias");
+  }
+
+  /**
+   * Deletes an alias of a course. This method returns the following error codes:
+   * * `PERMISSION_DENIED` if the requesting user is not permitted to remove the
+   * alias or for access errors. * `NOT_FOUND` if the alias does not exist.
+   * (aliases.delete)
+   *
+   * @param string $courseId Identifier of the course whose alias should be
+   * deleted. This identifier can be either the Classroom-assigned identifier or
+   * an alias.
+   * @param string $alias Alias to delete. This may not be the Classroom-assigned
+   * identifier.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Classroom_Empty
+   */
+  public function delete($courseId, $alias, $optParams = array())
+  {
+    $params = array('courseId' => $courseId, 'alias' => $alias);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Classroom_Empty");
+  }
+
+  /**
+   * Returns a list of aliases for a course. This method returns the following
+   * error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to
+   * access the course or for access errors. * `NOT_FOUND` if the course does not
+   * exist. (aliases.listCoursesAliases)
+   *
+   * @param string $courseId The identifier of the course. This identifier can be
+   * either the Classroom-assigned identifier or an alias.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken nextPageToken value returned from a previous list
+   * call, indicating that the subsequent page of results should be returned. The
+   * list request must be otherwise identical to the one that resulted in this
+   * token.
+   * @opt_param int pageSize Maximum number of items to return. Zero or
+   * unspecified indicates that the server may assign a maximum. The server may
+   * return fewer than the specified number of results.
+   * @return Google_Service_Classroom_ListCourseAliasesResponse
+   */
+  public function listCoursesAliases($courseId, $optParams = array())
+  {
+    $params = array('courseId' => $courseId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Classroom_ListCourseAliasesResponse");
+  }
+}
+/**
+ * The "students" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $classroomService = new Google_Service_Classroom(...);
+ *   $students = $classroomService->students;
+ *  </code>
+ */
+class Google_Service_Classroom_CoursesStudents_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Adds a user as a student of a course. This method returns the following error
+   * codes: * `PERMISSION_DENIED` if the requesting user is not permitted to
+   * create students in this course or for access errors. * `NOT_FOUND` if the
+   * requested course ID does not exist. * `FAILED_PRECONDITION` if the requested
+   * user's account is disabled, for the following request errors: *
+   * CourseMemberLimitReached * CourseNotModifiable *
+   * UserGroupsMembershipLimitReached * `ALREADY_EXISTS` if the user is already a
+   * student or teacher in the course. (students.create)
+   *
+   * @param string $courseId Identifier of the course to create the student in.
+   * This identifier can be either the Classroom-assigned identifier or an alias.
+   * @param Google_Student $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string enrollmentCode Enrollment code of the course to create the
+   * student in. This code is required if userId corresponds to the requesting
+   * user; it may be omitted if the requesting user has administrative permissions
+   * to create students for any user.
+   * @return Google_Service_Classroom_Student
+   */
+  public function create($courseId, Google_Service_Classroom_Student $postBody, $optParams = array())
+  {
+    $params = array('courseId' => $courseId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Classroom_Student");
+  }
+
+  /**
+   * Deletes a student of a course. This method returns the following error codes:
+   * * `PERMISSION_DENIED` if the requesting user is not permitted to delete
+   * students of this course or for access errors. * `NOT_FOUND` if no student of
+   * this course has the requested ID or if the course does not exist.
+   * (students.delete)
+   *
+   * @param string $courseId Identifier of the course. This identifier can be
+   * either the Classroom-assigned identifier or an alias.
+   * @param string $userId Identifier of the student to delete. The identifier can
+   * be one of the following: * the numeric identifier for the user * the email
+   * address of the user * the string literal `"me"`, indicating the requesting
+   * user
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Classroom_Empty
+   */
+  public function delete($courseId, $userId, $optParams = array())
+  {
+    $params = array('courseId' => $courseId, 'userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Classroom_Empty");
+  }
+
+  /**
+   * Returns a student of a course. This method returns the following error codes:
+   * * `PERMISSION_DENIED` if the requesting user is not permitted to view
+   * students of this course or for access errors. * `NOT_FOUND` if no student of
+   * this course has the requested ID or if the course does not exist.
+   * (students.get)
+   *
+   * @param string $courseId Identifier of the course. This identifier can be
+   * either the Classroom-assigned identifier or an alias.
+   * @param string $userId Identifier of the student to return. The identifier can
+   * be one of the following: * the numeric identifier for the user * the email
+   * address of the user * the string literal `"me"`, indicating the requesting
+   * user
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Classroom_Student
+   */
+  public function get($courseId, $userId, $optParams = array())
+  {
+    $params = array('courseId' => $courseId, 'userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Classroom_Student");
+  }
+
+  /**
+   * Returns a list of students of this course that the requester is permitted to
+   * view. This method returns the following error codes: * `NOT_FOUND` if the
+   * course does not exist. * `PERMISSION_DENIED` for access errors.
+   * (students.listCoursesStudents)
+   *
+   * @param string $courseId Identifier of the course. This identifier can be
+   * either the Classroom-assigned identifier or an alias.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken nextPageToken value returned from a previous list
+   * call, indicating that the subsequent page of results should be returned. The
+   * list request must be otherwise identical to the one that resulted in this
+   * token.
+   * @opt_param int pageSize Maximum number of items to return. Zero means no
+   * maximum. The server may return fewer than the specified number of results.
+   * @return Google_Service_Classroom_ListStudentsResponse
+   */
+  public function listCoursesStudents($courseId, $optParams = array())
+  {
+    $params = array('courseId' => $courseId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Classroom_ListStudentsResponse");
+  }
+}
+/**
+ * The "teachers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $classroomService = new Google_Service_Classroom(...);
+ *   $teachers = $classroomService->teachers;
+ *  </code>
+ */
+class Google_Service_Classroom_CoursesTeachers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a teacher of a course. This method returns the following error codes:
+   * * `PERMISSION_DENIED` if the requesting user is not permitted to create
+   * teachers in this course or for access errors. * `NOT_FOUND` if the requested
+   * course ID does not exist. * `FAILED_PRECONDITION` if the requested user's
+   * account is disabled, for the following request errors: *
+   * CourseMemberLimitReached * CourseNotModifiable * CourseTeacherLimitReached *
+   * UserGroupsMembershipLimitReached * `ALREADY_EXISTS` if the user is already a
+   * teacher or student in the course. (teachers.create)
+   *
+   * @param string $courseId Identifier of the course. This identifier can be
+   * either the Classroom-assigned identifier or an alias.
+   * @param Google_Teacher $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Classroom_Teacher
+   */
+  public function create($courseId, Google_Service_Classroom_Teacher $postBody, $optParams = array())
+  {
+    $params = array('courseId' => $courseId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Classroom_Teacher");
+  }
+
+  /**
+   * Deletes a teacher of a course. This method returns the following error codes:
+   * * `PERMISSION_DENIED` if the requesting user is not permitted to delete
+   * teachers of this course or for access errors. * `NOT_FOUND` if no teacher of
+   * this course has the requested ID or if the course does not exist. *
+   * `FAILED_PRECONDITION` if the requested ID belongs to the primary teacher of
+   * this course. (teachers.delete)
+   *
+   * @param string $courseId Identifier of the course. This identifier can be
+   * either the Classroom-assigned identifier or an alias.
+   * @param string $userId Identifier of the teacher to delete. The identifier can
+   * be one of the following: * the numeric identifier for the user * the email
+   * address of the user * the string literal `"me"`, indicating the requesting
+   * user
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Classroom_Empty
+   */
+  public function delete($courseId, $userId, $optParams = array())
+  {
+    $params = array('courseId' => $courseId, 'userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Classroom_Empty");
+  }
+
+  /**
+   * Returns a teacher of a course. This method returns the following error codes:
+   * * `PERMISSION_DENIED` if the requesting user is not permitted to view
+   * teachers of this course or for access errors. * `NOT_FOUND` if no teacher of
+   * this course has the requested ID or if the course does not exist.
+   * (teachers.get)
+   *
+   * @param string $courseId Identifier of the course. This identifier can be
+   * either the Classroom-assigned identifier or an alias.
+   * @param string $userId Identifier of the teacher to return. The identifier can
+   * be one of the following: * the numeric identifier for the user * the email
+   * address of the user * the string literal `"me"`, indicating the requesting
+   * user
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Classroom_Teacher
+   */
+  public function get($courseId, $userId, $optParams = array())
+  {
+    $params = array('courseId' => $courseId, 'userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Classroom_Teacher");
+  }
+
+  /**
+   * Returns a list of teachers of this course that the requester is permitted to
+   * view. This method returns the following error codes: * `NOT_FOUND` if the
+   * course does not exist. * `PERMISSION_DENIED` for access errors.
+   * (teachers.listCoursesTeachers)
+   *
+   * @param string $courseId Identifier of the course. This identifier can be
+   * either the Classroom-assigned identifier or an alias.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken nextPageToken value returned from a previous list
+   * call, indicating that the subsequent page of results should be returned. The
+   * list request must be otherwise identical to the one that resulted in this
+   * token.
+   * @opt_param int pageSize Maximum number of items to return. Zero means no
+   * maximum. The server may return fewer than the specified number of results.
+   * @return Google_Service_Classroom_ListTeachersResponse
+   */
+  public function listCoursesTeachers($courseId, $optParams = array())
+  {
+    $params = array('courseId' => $courseId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Classroom_ListTeachersResponse");
+  }
+}
+
+/**
+ * The "invitations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $classroomService = new Google_Service_Classroom(...);
+ *   $invitations = $classroomService->invitations;
+ *  </code>
+ */
+class Google_Service_Classroom_Invitations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Accepts an invitation, removing it and adding the invited user to the
+   * teachers or students (as appropriate) of the specified course. Only the
+   * invited user may accept an invitation. This method returns the following
+   * error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to
+   * accept the requested invitation or for access errors. * `FAILED_PRECONDITION`
+   * for the following request errors: * CourseMemberLimitReached *
+   * CourseNotModifiable * CourseTeacherLimitReached *
+   * UserGroupsMembershipLimitReached * `NOT_FOUND` if no invitation exists with
+   * the requested ID. (invitations.accept)
+   *
+   * @param string $id Identifier of the invitation to accept.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Classroom_Empty
+   */
+  public function accept($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('accept', array($params), "Google_Service_Classroom_Empty");
+  }
+
+  /**
+   * Creates an invitation. Only one invitation for a user and course may exist at
+   * a time. Delete and re-create an invitation to make changes. This method
+   * returns the following error codes: * `PERMISSION_DENIED` if the requesting
+   * user is not permitted to create invitations for this course or for access
+   * errors. * `NOT_FOUND` if the course or the user does not exist. *
+   * `FAILED_PRECONDITION` if the requested user's account is disabled or if the
+   * user already has this role or a role with greater permissions. *
+   * `ALREADY_EXISTS` if an invitation for the specified user and course already
+   * exists. (invitations.create)
+   *
+   * @param Google_Invitation $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Classroom_Invitation
+   */
+  public function create(Google_Service_Classroom_Invitation $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Classroom_Invitation");
+  }
+
+  /**
+   * Deletes an invitation. This method returns the following error codes: *
+   * `PERMISSION_DENIED` if the requesting user is not permitted to delete the
+   * requested invitation or for access errors. * `NOT_FOUND` if no invitation
+   * exists with the requested ID. (invitations.delete)
+   *
+   * @param string $id Identifier of the invitation to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Classroom_Empty
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Classroom_Empty");
+  }
+
+  /**
+   * Returns an invitation. This method returns the following error codes: *
+   * `PERMISSION_DENIED` if the requesting user is not permitted to view the
+   * requested invitation or for access errors. * `NOT_FOUND` if no invitation
+   * exists with the requested ID. (invitations.get)
+   *
+   * @param string $id Identifier of the invitation to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Classroom_Invitation
+   */
+  public function get($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Classroom_Invitation");
+  }
+
+  /**
+   * Returns a list of invitations that the requesting user is permitted to view,
+   * restricted to those that match the list request. *Note:* At least one of
+   * `user_id` or `course_id` must be supplied. Both fields can be supplied. This
+   * method returns the following error codes: * `PERMISSION_DENIED` for access
+   * errors. (invitations.listInvitations)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string courseId Restricts returned invitations to those for a
+   * course with the specified identifier.
+   * @opt_param string pageToken nextPageToken value returned from a previous list
+   * call, indicating that the subsequent page of results should be returned. The
+   * list request must be otherwise identical to the one that resulted in this
+   * token.
+   * @opt_param string userId Restricts returned invitations to those for a
+   * specific user. The identifier can be one of the following: * the numeric
+   * identifier for the user * the email address of the user * the string literal
+   * `"me"`, indicating the requesting user
+   * @opt_param int pageSize Maximum number of items to return. Zero means no
+   * maximum. The server may return fewer than the specified number of results.
+   * @return Google_Service_Classroom_ListInvitationsResponse
+   */
+  public function listInvitations($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Classroom_ListInvitationsResponse");
+  }
+}
+
+/**
+ * The "userProfiles" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $classroomService = new Google_Service_Classroom(...);
+ *   $userProfiles = $classroomService->userProfiles;
+ *  </code>
+ */
+class Google_Service_Classroom_UserProfiles_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns a user profile. This method returns the following error codes: *
+   * `PERMISSION_DENIED` if the requesting user is not permitted to access this
+   * user profile or if no profile exists with the requested ID or for access
+   * errors. (userProfiles.get)
+   *
+   * @param string $userId Identifier of the profile to return. The identifier can
+   * be one of the following: * the numeric identifier for the user * the email
+   * address of the user * the string literal `"me"`, indicating the requesting
+   * user
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Classroom_UserProfile
+   */
+  public function get($userId, $optParams = array())
+  {
+    $params = array('userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Classroom_UserProfile");
+  }
+}
+
+
+
+
+class Google_Service_Classroom_Course extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $alternateLink;
+  public $courseState;
+  public $creationTime;
+  public $description;
+  public $descriptionHeading;
+  public $enrollmentCode;
+  public $id;
+  public $name;
+  public $ownerId;
+  public $room;
+  public $section;
+  public $updateTime;
+
+
+  public function setAlternateLink($alternateLink)
+  {
+    $this->alternateLink = $alternateLink;
+  }
+  public function getAlternateLink()
+  {
+    return $this->alternateLink;
+  }
+  public function setCourseState($courseState)
+  {
+    $this->courseState = $courseState;
+  }
+  public function getCourseState()
+  {
+    return $this->courseState;
+  }
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDescriptionHeading($descriptionHeading)
+  {
+    $this->descriptionHeading = $descriptionHeading;
+  }
+  public function getDescriptionHeading()
+  {
+    return $this->descriptionHeading;
+  }
+  public function setEnrollmentCode($enrollmentCode)
+  {
+    $this->enrollmentCode = $enrollmentCode;
+  }
+  public function getEnrollmentCode()
+  {
+    return $this->enrollmentCode;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOwnerId($ownerId)
+  {
+    $this->ownerId = $ownerId;
+  }
+  public function getOwnerId()
+  {
+    return $this->ownerId;
+  }
+  public function setRoom($room)
+  {
+    $this->room = $room;
+  }
+  public function getRoom()
+  {
+    return $this->room;
+  }
+  public function setSection($section)
+  {
+    $this->section = $section;
+  }
+  public function getSection()
+  {
+    return $this->section;
+  }
+  public function setUpdateTime($updateTime)
+  {
+    $this->updateTime = $updateTime;
+  }
+  public function getUpdateTime()
+  {
+    return $this->updateTime;
+  }
+}
+
+class Google_Service_Classroom_CourseAlias extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $alias;
+
+
+  public function setAlias($alias)
+  {
+    $this->alias = $alias;
+  }
+  public function getAlias()
+  {
+    return $this->alias;
+  }
+}
+
+class Google_Service_Classroom_Empty extends Google_Model
+{
+}
+
+class Google_Service_Classroom_GlobalPermission extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $permission;
+
+
+  public function setPermission($permission)
+  {
+    $this->permission = $permission;
+  }
+  public function getPermission()
+  {
+    return $this->permission;
+  }
+}
+
+class Google_Service_Classroom_Invitation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $courseId;
+  public $id;
+  public $role;
+  public $userId;
+
+
+  public function setCourseId($courseId)
+  {
+    $this->courseId = $courseId;
+  }
+  public function getCourseId()
+  {
+    return $this->courseId;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setRole($role)
+  {
+    $this->role = $role;
+  }
+  public function getRole()
+  {
+    return $this->role;
+  }
+  public function setUserId($userId)
+  {
+    $this->userId = $userId;
+  }
+  public function getUserId()
+  {
+    return $this->userId;
+  }
+}
+
+class Google_Service_Classroom_ListCourseAliasesResponse extends Google_Collection
+{
+  protected $collection_key = 'aliases';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $aliasesType = 'Google_Service_Classroom_CourseAlias';
+  protected $aliasesDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setAliases($aliases)
+  {
+    $this->aliases = $aliases;
+  }
+  public function getAliases()
+  {
+    return $this->aliases;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Classroom_ListCoursesResponse extends Google_Collection
+{
+  protected $collection_key = 'courses';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $coursesType = 'Google_Service_Classroom_Course';
+  protected $coursesDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setCourses($courses)
+  {
+    $this->courses = $courses;
+  }
+  public function getCourses()
+  {
+    return $this->courses;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Classroom_ListInvitationsResponse extends Google_Collection
+{
+  protected $collection_key = 'invitations';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $invitationsType = 'Google_Service_Classroom_Invitation';
+  protected $invitationsDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setInvitations($invitations)
+  {
+    $this->invitations = $invitations;
+  }
+  public function getInvitations()
+  {
+    return $this->invitations;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Classroom_ListStudentsResponse extends Google_Collection
+{
+  protected $collection_key = 'students';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $studentsType = 'Google_Service_Classroom_Student';
+  protected $studentsDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setStudents($students)
+  {
+    $this->students = $students;
+  }
+  public function getStudents()
+  {
+    return $this->students;
+  }
+}
+
+class Google_Service_Classroom_ListTeachersResponse extends Google_Collection
+{
+  protected $collection_key = 'teachers';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $teachersType = 'Google_Service_Classroom_Teacher';
+  protected $teachersDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTeachers($teachers)
+  {
+    $this->teachers = $teachers;
+  }
+  public function getTeachers()
+  {
+    return $this->teachers;
+  }
+}
+
+class Google_Service_Classroom_Name extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $familyName;
+  public $fullName;
+  public $givenName;
+
+
+  public function setFamilyName($familyName)
+  {
+    $this->familyName = $familyName;
+  }
+  public function getFamilyName()
+  {
+    return $this->familyName;
+  }
+  public function setFullName($fullName)
+  {
+    $this->fullName = $fullName;
+  }
+  public function getFullName()
+  {
+    return $this->fullName;
+  }
+  public function setGivenName($givenName)
+  {
+    $this->givenName = $givenName;
+  }
+  public function getGivenName()
+  {
+    return $this->givenName;
+  }
+}
+
+class Google_Service_Classroom_Student extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $courseId;
+  protected $profileType = 'Google_Service_Classroom_UserProfile';
+  protected $profileDataType = '';
+  public $userId;
+
+
+  public function setCourseId($courseId)
+  {
+    $this->courseId = $courseId;
+  }
+  public function getCourseId()
+  {
+    return $this->courseId;
+  }
+  public function setProfile(Google_Service_Classroom_UserProfile $profile)
+  {
+    $this->profile = $profile;
+  }
+  public function getProfile()
+  {
+    return $this->profile;
+  }
+  public function setUserId($userId)
+  {
+    $this->userId = $userId;
+  }
+  public function getUserId()
+  {
+    return $this->userId;
+  }
+}
+
+class Google_Service_Classroom_Teacher extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $courseId;
+  protected $profileType = 'Google_Service_Classroom_UserProfile';
+  protected $profileDataType = '';
+  public $userId;
+
+
+  public function setCourseId($courseId)
+  {
+    $this->courseId = $courseId;
+  }
+  public function getCourseId()
+  {
+    return $this->courseId;
+  }
+  public function setProfile(Google_Service_Classroom_UserProfile $profile)
+  {
+    $this->profile = $profile;
+  }
+  public function getProfile()
+  {
+    return $this->profile;
+  }
+  public function setUserId($userId)
+  {
+    $this->userId = $userId;
+  }
+  public function getUserId()
+  {
+    return $this->userId;
+  }
+}
+
+class Google_Service_Classroom_UserProfile extends Google_Collection
+{
+  protected $collection_key = 'permissions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $emailAddress;
+  public $id;
+  protected $nameType = 'Google_Service_Classroom_Name';
+  protected $nameDataType = '';
+  protected $permissionsType = 'Google_Service_Classroom_GlobalPermission';
+  protected $permissionsDataType = 'array';
+  public $photoUrl;
+
+
+  public function setEmailAddress($emailAddress)
+  {
+    $this->emailAddress = $emailAddress;
+  }
+  public function getEmailAddress()
+  {
+    return $this->emailAddress;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName(Google_Service_Classroom_Name $name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPermissions($permissions)
+  {
+    $this->permissions = $permissions;
+  }
+  public function getPermissions()
+  {
+    return $this->permissions;
+  }
+  public function setPhotoUrl($photoUrl)
+  {
+    $this->photoUrl = $photoUrl;
+  }
+  public function getPhotoUrl()
+  {
+    return $this->photoUrl;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/CloudMonitoring.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/CloudMonitoring.php
@@ -1,0 +1,1171 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for CloudMonitoring (v2beta2).
+ *
+ * <p>
+ * API for accessing Google Cloud and API monitoring data.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://cloud.google.com/monitoring/v2beta2/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_CloudMonitoring extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+  /** View and write monitoring data for all of your Google and third-party Cloud and API projects. */
+  const MONITORING =
+      "https://www.googleapis.com/auth/monitoring";
+
+  public $metricDescriptors;
+  public $timeseries;
+  public $timeseriesDescriptors;
+  
+
+  /**
+   * Constructs the internal representation of the CloudMonitoring service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'cloudmonitoring/v2beta2/projects/';
+    $this->version = 'v2beta2';
+    $this->serviceName = 'cloudmonitoring';
+
+    $this->metricDescriptors = new Google_Service_CloudMonitoring_MetricDescriptors_Resource(
+        $this,
+        $this->serviceName,
+        'metricDescriptors',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => '{project}/metricDescriptors',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/metricDescriptors/{metric}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'metric' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/metricDescriptors',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'count' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'query' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->timeseries = new Google_Service_CloudMonitoring_Timeseries_Resource(
+        $this,
+        $this->serviceName,
+        'timeseries',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => '{project}/timeseries/{metric}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'metric' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'youngest' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'count' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'timespan' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'aggregator' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'labels' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'window' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'oldest' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'write' => array(
+              'path' => '{project}/timeseries:write',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->timeseriesDescriptors = new Google_Service_CloudMonitoring_TimeseriesDescriptors_Resource(
+        $this,
+        $this->serviceName,
+        'timeseriesDescriptors',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => '{project}/timeseriesDescriptors/{metric}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'metric' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'youngest' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'count' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'timespan' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'aggregator' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'labels' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'window' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'oldest' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "metricDescriptors" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $cloudmonitoringService = new Google_Service_CloudMonitoring(...);
+ *   $metricDescriptors = $cloudmonitoringService->metricDescriptors;
+ *  </code>
+ */
+class Google_Service_CloudMonitoring_MetricDescriptors_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Create a new metric. (metricDescriptors.create)
+   *
+   * @param string $project The project id. The value can be the numeric project
+   * ID or string-based project name.
+   * @param Google_MetricDescriptor $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudMonitoring_MetricDescriptor
+   */
+  public function create($project, Google_Service_CloudMonitoring_MetricDescriptor $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_CloudMonitoring_MetricDescriptor");
+  }
+
+  /**
+   * Delete an existing metric. (metricDescriptors.delete)
+   *
+   * @param string $project The project ID to which the metric belongs.
+   * @param string $metric Name of the metric.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudMonitoring_DeleteMetricDescriptorResponse
+   */
+  public function delete($project, $metric, $optParams = array())
+  {
+    $params = array('project' => $project, 'metric' => $metric);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_CloudMonitoring_DeleteMetricDescriptorResponse");
+  }
+
+  /**
+   * List metric descriptors that match the query. If the query is not set, then
+   * all of the metric descriptors will be returned. Large responses will be
+   * paginated, use the nextPageToken returned in the response to request
+   * subsequent pages of results by setting the pageToken query parameter to the
+   * value of the nextPageToken. (metricDescriptors.listMetricDescriptors)
+   *
+   * @param string $project The project id. The value can be the numeric project
+   * ID or string-based project name.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int count Maximum number of metric descriptors per page. Used for
+   * pagination. If not specified, count = 100.
+   * @opt_param string pageToken The pagination token, which is used to page
+   * through large result sets. Set this value to the value of the nextPageToken
+   * to retrieve the next page of results.
+   * @opt_param string query The query used to search against existing metrics.
+   * Separate keywords with a space; the service joins all keywords with AND,
+   * meaning that all keywords must match for a metric to be returned. If this
+   * field is omitted, all metrics are returned. If an empty string is passed with
+   * this field, no metrics are returned.
+   * @return Google_Service_CloudMonitoring_ListMetricDescriptorsResponse
+   */
+  public function listMetricDescriptors($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_CloudMonitoring_ListMetricDescriptorsResponse");
+  }
+}
+
+/**
+ * The "timeseries" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $cloudmonitoringService = new Google_Service_CloudMonitoring(...);
+ *   $timeseries = $cloudmonitoringService->timeseries;
+ *  </code>
+ */
+class Google_Service_CloudMonitoring_Timeseries_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List the data points of the time series that match the metric and labels
+   * values and that have data points in the interval. Large responses are
+   * paginated; use the nextPageToken returned in the response to request
+   * subsequent pages of results by setting the pageToken query parameter to the
+   * value of the nextPageToken. (timeseries.listTimeseries)
+   *
+   * @param string $project The project ID to which this time series belongs. The
+   * value can be the numeric project ID or string-based project name.
+   * @param string $metric Metric names are protocol-free URLs as listed in the
+   * Supported Metrics page. For example,
+   * compute.googleapis.com/instance/disk/read_ops_count.
+   * @param string $youngest End of the time interval (inclusive), which is
+   * expressed as an RFC 3339 timestamp.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int count Maximum number of data points per page, which is used
+   * for pagination of results.
+   * @opt_param string timespan Length of the time interval to query, which is an
+   * alternative way to declare the interval: (youngest - timespan, youngest]. The
+   * timespan and oldest parameters should not be used together. Units: - s:
+   * second  - m: minute  - h: hour  - d: day  - w: week  Examples: 2s, 3m, 4w.
+   * Only one unit is allowed, for example: 2w3d is not allowed; you should use
+   * 17d instead.
+   *
+   * If neither oldest nor timespan is specified, the default time interval will
+   * be (youngest - 4 hours, youngest].
+   * @opt_param string aggregator The aggregation function that will reduce the
+   * data points in each window to a single point. This parameter is only valid
+   * for non-cumulative metrics with a value type of INT64 or DOUBLE.
+   * @opt_param string labels A collection of labels for the matching time series,
+   * which are represented as: - key==value: key equals the value  - key=~value:
+   * key regex matches the value  - key!=value: key does not equal the value  -
+   * key!~value: key regex does not match the value  For example, to list all of
+   * the time series descriptors for the region us-central1, you could specify:
+   * label=cloud.googleapis.com%2Flocation=~us-central1.*
+   * @opt_param string pageToken The pagination token, which is used to page
+   * through large result sets. Set this value to the value of the nextPageToken
+   * to retrieve the next page of results.
+   * @opt_param string window The sampling window. At most one data point will be
+   * returned for each window in the requested time interval. This parameter is
+   * only valid for non-cumulative metric types. Units: - m: minute  - h: hour  -
+   * d: day  - w: week  Examples: 3m, 4w. Only one unit is allowed, for example:
+   * 2w3d is not allowed; you should use 17d instead.
+   * @opt_param string oldest Start of the time interval (exclusive), which is
+   * expressed as an RFC 3339 timestamp. If neither oldest nor timespan is
+   * specified, the default time interval will be (youngest - 4 hours, youngest]
+   * @return Google_Service_CloudMonitoring_ListTimeseriesResponse
+   */
+  public function listTimeseries($project, $metric, $youngest, $optParams = array())
+  {
+    $params = array('project' => $project, 'metric' => $metric, 'youngest' => $youngest);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_CloudMonitoring_ListTimeseriesResponse");
+  }
+
+  /**
+   * Put data points to one or more time series for one or more metrics. If a time
+   * series does not exist, a new time series will be created. It is not allowed
+   * to write a time series point that is older than the existing youngest point
+   * of that time series. Points that are older than the existing youngest point
+   * of that time series will be discarded silently. Therefore, users should make
+   * sure that points of a time series are written sequentially in the order of
+   * their end time. (timeseries.write)
+   *
+   * @param string $project The project ID. The value can be the numeric project
+   * ID or string-based project name.
+   * @param Google_WriteTimeseriesRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudMonitoring_WriteTimeseriesResponse
+   */
+  public function write($project, Google_Service_CloudMonitoring_WriteTimeseriesRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('write', array($params), "Google_Service_CloudMonitoring_WriteTimeseriesResponse");
+  }
+}
+
+/**
+ * The "timeseriesDescriptors" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $cloudmonitoringService = new Google_Service_CloudMonitoring(...);
+ *   $timeseriesDescriptors = $cloudmonitoringService->timeseriesDescriptors;
+ *  </code>
+ */
+class Google_Service_CloudMonitoring_TimeseriesDescriptors_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List the descriptors of the time series that match the metric and labels
+   * values and that have data points in the interval. Large responses are
+   * paginated; use the nextPageToken returned in the response to request
+   * subsequent pages of results by setting the pageToken query parameter to the
+   * value of the nextPageToken. (timeseriesDescriptors.listTimeseriesDescriptors)
+   *
+   * @param string $project The project ID to which this time series belongs. The
+   * value can be the numeric project ID or string-based project name.
+   * @param string $metric Metric names are protocol-free URLs as listed in the
+   * Supported Metrics page. For example,
+   * compute.googleapis.com/instance/disk/read_ops_count.
+   * @param string $youngest End of the time interval (inclusive), which is
+   * expressed as an RFC 3339 timestamp.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int count Maximum number of time series descriptors per page. Used
+   * for pagination. If not specified, count = 100.
+   * @opt_param string timespan Length of the time interval to query, which is an
+   * alternative way to declare the interval: (youngest - timespan, youngest]. The
+   * timespan and oldest parameters should not be used together. Units: - s:
+   * second  - m: minute  - h: hour  - d: day  - w: week  Examples: 2s, 3m, 4w.
+   * Only one unit is allowed, for example: 2w3d is not allowed; you should use
+   * 17d instead.
+   *
+   * If neither oldest nor timespan is specified, the default time interval will
+   * be (youngest - 4 hours, youngest].
+   * @opt_param string aggregator The aggregation function that will reduce the
+   * data points in each window to a single point. This parameter is only valid
+   * for non-cumulative metrics with a value type of INT64 or DOUBLE.
+   * @opt_param string labels A collection of labels for the matching time series,
+   * which are represented as: - key==value: key equals the value  - key=~value:
+   * key regex matches the value  - key!=value: key does not equal the value  -
+   * key!~value: key regex does not match the value  For example, to list all of
+   * the time series descriptors for the region us-central1, you could specify:
+   * label=cloud.googleapis.com%2Flocation=~us-central1.*
+   * @opt_param string pageToken The pagination token, which is used to page
+   * through large result sets. Set this value to the value of the nextPageToken
+   * to retrieve the next page of results.
+   * @opt_param string window The sampling window. At most one data point will be
+   * returned for each window in the requested time interval. This parameter is
+   * only valid for non-cumulative metric types. Units: - m: minute  - h: hour  -
+   * d: day  - w: week  Examples: 3m, 4w. Only one unit is allowed, for example:
+   * 2w3d is not allowed; you should use 17d instead.
+   * @opt_param string oldest Start of the time interval (exclusive), which is
+   * expressed as an RFC 3339 timestamp. If neither oldest nor timespan is
+   * specified, the default time interval will be (youngest - 4 hours, youngest]
+   * @return Google_Service_CloudMonitoring_ListTimeseriesDescriptorsResponse
+   */
+  public function listTimeseriesDescriptors($project, $metric, $youngest, $optParams = array())
+  {
+    $params = array('project' => $project, 'metric' => $metric, 'youngest' => $youngest);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_CloudMonitoring_ListTimeseriesDescriptorsResponse");
+  }
+}
+
+
+
+
+class Google_Service_CloudMonitoring_DeleteMetricDescriptorResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_CloudMonitoring_ListMetricDescriptorsRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_CloudMonitoring_ListMetricDescriptorsResponse extends Google_Collection
+{
+  protected $collection_key = 'metrics';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $metricsType = 'Google_Service_CloudMonitoring_MetricDescriptor';
+  protected $metricsDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMetrics($metrics)
+  {
+    $this->metrics = $metrics;
+  }
+  public function getMetrics()
+  {
+    return $this->metrics;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_CloudMonitoring_ListTimeseriesDescriptorsRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_CloudMonitoring_ListTimeseriesDescriptorsResponse extends Google_Collection
+{
+  protected $collection_key = 'timeseries';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  public $oldest;
+  protected $timeseriesType = 'Google_Service_CloudMonitoring_TimeseriesDescriptor';
+  protected $timeseriesDataType = 'array';
+  public $youngest;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setOldest($oldest)
+  {
+    $this->oldest = $oldest;
+  }
+  public function getOldest()
+  {
+    return $this->oldest;
+  }
+  public function setTimeseries($timeseries)
+  {
+    $this->timeseries = $timeseries;
+  }
+  public function getTimeseries()
+  {
+    return $this->timeseries;
+  }
+  public function setYoungest($youngest)
+  {
+    $this->youngest = $youngest;
+  }
+  public function getYoungest()
+  {
+    return $this->youngest;
+  }
+}
+
+class Google_Service_CloudMonitoring_ListTimeseriesRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_CloudMonitoring_ListTimeseriesResponse extends Google_Collection
+{
+  protected $collection_key = 'timeseries';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  public $oldest;
+  protected $timeseriesType = 'Google_Service_CloudMonitoring_Timeseries';
+  protected $timeseriesDataType = 'array';
+  public $youngest;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setOldest($oldest)
+  {
+    $this->oldest = $oldest;
+  }
+  public function getOldest()
+  {
+    return $this->oldest;
+  }
+  public function setTimeseries($timeseries)
+  {
+    $this->timeseries = $timeseries;
+  }
+  public function getTimeseries()
+  {
+    return $this->timeseries;
+  }
+  public function setYoungest($youngest)
+  {
+    $this->youngest = $youngest;
+  }
+  public function getYoungest()
+  {
+    return $this->youngest;
+  }
+}
+
+class Google_Service_CloudMonitoring_MetricDescriptor extends Google_Collection
+{
+  protected $collection_key = 'labels';
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  protected $labelsType = 'Google_Service_CloudMonitoring_MetricDescriptorLabelDescriptor';
+  protected $labelsDataType = 'array';
+  public $name;
+  public $project;
+  protected $typeDescriptorType = 'Google_Service_CloudMonitoring_MetricDescriptorTypeDescriptor';
+  protected $typeDescriptorDataType = '';
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setLabels($labels)
+  {
+    $this->labels = $labels;
+  }
+  public function getLabels()
+  {
+    return $this->labels;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProject($project)
+  {
+    $this->project = $project;
+  }
+  public function getProject()
+  {
+    return $this->project;
+  }
+  public function setTypeDescriptor(Google_Service_CloudMonitoring_MetricDescriptorTypeDescriptor $typeDescriptor)
+  {
+    $this->typeDescriptor = $typeDescriptor;
+  }
+  public function getTypeDescriptor()
+  {
+    return $this->typeDescriptor;
+  }
+}
+
+class Google_Service_CloudMonitoring_MetricDescriptorLabelDescriptor extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $key;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+}
+
+class Google_Service_CloudMonitoring_MetricDescriptorTypeDescriptor extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $metricType;
+  public $valueType;
+
+
+  public function setMetricType($metricType)
+  {
+    $this->metricType = $metricType;
+  }
+  public function getMetricType()
+  {
+    return $this->metricType;
+  }
+  public function setValueType($valueType)
+  {
+    $this->valueType = $valueType;
+  }
+  public function getValueType()
+  {
+    return $this->valueType;
+  }
+}
+
+class Google_Service_CloudMonitoring_Point extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $boolValue;
+  protected $distributionValueType = 'Google_Service_CloudMonitoring_PointDistribution';
+  protected $distributionValueDataType = '';
+  public $doubleValue;
+  public $end;
+  public $int64Value;
+  public $start;
+  public $stringValue;
+
+
+  public function setBoolValue($boolValue)
+  {
+    $this->boolValue = $boolValue;
+  }
+  public function getBoolValue()
+  {
+    return $this->boolValue;
+  }
+  public function setDistributionValue(Google_Service_CloudMonitoring_PointDistribution $distributionValue)
+  {
+    $this->distributionValue = $distributionValue;
+  }
+  public function getDistributionValue()
+  {
+    return $this->distributionValue;
+  }
+  public function setDoubleValue($doubleValue)
+  {
+    $this->doubleValue = $doubleValue;
+  }
+  public function getDoubleValue()
+  {
+    return $this->doubleValue;
+  }
+  public function setEnd($end)
+  {
+    $this->end = $end;
+  }
+  public function getEnd()
+  {
+    return $this->end;
+  }
+  public function setInt64Value($int64Value)
+  {
+    $this->int64Value = $int64Value;
+  }
+  public function getInt64Value()
+  {
+    return $this->int64Value;
+  }
+  public function setStart($start)
+  {
+    $this->start = $start;
+  }
+  public function getStart()
+  {
+    return $this->start;
+  }
+  public function setStringValue($stringValue)
+  {
+    $this->stringValue = $stringValue;
+  }
+  public function getStringValue()
+  {
+    return $this->stringValue;
+  }
+}
+
+class Google_Service_CloudMonitoring_PointDistribution extends Google_Collection
+{
+  protected $collection_key = 'buckets';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $bucketsType = 'Google_Service_CloudMonitoring_PointDistributionBucket';
+  protected $bucketsDataType = 'array';
+  protected $overflowBucketType = 'Google_Service_CloudMonitoring_PointDistributionOverflowBucket';
+  protected $overflowBucketDataType = '';
+  protected $underflowBucketType = 'Google_Service_CloudMonitoring_PointDistributionUnderflowBucket';
+  protected $underflowBucketDataType = '';
+
+
+  public function setBuckets($buckets)
+  {
+    $this->buckets = $buckets;
+  }
+  public function getBuckets()
+  {
+    return $this->buckets;
+  }
+  public function setOverflowBucket(Google_Service_CloudMonitoring_PointDistributionOverflowBucket $overflowBucket)
+  {
+    $this->overflowBucket = $overflowBucket;
+  }
+  public function getOverflowBucket()
+  {
+    return $this->overflowBucket;
+  }
+  public function setUnderflowBucket(Google_Service_CloudMonitoring_PointDistributionUnderflowBucket $underflowBucket)
+  {
+    $this->underflowBucket = $underflowBucket;
+  }
+  public function getUnderflowBucket()
+  {
+    return $this->underflowBucket;
+  }
+}
+
+class Google_Service_CloudMonitoring_PointDistributionBucket extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $count;
+  public $lowerBound;
+  public $upperBound;
+
+
+  public function setCount($count)
+  {
+    $this->count = $count;
+  }
+  public function getCount()
+  {
+    return $this->count;
+  }
+  public function setLowerBound($lowerBound)
+  {
+    $this->lowerBound = $lowerBound;
+  }
+  public function getLowerBound()
+  {
+    return $this->lowerBound;
+  }
+  public function setUpperBound($upperBound)
+  {
+    $this->upperBound = $upperBound;
+  }
+  public function getUpperBound()
+  {
+    return $this->upperBound;
+  }
+}
+
+class Google_Service_CloudMonitoring_PointDistributionOverflowBucket extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $count;
+  public $lowerBound;
+
+
+  public function setCount($count)
+  {
+    $this->count = $count;
+  }
+  public function getCount()
+  {
+    return $this->count;
+  }
+  public function setLowerBound($lowerBound)
+  {
+    $this->lowerBound = $lowerBound;
+  }
+  public function getLowerBound()
+  {
+    return $this->lowerBound;
+  }
+}
+
+class Google_Service_CloudMonitoring_PointDistributionUnderflowBucket extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $count;
+  public $upperBound;
+
+
+  public function setCount($count)
+  {
+    $this->count = $count;
+  }
+  public function getCount()
+  {
+    return $this->count;
+  }
+  public function setUpperBound($upperBound)
+  {
+    $this->upperBound = $upperBound;
+  }
+  public function getUpperBound()
+  {
+    return $this->upperBound;
+  }
+}
+
+class Google_Service_CloudMonitoring_Timeseries extends Google_Collection
+{
+  protected $collection_key = 'points';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $pointsType = 'Google_Service_CloudMonitoring_Point';
+  protected $pointsDataType = 'array';
+  protected $timeseriesDescType = 'Google_Service_CloudMonitoring_TimeseriesDescriptor';
+  protected $timeseriesDescDataType = '';
+
+
+  public function setPoints($points)
+  {
+    $this->points = $points;
+  }
+  public function getPoints()
+  {
+    return $this->points;
+  }
+  public function setTimeseriesDesc(Google_Service_CloudMonitoring_TimeseriesDescriptor $timeseriesDesc)
+  {
+    $this->timeseriesDesc = $timeseriesDesc;
+  }
+  public function getTimeseriesDesc()
+  {
+    return $this->timeseriesDesc;
+  }
+}
+
+class Google_Service_CloudMonitoring_TimeseriesDescriptor extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $labels;
+  public $metric;
+  public $project;
+
+
+  public function setLabels($labels)
+  {
+    $this->labels = $labels;
+  }
+  public function getLabels()
+  {
+    return $this->labels;
+  }
+  public function setMetric($metric)
+  {
+    $this->metric = $metric;
+  }
+  public function getMetric()
+  {
+    return $this->metric;
+  }
+  public function setProject($project)
+  {
+    $this->project = $project;
+  }
+  public function getProject()
+  {
+    return $this->project;
+  }
+}
+
+class Google_Service_CloudMonitoring_TimeseriesDescriptorLabel extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_CloudMonitoring_TimeseriesDescriptorLabels extends Google_Model
+{
+}
+
+class Google_Service_CloudMonitoring_TimeseriesPoint extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $pointType = 'Google_Service_CloudMonitoring_Point';
+  protected $pointDataType = '';
+  protected $timeseriesDescType = 'Google_Service_CloudMonitoring_TimeseriesDescriptor';
+  protected $timeseriesDescDataType = '';
+
+
+  public function setPoint(Google_Service_CloudMonitoring_Point $point)
+  {
+    $this->point = $point;
+  }
+  public function getPoint()
+  {
+    return $this->point;
+  }
+  public function setTimeseriesDesc(Google_Service_CloudMonitoring_TimeseriesDescriptor $timeseriesDesc)
+  {
+    $this->timeseriesDesc = $timeseriesDesc;
+  }
+  public function getTimeseriesDesc()
+  {
+    return $this->timeseriesDesc;
+  }
+}
+
+class Google_Service_CloudMonitoring_WriteTimeseriesRequest extends Google_Collection
+{
+  protected $collection_key = 'timeseries';
+  protected $internal_gapi_mappings = array(
+  );
+  public $commonLabels;
+  protected $timeseriesType = 'Google_Service_CloudMonitoring_TimeseriesPoint';
+  protected $timeseriesDataType = 'array';
+
+
+  public function setCommonLabels($commonLabels)
+  {
+    $this->commonLabels = $commonLabels;
+  }
+  public function getCommonLabels()
+  {
+    return $this->commonLabels;
+  }
+  public function setTimeseries($timeseries)
+  {
+    $this->timeseries = $timeseries;
+  }
+  public function getTimeseries()
+  {
+    return $this->timeseries;
+  }
+}
+
+class Google_Service_CloudMonitoring_WriteTimeseriesRequestCommonLabels extends Google_Model
+{
+}
+
+class Google_Service_CloudMonitoring_WriteTimeseriesResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/CloudUserAccounts.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/CloudUserAccounts.php
@@ -1,0 +1,2285 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for CloudUserAccounts (vm_alpha).
+ *
+ * <p>
+ * API for the Google Cloud User Accounts service.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://cloud.google.com/compute/docs/access/user-accounts/api/latest/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_CloudUserAccounts extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+  /** View your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM_READ_ONLY =
+      "https://www.googleapis.com/auth/cloud-platform.read-only";
+  /** Manage your Google Cloud User Accounts. */
+  const CLOUD_USERACCOUNTS =
+      "https://www.googleapis.com/auth/cloud.useraccounts";
+  /** View your Google Cloud User Accounts. */
+  const CLOUD_USERACCOUNTS_READONLY =
+      "https://www.googleapis.com/auth/cloud.useraccounts.readonly";
+
+  public $globalAccountsOperations;
+  public $groups;
+  public $linux;
+  public $users;
+  
+
+  /**
+   * Constructs the internal representation of the CloudUserAccounts service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'clouduseraccounts/vm_alpha/projects/';
+    $this->version = 'vm_alpha';
+    $this->serviceName = 'clouduseraccounts';
+
+    $this->globalAccountsOperations = new Google_Service_CloudUserAccounts_GlobalAccountsOperations_Resource(
+        $this,
+        $this->serviceName,
+        'globalAccountsOperations',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/global/operations/{operation}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operation' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/operations/{operation}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operation' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/operations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->groups = new Google_Service_CloudUserAccounts_Groups_Resource(
+        $this,
+        $this->serviceName,
+        'groups',
+        array(
+          'methods' => array(
+            'addMember' => array(
+              'path' => '{project}/global/groups/{groupName}/addMember',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'groupName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/global/groups/{groupName}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'groupName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/groups/{groupName}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'groupName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getIamPolicy' => array(
+              'path' => '{project}/global/groups/{resource}/getIamPolicy',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'resource' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/groups',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/groups',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'removeMember' => array(
+              'path' => '{project}/global/groups/{groupName}/removeMember',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'groupName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setIamPolicy' => array(
+              'path' => '{project}/global/groups/{resource}/setIamPolicy',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'resource' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'testIamPermissions' => array(
+              'path' => '{project}/global/groups/{resource}/testIamPermissions',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'resource' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->linux = new Google_Service_CloudUserAccounts_Linux_Resource(
+        $this,
+        $this->serviceName,
+        'linux',
+        array(
+          'methods' => array(
+            'getAuthorizedKeysView' => array(
+              'path' => '{project}/zones/{zone}/authorizedKeysView/{user}',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'user' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'login' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'getLinuxAccountViews' => array(
+              'path' => '{project}/zones/{zone}/linuxAccountViews',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->users = new Google_Service_CloudUserAccounts_Users_Resource(
+        $this,
+        $this->serviceName,
+        'users',
+        array(
+          'methods' => array(
+            'addPublicKey' => array(
+              'path' => '{project}/global/users/{user}/addPublicKey',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'user' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/global/users/{user}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'user' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/users/{user}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'user' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getIamPolicy' => array(
+              'path' => '{project}/global/users/{resource}/getIamPolicy',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'resource' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/users',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/users',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'removePublicKey' => array(
+              'path' => '{project}/global/users/{user}/removePublicKey',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'user' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'fingerprint' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setIamPolicy' => array(
+              'path' => '{project}/global/users/{resource}/setIamPolicy',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'resource' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'testIamPermissions' => array(
+              'path' => '{project}/global/users/{resource}/testIamPermissions',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'resource' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "globalAccountsOperations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $clouduseraccountsService = new Google_Service_CloudUserAccounts(...);
+ *   $globalAccountsOperations = $clouduseraccountsService->globalAccountsOperations;
+ *  </code>
+ */
+class Google_Service_CloudUserAccounts_GlobalAccountsOperations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified operation resource. (globalAccountsOperations.delete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $operation Name of the Operations resource to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($project, $operation, $optParams = array())
+  {
+    $params = array('project' => $project, 'operation' => $operation);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves the specified operation resource. (globalAccountsOperations.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $operation Name of the Operations resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudUserAccounts_Operation
+   */
+  public function get($project, $operation, $optParams = array())
+  {
+    $params = array('project' => $project, 'operation' => $operation);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_CloudUserAccounts_Operation");
+  }
+
+  /**
+   * Retrieves the list of operation resources contained within the specified
+   * project. (globalAccountsOperations.listGlobalAccountsOperations)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string orderBy Sorts list results by a certain order. By default,
+   * results are returned in alphanumerical order based on the resource name.
+   *
+   * You can also sort results in descending order based on the creation timestamp
+   * using orderBy="creationTimestamp desc". This sorts results based on the
+   * creationTimestamp field in reverse chronological order (newest result first).
+   * Use this to sort resources like operations so that the newest operation is
+   * returned first.
+   *
+   * Currently, only sorting by name or creationTimestamp desc is supported.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @return Google_Service_CloudUserAccounts_OperationList
+   */
+  public function listGlobalAccountsOperations($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_CloudUserAccounts_OperationList");
+  }
+}
+
+/**
+ * The "groups" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $clouduseraccountsService = new Google_Service_CloudUserAccounts(...);
+ *   $groups = $clouduseraccountsService->groups;
+ *  </code>
+ */
+class Google_Service_CloudUserAccounts_Groups_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Adds users to the specified group. (groups.addMember)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $groupName Name of the group for this request.
+   * @param Google_GroupsAddMemberRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudUserAccounts_Operation
+   */
+  public function addMember($project, $groupName, Google_Service_CloudUserAccounts_GroupsAddMemberRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'groupName' => $groupName, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('addMember', array($params), "Google_Service_CloudUserAccounts_Operation");
+  }
+
+  /**
+   * Deletes the specified Group resource. (groups.delete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $groupName Name of the Group resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudUserAccounts_Operation
+   */
+  public function delete($project, $groupName, $optParams = array())
+  {
+    $params = array('project' => $project, 'groupName' => $groupName);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_CloudUserAccounts_Operation");
+  }
+
+  /**
+   * Returns the specified Group resource. (groups.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $groupName Name of the Group resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudUserAccounts_Group
+   */
+  public function get($project, $groupName, $optParams = array())
+  {
+    $params = array('project' => $project, 'groupName' => $groupName);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_CloudUserAccounts_Group");
+  }
+
+  /**
+   * Gets the access control policy for a resource. May be empty if no such policy
+   * or resource exists. (groups.getIamPolicy)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $resource Name of the resource for this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudUserAccounts_Policy
+   */
+  public function getIamPolicy($project, $resource, $optParams = array())
+  {
+    $params = array('project' => $project, 'resource' => $resource);
+    $params = array_merge($params, $optParams);
+    return $this->call('getIamPolicy', array($params), "Google_Service_CloudUserAccounts_Policy");
+  }
+
+  /**
+   * Creates a Group resource in the specified project using the data included in
+   * the request. (groups.insert)
+   *
+   * @param string $project Project ID for this request.
+   * @param Google_Group $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudUserAccounts_Operation
+   */
+  public function insert($project, Google_Service_CloudUserAccounts_Group $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_CloudUserAccounts_Operation");
+  }
+
+  /**
+   * Retrieves the list of groups contained within the specified project.
+   * (groups.listGroups)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string orderBy Sorts list results by a certain order. By default,
+   * results are returned in alphanumerical order based on the resource name.
+   *
+   * You can also sort results in descending order based on the creation timestamp
+   * using orderBy="creationTimestamp desc". This sorts results based on the
+   * creationTimestamp field in reverse chronological order (newest result first).
+   * Use this to sort resources like operations so that the newest operation is
+   * returned first.
+   *
+   * Currently, only sorting by name or creationTimestamp desc is supported.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @return Google_Service_CloudUserAccounts_GroupList
+   */
+  public function listGroups($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_CloudUserAccounts_GroupList");
+  }
+
+  /**
+   * Removes users from the specified group. (groups.removeMember)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $groupName Name of the group for this request.
+   * @param Google_GroupsRemoveMemberRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudUserAccounts_Operation
+   */
+  public function removeMember($project, $groupName, Google_Service_CloudUserAccounts_GroupsRemoveMemberRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'groupName' => $groupName, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('removeMember', array($params), "Google_Service_CloudUserAccounts_Operation");
+  }
+
+  /**
+   * Sets the access control policy on the specified resource. Replaces any
+   * existing policy. (groups.setIamPolicy)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $resource Name of the resource for this request.
+   * @param Google_Policy $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudUserAccounts_Policy
+   */
+  public function setIamPolicy($project, $resource, Google_Service_CloudUserAccounts_Policy $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'resource' => $resource, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setIamPolicy', array($params), "Google_Service_CloudUserAccounts_Policy");
+  }
+
+  /**
+   * Returns permissions that a caller has on the specified resource.
+   * (groups.testIamPermissions)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $resource Name of the resource for this request.
+   * @param Google_TestPermissionsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudUserAccounts_TestPermissionsResponse
+   */
+  public function testIamPermissions($project, $resource, Google_Service_CloudUserAccounts_TestPermissionsRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'resource' => $resource, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('testIamPermissions', array($params), "Google_Service_CloudUserAccounts_TestPermissionsResponse");
+  }
+}
+
+/**
+ * The "linux" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $clouduseraccountsService = new Google_Service_CloudUserAccounts(...);
+ *   $linux = $clouduseraccountsService->linux;
+ *  </code>
+ */
+class Google_Service_CloudUserAccounts_Linux_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns a list of authorized public keys for a specific user account.
+   * (linux.getAuthorizedKeysView)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone Name of the zone for this request.
+   * @param string $user The user account for which you want to get a list of
+   * authorized public keys.
+   * @param string $instance The fully-qualified URL of the virtual machine
+   * requesting the view.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool login Whether the view was requested as part of a user-
+   * initiated login.
+   * @return Google_Service_CloudUserAccounts_LinuxGetAuthorizedKeysViewResponse
+   */
+  public function getAuthorizedKeysView($project, $zone, $user, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'user' => $user, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('getAuthorizedKeysView', array($params), "Google_Service_CloudUserAccounts_LinuxGetAuthorizedKeysViewResponse");
+  }
+
+  /**
+   * Retrieves a list of user accounts for an instance within a specific project.
+   * (linux.getLinuxAccountViews)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone Name of the zone for this request.
+   * @param string $instance The fully-qualified URL of the virtual machine
+   * requesting the views.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderBy Sorts list results by a certain order. By default,
+   * results are returned in alphanumerical order based on the resource name.
+   *
+   * You can also sort results in descending order based on the creation timestamp
+   * using orderBy="creationTimestamp desc". This sorts results based on the
+   * creationTimestamp field in reverse chronological order (newest result first).
+   * Use this to sort resources like operations so that the newest operation is
+   * returned first.
+   *
+   * Currently, only sorting by name or creationTimestamp desc is supported.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @return Google_Service_CloudUserAccounts_LinuxGetLinuxAccountViewsResponse
+   */
+  public function getLinuxAccountViews($project, $zone, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('getLinuxAccountViews', array($params), "Google_Service_CloudUserAccounts_LinuxGetLinuxAccountViewsResponse");
+  }
+}
+
+/**
+ * The "users" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $clouduseraccountsService = new Google_Service_CloudUserAccounts(...);
+ *   $users = $clouduseraccountsService->users;
+ *  </code>
+ */
+class Google_Service_CloudUserAccounts_Users_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Adds a public key to the specified User resource with the data included in
+   * the request. (users.addPublicKey)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $user Name of the user for this request.
+   * @param Google_PublicKey $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudUserAccounts_Operation
+   */
+  public function addPublicKey($project, $user, Google_Service_CloudUserAccounts_PublicKey $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'user' => $user, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('addPublicKey', array($params), "Google_Service_CloudUserAccounts_Operation");
+  }
+
+  /**
+   * Deletes the specified User resource. (users.delete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $user Name of the user resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudUserAccounts_Operation
+   */
+  public function delete($project, $user, $optParams = array())
+  {
+    $params = array('project' => $project, 'user' => $user);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_CloudUserAccounts_Operation");
+  }
+
+  /**
+   * Returns the specified User resource. (users.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $user Name of the user resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudUserAccounts_User
+   */
+  public function get($project, $user, $optParams = array())
+  {
+    $params = array('project' => $project, 'user' => $user);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_CloudUserAccounts_User");
+  }
+
+  /**
+   * Gets the access control policy for a resource. May be empty if no such policy
+   * or resource exists. (users.getIamPolicy)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $resource Name of the resource for this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudUserAccounts_Policy
+   */
+  public function getIamPolicy($project, $resource, $optParams = array())
+  {
+    $params = array('project' => $project, 'resource' => $resource);
+    $params = array_merge($params, $optParams);
+    return $this->call('getIamPolicy', array($params), "Google_Service_CloudUserAccounts_Policy");
+  }
+
+  /**
+   * Creates a User resource in the specified project using the data included in
+   * the request. (users.insert)
+   *
+   * @param string $project Project ID for this request.
+   * @param Google_User $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudUserAccounts_Operation
+   */
+  public function insert($project, Google_Service_CloudUserAccounts_User $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_CloudUserAccounts_Operation");
+  }
+
+  /**
+   * Retrieves a list of users contained within the specified project.
+   * (users.listUsers)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string orderBy Sorts list results by a certain order. By default,
+   * results are returned in alphanumerical order based on the resource name.
+   *
+   * You can also sort results in descending order based on the creation timestamp
+   * using orderBy="creationTimestamp desc". This sorts results based on the
+   * creationTimestamp field in reverse chronological order (newest result first).
+   * Use this to sort resources like operations so that the newest operation is
+   * returned first.
+   *
+   * Currently, only sorting by name or creationTimestamp desc is supported.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @return Google_Service_CloudUserAccounts_UserList
+   */
+  public function listUsers($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_CloudUserAccounts_UserList");
+  }
+
+  /**
+   * Removes the specified public key from the user. (users.removePublicKey)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $user Name of the user for this request.
+   * @param string $fingerprint The fingerprint of the public key to delete.
+   * Public keys are identified by their fingerprint, which is defined by RFC4716
+   * to be the MD5 digest of the public key.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudUserAccounts_Operation
+   */
+  public function removePublicKey($project, $user, $fingerprint, $optParams = array())
+  {
+    $params = array('project' => $project, 'user' => $user, 'fingerprint' => $fingerprint);
+    $params = array_merge($params, $optParams);
+    return $this->call('removePublicKey', array($params), "Google_Service_CloudUserAccounts_Operation");
+  }
+
+  /**
+   * Sets the access control policy on the specified resource. Replaces any
+   * existing policy. (users.setIamPolicy)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $resource Name of the resource for this request.
+   * @param Google_Policy $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudUserAccounts_Policy
+   */
+  public function setIamPolicy($project, $resource, Google_Service_CloudUserAccounts_Policy $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'resource' => $resource, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setIamPolicy', array($params), "Google_Service_CloudUserAccounts_Policy");
+  }
+
+  /**
+   * Returns permissions that a caller has on the specified resource.
+   * (users.testIamPermissions)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $resource Name of the resource for this request.
+   * @param Google_TestPermissionsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_CloudUserAccounts_TestPermissionsResponse
+   */
+  public function testIamPermissions($project, $resource, Google_Service_CloudUserAccounts_TestPermissionsRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'resource' => $resource, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('testIamPermissions', array($params), "Google_Service_CloudUserAccounts_TestPermissionsResponse");
+  }
+}
+
+
+
+
+class Google_Service_CloudUserAccounts_AuthorizedKeysView extends Google_Collection
+{
+  protected $collection_key = 'keys';
+  protected $internal_gapi_mappings = array(
+  );
+  public $keys;
+  public $sudoer;
+
+
+  public function setKeys($keys)
+  {
+    $this->keys = $keys;
+  }
+  public function getKeys()
+  {
+    return $this->keys;
+  }
+  public function setSudoer($sudoer)
+  {
+    $this->sudoer = $sudoer;
+  }
+  public function getSudoer()
+  {
+    return $this->sudoer;
+  }
+}
+
+class Google_Service_CloudUserAccounts_Binding extends Google_Collection
+{
+  protected $collection_key = 'members';
+  protected $internal_gapi_mappings = array(
+  );
+  public $members;
+  public $role;
+
+
+  public function setMembers($members)
+  {
+    $this->members = $members;
+  }
+  public function getMembers()
+  {
+    return $this->members;
+  }
+  public function setRole($role)
+  {
+    $this->role = $role;
+  }
+  public function getRole()
+  {
+    return $this->role;
+  }
+}
+
+class Google_Service_CloudUserAccounts_Condition extends Google_Collection
+{
+  protected $collection_key = 'values';
+  protected $internal_gapi_mappings = array(
+  );
+  public $iam;
+  public $op;
+  public $svc;
+  public $sys;
+  public $value;
+  public $values;
+
+
+  public function setIam($iam)
+  {
+    $this->iam = $iam;
+  }
+  public function getIam()
+  {
+    return $this->iam;
+  }
+  public function setOp($op)
+  {
+    $this->op = $op;
+  }
+  public function getOp()
+  {
+    return $this->op;
+  }
+  public function setSvc($svc)
+  {
+    $this->svc = $svc;
+  }
+  public function getSvc()
+  {
+    return $this->svc;
+  }
+  public function setSys($sys)
+  {
+    $this->sys = $sys;
+  }
+  public function getSys()
+  {
+    return $this->sys;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+  public function setValues($values)
+  {
+    $this->values = $values;
+  }
+  public function getValues()
+  {
+    return $this->values;
+  }
+}
+
+class Google_Service_CloudUserAccounts_Group extends Google_Collection
+{
+  protected $collection_key = 'members';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $description;
+  public $id;
+  public $kind;
+  public $members;
+  public $name;
+  public $selfLink;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMembers($members)
+  {
+    $this->members = $members;
+  }
+  public function getMembers()
+  {
+    return $this->members;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_CloudUserAccounts_GroupList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_CloudUserAccounts_Group';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_CloudUserAccounts_GroupsAddMemberRequest extends Google_Collection
+{
+  protected $collection_key = 'users';
+  protected $internal_gapi_mappings = array(
+  );
+  public $users;
+
+
+  public function setUsers($users)
+  {
+    $this->users = $users;
+  }
+  public function getUsers()
+  {
+    return $this->users;
+  }
+}
+
+class Google_Service_CloudUserAccounts_GroupsRemoveMemberRequest extends Google_Collection
+{
+  protected $collection_key = 'users';
+  protected $internal_gapi_mappings = array(
+  );
+  public $users;
+
+
+  public function setUsers($users)
+  {
+    $this->users = $users;
+  }
+  public function getUsers()
+  {
+    return $this->users;
+  }
+}
+
+class Google_Service_CloudUserAccounts_LinuxAccountViews extends Google_Collection
+{
+  protected $collection_key = 'userViews';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $groupViewsType = 'Google_Service_CloudUserAccounts_LinuxGroupView';
+  protected $groupViewsDataType = 'array';
+  public $kind;
+  protected $userViewsType = 'Google_Service_CloudUserAccounts_LinuxUserView';
+  protected $userViewsDataType = 'array';
+
+
+  public function setGroupViews($groupViews)
+  {
+    $this->groupViews = $groupViews;
+  }
+  public function getGroupViews()
+  {
+    return $this->groupViews;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUserViews($userViews)
+  {
+    $this->userViews = $userViews;
+  }
+  public function getUserViews()
+  {
+    return $this->userViews;
+  }
+}
+
+class Google_Service_CloudUserAccounts_LinuxGetAuthorizedKeysViewResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $resourceType = 'Google_Service_CloudUserAccounts_AuthorizedKeysView';
+  protected $resourceDataType = '';
+
+
+  public function setResource(Google_Service_CloudUserAccounts_AuthorizedKeysView $resource)
+  {
+    $this->resource = $resource;
+  }
+  public function getResource()
+  {
+    return $this->resource;
+  }
+}
+
+class Google_Service_CloudUserAccounts_LinuxGetLinuxAccountViewsResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $resourceType = 'Google_Service_CloudUserAccounts_LinuxAccountViews';
+  protected $resourceDataType = '';
+
+
+  public function setResource(Google_Service_CloudUserAccounts_LinuxAccountViews $resource)
+  {
+    $this->resource = $resource;
+  }
+  public function getResource()
+  {
+    return $this->resource;
+  }
+}
+
+class Google_Service_CloudUserAccounts_LinuxGroupView extends Google_Collection
+{
+  protected $collection_key = 'members';
+  protected $internal_gapi_mappings = array(
+  );
+  public $gid;
+  public $groupName;
+  public $members;
+
+
+  public function setGid($gid)
+  {
+    $this->gid = $gid;
+  }
+  public function getGid()
+  {
+    return $this->gid;
+  }
+  public function setGroupName($groupName)
+  {
+    $this->groupName = $groupName;
+  }
+  public function getGroupName()
+  {
+    return $this->groupName;
+  }
+  public function setMembers($members)
+  {
+    $this->members = $members;
+  }
+  public function getMembers()
+  {
+    return $this->members;
+  }
+}
+
+class Google_Service_CloudUserAccounts_LinuxUserView extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $gecos;
+  public $gid;
+  public $homeDirectory;
+  public $shell;
+  public $uid;
+  public $username;
+
+
+  public function setGecos($gecos)
+  {
+    $this->gecos = $gecos;
+  }
+  public function getGecos()
+  {
+    return $this->gecos;
+  }
+  public function setGid($gid)
+  {
+    $this->gid = $gid;
+  }
+  public function getGid()
+  {
+    return $this->gid;
+  }
+  public function setHomeDirectory($homeDirectory)
+  {
+    $this->homeDirectory = $homeDirectory;
+  }
+  public function getHomeDirectory()
+  {
+    return $this->homeDirectory;
+  }
+  public function setShell($shell)
+  {
+    $this->shell = $shell;
+  }
+  public function getShell()
+  {
+    return $this->shell;
+  }
+  public function setUid($uid)
+  {
+    $this->uid = $uid;
+  }
+  public function getUid()
+  {
+    return $this->uid;
+  }
+  public function setUsername($username)
+  {
+    $this->username = $username;
+  }
+  public function getUsername()
+  {
+    return $this->username;
+  }
+}
+
+class Google_Service_CloudUserAccounts_LogConfig extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $counterType = 'Google_Service_CloudUserAccounts_LogConfigCounterOptions';
+  protected $counterDataType = '';
+
+
+  public function setCounter(Google_Service_CloudUserAccounts_LogConfigCounterOptions $counter)
+  {
+    $this->counter = $counter;
+  }
+  public function getCounter()
+  {
+    return $this->counter;
+  }
+}
+
+class Google_Service_CloudUserAccounts_LogConfigCounterOptions extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $field;
+  public $metric;
+
+
+  public function setField($field)
+  {
+    $this->field = $field;
+  }
+  public function getField()
+  {
+    return $this->field;
+  }
+  public function setMetric($metric)
+  {
+    $this->metric = $metric;
+  }
+  public function getMetric()
+  {
+    return $this->metric;
+  }
+}
+
+class Google_Service_CloudUserAccounts_Operation extends Google_Collection
+{
+  protected $collection_key = 'warnings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $clientOperationId;
+  public $creationTimestamp;
+  public $endTime;
+  protected $errorType = 'Google_Service_CloudUserAccounts_OperationError';
+  protected $errorDataType = '';
+  public $httpErrorMessage;
+  public $httpErrorStatusCode;
+  public $id;
+  public $insertTime;
+  public $kind;
+  public $name;
+  public $operationType;
+  public $progress;
+  public $region;
+  public $selfLink;
+  public $startTime;
+  public $status;
+  public $statusMessage;
+  public $targetId;
+  public $targetLink;
+  public $user;
+  protected $warningsType = 'Google_Service_CloudUserAccounts_OperationWarnings';
+  protected $warningsDataType = 'array';
+  public $zone;
+
+
+  public function setClientOperationId($clientOperationId)
+  {
+    $this->clientOperationId = $clientOperationId;
+  }
+  public function getClientOperationId()
+  {
+    return $this->clientOperationId;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setError(Google_Service_CloudUserAccounts_OperationError $error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setHttpErrorMessage($httpErrorMessage)
+  {
+    $this->httpErrorMessage = $httpErrorMessage;
+  }
+  public function getHttpErrorMessage()
+  {
+    return $this->httpErrorMessage;
+  }
+  public function setHttpErrorStatusCode($httpErrorStatusCode)
+  {
+    $this->httpErrorStatusCode = $httpErrorStatusCode;
+  }
+  public function getHttpErrorStatusCode()
+  {
+    return $this->httpErrorStatusCode;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInsertTime($insertTime)
+  {
+    $this->insertTime = $insertTime;
+  }
+  public function getInsertTime()
+  {
+    return $this->insertTime;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOperationType($operationType)
+  {
+    $this->operationType = $operationType;
+  }
+  public function getOperationType()
+  {
+    return $this->operationType;
+  }
+  public function setProgress($progress)
+  {
+    $this->progress = $progress;
+  }
+  public function getProgress()
+  {
+    return $this->progress;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setStatusMessage($statusMessage)
+  {
+    $this->statusMessage = $statusMessage;
+  }
+  public function getStatusMessage()
+  {
+    return $this->statusMessage;
+  }
+  public function setTargetId($targetId)
+  {
+    $this->targetId = $targetId;
+  }
+  public function getTargetId()
+  {
+    return $this->targetId;
+  }
+  public function setTargetLink($targetLink)
+  {
+    $this->targetLink = $targetLink;
+  }
+  public function getTargetLink()
+  {
+    return $this->targetLink;
+  }
+  public function setUser($user)
+  {
+    $this->user = $user;
+  }
+  public function getUser()
+  {
+    return $this->user;
+  }
+  public function setWarnings($warnings)
+  {
+    $this->warnings = $warnings;
+  }
+  public function getWarnings()
+  {
+    return $this->warnings;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_CloudUserAccounts_OperationError extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorsType = 'Google_Service_CloudUserAccounts_OperationErrorErrors';
+  protected $errorsDataType = 'array';
+
+
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+}
+
+class Google_Service_CloudUserAccounts_OperationErrorErrors extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $location;
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_CloudUserAccounts_OperationList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_CloudUserAccounts_Operation';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_CloudUserAccounts_OperationWarnings extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_CloudUserAccounts_OperationWarningsData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_CloudUserAccounts_OperationWarningsData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_CloudUserAccounts_Policy extends Google_Collection
+{
+  protected $collection_key = 'rules';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $bindingsType = 'Google_Service_CloudUserAccounts_Binding';
+  protected $bindingsDataType = 'array';
+  public $etag;
+  protected $rulesType = 'Google_Service_CloudUserAccounts_Rule';
+  protected $rulesDataType = 'array';
+  public $version;
+
+
+  public function setBindings($bindings)
+  {
+    $this->bindings = $bindings;
+  }
+  public function getBindings()
+  {
+    return $this->bindings;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setRules($rules)
+  {
+    $this->rules = $rules;
+  }
+  public function getRules()
+  {
+    return $this->rules;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_CloudUserAccounts_PublicKey extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $description;
+  public $expirationTimestamp;
+  public $fingerprint;
+  public $key;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setExpirationTimestamp($expirationTimestamp)
+  {
+    $this->expirationTimestamp = $expirationTimestamp;
+  }
+  public function getExpirationTimestamp()
+  {
+    return $this->expirationTimestamp;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+}
+
+class Google_Service_CloudUserAccounts_Rule extends Google_Collection
+{
+  protected $collection_key = 'permissions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $action;
+  protected $conditionsType = 'Google_Service_CloudUserAccounts_Condition';
+  protected $conditionsDataType = 'array';
+  public $description;
+  public $ins;
+  protected $logConfigsType = 'Google_Service_CloudUserAccounts_LogConfig';
+  protected $logConfigsDataType = 'array';
+  public $notIns;
+  public $permissions;
+
+
+  public function setAction($action)
+  {
+    $this->action = $action;
+  }
+  public function getAction()
+  {
+    return $this->action;
+  }
+  public function setConditions($conditions)
+  {
+    $this->conditions = $conditions;
+  }
+  public function getConditions()
+  {
+    return $this->conditions;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setIns($ins)
+  {
+    $this->ins = $ins;
+  }
+  public function getIns()
+  {
+    return $this->ins;
+  }
+  public function setLogConfigs($logConfigs)
+  {
+    $this->logConfigs = $logConfigs;
+  }
+  public function getLogConfigs()
+  {
+    return $this->logConfigs;
+  }
+  public function setNotIns($notIns)
+  {
+    $this->notIns = $notIns;
+  }
+  public function getNotIns()
+  {
+    return $this->notIns;
+  }
+  public function setPermissions($permissions)
+  {
+    $this->permissions = $permissions;
+  }
+  public function getPermissions()
+  {
+    return $this->permissions;
+  }
+}
+
+class Google_Service_CloudUserAccounts_TestPermissionsRequest extends Google_Collection
+{
+  protected $collection_key = 'permissions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $permissions;
+
+
+  public function setPermissions($permissions)
+  {
+    $this->permissions = $permissions;
+  }
+  public function getPermissions()
+  {
+    return $this->permissions;
+  }
+}
+
+class Google_Service_CloudUserAccounts_TestPermissionsResponse extends Google_Collection
+{
+  protected $collection_key = 'permissions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $permissions;
+
+
+  public function setPermissions($permissions)
+  {
+    $this->permissions = $permissions;
+  }
+  public function getPermissions()
+  {
+    return $this->permissions;
+  }
+}
+
+class Google_Service_CloudUserAccounts_User extends Google_Collection
+{
+  protected $collection_key = 'publicKeys';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $description;
+  public $groups;
+  public $id;
+  public $kind;
+  public $name;
+  public $owner;
+  protected $publicKeysType = 'Google_Service_CloudUserAccounts_PublicKey';
+  protected $publicKeysDataType = 'array';
+  public $selfLink;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setGroups($groups)
+  {
+    $this->groups = $groups;
+  }
+  public function getGroups()
+  {
+    return $this->groups;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOwner($owner)
+  {
+    $this->owner = $owner;
+  }
+  public function getOwner()
+  {
+    return $this->owner;
+  }
+  public function setPublicKeys($publicKeys)
+  {
+    $this->publicKeys = $publicKeys;
+  }
+  public function getPublicKeys()
+  {
+    return $this->publicKeys;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_CloudUserAccounts_UserList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_CloudUserAccounts_User';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Cloudbilling.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Cloudbilling.php
@@ -1,0 +1,446 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Cloudbilling (v1).
+ *
+ * <p>
+ * Retrieves Google Developers Console billing accounts and associates them with
+ * projects.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://cloud.google.com/billing/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Cloudbilling extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+
+  public $billingAccounts;
+  public $billingAccounts_projects;
+  public $projects;
+  
+
+  /**
+   * Constructs the internal representation of the Cloudbilling service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://cloudbilling.googleapis.com/';
+    $this->servicePath = '';
+    $this->version = 'v1';
+    $this->serviceName = 'cloudbilling';
+
+    $this->billingAccounts = new Google_Service_Cloudbilling_BillingAccounts_Resource(
+        $this,
+        $this->serviceName,
+        'billingAccounts',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'v1/{+name}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'name' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1/billingAccounts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->billingAccounts_projects = new Google_Service_Cloudbilling_BillingAccountsProjects_Resource(
+        $this,
+        $this->serviceName,
+        'projects',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'v1/{+name}/projects',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'name' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->projects = new Google_Service_Cloudbilling_Projects_Resource(
+        $this,
+        $this->serviceName,
+        'projects',
+        array(
+          'methods' => array(
+            'getBillingInfo' => array(
+              'path' => 'v1/{+name}/billingInfo',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'name' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'updateBillingInfo' => array(
+              'path' => 'v1/{+name}/billingInfo',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'name' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "billingAccounts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $cloudbillingService = new Google_Service_Cloudbilling(...);
+ *   $billingAccounts = $cloudbillingService->billingAccounts;
+ *  </code>
+ */
+class Google_Service_Cloudbilling_BillingAccounts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets information about a billing account. The current authenticated user must
+   * be an [owner of the billing
+   * account](https://support.google.com/cloud/answer/4430947).
+   * (billingAccounts.get)
+   *
+   * @param string $name The resource name of the billing account to retrieve. For
+   * example, `billingAccounts/012345-567890-ABCDEF`.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudbilling_BillingAccount
+   */
+  public function get($name, $optParams = array())
+  {
+    $params = array('name' => $name);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Cloudbilling_BillingAccount");
+  }
+
+  /**
+   * Lists the billing accounts that the current authenticated user
+   * [owns](https://support.google.com/cloud/answer/4430947).
+   * (billingAccounts.listBillingAccounts)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A token identifying a page of results to return.
+   * This should be a `next_page_token` value returned from a previous
+   * `ListBillingAccounts` call. If unspecified, the first page of results is
+   * returned.
+   * @opt_param int pageSize Requested page size. The maximum page size is 100;
+   * this is also the default.
+   * @return Google_Service_Cloudbilling_ListBillingAccountsResponse
+   */
+  public function listBillingAccounts($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Cloudbilling_ListBillingAccountsResponse");
+  }
+}
+
+/**
+ * The "projects" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $cloudbillingService = new Google_Service_Cloudbilling(...);
+ *   $projects = $cloudbillingService->projects;
+ *  </code>
+ */
+class Google_Service_Cloudbilling_BillingAccountsProjects_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Lists the projects associated with a billing account. The current
+   * authenticated user must be an [owner of the billing
+   * account](https://support.google.com/cloud/answer/4430947).
+   * (projects.listBillingAccountsProjects)
+   *
+   * @param string $name The resource name of the billing account associated with
+   * the projects that you want to list. For example,
+   * `billingAccounts/012345-567890-ABCDEF`.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A token identifying a page of results to be
+   * returned. This should be a `next_page_token` value returned from a previous
+   * `ListProjectBillingInfo` call. If unspecified, the first page of results is
+   * returned.
+   * @opt_param int pageSize Requested page size. The maximum page size is 100;
+   * this is also the default.
+   * @return Google_Service_Cloudbilling_ListProjectBillingInfoResponse
+   */
+  public function listBillingAccountsProjects($name, $optParams = array())
+  {
+    $params = array('name' => $name);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Cloudbilling_ListProjectBillingInfoResponse");
+  }
+}
+
+/**
+ * The "projects" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $cloudbillingService = new Google_Service_Cloudbilling(...);
+ *   $projects = $cloudbillingService->projects;
+ *  </code>
+ */
+class Google_Service_Cloudbilling_Projects_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the billing information for a project. The current authenticated user
+   * must have [permission to view the project](https://cloud.google.com/docs
+   * /permissions-overview#h.bgs0oxofvnoo ). (projects.getBillingInfo)
+   *
+   * @param string $name The resource name of the project for which billing
+   * information is retrieved. For example, `projects/tokyo-rain-123`.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudbilling_ProjectBillingInfo
+   */
+  public function getBillingInfo($name, $optParams = array())
+  {
+    $params = array('name' => $name);
+    $params = array_merge($params, $optParams);
+    return $this->call('getBillingInfo', array($params), "Google_Service_Cloudbilling_ProjectBillingInfo");
+  }
+
+  /**
+   * Sets or updates the billing account associated with a project. You specify
+   * the new billing account by setting the `billing_account_name` in the
+   * `ProjectBillingInfo` resource to the resource name of a billing account.
+   * Associating a project with an open billing account enables billing on the
+   * project and allows charges for resource usage. If the project already had a
+   * billing account, this method changes the billing account used for resource
+   * usage charges. *Note:* Incurred charges that have not yet been reported in
+   * the transaction history of the Google Developers Console may be billed to the
+   * new billing account, even if the charge occurred before the new billing
+   * account was assigned to the project. The current authenticated user must have
+   * ownership privileges for both the [project](https://cloud.google.com/docs
+   * /permissions-overview#h.bgs0oxofvnoo ) and the [billing
+   * account](https://support.google.com/cloud/answer/4430947). You can disable
+   * billing on the project by setting the `billing_account_name` field to empty.
+   * This action disassociates the current billing account from the project. Any
+   * billable activity of your in-use services will stop, and your application
+   * could stop functioning as expected. Any unbilled charges to date will be
+   * billed to the previously associated account. The current authenticated user
+   * must be either an owner of the project or an owner of the billing account for
+   * the project. Note that associating a project with a *closed* billing account
+   * will have much the same effect as disabling billing on the project: any paid
+   * resources used by the project will be shut down. Thus, unless you wish to
+   * disable billing, you should always call this method with the name of an
+   * *open* billing account. (projects.updateBillingInfo)
+   *
+   * @param string $name The resource name of the project associated with the
+   * billing information that you want to update. For example, `projects/tokyo-
+   * rain-123`.
+   * @param Google_ProjectBillingInfo $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudbilling_ProjectBillingInfo
+   */
+  public function updateBillingInfo($name, Google_Service_Cloudbilling_ProjectBillingInfo $postBody, $optParams = array())
+  {
+    $params = array('name' => $name, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('updateBillingInfo', array($params), "Google_Service_Cloudbilling_ProjectBillingInfo");
+  }
+}
+
+
+
+
+class Google_Service_Cloudbilling_BillingAccount extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $displayName;
+  public $name;
+  public $open;
+
+
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOpen($open)
+  {
+    $this->open = $open;
+  }
+  public function getOpen()
+  {
+    return $this->open;
+  }
+}
+
+class Google_Service_Cloudbilling_ListBillingAccountsResponse extends Google_Collection
+{
+  protected $collection_key = 'billingAccounts';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $billingAccountsType = 'Google_Service_Cloudbilling_BillingAccount';
+  protected $billingAccountsDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setBillingAccounts($billingAccounts)
+  {
+    $this->billingAccounts = $billingAccounts;
+  }
+  public function getBillingAccounts()
+  {
+    return $this->billingAccounts;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Cloudbilling_ListProjectBillingInfoResponse extends Google_Collection
+{
+  protected $collection_key = 'projectBillingInfo';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $projectBillingInfoType = 'Google_Service_Cloudbilling_ProjectBillingInfo';
+  protected $projectBillingInfoDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setProjectBillingInfo($projectBillingInfo)
+  {
+    $this->projectBillingInfo = $projectBillingInfo;
+  }
+  public function getProjectBillingInfo()
+  {
+    return $this->projectBillingInfo;
+  }
+}
+
+class Google_Service_Cloudbilling_ProjectBillingInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $billingAccountName;
+  public $billingEnabled;
+  public $name;
+  public $projectId;
+
+
+  public function setBillingAccountName($billingAccountName)
+  {
+    $this->billingAccountName = $billingAccountName;
+  }
+  public function getBillingAccountName()
+  {
+    return $this->billingAccountName;
+  }
+  public function setBillingEnabled($billingEnabled)
+  {
+    $this->billingEnabled = $billingEnabled;
+  }
+  public function getBillingEnabled()
+  {
+    return $this->billingEnabled;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Clouddebugger.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Clouddebugger.php
@@ -1,0 +1,1343 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Clouddebugger (v2).
+ *
+ * <p>
+ * Lets you examine the stack and variables of your running application without
+ * stopping or slowing it down.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://cloud.google.com/tools/cloud-debugger" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Clouddebugger extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+  /** Manage cloud debugger. */
+  const CLOUD_DEBUGGER =
+      "https://www.googleapis.com/auth/cloud_debugger";
+  /** Manage active breakpoints in cloud debugger. */
+  const CLOUD_DEBUGLETCONTROLLER =
+      "https://www.googleapis.com/auth/cloud_debugletcontroller";
+
+  public $controller_debuggees;
+  public $controller_debuggees_breakpoints;
+  public $debugger_debuggees;
+  public $debugger_debuggees_breakpoints;
+  
+
+  /**
+   * Constructs the internal representation of the Clouddebugger service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://clouddebugger.googleapis.com/';
+    $this->servicePath = '';
+    $this->version = 'v2';
+    $this->serviceName = 'clouddebugger';
+
+    $this->controller_debuggees = new Google_Service_Clouddebugger_ControllerDebuggees_Resource(
+        $this,
+        $this->serviceName,
+        'debuggees',
+        array(
+          'methods' => array(
+            'register' => array(
+              'path' => 'v2/controller/debuggees/register',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->controller_debuggees_breakpoints = new Google_Service_Clouddebugger_ControllerDebuggeesBreakpoints_Resource(
+        $this,
+        $this->serviceName,
+        'breakpoints',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'v2/controller/debuggees/{debuggeeId}/breakpoints',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'debuggeeId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'waitToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'v2/controller/debuggees/{debuggeeId}/breakpoints/{id}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'debuggeeId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->debugger_debuggees = new Google_Service_Clouddebugger_DebuggerDebuggees_Resource(
+        $this,
+        $this->serviceName,
+        'debuggees',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'v2/debugger/debuggees',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'includeInactive' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->debugger_debuggees_breakpoints = new Google_Service_Clouddebugger_DebuggerDebuggeesBreakpoints_Resource(
+        $this,
+        $this->serviceName,
+        'breakpoints',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'v2/debugger/debuggees/{debuggeeId}/breakpoints/{breakpointId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'debuggeeId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'breakpointId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v2/debugger/debuggees/{debuggeeId}/breakpoints/{breakpointId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'debuggeeId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'breakpointId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v2/debugger/debuggees/{debuggeeId}/breakpoints',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'debuggeeId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'includeAllUsers' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'stripResults' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'action.value' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'includeInactive' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'waitToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'set' => array(
+              'path' => 'v2/debugger/debuggees/{debuggeeId}/breakpoints/set',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'debuggeeId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "controller" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $clouddebuggerService = new Google_Service_Clouddebugger(...);
+ *   $controller = $clouddebuggerService->controller;
+ *  </code>
+ */
+class Google_Service_Clouddebugger_Controller_Resource extends Google_Service_Resource
+{
+}
+
+/**
+ * The "debuggees" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $clouddebuggerService = new Google_Service_Clouddebugger(...);
+ *   $debuggees = $clouddebuggerService->debuggees;
+ *  </code>
+ */
+class Google_Service_Clouddebugger_ControllerDebuggees_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Registers the debuggee with the controller. All agents should call this API
+   * with the same request content to get back the same stable 'debuggee_id'.
+   * Agents should call this API again whenever ListActiveBreakpoints or
+   * UpdateActiveBreakpoint return the error google.rpc.Code.NOT_FOUND. It allows
+   * the server to disable the agent or recover from any registration loss. If the
+   * debuggee is disabled server, the response will have is_disabled' set to true.
+   * (debuggees.register)
+   *
+   * @param Google_RegisterDebuggeeRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Clouddebugger_RegisterDebuggeeResponse
+   */
+  public function register(Google_Service_Clouddebugger_RegisterDebuggeeRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('register', array($params), "Google_Service_Clouddebugger_RegisterDebuggeeResponse");
+  }
+}
+
+/**
+ * The "breakpoints" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $clouddebuggerService = new Google_Service_Clouddebugger(...);
+ *   $breakpoints = $clouddebuggerService->breakpoints;
+ *  </code>
+ */
+class Google_Service_Clouddebugger_ControllerDebuggeesBreakpoints_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns the list of all active breakpoints for the specified debuggee. The
+   * breakpoint specification (location, condition, and expression fields) is
+   * semantically immutable, although the field values may change. For example, an
+   * agent may update the location line number to reflect the actual line the
+   * breakpoint was set to, but that doesn't change the breakpoint semantics.
+   * Thus, an agent does not need to check if a breakpoint has changed when it
+   * encounters the same breakpoint on a successive call. Moreover, an agent
+   * should remember breakpoints that are complete until the controller removes
+   * them from the active list to avoid setting those breakpoints again.
+   * (breakpoints.listControllerDebuggeesBreakpoints)
+   *
+   * @param string $debuggeeId Identifies the debuggee.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string waitToken A wait token that, if specified, blocks the
+   * method call until the list of active breakpoints has changed, or a server
+   * selected timeout has expired. The value should be set from the last returned
+   * response. The error code google.rpc.Code.ABORTED is returned on wait timeout
+   * (which does not require the agent to re-register with the server)
+   * @return Google_Service_Clouddebugger_ListActiveBreakpointsResponse
+   */
+  public function listControllerDebuggeesBreakpoints($debuggeeId, $optParams = array())
+  {
+    $params = array('debuggeeId' => $debuggeeId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Clouddebugger_ListActiveBreakpointsResponse");
+  }
+
+  /**
+   * Updates the breakpoint state or mutable fields. The entire Breakpoint
+   * protobuf must be sent back to the controller. Updates to active breakpoint
+   * fields are only allowed if the new value does not change the breakpoint
+   * specification. Updates to the 'location', 'condition' and 'expression' fields
+   * should not alter the breakpoint semantics. They are restricted to changes
+   * such as canonicalizing a value or snapping the location to the correct line
+   * of code. (breakpoints.update)
+   *
+   * @param string $debuggeeId Identifies the debuggee being debugged.
+   * @param string $id Breakpoint identifier, unique in the scope of the debuggee.
+   * @param Google_UpdateActiveBreakpointRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Clouddebugger_UpdateActiveBreakpointResponse
+   */
+  public function update($debuggeeId, $id, Google_Service_Clouddebugger_UpdateActiveBreakpointRequest $postBody, $optParams = array())
+  {
+    $params = array('debuggeeId' => $debuggeeId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Clouddebugger_UpdateActiveBreakpointResponse");
+  }
+}
+
+/**
+ * The "debugger" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $clouddebuggerService = new Google_Service_Clouddebugger(...);
+ *   $debugger = $clouddebuggerService->debugger;
+ *  </code>
+ */
+class Google_Service_Clouddebugger_Debugger_Resource extends Google_Service_Resource
+{
+}
+
+/**
+ * The "debuggees" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $clouddebuggerService = new Google_Service_Clouddebugger(...);
+ *   $debuggees = $clouddebuggerService->debuggees;
+ *  </code>
+ */
+class Google_Service_Clouddebugger_DebuggerDebuggees_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Lists all the debuggees that the user can set breakpoints to.
+   * (debuggees.listDebuggerDebuggees)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string project Set to the project number of the Google Cloud
+   * Platform to list the debuggees that are part of that project.
+   * @opt_param bool includeInactive When set to true the result includes all
+   * debuggees, otherwise only debugees that are active.
+   * @return Google_Service_Clouddebugger_ListDebuggeesResponse
+   */
+  public function listDebuggerDebuggees($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Clouddebugger_ListDebuggeesResponse");
+  }
+}
+
+/**
+ * The "breakpoints" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $clouddebuggerService = new Google_Service_Clouddebugger(...);
+ *   $breakpoints = $clouddebuggerService->breakpoints;
+ *  </code>
+ */
+class Google_Service_Clouddebugger_DebuggerDebuggeesBreakpoints_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the breakpoint from the debuggee. (breakpoints.delete)
+   *
+   * @param string $debuggeeId The debuggee id to delete the breakpoint from.
+   * @param string $breakpointId The breakpoint to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Clouddebugger_Empty
+   */
+  public function delete($debuggeeId, $breakpointId, $optParams = array())
+  {
+    $params = array('debuggeeId' => $debuggeeId, 'breakpointId' => $breakpointId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Clouddebugger_Empty");
+  }
+
+  /**
+   * Gets breakpoint information. (breakpoints.get)
+   *
+   * @param string $debuggeeId The debuggee id to get the breakpoint from.
+   * @param string $breakpointId The breakpoint to get.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Clouddebugger_GetBreakpointResponse
+   */
+  public function get($debuggeeId, $breakpointId, $optParams = array())
+  {
+    $params = array('debuggeeId' => $debuggeeId, 'breakpointId' => $breakpointId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Clouddebugger_GetBreakpointResponse");
+  }
+
+  /**
+   * Lists all breakpoints of the debuggee that the user has access to.
+   * (breakpoints.listDebuggerDebuggeesBreakpoints)
+   *
+   * @param string $debuggeeId The debuggee id to list breakpoint from.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool includeAllUsers When set to true the response includes the
+   * list of breakpoints set by any user, otherwise only breakpoints set by the
+   * caller.
+   * @opt_param bool stripResults When set to true the response breakpoints will
+   * be stripped of the results fields: stack_frames, evaluated_expressions and
+   * variable_table.
+   * @opt_param string action.value Only breakpoints with the specified action
+   * will pass the filter.
+   * @opt_param bool includeInactive When set to true the response includes active
+   * and inactive breakpoints, otherwise only active breakpoints are returned.
+   * @opt_param string waitToken A wait token that, if specified, blocks the call
+   * until the breakpoints list has changed, or a server selected timeout has
+   * expired. The value should be set from the last response to ListBreakpoints.
+   * The error code ABORTED is returned on wait timeout, which should be called
+   * again with the same wait_token.
+   * @return Google_Service_Clouddebugger_ListBreakpointsResponse
+   */
+  public function listDebuggerDebuggeesBreakpoints($debuggeeId, $optParams = array())
+  {
+    $params = array('debuggeeId' => $debuggeeId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Clouddebugger_ListBreakpointsResponse");
+  }
+
+  /**
+   * Sets the breakpoint to the debuggee. (breakpoints.set)
+   *
+   * @param string $debuggeeId The debuggee id to set the breakpoint to.
+   * @param Google_Breakpoint $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Clouddebugger_SetBreakpointResponse
+   */
+  public function set($debuggeeId, Google_Service_Clouddebugger_Breakpoint $postBody, $optParams = array())
+  {
+    $params = array('debuggeeId' => $debuggeeId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('set', array($params), "Google_Service_Clouddebugger_SetBreakpointResponse");
+  }
+}
+
+
+
+
+class Google_Service_Clouddebugger_Breakpoint extends Google_Collection
+{
+  protected $collection_key = 'variableTable';
+  protected $internal_gapi_mappings = array(
+  );
+  public $action;
+  public $condition;
+  public $createTime;
+  protected $evaluatedExpressionsType = 'Google_Service_Clouddebugger_Variable';
+  protected $evaluatedExpressionsDataType = 'array';
+  public $expressions;
+  public $finalTime;
+  public $id;
+  public $isFinalState;
+  protected $locationType = 'Google_Service_Clouddebugger_SourceLocation';
+  protected $locationDataType = '';
+  public $logLevel;
+  public $logMessageFormat;
+  protected $stackFramesType = 'Google_Service_Clouddebugger_StackFrame';
+  protected $stackFramesDataType = 'array';
+  protected $statusType = 'Google_Service_Clouddebugger_StatusMessage';
+  protected $statusDataType = '';
+  public $userEmail;
+  protected $variableTableType = 'Google_Service_Clouddebugger_Variable';
+  protected $variableTableDataType = 'array';
+
+
+  public function setAction($action)
+  {
+    $this->action = $action;
+  }
+  public function getAction()
+  {
+    return $this->action;
+  }
+  public function setCondition($condition)
+  {
+    $this->condition = $condition;
+  }
+  public function getCondition()
+  {
+    return $this->condition;
+  }
+  public function setCreateTime($createTime)
+  {
+    $this->createTime = $createTime;
+  }
+  public function getCreateTime()
+  {
+    return $this->createTime;
+  }
+  public function setEvaluatedExpressions($evaluatedExpressions)
+  {
+    $this->evaluatedExpressions = $evaluatedExpressions;
+  }
+  public function getEvaluatedExpressions()
+  {
+    return $this->evaluatedExpressions;
+  }
+  public function setExpressions($expressions)
+  {
+    $this->expressions = $expressions;
+  }
+  public function getExpressions()
+  {
+    return $this->expressions;
+  }
+  public function setFinalTime($finalTime)
+  {
+    $this->finalTime = $finalTime;
+  }
+  public function getFinalTime()
+  {
+    return $this->finalTime;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIsFinalState($isFinalState)
+  {
+    $this->isFinalState = $isFinalState;
+  }
+  public function getIsFinalState()
+  {
+    return $this->isFinalState;
+  }
+  public function setLocation(Google_Service_Clouddebugger_SourceLocation $location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setLogLevel($logLevel)
+  {
+    $this->logLevel = $logLevel;
+  }
+  public function getLogLevel()
+  {
+    return $this->logLevel;
+  }
+  public function setLogMessageFormat($logMessageFormat)
+  {
+    $this->logMessageFormat = $logMessageFormat;
+  }
+  public function getLogMessageFormat()
+  {
+    return $this->logMessageFormat;
+  }
+  public function setStackFrames($stackFrames)
+  {
+    $this->stackFrames = $stackFrames;
+  }
+  public function getStackFrames()
+  {
+    return $this->stackFrames;
+  }
+  public function setStatus(Google_Service_Clouddebugger_StatusMessage $status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setUserEmail($userEmail)
+  {
+    $this->userEmail = $userEmail;
+  }
+  public function getUserEmail()
+  {
+    return $this->userEmail;
+  }
+  public function setVariableTable($variableTable)
+  {
+    $this->variableTable = $variableTable;
+  }
+  public function getVariableTable()
+  {
+    return $this->variableTable;
+  }
+}
+
+class Google_Service_Clouddebugger_CloudRepoSourceContext extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $aliasName;
+  protected $repoIdType = 'Google_Service_Clouddebugger_RepoId';
+  protected $repoIdDataType = '';
+  public $revisionId;
+
+
+  public function setAliasName($aliasName)
+  {
+    $this->aliasName = $aliasName;
+  }
+  public function getAliasName()
+  {
+    return $this->aliasName;
+  }
+  public function setRepoId(Google_Service_Clouddebugger_RepoId $repoId)
+  {
+    $this->repoId = $repoId;
+  }
+  public function getRepoId()
+  {
+    return $this->repoId;
+  }
+  public function setRevisionId($revisionId)
+  {
+    $this->revisionId = $revisionId;
+  }
+  public function getRevisionId()
+  {
+    return $this->revisionId;
+  }
+}
+
+class Google_Service_Clouddebugger_CloudWorkspaceId extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  protected $repoIdType = 'Google_Service_Clouddebugger_RepoId';
+  protected $repoIdDataType = '';
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setRepoId(Google_Service_Clouddebugger_RepoId $repoId)
+  {
+    $this->repoId = $repoId;
+  }
+  public function getRepoId()
+  {
+    return $this->repoId;
+  }
+}
+
+class Google_Service_Clouddebugger_CloudWorkspaceSourceContext extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $snapshotId;
+  protected $workspaceIdType = 'Google_Service_Clouddebugger_CloudWorkspaceId';
+  protected $workspaceIdDataType = '';
+
+
+  public function setSnapshotId($snapshotId)
+  {
+    $this->snapshotId = $snapshotId;
+  }
+  public function getSnapshotId()
+  {
+    return $this->snapshotId;
+  }
+  public function setWorkspaceId(Google_Service_Clouddebugger_CloudWorkspaceId $workspaceId)
+  {
+    $this->workspaceId = $workspaceId;
+  }
+  public function getWorkspaceId()
+  {
+    return $this->workspaceId;
+  }
+}
+
+class Google_Service_Clouddebugger_Debuggee extends Google_Collection
+{
+  protected $collection_key = 'sourceContexts';
+  protected $internal_gapi_mappings = array(
+  );
+  public $agentVersion;
+  public $description;
+  public $id;
+  public $isDisabled;
+  public $isInactive;
+  public $labels;
+  public $project;
+  protected $sourceContextsType = 'Google_Service_Clouddebugger_SourceContext';
+  protected $sourceContextsDataType = 'array';
+  protected $statusType = 'Google_Service_Clouddebugger_StatusMessage';
+  protected $statusDataType = '';
+  public $uniquifier;
+
+
+  public function setAgentVersion($agentVersion)
+  {
+    $this->agentVersion = $agentVersion;
+  }
+  public function getAgentVersion()
+  {
+    return $this->agentVersion;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIsDisabled($isDisabled)
+  {
+    $this->isDisabled = $isDisabled;
+  }
+  public function getIsDisabled()
+  {
+    return $this->isDisabled;
+  }
+  public function setIsInactive($isInactive)
+  {
+    $this->isInactive = $isInactive;
+  }
+  public function getIsInactive()
+  {
+    return $this->isInactive;
+  }
+  public function setLabels($labels)
+  {
+    $this->labels = $labels;
+  }
+  public function getLabels()
+  {
+    return $this->labels;
+  }
+  public function setProject($project)
+  {
+    $this->project = $project;
+  }
+  public function getProject()
+  {
+    return $this->project;
+  }
+  public function setSourceContexts($sourceContexts)
+  {
+    $this->sourceContexts = $sourceContexts;
+  }
+  public function getSourceContexts()
+  {
+    return $this->sourceContexts;
+  }
+  public function setStatus(Google_Service_Clouddebugger_StatusMessage $status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setUniquifier($uniquifier)
+  {
+    $this->uniquifier = $uniquifier;
+  }
+  public function getUniquifier()
+  {
+    return $this->uniquifier;
+  }
+}
+
+class Google_Service_Clouddebugger_DebuggeeLabels extends Google_Model
+{
+}
+
+class Google_Service_Clouddebugger_Empty extends Google_Model
+{
+}
+
+class Google_Service_Clouddebugger_FormatMessage extends Google_Collection
+{
+  protected $collection_key = 'parameters';
+  protected $internal_gapi_mappings = array(
+  );
+  public $format;
+  public $parameters;
+
+
+  public function setFormat($format)
+  {
+    $this->format = $format;
+  }
+  public function getFormat()
+  {
+    return $this->format;
+  }
+  public function setParameters($parameters)
+  {
+    $this->parameters = $parameters;
+  }
+  public function getParameters()
+  {
+    return $this->parameters;
+  }
+}
+
+class Google_Service_Clouddebugger_GerritSourceContext extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $aliasName;
+  public $gerritProject;
+  public $hostUri;
+  public $revisionId;
+
+
+  public function setAliasName($aliasName)
+  {
+    $this->aliasName = $aliasName;
+  }
+  public function getAliasName()
+  {
+    return $this->aliasName;
+  }
+  public function setGerritProject($gerritProject)
+  {
+    $this->gerritProject = $gerritProject;
+  }
+  public function getGerritProject()
+  {
+    return $this->gerritProject;
+  }
+  public function setHostUri($hostUri)
+  {
+    $this->hostUri = $hostUri;
+  }
+  public function getHostUri()
+  {
+    return $this->hostUri;
+  }
+  public function setRevisionId($revisionId)
+  {
+    $this->revisionId = $revisionId;
+  }
+  public function getRevisionId()
+  {
+    return $this->revisionId;
+  }
+}
+
+class Google_Service_Clouddebugger_GetBreakpointResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $breakpointType = 'Google_Service_Clouddebugger_Breakpoint';
+  protected $breakpointDataType = '';
+
+
+  public function setBreakpoint(Google_Service_Clouddebugger_Breakpoint $breakpoint)
+  {
+    $this->breakpoint = $breakpoint;
+  }
+  public function getBreakpoint()
+  {
+    return $this->breakpoint;
+  }
+}
+
+class Google_Service_Clouddebugger_GitSourceContext extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $revisionId;
+  public $url;
+
+
+  public function setRevisionId($revisionId)
+  {
+    $this->revisionId = $revisionId;
+  }
+  public function getRevisionId()
+  {
+    return $this->revisionId;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Clouddebugger_ListActiveBreakpointsResponse extends Google_Collection
+{
+  protected $collection_key = 'breakpoints';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $breakpointsType = 'Google_Service_Clouddebugger_Breakpoint';
+  protected $breakpointsDataType = 'array';
+  public $nextWaitToken;
+
+
+  public function setBreakpoints($breakpoints)
+  {
+    $this->breakpoints = $breakpoints;
+  }
+  public function getBreakpoints()
+  {
+    return $this->breakpoints;
+  }
+  public function setNextWaitToken($nextWaitToken)
+  {
+    $this->nextWaitToken = $nextWaitToken;
+  }
+  public function getNextWaitToken()
+  {
+    return $this->nextWaitToken;
+  }
+}
+
+class Google_Service_Clouddebugger_ListBreakpointsResponse extends Google_Collection
+{
+  protected $collection_key = 'breakpoints';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $breakpointsType = 'Google_Service_Clouddebugger_Breakpoint';
+  protected $breakpointsDataType = 'array';
+  public $nextWaitToken;
+
+
+  public function setBreakpoints($breakpoints)
+  {
+    $this->breakpoints = $breakpoints;
+  }
+  public function getBreakpoints()
+  {
+    return $this->breakpoints;
+  }
+  public function setNextWaitToken($nextWaitToken)
+  {
+    $this->nextWaitToken = $nextWaitToken;
+  }
+  public function getNextWaitToken()
+  {
+    return $this->nextWaitToken;
+  }
+}
+
+class Google_Service_Clouddebugger_ListDebuggeesResponse extends Google_Collection
+{
+  protected $collection_key = 'debuggees';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $debuggeesType = 'Google_Service_Clouddebugger_Debuggee';
+  protected $debuggeesDataType = 'array';
+
+
+  public function setDebuggees($debuggees)
+  {
+    $this->debuggees = $debuggees;
+  }
+  public function getDebuggees()
+  {
+    return $this->debuggees;
+  }
+}
+
+class Google_Service_Clouddebugger_ProjectRepoId extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $projectId;
+  public $repoName;
+
+
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setRepoName($repoName)
+  {
+    $this->repoName = $repoName;
+  }
+  public function getRepoName()
+  {
+    return $this->repoName;
+  }
+}
+
+class Google_Service_Clouddebugger_RegisterDebuggeeRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $debuggeeType = 'Google_Service_Clouddebugger_Debuggee';
+  protected $debuggeeDataType = '';
+
+
+  public function setDebuggee(Google_Service_Clouddebugger_Debuggee $debuggee)
+  {
+    $this->debuggee = $debuggee;
+  }
+  public function getDebuggee()
+  {
+    return $this->debuggee;
+  }
+}
+
+class Google_Service_Clouddebugger_RegisterDebuggeeResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $debuggeeType = 'Google_Service_Clouddebugger_Debuggee';
+  protected $debuggeeDataType = '';
+
+
+  public function setDebuggee(Google_Service_Clouddebugger_Debuggee $debuggee)
+  {
+    $this->debuggee = $debuggee;
+  }
+  public function getDebuggee()
+  {
+    return $this->debuggee;
+  }
+}
+
+class Google_Service_Clouddebugger_RepoId extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $projectRepoIdType = 'Google_Service_Clouddebugger_ProjectRepoId';
+  protected $projectRepoIdDataType = '';
+  public $uid;
+
+
+  public function setProjectRepoId(Google_Service_Clouddebugger_ProjectRepoId $projectRepoId)
+  {
+    $this->projectRepoId = $projectRepoId;
+  }
+  public function getProjectRepoId()
+  {
+    return $this->projectRepoId;
+  }
+  public function setUid($uid)
+  {
+    $this->uid = $uid;
+  }
+  public function getUid()
+  {
+    return $this->uid;
+  }
+}
+
+class Google_Service_Clouddebugger_SetBreakpointResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $breakpointType = 'Google_Service_Clouddebugger_Breakpoint';
+  protected $breakpointDataType = '';
+
+
+  public function setBreakpoint(Google_Service_Clouddebugger_Breakpoint $breakpoint)
+  {
+    $this->breakpoint = $breakpoint;
+  }
+  public function getBreakpoint()
+  {
+    return $this->breakpoint;
+  }
+}
+
+class Google_Service_Clouddebugger_SourceContext extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $cloudRepoType = 'Google_Service_Clouddebugger_CloudRepoSourceContext';
+  protected $cloudRepoDataType = '';
+  protected $cloudWorkspaceType = 'Google_Service_Clouddebugger_CloudWorkspaceSourceContext';
+  protected $cloudWorkspaceDataType = '';
+  protected $gerritType = 'Google_Service_Clouddebugger_GerritSourceContext';
+  protected $gerritDataType = '';
+  protected $gitType = 'Google_Service_Clouddebugger_GitSourceContext';
+  protected $gitDataType = '';
+
+
+  public function setCloudRepo(Google_Service_Clouddebugger_CloudRepoSourceContext $cloudRepo)
+  {
+    $this->cloudRepo = $cloudRepo;
+  }
+  public function getCloudRepo()
+  {
+    return $this->cloudRepo;
+  }
+  public function setCloudWorkspace(Google_Service_Clouddebugger_CloudWorkspaceSourceContext $cloudWorkspace)
+  {
+    $this->cloudWorkspace = $cloudWorkspace;
+  }
+  public function getCloudWorkspace()
+  {
+    return $this->cloudWorkspace;
+  }
+  public function setGerrit(Google_Service_Clouddebugger_GerritSourceContext $gerrit)
+  {
+    $this->gerrit = $gerrit;
+  }
+  public function getGerrit()
+  {
+    return $this->gerrit;
+  }
+  public function setGit(Google_Service_Clouddebugger_GitSourceContext $git)
+  {
+    $this->git = $git;
+  }
+  public function getGit()
+  {
+    return $this->git;
+  }
+}
+
+class Google_Service_Clouddebugger_SourceLocation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $line;
+  public $path;
+
+
+  public function setLine($line)
+  {
+    $this->line = $line;
+  }
+  public function getLine()
+  {
+    return $this->line;
+  }
+  public function setPath($path)
+  {
+    $this->path = $path;
+  }
+  public function getPath()
+  {
+    return $this->path;
+  }
+}
+
+class Google_Service_Clouddebugger_StackFrame extends Google_Collection
+{
+  protected $collection_key = 'locals';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $argumentsType = 'Google_Service_Clouddebugger_Variable';
+  protected $argumentsDataType = 'array';
+  public $function;
+  protected $localsType = 'Google_Service_Clouddebugger_Variable';
+  protected $localsDataType = 'array';
+  protected $locationType = 'Google_Service_Clouddebugger_SourceLocation';
+  protected $locationDataType = '';
+
+
+  public function setArguments($arguments)
+  {
+    $this->arguments = $arguments;
+  }
+  public function getArguments()
+  {
+    return $this->arguments;
+  }
+  public function setFunction($function)
+  {
+    $this->function = $function;
+  }
+  public function getFunction()
+  {
+    return $this->function;
+  }
+  public function setLocals($locals)
+  {
+    $this->locals = $locals;
+  }
+  public function getLocals()
+  {
+    return $this->locals;
+  }
+  public function setLocation(Google_Service_Clouddebugger_SourceLocation $location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+}
+
+class Google_Service_Clouddebugger_StatusMessage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $descriptionType = 'Google_Service_Clouddebugger_FormatMessage';
+  protected $descriptionDataType = '';
+  public $isError;
+  public $refersTo;
+
+
+  public function setDescription(Google_Service_Clouddebugger_FormatMessage $description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setIsError($isError)
+  {
+    $this->isError = $isError;
+  }
+  public function getIsError()
+  {
+    return $this->isError;
+  }
+  public function setRefersTo($refersTo)
+  {
+    $this->refersTo = $refersTo;
+  }
+  public function getRefersTo()
+  {
+    return $this->refersTo;
+  }
+}
+
+class Google_Service_Clouddebugger_UpdateActiveBreakpointRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $breakpointType = 'Google_Service_Clouddebugger_Breakpoint';
+  protected $breakpointDataType = '';
+
+
+  public function setBreakpoint(Google_Service_Clouddebugger_Breakpoint $breakpoint)
+  {
+    $this->breakpoint = $breakpoint;
+  }
+  public function getBreakpoint()
+  {
+    return $this->breakpoint;
+  }
+}
+
+class Google_Service_Clouddebugger_UpdateActiveBreakpointResponse extends Google_Model
+{
+}
+
+class Google_Service_Clouddebugger_Variable extends Google_Collection
+{
+  protected $collection_key = 'members';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $membersType = 'Google_Service_Clouddebugger_Variable';
+  protected $membersDataType = 'array';
+  public $name;
+  protected $statusType = 'Google_Service_Clouddebugger_StatusMessage';
+  protected $statusDataType = '';
+  public $value;
+  public $varTableIndex;
+
+
+  public function setMembers($members)
+  {
+    $this->members = $members;
+  }
+  public function getMembers()
+  {
+    return $this->members;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setStatus(Google_Service_Clouddebugger_StatusMessage $status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+  public function setVarTableIndex($varTableIndex)
+  {
+    $this->varTableIndex = $varTableIndex;
+  }
+  public function getVarTableIndex()
+  {
+    return $this->varTableIndex;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Cloudlatencytest.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Cloudlatencytest.php
@@ -1,0 +1,295 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Cloudlatencytest (v2).
+ *
+ * <p>
+ * A Test API to report latency data.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Cloudlatencytest extends Google_Service
+{
+  /** View monitoring data for all of your Google Cloud and API projects. */
+  const MONITORING_READONLY =
+      "https://www.googleapis.com/auth/monitoring.readonly";
+
+  public $statscollection;
+  
+
+  /**
+   * Constructs the internal representation of the Cloudlatencytest service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://cloudlatencytest-pa.googleapis.com/';
+    $this->servicePath = 'v2/statscollection/';
+    $this->version = 'v2';
+    $this->serviceName = 'cloudlatencytest';
+
+    $this->statscollection = new Google_Service_Cloudlatencytest_Statscollection_Resource(
+        $this,
+        $this->serviceName,
+        'statscollection',
+        array(
+          'methods' => array(
+            'updateaggregatedstats' => array(
+              'path' => 'updateaggregatedstats',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'updatestats' => array(
+              'path' => 'updatestats',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "statscollection" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $cloudlatencytestService = new Google_Service_Cloudlatencytest(...);
+ *   $statscollection = $cloudlatencytestService->statscollection;
+ *  </code>
+ */
+class Google_Service_Cloudlatencytest_Statscollection_Resource extends Google_Service_Resource
+{
+
+  /**
+   * RPC to update the new TCP stats. (statscollection.updateaggregatedstats)
+   *
+   * @param Google_AggregatedStats $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudlatencytest_AggregatedStatsReply
+   */
+  public function updateaggregatedstats(Google_Service_Cloudlatencytest_AggregatedStats $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('updateaggregatedstats', array($params), "Google_Service_Cloudlatencytest_AggregatedStatsReply");
+  }
+
+  /**
+   * RPC to update the new TCP stats. (statscollection.updatestats)
+   *
+   * @param Google_Stats $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudlatencytest_StatsReply
+   */
+  public function updatestats(Google_Service_Cloudlatencytest_Stats $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('updatestats', array($params), "Google_Service_Cloudlatencytest_StatsReply");
+  }
+}
+
+
+
+
+class Google_Service_Cloudlatencytest_AggregatedStats extends Google_Collection
+{
+  protected $collection_key = 'stats';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $statsType = 'Google_Service_Cloudlatencytest_Stats';
+  protected $statsDataType = 'array';
+
+
+  public function setStats($stats)
+  {
+    $this->stats = $stats;
+  }
+  public function getStats()
+  {
+    return $this->stats;
+  }
+}
+
+class Google_Service_Cloudlatencytest_AggregatedStatsReply extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $testValue;
+
+
+  public function setTestValue($testValue)
+  {
+    $this->testValue = $testValue;
+  }
+  public function getTestValue()
+  {
+    return $this->testValue;
+  }
+}
+
+class Google_Service_Cloudlatencytest_DoubleValue extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $label;
+  public $value;
+
+
+  public function setLabel($label)
+  {
+    $this->label = $label;
+  }
+  public function getLabel()
+  {
+    return $this->label;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Cloudlatencytest_IntValue extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $label;
+  public $value;
+
+
+  public function setLabel($label)
+  {
+    $this->label = $label;
+  }
+  public function getLabel()
+  {
+    return $this->label;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Cloudlatencytest_Stats extends Google_Collection
+{
+  protected $collection_key = 'stringValues';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $doubleValuesType = 'Google_Service_Cloudlatencytest_DoubleValue';
+  protected $doubleValuesDataType = 'array';
+  protected $intValuesType = 'Google_Service_Cloudlatencytest_IntValue';
+  protected $intValuesDataType = 'array';
+  protected $stringValuesType = 'Google_Service_Cloudlatencytest_StringValue';
+  protected $stringValuesDataType = 'array';
+  public $time;
+
+
+  public function setDoubleValues($doubleValues)
+  {
+    $this->doubleValues = $doubleValues;
+  }
+  public function getDoubleValues()
+  {
+    return $this->doubleValues;
+  }
+  public function setIntValues($intValues)
+  {
+    $this->intValues = $intValues;
+  }
+  public function getIntValues()
+  {
+    return $this->intValues;
+  }
+  public function setStringValues($stringValues)
+  {
+    $this->stringValues = $stringValues;
+  }
+  public function getStringValues()
+  {
+    return $this->stringValues;
+  }
+  public function setTime($time)
+  {
+    $this->time = $time;
+  }
+  public function getTime()
+  {
+    return $this->time;
+  }
+}
+
+class Google_Service_Cloudlatencytest_StatsReply extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $testValue;
+
+
+  public function setTestValue($testValue)
+  {
+    $this->testValue = $testValue;
+  }
+  public function getTestValue()
+  {
+    return $this->testValue;
+  }
+}
+
+class Google_Service_Cloudlatencytest_StringValue extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $label;
+  public $value;
+
+
+  public function setLabel($label)
+  {
+    $this->label = $label;
+  }
+  public function getLabel()
+  {
+    return $this->label;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Cloudresourcemanager.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Cloudresourcemanager.php
@@ -1,0 +1,912 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Cloudresourcemanager (v1beta1).
+ *
+ * <p>
+ * The Google Cloud Resource Manager API provides methods for creating, reading,
+ * and updating of project metadata.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://cloud.google.com/resource-manager" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Cloudresourcemanager extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+
+  public $organizations;
+  public $projects;
+  
+
+  /**
+   * Constructs the internal representation of the Cloudresourcemanager service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://cloudresourcemanager.googleapis.com/';
+    $this->servicePath = '';
+    $this->version = 'v1beta1';
+    $this->serviceName = 'cloudresourcemanager';
+
+    $this->organizations = new Google_Service_Cloudresourcemanager_Organizations_Resource(
+        $this,
+        $this->serviceName,
+        'organizations',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'v1beta1/organizations/{organizationId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'organizationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getIamPolicy' => array(
+              'path' => 'v1beta1/organizations/{resource}:getIamPolicy',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'resource' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1beta1/organizations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'setIamPolicy' => array(
+              'path' => 'v1beta1/organizations/{resource}:setIamPolicy',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'resource' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'testIamPermissions' => array(
+              'path' => 'v1beta1/organizations/{resource}:testIamPermissions',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'resource' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'v1beta1/organizations/{organizationId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'organizationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->projects = new Google_Service_Cloudresourcemanager_Projects_Resource(
+        $this,
+        $this->serviceName,
+        'projects',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'v1beta1/projects',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'delete' => array(
+              'path' => 'v1beta1/projects/{projectId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v1beta1/projects/{projectId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getIamPolicy' => array(
+              'path' => 'v1beta1/projects/{resource}:getIamPolicy',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'resource' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1beta1/projects',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'setIamPolicy' => array(
+              'path' => 'v1beta1/projects/{resource}:setIamPolicy',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'resource' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'testIamPermissions' => array(
+              'path' => 'v1beta1/projects/{resource}:testIamPermissions',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'resource' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'undelete' => array(
+              'path' => 'v1beta1/projects/{projectId}:undelete',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'v1beta1/projects/{projectId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "organizations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $cloudresourcemanagerService = new Google_Service_Cloudresourcemanager(...);
+ *   $organizations = $cloudresourcemanagerService->organizations;
+ *  </code>
+ */
+class Google_Service_Cloudresourcemanager_Organizations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Fetches an Organization resource by id. (organizations.get)
+   *
+   * @param string $organizationId The id of the Organization resource to fetch.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudresourcemanager_Organization
+   */
+  public function get($organizationId, $optParams = array())
+  {
+    $params = array('organizationId' => $organizationId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Cloudresourcemanager_Organization");
+  }
+
+  /**
+   * Gets the access control policy for a Organization resource. May be empty if
+   * no such policy or resource exists. (organizations.getIamPolicy)
+   *
+   * @param string $resource REQUIRED: The resource for which policy is being
+   * requested. Resource is usually specified as a path, such as,
+   * `projects/{project}`.
+   * @param Google_GetIamPolicyRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudresourcemanager_Policy
+   */
+  public function getIamPolicy($resource, Google_Service_Cloudresourcemanager_GetIamPolicyRequest $postBody, $optParams = array())
+  {
+    $params = array('resource' => $resource, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('getIamPolicy', array($params), "Google_Service_Cloudresourcemanager_Policy");
+  }
+
+  /**
+   * Query Organization resources. (organizations.listOrganizations)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter An optional query string used to filter the
+   * Organizations to be return in the response. Filter rules are case-
+   * insensitive. Organizations may be filtered by `owner.directoryCustomerId` or
+   * by `domain`, where the domain is a Google for Work domain, for example:
+   * |Filter|Description| |------|-----------|
+   * |owner.directorycustomerid:123456789|Organizations with
+   * `owner.directory_customer_id` equal to `123456789`.|
+   * |domain:google.com|Organizations corresponding to the domain `google.com`.|
+   * This field is optional.
+   * @opt_param string pageToken A pagination token returned from a previous call
+   * to ListOrganizations that indicates from where listing should continue. This
+   * field is optional.
+   * @opt_param int pageSize The maximum number of Organizations to return in the
+   * response. This field is optional.
+   * @return Google_Service_Cloudresourcemanager_ListOrganizationsResponse
+   */
+  public function listOrganizations($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Cloudresourcemanager_ListOrganizationsResponse");
+  }
+
+  /**
+   * Sets the access control policy on a Organization resource. Replaces any
+   * existing policy. (organizations.setIamPolicy)
+   *
+   * @param string $resource REQUIRED: The resource for which policy is being
+   * specified. `resource` is usually specified as a path, such as,
+   * `projects/{project}/zones/{zone}/disks/{disk}`.
+   * @param Google_SetIamPolicyRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudresourcemanager_Policy
+   */
+  public function setIamPolicy($resource, Google_Service_Cloudresourcemanager_SetIamPolicyRequest $postBody, $optParams = array())
+  {
+    $params = array('resource' => $resource, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setIamPolicy', array($params), "Google_Service_Cloudresourcemanager_Policy");
+  }
+
+  /**
+   * Returns permissions that a caller has on the specified Organization.
+   * (organizations.testIamPermissions)
+   *
+   * @param string $resource REQUIRED: The resource for which policy detail is
+   * being requested. `resource` is usually specified as a path, such as,
+   * `projects/{project}`.
+   * @param Google_TestIamPermissionsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudresourcemanager_TestIamPermissionsResponse
+   */
+  public function testIamPermissions($resource, Google_Service_Cloudresourcemanager_TestIamPermissionsRequest $postBody, $optParams = array())
+  {
+    $params = array('resource' => $resource, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('testIamPermissions', array($params), "Google_Service_Cloudresourcemanager_TestIamPermissionsResponse");
+  }
+
+  /**
+   * Updates an Organization resource. (organizations.update)
+   *
+   * @param string $organizationId An immutable id for the Organization that is
+   * assigned on creation. This should be omitted when creating a new
+   * Organization. This field is read-only.
+   * @param Google_Organization $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudresourcemanager_Organization
+   */
+  public function update($organizationId, Google_Service_Cloudresourcemanager_Organization $postBody, $optParams = array())
+  {
+    $params = array('organizationId' => $organizationId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Cloudresourcemanager_Organization");
+  }
+}
+
+/**
+ * The "projects" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $cloudresourcemanagerService = new Google_Service_Cloudresourcemanager(...);
+ *   $projects = $cloudresourcemanagerService->projects;
+ *  </code>
+ */
+class Google_Service_Cloudresourcemanager_Projects_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a project resource. Initially, the project resource is owned by its
+   * creator exclusively. The creator can later grant permission to others to read
+   * or update the project. Several APIs are activated automatically for the
+   * project, including Google Cloud Storage. (projects.create)
+   *
+   * @param Google_Project $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudresourcemanager_Project
+   */
+  public function create(Google_Service_Cloudresourcemanager_Project $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Cloudresourcemanager_Project");
+  }
+
+  /**
+   * Marks the project identified by the specified `project_id` (for example, `my-
+   * project-123`) for deletion. This method will only affect the project if the
+   * following criteria are met: + The project does not have a billing account
+   * associated with it. + The project has a lifecycle state of
+   * [ACTIVE][google.cloudresourcemanager.projects.v1beta1.LifecycleState.ACTIVE].
+   * This method changes the project's lifecycle state from
+   * [ACTIVE][google.cloudresourcemanager.projects.v1beta1.LifecycleState.ACTIVE]
+   * to [DELETE_REQUESTED] [google.cloudresourcemanager.projects.v1beta1.Lifecycle
+   * State.DELETE_REQUESTED]. The deletion starts at an unspecified time, at which
+   * point the lifecycle state changes to [DELETE_IN_PROGRESS] [google.cloudresour
+   * cemanager.projects.v1beta1.LifecycleState.DELETE_IN_PROGRESS]. Until the
+   * deletion completes, you can check the lifecycle state checked by retrieving
+   * the project with [GetProject]
+   * [google.cloudresourcemanager.projects.v1beta1.DeveloperProjects.GetProject],
+   * and the project remains visible to [ListProjects] [google.cloudresourcemanage
+   * r.projects.v1beta1.DeveloperProjects.ListProjects]. However, you cannot
+   * update the project. After the deletion completes, the project is not
+   * retrievable by the [GetProject]
+   * [google.cloudresourcemanager.projects.v1beta1.DeveloperProjects.GetProject]
+   * and [ListProjects]
+   * [google.cloudresourcemanager.projects.v1beta1.DeveloperProjects.ListProjects]
+   * methods. The caller must have modify permissions for this project.
+   * (projects.delete)
+   *
+   * @param string $projectId The project ID (for example, `foo-bar-123`).
+   * Required.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudresourcemanager_Empty
+   */
+  public function delete($projectId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Cloudresourcemanager_Empty");
+  }
+
+  /**
+   * Retrieves the project identified by the specified `project_id` (for example,
+   * `my-project-123`). The caller must have read permissions for this project.
+   * (projects.get)
+   *
+   * @param string $projectId The project ID (for example, `my-project-123`).
+   * Required.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudresourcemanager_Project
+   */
+  public function get($projectId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Cloudresourcemanager_Project");
+  }
+
+  /**
+   * Returns the IAM access control policy for specified project.
+   * (projects.getIamPolicy)
+   *
+   * @param string $resource REQUIRED: The resource for which policy is being
+   * requested. Resource is usually specified as a path, such as,
+   * `projects/{project}`.
+   * @param Google_GetIamPolicyRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudresourcemanager_Policy
+   */
+  public function getIamPolicy($resource, Google_Service_Cloudresourcemanager_GetIamPolicyRequest $postBody, $optParams = array())
+  {
+    $params = array('resource' => $resource, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('getIamPolicy', array($params), "Google_Service_Cloudresourcemanager_Policy");
+  }
+
+  /**
+   * Lists projects that are visible to the user and satisfy the specified filter.
+   * This method returns projects in an unspecified order. New projects do not
+   * necessarily appear at the end of the list. (projects.listProjects)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter An expression for filtering the results of the
+   * request. Filter rules are case insensitive. The fields eligible for filtering
+   * are: + `name` + `id` + labels.key where *key* is the name of a label Some
+   * examples of using labels as filters: |Filter|Description|
+   * |------|-----------| |name:*|The project has a name.| |name:Howl|The
+   * project's name is `Howl` or `howl`.| |name:HOWL|Equivalent to above.|
+   * |NAME:howl|Equivalent to above.| |labels.color:*|The project has the label
+   * `color`.| |labels.color:red|The project's label `color` has the value `red`.|
+   * |labels.color:red label.size:big|The project's label `color` has the value
+   * `red` and its label `size` has the value `big`. Optional.
+   * @opt_param string pageToken A pagination token returned from a previous call
+   * to ListProject that indicates from where listing should continue. Note:
+   * pagination is not yet supported; the server ignores this field. Optional.
+   * @opt_param int pageSize The maximum number of Projects to return in the
+   * response. The server can return fewer projects than requested. If
+   * unspecified, server picks an appropriate default. Note: pagination is not yet
+   * supported; the server ignores this field. Optional.
+   * @return Google_Service_Cloudresourcemanager_ListProjectsResponse
+   */
+  public function listProjects($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Cloudresourcemanager_ListProjectsResponse");
+  }
+
+  /**
+   * Sets the IAM access control policy for the specified project. We do not
+   * currently support 'domain:' prefixed members in a Binding of a Policy.
+   * Calling this method requires enabling the App Engine Admin API.
+   * (projects.setIamPolicy)
+   *
+   * @param string $resource REQUIRED: The resource for which policy is being
+   * specified. `resource` is usually specified as a path, such as,
+   * `projects/{project}/zones/{zone}/disks/{disk}`.
+   * @param Google_SetIamPolicyRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudresourcemanager_Policy
+   */
+  public function setIamPolicy($resource, Google_Service_Cloudresourcemanager_SetIamPolicyRequest $postBody, $optParams = array())
+  {
+    $params = array('resource' => $resource, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setIamPolicy', array($params), "Google_Service_Cloudresourcemanager_Policy");
+  }
+
+  /**
+   * Tests the specified permissions against the IAM access control policy for the
+   * specified project. (projects.testIamPermissions)
+   *
+   * @param string $resource REQUIRED: The resource for which policy detail is
+   * being requested. `resource` is usually specified as a path, such as,
+   * `projects/{project}`.
+   * @param Google_TestIamPermissionsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudresourcemanager_TestIamPermissionsResponse
+   */
+  public function testIamPermissions($resource, Google_Service_Cloudresourcemanager_TestIamPermissionsRequest $postBody, $optParams = array())
+  {
+    $params = array('resource' => $resource, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('testIamPermissions', array($params), "Google_Service_Cloudresourcemanager_TestIamPermissionsResponse");
+  }
+
+  /**
+   * Restores the project identified by the specified `project_id` (for example,
+   * `my-project-123`). You can only use this method for a project that has a
+   * lifecycle state of [DELETE_REQUESTED] [google.cloudresourcemanager.projects.v
+   * 1beta1.LifecycleState.DELETE_REQUESTED]. After deletion starts, as indicated
+   * by a lifecycle state of [DELETE_IN_PROGRESS] [google.cloudresourcemanager.pro
+   * jects.v1beta1.LifecycleState.DELETE_IN_PROGRESS], the project cannot be
+   * restored. The caller must have modify permissions for this project.
+   * (projects.undelete)
+   *
+   * @param string $projectId The project ID (for example, `foo-bar-123`).
+   * Required.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudresourcemanager_Empty
+   */
+  public function undelete($projectId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId);
+    $params = array_merge($params, $optParams);
+    return $this->call('undelete', array($params), "Google_Service_Cloudresourcemanager_Empty");
+  }
+
+  /**
+   * Updates the attributes of the project identified by the specified
+   * `project_id` (for example, `my-project-123`). The caller must have modify
+   * permissions for this project. (projects.update)
+   *
+   * @param string $projectId The project ID (for example, `my-project-123`).
+   * Required.
+   * @param Google_Project $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudresourcemanager_Project
+   */
+  public function update($projectId, Google_Service_Cloudresourcemanager_Project $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Cloudresourcemanager_Project");
+  }
+}
+
+
+
+
+class Google_Service_Cloudresourcemanager_Binding extends Google_Collection
+{
+  protected $collection_key = 'members';
+  protected $internal_gapi_mappings = array(
+  );
+  public $members;
+  public $role;
+
+
+  public function setMembers($members)
+  {
+    $this->members = $members;
+  }
+  public function getMembers()
+  {
+    return $this->members;
+  }
+  public function setRole($role)
+  {
+    $this->role = $role;
+  }
+  public function getRole()
+  {
+    return $this->role;
+  }
+}
+
+class Google_Service_Cloudresourcemanager_Empty extends Google_Model
+{
+}
+
+class Google_Service_Cloudresourcemanager_GetIamPolicyRequest extends Google_Model
+{
+}
+
+class Google_Service_Cloudresourcemanager_ListOrganizationsResponse extends Google_Collection
+{
+  protected $collection_key = 'organizations';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $organizationsType = 'Google_Service_Cloudresourcemanager_Organization';
+  protected $organizationsDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setOrganizations($organizations)
+  {
+    $this->organizations = $organizations;
+  }
+  public function getOrganizations()
+  {
+    return $this->organizations;
+  }
+}
+
+class Google_Service_Cloudresourcemanager_ListProjectsResponse extends Google_Collection
+{
+  protected $collection_key = 'projects';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $projectsType = 'Google_Service_Cloudresourcemanager_Project';
+  protected $projectsDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setProjects($projects)
+  {
+    $this->projects = $projects;
+  }
+  public function getProjects()
+  {
+    return $this->projects;
+  }
+}
+
+class Google_Service_Cloudresourcemanager_Organization extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $displayName;
+  public $organizationId;
+  protected $ownerType = 'Google_Service_Cloudresourcemanager_OrganizationOwner';
+  protected $ownerDataType = '';
+
+
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setOrganizationId($organizationId)
+  {
+    $this->organizationId = $organizationId;
+  }
+  public function getOrganizationId()
+  {
+    return $this->organizationId;
+  }
+  public function setOwner(Google_Service_Cloudresourcemanager_OrganizationOwner $owner)
+  {
+    $this->owner = $owner;
+  }
+  public function getOwner()
+  {
+    return $this->owner;
+  }
+}
+
+class Google_Service_Cloudresourcemanager_OrganizationOwner extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $directoryCustomerId;
+
+
+  public function setDirectoryCustomerId($directoryCustomerId)
+  {
+    $this->directoryCustomerId = $directoryCustomerId;
+  }
+  public function getDirectoryCustomerId()
+  {
+    return $this->directoryCustomerId;
+  }
+}
+
+class Google_Service_Cloudresourcemanager_Policy extends Google_Collection
+{
+  protected $collection_key = 'bindings';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $bindingsType = 'Google_Service_Cloudresourcemanager_Binding';
+  protected $bindingsDataType = 'array';
+  public $etag;
+  public $version;
+
+
+  public function setBindings($bindings)
+  {
+    $this->bindings = $bindings;
+  }
+  public function getBindings()
+  {
+    return $this->bindings;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Cloudresourcemanager_Project extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $createTime;
+  public $labels;
+  public $lifecycleState;
+  public $name;
+  protected $parentType = 'Google_Service_Cloudresourcemanager_ResourceId';
+  protected $parentDataType = '';
+  public $projectId;
+  public $projectNumber;
+
+
+  public function setCreateTime($createTime)
+  {
+    $this->createTime = $createTime;
+  }
+  public function getCreateTime()
+  {
+    return $this->createTime;
+  }
+  public function setLabels($labels)
+  {
+    $this->labels = $labels;
+  }
+  public function getLabels()
+  {
+    return $this->labels;
+  }
+  public function setLifecycleState($lifecycleState)
+  {
+    $this->lifecycleState = $lifecycleState;
+  }
+  public function getLifecycleState()
+  {
+    return $this->lifecycleState;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setParent(Google_Service_Cloudresourcemanager_ResourceId $parent)
+  {
+    $this->parent = $parent;
+  }
+  public function getParent()
+  {
+    return $this->parent;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setProjectNumber($projectNumber)
+  {
+    $this->projectNumber = $projectNumber;
+  }
+  public function getProjectNumber()
+  {
+    return $this->projectNumber;
+  }
+}
+
+class Google_Service_Cloudresourcemanager_ProjectLabels extends Google_Model
+{
+}
+
+class Google_Service_Cloudresourcemanager_ResourceId extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $type;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Cloudresourcemanager_SetIamPolicyRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $policyType = 'Google_Service_Cloudresourcemanager_Policy';
+  protected $policyDataType = '';
+
+
+  public function setPolicy(Google_Service_Cloudresourcemanager_Policy $policy)
+  {
+    $this->policy = $policy;
+  }
+  public function getPolicy()
+  {
+    return $this->policy;
+  }
+}
+
+class Google_Service_Cloudresourcemanager_TestIamPermissionsRequest extends Google_Collection
+{
+  protected $collection_key = 'permissions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $permissions;
+
+
+  public function setPermissions($permissions)
+  {
+    $this->permissions = $permissions;
+  }
+  public function getPermissions()
+  {
+    return $this->permissions;
+  }
+}
+
+class Google_Service_Cloudresourcemanager_TestIamPermissionsResponse extends Google_Collection
+{
+  protected $collection_key = 'permissions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $permissions;
+
+
+  public function setPermissions($permissions)
+  {
+    $this->permissions = $permissions;
+  }
+  public function getPermissions()
+  {
+    return $this->permissions;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Cloudsearch.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Cloudsearch.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Cloudsearch (v1).
+ *
+ * <p>
+ * The Google Cloud Search API defines an application interface to index
+ * documents that contain structured data and to search those indexes. It
+ * supports full text search.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Cloudsearch extends Google_Service
+{
+
+
+
+  
+
+  /**
+   * Constructs the internal representation of the Cloudsearch service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->servicePath = '';
+    $this->version = 'v1';
+    $this->serviceName = 'cloudsearch';
+
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Cloudtrace.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Cloudtrace.php
@@ -1,0 +1,460 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Cloudtrace (v1).
+ *
+ * <p>
+ * The Google Cloud Trace API provides services for reading and writing runtime
+ * trace data for Cloud applications.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://cloud.google.com/tools/cloud-trace" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Cloudtrace extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+
+  public $projects;
+  public $projects_traces;
+  public $v1;
+  
+
+  /**
+   * Constructs the internal representation of the Cloudtrace service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://cloudtrace.googleapis.com/';
+    $this->servicePath = '';
+    $this->version = 'v1';
+    $this->serviceName = 'cloudtrace';
+
+    $this->projects = new Google_Service_Cloudtrace_Projects_Resource(
+        $this,
+        $this->serviceName,
+        'projects',
+        array(
+          'methods' => array(
+            'patchTraces' => array(
+              'path' => 'v1/projects/{projectId}/traces',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->projects_traces = new Google_Service_Cloudtrace_ProjectsTraces_Resource(
+        $this,
+        $this->serviceName,
+        'traces',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'v1/projects/{projectId}/traces/{traceId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'traceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1/projects/{projectId}/traces',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'endTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->v1 = new Google_Service_Cloudtrace_V1_Resource(
+        $this,
+        $this->serviceName,
+        'v1',
+        array(
+          'methods' => array(
+            'getDiscovery' => array(
+              'path' => 'v1/discovery',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'labels' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'version' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'args' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'format' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "projects" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $cloudtraceService = new Google_Service_Cloudtrace(...);
+ *   $projects = $cloudtraceService->projects;
+ *  </code>
+ */
+class Google_Service_Cloudtrace_Projects_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Updates the existing traces specified by PatchTracesRequest and inserts the
+   * new traces. Any existing trace or span fields included in an update are
+   * overwritten by the update, and any additional fields in an update are merged
+   * with the existing trace data. (projects.patchTraces)
+   *
+   * @param string $projectId The project id of the trace to patch.
+   * @param Google_Traces $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudtrace_Empty
+   */
+  public function patchTraces($projectId, Google_Service_Cloudtrace_Traces $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patchTraces', array($params), "Google_Service_Cloudtrace_Empty");
+  }
+}
+
+/**
+ * The "traces" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $cloudtraceService = new Google_Service_Cloudtrace(...);
+ *   $traces = $cloudtraceService->traces;
+ *  </code>
+ */
+class Google_Service_Cloudtrace_ProjectsTraces_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one trace by id. (traces.get)
+   *
+   * @param string $projectId The project id of the trace to return.
+   * @param string $traceId The trace id of the trace to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Cloudtrace_Trace
+   */
+  public function get($projectId, $traceId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'traceId' => $traceId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Cloudtrace_Trace");
+  }
+
+  /**
+   * List traces matching the filter expression. (traces.listProjectsTraces)
+   *
+   * @param string $projectId The stringified-version of the project id.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderBy The trace field used to establish the order of
+   * traces returned by the ListTraces method. Possible options are: trace_id name
+   * (name field of root span) duration (different between end_time and start_time
+   * fields of root span) start (start_time field of root span) Descending order
+   * can be specified by appending "desc" to the sort field: name desc Only one
+   * sort field is permitted, though this may change in the future.
+   * @opt_param int pageSize Maximum number of topics to return. If not specified
+   * or <= 0, the implementation will select a reasonable value. The implemenation
+   * may always return fewer than the requested page_size.
+   * @opt_param string filter An optional filter for the request.
+   * @opt_param string pageToken The token identifying the page of results to
+   * return from the ListTraces method. If present, this value is should be taken
+   * from the next_page_token field of a previous ListTracesResponse.
+   * @opt_param string startTime End of the time interval (inclusive).
+   * @opt_param string endTime Start of the time interval (exclusive).
+   * @opt_param string view ViewType specifies the projection of the result.
+   * @return Google_Service_Cloudtrace_ListTracesResponse
+   */
+  public function listProjectsTraces($projectId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Cloudtrace_ListTracesResponse");
+  }
+}
+
+/**
+ * The "v1" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $cloudtraceService = new Google_Service_Cloudtrace(...);
+ *   $v1 = $cloudtraceService->v1;
+ *  </code>
+ */
+class Google_Service_Cloudtrace_V1_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns a discovery document in the specified `format`. The typeurl in the
+   * returned google.protobuf.Any value depends on the requested format.
+   * (v1.getDiscovery)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string labels A list of labels (like visibility) influencing the
+   * scope of the requested doc.
+   * @opt_param string version The API version of the requested discovery doc.
+   * @opt_param string args Any additional arguments.
+   * @opt_param string format The format requested for discovery.
+   */
+  public function getDiscovery($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('getDiscovery', array($params));
+  }
+}
+
+
+
+
+class Google_Service_Cloudtrace_Empty extends Google_Model
+{
+}
+
+class Google_Service_Cloudtrace_ListTracesResponse extends Google_Collection
+{
+  protected $collection_key = 'traces';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $tracesType = 'Google_Service_Cloudtrace_Trace';
+  protected $tracesDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTraces($traces)
+  {
+    $this->traces = $traces;
+  }
+  public function getTraces()
+  {
+    return $this->traces;
+  }
+}
+
+class Google_Service_Cloudtrace_Trace extends Google_Collection
+{
+  protected $collection_key = 'spans';
+  protected $internal_gapi_mappings = array(
+  );
+  public $projectId;
+  protected $spansType = 'Google_Service_Cloudtrace_TraceSpan';
+  protected $spansDataType = 'array';
+  public $traceId;
+
+
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setSpans($spans)
+  {
+    $this->spans = $spans;
+  }
+  public function getSpans()
+  {
+    return $this->spans;
+  }
+  public function setTraceId($traceId)
+  {
+    $this->traceId = $traceId;
+  }
+  public function getTraceId()
+  {
+    return $this->traceId;
+  }
+}
+
+class Google_Service_Cloudtrace_TraceSpan extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $endTime;
+  public $kind;
+  public $labels;
+  public $name;
+  public $parentSpanId;
+  public $spanId;
+  public $startTime;
+
+
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLabels($labels)
+  {
+    $this->labels = $labels;
+  }
+  public function getLabels()
+  {
+    return $this->labels;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setParentSpanId($parentSpanId)
+  {
+    $this->parentSpanId = $parentSpanId;
+  }
+  public function getParentSpanId()
+  {
+    return $this->parentSpanId;
+  }
+  public function setSpanId($spanId)
+  {
+    $this->spanId = $spanId;
+  }
+  public function getSpanId()
+  {
+    return $this->spanId;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+}
+
+class Google_Service_Cloudtrace_TraceSpanLabels extends Google_Model
+{
+}
+
+class Google_Service_Cloudtrace_Traces extends Google_Collection
+{
+  protected $collection_key = 'traces';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $tracesType = 'Google_Service_Cloudtrace_Trace';
+  protected $tracesDataType = 'array';
+
+
+  public function setTraces($traces)
+  {
+    $this->traces = $traces;
+  }
+  public function getTraces()
+  {
+    return $this->traces;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Compute.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Compute.php
@@ -1,0 +1,17953 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Compute (v1).
+ *
+ * <p>
+ * API for the Google Compute Engine service.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/compute/docs/reference/latest/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Compute extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+  /** View and manage your Google Compute Engine resources. */
+  const COMPUTE =
+      "https://www.googleapis.com/auth/compute";
+  /** View your Google Compute Engine resources. */
+  const COMPUTE_READONLY =
+      "https://www.googleapis.com/auth/compute.readonly";
+  /** Manage your data and permissions in Google Cloud Storage. */
+  const DEVSTORAGE_FULL_CONTROL =
+      "https://www.googleapis.com/auth/devstorage.full_control";
+  /** View your data in Google Cloud Storage. */
+  const DEVSTORAGE_READ_ONLY =
+      "https://www.googleapis.com/auth/devstorage.read_only";
+  /** Manage your data in Google Cloud Storage. */
+  const DEVSTORAGE_READ_WRITE =
+      "https://www.googleapis.com/auth/devstorage.read_write";
+
+  public $addresses;
+  public $autoscalers;
+  public $backendServices;
+  public $diskTypes;
+  public $disks;
+  public $firewalls;
+  public $forwardingRules;
+  public $globalAddresses;
+  public $globalForwardingRules;
+  public $globalOperations;
+  public $httpHealthChecks;
+  public $httpsHealthChecks;
+  public $images;
+  public $instanceGroupManagers;
+  public $instanceGroups;
+  public $instanceTemplates;
+  public $instances;
+  public $licenses;
+  public $machineTypes;
+  public $networks;
+  public $projects;
+  public $regionOperations;
+  public $regions;
+  public $routes;
+  public $snapshots;
+  public $sslCertificates;
+  public $targetHttpProxies;
+  public $targetHttpsProxies;
+  public $targetInstances;
+  public $targetPools;
+  public $targetVpnGateways;
+  public $urlMaps;
+  public $vpnTunnels;
+  public $zoneOperations;
+  public $zones;
+  
+
+  /**
+   * Constructs the internal representation of the Compute service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'compute/v1/projects/';
+    $this->version = 'v1';
+    $this->serviceName = 'compute';
+
+    $this->addresses = new Google_Service_Compute_Addresses_Resource(
+        $this,
+        $this->serviceName,
+        'addresses',
+        array(
+          'methods' => array(
+            'aggregatedList' => array(
+              'path' => '{project}/aggregated/addresses',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/regions/{region}/addresses/{address}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'address' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/regions/{region}/addresses/{address}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'address' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/regions/{region}/addresses',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/regions/{region}/addresses',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->autoscalers = new Google_Service_Compute_Autoscalers_Resource(
+        $this,
+        $this->serviceName,
+        'autoscalers',
+        array(
+          'methods' => array(
+            'aggregatedList' => array(
+              'path' => '{project}/aggregated/autoscalers',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/zones/{zone}/autoscalers/{autoscaler}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'autoscaler' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/zones/{zone}/autoscalers/{autoscaler}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'autoscaler' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/zones/{zone}/autoscalers',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/zones/{zone}/autoscalers',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{project}/zones/{zone}/autoscalers',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'autoscaler' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{project}/zones/{zone}/autoscalers',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'autoscaler' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->backendServices = new Google_Service_Compute_BackendServices_Resource(
+        $this,
+        $this->serviceName,
+        'backendServices',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/global/backendServices/{backendService}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'backendService' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/backendServices/{backendService}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'backendService' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getHealth' => array(
+              'path' => '{project}/global/backendServices/{backendService}/getHealth',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'backendService' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/backendServices',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/backendServices',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{project}/global/backendServices/{backendService}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'backendService' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{project}/global/backendServices/{backendService}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'backendService' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->diskTypes = new Google_Service_Compute_DiskTypes_Resource(
+        $this,
+        $this->serviceName,
+        'diskTypes',
+        array(
+          'methods' => array(
+            'aggregatedList' => array(
+              'path' => '{project}/aggregated/diskTypes',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/zones/{zone}/diskTypes/{diskType}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'diskType' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/zones/{zone}/diskTypes',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->disks = new Google_Service_Compute_Disks_Resource(
+        $this,
+        $this->serviceName,
+        'disks',
+        array(
+          'methods' => array(
+            'aggregatedList' => array(
+              'path' => '{project}/aggregated/disks',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'createSnapshot' => array(
+              'path' => '{project}/zones/{zone}/disks/{disk}/createSnapshot',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'disk' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/zones/{zone}/disks/{disk}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'disk' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/zones/{zone}/disks/{disk}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'disk' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/zones/{zone}/disks',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sourceImage' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/zones/{zone}/disks',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->firewalls = new Google_Service_Compute_Firewalls_Resource(
+        $this,
+        $this->serviceName,
+        'firewalls',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/global/firewalls/{firewall}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'firewall' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/firewalls/{firewall}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'firewall' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/firewalls',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/firewalls',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{project}/global/firewalls/{firewall}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'firewall' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{project}/global/firewalls/{firewall}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'firewall' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->forwardingRules = new Google_Service_Compute_ForwardingRules_Resource(
+        $this,
+        $this->serviceName,
+        'forwardingRules',
+        array(
+          'methods' => array(
+            'aggregatedList' => array(
+              'path' => '{project}/aggregated/forwardingRules',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/regions/{region}/forwardingRules/{forwardingRule}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'forwardingRule' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/regions/{region}/forwardingRules/{forwardingRule}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'forwardingRule' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/regions/{region}/forwardingRules',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/regions/{region}/forwardingRules',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'setTarget' => array(
+              'path' => '{project}/regions/{region}/forwardingRules/{forwardingRule}/setTarget',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'forwardingRule' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->globalAddresses = new Google_Service_Compute_GlobalAddresses_Resource(
+        $this,
+        $this->serviceName,
+        'globalAddresses',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/global/addresses/{address}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'address' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/addresses/{address}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'address' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/addresses',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/addresses',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->globalForwardingRules = new Google_Service_Compute_GlobalForwardingRules_Resource(
+        $this,
+        $this->serviceName,
+        'globalForwardingRules',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/global/forwardingRules/{forwardingRule}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'forwardingRule' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/forwardingRules/{forwardingRule}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'forwardingRule' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/forwardingRules',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/forwardingRules',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'setTarget' => array(
+              'path' => '{project}/global/forwardingRules/{forwardingRule}/setTarget',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'forwardingRule' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->globalOperations = new Google_Service_Compute_GlobalOperations_Resource(
+        $this,
+        $this->serviceName,
+        'globalOperations',
+        array(
+          'methods' => array(
+            'aggregatedList' => array(
+              'path' => '{project}/aggregated/operations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/global/operations/{operation}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operation' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/operations/{operation}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operation' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/operations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->httpHealthChecks = new Google_Service_Compute_HttpHealthChecks_Resource(
+        $this,
+        $this->serviceName,
+        'httpHealthChecks',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/global/httpHealthChecks/{httpHealthCheck}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'httpHealthCheck' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/httpHealthChecks/{httpHealthCheck}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'httpHealthCheck' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/httpHealthChecks',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/httpHealthChecks',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{project}/global/httpHealthChecks/{httpHealthCheck}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'httpHealthCheck' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{project}/global/httpHealthChecks/{httpHealthCheck}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'httpHealthCheck' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->httpsHealthChecks = new Google_Service_Compute_HttpsHealthChecks_Resource(
+        $this,
+        $this->serviceName,
+        'httpsHealthChecks',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/global/httpsHealthChecks/{httpsHealthCheck}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'httpsHealthCheck' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/httpsHealthChecks/{httpsHealthCheck}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'httpsHealthCheck' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/httpsHealthChecks',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/httpsHealthChecks',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{project}/global/httpsHealthChecks/{httpsHealthCheck}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'httpsHealthCheck' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{project}/global/httpsHealthChecks/{httpsHealthCheck}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'httpsHealthCheck' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->images = new Google_Service_Compute_Images_Resource(
+        $this,
+        $this->serviceName,
+        'images',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/global/images/{image}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'image' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'deprecate' => array(
+              'path' => '{project}/global/images/{image}/deprecate',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'image' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/images/{image}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'image' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/images',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/images',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->instanceGroupManagers = new Google_Service_Compute_InstanceGroupManagers_Resource(
+        $this,
+        $this->serviceName,
+        'instanceGroupManagers',
+        array(
+          'methods' => array(
+            'abandonInstances' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/abandonInstances',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroupManager' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'aggregatedList' => array(
+              'path' => '{project}/aggregated/instanceGroupManagers',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroupManager' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'deleteInstances' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/deleteInstances',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroupManager' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroupManager' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'listManagedInstances' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/listManagedInstances',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroupManager' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'recreateInstances' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/recreateInstances',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroupManager' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'resize' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/resize',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroupManager' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'size' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'setInstanceTemplate' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/setInstanceTemplate',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroupManager' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setTargetPools' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/setTargetPools',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroupManager' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->instanceGroups = new Google_Service_Compute_InstanceGroups_Resource(
+        $this,
+        $this->serviceName,
+        'instanceGroups',
+        array(
+          'methods' => array(
+            'addInstances' => array(
+              'path' => '{project}/zones/{zone}/instanceGroups/{instanceGroup}/addInstances',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroup' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'aggregatedList' => array(
+              'path' => '{project}/aggregated/instanceGroups',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/zones/{zone}/instanceGroups/{instanceGroup}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroup' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/zones/{zone}/instanceGroups/{instanceGroup}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroup' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/zones/{zone}/instanceGroups',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/zones/{zone}/instanceGroups',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'listInstances' => array(
+              'path' => '{project}/zones/{zone}/instanceGroups/{instanceGroup}/listInstances',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroup' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'removeInstances' => array(
+              'path' => '{project}/zones/{zone}/instanceGroups/{instanceGroup}/removeInstances',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroup' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setNamedPorts' => array(
+              'path' => '{project}/zones/{zone}/instanceGroups/{instanceGroup}/setNamedPorts',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroup' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->instanceTemplates = new Google_Service_Compute_InstanceTemplates_Resource(
+        $this,
+        $this->serviceName,
+        'instanceTemplates',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/global/instanceTemplates/{instanceTemplate}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceTemplate' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/instanceTemplates/{instanceTemplate}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceTemplate' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/instanceTemplates',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/instanceTemplates',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->instances = new Google_Service_Compute_Instances_Resource(
+        $this,
+        $this->serviceName,
+        'instances',
+        array(
+          'methods' => array(
+            'addAccessConfig' => array(
+              'path' => '{project}/zones/{zone}/instances/{instance}/addAccessConfig',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'networkInterface' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'aggregatedList' => array(
+              'path' => '{project}/aggregated/instances',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'attachDisk' => array(
+              'path' => '{project}/zones/{zone}/instances/{instance}/attachDisk',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/zones/{zone}/instances/{instance}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'deleteAccessConfig' => array(
+              'path' => '{project}/zones/{zone}/instances/{instance}/deleteAccessConfig',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'accessConfig' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'networkInterface' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'detachDisk' => array(
+              'path' => '{project}/zones/{zone}/instances/{instance}/detachDisk',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deviceName' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/zones/{zone}/instances/{instance}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getSerialPortOutput' => array(
+              'path' => '{project}/zones/{zone}/instances/{instance}/serialPort',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'port' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/zones/{zone}/instances',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/zones/{zone}/instances',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'reset' => array(
+              'path' => '{project}/zones/{zone}/instances/{instance}/reset',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setDiskAutoDelete' => array(
+              'path' => '{project}/zones/{zone}/instances/{instance}/setDiskAutoDelete',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'autoDelete' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                  'required' => true,
+                ),
+                'deviceName' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setMetadata' => array(
+              'path' => '{project}/zones/{zone}/instances/{instance}/setMetadata',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setScheduling' => array(
+              'path' => '{project}/zones/{zone}/instances/{instance}/setScheduling',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setTags' => array(
+              'path' => '{project}/zones/{zone}/instances/{instance}/setTags',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'start' => array(
+              'path' => '{project}/zones/{zone}/instances/{instance}/start',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'stop' => array(
+              'path' => '{project}/zones/{zone}/instances/{instance}/stop',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->licenses = new Google_Service_Compute_Licenses_Resource(
+        $this,
+        $this->serviceName,
+        'licenses',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{project}/global/licenses/{license}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'license' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->machineTypes = new Google_Service_Compute_MachineTypes_Resource(
+        $this,
+        $this->serviceName,
+        'machineTypes',
+        array(
+          'methods' => array(
+            'aggregatedList' => array(
+              'path' => '{project}/aggregated/machineTypes',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/zones/{zone}/machineTypes/{machineType}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'machineType' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/zones/{zone}/machineTypes',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->networks = new Google_Service_Compute_Networks_Resource(
+        $this,
+        $this->serviceName,
+        'networks',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/global/networks/{network}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'network' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/networks/{network}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'network' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/networks',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/networks',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->projects = new Google_Service_Compute_Projects_Resource(
+        $this,
+        $this->serviceName,
+        'projects',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{project}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'moveDisk' => array(
+              'path' => '{project}/moveDisk',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'moveInstance' => array(
+              'path' => '{project}/moveInstance',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setCommonInstanceMetadata' => array(
+              'path' => '{project}/setCommonInstanceMetadata',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setUsageExportBucket' => array(
+              'path' => '{project}/setUsageExportBucket',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->regionOperations = new Google_Service_Compute_RegionOperations_Resource(
+        $this,
+        $this->serviceName,
+        'regionOperations',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/regions/{region}/operations/{operation}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operation' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/regions/{region}/operations/{operation}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operation' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/regions/{region}/operations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->regions = new Google_Service_Compute_Regions_Resource(
+        $this,
+        $this->serviceName,
+        'regions',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{project}/regions/{region}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/regions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->routes = new Google_Service_Compute_Routes_Resource(
+        $this,
+        $this->serviceName,
+        'routes',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/global/routes/{route}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'route' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/routes/{route}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'route' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/routes',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/routes',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->snapshots = new Google_Service_Compute_Snapshots_Resource(
+        $this,
+        $this->serviceName,
+        'snapshots',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/global/snapshots/{snapshot}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'snapshot' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/snapshots/{snapshot}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'snapshot' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/snapshots',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->sslCertificates = new Google_Service_Compute_SslCertificates_Resource(
+        $this,
+        $this->serviceName,
+        'sslCertificates',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/global/sslCertificates/{sslCertificate}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sslCertificate' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/sslCertificates/{sslCertificate}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sslCertificate' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/sslCertificates',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/sslCertificates',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->targetHttpProxies = new Google_Service_Compute_TargetHttpProxies_Resource(
+        $this,
+        $this->serviceName,
+        'targetHttpProxies',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/global/targetHttpProxies/{targetHttpProxy}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetHttpProxy' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/targetHttpProxies/{targetHttpProxy}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetHttpProxy' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/targetHttpProxies',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/targetHttpProxies',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'setUrlMap' => array(
+              'path' => '{project}/targetHttpProxies/{targetHttpProxy}/setUrlMap',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetHttpProxy' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->targetHttpsProxies = new Google_Service_Compute_TargetHttpsProxies_Resource(
+        $this,
+        $this->serviceName,
+        'targetHttpsProxies',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/global/targetHttpsProxies/{targetHttpsProxy}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetHttpsProxy' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/targetHttpsProxies/{targetHttpsProxy}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetHttpsProxy' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/targetHttpsProxies',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/targetHttpsProxies',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'setSslCertificates' => array(
+              'path' => '{project}/targetHttpsProxies/{targetHttpsProxy}/setSslCertificates',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetHttpsProxy' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setUrlMap' => array(
+              'path' => '{project}/targetHttpsProxies/{targetHttpsProxy}/setUrlMap',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetHttpsProxy' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->targetInstances = new Google_Service_Compute_TargetInstances_Resource(
+        $this,
+        $this->serviceName,
+        'targetInstances',
+        array(
+          'methods' => array(
+            'aggregatedList' => array(
+              'path' => '{project}/aggregated/targetInstances',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/zones/{zone}/targetInstances/{targetInstance}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetInstance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/zones/{zone}/targetInstances/{targetInstance}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetInstance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/zones/{zone}/targetInstances',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/zones/{zone}/targetInstances',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->targetPools = new Google_Service_Compute_TargetPools_Resource(
+        $this,
+        $this->serviceName,
+        'targetPools',
+        array(
+          'methods' => array(
+            'addHealthCheck' => array(
+              'path' => '{project}/regions/{region}/targetPools/{targetPool}/addHealthCheck',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetPool' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'addInstance' => array(
+              'path' => '{project}/regions/{region}/targetPools/{targetPool}/addInstance',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetPool' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'aggregatedList' => array(
+              'path' => '{project}/aggregated/targetPools',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/regions/{region}/targetPools/{targetPool}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetPool' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/regions/{region}/targetPools/{targetPool}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetPool' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getHealth' => array(
+              'path' => '{project}/regions/{region}/targetPools/{targetPool}/getHealth',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetPool' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/regions/{region}/targetPools',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/regions/{region}/targetPools',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'removeHealthCheck' => array(
+              'path' => '{project}/regions/{region}/targetPools/{targetPool}/removeHealthCheck',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetPool' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'removeInstance' => array(
+              'path' => '{project}/regions/{region}/targetPools/{targetPool}/removeInstance',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetPool' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setBackup' => array(
+              'path' => '{project}/regions/{region}/targetPools/{targetPool}/setBackup',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetPool' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'failoverRatio' => array(
+                  'location' => 'query',
+                  'type' => 'number',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->targetVpnGateways = new Google_Service_Compute_TargetVpnGateways_Resource(
+        $this,
+        $this->serviceName,
+        'targetVpnGateways',
+        array(
+          'methods' => array(
+            'aggregatedList' => array(
+              'path' => '{project}/aggregated/targetVpnGateways',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/regions/{region}/targetVpnGateways/{targetVpnGateway}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetVpnGateway' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/regions/{region}/targetVpnGateways/{targetVpnGateway}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'targetVpnGateway' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/regions/{region}/targetVpnGateways',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/regions/{region}/targetVpnGateways',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->urlMaps = new Google_Service_Compute_UrlMaps_Resource(
+        $this,
+        $this->serviceName,
+        'urlMaps',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/global/urlMaps/{urlMap}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'urlMap' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/urlMaps/{urlMap}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'urlMap' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/urlMaps',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/urlMaps',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{project}/global/urlMaps/{urlMap}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'urlMap' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{project}/global/urlMaps/{urlMap}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'urlMap' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'validate' => array(
+              'path' => '{project}/global/urlMaps/{urlMap}/validate',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'urlMap' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->vpnTunnels = new Google_Service_Compute_VpnTunnels_Resource(
+        $this,
+        $this->serviceName,
+        'vpnTunnels',
+        array(
+          'methods' => array(
+            'aggregatedList' => array(
+              'path' => '{project}/aggregated/vpnTunnels',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/regions/{region}/vpnTunnels/{vpnTunnel}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'vpnTunnel' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/regions/{region}/vpnTunnels/{vpnTunnel}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'vpnTunnel' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/regions/{region}/vpnTunnels',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/regions/{region}/vpnTunnels',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->zoneOperations = new Google_Service_Compute_ZoneOperations_Resource(
+        $this,
+        $this->serviceName,
+        'zoneOperations',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/zones/{zone}/operations/{operation}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operation' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/zones/{zone}/operations/{operation}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operation' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/zones/{zone}/operations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->zones = new Google_Service_Compute_Zones_Resource(
+        $this,
+        $this->serviceName,
+        'zones',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{project}/zones/{zone}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/zones',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "addresses" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $addresses = $computeService->addresses;
+ *  </code>
+ */
+class Google_Service_Compute_Addresses_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the list of addresses grouped by scope. (addresses.aggregatedList)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_AddressAggregatedList
+   */
+  public function aggregatedList($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('aggregatedList', array($params), "Google_Service_Compute_AddressAggregatedList");
+  }
+
+  /**
+   * Deletes the specified address resource. (addresses.delete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $region The name of the region for this request.
+   * @param string $address Name of the address resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $region, $address, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'address' => $address);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified address resource. (addresses.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $region The name of the region for this request.
+   * @param string $address Name of the address resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Address
+   */
+  public function get($project, $region, $address, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'address' => $address);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_Address");
+  }
+
+  /**
+   * Creates an address resource in the specified project using the data included
+   * in the request. (addresses.insert)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $region The name of the region for this request.
+   * @param Google_Address $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, $region, Google_Service_Compute_Address $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of address resources contained within the specified
+   * region. (addresses.listAddresses)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $region The name of the region for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_AddressList
+   */
+  public function listAddresses($project, $region, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_AddressList");
+  }
+}
+
+/**
+ * The "autoscalers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $autoscalers = $computeService->autoscalers;
+ *  </code>
+ */
+class Google_Service_Compute_Autoscalers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the list of autoscalers grouped by scope.
+   * (autoscalers.aggregatedList)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_AutoscalerAggregatedList
+   */
+  public function aggregatedList($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('aggregatedList', array($params), "Google_Service_Compute_AutoscalerAggregatedList");
+  }
+
+  /**
+   * Deletes the specified autoscaler resource. (autoscalers.delete)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param string $autoscaler Name of the persistent autoscaler resource to
+   * delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $zone, $autoscaler, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'autoscaler' => $autoscaler);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified autoscaler resource. (autoscalers.get)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param string $autoscaler Name of the persistent autoscaler resource to
+   * return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Autoscaler
+   */
+  public function get($project, $zone, $autoscaler, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'autoscaler' => $autoscaler);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_Autoscaler");
+  }
+
+  /**
+   * Creates an autoscaler resource in the specified project using the data
+   * included in the request. (autoscalers.insert)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param Google_Autoscaler $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, $zone, Google_Service_Compute_Autoscaler $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of autoscaler resources contained within the specified
+   * zone. (autoscalers.listAutoscalers)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_AutoscalerList
+   */
+  public function listAutoscalers($project, $zone, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_AutoscalerList");
+  }
+
+  /**
+   * Updates an autoscaler resource in the specified project using the data
+   * included in the request. This method supports patch semantics.
+   * (autoscalers.patch)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param string $autoscaler Name of the autoscaler resource to update.
+   * @param Google_Autoscaler $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function patch($project, $zone, $autoscaler, Google_Service_Compute_Autoscaler $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'autoscaler' => $autoscaler, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Updates an autoscaler resource in the specified project using the data
+   * included in the request. (autoscalers.update)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param Google_Autoscaler $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string autoscaler Name of the autoscaler resource to update.
+   * @return Google_Service_Compute_Operation
+   */
+  public function update($project, $zone, Google_Service_Compute_Autoscaler $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Compute_Operation");
+  }
+}
+
+/**
+ * The "backendServices" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $backendServices = $computeService->backendServices;
+ *  </code>
+ */
+class Google_Service_Compute_BackendServices_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified BackendService resource. (backendServices.delete)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $backendService Name of the BackendService resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $backendService, $optParams = array())
+  {
+    $params = array('project' => $project, 'backendService' => $backendService);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified BackendService resource. (backendServices.get)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $backendService Name of the BackendService resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_BackendService
+   */
+  public function get($project, $backendService, $optParams = array())
+  {
+    $params = array('project' => $project, 'backendService' => $backendService);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_BackendService");
+  }
+
+  /**
+   * Gets the most recent health check results for this BackendService.
+   * (backendServices.getHealth)
+   *
+   * @param string $project
+   * @param string $backendService Name of the BackendService resource to which
+   * the queried instance belongs.
+   * @param Google_ResourceGroupReference $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_BackendServiceGroupHealth
+   */
+  public function getHealth($project, $backendService, Google_Service_Compute_ResourceGroupReference $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'backendService' => $backendService, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('getHealth', array($params), "Google_Service_Compute_BackendServiceGroupHealth");
+  }
+
+  /**
+   * Creates a BackendService resource in the specified project using the data
+   * included in the request. (backendServices.insert)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param Google_BackendService $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, Google_Service_Compute_BackendService $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of BackendService resources available to the specified
+   * project. (backendServices.listBackendServices)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_BackendServiceList
+   */
+  public function listBackendServices($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_BackendServiceList");
+  }
+
+  /**
+   * Update the entire content of the BackendService resource. This method
+   * supports patch semantics. (backendServices.patch)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $backendService Name of the BackendService resource to update.
+   * @param Google_BackendService $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function patch($project, $backendService, Google_Service_Compute_BackendService $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'backendService' => $backendService, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Update the entire content of the BackendService resource.
+   * (backendServices.update)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $backendService Name of the BackendService resource to update.
+   * @param Google_BackendService $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function update($project, $backendService, Google_Service_Compute_BackendService $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'backendService' => $backendService, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Compute_Operation");
+  }
+}
+
+/**
+ * The "diskTypes" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $diskTypes = $computeService->diskTypes;
+ *  </code>
+ */
+class Google_Service_Compute_DiskTypes_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the list of disk type resources grouped by scope.
+   * (diskTypes.aggregatedList)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_DiskTypeAggregatedList
+   */
+  public function aggregatedList($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('aggregatedList', array($params), "Google_Service_Compute_DiskTypeAggregatedList");
+  }
+
+  /**
+   * Returns the specified disk type resource. (diskTypes.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $diskType Name of the disk type resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_DiskType
+   */
+  public function get($project, $zone, $diskType, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'diskType' => $diskType);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_DiskType");
+  }
+
+  /**
+   * Retrieves the list of disk type resources available to the specified project.
+   * (diskTypes.listDiskTypes)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_DiskTypeList
+   */
+  public function listDiskTypes($project, $zone, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_DiskTypeList");
+  }
+}
+
+/**
+ * The "disks" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $disks = $computeService->disks;
+ *  </code>
+ */
+class Google_Service_Compute_Disks_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the list of disks grouped by scope. (disks.aggregatedList)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_DiskAggregatedList
+   */
+  public function aggregatedList($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('aggregatedList', array($params), "Google_Service_Compute_DiskAggregatedList");
+  }
+
+  /**
+   * Creates a snapshot of this disk. (disks.createSnapshot)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $disk Name of the persistent disk to snapshot.
+   * @param Google_Snapshot $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function createSnapshot($project, $zone, $disk, Google_Service_Compute_Snapshot $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'disk' => $disk, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('createSnapshot', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Deletes the specified persistent disk. Deleting a disk removes its data
+   * permanently and is irreversible. However, deleting a disk does not delete any
+   * snapshots previously made from the disk. You must separately delete
+   * snapshots. (disks.delete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $disk Name of the persistent disk to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $zone, $disk, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'disk' => $disk);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns a specified persistent disk. (disks.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $disk Name of the persistent disk to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Disk
+   */
+  public function get($project, $zone, $disk, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'disk' => $disk);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_Disk");
+  }
+
+  /**
+   * Creates a persistent disk in the specified project using the data included in
+   * the request. (disks.insert)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param Google_Disk $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string sourceImage Optional. Source image to restore onto a disk.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, $zone, Google_Service_Compute_Disk $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of persistent disks contained within the specified zone.
+   * (disks.listDisks)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_DiskList
+   */
+  public function listDisks($project, $zone, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_DiskList");
+  }
+}
+
+/**
+ * The "firewalls" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $firewalls = $computeService->firewalls;
+ *  </code>
+ */
+class Google_Service_Compute_Firewalls_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified firewall resource. (firewalls.delete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $firewall Name of the firewall resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $firewall, $optParams = array())
+  {
+    $params = array('project' => $project, 'firewall' => $firewall);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified firewall resource. (firewalls.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $firewall Name of the firewall resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Firewall
+   */
+  public function get($project, $firewall, $optParams = array())
+  {
+    $params = array('project' => $project, 'firewall' => $firewall);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_Firewall");
+  }
+
+  /**
+   * Creates a firewall resource in the specified project using the data included
+   * in the request. (firewalls.insert)
+   *
+   * @param string $project Project ID for this request.
+   * @param Google_Firewall $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, Google_Service_Compute_Firewall $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of firewall resources available to the specified project.
+   * (firewalls.listFirewalls)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_FirewallList
+   */
+  public function listFirewalls($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_FirewallList");
+  }
+
+  /**
+   * Updates the specified firewall resource with the data included in the
+   * request. This method supports patch semantics. (firewalls.patch)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $firewall Name of the firewall resource to update.
+   * @param Google_Firewall $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function patch($project, $firewall, Google_Service_Compute_Firewall $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'firewall' => $firewall, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Updates the specified firewall resource with the data included in the
+   * request. (firewalls.update)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $firewall Name of the firewall resource to update.
+   * @param Google_Firewall $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function update($project, $firewall, Google_Service_Compute_Firewall $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'firewall' => $firewall, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Compute_Operation");
+  }
+}
+
+/**
+ * The "forwardingRules" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $forwardingRules = $computeService->forwardingRules;
+ *  </code>
+ */
+class Google_Service_Compute_ForwardingRules_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the list of forwarding rules grouped by scope.
+   * (forwardingRules.aggregatedList)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_ForwardingRuleAggregatedList
+   */
+  public function aggregatedList($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('aggregatedList', array($params), "Google_Service_Compute_ForwardingRuleAggregatedList");
+  }
+
+  /**
+   * Deletes the specified ForwardingRule resource. (forwardingRules.delete)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $region Name of the region scoping this request.
+   * @param string $forwardingRule Name of the ForwardingRule resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $region, $forwardingRule, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'forwardingRule' => $forwardingRule);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified ForwardingRule resource. (forwardingRules.get)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $region Name of the region scoping this request.
+   * @param string $forwardingRule Name of the ForwardingRule resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_ForwardingRule
+   */
+  public function get($project, $region, $forwardingRule, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'forwardingRule' => $forwardingRule);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_ForwardingRule");
+  }
+
+  /**
+   * Creates a ForwardingRule resource in the specified project and region using
+   * the data included in the request. (forwardingRules.insert)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $region Name of the region scoping this request.
+   * @param Google_ForwardingRule $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, $region, Google_Service_Compute_ForwardingRule $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of ForwardingRule resources available to the specified
+   * project and region. (forwardingRules.listForwardingRules)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $region Name of the region scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_ForwardingRuleList
+   */
+  public function listForwardingRules($project, $region, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_ForwardingRuleList");
+  }
+
+  /**
+   * Changes target url for forwarding rule. (forwardingRules.setTarget)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $region Name of the region scoping this request.
+   * @param string $forwardingRule Name of the ForwardingRule resource in which
+   * target is to be set.
+   * @param Google_TargetReference $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function setTarget($project, $region, $forwardingRule, Google_Service_Compute_TargetReference $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'forwardingRule' => $forwardingRule, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setTarget', array($params), "Google_Service_Compute_Operation");
+  }
+}
+
+/**
+ * The "globalAddresses" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $globalAddresses = $computeService->globalAddresses;
+ *  </code>
+ */
+class Google_Service_Compute_GlobalAddresses_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified address resource. (globalAddresses.delete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $address Name of the address resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $address, $optParams = array())
+  {
+    $params = array('project' => $project, 'address' => $address);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified address resource. (globalAddresses.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $address Name of the address resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Address
+   */
+  public function get($project, $address, $optParams = array())
+  {
+    $params = array('project' => $project, 'address' => $address);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_Address");
+  }
+
+  /**
+   * Creates an address resource in the specified project using the data included
+   * in the request. (globalAddresses.insert)
+   *
+   * @param string $project Project ID for this request.
+   * @param Google_Address $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, Google_Service_Compute_Address $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of global address resources.
+   * (globalAddresses.listGlobalAddresses)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_AddressList
+   */
+  public function listGlobalAddresses($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_AddressList");
+  }
+}
+
+/**
+ * The "globalForwardingRules" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $globalForwardingRules = $computeService->globalForwardingRules;
+ *  </code>
+ */
+class Google_Service_Compute_GlobalForwardingRules_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified ForwardingRule resource. (globalForwardingRules.delete)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $forwardingRule Name of the ForwardingRule resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $forwardingRule, $optParams = array())
+  {
+    $params = array('project' => $project, 'forwardingRule' => $forwardingRule);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified ForwardingRule resource. (globalForwardingRules.get)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $forwardingRule Name of the ForwardingRule resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_ForwardingRule
+   */
+  public function get($project, $forwardingRule, $optParams = array())
+  {
+    $params = array('project' => $project, 'forwardingRule' => $forwardingRule);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_ForwardingRule");
+  }
+
+  /**
+   * Creates a ForwardingRule resource in the specified project and region using
+   * the data included in the request. (globalForwardingRules.insert)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param Google_ForwardingRule $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, Google_Service_Compute_ForwardingRule $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of ForwardingRule resources available to the specified
+   * project. (globalForwardingRules.listGlobalForwardingRules)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_ForwardingRuleList
+   */
+  public function listGlobalForwardingRules($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_ForwardingRuleList");
+  }
+
+  /**
+   * Changes target url for forwarding rule. (globalForwardingRules.setTarget)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $forwardingRule Name of the ForwardingRule resource in which
+   * target is to be set.
+   * @param Google_TargetReference $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function setTarget($project, $forwardingRule, Google_Service_Compute_TargetReference $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'forwardingRule' => $forwardingRule, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setTarget', array($params), "Google_Service_Compute_Operation");
+  }
+}
+
+/**
+ * The "globalOperations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $globalOperations = $computeService->globalOperations;
+ *  </code>
+ */
+class Google_Service_Compute_GlobalOperations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the list of all operations grouped by scope.
+   * (globalOperations.aggregatedList)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_OperationAggregatedList
+   */
+  public function aggregatedList($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('aggregatedList', array($params), "Google_Service_Compute_OperationAggregatedList");
+  }
+
+  /**
+   * Deletes the specified Operations resource. (globalOperations.delete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $operation Name of the Operations resource to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($project, $operation, $optParams = array())
+  {
+    $params = array('project' => $project, 'operation' => $operation);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves the specified Operations resource. (globalOperations.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $operation Name of the Operations resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function get($project, $operation, $optParams = array())
+  {
+    $params = array('project' => $project, 'operation' => $operation);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of Operation resources contained within the specified
+   * project. (globalOperations.listGlobalOperations)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_OperationList
+   */
+  public function listGlobalOperations($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_OperationList");
+  }
+}
+
+/**
+ * The "httpHealthChecks" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $httpHealthChecks = $computeService->httpHealthChecks;
+ *  </code>
+ */
+class Google_Service_Compute_HttpHealthChecks_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified HttpHealthCheck resource. (httpHealthChecks.delete)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $httpHealthCheck Name of the HttpHealthCheck resource to
+   * delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $httpHealthCheck, $optParams = array())
+  {
+    $params = array('project' => $project, 'httpHealthCheck' => $httpHealthCheck);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified HttpHealthCheck resource. (httpHealthChecks.get)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $httpHealthCheck Name of the HttpHealthCheck resource to
+   * return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_HttpHealthCheck
+   */
+  public function get($project, $httpHealthCheck, $optParams = array())
+  {
+    $params = array('project' => $project, 'httpHealthCheck' => $httpHealthCheck);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_HttpHealthCheck");
+  }
+
+  /**
+   * Creates a HttpHealthCheck resource in the specified project using the data
+   * included in the request. (httpHealthChecks.insert)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param Google_HttpHealthCheck $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, Google_Service_Compute_HttpHealthCheck $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of HttpHealthCheck resources available to the specified
+   * project. (httpHealthChecks.listHttpHealthChecks)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_HttpHealthCheckList
+   */
+  public function listHttpHealthChecks($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_HttpHealthCheckList");
+  }
+
+  /**
+   * Updates a HttpHealthCheck resource in the specified project using the data
+   * included in the request. This method supports patch semantics.
+   * (httpHealthChecks.patch)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $httpHealthCheck Name of the HttpHealthCheck resource to
+   * update.
+   * @param Google_HttpHealthCheck $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function patch($project, $httpHealthCheck, Google_Service_Compute_HttpHealthCheck $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'httpHealthCheck' => $httpHealthCheck, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Updates a HttpHealthCheck resource in the specified project using the data
+   * included in the request. (httpHealthChecks.update)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $httpHealthCheck Name of the HttpHealthCheck resource to
+   * update.
+   * @param Google_HttpHealthCheck $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function update($project, $httpHealthCheck, Google_Service_Compute_HttpHealthCheck $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'httpHealthCheck' => $httpHealthCheck, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Compute_Operation");
+  }
+}
+
+/**
+ * The "httpsHealthChecks" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $httpsHealthChecks = $computeService->httpsHealthChecks;
+ *  </code>
+ */
+class Google_Service_Compute_HttpsHealthChecks_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified HttpsHealthCheck resource. (httpsHealthChecks.delete)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $httpsHealthCheck Name of the HttpsHealthCheck resource to
+   * delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $httpsHealthCheck, $optParams = array())
+  {
+    $params = array('project' => $project, 'httpsHealthCheck' => $httpsHealthCheck);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified HttpsHealthCheck resource. (httpsHealthChecks.get)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $httpsHealthCheck Name of the HttpsHealthCheck resource to
+   * return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_HttpsHealthCheck
+   */
+  public function get($project, $httpsHealthCheck, $optParams = array())
+  {
+    $params = array('project' => $project, 'httpsHealthCheck' => $httpsHealthCheck);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_HttpsHealthCheck");
+  }
+
+  /**
+   * Creates a HttpsHealthCheck resource in the specified project using the data
+   * included in the request. (httpsHealthChecks.insert)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param Google_HttpsHealthCheck $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, Google_Service_Compute_HttpsHealthCheck $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of HttpsHealthCheck resources available to the specified
+   * project. (httpsHealthChecks.listHttpsHealthChecks)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_HttpsHealthCheckList
+   */
+  public function listHttpsHealthChecks($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_HttpsHealthCheckList");
+  }
+
+  /**
+   * Updates a HttpsHealthCheck resource in the specified project using the data
+   * included in the request. This method supports patch semantics.
+   * (httpsHealthChecks.patch)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $httpsHealthCheck Name of the HttpsHealthCheck resource to
+   * update.
+   * @param Google_HttpsHealthCheck $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function patch($project, $httpsHealthCheck, Google_Service_Compute_HttpsHealthCheck $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'httpsHealthCheck' => $httpsHealthCheck, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Updates a HttpsHealthCheck resource in the specified project using the data
+   * included in the request. (httpsHealthChecks.update)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $httpsHealthCheck Name of the HttpsHealthCheck resource to
+   * update.
+   * @param Google_HttpsHealthCheck $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function update($project, $httpsHealthCheck, Google_Service_Compute_HttpsHealthCheck $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'httpsHealthCheck' => $httpsHealthCheck, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Compute_Operation");
+  }
+}
+
+/**
+ * The "images" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $images = $computeService->images;
+ *  </code>
+ */
+class Google_Service_Compute_Images_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified image resource. (images.delete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $image Name of the image resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $image, $optParams = array())
+  {
+    $params = array('project' => $project, 'image' => $image);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Sets the deprecation status of an image.
+   *
+   * If an empty request body is given, clears the deprecation status instead.
+   * (images.deprecate)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $image Image name.
+   * @param Google_DeprecationStatus $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function deprecate($project, $image, Google_Service_Compute_DeprecationStatus $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'image' => $image, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('deprecate', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified image resource. (images.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $image Name of the image resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Image
+   */
+  public function get($project, $image, $optParams = array())
+  {
+    $params = array('project' => $project, 'image' => $image);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_Image");
+  }
+
+  /**
+   * Creates an image resource in the specified project using the data included in
+   * the request. (images.insert)
+   *
+   * @param string $project Project ID for this request.
+   * @param Google_Image $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, Google_Service_Compute_Image $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of private images available to the specified project.
+   * Private images are images you create that belong to your project. This method
+   * does not get any images that belong to other projects, including publicly-
+   * available images, like Debian 7. If you want to get a list of publicly-
+   * available images, use this method to make a request to the respective image
+   * project, such as debian-cloud or windows-cloud.
+   *
+   * See Accessing images for more information. (images.listImages)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_ImageList
+   */
+  public function listImages($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_ImageList");
+  }
+}
+
+/**
+ * The "instanceGroupManagers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $instanceGroupManagers = $computeService->instanceGroupManagers;
+ *  </code>
+ */
+class Google_Service_Compute_InstanceGroupManagers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Schedules a group action to remove the specified instances from the managed
+   * instance group. Abandoning an instance does not delete the instance, but it
+   * does remove the instance from any target pools that are applied by the
+   * managed instance group. This method reduces the targetSize of the managed
+   * instance group by the number of instances that you abandon. This operation is
+   * marked as DONE when the action is scheduled even if the instances have not
+   * yet been removed from the group. You must separately verify the status of the
+   * abandoning action with the listmanagedinstances method.
+   * (instanceGroupManagers.abandonInstances)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where the managed instance group is
+   * located.
+   * @param string $instanceGroupManager The name of the managed instance group.
+   * @param Google_InstanceGroupManagersAbandonInstancesRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function abandonInstances($project, $zone, $instanceGroupManager, Google_Service_Compute_InstanceGroupManagersAbandonInstancesRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroupManager' => $instanceGroupManager, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('abandonInstances', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of managed instance groups and groups them by zone.
+   * (instanceGroupManagers.aggregatedList)
+   *
+   * @param string $project The project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_InstanceGroupManagerAggregatedList
+   */
+  public function aggregatedList($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('aggregatedList', array($params), "Google_Service_Compute_InstanceGroupManagerAggregatedList");
+  }
+
+  /**
+   * Deletes the specified managed instance group and all of the instances in that
+   * group. (instanceGroupManagers.delete)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where the managed instance group is
+   * located.
+   * @param string $instanceGroupManager The name of the managed instance group to
+   * delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $zone, $instanceGroupManager, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroupManager' => $instanceGroupManager);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Schedules a group action to delete the specified instances in the managed
+   * instance group. The instances are also removed from any target pools of which
+   * they were a member. This method reduces the targetSize of the managed
+   * instance group by the number of instances that you delete. This operation is
+   * marked as DONE when the action is scheduled even if the instances are still
+   * being deleted. You must separately verify the status of the deleting action
+   * with the listmanagedinstances method. (instanceGroupManagers.deleteInstances)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where the managed instance group is
+   * located.
+   * @param string $instanceGroupManager The name of the managed instance group.
+   * @param Google_InstanceGroupManagersDeleteInstancesRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function deleteInstances($project, $zone, $instanceGroupManager, Google_Service_Compute_InstanceGroupManagersDeleteInstancesRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroupManager' => $instanceGroupManager, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('deleteInstances', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns all of the details about the specified managed instance group.
+   * (instanceGroupManagers.get)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where the managed instance group is
+   * located.
+   * @param string $instanceGroupManager The name of the managed instance group.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_InstanceGroupManager
+   */
+  public function get($project, $zone, $instanceGroupManager, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroupManager' => $instanceGroupManager);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_InstanceGroupManager");
+  }
+
+  /**
+   * Creates a managed instance group using the information that you specify in
+   * the request. After the group is created, it schedules an action to create
+   * instances in the group using the specified instance template. This operation
+   * is marked as DONE when the group is created even if the instances in the
+   * group have not yet been created. You must separately verify the status of the
+   * individual instances with the listmanagedinstances method.
+   * (instanceGroupManagers.insert)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where you want to create the managed
+   * instance group.
+   * @param Google_InstanceGroupManager $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, $zone, Google_Service_Compute_InstanceGroupManager $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves a list of managed instance groups that are contained within the
+   * specified project and zone. (instanceGroupManagers.listInstanceGroupManagers)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where the managed instance group is
+   * located.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_InstanceGroupManagerList
+   */
+  public function listInstanceGroupManagers($project, $zone, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_InstanceGroupManagerList");
+  }
+
+  /**
+   * Lists all of the instances in the managed instance group. Each instance in
+   * the list has a currentAction, which indicates the action that the managed
+   * instance group is performing on the instance. For example, if the group is
+   * still creating an instance, the currentAction is CREATING. If a previous
+   * action failed, the list displays the errors for that failed action.
+   * (instanceGroupManagers.listManagedInstances)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where the managed instance group is
+   * located.
+   * @param string $instanceGroupManager The name of the managed instance group.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_InstanceGroupManagersListManagedInstancesResponse
+   */
+  public function listManagedInstances($project, $zone, $instanceGroupManager, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroupManager' => $instanceGroupManager);
+    $params = array_merge($params, $optParams);
+    return $this->call('listManagedInstances', array($params), "Google_Service_Compute_InstanceGroupManagersListManagedInstancesResponse");
+  }
+
+  /**
+   * Schedules a group action to recreate the specified instances in the managed
+   * instance group. The instances are deleted and recreated using the current
+   * instance template for the managed instance group. This operation is marked as
+   * DONE when the action is scheduled even if the instances have not yet been
+   * recreated. You must separately verify the status of the recreating action
+   * with the listmanagedinstances method.
+   * (instanceGroupManagers.recreateInstances)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where the managed instance group is
+   * located.
+   * @param string $instanceGroupManager The name of the managed instance group.
+   * @param Google_InstanceGroupManagersRecreateInstancesRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function recreateInstances($project, $zone, $instanceGroupManager, Google_Service_Compute_InstanceGroupManagersRecreateInstancesRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroupManager' => $instanceGroupManager, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('recreateInstances', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Resizes the managed instance group. If you increase the size, the group
+   * creates new instances using the current instance template. If you decrease
+   * the size, the group deletes instances. The resize operation is marked DONE
+   * when the resize actions are scheduled even if the group has not yet added or
+   * deleted any instances. You must separately verify the status of the creating
+   * or deleting actions with the listmanagedinstances method.
+   * (instanceGroupManagers.resize)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where the managed instance group is
+   * located.
+   * @param string $instanceGroupManager The name of the managed instance group.
+   * @param int $size The number of running instances that the managed instance
+   * group should maintain at any given time. The group automatically adds or
+   * removes instances to maintain the number of instances specified by this
+   * parameter.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function resize($project, $zone, $instanceGroupManager, $size, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroupManager' => $instanceGroupManager, 'size' => $size);
+    $params = array_merge($params, $optParams);
+    return $this->call('resize', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Specifies the instance template to use when creating new instances in this
+   * group. The templates for existing instances in the group do not change unless
+   * you recreate them. (instanceGroupManagers.setInstanceTemplate)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where the managed instance group is
+   * located.
+   * @param string $instanceGroupManager The name of the managed instance group.
+   * @param Google_InstanceGroupManagersSetInstanceTemplateRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function setInstanceTemplate($project, $zone, $instanceGroupManager, Google_Service_Compute_InstanceGroupManagersSetInstanceTemplateRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroupManager' => $instanceGroupManager, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setInstanceTemplate', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Modifies the target pools to which all instances in this managed instance
+   * group are assigned. The target pools automatically apply to all of the
+   * instances in the managed instance group. This operation is marked DONE when
+   * you make the request even if the instances have not yet been added to their
+   * target pools. The change might take some time to apply to all of the
+   * instances in the group depending on the size of the group.
+   * (instanceGroupManagers.setTargetPools)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where the managed instance group is
+   * located.
+   * @param string $instanceGroupManager The name of the managed instance group.
+   * @param Google_InstanceGroupManagersSetTargetPoolsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function setTargetPools($project, $zone, $instanceGroupManager, Google_Service_Compute_InstanceGroupManagersSetTargetPoolsRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroupManager' => $instanceGroupManager, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setTargetPools', array($params), "Google_Service_Compute_Operation");
+  }
+}
+
+/**
+ * The "instanceGroups" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $instanceGroups = $computeService->instanceGroups;
+ *  </code>
+ */
+class Google_Service_Compute_InstanceGroups_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Adds a list of instances to the specified instance group. All of the
+   * instances in the instance group must be in the same network/subnetwork.
+   * (instanceGroups.addInstances)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where the instance group is located.
+   * @param string $instanceGroup The name of the instance group where you are
+   * adding instances.
+   * @param Google_InstanceGroupsAddInstancesRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function addInstances($project, $zone, $instanceGroup, Google_Service_Compute_InstanceGroupsAddInstancesRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroup' => $instanceGroup, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('addInstances', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of instance groups and sorts them by zone.
+   * (instanceGroups.aggregatedList)
+   *
+   * @param string $project The project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_InstanceGroupAggregatedList
+   */
+  public function aggregatedList($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('aggregatedList', array($params), "Google_Service_Compute_InstanceGroupAggregatedList");
+  }
+
+  /**
+   * Deletes the specified instance group. The instances in the group are not
+   * deleted. (instanceGroups.delete)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where the instance group is located.
+   * @param string $instanceGroup The name of the instance group to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $zone, $instanceGroup, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroup' => $instanceGroup);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified instance group resource. (instanceGroups.get)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where the instance group is located.
+   * @param string $instanceGroup The name of the instance group.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_InstanceGroup
+   */
+  public function get($project, $zone, $instanceGroup, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroup' => $instanceGroup);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_InstanceGroup");
+  }
+
+  /**
+   * Creates an instance group in the specified project using the parameters that
+   * are included in the request. (instanceGroups.insert)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where you want to create the
+   * instance group.
+   * @param Google_InstanceGroup $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, $zone, Google_Service_Compute_InstanceGroup $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of instance groups that are located in the specified
+   * project and zone. (instanceGroups.listInstanceGroups)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where the instance group is located.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_InstanceGroupList
+   */
+  public function listInstanceGroups($project, $zone, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_InstanceGroupList");
+  }
+
+  /**
+   * Lists the instances in the specified instance group.
+   * (instanceGroups.listInstances)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where the instance group is located.
+   * @param string $instanceGroup The name of the instance group from which you
+   * want to generate a list of included instances.
+   * @param Google_InstanceGroupsListInstancesRequest $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @return Google_Service_Compute_InstanceGroupsListInstances
+   */
+  public function listInstances($project, $zone, $instanceGroup, Google_Service_Compute_InstanceGroupsListInstancesRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroup' => $instanceGroup, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('listInstances', array($params), "Google_Service_Compute_InstanceGroupsListInstances");
+  }
+
+  /**
+   * Removes one or more instances from the specified instance group, but does not
+   * delete those instances. (instanceGroups.removeInstances)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where the instance group is located.
+   * @param string $instanceGroup The name of the instance group where the
+   * specified instances will be removed.
+   * @param Google_InstanceGroupsRemoveInstancesRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function removeInstances($project, $zone, $instanceGroup, Google_Service_Compute_InstanceGroupsRemoveInstancesRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroup' => $instanceGroup, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('removeInstances', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Sets the named ports for the specified instance group.
+   * (instanceGroups.setNamedPorts)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $zone The name of the zone where the instance group is located.
+   * @param string $instanceGroup The name of the instance group where the named
+   * ports are updated.
+   * @param Google_InstanceGroupsSetNamedPortsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function setNamedPorts($project, $zone, $instanceGroup, Google_Service_Compute_InstanceGroupsSetNamedPortsRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroup' => $instanceGroup, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setNamedPorts', array($params), "Google_Service_Compute_Operation");
+  }
+}
+
+/**
+ * The "instanceTemplates" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $instanceTemplates = $computeService->instanceTemplates;
+ *  </code>
+ */
+class Google_Service_Compute_InstanceTemplates_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified instance template. (instanceTemplates.delete)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $instanceTemplate The name of the instance template to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $instanceTemplate, $optParams = array())
+  {
+    $params = array('project' => $project, 'instanceTemplate' => $instanceTemplate);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified instance template resource. (instanceTemplates.get)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $instanceTemplate The name of the instance template.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_InstanceTemplate
+   */
+  public function get($project, $instanceTemplate, $optParams = array())
+  {
+    $params = array('project' => $project, 'instanceTemplate' => $instanceTemplate);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_InstanceTemplate");
+  }
+
+  /**
+   * Creates an instance template in the specified project using the data that is
+   * included in the request. (instanceTemplates.insert)
+   *
+   * @param string $project The project ID for this request.
+   * @param Google_InstanceTemplate $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, Google_Service_Compute_InstanceTemplate $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves a list of instance templates that are contained within the
+   * specified project and zone. (instanceTemplates.listInstanceTemplates)
+   *
+   * @param string $project The project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_InstanceTemplateList
+   */
+  public function listInstanceTemplates($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_InstanceTemplateList");
+  }
+}
+
+/**
+ * The "instances" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $instances = $computeService->instances;
+ *  </code>
+ */
+class Google_Service_Compute_Instances_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Adds an access config to an instance's network interface.
+   * (instances.addAccessConfig)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $instance The instance name for this request.
+   * @param string $networkInterface The name of the network interface to add to
+   * this instance.
+   * @param Google_AccessConfig $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function addAccessConfig($project, $zone, $instance, $networkInterface, Google_Service_Compute_AccessConfig $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instance' => $instance, 'networkInterface' => $networkInterface, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('addAccessConfig', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves aggregated list of instance resources. (instances.aggregatedList)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_InstanceAggregatedList
+   */
+  public function aggregatedList($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('aggregatedList', array($params), "Google_Service_Compute_InstanceAggregatedList");
+  }
+
+  /**
+   * Attaches a Disk resource to an instance. (instances.attachDisk)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $instance Instance name.
+   * @param Google_AttachedDisk $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function attachDisk($project, $zone, $instance, Google_Service_Compute_AttachedDisk $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instance' => $instance, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('attachDisk', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Deletes the specified Instance resource. For more information, see Shutting
+   * down an instance. (instances.delete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $instance Name of the instance resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $zone, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Deletes an access config from an instance's network interface.
+   * (instances.deleteAccessConfig)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $instance The instance name for this request.
+   * @param string $accessConfig The name of the access config to delete.
+   * @param string $networkInterface The name of the network interface.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function deleteAccessConfig($project, $zone, $instance, $accessConfig, $networkInterface, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instance' => $instance, 'accessConfig' => $accessConfig, 'networkInterface' => $networkInterface);
+    $params = array_merge($params, $optParams);
+    return $this->call('deleteAccessConfig', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Detaches a disk from an instance. (instances.detachDisk)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $instance Instance name.
+   * @param string $deviceName Disk device name to detach.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function detachDisk($project, $zone, $instance, $deviceName, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instance' => $instance, 'deviceName' => $deviceName);
+    $params = array_merge($params, $optParams);
+    return $this->call('detachDisk', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified instance resource. (instances.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $instance Name of the instance resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Instance
+   */
+  public function get($project, $zone, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_Instance");
+  }
+
+  /**
+   * Returns the specified instance's serial port output.
+   * (instances.getSerialPortOutput)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $instance Name of the instance scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int port Specifies which COM or serial port to retrieve data from.
+   * @return Google_Service_Compute_SerialPortOutput
+   */
+  public function getSerialPortOutput($project, $zone, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('getSerialPortOutput', array($params), "Google_Service_Compute_SerialPortOutput");
+  }
+
+  /**
+   * Creates an instance resource in the specified project using the data included
+   * in the request. (instances.insert)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param Google_Instance $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, $zone, Google_Service_Compute_Instance $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of instance resources contained within the specified zone.
+   * (instances.listInstances)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_InstanceList
+   */
+  public function listInstances($project, $zone, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_InstanceList");
+  }
+
+  /**
+   * Performs a hard reset on the instance. (instances.reset)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $instance Name of the instance scoping this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function reset($project, $zone, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('reset', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Sets the auto-delete flag for a disk attached to an instance.
+   * (instances.setDiskAutoDelete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $instance The instance name.
+   * @param bool $autoDelete Whether to auto-delete the disk when the instance is
+   * deleted.
+   * @param string $deviceName The device name of the disk to modify.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function setDiskAutoDelete($project, $zone, $instance, $autoDelete, $deviceName, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instance' => $instance, 'autoDelete' => $autoDelete, 'deviceName' => $deviceName);
+    $params = array_merge($params, $optParams);
+    return $this->call('setDiskAutoDelete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Sets metadata for the specified instance to the data included in the request.
+   * (instances.setMetadata)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $instance Name of the instance scoping this request.
+   * @param Google_Metadata $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function setMetadata($project, $zone, $instance, Google_Service_Compute_Metadata $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instance' => $instance, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setMetadata', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Sets an instance's scheduling options. (instances.setScheduling)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $instance Instance name.
+   * @param Google_Scheduling $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function setScheduling($project, $zone, $instance, Google_Service_Compute_Scheduling $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instance' => $instance, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setScheduling', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Sets tags for the specified instance to the data included in the request.
+   * (instances.setTags)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $instance Name of the instance scoping this request.
+   * @param Google_Tags $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function setTags($project, $zone, $instance, Google_Service_Compute_Tags $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instance' => $instance, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setTags', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * This method starts an instance that was stopped using the using the
+   * instances().stop method. For more information, see Restart an instance.
+   * (instances.start)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $instance Name of the instance resource to start.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function start($project, $zone, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('start', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * This method stops a running instance, shutting it down cleanly, and allows
+   * you to restart the instance at a later time. Stopped instances do not incur
+   * per-minute, virtual machine usage charges while they are stopped, but any
+   * resources that the virtual machine is using, such as persistent disks and
+   * static IP addresses,will continue to be charged until they are deleted. For
+   * more information, see Stopping an instance. (instances.stop)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $instance Name of the instance resource to stop.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function stop($project, $zone, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('stop', array($params), "Google_Service_Compute_Operation");
+  }
+}
+
+/**
+ * The "licenses" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $licenses = $computeService->licenses;
+ *  </code>
+ */
+class Google_Service_Compute_Licenses_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns the specified license resource. (licenses.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $license Name of the license resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_License
+   */
+  public function get($project, $license, $optParams = array())
+  {
+    $params = array('project' => $project, 'license' => $license);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_License");
+  }
+}
+
+/**
+ * The "machineTypes" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $machineTypes = $computeService->machineTypes;
+ *  </code>
+ */
+class Google_Service_Compute_MachineTypes_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the list of machine type resources grouped by scope.
+   * (machineTypes.aggregatedList)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_MachineTypeAggregatedList
+   */
+  public function aggregatedList($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('aggregatedList', array($params), "Google_Service_Compute_MachineTypeAggregatedList");
+  }
+
+  /**
+   * Returns the specified machine type resource. (machineTypes.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param string $machineType Name of the machine type resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_MachineType
+   */
+  public function get($project, $zone, $machineType, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'machineType' => $machineType);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_MachineType");
+  }
+
+  /**
+   * Retrieves the list of machine type resources available to the specified
+   * project. (machineTypes.listMachineTypes)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone The name of the zone for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_MachineTypeList
+   */
+  public function listMachineTypes($project, $zone, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_MachineTypeList");
+  }
+}
+
+/**
+ * The "networks" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $networks = $computeService->networks;
+ *  </code>
+ */
+class Google_Service_Compute_Networks_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified network resource. (networks.delete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $network Name of the network resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $network, $optParams = array())
+  {
+    $params = array('project' => $project, 'network' => $network);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified network resource. (networks.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $network Name of the network resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Network
+   */
+  public function get($project, $network, $optParams = array())
+  {
+    $params = array('project' => $project, 'network' => $network);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_Network");
+  }
+
+  /**
+   * Creates a network resource in the specified project using the data included
+   * in the request. (networks.insert)
+   *
+   * @param string $project Project ID for this request.
+   * @param Google_Network $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, Google_Service_Compute_Network $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of network resources available to the specified project.
+   * (networks.listNetworks)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_NetworkList
+   */
+  public function listNetworks($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_NetworkList");
+  }
+}
+
+/**
+ * The "projects" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $projects = $computeService->projects;
+ *  </code>
+ */
+class Google_Service_Compute_Projects_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns the specified project resource. (projects.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Project
+   */
+  public function get($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_Project");
+  }
+
+  /**
+   * Moves a persistent disk from one zone to another. (projects.moveDisk)
+   *
+   * @param string $project Project ID for this request.
+   * @param Google_DiskMoveRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function moveDisk($project, Google_Service_Compute_DiskMoveRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('moveDisk', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Moves an instance and its attached persistent disks from one zone to another.
+   * (projects.moveInstance)
+   *
+   * @param string $project Project ID for this request.
+   * @param Google_InstanceMoveRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function moveInstance($project, Google_Service_Compute_InstanceMoveRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('moveInstance', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Sets metadata common to all instances within the specified project using the
+   * data included in the request. (projects.setCommonInstanceMetadata)
+   *
+   * @param string $project Project ID for this request.
+   * @param Google_Metadata $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function setCommonInstanceMetadata($project, Google_Service_Compute_Metadata $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setCommonInstanceMetadata', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Enables the usage export feature and sets the usage export bucket where
+   * reports are stored. If you provide an empty request body using this method,
+   * the usage export feature will be disabled. (projects.setUsageExportBucket)
+   *
+   * @param string $project Project ID for this request.
+   * @param Google_UsageExportLocation $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function setUsageExportBucket($project, Google_Service_Compute_UsageExportLocation $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setUsageExportBucket', array($params), "Google_Service_Compute_Operation");
+  }
+}
+
+/**
+ * The "regionOperations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $regionOperations = $computeService->regionOperations;
+ *  </code>
+ */
+class Google_Service_Compute_RegionOperations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified region-specific Operations resource.
+   * (regionOperations.delete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $region Name of the region scoping this request.
+   * @param string $operation Name of the Operations resource to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($project, $region, $operation, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'operation' => $operation);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves the specified region-specific Operations resource.
+   * (regionOperations.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $region Name of the zone scoping this request.
+   * @param string $operation Name of the Operations resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function get($project, $region, $operation, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'operation' => $operation);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of Operation resources contained within the specified
+   * region. (regionOperations.listRegionOperations)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $region Name of the region scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_OperationList
+   */
+  public function listRegionOperations($project, $region, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_OperationList");
+  }
+}
+
+/**
+ * The "regions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $regions = $computeService->regions;
+ *  </code>
+ */
+class Google_Service_Compute_Regions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns the specified region resource. (regions.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $region Name of the region resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Region
+   */
+  public function get($project, $region, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_Region");
+  }
+
+  /**
+   * Retrieves the list of region resources available to the specified project.
+   * (regions.listRegions)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_RegionList
+   */
+  public function listRegions($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_RegionList");
+  }
+}
+
+/**
+ * The "routes" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $routes = $computeService->routes;
+ *  </code>
+ */
+class Google_Service_Compute_Routes_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified route resource. (routes.delete)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $route Name of the route resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $route, $optParams = array())
+  {
+    $params = array('project' => $project, 'route' => $route);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified route resource. (routes.get)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $route Name of the route resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Route
+   */
+  public function get($project, $route, $optParams = array())
+  {
+    $params = array('project' => $project, 'route' => $route);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_Route");
+  }
+
+  /**
+   * Creates a route resource in the specified project using the data included in
+   * the request. (routes.insert)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param Google_Route $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, Google_Service_Compute_Route $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of route resources available to the specified project.
+   * (routes.listRoutes)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_RouteList
+   */
+  public function listRoutes($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_RouteList");
+  }
+}
+
+/**
+ * The "snapshots" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $snapshots = $computeService->snapshots;
+ *  </code>
+ */
+class Google_Service_Compute_Snapshots_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified Snapshot resource. Keep in mind that deleting a single
+   * snapshot might not necessarily delete all the data on that snapshot. If any
+   * data on the snapshot that is marked for deletion is needed for subsequent
+   * snapshots, the data will be moved to the next corresponding snapshot.
+   *
+   * For more information, see Deleting snaphots. (snapshots.delete)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $snapshot Name of the Snapshot resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $snapshot, $optParams = array())
+  {
+    $params = array('project' => $project, 'snapshot' => $snapshot);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified Snapshot resource. (snapshots.get)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $snapshot Name of the Snapshot resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Snapshot
+   */
+  public function get($project, $snapshot, $optParams = array())
+  {
+    $params = array('project' => $project, 'snapshot' => $snapshot);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_Snapshot");
+  }
+
+  /**
+   * Retrieves the list of Snapshot resources contained within the specified
+   * project. (snapshots.listSnapshots)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_SnapshotList
+   */
+  public function listSnapshots($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_SnapshotList");
+  }
+}
+
+/**
+ * The "sslCertificates" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $sslCertificates = $computeService->sslCertificates;
+ *  </code>
+ */
+class Google_Service_Compute_SslCertificates_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified SslCertificate resource. (sslCertificates.delete)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $sslCertificate Name of the SslCertificate resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $sslCertificate, $optParams = array())
+  {
+    $params = array('project' => $project, 'sslCertificate' => $sslCertificate);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified SslCertificate resource. (sslCertificates.get)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $sslCertificate Name of the SslCertificate resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_SslCertificate
+   */
+  public function get($project, $sslCertificate, $optParams = array())
+  {
+    $params = array('project' => $project, 'sslCertificate' => $sslCertificate);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_SslCertificate");
+  }
+
+  /**
+   * Creates a SslCertificate resource in the specified project using the data
+   * included in the request. (sslCertificates.insert)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param Google_SslCertificate $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, Google_Service_Compute_SslCertificate $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of SslCertificate resources available to the specified
+   * project. (sslCertificates.listSslCertificates)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_SslCertificateList
+   */
+  public function listSslCertificates($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_SslCertificateList");
+  }
+}
+
+/**
+ * The "targetHttpProxies" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $targetHttpProxies = $computeService->targetHttpProxies;
+ *  </code>
+ */
+class Google_Service_Compute_TargetHttpProxies_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified TargetHttpProxy resource. (targetHttpProxies.delete)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $targetHttpProxy Name of the TargetHttpProxy resource to
+   * delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $targetHttpProxy, $optParams = array())
+  {
+    $params = array('project' => $project, 'targetHttpProxy' => $targetHttpProxy);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified TargetHttpProxy resource. (targetHttpProxies.get)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $targetHttpProxy Name of the TargetHttpProxy resource to
+   * return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_TargetHttpProxy
+   */
+  public function get($project, $targetHttpProxy, $optParams = array())
+  {
+    $params = array('project' => $project, 'targetHttpProxy' => $targetHttpProxy);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_TargetHttpProxy");
+  }
+
+  /**
+   * Creates a TargetHttpProxy resource in the specified project using the data
+   * included in the request. (targetHttpProxies.insert)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param Google_TargetHttpProxy $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, Google_Service_Compute_TargetHttpProxy $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of TargetHttpProxy resources available to the specified
+   * project. (targetHttpProxies.listTargetHttpProxies)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_TargetHttpProxyList
+   */
+  public function listTargetHttpProxies($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_TargetHttpProxyList");
+  }
+
+  /**
+   * Changes the URL map for TargetHttpProxy. (targetHttpProxies.setUrlMap)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $targetHttpProxy Name of the TargetHttpProxy resource whose URL
+   * map is to be set.
+   * @param Google_UrlMapReference $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function setUrlMap($project, $targetHttpProxy, Google_Service_Compute_UrlMapReference $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'targetHttpProxy' => $targetHttpProxy, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setUrlMap', array($params), "Google_Service_Compute_Operation");
+  }
+}
+
+/**
+ * The "targetHttpsProxies" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $targetHttpsProxies = $computeService->targetHttpsProxies;
+ *  </code>
+ */
+class Google_Service_Compute_TargetHttpsProxies_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified TargetHttpsProxy resource. (targetHttpsProxies.delete)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $targetHttpsProxy Name of the TargetHttpsProxy resource to
+   * delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $targetHttpsProxy, $optParams = array())
+  {
+    $params = array('project' => $project, 'targetHttpsProxy' => $targetHttpsProxy);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified TargetHttpsProxy resource. (targetHttpsProxies.get)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $targetHttpsProxy Name of the TargetHttpsProxy resource to
+   * return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_TargetHttpsProxy
+   */
+  public function get($project, $targetHttpsProxy, $optParams = array())
+  {
+    $params = array('project' => $project, 'targetHttpsProxy' => $targetHttpsProxy);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_TargetHttpsProxy");
+  }
+
+  /**
+   * Creates a TargetHttpsProxy resource in the specified project using the data
+   * included in the request. (targetHttpsProxies.insert)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param Google_TargetHttpsProxy $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, Google_Service_Compute_TargetHttpsProxy $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of TargetHttpsProxy resources available to the specified
+   * project. (targetHttpsProxies.listTargetHttpsProxies)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_TargetHttpsProxyList
+   */
+  public function listTargetHttpsProxies($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_TargetHttpsProxyList");
+  }
+
+  /**
+   * Replaces SslCertificates for TargetHttpsProxy.
+   * (targetHttpsProxies.setSslCertificates)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $targetHttpsProxy Name of the TargetHttpsProxy resource whose
+   * URL map is to be set.
+   * @param Google_TargetHttpsProxiesSetSslCertificatesRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function setSslCertificates($project, $targetHttpsProxy, Google_Service_Compute_TargetHttpsProxiesSetSslCertificatesRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'targetHttpsProxy' => $targetHttpsProxy, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setSslCertificates', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Changes the URL map for TargetHttpsProxy. (targetHttpsProxies.setUrlMap)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $targetHttpsProxy Name of the TargetHttpsProxy resource whose
+   * URL map is to be set.
+   * @param Google_UrlMapReference $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function setUrlMap($project, $targetHttpsProxy, Google_Service_Compute_UrlMapReference $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'targetHttpsProxy' => $targetHttpsProxy, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setUrlMap', array($params), "Google_Service_Compute_Operation");
+  }
+}
+
+/**
+ * The "targetInstances" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $targetInstances = $computeService->targetInstances;
+ *  </code>
+ */
+class Google_Service_Compute_TargetInstances_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the list of target instances grouped by scope.
+   * (targetInstances.aggregatedList)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_TargetInstanceAggregatedList
+   */
+  public function aggregatedList($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('aggregatedList', array($params), "Google_Service_Compute_TargetInstanceAggregatedList");
+  }
+
+  /**
+   * Deletes the specified TargetInstance resource. (targetInstances.delete)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param string $targetInstance Name of the TargetInstance resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $zone, $targetInstance, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'targetInstance' => $targetInstance);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified TargetInstance resource. (targetInstances.get)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param string $targetInstance Name of the TargetInstance resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_TargetInstance
+   */
+  public function get($project, $zone, $targetInstance, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'targetInstance' => $targetInstance);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_TargetInstance");
+  }
+
+  /**
+   * Creates a TargetInstance resource in the specified project and zone using the
+   * data included in the request. (targetInstances.insert)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param Google_TargetInstance $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, $zone, Google_Service_Compute_TargetInstance $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of TargetInstance resources available to the specified
+   * project and zone. (targetInstances.listTargetInstances)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_TargetInstanceList
+   */
+  public function listTargetInstances($project, $zone, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_TargetInstanceList");
+  }
+}
+
+/**
+ * The "targetPools" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $targetPools = $computeService->targetPools;
+ *  </code>
+ */
+class Google_Service_Compute_TargetPools_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Adds health check URL to targetPool. (targetPools.addHealthCheck)
+   *
+   * @param string $project
+   * @param string $region Name of the region scoping this request.
+   * @param string $targetPool Name of the TargetPool resource to which
+   * health_check_url is to be added.
+   * @param Google_TargetPoolsAddHealthCheckRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function addHealthCheck($project, $region, $targetPool, Google_Service_Compute_TargetPoolsAddHealthCheckRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'targetPool' => $targetPool, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('addHealthCheck', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Adds instance url to targetPool. (targetPools.addInstance)
+   *
+   * @param string $project
+   * @param string $region Name of the region scoping this request.
+   * @param string $targetPool Name of the TargetPool resource to which
+   * instance_url is to be added.
+   * @param Google_TargetPoolsAddInstanceRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function addInstance($project, $region, $targetPool, Google_Service_Compute_TargetPoolsAddInstanceRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'targetPool' => $targetPool, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('addInstance', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of target pools grouped by scope.
+   * (targetPools.aggregatedList)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_TargetPoolAggregatedList
+   */
+  public function aggregatedList($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('aggregatedList', array($params), "Google_Service_Compute_TargetPoolAggregatedList");
+  }
+
+  /**
+   * Deletes the specified TargetPool resource. (targetPools.delete)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $region Name of the region scoping this request.
+   * @param string $targetPool Name of the TargetPool resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $region, $targetPool, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'targetPool' => $targetPool);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified TargetPool resource. (targetPools.get)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $region Name of the region scoping this request.
+   * @param string $targetPool Name of the TargetPool resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_TargetPool
+   */
+  public function get($project, $region, $targetPool, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'targetPool' => $targetPool);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_TargetPool");
+  }
+
+  /**
+   * Gets the most recent health check results for each IP for the given instance
+   * that is referenced by given TargetPool. (targetPools.getHealth)
+   *
+   * @param string $project
+   * @param string $region Name of the region scoping this request.
+   * @param string $targetPool Name of the TargetPool resource to which the
+   * queried instance belongs.
+   * @param Google_InstanceReference $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_TargetPoolInstanceHealth
+   */
+  public function getHealth($project, $region, $targetPool, Google_Service_Compute_InstanceReference $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'targetPool' => $targetPool, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('getHealth', array($params), "Google_Service_Compute_TargetPoolInstanceHealth");
+  }
+
+  /**
+   * Creates a TargetPool resource in the specified project and region using the
+   * data included in the request. (targetPools.insert)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $region Name of the region scoping this request.
+   * @param Google_TargetPool $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, $region, Google_Service_Compute_TargetPool $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of TargetPool resources available to the specified project
+   * and region. (targetPools.listTargetPools)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $region Name of the region scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_TargetPoolList
+   */
+  public function listTargetPools($project, $region, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_TargetPoolList");
+  }
+
+  /**
+   * Removes health check URL from targetPool. (targetPools.removeHealthCheck)
+   *
+   * @param string $project
+   * @param string $region Name of the region scoping this request.
+   * @param string $targetPool Name of the TargetPool resource to which
+   * health_check_url is to be removed.
+   * @param Google_TargetPoolsRemoveHealthCheckRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function removeHealthCheck($project, $region, $targetPool, Google_Service_Compute_TargetPoolsRemoveHealthCheckRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'targetPool' => $targetPool, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('removeHealthCheck', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Removes instance URL from targetPool. (targetPools.removeInstance)
+   *
+   * @param string $project
+   * @param string $region Name of the region scoping this request.
+   * @param string $targetPool Name of the TargetPool resource to which
+   * instance_url is to be removed.
+   * @param Google_TargetPoolsRemoveInstanceRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function removeInstance($project, $region, $targetPool, Google_Service_Compute_TargetPoolsRemoveInstanceRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'targetPool' => $targetPool, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('removeInstance', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Changes backup pool configurations. (targetPools.setBackup)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $region Name of the region scoping this request.
+   * @param string $targetPool Name of the TargetPool resource for which the
+   * backup is to be set.
+   * @param Google_TargetReference $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param float failoverRatio New failoverRatio value for the containing
+   * target pool.
+   * @return Google_Service_Compute_Operation
+   */
+  public function setBackup($project, $region, $targetPool, Google_Service_Compute_TargetReference $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'targetPool' => $targetPool, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setBackup', array($params), "Google_Service_Compute_Operation");
+  }
+}
+
+/**
+ * The "targetVpnGateways" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $targetVpnGateways = $computeService->targetVpnGateways;
+ *  </code>
+ */
+class Google_Service_Compute_TargetVpnGateways_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the list of target VPN gateways grouped by scope.
+   * (targetVpnGateways.aggregatedList)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_TargetVpnGatewayAggregatedList
+   */
+  public function aggregatedList($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('aggregatedList', array($params), "Google_Service_Compute_TargetVpnGatewayAggregatedList");
+  }
+
+  /**
+   * Deletes the specified TargetVpnGateway resource. (targetVpnGateways.delete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $region The name of the region for this request.
+   * @param string $targetVpnGateway Name of the TargetVpnGateway resource to
+   * delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $region, $targetVpnGateway, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'targetVpnGateway' => $targetVpnGateway);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified TargetVpnGateway resource. (targetVpnGateways.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $region The name of the region for this request.
+   * @param string $targetVpnGateway Name of the TargetVpnGateway resource to
+   * return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_TargetVpnGateway
+   */
+  public function get($project, $region, $targetVpnGateway, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'targetVpnGateway' => $targetVpnGateway);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_TargetVpnGateway");
+  }
+
+  /**
+   * Creates a TargetVpnGateway resource in the specified project and region using
+   * the data included in the request. (targetVpnGateways.insert)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $region The name of the region for this request.
+   * @param Google_TargetVpnGateway $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, $region, Google_Service_Compute_TargetVpnGateway $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of TargetVpnGateway resources available to the specified
+   * project and region. (targetVpnGateways.listTargetVpnGateways)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $region The name of the region for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_TargetVpnGatewayList
+   */
+  public function listTargetVpnGateways($project, $region, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_TargetVpnGatewayList");
+  }
+}
+
+/**
+ * The "urlMaps" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $urlMaps = $computeService->urlMaps;
+ *  </code>
+ */
+class Google_Service_Compute_UrlMaps_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified UrlMap resource. (urlMaps.delete)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $urlMap Name of the UrlMap resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $urlMap, $optParams = array())
+  {
+    $params = array('project' => $project, 'urlMap' => $urlMap);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified UrlMap resource. (urlMaps.get)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $urlMap Name of the UrlMap resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_UrlMap
+   */
+  public function get($project, $urlMap, $optParams = array())
+  {
+    $params = array('project' => $project, 'urlMap' => $urlMap);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_UrlMap");
+  }
+
+  /**
+   * Creates a UrlMap resource in the specified project using the data included in
+   * the request. (urlMaps.insert)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param Google_UrlMap $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, Google_Service_Compute_UrlMap $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of UrlMap resources available to the specified project.
+   * (urlMaps.listUrlMaps)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_UrlMapList
+   */
+  public function listUrlMaps($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_UrlMapList");
+  }
+
+  /**
+   * Update the entire content of the UrlMap resource. This method supports patch
+   * semantics. (urlMaps.patch)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $urlMap Name of the UrlMap resource to update.
+   * @param Google_UrlMap $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function patch($project, $urlMap, Google_Service_Compute_UrlMap $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'urlMap' => $urlMap, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Update the entire content of the UrlMap resource. (urlMaps.update)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $urlMap Name of the UrlMap resource to update.
+   * @param Google_UrlMap $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function update($project, $urlMap, Google_Service_Compute_UrlMap $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'urlMap' => $urlMap, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Run static validation for the UrlMap. In particular, the tests of the
+   * provided UrlMap will be run. Calling this method does NOT create the UrlMap.
+   * (urlMaps.validate)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $urlMap Name of the UrlMap resource to be validated as.
+   * @param Google_UrlMapsValidateRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_UrlMapsValidateResponse
+   */
+  public function validate($project, $urlMap, Google_Service_Compute_UrlMapsValidateRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'urlMap' => $urlMap, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('validate', array($params), "Google_Service_Compute_UrlMapsValidateResponse");
+  }
+}
+
+/**
+ * The "vpnTunnels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $vpnTunnels = $computeService->vpnTunnels;
+ *  </code>
+ */
+class Google_Service_Compute_VpnTunnels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the list of VPN tunnels grouped by scope.
+   * (vpnTunnels.aggregatedList)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_VpnTunnelAggregatedList
+   */
+  public function aggregatedList($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('aggregatedList', array($params), "Google_Service_Compute_VpnTunnelAggregatedList");
+  }
+
+  /**
+   * Deletes the specified VpnTunnel resource. (vpnTunnels.delete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $region The name of the region for this request.
+   * @param string $vpnTunnel Name of the VpnTunnel resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function delete($project, $region, $vpnTunnel, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'vpnTunnel' => $vpnTunnel);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Returns the specified VpnTunnel resource. (vpnTunnels.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $region The name of the region for this request.
+   * @param string $vpnTunnel Name of the VpnTunnel resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_VpnTunnel
+   */
+  public function get($project, $region, $vpnTunnel, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'vpnTunnel' => $vpnTunnel);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_VpnTunnel");
+  }
+
+  /**
+   * Creates a VpnTunnel resource in the specified project and region using the
+   * data included in the request. (vpnTunnels.insert)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $region The name of the region for this request.
+   * @param Google_VpnTunnel $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function insert($project, $region, Google_Service_Compute_VpnTunnel $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of VpnTunnel resources contained in the specified project
+   * and region. (vpnTunnels.listVpnTunnels)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $region The name of the region for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_VpnTunnelList
+   */
+  public function listVpnTunnels($project, $region, $optParams = array())
+  {
+    $params = array('project' => $project, 'region' => $region);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_VpnTunnelList");
+  }
+}
+
+/**
+ * The "zoneOperations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $zoneOperations = $computeService->zoneOperations;
+ *  </code>
+ */
+class Google_Service_Compute_ZoneOperations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified zone-specific Operations resource.
+   * (zoneOperations.delete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param string $operation Name of the Operations resource to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($project, $zone, $operation, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'operation' => $operation);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves the specified zone-specific Operations resource.
+   * (zoneOperations.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param string $operation Name of the Operations resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Operation
+   */
+  public function get($project, $zone, $operation, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'operation' => $operation);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_Operation");
+  }
+
+  /**
+   * Retrieves the list of Operation resources contained within the specified
+   * zone. (zoneOperations.listZoneOperations)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_OperationList
+   */
+  public function listZoneOperations($project, $zone, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_OperationList");
+  }
+}
+
+/**
+ * The "zones" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeService = new Google_Service_Compute(...);
+ *   $zones = $computeService->zones;
+ *  </code>
+ */
+class Google_Service_Compute_Zones_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns the specified zone resource. (zones.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone Name of the zone resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Compute_Zone
+   */
+  public function get($project, $zone, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Compute_Zone");
+  }
+
+  /**
+   * Retrieves the list of zone resources available to the specified project.
+   * (zones.listZones)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_Compute_ZoneList
+   */
+  public function listZones($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Compute_ZoneList");
+  }
+}
+
+
+
+
+class Google_Service_Compute_AccessConfig extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $name;
+  public $natIP;
+  public $type;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNatIP($natIP)
+  {
+    $this->natIP = $natIP;
+  }
+  public function getNatIP()
+  {
+    return $this->natIP;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Compute_Address extends Google_Collection
+{
+  protected $collection_key = 'users';
+  protected $internal_gapi_mappings = array(
+  );
+  public $address;
+  public $creationTimestamp;
+  public $description;
+  public $id;
+  public $kind;
+  public $name;
+  public $region;
+  public $selfLink;
+  public $status;
+  public $users;
+
+
+  public function setAddress($address)
+  {
+    $this->address = $address;
+  }
+  public function getAddress()
+  {
+    return $this->address;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setUsers($users)
+  {
+    $this->users = $users;
+  }
+  public function getUsers()
+  {
+    return $this->users;
+  }
+}
+
+class Google_Service_Compute_AddressAggregatedList extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_AddressesScopedList';
+  protected $itemsDataType = 'map';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_AddressAggregatedListItems extends Google_Model
+{
+}
+
+class Google_Service_Compute_AddressList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_Address';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_AddressesScopedList extends Google_Collection
+{
+  protected $collection_key = 'addresses';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $addressesType = 'Google_Service_Compute_Address';
+  protected $addressesDataType = 'array';
+  protected $warningType = 'Google_Service_Compute_AddressesScopedListWarning';
+  protected $warningDataType = '';
+
+
+  public function setAddresses($addresses)
+  {
+    $this->addresses = $addresses;
+  }
+  public function getAddresses()
+  {
+    return $this->addresses;
+  }
+  public function setWarning(Google_Service_Compute_AddressesScopedListWarning $warning)
+  {
+    $this->warning = $warning;
+  }
+  public function getWarning()
+  {
+    return $this->warning;
+  }
+}
+
+class Google_Service_Compute_AddressesScopedListWarning extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Compute_AddressesScopedListWarningData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Compute_AddressesScopedListWarningData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Compute_AttachedDisk extends Google_Collection
+{
+  protected $collection_key = 'licenses';
+  protected $internal_gapi_mappings = array(
+  );
+  public $autoDelete;
+  public $boot;
+  public $deviceName;
+  public $index;
+  protected $initializeParamsType = 'Google_Service_Compute_AttachedDiskInitializeParams';
+  protected $initializeParamsDataType = '';
+  public $interface;
+  public $kind;
+  public $licenses;
+  public $mode;
+  public $source;
+  public $type;
+
+
+  public function setAutoDelete($autoDelete)
+  {
+    $this->autoDelete = $autoDelete;
+  }
+  public function getAutoDelete()
+  {
+    return $this->autoDelete;
+  }
+  public function setBoot($boot)
+  {
+    $this->boot = $boot;
+  }
+  public function getBoot()
+  {
+    return $this->boot;
+  }
+  public function setDeviceName($deviceName)
+  {
+    $this->deviceName = $deviceName;
+  }
+  public function getDeviceName()
+  {
+    return $this->deviceName;
+  }
+  public function setIndex($index)
+  {
+    $this->index = $index;
+  }
+  public function getIndex()
+  {
+    return $this->index;
+  }
+  public function setInitializeParams(Google_Service_Compute_AttachedDiskInitializeParams $initializeParams)
+  {
+    $this->initializeParams = $initializeParams;
+  }
+  public function getInitializeParams()
+  {
+    return $this->initializeParams;
+  }
+  public function setInterface($interface)
+  {
+    $this->interface = $interface;
+  }
+  public function getInterface()
+  {
+    return $this->interface;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLicenses($licenses)
+  {
+    $this->licenses = $licenses;
+  }
+  public function getLicenses()
+  {
+    return $this->licenses;
+  }
+  public function setMode($mode)
+  {
+    $this->mode = $mode;
+  }
+  public function getMode()
+  {
+    return $this->mode;
+  }
+  public function setSource($source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Compute_AttachedDiskInitializeParams extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $diskName;
+  public $diskSizeGb;
+  public $diskType;
+  public $sourceImage;
+
+
+  public function setDiskName($diskName)
+  {
+    $this->diskName = $diskName;
+  }
+  public function getDiskName()
+  {
+    return $this->diskName;
+  }
+  public function setDiskSizeGb($diskSizeGb)
+  {
+    $this->diskSizeGb = $diskSizeGb;
+  }
+  public function getDiskSizeGb()
+  {
+    return $this->diskSizeGb;
+  }
+  public function setDiskType($diskType)
+  {
+    $this->diskType = $diskType;
+  }
+  public function getDiskType()
+  {
+    return $this->diskType;
+  }
+  public function setSourceImage($sourceImage)
+  {
+    $this->sourceImage = $sourceImage;
+  }
+  public function getSourceImage()
+  {
+    return $this->sourceImage;
+  }
+}
+
+class Google_Service_Compute_Autoscaler extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $autoscalingPolicyType = 'Google_Service_Compute_AutoscalingPolicy';
+  protected $autoscalingPolicyDataType = '';
+  public $creationTimestamp;
+  public $description;
+  public $id;
+  public $kind;
+  public $name;
+  public $selfLink;
+  public $target;
+  public $zone;
+
+
+  public function setAutoscalingPolicy(Google_Service_Compute_AutoscalingPolicy $autoscalingPolicy)
+  {
+    $this->autoscalingPolicy = $autoscalingPolicy;
+  }
+  public function getAutoscalingPolicy()
+  {
+    return $this->autoscalingPolicy;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTarget($target)
+  {
+    $this->target = $target;
+  }
+  public function getTarget()
+  {
+    return $this->target;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_Compute_AutoscalerAggregatedList extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_AutoscalersScopedList';
+  protected $itemsDataType = 'map';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_AutoscalerAggregatedListItems extends Google_Model
+{
+}
+
+class Google_Service_Compute_AutoscalerList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_Autoscaler';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_AutoscalersScopedList extends Google_Collection
+{
+  protected $collection_key = 'autoscalers';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $autoscalersType = 'Google_Service_Compute_Autoscaler';
+  protected $autoscalersDataType = 'array';
+  protected $warningType = 'Google_Service_Compute_AutoscalersScopedListWarning';
+  protected $warningDataType = '';
+
+
+  public function setAutoscalers($autoscalers)
+  {
+    $this->autoscalers = $autoscalers;
+  }
+  public function getAutoscalers()
+  {
+    return $this->autoscalers;
+  }
+  public function setWarning(Google_Service_Compute_AutoscalersScopedListWarning $warning)
+  {
+    $this->warning = $warning;
+  }
+  public function getWarning()
+  {
+    return $this->warning;
+  }
+}
+
+class Google_Service_Compute_AutoscalersScopedListWarning extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Compute_AutoscalersScopedListWarningData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Compute_AutoscalersScopedListWarningData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Compute_AutoscalingPolicy extends Google_Collection
+{
+  protected $collection_key = 'customMetricUtilizations';
+  protected $internal_gapi_mappings = array(
+  );
+  public $coolDownPeriodSec;
+  protected $cpuUtilizationType = 'Google_Service_Compute_AutoscalingPolicyCpuUtilization';
+  protected $cpuUtilizationDataType = '';
+  protected $customMetricUtilizationsType = 'Google_Service_Compute_AutoscalingPolicyCustomMetricUtilization';
+  protected $customMetricUtilizationsDataType = 'array';
+  protected $loadBalancingUtilizationType = 'Google_Service_Compute_AutoscalingPolicyLoadBalancingUtilization';
+  protected $loadBalancingUtilizationDataType = '';
+  public $maxNumReplicas;
+  public $minNumReplicas;
+
+
+  public function setCoolDownPeriodSec($coolDownPeriodSec)
+  {
+    $this->coolDownPeriodSec = $coolDownPeriodSec;
+  }
+  public function getCoolDownPeriodSec()
+  {
+    return $this->coolDownPeriodSec;
+  }
+  public function setCpuUtilization(Google_Service_Compute_AutoscalingPolicyCpuUtilization $cpuUtilization)
+  {
+    $this->cpuUtilization = $cpuUtilization;
+  }
+  public function getCpuUtilization()
+  {
+    return $this->cpuUtilization;
+  }
+  public function setCustomMetricUtilizations($customMetricUtilizations)
+  {
+    $this->customMetricUtilizations = $customMetricUtilizations;
+  }
+  public function getCustomMetricUtilizations()
+  {
+    return $this->customMetricUtilizations;
+  }
+  public function setLoadBalancingUtilization(Google_Service_Compute_AutoscalingPolicyLoadBalancingUtilization $loadBalancingUtilization)
+  {
+    $this->loadBalancingUtilization = $loadBalancingUtilization;
+  }
+  public function getLoadBalancingUtilization()
+  {
+    return $this->loadBalancingUtilization;
+  }
+  public function setMaxNumReplicas($maxNumReplicas)
+  {
+    $this->maxNumReplicas = $maxNumReplicas;
+  }
+  public function getMaxNumReplicas()
+  {
+    return $this->maxNumReplicas;
+  }
+  public function setMinNumReplicas($minNumReplicas)
+  {
+    $this->minNumReplicas = $minNumReplicas;
+  }
+  public function getMinNumReplicas()
+  {
+    return $this->minNumReplicas;
+  }
+}
+
+class Google_Service_Compute_AutoscalingPolicyCpuUtilization extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $utilizationTarget;
+
+
+  public function setUtilizationTarget($utilizationTarget)
+  {
+    $this->utilizationTarget = $utilizationTarget;
+  }
+  public function getUtilizationTarget()
+  {
+    return $this->utilizationTarget;
+  }
+}
+
+class Google_Service_Compute_AutoscalingPolicyCustomMetricUtilization extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $metric;
+  public $utilizationTarget;
+  public $utilizationTargetType;
+
+
+  public function setMetric($metric)
+  {
+    $this->metric = $metric;
+  }
+  public function getMetric()
+  {
+    return $this->metric;
+  }
+  public function setUtilizationTarget($utilizationTarget)
+  {
+    $this->utilizationTarget = $utilizationTarget;
+  }
+  public function getUtilizationTarget()
+  {
+    return $this->utilizationTarget;
+  }
+  public function setUtilizationTargetType($utilizationTargetType)
+  {
+    $this->utilizationTargetType = $utilizationTargetType;
+  }
+  public function getUtilizationTargetType()
+  {
+    return $this->utilizationTargetType;
+  }
+}
+
+class Google_Service_Compute_AutoscalingPolicyLoadBalancingUtilization extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $utilizationTarget;
+
+
+  public function setUtilizationTarget($utilizationTarget)
+  {
+    $this->utilizationTarget = $utilizationTarget;
+  }
+  public function getUtilizationTarget()
+  {
+    return $this->utilizationTarget;
+  }
+}
+
+class Google_Service_Compute_Backend extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $balancingMode;
+  public $capacityScaler;
+  public $description;
+  public $group;
+  public $maxRate;
+  public $maxRatePerInstance;
+  public $maxUtilization;
+
+
+  public function setBalancingMode($balancingMode)
+  {
+    $this->balancingMode = $balancingMode;
+  }
+  public function getBalancingMode()
+  {
+    return $this->balancingMode;
+  }
+  public function setCapacityScaler($capacityScaler)
+  {
+    $this->capacityScaler = $capacityScaler;
+  }
+  public function getCapacityScaler()
+  {
+    return $this->capacityScaler;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setGroup($group)
+  {
+    $this->group = $group;
+  }
+  public function getGroup()
+  {
+    return $this->group;
+  }
+  public function setMaxRate($maxRate)
+  {
+    $this->maxRate = $maxRate;
+  }
+  public function getMaxRate()
+  {
+    return $this->maxRate;
+  }
+  public function setMaxRatePerInstance($maxRatePerInstance)
+  {
+    $this->maxRatePerInstance = $maxRatePerInstance;
+  }
+  public function getMaxRatePerInstance()
+  {
+    return $this->maxRatePerInstance;
+  }
+  public function setMaxUtilization($maxUtilization)
+  {
+    $this->maxUtilization = $maxUtilization;
+  }
+  public function getMaxUtilization()
+  {
+    return $this->maxUtilization;
+  }
+}
+
+class Google_Service_Compute_BackendService extends Google_Collection
+{
+  protected $collection_key = 'healthChecks';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $backendsType = 'Google_Service_Compute_Backend';
+  protected $backendsDataType = 'array';
+  public $creationTimestamp;
+  public $description;
+  public $fingerprint;
+  public $healthChecks;
+  public $id;
+  public $kind;
+  public $name;
+  public $port;
+  public $portName;
+  public $protocol;
+  public $selfLink;
+  public $timeoutSec;
+
+
+  public function setBackends($backends)
+  {
+    $this->backends = $backends;
+  }
+  public function getBackends()
+  {
+    return $this->backends;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setHealthChecks($healthChecks)
+  {
+    $this->healthChecks = $healthChecks;
+  }
+  public function getHealthChecks()
+  {
+    return $this->healthChecks;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPort($port)
+  {
+    $this->port = $port;
+  }
+  public function getPort()
+  {
+    return $this->port;
+  }
+  public function setPortName($portName)
+  {
+    $this->portName = $portName;
+  }
+  public function getPortName()
+  {
+    return $this->portName;
+  }
+  public function setProtocol($protocol)
+  {
+    $this->protocol = $protocol;
+  }
+  public function getProtocol()
+  {
+    return $this->protocol;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTimeoutSec($timeoutSec)
+  {
+    $this->timeoutSec = $timeoutSec;
+  }
+  public function getTimeoutSec()
+  {
+    return $this->timeoutSec;
+  }
+}
+
+class Google_Service_Compute_BackendServiceGroupHealth extends Google_Collection
+{
+  protected $collection_key = 'healthStatus';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $healthStatusType = 'Google_Service_Compute_HealthStatus';
+  protected $healthStatusDataType = 'array';
+  public $kind;
+
+
+  public function setHealthStatus($healthStatus)
+  {
+    $this->healthStatus = $healthStatus;
+  }
+  public function getHealthStatus()
+  {
+    return $this->healthStatus;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Compute_BackendServiceList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_BackendService';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_DeprecationStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $deleted;
+  public $deprecated;
+  public $obsolete;
+  public $replacement;
+  public $state;
+
+
+  public function setDeleted($deleted)
+  {
+    $this->deleted = $deleted;
+  }
+  public function getDeleted()
+  {
+    return $this->deleted;
+  }
+  public function setDeprecated($deprecated)
+  {
+    $this->deprecated = $deprecated;
+  }
+  public function getDeprecated()
+  {
+    return $this->deprecated;
+  }
+  public function setObsolete($obsolete)
+  {
+    $this->obsolete = $obsolete;
+  }
+  public function getObsolete()
+  {
+    return $this->obsolete;
+  }
+  public function setReplacement($replacement)
+  {
+    $this->replacement = $replacement;
+  }
+  public function getReplacement()
+  {
+    return $this->replacement;
+  }
+  public function setState($state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+}
+
+class Google_Service_Compute_Disk extends Google_Collection
+{
+  protected $collection_key = 'users';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $description;
+  public $id;
+  public $kind;
+  public $lastAttachTimestamp;
+  public $lastDetachTimestamp;
+  public $licenses;
+  public $name;
+  public $options;
+  public $selfLink;
+  public $sizeGb;
+  public $sourceImage;
+  public $sourceImageId;
+  public $sourceSnapshot;
+  public $sourceSnapshotId;
+  public $status;
+  public $type;
+  public $users;
+  public $zone;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastAttachTimestamp($lastAttachTimestamp)
+  {
+    $this->lastAttachTimestamp = $lastAttachTimestamp;
+  }
+  public function getLastAttachTimestamp()
+  {
+    return $this->lastAttachTimestamp;
+  }
+  public function setLastDetachTimestamp($lastDetachTimestamp)
+  {
+    $this->lastDetachTimestamp = $lastDetachTimestamp;
+  }
+  public function getLastDetachTimestamp()
+  {
+    return $this->lastDetachTimestamp;
+  }
+  public function setLicenses($licenses)
+  {
+    $this->licenses = $licenses;
+  }
+  public function getLicenses()
+  {
+    return $this->licenses;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOptions($options)
+  {
+    $this->options = $options;
+  }
+  public function getOptions()
+  {
+    return $this->options;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setSizeGb($sizeGb)
+  {
+    $this->sizeGb = $sizeGb;
+  }
+  public function getSizeGb()
+  {
+    return $this->sizeGb;
+  }
+  public function setSourceImage($sourceImage)
+  {
+    $this->sourceImage = $sourceImage;
+  }
+  public function getSourceImage()
+  {
+    return $this->sourceImage;
+  }
+  public function setSourceImageId($sourceImageId)
+  {
+    $this->sourceImageId = $sourceImageId;
+  }
+  public function getSourceImageId()
+  {
+    return $this->sourceImageId;
+  }
+  public function setSourceSnapshot($sourceSnapshot)
+  {
+    $this->sourceSnapshot = $sourceSnapshot;
+  }
+  public function getSourceSnapshot()
+  {
+    return $this->sourceSnapshot;
+  }
+  public function setSourceSnapshotId($sourceSnapshotId)
+  {
+    $this->sourceSnapshotId = $sourceSnapshotId;
+  }
+  public function getSourceSnapshotId()
+  {
+    return $this->sourceSnapshotId;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUsers($users)
+  {
+    $this->users = $users;
+  }
+  public function getUsers()
+  {
+    return $this->users;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_Compute_DiskAggregatedList extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_DisksScopedList';
+  protected $itemsDataType = 'map';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_DiskAggregatedListItems extends Google_Model
+{
+}
+
+class Google_Service_Compute_DiskList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_Disk';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_DiskMoveRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $destinationZone;
+  public $targetDisk;
+
+
+  public function setDestinationZone($destinationZone)
+  {
+    $this->destinationZone = $destinationZone;
+  }
+  public function getDestinationZone()
+  {
+    return $this->destinationZone;
+  }
+  public function setTargetDisk($targetDisk)
+  {
+    $this->targetDisk = $targetDisk;
+  }
+  public function getTargetDisk()
+  {
+    return $this->targetDisk;
+  }
+}
+
+class Google_Service_Compute_DiskType extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $defaultDiskSizeGb;
+  protected $deprecatedType = 'Google_Service_Compute_DeprecationStatus';
+  protected $deprecatedDataType = '';
+  public $description;
+  public $id;
+  public $kind;
+  public $name;
+  public $selfLink;
+  public $validDiskSize;
+  public $zone;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDefaultDiskSizeGb($defaultDiskSizeGb)
+  {
+    $this->defaultDiskSizeGb = $defaultDiskSizeGb;
+  }
+  public function getDefaultDiskSizeGb()
+  {
+    return $this->defaultDiskSizeGb;
+  }
+  public function setDeprecated(Google_Service_Compute_DeprecationStatus $deprecated)
+  {
+    $this->deprecated = $deprecated;
+  }
+  public function getDeprecated()
+  {
+    return $this->deprecated;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setValidDiskSize($validDiskSize)
+  {
+    $this->validDiskSize = $validDiskSize;
+  }
+  public function getValidDiskSize()
+  {
+    return $this->validDiskSize;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_Compute_DiskTypeAggregatedList extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_DiskTypesScopedList';
+  protected $itemsDataType = 'map';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_DiskTypeAggregatedListItems extends Google_Model
+{
+}
+
+class Google_Service_Compute_DiskTypeList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_DiskType';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_DiskTypesScopedList extends Google_Collection
+{
+  protected $collection_key = 'diskTypes';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $diskTypesType = 'Google_Service_Compute_DiskType';
+  protected $diskTypesDataType = 'array';
+  protected $warningType = 'Google_Service_Compute_DiskTypesScopedListWarning';
+  protected $warningDataType = '';
+
+
+  public function setDiskTypes($diskTypes)
+  {
+    $this->diskTypes = $diskTypes;
+  }
+  public function getDiskTypes()
+  {
+    return $this->diskTypes;
+  }
+  public function setWarning(Google_Service_Compute_DiskTypesScopedListWarning $warning)
+  {
+    $this->warning = $warning;
+  }
+  public function getWarning()
+  {
+    return $this->warning;
+  }
+}
+
+class Google_Service_Compute_DiskTypesScopedListWarning extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Compute_DiskTypesScopedListWarningData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Compute_DiskTypesScopedListWarningData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Compute_DisksScopedList extends Google_Collection
+{
+  protected $collection_key = 'disks';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $disksType = 'Google_Service_Compute_Disk';
+  protected $disksDataType = 'array';
+  protected $warningType = 'Google_Service_Compute_DisksScopedListWarning';
+  protected $warningDataType = '';
+
+
+  public function setDisks($disks)
+  {
+    $this->disks = $disks;
+  }
+  public function getDisks()
+  {
+    return $this->disks;
+  }
+  public function setWarning(Google_Service_Compute_DisksScopedListWarning $warning)
+  {
+    $this->warning = $warning;
+  }
+  public function getWarning()
+  {
+    return $this->warning;
+  }
+}
+
+class Google_Service_Compute_DisksScopedListWarning extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Compute_DisksScopedListWarningData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Compute_DisksScopedListWarningData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Compute_Firewall extends Google_Collection
+{
+  protected $collection_key = 'targetTags';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $allowedType = 'Google_Service_Compute_FirewallAllowed';
+  protected $allowedDataType = 'array';
+  public $creationTimestamp;
+  public $description;
+  public $id;
+  public $kind;
+  public $name;
+  public $network;
+  public $selfLink;
+  public $sourceRanges;
+  public $sourceTags;
+  public $targetTags;
+
+
+  public function setAllowed($allowed)
+  {
+    $this->allowed = $allowed;
+  }
+  public function getAllowed()
+  {
+    return $this->allowed;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNetwork($network)
+  {
+    $this->network = $network;
+  }
+  public function getNetwork()
+  {
+    return $this->network;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setSourceRanges($sourceRanges)
+  {
+    $this->sourceRanges = $sourceRanges;
+  }
+  public function getSourceRanges()
+  {
+    return $this->sourceRanges;
+  }
+  public function setSourceTags($sourceTags)
+  {
+    $this->sourceTags = $sourceTags;
+  }
+  public function getSourceTags()
+  {
+    return $this->sourceTags;
+  }
+  public function setTargetTags($targetTags)
+  {
+    $this->targetTags = $targetTags;
+  }
+  public function getTargetTags()
+  {
+    return $this->targetTags;
+  }
+}
+
+class Google_Service_Compute_FirewallAllowed extends Google_Collection
+{
+  protected $collection_key = 'ports';
+  protected $internal_gapi_mappings = array(
+        "iPProtocol" => "IPProtocol",
+  );
+  public $iPProtocol;
+  public $ports;
+
+
+  public function setIPProtocol($iPProtocol)
+  {
+    $this->iPProtocol = $iPProtocol;
+  }
+  public function getIPProtocol()
+  {
+    return $this->iPProtocol;
+  }
+  public function setPorts($ports)
+  {
+    $this->ports = $ports;
+  }
+  public function getPorts()
+  {
+    return $this->ports;
+  }
+}
+
+class Google_Service_Compute_FirewallList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_Firewall';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_ForwardingRule extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "iPAddress" => "IPAddress",
+        "iPProtocol" => "IPProtocol",
+  );
+  public $iPAddress;
+  public $iPProtocol;
+  public $creationTimestamp;
+  public $description;
+  public $id;
+  public $kind;
+  public $name;
+  public $portRange;
+  public $region;
+  public $selfLink;
+  public $target;
+
+
+  public function setIPAddress($iPAddress)
+  {
+    $this->iPAddress = $iPAddress;
+  }
+  public function getIPAddress()
+  {
+    return $this->iPAddress;
+  }
+  public function setIPProtocol($iPProtocol)
+  {
+    $this->iPProtocol = $iPProtocol;
+  }
+  public function getIPProtocol()
+  {
+    return $this->iPProtocol;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPortRange($portRange)
+  {
+    $this->portRange = $portRange;
+  }
+  public function getPortRange()
+  {
+    return $this->portRange;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTarget($target)
+  {
+    $this->target = $target;
+  }
+  public function getTarget()
+  {
+    return $this->target;
+  }
+}
+
+class Google_Service_Compute_ForwardingRuleAggregatedList extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_ForwardingRulesScopedList';
+  protected $itemsDataType = 'map';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_ForwardingRuleAggregatedListItems extends Google_Model
+{
+}
+
+class Google_Service_Compute_ForwardingRuleList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_ForwardingRule';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_ForwardingRulesScopedList extends Google_Collection
+{
+  protected $collection_key = 'forwardingRules';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $forwardingRulesType = 'Google_Service_Compute_ForwardingRule';
+  protected $forwardingRulesDataType = 'array';
+  protected $warningType = 'Google_Service_Compute_ForwardingRulesScopedListWarning';
+  protected $warningDataType = '';
+
+
+  public function setForwardingRules($forwardingRules)
+  {
+    $this->forwardingRules = $forwardingRules;
+  }
+  public function getForwardingRules()
+  {
+    return $this->forwardingRules;
+  }
+  public function setWarning(Google_Service_Compute_ForwardingRulesScopedListWarning $warning)
+  {
+    $this->warning = $warning;
+  }
+  public function getWarning()
+  {
+    return $this->warning;
+  }
+}
+
+class Google_Service_Compute_ForwardingRulesScopedListWarning extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Compute_ForwardingRulesScopedListWarningData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Compute_ForwardingRulesScopedListWarningData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Compute_HealthCheckReference extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $healthCheck;
+
+
+  public function setHealthCheck($healthCheck)
+  {
+    $this->healthCheck = $healthCheck;
+  }
+  public function getHealthCheck()
+  {
+    return $this->healthCheck;
+  }
+}
+
+class Google_Service_Compute_HealthStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $healthState;
+  public $instance;
+  public $ipAddress;
+  public $port;
+
+
+  public function setHealthState($healthState)
+  {
+    $this->healthState = $healthState;
+  }
+  public function getHealthState()
+  {
+    return $this->healthState;
+  }
+  public function setInstance($instance)
+  {
+    $this->instance = $instance;
+  }
+  public function getInstance()
+  {
+    return $this->instance;
+  }
+  public function setIpAddress($ipAddress)
+  {
+    $this->ipAddress = $ipAddress;
+  }
+  public function getIpAddress()
+  {
+    return $this->ipAddress;
+  }
+  public function setPort($port)
+  {
+    $this->port = $port;
+  }
+  public function getPort()
+  {
+    return $this->port;
+  }
+}
+
+class Google_Service_Compute_HostRule extends Google_Collection
+{
+  protected $collection_key = 'hosts';
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $hosts;
+  public $pathMatcher;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setHosts($hosts)
+  {
+    $this->hosts = $hosts;
+  }
+  public function getHosts()
+  {
+    return $this->hosts;
+  }
+  public function setPathMatcher($pathMatcher)
+  {
+    $this->pathMatcher = $pathMatcher;
+  }
+  public function getPathMatcher()
+  {
+    return $this->pathMatcher;
+  }
+}
+
+class Google_Service_Compute_HttpHealthCheck extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $checkIntervalSec;
+  public $creationTimestamp;
+  public $description;
+  public $healthyThreshold;
+  public $host;
+  public $id;
+  public $kind;
+  public $name;
+  public $port;
+  public $requestPath;
+  public $selfLink;
+  public $timeoutSec;
+  public $unhealthyThreshold;
+
+
+  public function setCheckIntervalSec($checkIntervalSec)
+  {
+    $this->checkIntervalSec = $checkIntervalSec;
+  }
+  public function getCheckIntervalSec()
+  {
+    return $this->checkIntervalSec;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setHealthyThreshold($healthyThreshold)
+  {
+    $this->healthyThreshold = $healthyThreshold;
+  }
+  public function getHealthyThreshold()
+  {
+    return $this->healthyThreshold;
+  }
+  public function setHost($host)
+  {
+    $this->host = $host;
+  }
+  public function getHost()
+  {
+    return $this->host;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPort($port)
+  {
+    $this->port = $port;
+  }
+  public function getPort()
+  {
+    return $this->port;
+  }
+  public function setRequestPath($requestPath)
+  {
+    $this->requestPath = $requestPath;
+  }
+  public function getRequestPath()
+  {
+    return $this->requestPath;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTimeoutSec($timeoutSec)
+  {
+    $this->timeoutSec = $timeoutSec;
+  }
+  public function getTimeoutSec()
+  {
+    return $this->timeoutSec;
+  }
+  public function setUnhealthyThreshold($unhealthyThreshold)
+  {
+    $this->unhealthyThreshold = $unhealthyThreshold;
+  }
+  public function getUnhealthyThreshold()
+  {
+    return $this->unhealthyThreshold;
+  }
+}
+
+class Google_Service_Compute_HttpHealthCheckList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_HttpHealthCheck';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_HttpsHealthCheck extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $checkIntervalSec;
+  public $creationTimestamp;
+  public $description;
+  public $healthyThreshold;
+  public $host;
+  public $id;
+  public $kind;
+  public $name;
+  public $port;
+  public $requestPath;
+  public $selfLink;
+  public $timeoutSec;
+  public $unhealthyThreshold;
+
+
+  public function setCheckIntervalSec($checkIntervalSec)
+  {
+    $this->checkIntervalSec = $checkIntervalSec;
+  }
+  public function getCheckIntervalSec()
+  {
+    return $this->checkIntervalSec;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setHealthyThreshold($healthyThreshold)
+  {
+    $this->healthyThreshold = $healthyThreshold;
+  }
+  public function getHealthyThreshold()
+  {
+    return $this->healthyThreshold;
+  }
+  public function setHost($host)
+  {
+    $this->host = $host;
+  }
+  public function getHost()
+  {
+    return $this->host;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPort($port)
+  {
+    $this->port = $port;
+  }
+  public function getPort()
+  {
+    return $this->port;
+  }
+  public function setRequestPath($requestPath)
+  {
+    $this->requestPath = $requestPath;
+  }
+  public function getRequestPath()
+  {
+    return $this->requestPath;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTimeoutSec($timeoutSec)
+  {
+    $this->timeoutSec = $timeoutSec;
+  }
+  public function getTimeoutSec()
+  {
+    return $this->timeoutSec;
+  }
+  public function setUnhealthyThreshold($unhealthyThreshold)
+  {
+    $this->unhealthyThreshold = $unhealthyThreshold;
+  }
+  public function getUnhealthyThreshold()
+  {
+    return $this->unhealthyThreshold;
+  }
+}
+
+class Google_Service_Compute_HttpsHealthCheckList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_HttpsHealthCheck';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_Image extends Google_Collection
+{
+  protected $collection_key = 'licenses';
+  protected $internal_gapi_mappings = array(
+  );
+  public $archiveSizeBytes;
+  public $creationTimestamp;
+  protected $deprecatedType = 'Google_Service_Compute_DeprecationStatus';
+  protected $deprecatedDataType = '';
+  public $description;
+  public $diskSizeGb;
+  public $id;
+  public $kind;
+  public $licenses;
+  public $name;
+  protected $rawDiskType = 'Google_Service_Compute_ImageRawDisk';
+  protected $rawDiskDataType = '';
+  public $selfLink;
+  public $sourceDisk;
+  public $sourceDiskId;
+  public $sourceType;
+  public $status;
+
+
+  public function setArchiveSizeBytes($archiveSizeBytes)
+  {
+    $this->archiveSizeBytes = $archiveSizeBytes;
+  }
+  public function getArchiveSizeBytes()
+  {
+    return $this->archiveSizeBytes;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDeprecated(Google_Service_Compute_DeprecationStatus $deprecated)
+  {
+    $this->deprecated = $deprecated;
+  }
+  public function getDeprecated()
+  {
+    return $this->deprecated;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDiskSizeGb($diskSizeGb)
+  {
+    $this->diskSizeGb = $diskSizeGb;
+  }
+  public function getDiskSizeGb()
+  {
+    return $this->diskSizeGb;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLicenses($licenses)
+  {
+    $this->licenses = $licenses;
+  }
+  public function getLicenses()
+  {
+    return $this->licenses;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setRawDisk(Google_Service_Compute_ImageRawDisk $rawDisk)
+  {
+    $this->rawDisk = $rawDisk;
+  }
+  public function getRawDisk()
+  {
+    return $this->rawDisk;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setSourceDisk($sourceDisk)
+  {
+    $this->sourceDisk = $sourceDisk;
+  }
+  public function getSourceDisk()
+  {
+    return $this->sourceDisk;
+  }
+  public function setSourceDiskId($sourceDiskId)
+  {
+    $this->sourceDiskId = $sourceDiskId;
+  }
+  public function getSourceDiskId()
+  {
+    return $this->sourceDiskId;
+  }
+  public function setSourceType($sourceType)
+  {
+    $this->sourceType = $sourceType;
+  }
+  public function getSourceType()
+  {
+    return $this->sourceType;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_Compute_ImageList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_Image';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_ImageRawDisk extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $containerType;
+  public $sha1Checksum;
+  public $source;
+
+
+  public function setContainerType($containerType)
+  {
+    $this->containerType = $containerType;
+  }
+  public function getContainerType()
+  {
+    return $this->containerType;
+  }
+  public function setSha1Checksum($sha1Checksum)
+  {
+    $this->sha1Checksum = $sha1Checksum;
+  }
+  public function getSha1Checksum()
+  {
+    return $this->sha1Checksum;
+  }
+  public function setSource($source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+}
+
+class Google_Service_Compute_Instance extends Google_Collection
+{
+  protected $collection_key = 'serviceAccounts';
+  protected $internal_gapi_mappings = array(
+  );
+  public $canIpForward;
+  public $cpuPlatform;
+  public $creationTimestamp;
+  public $description;
+  protected $disksType = 'Google_Service_Compute_AttachedDisk';
+  protected $disksDataType = 'array';
+  public $id;
+  public $kind;
+  public $machineType;
+  protected $metadataType = 'Google_Service_Compute_Metadata';
+  protected $metadataDataType = '';
+  public $name;
+  protected $networkInterfacesType = 'Google_Service_Compute_NetworkInterface';
+  protected $networkInterfacesDataType = 'array';
+  protected $schedulingType = 'Google_Service_Compute_Scheduling';
+  protected $schedulingDataType = '';
+  public $selfLink;
+  protected $serviceAccountsType = 'Google_Service_Compute_ServiceAccount';
+  protected $serviceAccountsDataType = 'array';
+  public $status;
+  public $statusMessage;
+  protected $tagsType = 'Google_Service_Compute_Tags';
+  protected $tagsDataType = '';
+  public $zone;
+
+
+  public function setCanIpForward($canIpForward)
+  {
+    $this->canIpForward = $canIpForward;
+  }
+  public function getCanIpForward()
+  {
+    return $this->canIpForward;
+  }
+  public function setCpuPlatform($cpuPlatform)
+  {
+    $this->cpuPlatform = $cpuPlatform;
+  }
+  public function getCpuPlatform()
+  {
+    return $this->cpuPlatform;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDisks($disks)
+  {
+    $this->disks = $disks;
+  }
+  public function getDisks()
+  {
+    return $this->disks;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMachineType($machineType)
+  {
+    $this->machineType = $machineType;
+  }
+  public function getMachineType()
+  {
+    return $this->machineType;
+  }
+  public function setMetadata(Google_Service_Compute_Metadata $metadata)
+  {
+    $this->metadata = $metadata;
+  }
+  public function getMetadata()
+  {
+    return $this->metadata;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNetworkInterfaces($networkInterfaces)
+  {
+    $this->networkInterfaces = $networkInterfaces;
+  }
+  public function getNetworkInterfaces()
+  {
+    return $this->networkInterfaces;
+  }
+  public function setScheduling(Google_Service_Compute_Scheduling $scheduling)
+  {
+    $this->scheduling = $scheduling;
+  }
+  public function getScheduling()
+  {
+    return $this->scheduling;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setServiceAccounts($serviceAccounts)
+  {
+    $this->serviceAccounts = $serviceAccounts;
+  }
+  public function getServiceAccounts()
+  {
+    return $this->serviceAccounts;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setStatusMessage($statusMessage)
+  {
+    $this->statusMessage = $statusMessage;
+  }
+  public function getStatusMessage()
+  {
+    return $this->statusMessage;
+  }
+  public function setTags(Google_Service_Compute_Tags $tags)
+  {
+    $this->tags = $tags;
+  }
+  public function getTags()
+  {
+    return $this->tags;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_Compute_InstanceAggregatedList extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_InstancesScopedList';
+  protected $itemsDataType = 'map';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_InstanceAggregatedListItems extends Google_Model
+{
+}
+
+class Google_Service_Compute_InstanceGroup extends Google_Collection
+{
+  protected $collection_key = 'namedPorts';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $description;
+  public $fingerprint;
+  public $id;
+  public $kind;
+  public $name;
+  protected $namedPortsType = 'Google_Service_Compute_NamedPort';
+  protected $namedPortsDataType = 'array';
+  public $network;
+  public $selfLink;
+  public $size;
+  public $zone;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNamedPorts($namedPorts)
+  {
+    $this->namedPorts = $namedPorts;
+  }
+  public function getNamedPorts()
+  {
+    return $this->namedPorts;
+  }
+  public function setNetwork($network)
+  {
+    $this->network = $network;
+  }
+  public function getNetwork()
+  {
+    return $this->network;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setSize($size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupAggregatedList extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_InstanceGroupsScopedList';
+  protected $itemsDataType = 'map';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupAggregatedListItems extends Google_Model
+{
+}
+
+class Google_Service_Compute_InstanceGroupList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_InstanceGroup';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupManager extends Google_Collection
+{
+  protected $collection_key = 'targetPools';
+  protected $internal_gapi_mappings = array(
+  );
+  public $baseInstanceName;
+  public $creationTimestamp;
+  protected $currentActionsType = 'Google_Service_Compute_InstanceGroupManagerActionsSummary';
+  protected $currentActionsDataType = '';
+  public $description;
+  public $fingerprint;
+  public $id;
+  public $instanceGroup;
+  public $instanceTemplate;
+  public $kind;
+  public $name;
+  public $selfLink;
+  public $targetPools;
+  public $targetSize;
+  public $zone;
+
+
+  public function setBaseInstanceName($baseInstanceName)
+  {
+    $this->baseInstanceName = $baseInstanceName;
+  }
+  public function getBaseInstanceName()
+  {
+    return $this->baseInstanceName;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setCurrentActions(Google_Service_Compute_InstanceGroupManagerActionsSummary $currentActions)
+  {
+    $this->currentActions = $currentActions;
+  }
+  public function getCurrentActions()
+  {
+    return $this->currentActions;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInstanceGroup($instanceGroup)
+  {
+    $this->instanceGroup = $instanceGroup;
+  }
+  public function getInstanceGroup()
+  {
+    return $this->instanceGroup;
+  }
+  public function setInstanceTemplate($instanceTemplate)
+  {
+    $this->instanceTemplate = $instanceTemplate;
+  }
+  public function getInstanceTemplate()
+  {
+    return $this->instanceTemplate;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTargetPools($targetPools)
+  {
+    $this->targetPools = $targetPools;
+  }
+  public function getTargetPools()
+  {
+    return $this->targetPools;
+  }
+  public function setTargetSize($targetSize)
+  {
+    $this->targetSize = $targetSize;
+  }
+  public function getTargetSize()
+  {
+    return $this->targetSize;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupManagerActionsSummary extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $abandoning;
+  public $creating;
+  public $deleting;
+  public $none;
+  public $recreating;
+  public $refreshing;
+  public $restarting;
+
+
+  public function setAbandoning($abandoning)
+  {
+    $this->abandoning = $abandoning;
+  }
+  public function getAbandoning()
+  {
+    return $this->abandoning;
+  }
+  public function setCreating($creating)
+  {
+    $this->creating = $creating;
+  }
+  public function getCreating()
+  {
+    return $this->creating;
+  }
+  public function setDeleting($deleting)
+  {
+    $this->deleting = $deleting;
+  }
+  public function getDeleting()
+  {
+    return $this->deleting;
+  }
+  public function setNone($none)
+  {
+    $this->none = $none;
+  }
+  public function getNone()
+  {
+    return $this->none;
+  }
+  public function setRecreating($recreating)
+  {
+    $this->recreating = $recreating;
+  }
+  public function getRecreating()
+  {
+    return $this->recreating;
+  }
+  public function setRefreshing($refreshing)
+  {
+    $this->refreshing = $refreshing;
+  }
+  public function getRefreshing()
+  {
+    return $this->refreshing;
+  }
+  public function setRestarting($restarting)
+  {
+    $this->restarting = $restarting;
+  }
+  public function getRestarting()
+  {
+    return $this->restarting;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupManagerAggregatedList extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_InstanceGroupManagersScopedList';
+  protected $itemsDataType = 'map';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupManagerAggregatedListItems extends Google_Model
+{
+}
+
+class Google_Service_Compute_InstanceGroupManagerList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_InstanceGroupManager';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupManagersAbandonInstancesRequest extends Google_Collection
+{
+  protected $collection_key = 'instances';
+  protected $internal_gapi_mappings = array(
+  );
+  public $instances;
+
+
+  public function setInstances($instances)
+  {
+    $this->instances = $instances;
+  }
+  public function getInstances()
+  {
+    return $this->instances;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupManagersDeleteInstancesRequest extends Google_Collection
+{
+  protected $collection_key = 'instances';
+  protected $internal_gapi_mappings = array(
+  );
+  public $instances;
+
+
+  public function setInstances($instances)
+  {
+    $this->instances = $instances;
+  }
+  public function getInstances()
+  {
+    return $this->instances;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupManagersListManagedInstancesResponse extends Google_Collection
+{
+  protected $collection_key = 'managedInstances';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $managedInstancesType = 'Google_Service_Compute_ManagedInstance';
+  protected $managedInstancesDataType = 'array';
+
+
+  public function setManagedInstances($managedInstances)
+  {
+    $this->managedInstances = $managedInstances;
+  }
+  public function getManagedInstances()
+  {
+    return $this->managedInstances;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupManagersRecreateInstancesRequest extends Google_Collection
+{
+  protected $collection_key = 'instances';
+  protected $internal_gapi_mappings = array(
+  );
+  public $instances;
+
+
+  public function setInstances($instances)
+  {
+    $this->instances = $instances;
+  }
+  public function getInstances()
+  {
+    return $this->instances;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupManagersScopedList extends Google_Collection
+{
+  protected $collection_key = 'instanceGroupManagers';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $instanceGroupManagersType = 'Google_Service_Compute_InstanceGroupManager';
+  protected $instanceGroupManagersDataType = 'array';
+  protected $warningType = 'Google_Service_Compute_InstanceGroupManagersScopedListWarning';
+  protected $warningDataType = '';
+
+
+  public function setInstanceGroupManagers($instanceGroupManagers)
+  {
+    $this->instanceGroupManagers = $instanceGroupManagers;
+  }
+  public function getInstanceGroupManagers()
+  {
+    return $this->instanceGroupManagers;
+  }
+  public function setWarning(Google_Service_Compute_InstanceGroupManagersScopedListWarning $warning)
+  {
+    $this->warning = $warning;
+  }
+  public function getWarning()
+  {
+    return $this->warning;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupManagersScopedListWarning extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Compute_InstanceGroupManagersScopedListWarningData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupManagersScopedListWarningData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupManagersSetInstanceTemplateRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $instanceTemplate;
+
+
+  public function setInstanceTemplate($instanceTemplate)
+  {
+    $this->instanceTemplate = $instanceTemplate;
+  }
+  public function getInstanceTemplate()
+  {
+    return $this->instanceTemplate;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupManagersSetTargetPoolsRequest extends Google_Collection
+{
+  protected $collection_key = 'targetPools';
+  protected $internal_gapi_mappings = array(
+  );
+  public $fingerprint;
+  public $targetPools;
+
+
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setTargetPools($targetPools)
+  {
+    $this->targetPools = $targetPools;
+  }
+  public function getTargetPools()
+  {
+    return $this->targetPools;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupsAddInstancesRequest extends Google_Collection
+{
+  protected $collection_key = 'instances';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $instancesType = 'Google_Service_Compute_InstanceReference';
+  protected $instancesDataType = 'array';
+
+
+  public function setInstances($instances)
+  {
+    $this->instances = $instances;
+  }
+  public function getInstances()
+  {
+    return $this->instances;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupsListInstances extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_InstanceWithNamedPorts';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupsListInstancesRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $instanceState;
+
+
+  public function setInstanceState($instanceState)
+  {
+    $this->instanceState = $instanceState;
+  }
+  public function getInstanceState()
+  {
+    return $this->instanceState;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupsRemoveInstancesRequest extends Google_Collection
+{
+  protected $collection_key = 'instances';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $instancesType = 'Google_Service_Compute_InstanceReference';
+  protected $instancesDataType = 'array';
+
+
+  public function setInstances($instances)
+  {
+    $this->instances = $instances;
+  }
+  public function getInstances()
+  {
+    return $this->instances;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupsScopedList extends Google_Collection
+{
+  protected $collection_key = 'instanceGroups';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $instanceGroupsType = 'Google_Service_Compute_InstanceGroup';
+  protected $instanceGroupsDataType = 'array';
+  protected $warningType = 'Google_Service_Compute_InstanceGroupsScopedListWarning';
+  protected $warningDataType = '';
+
+
+  public function setInstanceGroups($instanceGroups)
+  {
+    $this->instanceGroups = $instanceGroups;
+  }
+  public function getInstanceGroups()
+  {
+    return $this->instanceGroups;
+  }
+  public function setWarning(Google_Service_Compute_InstanceGroupsScopedListWarning $warning)
+  {
+    $this->warning = $warning;
+  }
+  public function getWarning()
+  {
+    return $this->warning;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupsScopedListWarning extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Compute_InstanceGroupsScopedListWarningData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupsScopedListWarningData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Compute_InstanceGroupsSetNamedPortsRequest extends Google_Collection
+{
+  protected $collection_key = 'namedPorts';
+  protected $internal_gapi_mappings = array(
+  );
+  public $fingerprint;
+  protected $namedPortsType = 'Google_Service_Compute_NamedPort';
+  protected $namedPortsDataType = 'array';
+
+
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setNamedPorts($namedPorts)
+  {
+    $this->namedPorts = $namedPorts;
+  }
+  public function getNamedPorts()
+  {
+    return $this->namedPorts;
+  }
+}
+
+class Google_Service_Compute_InstanceList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_Instance';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_InstanceMoveRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $destinationZone;
+  public $targetInstance;
+
+
+  public function setDestinationZone($destinationZone)
+  {
+    $this->destinationZone = $destinationZone;
+  }
+  public function getDestinationZone()
+  {
+    return $this->destinationZone;
+  }
+  public function setTargetInstance($targetInstance)
+  {
+    $this->targetInstance = $targetInstance;
+  }
+  public function getTargetInstance()
+  {
+    return $this->targetInstance;
+  }
+}
+
+class Google_Service_Compute_InstanceProperties extends Google_Collection
+{
+  protected $collection_key = 'serviceAccounts';
+  protected $internal_gapi_mappings = array(
+  );
+  public $canIpForward;
+  public $description;
+  protected $disksType = 'Google_Service_Compute_AttachedDisk';
+  protected $disksDataType = 'array';
+  public $machineType;
+  protected $metadataType = 'Google_Service_Compute_Metadata';
+  protected $metadataDataType = '';
+  protected $networkInterfacesType = 'Google_Service_Compute_NetworkInterface';
+  protected $networkInterfacesDataType = 'array';
+  protected $schedulingType = 'Google_Service_Compute_Scheduling';
+  protected $schedulingDataType = '';
+  protected $serviceAccountsType = 'Google_Service_Compute_ServiceAccount';
+  protected $serviceAccountsDataType = 'array';
+  protected $tagsType = 'Google_Service_Compute_Tags';
+  protected $tagsDataType = '';
+
+
+  public function setCanIpForward($canIpForward)
+  {
+    $this->canIpForward = $canIpForward;
+  }
+  public function getCanIpForward()
+  {
+    return $this->canIpForward;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDisks($disks)
+  {
+    $this->disks = $disks;
+  }
+  public function getDisks()
+  {
+    return $this->disks;
+  }
+  public function setMachineType($machineType)
+  {
+    $this->machineType = $machineType;
+  }
+  public function getMachineType()
+  {
+    return $this->machineType;
+  }
+  public function setMetadata(Google_Service_Compute_Metadata $metadata)
+  {
+    $this->metadata = $metadata;
+  }
+  public function getMetadata()
+  {
+    return $this->metadata;
+  }
+  public function setNetworkInterfaces($networkInterfaces)
+  {
+    $this->networkInterfaces = $networkInterfaces;
+  }
+  public function getNetworkInterfaces()
+  {
+    return $this->networkInterfaces;
+  }
+  public function setScheduling(Google_Service_Compute_Scheduling $scheduling)
+  {
+    $this->scheduling = $scheduling;
+  }
+  public function getScheduling()
+  {
+    return $this->scheduling;
+  }
+  public function setServiceAccounts($serviceAccounts)
+  {
+    $this->serviceAccounts = $serviceAccounts;
+  }
+  public function getServiceAccounts()
+  {
+    return $this->serviceAccounts;
+  }
+  public function setTags(Google_Service_Compute_Tags $tags)
+  {
+    $this->tags = $tags;
+  }
+  public function getTags()
+  {
+    return $this->tags;
+  }
+}
+
+class Google_Service_Compute_InstanceReference extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $instance;
+
+
+  public function setInstance($instance)
+  {
+    $this->instance = $instance;
+  }
+  public function getInstance()
+  {
+    return $this->instance;
+  }
+}
+
+class Google_Service_Compute_InstanceTemplate extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $description;
+  public $id;
+  public $kind;
+  public $name;
+  protected $propertiesType = 'Google_Service_Compute_InstanceProperties';
+  protected $propertiesDataType = '';
+  public $selfLink;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProperties(Google_Service_Compute_InstanceProperties $properties)
+  {
+    $this->properties = $properties;
+  }
+  public function getProperties()
+  {
+    return $this->properties;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_InstanceTemplateList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_InstanceTemplate';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_InstanceWithNamedPorts extends Google_Collection
+{
+  protected $collection_key = 'namedPorts';
+  protected $internal_gapi_mappings = array(
+  );
+  public $instance;
+  protected $namedPortsType = 'Google_Service_Compute_NamedPort';
+  protected $namedPortsDataType = 'array';
+  public $status;
+
+
+  public function setInstance($instance)
+  {
+    $this->instance = $instance;
+  }
+  public function getInstance()
+  {
+    return $this->instance;
+  }
+  public function setNamedPorts($namedPorts)
+  {
+    $this->namedPorts = $namedPorts;
+  }
+  public function getNamedPorts()
+  {
+    return $this->namedPorts;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_Compute_InstancesScopedList extends Google_Collection
+{
+  protected $collection_key = 'instances';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $instancesType = 'Google_Service_Compute_Instance';
+  protected $instancesDataType = 'array';
+  protected $warningType = 'Google_Service_Compute_InstancesScopedListWarning';
+  protected $warningDataType = '';
+
+
+  public function setInstances($instances)
+  {
+    $this->instances = $instances;
+  }
+  public function getInstances()
+  {
+    return $this->instances;
+  }
+  public function setWarning(Google_Service_Compute_InstancesScopedListWarning $warning)
+  {
+    $this->warning = $warning;
+  }
+  public function getWarning()
+  {
+    return $this->warning;
+  }
+}
+
+class Google_Service_Compute_InstancesScopedListWarning extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Compute_InstancesScopedListWarningData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Compute_InstancesScopedListWarningData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Compute_License extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $chargesUseFee;
+  public $kind;
+  public $name;
+  public $selfLink;
+
+
+  public function setChargesUseFee($chargesUseFee)
+  {
+    $this->chargesUseFee = $chargesUseFee;
+  }
+  public function getChargesUseFee()
+  {
+    return $this->chargesUseFee;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_MachineType extends Google_Collection
+{
+  protected $collection_key = 'scratchDisks';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  protected $deprecatedType = 'Google_Service_Compute_DeprecationStatus';
+  protected $deprecatedDataType = '';
+  public $description;
+  public $guestCpus;
+  public $id;
+  public $imageSpaceGb;
+  public $kind;
+  public $maximumPersistentDisks;
+  public $maximumPersistentDisksSizeGb;
+  public $memoryMb;
+  public $name;
+  protected $scratchDisksType = 'Google_Service_Compute_MachineTypeScratchDisks';
+  protected $scratchDisksDataType = 'array';
+  public $selfLink;
+  public $zone;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDeprecated(Google_Service_Compute_DeprecationStatus $deprecated)
+  {
+    $this->deprecated = $deprecated;
+  }
+  public function getDeprecated()
+  {
+    return $this->deprecated;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setGuestCpus($guestCpus)
+  {
+    $this->guestCpus = $guestCpus;
+  }
+  public function getGuestCpus()
+  {
+    return $this->guestCpus;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImageSpaceGb($imageSpaceGb)
+  {
+    $this->imageSpaceGb = $imageSpaceGb;
+  }
+  public function getImageSpaceGb()
+  {
+    return $this->imageSpaceGb;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMaximumPersistentDisks($maximumPersistentDisks)
+  {
+    $this->maximumPersistentDisks = $maximumPersistentDisks;
+  }
+  public function getMaximumPersistentDisks()
+  {
+    return $this->maximumPersistentDisks;
+  }
+  public function setMaximumPersistentDisksSizeGb($maximumPersistentDisksSizeGb)
+  {
+    $this->maximumPersistentDisksSizeGb = $maximumPersistentDisksSizeGb;
+  }
+  public function getMaximumPersistentDisksSizeGb()
+  {
+    return $this->maximumPersistentDisksSizeGb;
+  }
+  public function setMemoryMb($memoryMb)
+  {
+    $this->memoryMb = $memoryMb;
+  }
+  public function getMemoryMb()
+  {
+    return $this->memoryMb;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setScratchDisks($scratchDisks)
+  {
+    $this->scratchDisks = $scratchDisks;
+  }
+  public function getScratchDisks()
+  {
+    return $this->scratchDisks;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_Compute_MachineTypeAggregatedList extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_MachineTypesScopedList';
+  protected $itemsDataType = 'map';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_MachineTypeAggregatedListItems extends Google_Model
+{
+}
+
+class Google_Service_Compute_MachineTypeList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_MachineType';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_MachineTypeScratchDisks extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $diskGb;
+
+
+  public function setDiskGb($diskGb)
+  {
+    $this->diskGb = $diskGb;
+  }
+  public function getDiskGb()
+  {
+    return $this->diskGb;
+  }
+}
+
+class Google_Service_Compute_MachineTypesScopedList extends Google_Collection
+{
+  protected $collection_key = 'machineTypes';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $machineTypesType = 'Google_Service_Compute_MachineType';
+  protected $machineTypesDataType = 'array';
+  protected $warningType = 'Google_Service_Compute_MachineTypesScopedListWarning';
+  protected $warningDataType = '';
+
+
+  public function setMachineTypes($machineTypes)
+  {
+    $this->machineTypes = $machineTypes;
+  }
+  public function getMachineTypes()
+  {
+    return $this->machineTypes;
+  }
+  public function setWarning(Google_Service_Compute_MachineTypesScopedListWarning $warning)
+  {
+    $this->warning = $warning;
+  }
+  public function getWarning()
+  {
+    return $this->warning;
+  }
+}
+
+class Google_Service_Compute_MachineTypesScopedListWarning extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Compute_MachineTypesScopedListWarningData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Compute_MachineTypesScopedListWarningData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Compute_ManagedInstance extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $currentAction;
+  public $id;
+  public $instance;
+  public $instanceStatus;
+  protected $lastAttemptType = 'Google_Service_Compute_ManagedInstanceLastAttempt';
+  protected $lastAttemptDataType = '';
+
+
+  public function setCurrentAction($currentAction)
+  {
+    $this->currentAction = $currentAction;
+  }
+  public function getCurrentAction()
+  {
+    return $this->currentAction;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInstance($instance)
+  {
+    $this->instance = $instance;
+  }
+  public function getInstance()
+  {
+    return $this->instance;
+  }
+  public function setInstanceStatus($instanceStatus)
+  {
+    $this->instanceStatus = $instanceStatus;
+  }
+  public function getInstanceStatus()
+  {
+    return $this->instanceStatus;
+  }
+  public function setLastAttempt(Google_Service_Compute_ManagedInstanceLastAttempt $lastAttempt)
+  {
+    $this->lastAttempt = $lastAttempt;
+  }
+  public function getLastAttempt()
+  {
+    return $this->lastAttempt;
+  }
+}
+
+class Google_Service_Compute_ManagedInstanceLastAttempt extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorsType = 'Google_Service_Compute_ManagedInstanceLastAttemptErrors';
+  protected $errorsDataType = '';
+
+
+  public function setErrors(Google_Service_Compute_ManagedInstanceLastAttemptErrors $errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+}
+
+class Google_Service_Compute_ManagedInstanceLastAttemptErrors extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorsType = 'Google_Service_Compute_ManagedInstanceLastAttemptErrorsErrors';
+  protected $errorsDataType = 'array';
+
+
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+}
+
+class Google_Service_Compute_ManagedInstanceLastAttemptErrorsErrors extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $location;
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Compute_Metadata extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $fingerprint;
+  protected $itemsType = 'Google_Service_Compute_MetadataItems';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Compute_MetadataItems extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Compute_NamedPort extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $port;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPort($port)
+  {
+    $this->port = $port;
+  }
+  public function getPort()
+  {
+    return $this->port;
+  }
+}
+
+class Google_Service_Compute_Network extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "iPv4Range" => "IPv4Range",
+  );
+  public $iPv4Range;
+  public $creationTimestamp;
+  public $description;
+  public $gatewayIPv4;
+  public $id;
+  public $kind;
+  public $name;
+  public $selfLink;
+
+
+  public function setIPv4Range($iPv4Range)
+  {
+    $this->iPv4Range = $iPv4Range;
+  }
+  public function getIPv4Range()
+  {
+    return $this->iPv4Range;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setGatewayIPv4($gatewayIPv4)
+  {
+    $this->gatewayIPv4 = $gatewayIPv4;
+  }
+  public function getGatewayIPv4()
+  {
+    return $this->gatewayIPv4;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_NetworkInterface extends Google_Collection
+{
+  protected $collection_key = 'accessConfigs';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accessConfigsType = 'Google_Service_Compute_AccessConfig';
+  protected $accessConfigsDataType = 'array';
+  public $name;
+  public $network;
+  public $networkIP;
+
+
+  public function setAccessConfigs($accessConfigs)
+  {
+    $this->accessConfigs = $accessConfigs;
+  }
+  public function getAccessConfigs()
+  {
+    return $this->accessConfigs;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNetwork($network)
+  {
+    $this->network = $network;
+  }
+  public function getNetwork()
+  {
+    return $this->network;
+  }
+  public function setNetworkIP($networkIP)
+  {
+    $this->networkIP = $networkIP;
+  }
+  public function getNetworkIP()
+  {
+    return $this->networkIP;
+  }
+}
+
+class Google_Service_Compute_NetworkList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_Network';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_Operation extends Google_Collection
+{
+  protected $collection_key = 'warnings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $clientOperationId;
+  public $creationTimestamp;
+  public $endTime;
+  protected $errorType = 'Google_Service_Compute_OperationError';
+  protected $errorDataType = '';
+  public $httpErrorMessage;
+  public $httpErrorStatusCode;
+  public $id;
+  public $insertTime;
+  public $kind;
+  public $name;
+  public $operationType;
+  public $progress;
+  public $region;
+  public $selfLink;
+  public $startTime;
+  public $status;
+  public $statusMessage;
+  public $targetId;
+  public $targetLink;
+  public $user;
+  protected $warningsType = 'Google_Service_Compute_OperationWarnings';
+  protected $warningsDataType = 'array';
+  public $zone;
+
+
+  public function setClientOperationId($clientOperationId)
+  {
+    $this->clientOperationId = $clientOperationId;
+  }
+  public function getClientOperationId()
+  {
+    return $this->clientOperationId;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setError(Google_Service_Compute_OperationError $error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setHttpErrorMessage($httpErrorMessage)
+  {
+    $this->httpErrorMessage = $httpErrorMessage;
+  }
+  public function getHttpErrorMessage()
+  {
+    return $this->httpErrorMessage;
+  }
+  public function setHttpErrorStatusCode($httpErrorStatusCode)
+  {
+    $this->httpErrorStatusCode = $httpErrorStatusCode;
+  }
+  public function getHttpErrorStatusCode()
+  {
+    return $this->httpErrorStatusCode;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInsertTime($insertTime)
+  {
+    $this->insertTime = $insertTime;
+  }
+  public function getInsertTime()
+  {
+    return $this->insertTime;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOperationType($operationType)
+  {
+    $this->operationType = $operationType;
+  }
+  public function getOperationType()
+  {
+    return $this->operationType;
+  }
+  public function setProgress($progress)
+  {
+    $this->progress = $progress;
+  }
+  public function getProgress()
+  {
+    return $this->progress;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setStatusMessage($statusMessage)
+  {
+    $this->statusMessage = $statusMessage;
+  }
+  public function getStatusMessage()
+  {
+    return $this->statusMessage;
+  }
+  public function setTargetId($targetId)
+  {
+    $this->targetId = $targetId;
+  }
+  public function getTargetId()
+  {
+    return $this->targetId;
+  }
+  public function setTargetLink($targetLink)
+  {
+    $this->targetLink = $targetLink;
+  }
+  public function getTargetLink()
+  {
+    return $this->targetLink;
+  }
+  public function setUser($user)
+  {
+    $this->user = $user;
+  }
+  public function getUser()
+  {
+    return $this->user;
+  }
+  public function setWarnings($warnings)
+  {
+    $this->warnings = $warnings;
+  }
+  public function getWarnings()
+  {
+    return $this->warnings;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_Compute_OperationAggregatedList extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_OperationsScopedList';
+  protected $itemsDataType = 'map';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_OperationAggregatedListItems extends Google_Model
+{
+}
+
+class Google_Service_Compute_OperationError extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorsType = 'Google_Service_Compute_OperationErrorErrors';
+  protected $errorsDataType = 'array';
+
+
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+}
+
+class Google_Service_Compute_OperationErrorErrors extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $location;
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Compute_OperationList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_Operation';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_OperationWarnings extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Compute_OperationWarningsData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Compute_OperationWarningsData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Compute_OperationsScopedList extends Google_Collection
+{
+  protected $collection_key = 'operations';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $operationsType = 'Google_Service_Compute_Operation';
+  protected $operationsDataType = 'array';
+  protected $warningType = 'Google_Service_Compute_OperationsScopedListWarning';
+  protected $warningDataType = '';
+
+
+  public function setOperations($operations)
+  {
+    $this->operations = $operations;
+  }
+  public function getOperations()
+  {
+    return $this->operations;
+  }
+  public function setWarning(Google_Service_Compute_OperationsScopedListWarning $warning)
+  {
+    $this->warning = $warning;
+  }
+  public function getWarning()
+  {
+    return $this->warning;
+  }
+}
+
+class Google_Service_Compute_OperationsScopedListWarning extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Compute_OperationsScopedListWarningData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Compute_OperationsScopedListWarningData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Compute_PathMatcher extends Google_Collection
+{
+  protected $collection_key = 'pathRules';
+  protected $internal_gapi_mappings = array(
+  );
+  public $defaultService;
+  public $description;
+  public $name;
+  protected $pathRulesType = 'Google_Service_Compute_PathRule';
+  protected $pathRulesDataType = 'array';
+
+
+  public function setDefaultService($defaultService)
+  {
+    $this->defaultService = $defaultService;
+  }
+  public function getDefaultService()
+  {
+    return $this->defaultService;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPathRules($pathRules)
+  {
+    $this->pathRules = $pathRules;
+  }
+  public function getPathRules()
+  {
+    return $this->pathRules;
+  }
+}
+
+class Google_Service_Compute_PathRule extends Google_Collection
+{
+  protected $collection_key = 'paths';
+  protected $internal_gapi_mappings = array(
+  );
+  public $paths;
+  public $service;
+
+
+  public function setPaths($paths)
+  {
+    $this->paths = $paths;
+  }
+  public function getPaths()
+  {
+    return $this->paths;
+  }
+  public function setService($service)
+  {
+    $this->service = $service;
+  }
+  public function getService()
+  {
+    return $this->service;
+  }
+}
+
+class Google_Service_Compute_Project extends Google_Collection
+{
+  protected $collection_key = 'quotas';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $commonInstanceMetadataType = 'Google_Service_Compute_Metadata';
+  protected $commonInstanceMetadataDataType = '';
+  public $creationTimestamp;
+  public $description;
+  public $enabledFeatures;
+  public $id;
+  public $kind;
+  public $name;
+  protected $quotasType = 'Google_Service_Compute_Quota';
+  protected $quotasDataType = 'array';
+  public $selfLink;
+  protected $usageExportLocationType = 'Google_Service_Compute_UsageExportLocation';
+  protected $usageExportLocationDataType = '';
+
+
+  public function setCommonInstanceMetadata(Google_Service_Compute_Metadata $commonInstanceMetadata)
+  {
+    $this->commonInstanceMetadata = $commonInstanceMetadata;
+  }
+  public function getCommonInstanceMetadata()
+  {
+    return $this->commonInstanceMetadata;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEnabledFeatures($enabledFeatures)
+  {
+    $this->enabledFeatures = $enabledFeatures;
+  }
+  public function getEnabledFeatures()
+  {
+    return $this->enabledFeatures;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setQuotas($quotas)
+  {
+    $this->quotas = $quotas;
+  }
+  public function getQuotas()
+  {
+    return $this->quotas;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setUsageExportLocation(Google_Service_Compute_UsageExportLocation $usageExportLocation)
+  {
+    $this->usageExportLocation = $usageExportLocation;
+  }
+  public function getUsageExportLocation()
+  {
+    return $this->usageExportLocation;
+  }
+}
+
+class Google_Service_Compute_Quota extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $limit;
+  public $metric;
+  public $usage;
+
+
+  public function setLimit($limit)
+  {
+    $this->limit = $limit;
+  }
+  public function getLimit()
+  {
+    return $this->limit;
+  }
+  public function setMetric($metric)
+  {
+    $this->metric = $metric;
+  }
+  public function getMetric()
+  {
+    return $this->metric;
+  }
+  public function setUsage($usage)
+  {
+    $this->usage = $usage;
+  }
+  public function getUsage()
+  {
+    return $this->usage;
+  }
+}
+
+class Google_Service_Compute_Region extends Google_Collection
+{
+  protected $collection_key = 'zones';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  protected $deprecatedType = 'Google_Service_Compute_DeprecationStatus';
+  protected $deprecatedDataType = '';
+  public $description;
+  public $id;
+  public $kind;
+  public $name;
+  protected $quotasType = 'Google_Service_Compute_Quota';
+  protected $quotasDataType = 'array';
+  public $selfLink;
+  public $status;
+  public $zones;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDeprecated(Google_Service_Compute_DeprecationStatus $deprecated)
+  {
+    $this->deprecated = $deprecated;
+  }
+  public function getDeprecated()
+  {
+    return $this->deprecated;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setQuotas($quotas)
+  {
+    $this->quotas = $quotas;
+  }
+  public function getQuotas()
+  {
+    return $this->quotas;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setZones($zones)
+  {
+    $this->zones = $zones;
+  }
+  public function getZones()
+  {
+    return $this->zones;
+  }
+}
+
+class Google_Service_Compute_RegionList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_Region';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_ResourceGroupReference extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $group;
+
+
+  public function setGroup($group)
+  {
+    $this->group = $group;
+  }
+  public function getGroup()
+  {
+    return $this->group;
+  }
+}
+
+class Google_Service_Compute_Route extends Google_Collection
+{
+  protected $collection_key = 'warnings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $description;
+  public $destRange;
+  public $id;
+  public $kind;
+  public $name;
+  public $network;
+  public $nextHopGateway;
+  public $nextHopInstance;
+  public $nextHopIp;
+  public $nextHopNetwork;
+  public $nextHopVpnTunnel;
+  public $priority;
+  public $selfLink;
+  public $tags;
+  protected $warningsType = 'Google_Service_Compute_RouteWarnings';
+  protected $warningsDataType = 'array';
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDestRange($destRange)
+  {
+    $this->destRange = $destRange;
+  }
+  public function getDestRange()
+  {
+    return $this->destRange;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNetwork($network)
+  {
+    $this->network = $network;
+  }
+  public function getNetwork()
+  {
+    return $this->network;
+  }
+  public function setNextHopGateway($nextHopGateway)
+  {
+    $this->nextHopGateway = $nextHopGateway;
+  }
+  public function getNextHopGateway()
+  {
+    return $this->nextHopGateway;
+  }
+  public function setNextHopInstance($nextHopInstance)
+  {
+    $this->nextHopInstance = $nextHopInstance;
+  }
+  public function getNextHopInstance()
+  {
+    return $this->nextHopInstance;
+  }
+  public function setNextHopIp($nextHopIp)
+  {
+    $this->nextHopIp = $nextHopIp;
+  }
+  public function getNextHopIp()
+  {
+    return $this->nextHopIp;
+  }
+  public function setNextHopNetwork($nextHopNetwork)
+  {
+    $this->nextHopNetwork = $nextHopNetwork;
+  }
+  public function getNextHopNetwork()
+  {
+    return $this->nextHopNetwork;
+  }
+  public function setNextHopVpnTunnel($nextHopVpnTunnel)
+  {
+    $this->nextHopVpnTunnel = $nextHopVpnTunnel;
+  }
+  public function getNextHopVpnTunnel()
+  {
+    return $this->nextHopVpnTunnel;
+  }
+  public function setPriority($priority)
+  {
+    $this->priority = $priority;
+  }
+  public function getPriority()
+  {
+    return $this->priority;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTags($tags)
+  {
+    $this->tags = $tags;
+  }
+  public function getTags()
+  {
+    return $this->tags;
+  }
+  public function setWarnings($warnings)
+  {
+    $this->warnings = $warnings;
+  }
+  public function getWarnings()
+  {
+    return $this->warnings;
+  }
+}
+
+class Google_Service_Compute_RouteList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_Route';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_RouteWarnings extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Compute_RouteWarningsData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Compute_RouteWarningsData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Compute_Scheduling extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $automaticRestart;
+  public $onHostMaintenance;
+  public $preemptible;
+
+
+  public function setAutomaticRestart($automaticRestart)
+  {
+    $this->automaticRestart = $automaticRestart;
+  }
+  public function getAutomaticRestart()
+  {
+    return $this->automaticRestart;
+  }
+  public function setOnHostMaintenance($onHostMaintenance)
+  {
+    $this->onHostMaintenance = $onHostMaintenance;
+  }
+  public function getOnHostMaintenance()
+  {
+    return $this->onHostMaintenance;
+  }
+  public function setPreemptible($preemptible)
+  {
+    $this->preemptible = $preemptible;
+  }
+  public function getPreemptible()
+  {
+    return $this->preemptible;
+  }
+}
+
+class Google_Service_Compute_SerialPortOutput extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $contents;
+  public $kind;
+  public $selfLink;
+
+
+  public function setContents($contents)
+  {
+    $this->contents = $contents;
+  }
+  public function getContents()
+  {
+    return $this->contents;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_ServiceAccount extends Google_Collection
+{
+  protected $collection_key = 'scopes';
+  protected $internal_gapi_mappings = array(
+  );
+  public $email;
+  public $scopes;
+
+
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setScopes($scopes)
+  {
+    $this->scopes = $scopes;
+  }
+  public function getScopes()
+  {
+    return $this->scopes;
+  }
+}
+
+class Google_Service_Compute_Snapshot extends Google_Collection
+{
+  protected $collection_key = 'licenses';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $description;
+  public $diskSizeGb;
+  public $id;
+  public $kind;
+  public $licenses;
+  public $name;
+  public $selfLink;
+  public $sourceDisk;
+  public $sourceDiskId;
+  public $status;
+  public $storageBytes;
+  public $storageBytesStatus;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDiskSizeGb($diskSizeGb)
+  {
+    $this->diskSizeGb = $diskSizeGb;
+  }
+  public function getDiskSizeGb()
+  {
+    return $this->diskSizeGb;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLicenses($licenses)
+  {
+    $this->licenses = $licenses;
+  }
+  public function getLicenses()
+  {
+    return $this->licenses;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setSourceDisk($sourceDisk)
+  {
+    $this->sourceDisk = $sourceDisk;
+  }
+  public function getSourceDisk()
+  {
+    return $this->sourceDisk;
+  }
+  public function setSourceDiskId($sourceDiskId)
+  {
+    $this->sourceDiskId = $sourceDiskId;
+  }
+  public function getSourceDiskId()
+  {
+    return $this->sourceDiskId;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setStorageBytes($storageBytes)
+  {
+    $this->storageBytes = $storageBytes;
+  }
+  public function getStorageBytes()
+  {
+    return $this->storageBytes;
+  }
+  public function setStorageBytesStatus($storageBytesStatus)
+  {
+    $this->storageBytesStatus = $storageBytesStatus;
+  }
+  public function getStorageBytesStatus()
+  {
+    return $this->storageBytesStatus;
+  }
+}
+
+class Google_Service_Compute_SnapshotList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_Snapshot';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_SslCertificate extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $certificate;
+  public $creationTimestamp;
+  public $description;
+  public $id;
+  public $kind;
+  public $name;
+  public $privateKey;
+  public $selfLink;
+
+
+  public function setCertificate($certificate)
+  {
+    $this->certificate = $certificate;
+  }
+  public function getCertificate()
+  {
+    return $this->certificate;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPrivateKey($privateKey)
+  {
+    $this->privateKey = $privateKey;
+  }
+  public function getPrivateKey()
+  {
+    return $this->privateKey;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_SslCertificateList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_SslCertificate';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_Tags extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $fingerprint;
+  public $items;
+
+
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+}
+
+class Google_Service_Compute_TargetHttpProxy extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $description;
+  public $id;
+  public $kind;
+  public $name;
+  public $selfLink;
+  public $urlMap;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setUrlMap($urlMap)
+  {
+    $this->urlMap = $urlMap;
+  }
+  public function getUrlMap()
+  {
+    return $this->urlMap;
+  }
+}
+
+class Google_Service_Compute_TargetHttpProxyList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_TargetHttpProxy';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_TargetHttpsProxiesSetSslCertificatesRequest extends Google_Collection
+{
+  protected $collection_key = 'sslCertificates';
+  protected $internal_gapi_mappings = array(
+  );
+  public $sslCertificates;
+
+
+  public function setSslCertificates($sslCertificates)
+  {
+    $this->sslCertificates = $sslCertificates;
+  }
+  public function getSslCertificates()
+  {
+    return $this->sslCertificates;
+  }
+}
+
+class Google_Service_Compute_TargetHttpsProxy extends Google_Collection
+{
+  protected $collection_key = 'sslCertificates';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $description;
+  public $id;
+  public $kind;
+  public $name;
+  public $selfLink;
+  public $sslCertificates;
+  public $urlMap;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setSslCertificates($sslCertificates)
+  {
+    $this->sslCertificates = $sslCertificates;
+  }
+  public function getSslCertificates()
+  {
+    return $this->sslCertificates;
+  }
+  public function setUrlMap($urlMap)
+  {
+    $this->urlMap = $urlMap;
+  }
+  public function getUrlMap()
+  {
+    return $this->urlMap;
+  }
+}
+
+class Google_Service_Compute_TargetHttpsProxyList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_TargetHttpsProxy';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_TargetInstance extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $description;
+  public $id;
+  public $instance;
+  public $kind;
+  public $name;
+  public $natPolicy;
+  public $selfLink;
+  public $zone;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInstance($instance)
+  {
+    $this->instance = $instance;
+  }
+  public function getInstance()
+  {
+    return $this->instance;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNatPolicy($natPolicy)
+  {
+    $this->natPolicy = $natPolicy;
+  }
+  public function getNatPolicy()
+  {
+    return $this->natPolicy;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_Compute_TargetInstanceAggregatedList extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_TargetInstancesScopedList';
+  protected $itemsDataType = 'map';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_TargetInstanceAggregatedListItems extends Google_Model
+{
+}
+
+class Google_Service_Compute_TargetInstanceList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_TargetInstance';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_TargetInstancesScopedList extends Google_Collection
+{
+  protected $collection_key = 'targetInstances';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $targetInstancesType = 'Google_Service_Compute_TargetInstance';
+  protected $targetInstancesDataType = 'array';
+  protected $warningType = 'Google_Service_Compute_TargetInstancesScopedListWarning';
+  protected $warningDataType = '';
+
+
+  public function setTargetInstances($targetInstances)
+  {
+    $this->targetInstances = $targetInstances;
+  }
+  public function getTargetInstances()
+  {
+    return $this->targetInstances;
+  }
+  public function setWarning(Google_Service_Compute_TargetInstancesScopedListWarning $warning)
+  {
+    $this->warning = $warning;
+  }
+  public function getWarning()
+  {
+    return $this->warning;
+  }
+}
+
+class Google_Service_Compute_TargetInstancesScopedListWarning extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Compute_TargetInstancesScopedListWarningData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Compute_TargetInstancesScopedListWarningData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Compute_TargetPool extends Google_Collection
+{
+  protected $collection_key = 'instances';
+  protected $internal_gapi_mappings = array(
+  );
+  public $backupPool;
+  public $creationTimestamp;
+  public $description;
+  public $failoverRatio;
+  public $healthChecks;
+  public $id;
+  public $instances;
+  public $kind;
+  public $name;
+  public $region;
+  public $selfLink;
+  public $sessionAffinity;
+
+
+  public function setBackupPool($backupPool)
+  {
+    $this->backupPool = $backupPool;
+  }
+  public function getBackupPool()
+  {
+    return $this->backupPool;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setFailoverRatio($failoverRatio)
+  {
+    $this->failoverRatio = $failoverRatio;
+  }
+  public function getFailoverRatio()
+  {
+    return $this->failoverRatio;
+  }
+  public function setHealthChecks($healthChecks)
+  {
+    $this->healthChecks = $healthChecks;
+  }
+  public function getHealthChecks()
+  {
+    return $this->healthChecks;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInstances($instances)
+  {
+    $this->instances = $instances;
+  }
+  public function getInstances()
+  {
+    return $this->instances;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setSessionAffinity($sessionAffinity)
+  {
+    $this->sessionAffinity = $sessionAffinity;
+  }
+  public function getSessionAffinity()
+  {
+    return $this->sessionAffinity;
+  }
+}
+
+class Google_Service_Compute_TargetPoolAggregatedList extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_TargetPoolsScopedList';
+  protected $itemsDataType = 'map';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_TargetPoolAggregatedListItems extends Google_Model
+{
+}
+
+class Google_Service_Compute_TargetPoolInstanceHealth extends Google_Collection
+{
+  protected $collection_key = 'healthStatus';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $healthStatusType = 'Google_Service_Compute_HealthStatus';
+  protected $healthStatusDataType = 'array';
+  public $kind;
+
+
+  public function setHealthStatus($healthStatus)
+  {
+    $this->healthStatus = $healthStatus;
+  }
+  public function getHealthStatus()
+  {
+    return $this->healthStatus;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Compute_TargetPoolList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_TargetPool';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_TargetPoolsAddHealthCheckRequest extends Google_Collection
+{
+  protected $collection_key = 'healthChecks';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $healthChecksType = 'Google_Service_Compute_HealthCheckReference';
+  protected $healthChecksDataType = 'array';
+
+
+  public function setHealthChecks($healthChecks)
+  {
+    $this->healthChecks = $healthChecks;
+  }
+  public function getHealthChecks()
+  {
+    return $this->healthChecks;
+  }
+}
+
+class Google_Service_Compute_TargetPoolsAddInstanceRequest extends Google_Collection
+{
+  protected $collection_key = 'instances';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $instancesType = 'Google_Service_Compute_InstanceReference';
+  protected $instancesDataType = 'array';
+
+
+  public function setInstances($instances)
+  {
+    $this->instances = $instances;
+  }
+  public function getInstances()
+  {
+    return $this->instances;
+  }
+}
+
+class Google_Service_Compute_TargetPoolsRemoveHealthCheckRequest extends Google_Collection
+{
+  protected $collection_key = 'healthChecks';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $healthChecksType = 'Google_Service_Compute_HealthCheckReference';
+  protected $healthChecksDataType = 'array';
+
+
+  public function setHealthChecks($healthChecks)
+  {
+    $this->healthChecks = $healthChecks;
+  }
+  public function getHealthChecks()
+  {
+    return $this->healthChecks;
+  }
+}
+
+class Google_Service_Compute_TargetPoolsRemoveInstanceRequest extends Google_Collection
+{
+  protected $collection_key = 'instances';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $instancesType = 'Google_Service_Compute_InstanceReference';
+  protected $instancesDataType = 'array';
+
+
+  public function setInstances($instances)
+  {
+    $this->instances = $instances;
+  }
+  public function getInstances()
+  {
+    return $this->instances;
+  }
+}
+
+class Google_Service_Compute_TargetPoolsScopedList extends Google_Collection
+{
+  protected $collection_key = 'targetPools';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $targetPoolsType = 'Google_Service_Compute_TargetPool';
+  protected $targetPoolsDataType = 'array';
+  protected $warningType = 'Google_Service_Compute_TargetPoolsScopedListWarning';
+  protected $warningDataType = '';
+
+
+  public function setTargetPools($targetPools)
+  {
+    $this->targetPools = $targetPools;
+  }
+  public function getTargetPools()
+  {
+    return $this->targetPools;
+  }
+  public function setWarning(Google_Service_Compute_TargetPoolsScopedListWarning $warning)
+  {
+    $this->warning = $warning;
+  }
+  public function getWarning()
+  {
+    return $this->warning;
+  }
+}
+
+class Google_Service_Compute_TargetPoolsScopedListWarning extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Compute_TargetPoolsScopedListWarningData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Compute_TargetPoolsScopedListWarningData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Compute_TargetReference extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $target;
+
+
+  public function setTarget($target)
+  {
+    $this->target = $target;
+  }
+  public function getTarget()
+  {
+    return $this->target;
+  }
+}
+
+class Google_Service_Compute_TargetVpnGateway extends Google_Collection
+{
+  protected $collection_key = 'tunnels';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $description;
+  public $forwardingRules;
+  public $id;
+  public $kind;
+  public $name;
+  public $network;
+  public $region;
+  public $selfLink;
+  public $status;
+  public $tunnels;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setForwardingRules($forwardingRules)
+  {
+    $this->forwardingRules = $forwardingRules;
+  }
+  public function getForwardingRules()
+  {
+    return $this->forwardingRules;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNetwork($network)
+  {
+    $this->network = $network;
+  }
+  public function getNetwork()
+  {
+    return $this->network;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setTunnels($tunnels)
+  {
+    $this->tunnels = $tunnels;
+  }
+  public function getTunnels()
+  {
+    return $this->tunnels;
+  }
+}
+
+class Google_Service_Compute_TargetVpnGatewayAggregatedList extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_TargetVpnGatewaysScopedList';
+  protected $itemsDataType = 'map';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_TargetVpnGatewayAggregatedListItems extends Google_Model
+{
+}
+
+class Google_Service_Compute_TargetVpnGatewayList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_TargetVpnGateway';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_TargetVpnGatewaysScopedList extends Google_Collection
+{
+  protected $collection_key = 'targetVpnGateways';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $targetVpnGatewaysType = 'Google_Service_Compute_TargetVpnGateway';
+  protected $targetVpnGatewaysDataType = 'array';
+  protected $warningType = 'Google_Service_Compute_TargetVpnGatewaysScopedListWarning';
+  protected $warningDataType = '';
+
+
+  public function setTargetVpnGateways($targetVpnGateways)
+  {
+    $this->targetVpnGateways = $targetVpnGateways;
+  }
+  public function getTargetVpnGateways()
+  {
+    return $this->targetVpnGateways;
+  }
+  public function setWarning(Google_Service_Compute_TargetVpnGatewaysScopedListWarning $warning)
+  {
+    $this->warning = $warning;
+  }
+  public function getWarning()
+  {
+    return $this->warning;
+  }
+}
+
+class Google_Service_Compute_TargetVpnGatewaysScopedListWarning extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Compute_TargetVpnGatewaysScopedListWarningData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Compute_TargetVpnGatewaysScopedListWarningData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Compute_TestFailure extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $actualService;
+  public $expectedService;
+  public $host;
+  public $path;
+
+
+  public function setActualService($actualService)
+  {
+    $this->actualService = $actualService;
+  }
+  public function getActualService()
+  {
+    return $this->actualService;
+  }
+  public function setExpectedService($expectedService)
+  {
+    $this->expectedService = $expectedService;
+  }
+  public function getExpectedService()
+  {
+    return $this->expectedService;
+  }
+  public function setHost($host)
+  {
+    $this->host = $host;
+  }
+  public function getHost()
+  {
+    return $this->host;
+  }
+  public function setPath($path)
+  {
+    $this->path = $path;
+  }
+  public function getPath()
+  {
+    return $this->path;
+  }
+}
+
+class Google_Service_Compute_UrlMap extends Google_Collection
+{
+  protected $collection_key = 'tests';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $defaultService;
+  public $description;
+  public $fingerprint;
+  protected $hostRulesType = 'Google_Service_Compute_HostRule';
+  protected $hostRulesDataType = 'array';
+  public $id;
+  public $kind;
+  public $name;
+  protected $pathMatchersType = 'Google_Service_Compute_PathMatcher';
+  protected $pathMatchersDataType = 'array';
+  public $selfLink;
+  protected $testsType = 'Google_Service_Compute_UrlMapTest';
+  protected $testsDataType = 'array';
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDefaultService($defaultService)
+  {
+    $this->defaultService = $defaultService;
+  }
+  public function getDefaultService()
+  {
+    return $this->defaultService;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setHostRules($hostRules)
+  {
+    $this->hostRules = $hostRules;
+  }
+  public function getHostRules()
+  {
+    return $this->hostRules;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPathMatchers($pathMatchers)
+  {
+    $this->pathMatchers = $pathMatchers;
+  }
+  public function getPathMatchers()
+  {
+    return $this->pathMatchers;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTests($tests)
+  {
+    $this->tests = $tests;
+  }
+  public function getTests()
+  {
+    return $this->tests;
+  }
+}
+
+class Google_Service_Compute_UrlMapList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_UrlMap';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_UrlMapReference extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $urlMap;
+
+
+  public function setUrlMap($urlMap)
+  {
+    $this->urlMap = $urlMap;
+  }
+  public function getUrlMap()
+  {
+    return $this->urlMap;
+  }
+}
+
+class Google_Service_Compute_UrlMapTest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $host;
+  public $path;
+  public $service;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setHost($host)
+  {
+    $this->host = $host;
+  }
+  public function getHost()
+  {
+    return $this->host;
+  }
+  public function setPath($path)
+  {
+    $this->path = $path;
+  }
+  public function getPath()
+  {
+    return $this->path;
+  }
+  public function setService($service)
+  {
+    $this->service = $service;
+  }
+  public function getService()
+  {
+    return $this->service;
+  }
+}
+
+class Google_Service_Compute_UrlMapValidationResult extends Google_Collection
+{
+  protected $collection_key = 'testFailures';
+  protected $internal_gapi_mappings = array(
+  );
+  public $loadErrors;
+  public $loadSucceeded;
+  protected $testFailuresType = 'Google_Service_Compute_TestFailure';
+  protected $testFailuresDataType = 'array';
+  public $testPassed;
+
+
+  public function setLoadErrors($loadErrors)
+  {
+    $this->loadErrors = $loadErrors;
+  }
+  public function getLoadErrors()
+  {
+    return $this->loadErrors;
+  }
+  public function setLoadSucceeded($loadSucceeded)
+  {
+    $this->loadSucceeded = $loadSucceeded;
+  }
+  public function getLoadSucceeded()
+  {
+    return $this->loadSucceeded;
+  }
+  public function setTestFailures($testFailures)
+  {
+    $this->testFailures = $testFailures;
+  }
+  public function getTestFailures()
+  {
+    return $this->testFailures;
+  }
+  public function setTestPassed($testPassed)
+  {
+    $this->testPassed = $testPassed;
+  }
+  public function getTestPassed()
+  {
+    return $this->testPassed;
+  }
+}
+
+class Google_Service_Compute_UrlMapsValidateRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $resourceType = 'Google_Service_Compute_UrlMap';
+  protected $resourceDataType = '';
+
+
+  public function setResource(Google_Service_Compute_UrlMap $resource)
+  {
+    $this->resource = $resource;
+  }
+  public function getResource()
+  {
+    return $this->resource;
+  }
+}
+
+class Google_Service_Compute_UrlMapsValidateResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $resultType = 'Google_Service_Compute_UrlMapValidationResult';
+  protected $resultDataType = '';
+
+
+  public function setResult(Google_Service_Compute_UrlMapValidationResult $result)
+  {
+    $this->result = $result;
+  }
+  public function getResult()
+  {
+    return $this->result;
+  }
+}
+
+class Google_Service_Compute_UsageExportLocation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $bucketName;
+  public $reportNamePrefix;
+
+
+  public function setBucketName($bucketName)
+  {
+    $this->bucketName = $bucketName;
+  }
+  public function getBucketName()
+  {
+    return $this->bucketName;
+  }
+  public function setReportNamePrefix($reportNamePrefix)
+  {
+    $this->reportNamePrefix = $reportNamePrefix;
+  }
+  public function getReportNamePrefix()
+  {
+    return $this->reportNamePrefix;
+  }
+}
+
+class Google_Service_Compute_VpnTunnel extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $description;
+  public $detailedStatus;
+  public $id;
+  public $ikeVersion;
+  public $kind;
+  public $name;
+  public $peerIp;
+  public $region;
+  public $selfLink;
+  public $sharedSecret;
+  public $sharedSecretHash;
+  public $status;
+  public $targetVpnGateway;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDetailedStatus($detailedStatus)
+  {
+    $this->detailedStatus = $detailedStatus;
+  }
+  public function getDetailedStatus()
+  {
+    return $this->detailedStatus;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIkeVersion($ikeVersion)
+  {
+    $this->ikeVersion = $ikeVersion;
+  }
+  public function getIkeVersion()
+  {
+    return $this->ikeVersion;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPeerIp($peerIp)
+  {
+    $this->peerIp = $peerIp;
+  }
+  public function getPeerIp()
+  {
+    return $this->peerIp;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setSharedSecret($sharedSecret)
+  {
+    $this->sharedSecret = $sharedSecret;
+  }
+  public function getSharedSecret()
+  {
+    return $this->sharedSecret;
+  }
+  public function setSharedSecretHash($sharedSecretHash)
+  {
+    $this->sharedSecretHash = $sharedSecretHash;
+  }
+  public function getSharedSecretHash()
+  {
+    return $this->sharedSecretHash;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setTargetVpnGateway($targetVpnGateway)
+  {
+    $this->targetVpnGateway = $targetVpnGateway;
+  }
+  public function getTargetVpnGateway()
+  {
+    return $this->targetVpnGateway;
+  }
+}
+
+class Google_Service_Compute_VpnTunnelAggregatedList extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_VpnTunnelsScopedList';
+  protected $itemsDataType = 'map';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_VpnTunnelAggregatedListItems extends Google_Model
+{
+}
+
+class Google_Service_Compute_VpnTunnelList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_VpnTunnel';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_VpnTunnelsScopedList extends Google_Collection
+{
+  protected $collection_key = 'vpnTunnels';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $vpnTunnelsType = 'Google_Service_Compute_VpnTunnel';
+  protected $vpnTunnelsDataType = 'array';
+  protected $warningType = 'Google_Service_Compute_VpnTunnelsScopedListWarning';
+  protected $warningDataType = '';
+
+
+  public function setVpnTunnels($vpnTunnels)
+  {
+    $this->vpnTunnels = $vpnTunnels;
+  }
+  public function getVpnTunnels()
+  {
+    return $this->vpnTunnels;
+  }
+  public function setWarning(Google_Service_Compute_VpnTunnelsScopedListWarning $warning)
+  {
+    $this->warning = $warning;
+  }
+  public function getWarning()
+  {
+    return $this->warning;
+  }
+}
+
+class Google_Service_Compute_VpnTunnelsScopedListWarning extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Compute_VpnTunnelsScopedListWarningData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Compute_VpnTunnelsScopedListWarningData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Compute_Zone extends Google_Collection
+{
+  protected $collection_key = 'maintenanceWindows';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  protected $deprecatedType = 'Google_Service_Compute_DeprecationStatus';
+  protected $deprecatedDataType = '';
+  public $description;
+  public $id;
+  public $kind;
+  protected $maintenanceWindowsType = 'Google_Service_Compute_ZoneMaintenanceWindows';
+  protected $maintenanceWindowsDataType = 'array';
+  public $name;
+  public $region;
+  public $selfLink;
+  public $status;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDeprecated(Google_Service_Compute_DeprecationStatus $deprecated)
+  {
+    $this->deprecated = $deprecated;
+  }
+  public function getDeprecated()
+  {
+    return $this->deprecated;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMaintenanceWindows($maintenanceWindows)
+  {
+    $this->maintenanceWindows = $maintenanceWindows;
+  }
+  public function getMaintenanceWindows()
+  {
+    return $this->maintenanceWindows;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_Compute_ZoneList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Compute_Zone';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Compute_ZoneMaintenanceWindows extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $beginTime;
+  public $description;
+  public $endTime;
+  public $name;
+
+
+  public function setBeginTime($beginTime)
+  {
+    $this->beginTime = $beginTime;
+  }
+  public function getBeginTime()
+  {
+    return $this->beginTime;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Computeaccounts.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Computeaccounts.php
@@ -1,0 +1,1689 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Computeaccounts (alpha).
+ *
+ * <p>
+ * API for the Google Compute Accounts service.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://cloud.google.com/compute/docs/access/user-accounts/api/latest/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Computeaccounts extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+  /** New Service: https://www.googleapis.com/auth/computeaccounts. */
+  const COMPUTEACCOUNTS =
+      "https://www.googleapis.com/auth/computeaccounts";
+  /** New Service: https://www.googleapis.com/auth/computeaccounts.readonly. */
+  const COMPUTEACCOUNTS_READONLY =
+      "https://www.googleapis.com/auth/computeaccounts.readonly";
+
+  public $globalAccountsOperations;
+  public $groups;
+  public $linux;
+  public $users;
+  
+
+  /**
+   * Constructs the internal representation of the Computeaccounts service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->servicePath = 'computeaccounts/alpha/projects/';
+    $this->version = 'alpha';
+    $this->serviceName = 'computeaccounts';
+
+    $this->globalAccountsOperations = new Google_Service_Computeaccounts_GlobalAccountsOperations_Resource(
+        $this,
+        $this->serviceName,
+        'globalAccountsOperations',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/global/operations/{operation}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operation' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/operations/{operation}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operation' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/operations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->groups = new Google_Service_Computeaccounts_Groups_Resource(
+        $this,
+        $this->serviceName,
+        'groups',
+        array(
+          'methods' => array(
+            'addMember' => array(
+              'path' => '{project}/global/groups/{groupName}/addMember',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'groupName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/global/groups/{groupName}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'groupName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/groups/{groupName}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'groupName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/groups',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/groups',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'removeMember' => array(
+              'path' => '{project}/global/groups/{groupName}/removeMember',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'groupName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->linux = new Google_Service_Computeaccounts_Linux_Resource(
+        $this,
+        $this->serviceName,
+        'linux',
+        array(
+          'methods' => array(
+            'getAuthorizedKeysView' => array(
+              'path' => '{project}/zones/{zone}/authorizedKeysView/{user}',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'user' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getLinuxAccountViews' => array(
+              'path' => '{project}/zones/{zone}/linuxAccountViews',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'user' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->users = new Google_Service_Computeaccounts_Users_Resource(
+        $this,
+        $this->serviceName,
+        'users',
+        array(
+          'methods' => array(
+            'addPublicKey' => array(
+              'path' => '{project}/global/users/{user}/addPublicKey',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'user' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/global/users/{user}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'user' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/users/{user}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'user' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/users',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/users',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'removePublicKey' => array(
+              'path' => '{project}/global/users/{user}/removePublicKey',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'user' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'fingerprint' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "globalAccountsOperations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeaccountsService = new Google_Service_Computeaccounts(...);
+ *   $globalAccountsOperations = $computeaccountsService->globalAccountsOperations;
+ *  </code>
+ */
+class Google_Service_Computeaccounts_GlobalAccountsOperations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified operation resource. (globalAccountsOperations.delete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $operation Name of the operation resource to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($project, $operation, $optParams = array())
+  {
+    $params = array('project' => $project, 'operation' => $operation);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves the specified operation resource. (globalAccountsOperations.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $operation Name of the operation resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Computeaccounts_Operation
+   */
+  public function get($project, $operation, $optParams = array())
+  {
+    $params = array('project' => $project, 'operation' => $operation);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Computeaccounts_Operation");
+  }
+
+  /**
+   * Retrieves the list of operation resources contained within the specified
+   * project. (globalAccountsOperations.listGlobalAccountsOperations)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Optional. Filter expression for filtering listed
+   * resources.
+   * @opt_param string pageToken Optional. Tag returned by a previous list request
+   * truncated by maxResults. Used to continue a previous list request.
+   * @opt_param string maxResults Optional. Maximum count of results to be
+   * returned. Maximum value is 500 and default value is 500.
+   * @return Google_Service_Computeaccounts_OperationList
+   */
+  public function listGlobalAccountsOperations($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Computeaccounts_OperationList");
+  }
+}
+
+/**
+ * The "groups" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeaccountsService = new Google_Service_Computeaccounts(...);
+ *   $groups = $computeaccountsService->groups;
+ *  </code>
+ */
+class Google_Service_Computeaccounts_Groups_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Adds users to the specified group. (groups.addMember)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $groupName Name of the group for this request.
+   * @param Google_GroupsAddMemberRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Computeaccounts_Operation
+   */
+  public function addMember($project, $groupName, Google_Service_Computeaccounts_GroupsAddMemberRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'groupName' => $groupName, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('addMember', array($params), "Google_Service_Computeaccounts_Operation");
+  }
+
+  /**
+   * Deletes the specified group resource. (groups.delete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $groupName Name of the group resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Computeaccounts_Operation
+   */
+  public function delete($project, $groupName, $optParams = array())
+  {
+    $params = array('project' => $project, 'groupName' => $groupName);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Computeaccounts_Operation");
+  }
+
+  /**
+   * Returns the specified group resource. (groups.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $groupName Name of the group resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Computeaccounts_Group
+   */
+  public function get($project, $groupName, $optParams = array())
+  {
+    $params = array('project' => $project, 'groupName' => $groupName);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Computeaccounts_Group");
+  }
+
+  /**
+   * Creates a group resource in the specified project using the data included in
+   * the request. (groups.insert)
+   *
+   * @param string $project Project ID for this request.
+   * @param Google_Group $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Computeaccounts_Operation
+   */
+  public function insert($project, Google_Service_Computeaccounts_Group $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Computeaccounts_Operation");
+  }
+
+  /**
+   * Retrieves the list of groups contained within the specified project.
+   * (groups.listGroups)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Optional. Filter expression for filtering listed
+   * resources.
+   * @opt_param string pageToken Optional. Tag returned by a previous list request
+   * truncated by maxResults. Used to continue a previous list request.
+   * @opt_param string maxResults Optional. Maximum count of results to be
+   * returned. Maximum value is 500 and default value is 500.
+   * @return Google_Service_Computeaccounts_GroupList
+   */
+  public function listGroups($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Computeaccounts_GroupList");
+  }
+
+  /**
+   * Removes users from the specified group. (groups.removeMember)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $groupName Name of the group for this request.
+   * @param Google_GroupsRemoveMemberRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Computeaccounts_Operation
+   */
+  public function removeMember($project, $groupName, Google_Service_Computeaccounts_GroupsRemoveMemberRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'groupName' => $groupName, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('removeMember', array($params), "Google_Service_Computeaccounts_Operation");
+  }
+}
+
+/**
+ * The "linux" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeaccountsService = new Google_Service_Computeaccounts(...);
+ *   $linux = $computeaccountsService->linux;
+ *  </code>
+ */
+class Google_Service_Computeaccounts_Linux_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns the AuthorizedKeysView of the specified user.
+   * (linux.getAuthorizedKeysView)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone Name of the zone for this request.
+   * @param string $user Username of the AuthorizedKeysView to return.
+   * @param string $instance The fully-qualified URL of the instance requesting
+   * the view.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Computeaccounts_LinuxGetAuthorizedKeysViewResponse
+   */
+  public function getAuthorizedKeysView($project, $zone, $user, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'user' => $user, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('getAuthorizedKeysView', array($params), "Google_Service_Computeaccounts_LinuxGetAuthorizedKeysViewResponse");
+  }
+
+  /**
+   * Retrieves the Linux views for an instance contained within the specified
+   * project. (linux.getLinuxAccountViews)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $zone Name of the zone for this request.
+   * @param string $instance The fully-qualified URL of the instance requesting
+   * the views.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Optional. Tag returned by a previous list request
+   * truncated by maxResults. Used to continue a previous list request.
+   * @opt_param string maxResults Optional. Maximum count of results to be
+   * returned. Maximum value is 500 and default value is 500.
+   * @opt_param string filter Optional. Filter expression for filtering listed
+   * resources.
+   * @opt_param string user If provided, the user whose login is triggering an
+   * immediate refresh of the views.
+   * @return Google_Service_Computeaccounts_LinuxGetLinuxAccountViewsResponse
+   */
+  public function getLinuxAccountViews($project, $zone, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('getLinuxAccountViews', array($params), "Google_Service_Computeaccounts_LinuxGetLinuxAccountViewsResponse");
+  }
+}
+
+/**
+ * The "users" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $computeaccountsService = new Google_Service_Computeaccounts(...);
+ *   $users = $computeaccountsService->users;
+ *  </code>
+ */
+class Google_Service_Computeaccounts_Users_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Adds a public key to the specified user using the data included in the
+   * request. (users.addPublicKey)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $user Name of the user for this request.
+   * @param Google_PublicKey $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Computeaccounts_Operation
+   */
+  public function addPublicKey($project, $user, Google_Service_Computeaccounts_PublicKey $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'user' => $user, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('addPublicKey', array($params), "Google_Service_Computeaccounts_Operation");
+  }
+
+  /**
+   * Deletes the specified user resource. (users.delete)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $user Name of the user resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Computeaccounts_Operation
+   */
+  public function delete($project, $user, $optParams = array())
+  {
+    $params = array('project' => $project, 'user' => $user);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Computeaccounts_Operation");
+  }
+
+  /**
+   * Returns the specified user resource. (users.get)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $user Name of the user resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Computeaccounts_User
+   */
+  public function get($project, $user, $optParams = array())
+  {
+    $params = array('project' => $project, 'user' => $user);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Computeaccounts_User");
+  }
+
+  /**
+   * Creates a user resource in the specified project using the data included in
+   * the request. (users.insert)
+   *
+   * @param string $project Project ID for this request.
+   * @param Google_User $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Computeaccounts_Operation
+   */
+  public function insert($project, Google_Service_Computeaccounts_User $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Computeaccounts_Operation");
+  }
+
+  /**
+   * Retrieves the list of users contained within the specified project.
+   * (users.listUsers)
+   *
+   * @param string $project Project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Optional. Filter expression for filtering listed
+   * resources.
+   * @opt_param string pageToken Optional. Tag returned by a previous list request
+   * truncated by maxResults. Used to continue a previous list request.
+   * @opt_param string maxResults Optional. Maximum count of results to be
+   * returned. Maximum value is 500 and default value is 500.
+   * @return Google_Service_Computeaccounts_UserList
+   */
+  public function listUsers($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Computeaccounts_UserList");
+  }
+
+  /**
+   * Removes the specified public key from the user. (users.removePublicKey)
+   *
+   * @param string $project Project ID for this request.
+   * @param string $user Name of the user for this request.
+   * @param string $fingerprint The fingerprint of the public key to delete.
+   * Public keys are identified by their fingerprint, which is defined by RFC4716
+   * to be the MD5 digest of the public key.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Computeaccounts_Operation
+   */
+  public function removePublicKey($project, $user, $fingerprint, $optParams = array())
+  {
+    $params = array('project' => $project, 'user' => $user, 'fingerprint' => $fingerprint);
+    $params = array_merge($params, $optParams);
+    return $this->call('removePublicKey', array($params), "Google_Service_Computeaccounts_Operation");
+  }
+}
+
+
+
+
+class Google_Service_Computeaccounts_AuthorizedKeysView extends Google_Collection
+{
+  protected $collection_key = 'keys';
+  protected $internal_gapi_mappings = array(
+  );
+  public $keys;
+
+
+  public function setKeys($keys)
+  {
+    $this->keys = $keys;
+  }
+  public function getKeys()
+  {
+    return $this->keys;
+  }
+}
+
+class Google_Service_Computeaccounts_Group extends Google_Collection
+{
+  protected $collection_key = 'members';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $description;
+  public $id;
+  public $kind;
+  public $members;
+  public $name;
+  public $selfLink;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMembers($members)
+  {
+    $this->members = $members;
+  }
+  public function getMembers()
+  {
+    return $this->members;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Computeaccounts_GroupList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Computeaccounts_Group';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Computeaccounts_GroupsAddMemberRequest extends Google_Collection
+{
+  protected $collection_key = 'users';
+  protected $internal_gapi_mappings = array(
+  );
+  public $users;
+
+
+  public function setUsers($users)
+  {
+    $this->users = $users;
+  }
+  public function getUsers()
+  {
+    return $this->users;
+  }
+}
+
+class Google_Service_Computeaccounts_GroupsRemoveMemberRequest extends Google_Collection
+{
+  protected $collection_key = 'users';
+  protected $internal_gapi_mappings = array(
+  );
+  public $users;
+
+
+  public function setUsers($users)
+  {
+    $this->users = $users;
+  }
+  public function getUsers()
+  {
+    return $this->users;
+  }
+}
+
+class Google_Service_Computeaccounts_LinuxAccountViews extends Google_Collection
+{
+  protected $collection_key = 'userViews';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $groupViewsType = 'Google_Service_Computeaccounts_LinuxGroupView';
+  protected $groupViewsDataType = 'array';
+  public $kind;
+  protected $userViewsType = 'Google_Service_Computeaccounts_LinuxUserView';
+  protected $userViewsDataType = 'array';
+
+
+  public function setGroupViews($groupViews)
+  {
+    $this->groupViews = $groupViews;
+  }
+  public function getGroupViews()
+  {
+    return $this->groupViews;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUserViews($userViews)
+  {
+    $this->userViews = $userViews;
+  }
+  public function getUserViews()
+  {
+    return $this->userViews;
+  }
+}
+
+class Google_Service_Computeaccounts_LinuxGetAuthorizedKeysViewResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $resourceType = 'Google_Service_Computeaccounts_AuthorizedKeysView';
+  protected $resourceDataType = '';
+
+
+  public function setResource(Google_Service_Computeaccounts_AuthorizedKeysView $resource)
+  {
+    $this->resource = $resource;
+  }
+  public function getResource()
+  {
+    return $this->resource;
+  }
+}
+
+class Google_Service_Computeaccounts_LinuxGetLinuxAccountViewsResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $resourceType = 'Google_Service_Computeaccounts_LinuxAccountViews';
+  protected $resourceDataType = '';
+
+
+  public function setResource(Google_Service_Computeaccounts_LinuxAccountViews $resource)
+  {
+    $this->resource = $resource;
+  }
+  public function getResource()
+  {
+    return $this->resource;
+  }
+}
+
+class Google_Service_Computeaccounts_LinuxGroupView extends Google_Collection
+{
+  protected $collection_key = 'members';
+  protected $internal_gapi_mappings = array(
+  );
+  public $gid;
+  public $groupName;
+  public $members;
+
+
+  public function setGid($gid)
+  {
+    $this->gid = $gid;
+  }
+  public function getGid()
+  {
+    return $this->gid;
+  }
+  public function setGroupName($groupName)
+  {
+    $this->groupName = $groupName;
+  }
+  public function getGroupName()
+  {
+    return $this->groupName;
+  }
+  public function setMembers($members)
+  {
+    $this->members = $members;
+  }
+  public function getMembers()
+  {
+    return $this->members;
+  }
+}
+
+class Google_Service_Computeaccounts_LinuxUserView extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $gecos;
+  public $gid;
+  public $homeDirectory;
+  public $shell;
+  public $uid;
+  public $username;
+
+
+  public function setGecos($gecos)
+  {
+    $this->gecos = $gecos;
+  }
+  public function getGecos()
+  {
+    return $this->gecos;
+  }
+  public function setGid($gid)
+  {
+    $this->gid = $gid;
+  }
+  public function getGid()
+  {
+    return $this->gid;
+  }
+  public function setHomeDirectory($homeDirectory)
+  {
+    $this->homeDirectory = $homeDirectory;
+  }
+  public function getHomeDirectory()
+  {
+    return $this->homeDirectory;
+  }
+  public function setShell($shell)
+  {
+    $this->shell = $shell;
+  }
+  public function getShell()
+  {
+    return $this->shell;
+  }
+  public function setUid($uid)
+  {
+    $this->uid = $uid;
+  }
+  public function getUid()
+  {
+    return $this->uid;
+  }
+  public function setUsername($username)
+  {
+    $this->username = $username;
+  }
+  public function getUsername()
+  {
+    return $this->username;
+  }
+}
+
+class Google_Service_Computeaccounts_Operation extends Google_Collection
+{
+  protected $collection_key = 'warnings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $clientOperationId;
+  public $creationTimestamp;
+  public $endTime;
+  protected $errorType = 'Google_Service_Computeaccounts_OperationError';
+  protected $errorDataType = '';
+  public $httpErrorMessage;
+  public $httpErrorStatusCode;
+  public $id;
+  public $insertTime;
+  public $kind;
+  public $name;
+  public $operationType;
+  public $progress;
+  public $region;
+  public $selfLink;
+  public $startTime;
+  public $status;
+  public $statusMessage;
+  public $targetId;
+  public $targetLink;
+  public $user;
+  protected $warningsType = 'Google_Service_Computeaccounts_OperationWarnings';
+  protected $warningsDataType = 'array';
+  public $zone;
+
+
+  public function setClientOperationId($clientOperationId)
+  {
+    $this->clientOperationId = $clientOperationId;
+  }
+  public function getClientOperationId()
+  {
+    return $this->clientOperationId;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setError(Google_Service_Computeaccounts_OperationError $error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setHttpErrorMessage($httpErrorMessage)
+  {
+    $this->httpErrorMessage = $httpErrorMessage;
+  }
+  public function getHttpErrorMessage()
+  {
+    return $this->httpErrorMessage;
+  }
+  public function setHttpErrorStatusCode($httpErrorStatusCode)
+  {
+    $this->httpErrorStatusCode = $httpErrorStatusCode;
+  }
+  public function getHttpErrorStatusCode()
+  {
+    return $this->httpErrorStatusCode;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInsertTime($insertTime)
+  {
+    $this->insertTime = $insertTime;
+  }
+  public function getInsertTime()
+  {
+    return $this->insertTime;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOperationType($operationType)
+  {
+    $this->operationType = $operationType;
+  }
+  public function getOperationType()
+  {
+    return $this->operationType;
+  }
+  public function setProgress($progress)
+  {
+    $this->progress = $progress;
+  }
+  public function getProgress()
+  {
+    return $this->progress;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setStatusMessage($statusMessage)
+  {
+    $this->statusMessage = $statusMessage;
+  }
+  public function getStatusMessage()
+  {
+    return $this->statusMessage;
+  }
+  public function setTargetId($targetId)
+  {
+    $this->targetId = $targetId;
+  }
+  public function getTargetId()
+  {
+    return $this->targetId;
+  }
+  public function setTargetLink($targetLink)
+  {
+    $this->targetLink = $targetLink;
+  }
+  public function getTargetLink()
+  {
+    return $this->targetLink;
+  }
+  public function setUser($user)
+  {
+    $this->user = $user;
+  }
+  public function getUser()
+  {
+    return $this->user;
+  }
+  public function setWarnings($warnings)
+  {
+    $this->warnings = $warnings;
+  }
+  public function getWarnings()
+  {
+    return $this->warnings;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_Computeaccounts_OperationError extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorsType = 'Google_Service_Computeaccounts_OperationErrorErrors';
+  protected $errorsDataType = 'array';
+
+
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+}
+
+class Google_Service_Computeaccounts_OperationErrorErrors extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $location;
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Computeaccounts_OperationList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Computeaccounts_Operation';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Computeaccounts_OperationWarnings extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Computeaccounts_OperationWarningsData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Computeaccounts_OperationWarningsData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Computeaccounts_PublicKey extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $description;
+  public $expirationTimestamp;
+  public $fingerprint;
+  public $key;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setExpirationTimestamp($expirationTimestamp)
+  {
+    $this->expirationTimestamp = $expirationTimestamp;
+  }
+  public function getExpirationTimestamp()
+  {
+    return $this->expirationTimestamp;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+}
+
+class Google_Service_Computeaccounts_User extends Google_Collection
+{
+  protected $collection_key = 'publicKeys';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $description;
+  public $groups;
+  public $id;
+  public $kind;
+  public $name;
+  public $owner;
+  protected $publicKeysType = 'Google_Service_Computeaccounts_PublicKey';
+  protected $publicKeysDataType = 'array';
+  public $selfLink;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setGroups($groups)
+  {
+    $this->groups = $groups;
+  }
+  public function getGroups()
+  {
+    return $this->groups;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOwner($owner)
+  {
+    $this->owner = $owner;
+  }
+  public function getOwner()
+  {
+    return $this->owner;
+  }
+  public function setPublicKeys($publicKeys)
+  {
+    $this->publicKeys = $publicKeys;
+  }
+  public function getPublicKeys()
+  {
+    return $this->publicKeys;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Computeaccounts_UserList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Computeaccounts_User';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Container.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Container.php
@@ -1,0 +1,913 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Container (v1).
+ *
+ * <p>
+ * The Google Container Engine API is used for building and managing container
+ * based applications, powered by the open source Kubernetes technology.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://cloud.google.com/container-engine/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Container extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+
+  public $projects_zones;
+  public $projects_zones_clusters;
+  public $projects_zones_operations;
+  
+
+  /**
+   * Constructs the internal representation of the Container service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://container.googleapis.com/';
+    $this->servicePath = '';
+    $this->version = 'v1';
+    $this->serviceName = 'container';
+
+    $this->projects_zones = new Google_Service_Container_ProjectsZones_Resource(
+        $this,
+        $this->serviceName,
+        'zones',
+        array(
+          'methods' => array(
+            'getServerconfig' => array(
+              'path' => 'v1/projects/{projectId}/zones/{zone}/serverconfig',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->projects_zones_clusters = new Google_Service_Container_ProjectsZonesClusters_Resource(
+        $this,
+        $this->serviceName,
+        'clusters',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'v1/projects/{projectId}/zones/{zone}/clusters',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'clusterId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'clusterId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1/projects/{projectId}/zones/{zone}/clusters',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'clusterId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->projects_zones_operations = new Google_Service_Container_ProjectsZonesOperations_Resource(
+        $this,
+        $this->serviceName,
+        'operations',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'v1/projects/{projectId}/zones/{zone}/operations/{operationId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1/projects/{projectId}/zones/{zone}/operations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "projects" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $containerService = new Google_Service_Container(...);
+ *   $projects = $containerService->projects;
+ *  </code>
+ */
+class Google_Service_Container_Projects_Resource extends Google_Service_Resource
+{
+}
+
+/**
+ * The "zones" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $containerService = new Google_Service_Container(...);
+ *   $zones = $containerService->zones;
+ *  </code>
+ */
+class Google_Service_Container_ProjectsZones_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns configuration info about the Container Engine service.
+   * (zones.getServerconfig)
+   *
+   * @param string $projectId The Google Developers Console [project ID or project
+   * number](https://developers.google.com/console/help/new/#projectnumber).
+   * @param string $zone The name of the Google Compute Engine
+   * [zone](/compute/docs/zones#available) to return operations for, or "-" for
+   * all zones.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Container_ServerConfig
+   */
+  public function getServerconfig($projectId, $zone, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('getServerconfig', array($params), "Google_Service_Container_ServerConfig");
+  }
+}
+
+/**
+ * The "clusters" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $containerService = new Google_Service_Container(...);
+ *   $clusters = $containerService->clusters;
+ *  </code>
+ */
+class Google_Service_Container_ProjectsZonesClusters_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a cluster, consisting of the specified number and type of Google
+   * Compute Engine instances, plus a Kubernetes master endpoint. By default, the
+   * cluster is created in the project's [default
+   * network](/compute/docs/networking#networks_1). One firewall is added for the
+   * cluster. After cluster creation, the cluster creates routes for each node to
+   * allow the containers on that node to communicate with all other instances in
+   * the cluster. Finally, an entry is added to the project's global metadata
+   * indicating which CIDR range is being used by the cluster. (clusters.create)
+   *
+   * @param string $projectId The Google Developers Console [project ID or project
+   * number](https://developers.google.com/console/help/new/#projectnumber).
+   * @param string $zone The name of the Google Compute Engine
+   * [zone](/compute/docs/zones#available) in which the cluster resides.
+   * @param Google_CreateClusterRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Container_Operation
+   */
+  public function create($projectId, $zone, Google_Service_Container_CreateClusterRequest $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'zone' => $zone, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Container_Operation");
+  }
+
+  /**
+   * Deletes the cluster, including the Kubernetes endpoint and all worker nodes.
+   * Firewalls and routes that were configured during cluster creation are also
+   * deleted. (clusters.delete)
+   *
+   * @param string $projectId The Google Developers Console [project ID or project
+   * number](https://developers.google.com/console/help/new/#projectnumber).
+   * @param string $zone The name of the Google Compute Engine
+   * [zone](/compute/docs/zones#available) in which the cluster resides.
+   * @param string $clusterId The name of the cluster to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Container_Operation
+   */
+  public function delete($projectId, $zone, $clusterId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'zone' => $zone, 'clusterId' => $clusterId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Container_Operation");
+  }
+
+  /**
+   * Gets a specific cluster. (clusters.get)
+   *
+   * @param string $projectId The Google Developers Console [project ID or project
+   * number](https://developers.google.com/console/help/new/#projectnumber).
+   * @param string $zone The name of the Google Compute Engine
+   * [zone](/compute/docs/zones#available) in which the cluster resides.
+   * @param string $clusterId The name of the cluster to retrieve.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Container_Cluster
+   */
+  public function get($projectId, $zone, $clusterId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'zone' => $zone, 'clusterId' => $clusterId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Container_Cluster");
+  }
+
+  /**
+   * Lists all clusters owned by a project in either the specified zone or all
+   * zones. (clusters.listProjectsZonesClusters)
+   *
+   * @param string $projectId The Google Developers Console [project ID or project
+   * number](https://developers.google.com/console/help/new/#projectnumber).
+   * @param string $zone The name of the Google Compute Engine
+   * [zone](/compute/docs/zones#available) in which the cluster resides, or "-"
+   * for all zones.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Container_ListClustersResponse
+   */
+  public function listProjectsZonesClusters($projectId, $zone, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Container_ListClustersResponse");
+  }
+
+  /**
+   * Update settings of a specific cluster. (clusters.update)
+   *
+   * @param string $projectId The Google Developers Console [project ID or project
+   * number](https://developers.google.com/console/help/new/#projectnumber).
+   * @param string $zone The name of the Google Compute Engine
+   * [zone](/compute/docs/zones#available) in which the cluster resides.
+   * @param string $clusterId The name of the cluster to upgrade.
+   * @param Google_UpdateClusterRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Container_Operation
+   */
+  public function update($projectId, $zone, $clusterId, Google_Service_Container_UpdateClusterRequest $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'zone' => $zone, 'clusterId' => $clusterId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Container_Operation");
+  }
+}
+/**
+ * The "operations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $containerService = new Google_Service_Container(...);
+ *   $operations = $containerService->operations;
+ *  </code>
+ */
+class Google_Service_Container_ProjectsZonesOperations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the specified operation. (operations.get)
+   *
+   * @param string $projectId The Google Developers Console [project ID or project
+   * number](https://developers.google.com/console/help/new/#projectnumber).
+   * @param string $zone The name of the Google Compute Engine
+   * [zone](/compute/docs/zones#available) in which the cluster resides.
+   * @param string $operationId The server-assigned `name` of the operation.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Container_Operation
+   */
+  public function get($projectId, $zone, $operationId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'zone' => $zone, 'operationId' => $operationId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Container_Operation");
+  }
+
+  /**
+   * Lists all operations in a project in a specific zone or all zones.
+   * (operations.listProjectsZonesOperations)
+   *
+   * @param string $projectId The Google Developers Console [project ID or project
+   * number](https://developers.google.com/console/help/new/#projectnumber).
+   * @param string $zone The name of the Google Compute Engine
+   * [zone](/compute/docs/zones#available) to return operations for, or "-" for
+   * all zones.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Container_ListOperationsResponse
+   */
+  public function listProjectsZonesOperations($projectId, $zone, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Container_ListOperationsResponse");
+  }
+}
+
+
+
+
+class Google_Service_Container_Cluster extends Google_Collection
+{
+  protected $collection_key = 'instanceGroupUrls';
+  protected $internal_gapi_mappings = array(
+  );
+  public $clusterIpv4Cidr;
+  public $createTime;
+  public $currentMasterVersion;
+  public $currentNodeVersion;
+  public $description;
+  public $endpoint;
+  public $initialClusterVersion;
+  public $initialNodeCount;
+  public $instanceGroupUrls;
+  public $loggingService;
+  protected $masterAuthType = 'Google_Service_Container_MasterAuth';
+  protected $masterAuthDataType = '';
+  public $monitoringService;
+  public $name;
+  public $network;
+  protected $nodeConfigType = 'Google_Service_Container_NodeConfig';
+  protected $nodeConfigDataType = '';
+  public $nodeIpv4CidrSize;
+  public $selfLink;
+  public $servicesIpv4Cidr;
+  public $status;
+  public $statusMessage;
+  public $zone;
+
+
+  public function setClusterIpv4Cidr($clusterIpv4Cidr)
+  {
+    $this->clusterIpv4Cidr = $clusterIpv4Cidr;
+  }
+  public function getClusterIpv4Cidr()
+  {
+    return $this->clusterIpv4Cidr;
+  }
+  public function setCreateTime($createTime)
+  {
+    $this->createTime = $createTime;
+  }
+  public function getCreateTime()
+  {
+    return $this->createTime;
+  }
+  public function setCurrentMasterVersion($currentMasterVersion)
+  {
+    $this->currentMasterVersion = $currentMasterVersion;
+  }
+  public function getCurrentMasterVersion()
+  {
+    return $this->currentMasterVersion;
+  }
+  public function setCurrentNodeVersion($currentNodeVersion)
+  {
+    $this->currentNodeVersion = $currentNodeVersion;
+  }
+  public function getCurrentNodeVersion()
+  {
+    return $this->currentNodeVersion;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEndpoint($endpoint)
+  {
+    $this->endpoint = $endpoint;
+  }
+  public function getEndpoint()
+  {
+    return $this->endpoint;
+  }
+  public function setInitialClusterVersion($initialClusterVersion)
+  {
+    $this->initialClusterVersion = $initialClusterVersion;
+  }
+  public function getInitialClusterVersion()
+  {
+    return $this->initialClusterVersion;
+  }
+  public function setInitialNodeCount($initialNodeCount)
+  {
+    $this->initialNodeCount = $initialNodeCount;
+  }
+  public function getInitialNodeCount()
+  {
+    return $this->initialNodeCount;
+  }
+  public function setInstanceGroupUrls($instanceGroupUrls)
+  {
+    $this->instanceGroupUrls = $instanceGroupUrls;
+  }
+  public function getInstanceGroupUrls()
+  {
+    return $this->instanceGroupUrls;
+  }
+  public function setLoggingService($loggingService)
+  {
+    $this->loggingService = $loggingService;
+  }
+  public function getLoggingService()
+  {
+    return $this->loggingService;
+  }
+  public function setMasterAuth(Google_Service_Container_MasterAuth $masterAuth)
+  {
+    $this->masterAuth = $masterAuth;
+  }
+  public function getMasterAuth()
+  {
+    return $this->masterAuth;
+  }
+  public function setMonitoringService($monitoringService)
+  {
+    $this->monitoringService = $monitoringService;
+  }
+  public function getMonitoringService()
+  {
+    return $this->monitoringService;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNetwork($network)
+  {
+    $this->network = $network;
+  }
+  public function getNetwork()
+  {
+    return $this->network;
+  }
+  public function setNodeConfig(Google_Service_Container_NodeConfig $nodeConfig)
+  {
+    $this->nodeConfig = $nodeConfig;
+  }
+  public function getNodeConfig()
+  {
+    return $this->nodeConfig;
+  }
+  public function setNodeIpv4CidrSize($nodeIpv4CidrSize)
+  {
+    $this->nodeIpv4CidrSize = $nodeIpv4CidrSize;
+  }
+  public function getNodeIpv4CidrSize()
+  {
+    return $this->nodeIpv4CidrSize;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setServicesIpv4Cidr($servicesIpv4Cidr)
+  {
+    $this->servicesIpv4Cidr = $servicesIpv4Cidr;
+  }
+  public function getServicesIpv4Cidr()
+  {
+    return $this->servicesIpv4Cidr;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setStatusMessage($statusMessage)
+  {
+    $this->statusMessage = $statusMessage;
+  }
+  public function getStatusMessage()
+  {
+    return $this->statusMessage;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_Container_ClusterUpdate extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $desiredNodeVersion;
+
+
+  public function setDesiredNodeVersion($desiredNodeVersion)
+  {
+    $this->desiredNodeVersion = $desiredNodeVersion;
+  }
+  public function getDesiredNodeVersion()
+  {
+    return $this->desiredNodeVersion;
+  }
+}
+
+class Google_Service_Container_CreateClusterRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $clusterType = 'Google_Service_Container_Cluster';
+  protected $clusterDataType = '';
+
+
+  public function setCluster(Google_Service_Container_Cluster $cluster)
+  {
+    $this->cluster = $cluster;
+  }
+  public function getCluster()
+  {
+    return $this->cluster;
+  }
+}
+
+class Google_Service_Container_ListClustersResponse extends Google_Collection
+{
+  protected $collection_key = 'clusters';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $clustersType = 'Google_Service_Container_Cluster';
+  protected $clustersDataType = 'array';
+
+
+  public function setClusters($clusters)
+  {
+    $this->clusters = $clusters;
+  }
+  public function getClusters()
+  {
+    return $this->clusters;
+  }
+}
+
+class Google_Service_Container_ListOperationsResponse extends Google_Collection
+{
+  protected $collection_key = 'operations';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $operationsType = 'Google_Service_Container_Operation';
+  protected $operationsDataType = 'array';
+
+
+  public function setOperations($operations)
+  {
+    $this->operations = $operations;
+  }
+  public function getOperations()
+  {
+    return $this->operations;
+  }
+}
+
+class Google_Service_Container_MasterAuth extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $clientCertificate;
+  public $clientKey;
+  public $clusterCaCertificate;
+  public $password;
+  public $username;
+
+
+  public function setClientCertificate($clientCertificate)
+  {
+    $this->clientCertificate = $clientCertificate;
+  }
+  public function getClientCertificate()
+  {
+    return $this->clientCertificate;
+  }
+  public function setClientKey($clientKey)
+  {
+    $this->clientKey = $clientKey;
+  }
+  public function getClientKey()
+  {
+    return $this->clientKey;
+  }
+  public function setClusterCaCertificate($clusterCaCertificate)
+  {
+    $this->clusterCaCertificate = $clusterCaCertificate;
+  }
+  public function getClusterCaCertificate()
+  {
+    return $this->clusterCaCertificate;
+  }
+  public function setPassword($password)
+  {
+    $this->password = $password;
+  }
+  public function getPassword()
+  {
+    return $this->password;
+  }
+  public function setUsername($username)
+  {
+    $this->username = $username;
+  }
+  public function getUsername()
+  {
+    return $this->username;
+  }
+}
+
+class Google_Service_Container_NodeConfig extends Google_Collection
+{
+  protected $collection_key = 'oauthScopes';
+  protected $internal_gapi_mappings = array(
+  );
+  public $diskSizeGb;
+  public $machineType;
+  public $oauthScopes;
+
+
+  public function setDiskSizeGb($diskSizeGb)
+  {
+    $this->diskSizeGb = $diskSizeGb;
+  }
+  public function getDiskSizeGb()
+  {
+    return $this->diskSizeGb;
+  }
+  public function setMachineType($machineType)
+  {
+    $this->machineType = $machineType;
+  }
+  public function getMachineType()
+  {
+    return $this->machineType;
+  }
+  public function setOauthScopes($oauthScopes)
+  {
+    $this->oauthScopes = $oauthScopes;
+  }
+  public function getOauthScopes()
+  {
+    return $this->oauthScopes;
+  }
+}
+
+class Google_Service_Container_Operation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $operationType;
+  public $selfLink;
+  public $status;
+  public $statusMessage;
+  public $targetLink;
+  public $zone;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOperationType($operationType)
+  {
+    $this->operationType = $operationType;
+  }
+  public function getOperationType()
+  {
+    return $this->operationType;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setStatusMessage($statusMessage)
+  {
+    $this->statusMessage = $statusMessage;
+  }
+  public function getStatusMessage()
+  {
+    return $this->statusMessage;
+  }
+  public function setTargetLink($targetLink)
+  {
+    $this->targetLink = $targetLink;
+  }
+  public function getTargetLink()
+  {
+    return $this->targetLink;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_Container_ServerConfig extends Google_Collection
+{
+  protected $collection_key = 'validNodeVersions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $defaultClusterVersion;
+  public $validNodeVersions;
+
+
+  public function setDefaultClusterVersion($defaultClusterVersion)
+  {
+    $this->defaultClusterVersion = $defaultClusterVersion;
+  }
+  public function getDefaultClusterVersion()
+  {
+    return $this->defaultClusterVersion;
+  }
+  public function setValidNodeVersions($validNodeVersions)
+  {
+    $this->validNodeVersions = $validNodeVersions;
+  }
+  public function getValidNodeVersions()
+  {
+    return $this->validNodeVersions;
+  }
+}
+
+class Google_Service_Container_UpdateClusterRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $updateType = 'Google_Service_Container_ClusterUpdate';
+  protected $updateDataType = '';
+
+
+  public function setUpdate(Google_Service_Container_ClusterUpdate $update)
+  {
+    $this->update = $update;
+  }
+  public function getUpdate()
+  {
+    return $this->update;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Coordinate.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Coordinate.php
@@ -1,0 +1,1570 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Coordinate (v1).
+ *
+ * <p>
+ * Lets you view and manage jobs in a Coordinate team.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/coordinate/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Coordinate extends Google_Service
+{
+  /** View and manage your Google Maps Coordinate jobs. */
+  const COORDINATE =
+      "https://www.googleapis.com/auth/coordinate";
+  /** View your Google Coordinate jobs. */
+  const COORDINATE_READONLY =
+      "https://www.googleapis.com/auth/coordinate.readonly";
+
+  public $customFieldDef;
+  public $jobs;
+  public $location;
+  public $schedule;
+  public $team;
+  public $worker;
+  
+
+  /**
+   * Constructs the internal representation of the Coordinate service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'coordinate/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'coordinate';
+
+    $this->customFieldDef = new Google_Service_Coordinate_CustomFieldDef_Resource(
+        $this,
+        $this->serviceName,
+        'customFieldDef',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'teams/{teamId}/custom_fields',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'teamId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->jobs = new Google_Service_Coordinate_Jobs_Resource(
+        $this,
+        $this->serviceName,
+        'jobs',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'teams/{teamId}/jobs/{jobId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'teamId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'teams/{teamId}/jobs',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'teamId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'address' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'lat' => array(
+                  'location' => 'query',
+                  'type' => 'number',
+                  'required' => true,
+                ),
+                'lng' => array(
+                  'location' => 'query',
+                  'type' => 'number',
+                  'required' => true,
+                ),
+                'title' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customerName' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'note' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'assignee' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'customerPhoneNumber' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'customField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'teams/{teamId}/jobs',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'teamId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'minModifiedTimestampMs' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'omitJobChanges' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'teams/{teamId}/jobs/{jobId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'teamId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customerName' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'title' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'note' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'assignee' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'customerPhoneNumber' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'address' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'lat' => array(
+                  'location' => 'query',
+                  'type' => 'number',
+                ),
+                'progress' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'lng' => array(
+                  'location' => 'query',
+                  'type' => 'number',
+                ),
+                'customField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'teams/{teamId}/jobs/{jobId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'teamId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customerName' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'title' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'note' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'assignee' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'customerPhoneNumber' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'address' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'lat' => array(
+                  'location' => 'query',
+                  'type' => 'number',
+                ),
+                'progress' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'lng' => array(
+                  'location' => 'query',
+                  'type' => 'number',
+                ),
+                'customField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->location = new Google_Service_Coordinate_Location_Resource(
+        $this,
+        $this->serviceName,
+        'location',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'teams/{teamId}/workers/{workerEmail}/locations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'teamId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'workerEmail' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'startTimestampMs' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->schedule = new Google_Service_Coordinate_Schedule_Resource(
+        $this,
+        $this->serviceName,
+        'schedule',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'teams/{teamId}/jobs/{jobId}/schedule',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'teamId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'teams/{teamId}/jobs/{jobId}/schedule',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'teamId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'allDay' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'startTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'duration' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'endTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'teams/{teamId}/jobs/{jobId}/schedule',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'teamId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'allDay' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'startTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'duration' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'endTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->team = new Google_Service_Coordinate_Team_Resource(
+        $this,
+        $this->serviceName,
+        'team',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'teams',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'admin' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'worker' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'dispatcher' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->worker = new Google_Service_Coordinate_Worker_Resource(
+        $this,
+        $this->serviceName,
+        'worker',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'teams/{teamId}/workers',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'teamId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "customFieldDef" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $coordinateService = new Google_Service_Coordinate(...);
+ *   $customFieldDef = $coordinateService->customFieldDef;
+ *  </code>
+ */
+class Google_Service_Coordinate_CustomFieldDef_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a list of custom field definitions for a team.
+   * (customFieldDef.listCustomFieldDef)
+   *
+   * @param string $teamId Team ID
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Coordinate_CustomFieldDefListResponse
+   */
+  public function listCustomFieldDef($teamId, $optParams = array())
+  {
+    $params = array('teamId' => $teamId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Coordinate_CustomFieldDefListResponse");
+  }
+}
+
+/**
+ * The "jobs" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $coordinateService = new Google_Service_Coordinate(...);
+ *   $jobs = $coordinateService->jobs;
+ *  </code>
+ */
+class Google_Service_Coordinate_Jobs_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a job, including all the changes made to the job. (jobs.get)
+   *
+   * @param string $teamId Team ID
+   * @param string $jobId Job number
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Coordinate_Job
+   */
+  public function get($teamId, $jobId, $optParams = array())
+  {
+    $params = array('teamId' => $teamId, 'jobId' => $jobId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Coordinate_Job");
+  }
+
+  /**
+   * Inserts a new job. Only the state field of the job should be set.
+   * (jobs.insert)
+   *
+   * @param string $teamId Team ID
+   * @param string $address Job address as newline (Unix) separated string
+   * @param double $lat The latitude coordinate of this job's location.
+   * @param double $lng The longitude coordinate of this job's location.
+   * @param string $title Job title
+   * @param Google_Job $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string customerName Customer name
+   * @opt_param string note Job note as newline (Unix) separated string
+   * @opt_param string assignee Assignee email address, or empty string to
+   * unassign.
+   * @opt_param string customerPhoneNumber Customer phone number
+   * @opt_param string customField Sets the value of custom fields. To set a
+   * custom field, pass the field id (from /team/teamId/custom_fields), a URL
+   * escaped '=' character, and the desired value as a parameter. For example,
+   * customField=12%3DAlice. Repeat the parameter for each custom field. Note that
+   * '=' cannot appear in the parameter value. Specifying an invalid, or inactive
+   * enum field will result in an error 500.
+   * @return Google_Service_Coordinate_Job
+   */
+  public function insert($teamId, $address, $lat, $lng, $title, Google_Service_Coordinate_Job $postBody, $optParams = array())
+  {
+    $params = array('teamId' => $teamId, 'address' => $address, 'lat' => $lat, 'lng' => $lng, 'title' => $title, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Coordinate_Job");
+  }
+
+  /**
+   * Retrieves jobs created or modified since the given timestamp. (jobs.listJobs)
+   *
+   * @param string $teamId Team ID
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string minModifiedTimestampMs Minimum time a job was modified in
+   * milliseconds since epoch.
+   * @opt_param string pageToken Continuation token
+   * @opt_param string maxResults Maximum number of results to return in one page.
+   * @opt_param bool omitJobChanges Whether to omit detail job history
+   * information.
+   * @return Google_Service_Coordinate_JobListResponse
+   */
+  public function listJobs($teamId, $optParams = array())
+  {
+    $params = array('teamId' => $teamId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Coordinate_JobListResponse");
+  }
+
+  /**
+   * Updates a job. Fields that are set in the job state will be updated. This
+   * method supports patch semantics. (jobs.patch)
+   *
+   * @param string $teamId Team ID
+   * @param string $jobId Job number
+   * @param Google_Job $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string customerName Customer name
+   * @opt_param string title Job title
+   * @opt_param string note Job note as newline (Unix) separated string
+   * @opt_param string assignee Assignee email address, or empty string to
+   * unassign.
+   * @opt_param string customerPhoneNumber Customer phone number
+   * @opt_param string address Job address as newline (Unix) separated string
+   * @opt_param double lat The latitude coordinate of this job's location.
+   * @opt_param string progress Job progress
+   * @opt_param double lng The longitude coordinate of this job's location.
+   * @opt_param string customField Sets the value of custom fields. To set a
+   * custom field, pass the field id (from /team/teamId/custom_fields), a URL
+   * escaped '=' character, and the desired value as a parameter. For example,
+   * customField=12%3DAlice. Repeat the parameter for each custom field. Note that
+   * '=' cannot appear in the parameter value. Specifying an invalid, or inactive
+   * enum field will result in an error 500.
+   * @return Google_Service_Coordinate_Job
+   */
+  public function patch($teamId, $jobId, Google_Service_Coordinate_Job $postBody, $optParams = array())
+  {
+    $params = array('teamId' => $teamId, 'jobId' => $jobId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Coordinate_Job");
+  }
+
+  /**
+   * Updates a job. Fields that are set in the job state will be updated.
+   * (jobs.update)
+   *
+   * @param string $teamId Team ID
+   * @param string $jobId Job number
+   * @param Google_Job $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string customerName Customer name
+   * @opt_param string title Job title
+   * @opt_param string note Job note as newline (Unix) separated string
+   * @opt_param string assignee Assignee email address, or empty string to
+   * unassign.
+   * @opt_param string customerPhoneNumber Customer phone number
+   * @opt_param string address Job address as newline (Unix) separated string
+   * @opt_param double lat The latitude coordinate of this job's location.
+   * @opt_param string progress Job progress
+   * @opt_param double lng The longitude coordinate of this job's location.
+   * @opt_param string customField Sets the value of custom fields. To set a
+   * custom field, pass the field id (from /team/teamId/custom_fields), a URL
+   * escaped '=' character, and the desired value as a parameter. For example,
+   * customField=12%3DAlice. Repeat the parameter for each custom field. Note that
+   * '=' cannot appear in the parameter value. Specifying an invalid, or inactive
+   * enum field will result in an error 500.
+   * @return Google_Service_Coordinate_Job
+   */
+  public function update($teamId, $jobId, Google_Service_Coordinate_Job $postBody, $optParams = array())
+  {
+    $params = array('teamId' => $teamId, 'jobId' => $jobId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Coordinate_Job");
+  }
+}
+
+/**
+ * The "location" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $coordinateService = new Google_Service_Coordinate(...);
+ *   $location = $coordinateService->location;
+ *  </code>
+ */
+class Google_Service_Coordinate_Location_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a list of locations for a worker. (location.listLocation)
+   *
+   * @param string $teamId Team ID
+   * @param string $workerEmail Worker email address.
+   * @param string $startTimestampMs Start timestamp in milliseconds since the
+   * epoch.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Continuation token
+   * @opt_param string maxResults Maximum number of results to return in one page.
+   * @return Google_Service_Coordinate_LocationListResponse
+   */
+  public function listLocation($teamId, $workerEmail, $startTimestampMs, $optParams = array())
+  {
+    $params = array('teamId' => $teamId, 'workerEmail' => $workerEmail, 'startTimestampMs' => $startTimestampMs);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Coordinate_LocationListResponse");
+  }
+}
+
+/**
+ * The "schedule" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $coordinateService = new Google_Service_Coordinate(...);
+ *   $schedule = $coordinateService->schedule;
+ *  </code>
+ */
+class Google_Service_Coordinate_Schedule_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the schedule for a job. (schedule.get)
+   *
+   * @param string $teamId Team ID
+   * @param string $jobId Job number
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Coordinate_Schedule
+   */
+  public function get($teamId, $jobId, $optParams = array())
+  {
+    $params = array('teamId' => $teamId, 'jobId' => $jobId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Coordinate_Schedule");
+  }
+
+  /**
+   * Replaces the schedule of a job with the provided schedule. This method
+   * supports patch semantics. (schedule.patch)
+   *
+   * @param string $teamId Team ID
+   * @param string $jobId Job number
+   * @param Google_Schedule $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool allDay Whether the job is scheduled for the whole day. Time
+   * of day in start/end times is ignored if this is true.
+   * @opt_param string startTime Scheduled start time in milliseconds since epoch.
+   * @opt_param string duration Job duration in milliseconds.
+   * @opt_param string endTime Scheduled end time in milliseconds since epoch.
+   * @return Google_Service_Coordinate_Schedule
+   */
+  public function patch($teamId, $jobId, Google_Service_Coordinate_Schedule $postBody, $optParams = array())
+  {
+    $params = array('teamId' => $teamId, 'jobId' => $jobId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Coordinate_Schedule");
+  }
+
+  /**
+   * Replaces the schedule of a job with the provided schedule. (schedule.update)
+   *
+   * @param string $teamId Team ID
+   * @param string $jobId Job number
+   * @param Google_Schedule $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool allDay Whether the job is scheduled for the whole day. Time
+   * of day in start/end times is ignored if this is true.
+   * @opt_param string startTime Scheduled start time in milliseconds since epoch.
+   * @opt_param string duration Job duration in milliseconds.
+   * @opt_param string endTime Scheduled end time in milliseconds since epoch.
+   * @return Google_Service_Coordinate_Schedule
+   */
+  public function update($teamId, $jobId, Google_Service_Coordinate_Schedule $postBody, $optParams = array())
+  {
+    $params = array('teamId' => $teamId, 'jobId' => $jobId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Coordinate_Schedule");
+  }
+}
+
+/**
+ * The "team" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $coordinateService = new Google_Service_Coordinate(...);
+ *   $team = $coordinateService->team;
+ *  </code>
+ */
+class Google_Service_Coordinate_Team_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a list of teams for a user. (team.listTeam)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool admin Whether to include teams for which the user has the
+   * Admin role.
+   * @opt_param bool worker Whether to include teams for which the user has the
+   * Worker role.
+   * @opt_param bool dispatcher Whether to include teams for which the user has
+   * the Dispatcher role.
+   * @return Google_Service_Coordinate_TeamListResponse
+   */
+  public function listTeam($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Coordinate_TeamListResponse");
+  }
+}
+
+/**
+ * The "worker" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $coordinateService = new Google_Service_Coordinate(...);
+ *   $worker = $coordinateService->worker;
+ *  </code>
+ */
+class Google_Service_Coordinate_Worker_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a list of workers in a team. (worker.listWorker)
+   *
+   * @param string $teamId Team ID
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Coordinate_WorkerListResponse
+   */
+  public function listWorker($teamId, $optParams = array())
+  {
+    $params = array('teamId' => $teamId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Coordinate_WorkerListResponse");
+  }
+}
+
+
+
+
+class Google_Service_Coordinate_CustomField extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $customFieldId;
+  public $kind;
+  public $value;
+
+
+  public function setCustomFieldId($customFieldId)
+  {
+    $this->customFieldId = $customFieldId;
+  }
+  public function getCustomFieldId()
+  {
+    return $this->customFieldId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Coordinate_CustomFieldDef extends Google_Collection
+{
+  protected $collection_key = 'enumitems';
+  protected $internal_gapi_mappings = array(
+  );
+  public $enabled;
+  protected $enumitemsType = 'Google_Service_Coordinate_EnumItemDef';
+  protected $enumitemsDataType = 'array';
+  public $id;
+  public $kind;
+  public $name;
+  public $requiredForCheckout;
+  public $type;
+
+
+  public function setEnabled($enabled)
+  {
+    $this->enabled = $enabled;
+  }
+  public function getEnabled()
+  {
+    return $this->enabled;
+  }
+  public function setEnumitems($enumitems)
+  {
+    $this->enumitems = $enumitems;
+  }
+  public function getEnumitems()
+  {
+    return $this->enumitems;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setRequiredForCheckout($requiredForCheckout)
+  {
+    $this->requiredForCheckout = $requiredForCheckout;
+  }
+  public function getRequiredForCheckout()
+  {
+    return $this->requiredForCheckout;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Coordinate_CustomFieldDefListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Coordinate_CustomFieldDef';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Coordinate_CustomFields extends Google_Collection
+{
+  protected $collection_key = 'customField';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $customFieldType = 'Google_Service_Coordinate_CustomField';
+  protected $customFieldDataType = 'array';
+  public $kind;
+
+
+  public function setCustomField($customField)
+  {
+    $this->customField = $customField;
+  }
+  public function getCustomField()
+  {
+    return $this->customField;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Coordinate_EnumItemDef extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $active;
+  public $kind;
+  public $value;
+
+
+  public function setActive($active)
+  {
+    $this->active = $active;
+  }
+  public function getActive()
+  {
+    return $this->active;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Coordinate_Job extends Google_Collection
+{
+  protected $collection_key = 'jobChange';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $jobChangeType = 'Google_Service_Coordinate_JobChange';
+  protected $jobChangeDataType = 'array';
+  public $kind;
+  protected $stateType = 'Google_Service_Coordinate_JobState';
+  protected $stateDataType = '';
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setJobChange($jobChange)
+  {
+    $this->jobChange = $jobChange;
+  }
+  public function getJobChange()
+  {
+    return $this->jobChange;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setState(Google_Service_Coordinate_JobState $state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+}
+
+class Google_Service_Coordinate_JobChange extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $stateType = 'Google_Service_Coordinate_JobState';
+  protected $stateDataType = '';
+  public $timestamp;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setState(Google_Service_Coordinate_JobState $state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+  public function setTimestamp($timestamp)
+  {
+    $this->timestamp = $timestamp;
+  }
+  public function getTimestamp()
+  {
+    return $this->timestamp;
+  }
+}
+
+class Google_Service_Coordinate_JobListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Coordinate_Job';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Coordinate_JobState extends Google_Collection
+{
+  protected $collection_key = 'note';
+  protected $internal_gapi_mappings = array(
+  );
+  public $assignee;
+  protected $customFieldsType = 'Google_Service_Coordinate_CustomFields';
+  protected $customFieldsDataType = '';
+  public $customerName;
+  public $customerPhoneNumber;
+  public $kind;
+  protected $locationType = 'Google_Service_Coordinate_Location';
+  protected $locationDataType = '';
+  public $note;
+  public $progress;
+  public $title;
+
+
+  public function setAssignee($assignee)
+  {
+    $this->assignee = $assignee;
+  }
+  public function getAssignee()
+  {
+    return $this->assignee;
+  }
+  public function setCustomFields(Google_Service_Coordinate_CustomFields $customFields)
+  {
+    $this->customFields = $customFields;
+  }
+  public function getCustomFields()
+  {
+    return $this->customFields;
+  }
+  public function setCustomerName($customerName)
+  {
+    $this->customerName = $customerName;
+  }
+  public function getCustomerName()
+  {
+    return $this->customerName;
+  }
+  public function setCustomerPhoneNumber($customerPhoneNumber)
+  {
+    $this->customerPhoneNumber = $customerPhoneNumber;
+  }
+  public function getCustomerPhoneNumber()
+  {
+    return $this->customerPhoneNumber;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocation(Google_Service_Coordinate_Location $location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setNote($note)
+  {
+    $this->note = $note;
+  }
+  public function getNote()
+  {
+    return $this->note;
+  }
+  public function setProgress($progress)
+  {
+    $this->progress = $progress;
+  }
+  public function getProgress()
+  {
+    return $this->progress;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_Coordinate_Location extends Google_Collection
+{
+  protected $collection_key = 'addressLine';
+  protected $internal_gapi_mappings = array(
+  );
+  public $addressLine;
+  public $kind;
+  public $lat;
+  public $lng;
+
+
+  public function setAddressLine($addressLine)
+  {
+    $this->addressLine = $addressLine;
+  }
+  public function getAddressLine()
+  {
+    return $this->addressLine;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLat($lat)
+  {
+    $this->lat = $lat;
+  }
+  public function getLat()
+  {
+    return $this->lat;
+  }
+  public function setLng($lng)
+  {
+    $this->lng = $lng;
+  }
+  public function getLng()
+  {
+    return $this->lng;
+  }
+}
+
+class Google_Service_Coordinate_LocationListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Coordinate_LocationRecord';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  protected $tokenPaginationType = 'Google_Service_Coordinate_TokenPagination';
+  protected $tokenPaginationDataType = '';
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTokenPagination(Google_Service_Coordinate_TokenPagination $tokenPagination)
+  {
+    $this->tokenPagination = $tokenPagination;
+  }
+  public function getTokenPagination()
+  {
+    return $this->tokenPagination;
+  }
+}
+
+class Google_Service_Coordinate_LocationRecord extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $collectionTime;
+  public $confidenceRadius;
+  public $kind;
+  public $latitude;
+  public $longitude;
+
+
+  public function setCollectionTime($collectionTime)
+  {
+    $this->collectionTime = $collectionTime;
+  }
+  public function getCollectionTime()
+  {
+    return $this->collectionTime;
+  }
+  public function setConfidenceRadius($confidenceRadius)
+  {
+    $this->confidenceRadius = $confidenceRadius;
+  }
+  public function getConfidenceRadius()
+  {
+    return $this->confidenceRadius;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLatitude($latitude)
+  {
+    $this->latitude = $latitude;
+  }
+  public function getLatitude()
+  {
+    return $this->latitude;
+  }
+  public function setLongitude($longitude)
+  {
+    $this->longitude = $longitude;
+  }
+  public function getLongitude()
+  {
+    return $this->longitude;
+  }
+}
+
+class Google_Service_Coordinate_Schedule extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $allDay;
+  public $duration;
+  public $endTime;
+  public $kind;
+  public $startTime;
+
+
+  public function setAllDay($allDay)
+  {
+    $this->allDay = $allDay;
+  }
+  public function getAllDay()
+  {
+    return $this->allDay;
+  }
+  public function setDuration($duration)
+  {
+    $this->duration = $duration;
+  }
+  public function getDuration()
+  {
+    return $this->duration;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+}
+
+class Google_Service_Coordinate_Team extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Coordinate_TeamListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Coordinate_Team';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Coordinate_TokenPagination extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  public $previousPageToken;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPreviousPageToken($previousPageToken)
+  {
+    $this->previousPageToken = $previousPageToken;
+  }
+  public function getPreviousPageToken()
+  {
+    return $this->previousPageToken;
+  }
+}
+
+class Google_Service_Coordinate_Worker extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Coordinate_WorkerListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Coordinate_Worker';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Customsearch.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Customsearch.php
@@ -1,0 +1,1277 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Customsearch (v1).
+ *
+ * <p>
+ * Lets you search over a website or collection of websites</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/custom-search/v1/using_rest" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Customsearch extends Google_Service
+{
+
+
+  public $cse;
+  
+
+  /**
+   * Constructs the internal representation of the Customsearch service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'customsearch/';
+    $this->version = 'v1';
+    $this->serviceName = 'customsearch';
+
+    $this->cse = new Google_Service_Customsearch_Cse_Resource(
+        $this,
+        $this->serviceName,
+        'cse',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'v1',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'q' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sort' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'orTerms' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'highRange' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'num' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'cr' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'imgType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'gl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'relatedSite' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'searchType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'fileType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'start' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'imgDominantColor' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'lr' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'siteSearch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'cref' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'dateRestrict' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'safe' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'c2coff' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'googlehost' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'hq' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'exactTerms' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'hl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'lowRange' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'imgSize' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'imgColorType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'rights' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'excludeTerms' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'linkSite' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'cx' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'siteSearchFilter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "cse" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $customsearchService = new Google_Service_Customsearch(...);
+ *   $cse = $customsearchService->cse;
+ *  </code>
+ */
+class Google_Service_Customsearch_Cse_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns metadata about the search performed, metadata about the custom search
+   * engine used for the search, and the search results. (cse.listCse)
+   *
+   * @param string $q Query
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string sort The sort expression to apply to the results
+   * @opt_param string orTerms Provides additional search terms to check for in a
+   * document, where each document in the search results must contain at least one
+   * of the additional search terms
+   * @opt_param string highRange Creates a range in form as_nlo value..as_nhi
+   * value and attempts to append it to query
+   * @opt_param string num Number of search results to return
+   * @opt_param string cr Country restrict(s).
+   * @opt_param string imgType Returns images of a type, which can be one of:
+   * clipart, face, lineart, news, and photo.
+   * @opt_param string gl Geolocation of end user.
+   * @opt_param string relatedSite Specifies that all search results should be
+   * pages that are related to the specified URL
+   * @opt_param string searchType Specifies the search type: image.
+   * @opt_param string fileType Returns images of a specified type. Some of the
+   * allowed values are: bmp, gif, png, jpg, svg, pdf, ...
+   * @opt_param string start The index of the first result to return
+   * @opt_param string imgDominantColor Returns images of a specific dominant
+   * color: yellow, green, teal, blue, purple, pink, white, gray, black and brown.
+   * @opt_param string lr The language restriction for the search results
+   * @opt_param string siteSearch Specifies all search results should be pages
+   * from a given site
+   * @opt_param string cref The URL of a linked custom search engine
+   * @opt_param string dateRestrict Specifies all search results are from a time
+   * period
+   * @opt_param string safe Search safety level
+   * @opt_param string c2coff Turns off the translation between zh-CN and zh-TW.
+   * @opt_param string googlehost The local Google domain to use to perform the
+   * search.
+   * @opt_param string hq Appends the extra query terms to the query.
+   * @opt_param string exactTerms Identifies a phrase that all documents in the
+   * search results must contain
+   * @opt_param string hl Sets the user interface language.
+   * @opt_param string lowRange Creates a range in form as_nlo value..as_nhi value
+   * and attempts to append it to query
+   * @opt_param string imgSize Returns images of a specified size, where size can
+   * be one of: icon, small, medium, large, xlarge, xxlarge, and huge.
+   * @opt_param string imgColorType Returns black and white, grayscale, or color
+   * images: mono, gray, and color.
+   * @opt_param string rights Filters based on licensing. Supported values
+   * include: cc_publicdomain, cc_attribute, cc_sharealike, cc_noncommercial,
+   * cc_nonderived and combinations of these.
+   * @opt_param string excludeTerms Identifies a word or phrase that should not
+   * appear in any documents in the search results
+   * @opt_param string filter Controls turning on or off the duplicate content
+   * filter.
+   * @opt_param string linkSite Specifies that all search results should contain a
+   * link to a particular URL
+   * @opt_param string cx The custom search engine ID to scope this search query
+   * @opt_param string siteSearchFilter Controls whether to include or exclude
+   * results from the site named in the as_sitesearch parameter
+   * @return Google_Service_Customsearch_Search
+   */
+  public function listCse($q, $optParams = array())
+  {
+    $params = array('q' => $q);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Customsearch_Search");
+  }
+}
+
+
+
+
+class Google_Service_Customsearch_Context extends Google_Collection
+{
+  protected $collection_key = 'facets';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $facetsType = 'Google_Service_Customsearch_ContextFacets';
+  protected $facetsDataType = 'array';
+  public $title;
+
+
+  public function setFacets($facets)
+  {
+    $this->facets = $facets;
+  }
+  public function getFacets()
+  {
+    return $this->facets;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_Customsearch_ContextFacets extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "labelWithOp" => "label_with_op",
+  );
+  public $anchor;
+  public $label;
+  public $labelWithOp;
+
+
+  public function setAnchor($anchor)
+  {
+    $this->anchor = $anchor;
+  }
+  public function getAnchor()
+  {
+    return $this->anchor;
+  }
+  public function setLabel($label)
+  {
+    $this->label = $label;
+  }
+  public function getLabel()
+  {
+    return $this->label;
+  }
+  public function setLabelWithOp($labelWithOp)
+  {
+    $this->labelWithOp = $labelWithOp;
+  }
+  public function getLabelWithOp()
+  {
+    return $this->labelWithOp;
+  }
+}
+
+class Google_Service_Customsearch_Promotion extends Google_Collection
+{
+  protected $collection_key = 'bodyLines';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $bodyLinesType = 'Google_Service_Customsearch_PromotionBodyLines';
+  protected $bodyLinesDataType = 'array';
+  public $displayLink;
+  public $htmlTitle;
+  protected $imageType = 'Google_Service_Customsearch_PromotionImage';
+  protected $imageDataType = '';
+  public $link;
+  public $title;
+
+
+  public function setBodyLines($bodyLines)
+  {
+    $this->bodyLines = $bodyLines;
+  }
+  public function getBodyLines()
+  {
+    return $this->bodyLines;
+  }
+  public function setDisplayLink($displayLink)
+  {
+    $this->displayLink = $displayLink;
+  }
+  public function getDisplayLink()
+  {
+    return $this->displayLink;
+  }
+  public function setHtmlTitle($htmlTitle)
+  {
+    $this->htmlTitle = $htmlTitle;
+  }
+  public function getHtmlTitle()
+  {
+    return $this->htmlTitle;
+  }
+  public function setImage(Google_Service_Customsearch_PromotionImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setLink($link)
+  {
+    $this->link = $link;
+  }
+  public function getLink()
+  {
+    return $this->link;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_Customsearch_PromotionBodyLines extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $htmlTitle;
+  public $link;
+  public $title;
+  public $url;
+
+
+  public function setHtmlTitle($htmlTitle)
+  {
+    $this->htmlTitle = $htmlTitle;
+  }
+  public function getHtmlTitle()
+  {
+    return $this->htmlTitle;
+  }
+  public function setLink($link)
+  {
+    $this->link = $link;
+  }
+  public function getLink()
+  {
+    return $this->link;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Customsearch_PromotionImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $source;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setSource($source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_Customsearch_Query extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $count;
+  public $cr;
+  public $cref;
+  public $cx;
+  public $dateRestrict;
+  public $disableCnTwTranslation;
+  public $exactTerms;
+  public $excludeTerms;
+  public $fileType;
+  public $filter;
+  public $gl;
+  public $googleHost;
+  public $highRange;
+  public $hl;
+  public $hq;
+  public $imgColorType;
+  public $imgDominantColor;
+  public $imgSize;
+  public $imgType;
+  public $inputEncoding;
+  public $language;
+  public $linkSite;
+  public $lowRange;
+  public $orTerms;
+  public $outputEncoding;
+  public $relatedSite;
+  public $rights;
+  public $safe;
+  public $searchTerms;
+  public $searchType;
+  public $siteSearch;
+  public $siteSearchFilter;
+  public $sort;
+  public $startIndex;
+  public $startPage;
+  public $title;
+  public $totalResults;
+
+
+  public function setCount($count)
+  {
+    $this->count = $count;
+  }
+  public function getCount()
+  {
+    return $this->count;
+  }
+  public function setCr($cr)
+  {
+    $this->cr = $cr;
+  }
+  public function getCr()
+  {
+    return $this->cr;
+  }
+  public function setCref($cref)
+  {
+    $this->cref = $cref;
+  }
+  public function getCref()
+  {
+    return $this->cref;
+  }
+  public function setCx($cx)
+  {
+    $this->cx = $cx;
+  }
+  public function getCx()
+  {
+    return $this->cx;
+  }
+  public function setDateRestrict($dateRestrict)
+  {
+    $this->dateRestrict = $dateRestrict;
+  }
+  public function getDateRestrict()
+  {
+    return $this->dateRestrict;
+  }
+  public function setDisableCnTwTranslation($disableCnTwTranslation)
+  {
+    $this->disableCnTwTranslation = $disableCnTwTranslation;
+  }
+  public function getDisableCnTwTranslation()
+  {
+    return $this->disableCnTwTranslation;
+  }
+  public function setExactTerms($exactTerms)
+  {
+    $this->exactTerms = $exactTerms;
+  }
+  public function getExactTerms()
+  {
+    return $this->exactTerms;
+  }
+  public function setExcludeTerms($excludeTerms)
+  {
+    $this->excludeTerms = $excludeTerms;
+  }
+  public function getExcludeTerms()
+  {
+    return $this->excludeTerms;
+  }
+  public function setFileType($fileType)
+  {
+    $this->fileType = $fileType;
+  }
+  public function getFileType()
+  {
+    return $this->fileType;
+  }
+  public function setFilter($filter)
+  {
+    $this->filter = $filter;
+  }
+  public function getFilter()
+  {
+    return $this->filter;
+  }
+  public function setGl($gl)
+  {
+    $this->gl = $gl;
+  }
+  public function getGl()
+  {
+    return $this->gl;
+  }
+  public function setGoogleHost($googleHost)
+  {
+    $this->googleHost = $googleHost;
+  }
+  public function getGoogleHost()
+  {
+    return $this->googleHost;
+  }
+  public function setHighRange($highRange)
+  {
+    $this->highRange = $highRange;
+  }
+  public function getHighRange()
+  {
+    return $this->highRange;
+  }
+  public function setHl($hl)
+  {
+    $this->hl = $hl;
+  }
+  public function getHl()
+  {
+    return $this->hl;
+  }
+  public function setHq($hq)
+  {
+    $this->hq = $hq;
+  }
+  public function getHq()
+  {
+    return $this->hq;
+  }
+  public function setImgColorType($imgColorType)
+  {
+    $this->imgColorType = $imgColorType;
+  }
+  public function getImgColorType()
+  {
+    return $this->imgColorType;
+  }
+  public function setImgDominantColor($imgDominantColor)
+  {
+    $this->imgDominantColor = $imgDominantColor;
+  }
+  public function getImgDominantColor()
+  {
+    return $this->imgDominantColor;
+  }
+  public function setImgSize($imgSize)
+  {
+    $this->imgSize = $imgSize;
+  }
+  public function getImgSize()
+  {
+    return $this->imgSize;
+  }
+  public function setImgType($imgType)
+  {
+    $this->imgType = $imgType;
+  }
+  public function getImgType()
+  {
+    return $this->imgType;
+  }
+  public function setInputEncoding($inputEncoding)
+  {
+    $this->inputEncoding = $inputEncoding;
+  }
+  public function getInputEncoding()
+  {
+    return $this->inputEncoding;
+  }
+  public function setLanguage($language)
+  {
+    $this->language = $language;
+  }
+  public function getLanguage()
+  {
+    return $this->language;
+  }
+  public function setLinkSite($linkSite)
+  {
+    $this->linkSite = $linkSite;
+  }
+  public function getLinkSite()
+  {
+    return $this->linkSite;
+  }
+  public function setLowRange($lowRange)
+  {
+    $this->lowRange = $lowRange;
+  }
+  public function getLowRange()
+  {
+    return $this->lowRange;
+  }
+  public function setOrTerms($orTerms)
+  {
+    $this->orTerms = $orTerms;
+  }
+  public function getOrTerms()
+  {
+    return $this->orTerms;
+  }
+  public function setOutputEncoding($outputEncoding)
+  {
+    $this->outputEncoding = $outputEncoding;
+  }
+  public function getOutputEncoding()
+  {
+    return $this->outputEncoding;
+  }
+  public function setRelatedSite($relatedSite)
+  {
+    $this->relatedSite = $relatedSite;
+  }
+  public function getRelatedSite()
+  {
+    return $this->relatedSite;
+  }
+  public function setRights($rights)
+  {
+    $this->rights = $rights;
+  }
+  public function getRights()
+  {
+    return $this->rights;
+  }
+  public function setSafe($safe)
+  {
+    $this->safe = $safe;
+  }
+  public function getSafe()
+  {
+    return $this->safe;
+  }
+  public function setSearchTerms($searchTerms)
+  {
+    $this->searchTerms = $searchTerms;
+  }
+  public function getSearchTerms()
+  {
+    return $this->searchTerms;
+  }
+  public function setSearchType($searchType)
+  {
+    $this->searchType = $searchType;
+  }
+  public function getSearchType()
+  {
+    return $this->searchType;
+  }
+  public function setSiteSearch($siteSearch)
+  {
+    $this->siteSearch = $siteSearch;
+  }
+  public function getSiteSearch()
+  {
+    return $this->siteSearch;
+  }
+  public function setSiteSearchFilter($siteSearchFilter)
+  {
+    $this->siteSearchFilter = $siteSearchFilter;
+  }
+  public function getSiteSearchFilter()
+  {
+    return $this->siteSearchFilter;
+  }
+  public function setSort($sort)
+  {
+    $this->sort = $sort;
+  }
+  public function getSort()
+  {
+    return $this->sort;
+  }
+  public function setStartIndex($startIndex)
+  {
+    $this->startIndex = $startIndex;
+  }
+  public function getStartIndex()
+  {
+    return $this->startIndex;
+  }
+  public function setStartPage($startPage)
+  {
+    $this->startPage = $startPage;
+  }
+  public function getStartPage()
+  {
+    return $this->startPage;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+}
+
+class Google_Service_Customsearch_Result extends Google_Collection
+{
+  protected $collection_key = 'labels';
+  protected $internal_gapi_mappings = array(
+  );
+  public $cacheId;
+  public $displayLink;
+  public $fileFormat;
+  public $formattedUrl;
+  public $htmlFormattedUrl;
+  public $htmlSnippet;
+  public $htmlTitle;
+  protected $imageType = 'Google_Service_Customsearch_ResultImage';
+  protected $imageDataType = '';
+  public $kind;
+  protected $labelsType = 'Google_Service_Customsearch_ResultLabels';
+  protected $labelsDataType = 'array';
+  public $link;
+  public $mime;
+  public $pagemap;
+  public $snippet;
+  public $title;
+
+
+  public function setCacheId($cacheId)
+  {
+    $this->cacheId = $cacheId;
+  }
+  public function getCacheId()
+  {
+    return $this->cacheId;
+  }
+  public function setDisplayLink($displayLink)
+  {
+    $this->displayLink = $displayLink;
+  }
+  public function getDisplayLink()
+  {
+    return $this->displayLink;
+  }
+  public function setFileFormat($fileFormat)
+  {
+    $this->fileFormat = $fileFormat;
+  }
+  public function getFileFormat()
+  {
+    return $this->fileFormat;
+  }
+  public function setFormattedUrl($formattedUrl)
+  {
+    $this->formattedUrl = $formattedUrl;
+  }
+  public function getFormattedUrl()
+  {
+    return $this->formattedUrl;
+  }
+  public function setHtmlFormattedUrl($htmlFormattedUrl)
+  {
+    $this->htmlFormattedUrl = $htmlFormattedUrl;
+  }
+  public function getHtmlFormattedUrl()
+  {
+    return $this->htmlFormattedUrl;
+  }
+  public function setHtmlSnippet($htmlSnippet)
+  {
+    $this->htmlSnippet = $htmlSnippet;
+  }
+  public function getHtmlSnippet()
+  {
+    return $this->htmlSnippet;
+  }
+  public function setHtmlTitle($htmlTitle)
+  {
+    $this->htmlTitle = $htmlTitle;
+  }
+  public function getHtmlTitle()
+  {
+    return $this->htmlTitle;
+  }
+  public function setImage(Google_Service_Customsearch_ResultImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLabels($labels)
+  {
+    $this->labels = $labels;
+  }
+  public function getLabels()
+  {
+    return $this->labels;
+  }
+  public function setLink($link)
+  {
+    $this->link = $link;
+  }
+  public function getLink()
+  {
+    return $this->link;
+  }
+  public function setMime($mime)
+  {
+    $this->mime = $mime;
+  }
+  public function getMime()
+  {
+    return $this->mime;
+  }
+  public function setPagemap($pagemap)
+  {
+    $this->pagemap = $pagemap;
+  }
+  public function getPagemap()
+  {
+    return $this->pagemap;
+  }
+  public function setSnippet($snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_Customsearch_ResultImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $byteSize;
+  public $contextLink;
+  public $height;
+  public $thumbnailHeight;
+  public $thumbnailLink;
+  public $thumbnailWidth;
+  public $width;
+
+
+  public function setByteSize($byteSize)
+  {
+    $this->byteSize = $byteSize;
+  }
+  public function getByteSize()
+  {
+    return $this->byteSize;
+  }
+  public function setContextLink($contextLink)
+  {
+    $this->contextLink = $contextLink;
+  }
+  public function getContextLink()
+  {
+    return $this->contextLink;
+  }
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setThumbnailHeight($thumbnailHeight)
+  {
+    $this->thumbnailHeight = $thumbnailHeight;
+  }
+  public function getThumbnailHeight()
+  {
+    return $this->thumbnailHeight;
+  }
+  public function setThumbnailLink($thumbnailLink)
+  {
+    $this->thumbnailLink = $thumbnailLink;
+  }
+  public function getThumbnailLink()
+  {
+    return $this->thumbnailLink;
+  }
+  public function setThumbnailWidth($thumbnailWidth)
+  {
+    $this->thumbnailWidth = $thumbnailWidth;
+  }
+  public function getThumbnailWidth()
+  {
+    return $this->thumbnailWidth;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_Customsearch_ResultLabels extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "labelWithOp" => "label_with_op",
+  );
+  public $displayName;
+  public $labelWithOp;
+  public $name;
+
+
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setLabelWithOp($labelWithOp)
+  {
+    $this->labelWithOp = $labelWithOp;
+  }
+  public function getLabelWithOp()
+  {
+    return $this->labelWithOp;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Customsearch_ResultPagemap extends Google_Model
+{
+}
+
+class Google_Service_Customsearch_ResultPagemapItemElement extends Google_Model
+{
+}
+
+class Google_Service_Customsearch_Search extends Google_Collection
+{
+  protected $collection_key = 'promotions';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $contextType = 'Google_Service_Customsearch_Context';
+  protected $contextDataType = '';
+  protected $itemsType = 'Google_Service_Customsearch_Result';
+  protected $itemsDataType = 'array';
+  public $kind;
+  protected $promotionsType = 'Google_Service_Customsearch_Promotion';
+  protected $promotionsDataType = 'array';
+  protected $queriesType = 'Google_Service_Customsearch_Query';
+  protected $queriesDataType = 'map';
+  protected $searchInformationType = 'Google_Service_Customsearch_SearchSearchInformation';
+  protected $searchInformationDataType = '';
+  protected $spellingType = 'Google_Service_Customsearch_SearchSpelling';
+  protected $spellingDataType = '';
+  protected $urlType = 'Google_Service_Customsearch_SearchUrl';
+  protected $urlDataType = '';
+
+
+  public function setContext(Google_Service_Customsearch_Context $context)
+  {
+    $this->context = $context;
+  }
+  public function getContext()
+  {
+    return $this->context;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPromotions($promotions)
+  {
+    $this->promotions = $promotions;
+  }
+  public function getPromotions()
+  {
+    return $this->promotions;
+  }
+  public function setQueries($queries)
+  {
+    $this->queries = $queries;
+  }
+  public function getQueries()
+  {
+    return $this->queries;
+  }
+  public function setSearchInformation(Google_Service_Customsearch_SearchSearchInformation $searchInformation)
+  {
+    $this->searchInformation = $searchInformation;
+  }
+  public function getSearchInformation()
+  {
+    return $this->searchInformation;
+  }
+  public function setSpelling(Google_Service_Customsearch_SearchSpelling $spelling)
+  {
+    $this->spelling = $spelling;
+  }
+  public function getSpelling()
+  {
+    return $this->spelling;
+  }
+  public function setUrl(Google_Service_Customsearch_SearchUrl $url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Customsearch_SearchQueries extends Google_Model
+{
+}
+
+class Google_Service_Customsearch_SearchSearchInformation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $formattedSearchTime;
+  public $formattedTotalResults;
+  public $searchTime;
+  public $totalResults;
+
+
+  public function setFormattedSearchTime($formattedSearchTime)
+  {
+    $this->formattedSearchTime = $formattedSearchTime;
+  }
+  public function getFormattedSearchTime()
+  {
+    return $this->formattedSearchTime;
+  }
+  public function setFormattedTotalResults($formattedTotalResults)
+  {
+    $this->formattedTotalResults = $formattedTotalResults;
+  }
+  public function getFormattedTotalResults()
+  {
+    return $this->formattedTotalResults;
+  }
+  public function setSearchTime($searchTime)
+  {
+    $this->searchTime = $searchTime;
+  }
+  public function getSearchTime()
+  {
+    return $this->searchTime;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+}
+
+class Google_Service_Customsearch_SearchSpelling extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $correctedQuery;
+  public $htmlCorrectedQuery;
+
+
+  public function setCorrectedQuery($correctedQuery)
+  {
+    $this->correctedQuery = $correctedQuery;
+  }
+  public function getCorrectedQuery()
+  {
+    return $this->correctedQuery;
+  }
+  public function setHtmlCorrectedQuery($htmlCorrectedQuery)
+  {
+    $this->htmlCorrectedQuery = $htmlCorrectedQuery;
+  }
+  public function getHtmlCorrectedQuery()
+  {
+    return $this->htmlCorrectedQuery;
+  }
+}
+
+class Google_Service_Customsearch_SearchUrl extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $template;
+  public $type;
+
+
+  public function setTemplate($template)
+  {
+    $this->template = $template;
+  }
+  public function getTemplate()
+  {
+    return $this->template;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/DataTransfer.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/DataTransfer.php
@@ -1,0 +1,554 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for DataTransfer (datatransfer_v1).
+ *
+ * <p>
+ * Admin Data Transfer API lets you transfer user data from one user to another.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/admin-sdk/data-transfer/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_DataTransfer extends Google_Service
+{
+  /** View and manage data transfers between users in your organization. */
+  const ADMIN_DATATRANSFER =
+      "https://www.googleapis.com/auth/admin.datatransfer";
+  /** View data transfers between users in your organization. */
+  const ADMIN_DATATRANSFER_READONLY =
+      "https://www.googleapis.com/auth/admin.datatransfer.readonly";
+
+  public $applications;
+  public $transfers;
+  
+
+  /**
+   * Constructs the internal representation of the DataTransfer service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'admin/datatransfer/v1/';
+    $this->version = 'datatransfer_v1';
+    $this->serviceName = 'admin';
+
+    $this->applications = new Google_Service_DataTransfer_Applications_Resource(
+        $this,
+        $this->serviceName,
+        'applications',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'applications/{applicationId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'applicationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'applications',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'customerId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->transfers = new Google_Service_DataTransfer_Transfers_Resource(
+        $this,
+        $this->serviceName,
+        'transfers',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'transfers/{dataTransferId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'dataTransferId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'transfers',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'list' => array(
+              'path' => 'transfers',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'status' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'newOwnerUserId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'oldOwnerUserId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'customerId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "applications" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_DataTransfer(...);
+ *   $applications = $adminService->applications;
+ *  </code>
+ */
+class Google_Service_DataTransfer_Applications_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves information about an application for the given application ID.
+   * (applications.get)
+   *
+   * @param string $applicationId ID of the application resource to be retrieved.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_DataTransfer_Application
+   */
+  public function get($applicationId, $optParams = array())
+  {
+    $params = array('applicationId' => $applicationId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_DataTransfer_Application");
+  }
+
+  /**
+   * Lists the applications available for data transfer for a customer.
+   * (applications.listApplications)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Token to specify next page in the list.
+   * @opt_param string customerId Immutable ID of the Google Apps account.
+   * @opt_param string maxResults Maximum number of results to return. Default is
+   * 100.
+   * @return Google_Service_DataTransfer_ApplicationsListResponse
+   */
+  public function listApplications($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_DataTransfer_ApplicationsListResponse");
+  }
+}
+
+/**
+ * The "transfers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_DataTransfer(...);
+ *   $transfers = $adminService->transfers;
+ *  </code>
+ */
+class Google_Service_DataTransfer_Transfers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a data transfer request by its resource ID. (transfers.get)
+   *
+   * @param string $dataTransferId ID of the resource to be retrieved. This is
+   * returned in the response from the insert method.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_DataTransfer_DataTransfer
+   */
+  public function get($dataTransferId, $optParams = array())
+  {
+    $params = array('dataTransferId' => $dataTransferId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_DataTransfer_DataTransfer");
+  }
+
+  /**
+   * Inserts a data transfer request. (transfers.insert)
+   *
+   * @param Google_DataTransfer $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_DataTransfer_DataTransfer
+   */
+  public function insert(Google_Service_DataTransfer_DataTransfer $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_DataTransfer_DataTransfer");
+  }
+
+  /**
+   * Lists the transfers for a customer by source user, destination user, or
+   * status. (transfers.listTransfers)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string status Status of the transfer.
+   * @opt_param int maxResults Maximum number of results to return. Default is
+   * 100.
+   * @opt_param string newOwnerUserId Destination user's profile ID.
+   * @opt_param string oldOwnerUserId Source user's profile ID.
+   * @opt_param string pageToken Token to specify the next page in the list.
+   * @opt_param string customerId Immutable ID of the Google Apps account.
+   * @return Google_Service_DataTransfer_DataTransfersListResponse
+   */
+  public function listTransfers($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_DataTransfer_DataTransfersListResponse");
+  }
+}
+
+
+
+
+class Google_Service_DataTransfer_Application extends Google_Collection
+{
+  protected $collection_key = 'transferParams';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $id;
+  public $kind;
+  public $name;
+  protected $transferParamsType = 'Google_Service_DataTransfer_ApplicationTransferParam';
+  protected $transferParamsDataType = 'array';
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setTransferParams($transferParams)
+  {
+    $this->transferParams = $transferParams;
+  }
+  public function getTransferParams()
+  {
+    return $this->transferParams;
+  }
+}
+
+class Google_Service_DataTransfer_ApplicationDataTransfer extends Google_Collection
+{
+  protected $collection_key = 'applicationTransferParams';
+  protected $internal_gapi_mappings = array(
+  );
+  public $applicationId;
+  protected $applicationTransferParamsType = 'Google_Service_DataTransfer_ApplicationTransferParam';
+  protected $applicationTransferParamsDataType = 'array';
+  public $applicationTransferStatus;
+
+
+  public function setApplicationId($applicationId)
+  {
+    $this->applicationId = $applicationId;
+  }
+  public function getApplicationId()
+  {
+    return $this->applicationId;
+  }
+  public function setApplicationTransferParams($applicationTransferParams)
+  {
+    $this->applicationTransferParams = $applicationTransferParams;
+  }
+  public function getApplicationTransferParams()
+  {
+    return $this->applicationTransferParams;
+  }
+  public function setApplicationTransferStatus($applicationTransferStatus)
+  {
+    $this->applicationTransferStatus = $applicationTransferStatus;
+  }
+  public function getApplicationTransferStatus()
+  {
+    return $this->applicationTransferStatus;
+  }
+}
+
+class Google_Service_DataTransfer_ApplicationTransferParam extends Google_Collection
+{
+  protected $collection_key = 'value';
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_DataTransfer_ApplicationsListResponse extends Google_Collection
+{
+  protected $collection_key = 'applications';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $applicationsType = 'Google_Service_DataTransfer_Application';
+  protected $applicationsDataType = 'array';
+  public $etag;
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setApplications($applications)
+  {
+    $this->applications = $applications;
+  }
+  public function getApplications()
+  {
+    return $this->applications;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_DataTransfer_DataTransfer extends Google_Collection
+{
+  protected $collection_key = 'applicationDataTransfers';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $applicationDataTransfersType = 'Google_Service_DataTransfer_ApplicationDataTransfer';
+  protected $applicationDataTransfersDataType = 'array';
+  public $etag;
+  public $id;
+  public $kind;
+  public $newOwnerUserId;
+  public $oldOwnerUserId;
+  public $overallTransferStatusCode;
+  public $requestTime;
+
+
+  public function setApplicationDataTransfers($applicationDataTransfers)
+  {
+    $this->applicationDataTransfers = $applicationDataTransfers;
+  }
+  public function getApplicationDataTransfers()
+  {
+    return $this->applicationDataTransfers;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNewOwnerUserId($newOwnerUserId)
+  {
+    $this->newOwnerUserId = $newOwnerUserId;
+  }
+  public function getNewOwnerUserId()
+  {
+    return $this->newOwnerUserId;
+  }
+  public function setOldOwnerUserId($oldOwnerUserId)
+  {
+    $this->oldOwnerUserId = $oldOwnerUserId;
+  }
+  public function getOldOwnerUserId()
+  {
+    return $this->oldOwnerUserId;
+  }
+  public function setOverallTransferStatusCode($overallTransferStatusCode)
+  {
+    $this->overallTransferStatusCode = $overallTransferStatusCode;
+  }
+  public function getOverallTransferStatusCode()
+  {
+    return $this->overallTransferStatusCode;
+  }
+  public function setRequestTime($requestTime)
+  {
+    $this->requestTime = $requestTime;
+  }
+  public function getRequestTime()
+  {
+    return $this->requestTime;
+  }
+}
+
+class Google_Service_DataTransfer_DataTransfersListResponse extends Google_Collection
+{
+  protected $collection_key = 'dataTransfers';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $dataTransfersType = 'Google_Service_DataTransfer_DataTransfer';
+  protected $dataTransfersDataType = 'array';
+  public $etag;
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setDataTransfers($dataTransfers)
+  {
+    $this->dataTransfers = $dataTransfers;
+  }
+  public function getDataTransfers()
+  {
+    return $this->dataTransfers;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Dataflow.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Dataflow.php
@@ -1,0 +1,3708 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Dataflow (v1b3).
+ *
+ * <p>
+ * Google Dataflow API.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://cloud.google.com/dataflow" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Dataflow extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+  /** View your email address. */
+  const USERINFO_EMAIL =
+      "https://www.googleapis.com/auth/userinfo.email";
+
+  public $projects_jobs;
+  public $projects_jobs_messages;
+  public $projects_jobs_workItems;
+  
+
+  /**
+   * Constructs the internal representation of the Dataflow service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://dataflow.googleapis.com/';
+    $this->servicePath = '';
+    $this->version = 'v1b3';
+    $this->serviceName = 'dataflow';
+
+    $this->projects_jobs = new Google_Service_Dataflow_ProjectsJobs_Resource(
+        $this,
+        $this->serviceName,
+        'jobs',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'v1b3/projects/{projectId}/jobs',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'replaceJobId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v1b3/projects/{projectId}/jobs/{jobId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'getMetrics' => array(
+              'path' => 'v1b3/projects/{projectId}/jobs/{jobId}/metrics',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'startTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1b3/projects/{projectId}/jobs',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'v1b3/projects/{projectId}/jobs/{jobId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->projects_jobs_messages = new Google_Service_Dataflow_ProjectsJobsMessages_Resource(
+        $this,
+        $this->serviceName,
+        'messages',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'v1b3/projects/{projectId}/jobs/{jobId}/messages',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'endTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'minimumImportance' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->projects_jobs_workItems = new Google_Service_Dataflow_ProjectsJobsWorkItems_Resource(
+        $this,
+        $this->serviceName,
+        'workItems',
+        array(
+          'methods' => array(
+            'lease' => array(
+              'path' => 'v1b3/projects/{projectId}/jobs/{jobId}/workItems:lease',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'reportStatus' => array(
+              'path' => 'v1b3/projects/{projectId}/jobs/{jobId}/workItems:reportStatus',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "projects" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dataflowService = new Google_Service_Dataflow(...);
+ *   $projects = $dataflowService->projects;
+ *  </code>
+ */
+class Google_Service_Dataflow_Projects_Resource extends Google_Service_Resource
+{
+}
+
+/**
+ * The "jobs" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dataflowService = new Google_Service_Dataflow(...);
+ *   $jobs = $dataflowService->jobs;
+ *  </code>
+ */
+class Google_Service_Dataflow_ProjectsJobs_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a dataflow job. (jobs.create)
+   *
+   * @param string $projectId The project which owns the job.
+   * @param Google_Job $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string replaceJobId DEPRECATED. This field is now on the Job
+   * message.
+   * @opt_param string view Level of information requested in response.
+   * @return Google_Service_Dataflow_Job
+   */
+  public function create($projectId, Google_Service_Dataflow_Job $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Dataflow_Job");
+  }
+
+  /**
+   * Gets the state of the specified dataflow job. (jobs.get)
+   *
+   * @param string $projectId The project which owns the job.
+   * @param string $jobId Identifies a single job.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string view Level of information requested in response.
+   * @return Google_Service_Dataflow_Job
+   */
+  public function get($projectId, $jobId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'jobId' => $jobId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dataflow_Job");
+  }
+
+  /**
+   * Request the job status. (jobs.getMetrics)
+   *
+   * @param string $projectId A project id.
+   * @param string $jobId The job to get messages for.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string startTime Return only metric data that has changed since
+   * this time. Default is to return all information about all metrics for the
+   * job.
+   * @return Google_Service_Dataflow_JobMetrics
+   */
+  public function getMetrics($projectId, $jobId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'jobId' => $jobId);
+    $params = array_merge($params, $optParams);
+    return $this->call('getMetrics', array($params), "Google_Service_Dataflow_JobMetrics");
+  }
+
+  /**
+   * List the jobs of a project (jobs.listProjectsJobs)
+   *
+   * @param string $projectId The project which owns the jobs.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Set this to the 'next_page_token' field of a
+   * previous response to request additional results in a long list.
+   * @opt_param int pageSize If there are many jobs, limit response to at most
+   * this many. The actual number of jobs returned will be the lesser of
+   * max_responses and an unspecified server-defined limit.
+   * @opt_param string view Level of information requested in response. Default is
+   * SUMMARY.
+   * @return Google_Service_Dataflow_ListJobsResponse
+   */
+  public function listProjectsJobs($projectId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dataflow_ListJobsResponse");
+  }
+
+  /**
+   * Updates the state of an existing dataflow job. (jobs.update)
+   *
+   * @param string $projectId The project which owns the job.
+   * @param string $jobId Identifies a single job.
+   * @param Google_Job $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dataflow_Job
+   */
+  public function update($projectId, $jobId, Google_Service_Dataflow_Job $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'jobId' => $jobId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dataflow_Job");
+  }
+}
+
+/**
+ * The "messages" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dataflowService = new Google_Service_Dataflow(...);
+ *   $messages = $dataflowService->messages;
+ *  </code>
+ */
+class Google_Service_Dataflow_ProjectsJobsMessages_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Request the job status. (messages.listProjectsJobsMessages)
+   *
+   * @param string $projectId A project id.
+   * @param string $jobId The job to get messages about.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int pageSize If specified, determines the maximum number of
+   * messages to return. If unspecified, the service may choose an appropriate
+   * default, or may return an arbitrarily large number of results.
+   * @opt_param string pageToken If supplied, this should be the value of
+   * next_page_token returned by an earlier call. This will cause the next page of
+   * results to be returned.
+   * @opt_param string startTime If specified, return only messages with
+   * timestamps >= start_time. The default is the job creation time (i.e.
+   * beginning of messages).
+   * @opt_param string endTime Return only messages with timestamps < end_time.
+   * The default is now (i.e. return up to the latest messages available).
+   * @opt_param string minimumImportance Filter to only get messages with
+   * importance >= level
+   * @return Google_Service_Dataflow_ListJobMessagesResponse
+   */
+  public function listProjectsJobsMessages($projectId, $jobId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'jobId' => $jobId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dataflow_ListJobMessagesResponse");
+  }
+}
+/**
+ * The "workItems" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dataflowService = new Google_Service_Dataflow(...);
+ *   $workItems = $dataflowService->workItems;
+ *  </code>
+ */
+class Google_Service_Dataflow_ProjectsJobsWorkItems_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Leases a dataflow WorkItem to run. (workItems.lease)
+   *
+   * @param string $projectId Identifies the project this worker belongs to.
+   * @param string $jobId Identifies the workflow job this worker belongs to.
+   * @param Google_LeaseWorkItemRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dataflow_LeaseWorkItemResponse
+   */
+  public function lease($projectId, $jobId, Google_Service_Dataflow_LeaseWorkItemRequest $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'jobId' => $jobId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('lease', array($params), "Google_Service_Dataflow_LeaseWorkItemResponse");
+  }
+
+  /**
+   * Reports the status of dataflow WorkItems leased by a worker.
+   * (workItems.reportStatus)
+   *
+   * @param string $projectId The project which owns the WorkItem's job.
+   * @param string $jobId The job which the WorkItem is part of.
+   * @param Google_ReportWorkItemStatusRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dataflow_ReportWorkItemStatusResponse
+   */
+  public function reportStatus($projectId, $jobId, Google_Service_Dataflow_ReportWorkItemStatusRequest $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'jobId' => $jobId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('reportStatus', array($params), "Google_Service_Dataflow_ReportWorkItemStatusResponse");
+  }
+}
+
+
+
+
+class Google_Service_Dataflow_ApproximateProgress extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $percentComplete;
+  protected $positionType = 'Google_Service_Dataflow_Position';
+  protected $positionDataType = '';
+  public $remainingTime;
+
+
+  public function setPercentComplete($percentComplete)
+  {
+    $this->percentComplete = $percentComplete;
+  }
+  public function getPercentComplete()
+  {
+    return $this->percentComplete;
+  }
+  public function setPosition(Google_Service_Dataflow_Position $position)
+  {
+    $this->position = $position;
+  }
+  public function getPosition()
+  {
+    return $this->position;
+  }
+  public function setRemainingTime($remainingTime)
+  {
+    $this->remainingTime = $remainingTime;
+  }
+  public function getRemainingTime()
+  {
+    return $this->remainingTime;
+  }
+}
+
+class Google_Service_Dataflow_AutoscalingSettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $algorithm;
+  public $maxNumWorkers;
+
+
+  public function setAlgorithm($algorithm)
+  {
+    $this->algorithm = $algorithm;
+  }
+  public function getAlgorithm()
+  {
+    return $this->algorithm;
+  }
+  public function setMaxNumWorkers($maxNumWorkers)
+  {
+    $this->maxNumWorkers = $maxNumWorkers;
+  }
+  public function getMaxNumWorkers()
+  {
+    return $this->maxNumWorkers;
+  }
+}
+
+class Google_Service_Dataflow_ComputationTopology extends Google_Collection
+{
+  protected $collection_key = 'stateFamilies';
+  protected $internal_gapi_mappings = array(
+  );
+  public $computationId;
+  protected $inputsType = 'Google_Service_Dataflow_StreamLocation';
+  protected $inputsDataType = 'array';
+  protected $keyRangesType = 'Google_Service_Dataflow_KeyRangeLocation';
+  protected $keyRangesDataType = 'array';
+  protected $outputsType = 'Google_Service_Dataflow_StreamLocation';
+  protected $outputsDataType = 'array';
+  protected $stateFamiliesType = 'Google_Service_Dataflow_StateFamilyConfig';
+  protected $stateFamiliesDataType = 'array';
+  public $systemStageName;
+  public $userStageName;
+
+
+  public function setComputationId($computationId)
+  {
+    $this->computationId = $computationId;
+  }
+  public function getComputationId()
+  {
+    return $this->computationId;
+  }
+  public function setInputs($inputs)
+  {
+    $this->inputs = $inputs;
+  }
+  public function getInputs()
+  {
+    return $this->inputs;
+  }
+  public function setKeyRanges($keyRanges)
+  {
+    $this->keyRanges = $keyRanges;
+  }
+  public function getKeyRanges()
+  {
+    return $this->keyRanges;
+  }
+  public function setOutputs($outputs)
+  {
+    $this->outputs = $outputs;
+  }
+  public function getOutputs()
+  {
+    return $this->outputs;
+  }
+  public function setStateFamilies($stateFamilies)
+  {
+    $this->stateFamilies = $stateFamilies;
+  }
+  public function getStateFamilies()
+  {
+    return $this->stateFamilies;
+  }
+  public function setSystemStageName($systemStageName)
+  {
+    $this->systemStageName = $systemStageName;
+  }
+  public function getSystemStageName()
+  {
+    return $this->systemStageName;
+  }
+  public function setUserStageName($userStageName)
+  {
+    $this->userStageName = $userStageName;
+  }
+  public function getUserStageName()
+  {
+    return $this->userStageName;
+  }
+}
+
+class Google_Service_Dataflow_ConcatPosition extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $index;
+  protected $positionType = 'Google_Service_Dataflow_Position';
+  protected $positionDataType = '';
+
+
+  public function setIndex($index)
+  {
+    $this->index = $index;
+  }
+  public function getIndex()
+  {
+    return $this->index;
+  }
+  public function setPosition(Google_Service_Dataflow_Position $position)
+  {
+    $this->position = $position;
+  }
+  public function getPosition()
+  {
+    return $this->position;
+  }
+}
+
+class Google_Service_Dataflow_CustomSourceLocation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $stateful;
+
+
+  public function setStateful($stateful)
+  {
+    $this->stateful = $stateful;
+  }
+  public function getStateful()
+  {
+    return $this->stateful;
+  }
+}
+
+class Google_Service_Dataflow_DataDiskAssignment extends Google_Collection
+{
+  protected $collection_key = 'dataDisks';
+  protected $internal_gapi_mappings = array(
+  );
+  public $dataDisks;
+  public $vmInstance;
+
+
+  public function setDataDisks($dataDisks)
+  {
+    $this->dataDisks = $dataDisks;
+  }
+  public function getDataDisks()
+  {
+    return $this->dataDisks;
+  }
+  public function setVmInstance($vmInstance)
+  {
+    $this->vmInstance = $vmInstance;
+  }
+  public function getVmInstance()
+  {
+    return $this->vmInstance;
+  }
+}
+
+class Google_Service_Dataflow_DerivedSource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $derivationMode;
+  protected $sourceType = 'Google_Service_Dataflow_Source';
+  protected $sourceDataType = '';
+
+
+  public function setDerivationMode($derivationMode)
+  {
+    $this->derivationMode = $derivationMode;
+  }
+  public function getDerivationMode()
+  {
+    return $this->derivationMode;
+  }
+  public function setSource(Google_Service_Dataflow_Source $source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+}
+
+class Google_Service_Dataflow_Disk extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $diskType;
+  public $mountPoint;
+  public $sizeGb;
+
+
+  public function setDiskType($diskType)
+  {
+    $this->diskType = $diskType;
+  }
+  public function getDiskType()
+  {
+    return $this->diskType;
+  }
+  public function setMountPoint($mountPoint)
+  {
+    $this->mountPoint = $mountPoint;
+  }
+  public function getMountPoint()
+  {
+    return $this->mountPoint;
+  }
+  public function setSizeGb($sizeGb)
+  {
+    $this->sizeGb = $sizeGb;
+  }
+  public function getSizeGb()
+  {
+    return $this->sizeGb;
+  }
+}
+
+class Google_Service_Dataflow_DynamicSourceSplit extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $primaryType = 'Google_Service_Dataflow_DerivedSource';
+  protected $primaryDataType = '';
+  protected $residualType = 'Google_Service_Dataflow_DerivedSource';
+  protected $residualDataType = '';
+
+
+  public function setPrimary(Google_Service_Dataflow_DerivedSource $primary)
+  {
+    $this->primary = $primary;
+  }
+  public function getPrimary()
+  {
+    return $this->primary;
+  }
+  public function setResidual(Google_Service_Dataflow_DerivedSource $residual)
+  {
+    $this->residual = $residual;
+  }
+  public function getResidual()
+  {
+    return $this->residual;
+  }
+}
+
+class Google_Service_Dataflow_Environment extends Google_Collection
+{
+  protected $collection_key = 'workerPools';
+  protected $internal_gapi_mappings = array(
+  );
+  public $clusterManagerApiService;
+  public $dataset;
+  public $experiments;
+  public $internalExperiments;
+  public $sdkPipelineOptions;
+  public $tempStoragePrefix;
+  public $userAgent;
+  public $version;
+  protected $workerPoolsType = 'Google_Service_Dataflow_WorkerPool';
+  protected $workerPoolsDataType = 'array';
+
+
+  public function setClusterManagerApiService($clusterManagerApiService)
+  {
+    $this->clusterManagerApiService = $clusterManagerApiService;
+  }
+  public function getClusterManagerApiService()
+  {
+    return $this->clusterManagerApiService;
+  }
+  public function setDataset($dataset)
+  {
+    $this->dataset = $dataset;
+  }
+  public function getDataset()
+  {
+    return $this->dataset;
+  }
+  public function setExperiments($experiments)
+  {
+    $this->experiments = $experiments;
+  }
+  public function getExperiments()
+  {
+    return $this->experiments;
+  }
+  public function setInternalExperiments($internalExperiments)
+  {
+    $this->internalExperiments = $internalExperiments;
+  }
+  public function getInternalExperiments()
+  {
+    return $this->internalExperiments;
+  }
+  public function setSdkPipelineOptions($sdkPipelineOptions)
+  {
+    $this->sdkPipelineOptions = $sdkPipelineOptions;
+  }
+  public function getSdkPipelineOptions()
+  {
+    return $this->sdkPipelineOptions;
+  }
+  public function setTempStoragePrefix($tempStoragePrefix)
+  {
+    $this->tempStoragePrefix = $tempStoragePrefix;
+  }
+  public function getTempStoragePrefix()
+  {
+    return $this->tempStoragePrefix;
+  }
+  public function setUserAgent($userAgent)
+  {
+    $this->userAgent = $userAgent;
+  }
+  public function getUserAgent()
+  {
+    return $this->userAgent;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+  public function setWorkerPools($workerPools)
+  {
+    $this->workerPools = $workerPools;
+  }
+  public function getWorkerPools()
+  {
+    return $this->workerPools;
+  }
+}
+
+class Google_Service_Dataflow_EnvironmentInternalExperiments extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_EnvironmentSdkPipelineOptions extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_EnvironmentUserAgent extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_EnvironmentVersion extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_FlattenInstruction extends Google_Collection
+{
+  protected $collection_key = 'inputs';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $inputsType = 'Google_Service_Dataflow_InstructionInput';
+  protected $inputsDataType = 'array';
+
+
+  public function setInputs($inputs)
+  {
+    $this->inputs = $inputs;
+  }
+  public function getInputs()
+  {
+    return $this->inputs;
+  }
+}
+
+class Google_Service_Dataflow_InstructionInput extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $outputNum;
+  public $producerInstructionIndex;
+
+
+  public function setOutputNum($outputNum)
+  {
+    $this->outputNum = $outputNum;
+  }
+  public function getOutputNum()
+  {
+    return $this->outputNum;
+  }
+  public function setProducerInstructionIndex($producerInstructionIndex)
+  {
+    $this->producerInstructionIndex = $producerInstructionIndex;
+  }
+  public function getProducerInstructionIndex()
+  {
+    return $this->producerInstructionIndex;
+  }
+}
+
+class Google_Service_Dataflow_InstructionOutput extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $codec;
+  public $name;
+  public $systemName;
+
+
+  public function setCodec($codec)
+  {
+    $this->codec = $codec;
+  }
+  public function getCodec()
+  {
+    return $this->codec;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSystemName($systemName)
+  {
+    $this->systemName = $systemName;
+  }
+  public function getSystemName()
+  {
+    return $this->systemName;
+  }
+}
+
+class Google_Service_Dataflow_InstructionOutputCodec extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_Job extends Google_Collection
+{
+  protected $collection_key = 'steps';
+  protected $internal_gapi_mappings = array(
+  );
+  public $clientRequestId;
+  public $createTime;
+  public $currentState;
+  public $currentStateTime;
+  protected $environmentType = 'Google_Service_Dataflow_Environment';
+  protected $environmentDataType = '';
+  protected $executionInfoType = 'Google_Service_Dataflow_JobExecutionInfo';
+  protected $executionInfoDataType = '';
+  public $id;
+  public $name;
+  public $projectId;
+  public $replaceJobId;
+  public $replacedByJobId;
+  public $requestedState;
+  protected $stepsType = 'Google_Service_Dataflow_Step';
+  protected $stepsDataType = 'array';
+  public $transformNameMapping;
+  public $type;
+
+
+  public function setClientRequestId($clientRequestId)
+  {
+    $this->clientRequestId = $clientRequestId;
+  }
+  public function getClientRequestId()
+  {
+    return $this->clientRequestId;
+  }
+  public function setCreateTime($createTime)
+  {
+    $this->createTime = $createTime;
+  }
+  public function getCreateTime()
+  {
+    return $this->createTime;
+  }
+  public function setCurrentState($currentState)
+  {
+    $this->currentState = $currentState;
+  }
+  public function getCurrentState()
+  {
+    return $this->currentState;
+  }
+  public function setCurrentStateTime($currentStateTime)
+  {
+    $this->currentStateTime = $currentStateTime;
+  }
+  public function getCurrentStateTime()
+  {
+    return $this->currentStateTime;
+  }
+  public function setEnvironment(Google_Service_Dataflow_Environment $environment)
+  {
+    $this->environment = $environment;
+  }
+  public function getEnvironment()
+  {
+    return $this->environment;
+  }
+  public function setExecutionInfo(Google_Service_Dataflow_JobExecutionInfo $executionInfo)
+  {
+    $this->executionInfo = $executionInfo;
+  }
+  public function getExecutionInfo()
+  {
+    return $this->executionInfo;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setReplaceJobId($replaceJobId)
+  {
+    $this->replaceJobId = $replaceJobId;
+  }
+  public function getReplaceJobId()
+  {
+    return $this->replaceJobId;
+  }
+  public function setReplacedByJobId($replacedByJobId)
+  {
+    $this->replacedByJobId = $replacedByJobId;
+  }
+  public function getReplacedByJobId()
+  {
+    return $this->replacedByJobId;
+  }
+  public function setRequestedState($requestedState)
+  {
+    $this->requestedState = $requestedState;
+  }
+  public function getRequestedState()
+  {
+    return $this->requestedState;
+  }
+  public function setSteps($steps)
+  {
+    $this->steps = $steps;
+  }
+  public function getSteps()
+  {
+    return $this->steps;
+  }
+  public function setTransformNameMapping($transformNameMapping)
+  {
+    $this->transformNameMapping = $transformNameMapping;
+  }
+  public function getTransformNameMapping()
+  {
+    return $this->transformNameMapping;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Dataflow_JobExecutionInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $stagesType = 'Google_Service_Dataflow_JobExecutionStageInfo';
+  protected $stagesDataType = 'map';
+
+
+  public function setStages($stages)
+  {
+    $this->stages = $stages;
+  }
+  public function getStages()
+  {
+    return $this->stages;
+  }
+}
+
+class Google_Service_Dataflow_JobExecutionInfoStages extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_JobExecutionStageInfo extends Google_Collection
+{
+  protected $collection_key = 'stepName';
+  protected $internal_gapi_mappings = array(
+  );
+  public $stepName;
+
+
+  public function setStepName($stepName)
+  {
+    $this->stepName = $stepName;
+  }
+  public function getStepName()
+  {
+    return $this->stepName;
+  }
+}
+
+class Google_Service_Dataflow_JobMessage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $messageImportance;
+  public $messageText;
+  public $time;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setMessageImportance($messageImportance)
+  {
+    $this->messageImportance = $messageImportance;
+  }
+  public function getMessageImportance()
+  {
+    return $this->messageImportance;
+  }
+  public function setMessageText($messageText)
+  {
+    $this->messageText = $messageText;
+  }
+  public function getMessageText()
+  {
+    return $this->messageText;
+  }
+  public function setTime($time)
+  {
+    $this->time = $time;
+  }
+  public function getTime()
+  {
+    return $this->time;
+  }
+}
+
+class Google_Service_Dataflow_JobMetrics extends Google_Collection
+{
+  protected $collection_key = 'metrics';
+  protected $internal_gapi_mappings = array(
+  );
+  public $metricTime;
+  protected $metricsType = 'Google_Service_Dataflow_MetricUpdate';
+  protected $metricsDataType = 'array';
+
+
+  public function setMetricTime($metricTime)
+  {
+    $this->metricTime = $metricTime;
+  }
+  public function getMetricTime()
+  {
+    return $this->metricTime;
+  }
+  public function setMetrics($metrics)
+  {
+    $this->metrics = $metrics;
+  }
+  public function getMetrics()
+  {
+    return $this->metrics;
+  }
+}
+
+class Google_Service_Dataflow_JobTransformNameMapping extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_KeyRangeDataDiskAssignment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $dataDisk;
+  public $end;
+  public $start;
+
+
+  public function setDataDisk($dataDisk)
+  {
+    $this->dataDisk = $dataDisk;
+  }
+  public function getDataDisk()
+  {
+    return $this->dataDisk;
+  }
+  public function setEnd($end)
+  {
+    $this->end = $end;
+  }
+  public function getEnd()
+  {
+    return $this->end;
+  }
+  public function setStart($start)
+  {
+    $this->start = $start;
+  }
+  public function getStart()
+  {
+    return $this->start;
+  }
+}
+
+class Google_Service_Dataflow_KeyRangeLocation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $dataDisk;
+  public $deliveryEndpoint;
+  public $end;
+  public $persistentDirectory;
+  public $start;
+
+
+  public function setDataDisk($dataDisk)
+  {
+    $this->dataDisk = $dataDisk;
+  }
+  public function getDataDisk()
+  {
+    return $this->dataDisk;
+  }
+  public function setDeliveryEndpoint($deliveryEndpoint)
+  {
+    $this->deliveryEndpoint = $deliveryEndpoint;
+  }
+  public function getDeliveryEndpoint()
+  {
+    return $this->deliveryEndpoint;
+  }
+  public function setEnd($end)
+  {
+    $this->end = $end;
+  }
+  public function getEnd()
+  {
+    return $this->end;
+  }
+  public function setPersistentDirectory($persistentDirectory)
+  {
+    $this->persistentDirectory = $persistentDirectory;
+  }
+  public function getPersistentDirectory()
+  {
+    return $this->persistentDirectory;
+  }
+  public function setStart($start)
+  {
+    $this->start = $start;
+  }
+  public function getStart()
+  {
+    return $this->start;
+  }
+}
+
+class Google_Service_Dataflow_LeaseWorkItemRequest extends Google_Collection
+{
+  protected $collection_key = 'workerCapabilities';
+  protected $internal_gapi_mappings = array(
+  );
+  public $currentWorkerTime;
+  public $requestedLeaseDuration;
+  public $workItemTypes;
+  public $workerCapabilities;
+  public $workerId;
+
+
+  public function setCurrentWorkerTime($currentWorkerTime)
+  {
+    $this->currentWorkerTime = $currentWorkerTime;
+  }
+  public function getCurrentWorkerTime()
+  {
+    return $this->currentWorkerTime;
+  }
+  public function setRequestedLeaseDuration($requestedLeaseDuration)
+  {
+    $this->requestedLeaseDuration = $requestedLeaseDuration;
+  }
+  public function getRequestedLeaseDuration()
+  {
+    return $this->requestedLeaseDuration;
+  }
+  public function setWorkItemTypes($workItemTypes)
+  {
+    $this->workItemTypes = $workItemTypes;
+  }
+  public function getWorkItemTypes()
+  {
+    return $this->workItemTypes;
+  }
+  public function setWorkerCapabilities($workerCapabilities)
+  {
+    $this->workerCapabilities = $workerCapabilities;
+  }
+  public function getWorkerCapabilities()
+  {
+    return $this->workerCapabilities;
+  }
+  public function setWorkerId($workerId)
+  {
+    $this->workerId = $workerId;
+  }
+  public function getWorkerId()
+  {
+    return $this->workerId;
+  }
+}
+
+class Google_Service_Dataflow_LeaseWorkItemResponse extends Google_Collection
+{
+  protected $collection_key = 'workItems';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $workItemsType = 'Google_Service_Dataflow_WorkItem';
+  protected $workItemsDataType = 'array';
+
+
+  public function setWorkItems($workItems)
+  {
+    $this->workItems = $workItems;
+  }
+  public function getWorkItems()
+  {
+    return $this->workItems;
+  }
+}
+
+class Google_Service_Dataflow_ListJobMessagesResponse extends Google_Collection
+{
+  protected $collection_key = 'jobMessages';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $jobMessagesType = 'Google_Service_Dataflow_JobMessage';
+  protected $jobMessagesDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setJobMessages($jobMessages)
+  {
+    $this->jobMessages = $jobMessages;
+  }
+  public function getJobMessages()
+  {
+    return $this->jobMessages;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dataflow_ListJobsResponse extends Google_Collection
+{
+  protected $collection_key = 'jobs';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $jobsType = 'Google_Service_Dataflow_Job';
+  protected $jobsDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setJobs($jobs)
+  {
+    $this->jobs = $jobs;
+  }
+  public function getJobs()
+  {
+    return $this->jobs;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dataflow_MapTask extends Google_Collection
+{
+  protected $collection_key = 'instructions';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $instructionsType = 'Google_Service_Dataflow_ParallelInstruction';
+  protected $instructionsDataType = 'array';
+  public $stageName;
+  public $systemName;
+
+
+  public function setInstructions($instructions)
+  {
+    $this->instructions = $instructions;
+  }
+  public function getInstructions()
+  {
+    return $this->instructions;
+  }
+  public function setStageName($stageName)
+  {
+    $this->stageName = $stageName;
+  }
+  public function getStageName()
+  {
+    return $this->stageName;
+  }
+  public function setSystemName($systemName)
+  {
+    $this->systemName = $systemName;
+  }
+  public function getSystemName()
+  {
+    return $this->systemName;
+  }
+}
+
+class Google_Service_Dataflow_MetricStructuredName extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $context;
+  public $name;
+  public $origin;
+
+
+  public function setContext($context)
+  {
+    $this->context = $context;
+  }
+  public function getContext()
+  {
+    return $this->context;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOrigin($origin)
+  {
+    $this->origin = $origin;
+  }
+  public function getOrigin()
+  {
+    return $this->origin;
+  }
+}
+
+class Google_Service_Dataflow_MetricStructuredNameContext extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_MetricUpdate extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $cumulative;
+  public $internal;
+  public $kind;
+  public $meanCount;
+  public $meanSum;
+  protected $nameType = 'Google_Service_Dataflow_MetricStructuredName';
+  protected $nameDataType = '';
+  public $scalar;
+  public $set;
+  public $updateTime;
+
+
+  public function setCumulative($cumulative)
+  {
+    $this->cumulative = $cumulative;
+  }
+  public function getCumulative()
+  {
+    return $this->cumulative;
+  }
+  public function setInternal($internal)
+  {
+    $this->internal = $internal;
+  }
+  public function getInternal()
+  {
+    return $this->internal;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMeanCount($meanCount)
+  {
+    $this->meanCount = $meanCount;
+  }
+  public function getMeanCount()
+  {
+    return $this->meanCount;
+  }
+  public function setMeanSum($meanSum)
+  {
+    $this->meanSum = $meanSum;
+  }
+  public function getMeanSum()
+  {
+    return $this->meanSum;
+  }
+  public function setName(Google_Service_Dataflow_MetricStructuredName $name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setScalar($scalar)
+  {
+    $this->scalar = $scalar;
+  }
+  public function getScalar()
+  {
+    return $this->scalar;
+  }
+  public function setSet($set)
+  {
+    $this->set = $set;
+  }
+  public function getSet()
+  {
+    return $this->set;
+  }
+  public function setUpdateTime($updateTime)
+  {
+    $this->updateTime = $updateTime;
+  }
+  public function getUpdateTime()
+  {
+    return $this->updateTime;
+  }
+}
+
+class Google_Service_Dataflow_MountedDataDisk extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $dataDisk;
+
+
+  public function setDataDisk($dataDisk)
+  {
+    $this->dataDisk = $dataDisk;
+  }
+  public function getDataDisk()
+  {
+    return $this->dataDisk;
+  }
+}
+
+class Google_Service_Dataflow_MultiOutputInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $tag;
+
+
+  public function setTag($tag)
+  {
+    $this->tag = $tag;
+  }
+  public function getTag()
+  {
+    return $this->tag;
+  }
+}
+
+class Google_Service_Dataflow_Package extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $location;
+  public $name;
+
+
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Dataflow_ParDoInstruction extends Google_Collection
+{
+  protected $collection_key = 'sideInputs';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $inputType = 'Google_Service_Dataflow_InstructionInput';
+  protected $inputDataType = '';
+  protected $multiOutputInfosType = 'Google_Service_Dataflow_MultiOutputInfo';
+  protected $multiOutputInfosDataType = 'array';
+  public $numOutputs;
+  protected $sideInputsType = 'Google_Service_Dataflow_SideInputInfo';
+  protected $sideInputsDataType = 'array';
+  public $userFn;
+
+
+  public function setInput(Google_Service_Dataflow_InstructionInput $input)
+  {
+    $this->input = $input;
+  }
+  public function getInput()
+  {
+    return $this->input;
+  }
+  public function setMultiOutputInfos($multiOutputInfos)
+  {
+    $this->multiOutputInfos = $multiOutputInfos;
+  }
+  public function getMultiOutputInfos()
+  {
+    return $this->multiOutputInfos;
+  }
+  public function setNumOutputs($numOutputs)
+  {
+    $this->numOutputs = $numOutputs;
+  }
+  public function getNumOutputs()
+  {
+    return $this->numOutputs;
+  }
+  public function setSideInputs($sideInputs)
+  {
+    $this->sideInputs = $sideInputs;
+  }
+  public function getSideInputs()
+  {
+    return $this->sideInputs;
+  }
+  public function setUserFn($userFn)
+  {
+    $this->userFn = $userFn;
+  }
+  public function getUserFn()
+  {
+    return $this->userFn;
+  }
+}
+
+class Google_Service_Dataflow_ParDoInstructionUserFn extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_ParallelInstruction extends Google_Collection
+{
+  protected $collection_key = 'outputs';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $flattenType = 'Google_Service_Dataflow_FlattenInstruction';
+  protected $flattenDataType = '';
+  public $name;
+  protected $outputsType = 'Google_Service_Dataflow_InstructionOutput';
+  protected $outputsDataType = 'array';
+  protected $parDoType = 'Google_Service_Dataflow_ParDoInstruction';
+  protected $parDoDataType = '';
+  protected $partialGroupByKeyType = 'Google_Service_Dataflow_PartialGroupByKeyInstruction';
+  protected $partialGroupByKeyDataType = '';
+  protected $readType = 'Google_Service_Dataflow_ReadInstruction';
+  protected $readDataType = '';
+  public $systemName;
+  protected $writeType = 'Google_Service_Dataflow_WriteInstruction';
+  protected $writeDataType = '';
+
+
+  public function setFlatten(Google_Service_Dataflow_FlattenInstruction $flatten)
+  {
+    $this->flatten = $flatten;
+  }
+  public function getFlatten()
+  {
+    return $this->flatten;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOutputs($outputs)
+  {
+    $this->outputs = $outputs;
+  }
+  public function getOutputs()
+  {
+    return $this->outputs;
+  }
+  public function setParDo(Google_Service_Dataflow_ParDoInstruction $parDo)
+  {
+    $this->parDo = $parDo;
+  }
+  public function getParDo()
+  {
+    return $this->parDo;
+  }
+  public function setPartialGroupByKey(Google_Service_Dataflow_PartialGroupByKeyInstruction $partialGroupByKey)
+  {
+    $this->partialGroupByKey = $partialGroupByKey;
+  }
+  public function getPartialGroupByKey()
+  {
+    return $this->partialGroupByKey;
+  }
+  public function setRead(Google_Service_Dataflow_ReadInstruction $read)
+  {
+    $this->read = $read;
+  }
+  public function getRead()
+  {
+    return $this->read;
+  }
+  public function setSystemName($systemName)
+  {
+    $this->systemName = $systemName;
+  }
+  public function getSystemName()
+  {
+    return $this->systemName;
+  }
+  public function setWrite(Google_Service_Dataflow_WriteInstruction $write)
+  {
+    $this->write = $write;
+  }
+  public function getWrite()
+  {
+    return $this->write;
+  }
+}
+
+class Google_Service_Dataflow_PartialGroupByKeyInstruction extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $inputType = 'Google_Service_Dataflow_InstructionInput';
+  protected $inputDataType = '';
+  public $inputElementCodec;
+  public $valueCombiningFn;
+
+
+  public function setInput(Google_Service_Dataflow_InstructionInput $input)
+  {
+    $this->input = $input;
+  }
+  public function getInput()
+  {
+    return $this->input;
+  }
+  public function setInputElementCodec($inputElementCodec)
+  {
+    $this->inputElementCodec = $inputElementCodec;
+  }
+  public function getInputElementCodec()
+  {
+    return $this->inputElementCodec;
+  }
+  public function setValueCombiningFn($valueCombiningFn)
+  {
+    $this->valueCombiningFn = $valueCombiningFn;
+  }
+  public function getValueCombiningFn()
+  {
+    return $this->valueCombiningFn;
+  }
+}
+
+class Google_Service_Dataflow_PartialGroupByKeyInstructionInputElementCodec extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_PartialGroupByKeyInstructionValueCombiningFn extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_Position extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $byteOffset;
+  protected $concatPositionType = 'Google_Service_Dataflow_ConcatPosition';
+  protected $concatPositionDataType = '';
+  public $end;
+  public $key;
+  public $recordIndex;
+  public $shufflePosition;
+
+
+  public function setByteOffset($byteOffset)
+  {
+    $this->byteOffset = $byteOffset;
+  }
+  public function getByteOffset()
+  {
+    return $this->byteOffset;
+  }
+  public function setConcatPosition(Google_Service_Dataflow_ConcatPosition $concatPosition)
+  {
+    $this->concatPosition = $concatPosition;
+  }
+  public function getConcatPosition()
+  {
+    return $this->concatPosition;
+  }
+  public function setEnd($end)
+  {
+    $this->end = $end;
+  }
+  public function getEnd()
+  {
+    return $this->end;
+  }
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setRecordIndex($recordIndex)
+  {
+    $this->recordIndex = $recordIndex;
+  }
+  public function getRecordIndex()
+  {
+    return $this->recordIndex;
+  }
+  public function setShufflePosition($shufflePosition)
+  {
+    $this->shufflePosition = $shufflePosition;
+  }
+  public function getShufflePosition()
+  {
+    return $this->shufflePosition;
+  }
+}
+
+class Google_Service_Dataflow_PubsubLocation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $dropLateData;
+  public $idLabel;
+  public $subscription;
+  public $timestampLabel;
+  public $topic;
+  public $trackingSubscription;
+
+
+  public function setDropLateData($dropLateData)
+  {
+    $this->dropLateData = $dropLateData;
+  }
+  public function getDropLateData()
+  {
+    return $this->dropLateData;
+  }
+  public function setIdLabel($idLabel)
+  {
+    $this->idLabel = $idLabel;
+  }
+  public function getIdLabel()
+  {
+    return $this->idLabel;
+  }
+  public function setSubscription($subscription)
+  {
+    $this->subscription = $subscription;
+  }
+  public function getSubscription()
+  {
+    return $this->subscription;
+  }
+  public function setTimestampLabel($timestampLabel)
+  {
+    $this->timestampLabel = $timestampLabel;
+  }
+  public function getTimestampLabel()
+  {
+    return $this->timestampLabel;
+  }
+  public function setTopic($topic)
+  {
+    $this->topic = $topic;
+  }
+  public function getTopic()
+  {
+    return $this->topic;
+  }
+  public function setTrackingSubscription($trackingSubscription)
+  {
+    $this->trackingSubscription = $trackingSubscription;
+  }
+  public function getTrackingSubscription()
+  {
+    return $this->trackingSubscription;
+  }
+}
+
+class Google_Service_Dataflow_ReadInstruction extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $sourceType = 'Google_Service_Dataflow_Source';
+  protected $sourceDataType = '';
+
+
+  public function setSource(Google_Service_Dataflow_Source $source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+}
+
+class Google_Service_Dataflow_ReportWorkItemStatusRequest extends Google_Collection
+{
+  protected $collection_key = 'workItemStatuses';
+  protected $internal_gapi_mappings = array(
+  );
+  public $currentWorkerTime;
+  protected $workItemStatusesType = 'Google_Service_Dataflow_WorkItemStatus';
+  protected $workItemStatusesDataType = 'array';
+  public $workerId;
+
+
+  public function setCurrentWorkerTime($currentWorkerTime)
+  {
+    $this->currentWorkerTime = $currentWorkerTime;
+  }
+  public function getCurrentWorkerTime()
+  {
+    return $this->currentWorkerTime;
+  }
+  public function setWorkItemStatuses($workItemStatuses)
+  {
+    $this->workItemStatuses = $workItemStatuses;
+  }
+  public function getWorkItemStatuses()
+  {
+    return $this->workItemStatuses;
+  }
+  public function setWorkerId($workerId)
+  {
+    $this->workerId = $workerId;
+  }
+  public function getWorkerId()
+  {
+    return $this->workerId;
+  }
+}
+
+class Google_Service_Dataflow_ReportWorkItemStatusResponse extends Google_Collection
+{
+  protected $collection_key = 'workItemServiceStates';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $workItemServiceStatesType = 'Google_Service_Dataflow_WorkItemServiceState';
+  protected $workItemServiceStatesDataType = 'array';
+
+
+  public function setWorkItemServiceStates($workItemServiceStates)
+  {
+    $this->workItemServiceStates = $workItemServiceStates;
+  }
+  public function getWorkItemServiceStates()
+  {
+    return $this->workItemServiceStates;
+  }
+}
+
+class Google_Service_Dataflow_SeqMapTask extends Google_Collection
+{
+  protected $collection_key = 'outputInfos';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $inputsType = 'Google_Service_Dataflow_SideInputInfo';
+  protected $inputsDataType = 'array';
+  public $name;
+  protected $outputInfosType = 'Google_Service_Dataflow_SeqMapTaskOutputInfo';
+  protected $outputInfosDataType = 'array';
+  public $stageName;
+  public $systemName;
+  public $userFn;
+
+
+  public function setInputs($inputs)
+  {
+    $this->inputs = $inputs;
+  }
+  public function getInputs()
+  {
+    return $this->inputs;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOutputInfos($outputInfos)
+  {
+    $this->outputInfos = $outputInfos;
+  }
+  public function getOutputInfos()
+  {
+    return $this->outputInfos;
+  }
+  public function setStageName($stageName)
+  {
+    $this->stageName = $stageName;
+  }
+  public function getStageName()
+  {
+    return $this->stageName;
+  }
+  public function setSystemName($systemName)
+  {
+    $this->systemName = $systemName;
+  }
+  public function getSystemName()
+  {
+    return $this->systemName;
+  }
+  public function setUserFn($userFn)
+  {
+    $this->userFn = $userFn;
+  }
+  public function getUserFn()
+  {
+    return $this->userFn;
+  }
+}
+
+class Google_Service_Dataflow_SeqMapTaskOutputInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $sinkType = 'Google_Service_Dataflow_Sink';
+  protected $sinkDataType = '';
+  public $tag;
+
+
+  public function setSink(Google_Service_Dataflow_Sink $sink)
+  {
+    $this->sink = $sink;
+  }
+  public function getSink()
+  {
+    return $this->sink;
+  }
+  public function setTag($tag)
+  {
+    $this->tag = $tag;
+  }
+  public function getTag()
+  {
+    return $this->tag;
+  }
+}
+
+class Google_Service_Dataflow_SeqMapTaskUserFn extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_ShellTask extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $command;
+  public $exitCode;
+
+
+  public function setCommand($command)
+  {
+    $this->command = $command;
+  }
+  public function getCommand()
+  {
+    return $this->command;
+  }
+  public function setExitCode($exitCode)
+  {
+    $this->exitCode = $exitCode;
+  }
+  public function getExitCode()
+  {
+    return $this->exitCode;
+  }
+}
+
+class Google_Service_Dataflow_SideInputInfo extends Google_Collection
+{
+  protected $collection_key = 'sources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $sourcesType = 'Google_Service_Dataflow_Source';
+  protected $sourcesDataType = 'array';
+  public $tag;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSources($sources)
+  {
+    $this->sources = $sources;
+  }
+  public function getSources()
+  {
+    return $this->sources;
+  }
+  public function setTag($tag)
+  {
+    $this->tag = $tag;
+  }
+  public function getTag()
+  {
+    return $this->tag;
+  }
+}
+
+class Google_Service_Dataflow_SideInputInfoKind extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_Sink extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $codec;
+  public $spec;
+
+
+  public function setCodec($codec)
+  {
+    $this->codec = $codec;
+  }
+  public function getCodec()
+  {
+    return $this->codec;
+  }
+  public function setSpec($spec)
+  {
+    $this->spec = $spec;
+  }
+  public function getSpec()
+  {
+    return $this->spec;
+  }
+}
+
+class Google_Service_Dataflow_SinkCodec extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_SinkSpec extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_Source extends Google_Collection
+{
+  protected $collection_key = 'baseSpecs';
+  protected $internal_gapi_mappings = array(
+  );
+  public $baseSpecs;
+  public $codec;
+  public $doesNotNeedSplitting;
+  protected $metadataType = 'Google_Service_Dataflow_SourceMetadata';
+  protected $metadataDataType = '';
+  public $spec;
+
+
+  public function setBaseSpecs($baseSpecs)
+  {
+    $this->baseSpecs = $baseSpecs;
+  }
+  public function getBaseSpecs()
+  {
+    return $this->baseSpecs;
+  }
+  public function setCodec($codec)
+  {
+    $this->codec = $codec;
+  }
+  public function getCodec()
+  {
+    return $this->codec;
+  }
+  public function setDoesNotNeedSplitting($doesNotNeedSplitting)
+  {
+    $this->doesNotNeedSplitting = $doesNotNeedSplitting;
+  }
+  public function getDoesNotNeedSplitting()
+  {
+    return $this->doesNotNeedSplitting;
+  }
+  public function setMetadata(Google_Service_Dataflow_SourceMetadata $metadata)
+  {
+    $this->metadata = $metadata;
+  }
+  public function getMetadata()
+  {
+    return $this->metadata;
+  }
+  public function setSpec($spec)
+  {
+    $this->spec = $spec;
+  }
+  public function getSpec()
+  {
+    return $this->spec;
+  }
+}
+
+class Google_Service_Dataflow_SourceBaseSpecs extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_SourceCodec extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_SourceFork extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $primaryType = 'Google_Service_Dataflow_SourceSplitShard';
+  protected $primaryDataType = '';
+  protected $primarySourceType = 'Google_Service_Dataflow_DerivedSource';
+  protected $primarySourceDataType = '';
+  protected $residualType = 'Google_Service_Dataflow_SourceSplitShard';
+  protected $residualDataType = '';
+  protected $residualSourceType = 'Google_Service_Dataflow_DerivedSource';
+  protected $residualSourceDataType = '';
+
+
+  public function setPrimary(Google_Service_Dataflow_SourceSplitShard $primary)
+  {
+    $this->primary = $primary;
+  }
+  public function getPrimary()
+  {
+    return $this->primary;
+  }
+  public function setPrimarySource(Google_Service_Dataflow_DerivedSource $primarySource)
+  {
+    $this->primarySource = $primarySource;
+  }
+  public function getPrimarySource()
+  {
+    return $this->primarySource;
+  }
+  public function setResidual(Google_Service_Dataflow_SourceSplitShard $residual)
+  {
+    $this->residual = $residual;
+  }
+  public function getResidual()
+  {
+    return $this->residual;
+  }
+  public function setResidualSource(Google_Service_Dataflow_DerivedSource $residualSource)
+  {
+    $this->residualSource = $residualSource;
+  }
+  public function getResidualSource()
+  {
+    return $this->residualSource;
+  }
+}
+
+class Google_Service_Dataflow_SourceGetMetadataRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $sourceType = 'Google_Service_Dataflow_Source';
+  protected $sourceDataType = '';
+
+
+  public function setSource(Google_Service_Dataflow_Source $source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+}
+
+class Google_Service_Dataflow_SourceGetMetadataResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $metadataType = 'Google_Service_Dataflow_SourceMetadata';
+  protected $metadataDataType = '';
+
+
+  public function setMetadata(Google_Service_Dataflow_SourceMetadata $metadata)
+  {
+    $this->metadata = $metadata;
+  }
+  public function getMetadata()
+  {
+    return $this->metadata;
+  }
+}
+
+class Google_Service_Dataflow_SourceMetadata extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $estimatedSizeBytes;
+  public $infinite;
+  public $producesSortedKeys;
+
+
+  public function setEstimatedSizeBytes($estimatedSizeBytes)
+  {
+    $this->estimatedSizeBytes = $estimatedSizeBytes;
+  }
+  public function getEstimatedSizeBytes()
+  {
+    return $this->estimatedSizeBytes;
+  }
+  public function setInfinite($infinite)
+  {
+    $this->infinite = $infinite;
+  }
+  public function getInfinite()
+  {
+    return $this->infinite;
+  }
+  public function setProducesSortedKeys($producesSortedKeys)
+  {
+    $this->producesSortedKeys = $producesSortedKeys;
+  }
+  public function getProducesSortedKeys()
+  {
+    return $this->producesSortedKeys;
+  }
+}
+
+class Google_Service_Dataflow_SourceOperationRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $getMetadataType = 'Google_Service_Dataflow_SourceGetMetadataRequest';
+  protected $getMetadataDataType = '';
+  protected $splitType = 'Google_Service_Dataflow_SourceSplitRequest';
+  protected $splitDataType = '';
+
+
+  public function setGetMetadata(Google_Service_Dataflow_SourceGetMetadataRequest $getMetadata)
+  {
+    $this->getMetadata = $getMetadata;
+  }
+  public function getGetMetadata()
+  {
+    return $this->getMetadata;
+  }
+  public function setSplit(Google_Service_Dataflow_SourceSplitRequest $split)
+  {
+    $this->split = $split;
+  }
+  public function getSplit()
+  {
+    return $this->split;
+  }
+}
+
+class Google_Service_Dataflow_SourceOperationResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $getMetadataType = 'Google_Service_Dataflow_SourceGetMetadataResponse';
+  protected $getMetadataDataType = '';
+  protected $splitType = 'Google_Service_Dataflow_SourceSplitResponse';
+  protected $splitDataType = '';
+
+
+  public function setGetMetadata(Google_Service_Dataflow_SourceGetMetadataResponse $getMetadata)
+  {
+    $this->getMetadata = $getMetadata;
+  }
+  public function getGetMetadata()
+  {
+    return $this->getMetadata;
+  }
+  public function setSplit(Google_Service_Dataflow_SourceSplitResponse $split)
+  {
+    $this->split = $split;
+  }
+  public function getSplit()
+  {
+    return $this->split;
+  }
+}
+
+class Google_Service_Dataflow_SourceSpec extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_SourceSplitOptions extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $desiredBundleSizeBytes;
+  public $desiredShardSizeBytes;
+
+
+  public function setDesiredBundleSizeBytes($desiredBundleSizeBytes)
+  {
+    $this->desiredBundleSizeBytes = $desiredBundleSizeBytes;
+  }
+  public function getDesiredBundleSizeBytes()
+  {
+    return $this->desiredBundleSizeBytes;
+  }
+  public function setDesiredShardSizeBytes($desiredShardSizeBytes)
+  {
+    $this->desiredShardSizeBytes = $desiredShardSizeBytes;
+  }
+  public function getDesiredShardSizeBytes()
+  {
+    return $this->desiredShardSizeBytes;
+  }
+}
+
+class Google_Service_Dataflow_SourceSplitRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $optionsType = 'Google_Service_Dataflow_SourceSplitOptions';
+  protected $optionsDataType = '';
+  protected $sourceType = 'Google_Service_Dataflow_Source';
+  protected $sourceDataType = '';
+
+
+  public function setOptions(Google_Service_Dataflow_SourceSplitOptions $options)
+  {
+    $this->options = $options;
+  }
+  public function getOptions()
+  {
+    return $this->options;
+  }
+  public function setSource(Google_Service_Dataflow_Source $source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+}
+
+class Google_Service_Dataflow_SourceSplitResponse extends Google_Collection
+{
+  protected $collection_key = 'shards';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $bundlesType = 'Google_Service_Dataflow_DerivedSource';
+  protected $bundlesDataType = 'array';
+  public $outcome;
+  protected $shardsType = 'Google_Service_Dataflow_SourceSplitShard';
+  protected $shardsDataType = 'array';
+
+
+  public function setBundles($bundles)
+  {
+    $this->bundles = $bundles;
+  }
+  public function getBundles()
+  {
+    return $this->bundles;
+  }
+  public function setOutcome($outcome)
+  {
+    $this->outcome = $outcome;
+  }
+  public function getOutcome()
+  {
+    return $this->outcome;
+  }
+  public function setShards($shards)
+  {
+    $this->shards = $shards;
+  }
+  public function getShards()
+  {
+    return $this->shards;
+  }
+}
+
+class Google_Service_Dataflow_SourceSplitShard extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $derivationMode;
+  protected $sourceType = 'Google_Service_Dataflow_Source';
+  protected $sourceDataType = '';
+
+
+  public function setDerivationMode($derivationMode)
+  {
+    $this->derivationMode = $derivationMode;
+  }
+  public function getDerivationMode()
+  {
+    return $this->derivationMode;
+  }
+  public function setSource(Google_Service_Dataflow_Source $source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+}
+
+class Google_Service_Dataflow_StateFamilyConfig extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $isRead;
+  public $stateFamily;
+
+
+  public function setIsRead($isRead)
+  {
+    $this->isRead = $isRead;
+  }
+  public function getIsRead()
+  {
+    return $this->isRead;
+  }
+  public function setStateFamily($stateFamily)
+  {
+    $this->stateFamily = $stateFamily;
+  }
+  public function getStateFamily()
+  {
+    return $this->stateFamily;
+  }
+}
+
+class Google_Service_Dataflow_Status extends Google_Collection
+{
+  protected $collection_key = 'details';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $details;
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setDetails($details)
+  {
+    $this->details = $details;
+  }
+  public function getDetails()
+  {
+    return $this->details;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Dataflow_StatusDetails extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_Step extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $name;
+  public $properties;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProperties($properties)
+  {
+    $this->properties = $properties;
+  }
+  public function getProperties()
+  {
+    return $this->properties;
+  }
+}
+
+class Google_Service_Dataflow_StepProperties extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_StreamLocation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $customSourceLocationType = 'Google_Service_Dataflow_CustomSourceLocation';
+  protected $customSourceLocationDataType = '';
+  protected $pubsubLocationType = 'Google_Service_Dataflow_PubsubLocation';
+  protected $pubsubLocationDataType = '';
+  protected $sideInputLocationType = 'Google_Service_Dataflow_StreamingSideInputLocation';
+  protected $sideInputLocationDataType = '';
+  protected $streamingStageLocationType = 'Google_Service_Dataflow_StreamingStageLocation';
+  protected $streamingStageLocationDataType = '';
+
+
+  public function setCustomSourceLocation(Google_Service_Dataflow_CustomSourceLocation $customSourceLocation)
+  {
+    $this->customSourceLocation = $customSourceLocation;
+  }
+  public function getCustomSourceLocation()
+  {
+    return $this->customSourceLocation;
+  }
+  public function setPubsubLocation(Google_Service_Dataflow_PubsubLocation $pubsubLocation)
+  {
+    $this->pubsubLocation = $pubsubLocation;
+  }
+  public function getPubsubLocation()
+  {
+    return $this->pubsubLocation;
+  }
+  public function setSideInputLocation(Google_Service_Dataflow_StreamingSideInputLocation $sideInputLocation)
+  {
+    $this->sideInputLocation = $sideInputLocation;
+  }
+  public function getSideInputLocation()
+  {
+    return $this->sideInputLocation;
+  }
+  public function setStreamingStageLocation(Google_Service_Dataflow_StreamingStageLocation $streamingStageLocation)
+  {
+    $this->streamingStageLocation = $streamingStageLocation;
+  }
+  public function getStreamingStageLocation()
+  {
+    return $this->streamingStageLocation;
+  }
+}
+
+class Google_Service_Dataflow_StreamingComputationRanges extends Google_Collection
+{
+  protected $collection_key = 'rangeAssignments';
+  protected $internal_gapi_mappings = array(
+  );
+  public $computationId;
+  protected $rangeAssignmentsType = 'Google_Service_Dataflow_KeyRangeDataDiskAssignment';
+  protected $rangeAssignmentsDataType = 'array';
+
+
+  public function setComputationId($computationId)
+  {
+    $this->computationId = $computationId;
+  }
+  public function getComputationId()
+  {
+    return $this->computationId;
+  }
+  public function setRangeAssignments($rangeAssignments)
+  {
+    $this->rangeAssignments = $rangeAssignments;
+  }
+  public function getRangeAssignments()
+  {
+    return $this->rangeAssignments;
+  }
+}
+
+class Google_Service_Dataflow_StreamingComputationTask extends Google_Collection
+{
+  protected $collection_key = 'dataDisks';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $computationRangesType = 'Google_Service_Dataflow_StreamingComputationRanges';
+  protected $computationRangesDataType = 'array';
+  protected $dataDisksType = 'Google_Service_Dataflow_MountedDataDisk';
+  protected $dataDisksDataType = 'array';
+  public $taskType;
+
+
+  public function setComputationRanges($computationRanges)
+  {
+    $this->computationRanges = $computationRanges;
+  }
+  public function getComputationRanges()
+  {
+    return $this->computationRanges;
+  }
+  public function setDataDisks($dataDisks)
+  {
+    $this->dataDisks = $dataDisks;
+  }
+  public function getDataDisks()
+  {
+    return $this->dataDisks;
+  }
+  public function setTaskType($taskType)
+  {
+    $this->taskType = $taskType;
+  }
+  public function getTaskType()
+  {
+    return $this->taskType;
+  }
+}
+
+class Google_Service_Dataflow_StreamingSetupTask extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $receiveWorkPort;
+  protected $streamingComputationTopologyType = 'Google_Service_Dataflow_TopologyConfig';
+  protected $streamingComputationTopologyDataType = '';
+  public $workerHarnessPort;
+
+
+  public function setReceiveWorkPort($receiveWorkPort)
+  {
+    $this->receiveWorkPort = $receiveWorkPort;
+  }
+  public function getReceiveWorkPort()
+  {
+    return $this->receiveWorkPort;
+  }
+  public function setStreamingComputationTopology(Google_Service_Dataflow_TopologyConfig $streamingComputationTopology)
+  {
+    $this->streamingComputationTopology = $streamingComputationTopology;
+  }
+  public function getStreamingComputationTopology()
+  {
+    return $this->streamingComputationTopology;
+  }
+  public function setWorkerHarnessPort($workerHarnessPort)
+  {
+    $this->workerHarnessPort = $workerHarnessPort;
+  }
+  public function getWorkerHarnessPort()
+  {
+    return $this->workerHarnessPort;
+  }
+}
+
+class Google_Service_Dataflow_StreamingSideInputLocation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $stateFamily;
+  public $tag;
+
+
+  public function setStateFamily($stateFamily)
+  {
+    $this->stateFamily = $stateFamily;
+  }
+  public function getStateFamily()
+  {
+    return $this->stateFamily;
+  }
+  public function setTag($tag)
+  {
+    $this->tag = $tag;
+  }
+  public function getTag()
+  {
+    return $this->tag;
+  }
+}
+
+class Google_Service_Dataflow_StreamingStageLocation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $streamId;
+
+
+  public function setStreamId($streamId)
+  {
+    $this->streamId = $streamId;
+  }
+  public function getStreamId()
+  {
+    return $this->streamId;
+  }
+}
+
+class Google_Service_Dataflow_TaskRunnerSettings extends Google_Collection
+{
+  protected $collection_key = 'oauthScopes';
+  protected $internal_gapi_mappings = array(
+  );
+  public $alsologtostderr;
+  public $baseTaskDir;
+  public $baseUrl;
+  public $commandlinesFileName;
+  public $continueOnException;
+  public $dataflowApiVersion;
+  public $harnessCommand;
+  public $languageHint;
+  public $logDir;
+  public $logToSerialconsole;
+  public $logUploadLocation;
+  public $oauthScopes;
+  protected $parallelWorkerSettingsType = 'Google_Service_Dataflow_WorkerSettings';
+  protected $parallelWorkerSettingsDataType = '';
+  public $streamingWorkerMainClass;
+  public $taskGroup;
+  public $taskUser;
+  public $tempStoragePrefix;
+  public $vmId;
+  public $workflowFileName;
+
+
+  public function setAlsologtostderr($alsologtostderr)
+  {
+    $this->alsologtostderr = $alsologtostderr;
+  }
+  public function getAlsologtostderr()
+  {
+    return $this->alsologtostderr;
+  }
+  public function setBaseTaskDir($baseTaskDir)
+  {
+    $this->baseTaskDir = $baseTaskDir;
+  }
+  public function getBaseTaskDir()
+  {
+    return $this->baseTaskDir;
+  }
+  public function setBaseUrl($baseUrl)
+  {
+    $this->baseUrl = $baseUrl;
+  }
+  public function getBaseUrl()
+  {
+    return $this->baseUrl;
+  }
+  public function setCommandlinesFileName($commandlinesFileName)
+  {
+    $this->commandlinesFileName = $commandlinesFileName;
+  }
+  public function getCommandlinesFileName()
+  {
+    return $this->commandlinesFileName;
+  }
+  public function setContinueOnException($continueOnException)
+  {
+    $this->continueOnException = $continueOnException;
+  }
+  public function getContinueOnException()
+  {
+    return $this->continueOnException;
+  }
+  public function setDataflowApiVersion($dataflowApiVersion)
+  {
+    $this->dataflowApiVersion = $dataflowApiVersion;
+  }
+  public function getDataflowApiVersion()
+  {
+    return $this->dataflowApiVersion;
+  }
+  public function setHarnessCommand($harnessCommand)
+  {
+    $this->harnessCommand = $harnessCommand;
+  }
+  public function getHarnessCommand()
+  {
+    return $this->harnessCommand;
+  }
+  public function setLanguageHint($languageHint)
+  {
+    $this->languageHint = $languageHint;
+  }
+  public function getLanguageHint()
+  {
+    return $this->languageHint;
+  }
+  public function setLogDir($logDir)
+  {
+    $this->logDir = $logDir;
+  }
+  public function getLogDir()
+  {
+    return $this->logDir;
+  }
+  public function setLogToSerialconsole($logToSerialconsole)
+  {
+    $this->logToSerialconsole = $logToSerialconsole;
+  }
+  public function getLogToSerialconsole()
+  {
+    return $this->logToSerialconsole;
+  }
+  public function setLogUploadLocation($logUploadLocation)
+  {
+    $this->logUploadLocation = $logUploadLocation;
+  }
+  public function getLogUploadLocation()
+  {
+    return $this->logUploadLocation;
+  }
+  public function setOauthScopes($oauthScopes)
+  {
+    $this->oauthScopes = $oauthScopes;
+  }
+  public function getOauthScopes()
+  {
+    return $this->oauthScopes;
+  }
+  public function setParallelWorkerSettings(Google_Service_Dataflow_WorkerSettings $parallelWorkerSettings)
+  {
+    $this->parallelWorkerSettings = $parallelWorkerSettings;
+  }
+  public function getParallelWorkerSettings()
+  {
+    return $this->parallelWorkerSettings;
+  }
+  public function setStreamingWorkerMainClass($streamingWorkerMainClass)
+  {
+    $this->streamingWorkerMainClass = $streamingWorkerMainClass;
+  }
+  public function getStreamingWorkerMainClass()
+  {
+    return $this->streamingWorkerMainClass;
+  }
+  public function setTaskGroup($taskGroup)
+  {
+    $this->taskGroup = $taskGroup;
+  }
+  public function getTaskGroup()
+  {
+    return $this->taskGroup;
+  }
+  public function setTaskUser($taskUser)
+  {
+    $this->taskUser = $taskUser;
+  }
+  public function getTaskUser()
+  {
+    return $this->taskUser;
+  }
+  public function setTempStoragePrefix($tempStoragePrefix)
+  {
+    $this->tempStoragePrefix = $tempStoragePrefix;
+  }
+  public function getTempStoragePrefix()
+  {
+    return $this->tempStoragePrefix;
+  }
+  public function setVmId($vmId)
+  {
+    $this->vmId = $vmId;
+  }
+  public function getVmId()
+  {
+    return $this->vmId;
+  }
+  public function setWorkflowFileName($workflowFileName)
+  {
+    $this->workflowFileName = $workflowFileName;
+  }
+  public function getWorkflowFileName()
+  {
+    return $this->workflowFileName;
+  }
+}
+
+class Google_Service_Dataflow_TopologyConfig extends Google_Collection
+{
+  protected $collection_key = 'dataDiskAssignments';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $computationsType = 'Google_Service_Dataflow_ComputationTopology';
+  protected $computationsDataType = 'array';
+  protected $dataDiskAssignmentsType = 'Google_Service_Dataflow_DataDiskAssignment';
+  protected $dataDiskAssignmentsDataType = 'array';
+  public $userStageToComputationNameMap;
+
+
+  public function setComputations($computations)
+  {
+    $this->computations = $computations;
+  }
+  public function getComputations()
+  {
+    return $this->computations;
+  }
+  public function setDataDiskAssignments($dataDiskAssignments)
+  {
+    $this->dataDiskAssignments = $dataDiskAssignments;
+  }
+  public function getDataDiskAssignments()
+  {
+    return $this->dataDiskAssignments;
+  }
+  public function setUserStageToComputationNameMap($userStageToComputationNameMap)
+  {
+    $this->userStageToComputationNameMap = $userStageToComputationNameMap;
+  }
+  public function getUserStageToComputationNameMap()
+  {
+    return $this->userStageToComputationNameMap;
+  }
+}
+
+class Google_Service_Dataflow_TopologyConfigUserStageToComputationNameMap extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_WorkItem extends Google_Collection
+{
+  protected $collection_key = 'packages';
+  protected $internal_gapi_mappings = array(
+  );
+  public $configuration;
+  public $id;
+  public $initialReportIndex;
+  public $jobId;
+  public $leaseExpireTime;
+  protected $mapTaskType = 'Google_Service_Dataflow_MapTask';
+  protected $mapTaskDataType = '';
+  protected $packagesType = 'Google_Service_Dataflow_Package';
+  protected $packagesDataType = 'array';
+  public $projectId;
+  public $reportStatusInterval;
+  protected $seqMapTaskType = 'Google_Service_Dataflow_SeqMapTask';
+  protected $seqMapTaskDataType = '';
+  protected $shellTaskType = 'Google_Service_Dataflow_ShellTask';
+  protected $shellTaskDataType = '';
+  protected $sourceOperationTaskType = 'Google_Service_Dataflow_SourceOperationRequest';
+  protected $sourceOperationTaskDataType = '';
+  protected $streamingComputationTaskType = 'Google_Service_Dataflow_StreamingComputationTask';
+  protected $streamingComputationTaskDataType = '';
+  protected $streamingSetupTaskType = 'Google_Service_Dataflow_StreamingSetupTask';
+  protected $streamingSetupTaskDataType = '';
+
+
+  public function setConfiguration($configuration)
+  {
+    $this->configuration = $configuration;
+  }
+  public function getConfiguration()
+  {
+    return $this->configuration;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInitialReportIndex($initialReportIndex)
+  {
+    $this->initialReportIndex = $initialReportIndex;
+  }
+  public function getInitialReportIndex()
+  {
+    return $this->initialReportIndex;
+  }
+  public function setJobId($jobId)
+  {
+    $this->jobId = $jobId;
+  }
+  public function getJobId()
+  {
+    return $this->jobId;
+  }
+  public function setLeaseExpireTime($leaseExpireTime)
+  {
+    $this->leaseExpireTime = $leaseExpireTime;
+  }
+  public function getLeaseExpireTime()
+  {
+    return $this->leaseExpireTime;
+  }
+  public function setMapTask(Google_Service_Dataflow_MapTask $mapTask)
+  {
+    $this->mapTask = $mapTask;
+  }
+  public function getMapTask()
+  {
+    return $this->mapTask;
+  }
+  public function setPackages($packages)
+  {
+    $this->packages = $packages;
+  }
+  public function getPackages()
+  {
+    return $this->packages;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setReportStatusInterval($reportStatusInterval)
+  {
+    $this->reportStatusInterval = $reportStatusInterval;
+  }
+  public function getReportStatusInterval()
+  {
+    return $this->reportStatusInterval;
+  }
+  public function setSeqMapTask(Google_Service_Dataflow_SeqMapTask $seqMapTask)
+  {
+    $this->seqMapTask = $seqMapTask;
+  }
+  public function getSeqMapTask()
+  {
+    return $this->seqMapTask;
+  }
+  public function setShellTask(Google_Service_Dataflow_ShellTask $shellTask)
+  {
+    $this->shellTask = $shellTask;
+  }
+  public function getShellTask()
+  {
+    return $this->shellTask;
+  }
+  public function setSourceOperationTask(Google_Service_Dataflow_SourceOperationRequest $sourceOperationTask)
+  {
+    $this->sourceOperationTask = $sourceOperationTask;
+  }
+  public function getSourceOperationTask()
+  {
+    return $this->sourceOperationTask;
+  }
+  public function setStreamingComputationTask(Google_Service_Dataflow_StreamingComputationTask $streamingComputationTask)
+  {
+    $this->streamingComputationTask = $streamingComputationTask;
+  }
+  public function getStreamingComputationTask()
+  {
+    return $this->streamingComputationTask;
+  }
+  public function setStreamingSetupTask(Google_Service_Dataflow_StreamingSetupTask $streamingSetupTask)
+  {
+    $this->streamingSetupTask = $streamingSetupTask;
+  }
+  public function getStreamingSetupTask()
+  {
+    return $this->streamingSetupTask;
+  }
+}
+
+class Google_Service_Dataflow_WorkItemServiceState extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $harnessData;
+  public $leaseExpireTime;
+  public $nextReportIndex;
+  public $reportStatusInterval;
+  protected $suggestedStopPointType = 'Google_Service_Dataflow_ApproximateProgress';
+  protected $suggestedStopPointDataType = '';
+  protected $suggestedStopPositionType = 'Google_Service_Dataflow_Position';
+  protected $suggestedStopPositionDataType = '';
+
+
+  public function setHarnessData($harnessData)
+  {
+    $this->harnessData = $harnessData;
+  }
+  public function getHarnessData()
+  {
+    return $this->harnessData;
+  }
+  public function setLeaseExpireTime($leaseExpireTime)
+  {
+    $this->leaseExpireTime = $leaseExpireTime;
+  }
+  public function getLeaseExpireTime()
+  {
+    return $this->leaseExpireTime;
+  }
+  public function setNextReportIndex($nextReportIndex)
+  {
+    $this->nextReportIndex = $nextReportIndex;
+  }
+  public function getNextReportIndex()
+  {
+    return $this->nextReportIndex;
+  }
+  public function setReportStatusInterval($reportStatusInterval)
+  {
+    $this->reportStatusInterval = $reportStatusInterval;
+  }
+  public function getReportStatusInterval()
+  {
+    return $this->reportStatusInterval;
+  }
+  public function setSuggestedStopPoint(Google_Service_Dataflow_ApproximateProgress $suggestedStopPoint)
+  {
+    $this->suggestedStopPoint = $suggestedStopPoint;
+  }
+  public function getSuggestedStopPoint()
+  {
+    return $this->suggestedStopPoint;
+  }
+  public function setSuggestedStopPosition(Google_Service_Dataflow_Position $suggestedStopPosition)
+  {
+    $this->suggestedStopPosition = $suggestedStopPosition;
+  }
+  public function getSuggestedStopPosition()
+  {
+    return $this->suggestedStopPosition;
+  }
+}
+
+class Google_Service_Dataflow_WorkItemServiceStateHarnessData extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_WorkItemStatus extends Google_Collection
+{
+  protected $collection_key = 'metricUpdates';
+  protected $internal_gapi_mappings = array(
+  );
+  public $completed;
+  protected $dynamicSourceSplitType = 'Google_Service_Dataflow_DynamicSourceSplit';
+  protected $dynamicSourceSplitDataType = '';
+  protected $errorsType = 'Google_Service_Dataflow_Status';
+  protected $errorsDataType = 'array';
+  protected $metricUpdatesType = 'Google_Service_Dataflow_MetricUpdate';
+  protected $metricUpdatesDataType = 'array';
+  protected $progressType = 'Google_Service_Dataflow_ApproximateProgress';
+  protected $progressDataType = '';
+  public $reportIndex;
+  public $requestedLeaseDuration;
+  protected $sourceForkType = 'Google_Service_Dataflow_SourceFork';
+  protected $sourceForkDataType = '';
+  protected $sourceOperationResponseType = 'Google_Service_Dataflow_SourceOperationResponse';
+  protected $sourceOperationResponseDataType = '';
+  protected $stopPositionType = 'Google_Service_Dataflow_Position';
+  protected $stopPositionDataType = '';
+  public $workItemId;
+
+
+  public function setCompleted($completed)
+  {
+    $this->completed = $completed;
+  }
+  public function getCompleted()
+  {
+    return $this->completed;
+  }
+  public function setDynamicSourceSplit(Google_Service_Dataflow_DynamicSourceSplit $dynamicSourceSplit)
+  {
+    $this->dynamicSourceSplit = $dynamicSourceSplit;
+  }
+  public function getDynamicSourceSplit()
+  {
+    return $this->dynamicSourceSplit;
+  }
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setMetricUpdates($metricUpdates)
+  {
+    $this->metricUpdates = $metricUpdates;
+  }
+  public function getMetricUpdates()
+  {
+    return $this->metricUpdates;
+  }
+  public function setProgress(Google_Service_Dataflow_ApproximateProgress $progress)
+  {
+    $this->progress = $progress;
+  }
+  public function getProgress()
+  {
+    return $this->progress;
+  }
+  public function setReportIndex($reportIndex)
+  {
+    $this->reportIndex = $reportIndex;
+  }
+  public function getReportIndex()
+  {
+    return $this->reportIndex;
+  }
+  public function setRequestedLeaseDuration($requestedLeaseDuration)
+  {
+    $this->requestedLeaseDuration = $requestedLeaseDuration;
+  }
+  public function getRequestedLeaseDuration()
+  {
+    return $this->requestedLeaseDuration;
+  }
+  public function setSourceFork(Google_Service_Dataflow_SourceFork $sourceFork)
+  {
+    $this->sourceFork = $sourceFork;
+  }
+  public function getSourceFork()
+  {
+    return $this->sourceFork;
+  }
+  public function setSourceOperationResponse(Google_Service_Dataflow_SourceOperationResponse $sourceOperationResponse)
+  {
+    $this->sourceOperationResponse = $sourceOperationResponse;
+  }
+  public function getSourceOperationResponse()
+  {
+    return $this->sourceOperationResponse;
+  }
+  public function setStopPosition(Google_Service_Dataflow_Position $stopPosition)
+  {
+    $this->stopPosition = $stopPosition;
+  }
+  public function getStopPosition()
+  {
+    return $this->stopPosition;
+  }
+  public function setWorkItemId($workItemId)
+  {
+    $this->workItemId = $workItemId;
+  }
+  public function getWorkItemId()
+  {
+    return $this->workItemId;
+  }
+}
+
+class Google_Service_Dataflow_WorkerPool extends Google_Collection
+{
+  protected $collection_key = 'packages';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $autoscalingSettingsType = 'Google_Service_Dataflow_AutoscalingSettings';
+  protected $autoscalingSettingsDataType = '';
+  protected $dataDisksType = 'Google_Service_Dataflow_Disk';
+  protected $dataDisksDataType = 'array';
+  public $defaultPackageSet;
+  public $diskSizeGb;
+  public $diskSourceImage;
+  public $diskType;
+  public $kind;
+  public $machineType;
+  public $metadata;
+  public $network;
+  public $numWorkers;
+  public $onHostMaintenance;
+  protected $packagesType = 'Google_Service_Dataflow_Package';
+  protected $packagesDataType = 'array';
+  public $poolArgs;
+  protected $taskrunnerSettingsType = 'Google_Service_Dataflow_TaskRunnerSettings';
+  protected $taskrunnerSettingsDataType = '';
+  public $teardownPolicy;
+  public $zone;
+
+
+  public function setAutoscalingSettings(Google_Service_Dataflow_AutoscalingSettings $autoscalingSettings)
+  {
+    $this->autoscalingSettings = $autoscalingSettings;
+  }
+  public function getAutoscalingSettings()
+  {
+    return $this->autoscalingSettings;
+  }
+  public function setDataDisks($dataDisks)
+  {
+    $this->dataDisks = $dataDisks;
+  }
+  public function getDataDisks()
+  {
+    return $this->dataDisks;
+  }
+  public function setDefaultPackageSet($defaultPackageSet)
+  {
+    $this->defaultPackageSet = $defaultPackageSet;
+  }
+  public function getDefaultPackageSet()
+  {
+    return $this->defaultPackageSet;
+  }
+  public function setDiskSizeGb($diskSizeGb)
+  {
+    $this->diskSizeGb = $diskSizeGb;
+  }
+  public function getDiskSizeGb()
+  {
+    return $this->diskSizeGb;
+  }
+  public function setDiskSourceImage($diskSourceImage)
+  {
+    $this->diskSourceImage = $diskSourceImage;
+  }
+  public function getDiskSourceImage()
+  {
+    return $this->diskSourceImage;
+  }
+  public function setDiskType($diskType)
+  {
+    $this->diskType = $diskType;
+  }
+  public function getDiskType()
+  {
+    return $this->diskType;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMachineType($machineType)
+  {
+    $this->machineType = $machineType;
+  }
+  public function getMachineType()
+  {
+    return $this->machineType;
+  }
+  public function setMetadata($metadata)
+  {
+    $this->metadata = $metadata;
+  }
+  public function getMetadata()
+  {
+    return $this->metadata;
+  }
+  public function setNetwork($network)
+  {
+    $this->network = $network;
+  }
+  public function getNetwork()
+  {
+    return $this->network;
+  }
+  public function setNumWorkers($numWorkers)
+  {
+    $this->numWorkers = $numWorkers;
+  }
+  public function getNumWorkers()
+  {
+    return $this->numWorkers;
+  }
+  public function setOnHostMaintenance($onHostMaintenance)
+  {
+    $this->onHostMaintenance = $onHostMaintenance;
+  }
+  public function getOnHostMaintenance()
+  {
+    return $this->onHostMaintenance;
+  }
+  public function setPackages($packages)
+  {
+    $this->packages = $packages;
+  }
+  public function getPackages()
+  {
+    return $this->packages;
+  }
+  public function setPoolArgs($poolArgs)
+  {
+    $this->poolArgs = $poolArgs;
+  }
+  public function getPoolArgs()
+  {
+    return $this->poolArgs;
+  }
+  public function setTaskrunnerSettings(Google_Service_Dataflow_TaskRunnerSettings $taskrunnerSettings)
+  {
+    $this->taskrunnerSettings = $taskrunnerSettings;
+  }
+  public function getTaskrunnerSettings()
+  {
+    return $this->taskrunnerSettings;
+  }
+  public function setTeardownPolicy($teardownPolicy)
+  {
+    $this->teardownPolicy = $teardownPolicy;
+  }
+  public function getTeardownPolicy()
+  {
+    return $this->teardownPolicy;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_Dataflow_WorkerPoolMetadata extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_WorkerPoolPoolArgs extends Google_Model
+{
+}
+
+class Google_Service_Dataflow_WorkerSettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $baseUrl;
+  public $reportingEnabled;
+  public $servicePath;
+  public $shuffleServicePath;
+  public $tempStoragePrefix;
+  public $workerId;
+
+
+  public function setBaseUrl($baseUrl)
+  {
+    $this->baseUrl = $baseUrl;
+  }
+  public function getBaseUrl()
+  {
+    return $this->baseUrl;
+  }
+  public function setReportingEnabled($reportingEnabled)
+  {
+    $this->reportingEnabled = $reportingEnabled;
+  }
+  public function getReportingEnabled()
+  {
+    return $this->reportingEnabled;
+  }
+  public function setServicePath($servicePath)
+  {
+    $this->servicePath = $servicePath;
+  }
+  public function getServicePath()
+  {
+    return $this->servicePath;
+  }
+  public function setShuffleServicePath($shuffleServicePath)
+  {
+    $this->shuffleServicePath = $shuffleServicePath;
+  }
+  public function getShuffleServicePath()
+  {
+    return $this->shuffleServicePath;
+  }
+  public function setTempStoragePrefix($tempStoragePrefix)
+  {
+    $this->tempStoragePrefix = $tempStoragePrefix;
+  }
+  public function getTempStoragePrefix()
+  {
+    return $this->tempStoragePrefix;
+  }
+  public function setWorkerId($workerId)
+  {
+    $this->workerId = $workerId;
+  }
+  public function getWorkerId()
+  {
+    return $this->workerId;
+  }
+}
+
+class Google_Service_Dataflow_WriteInstruction extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $inputType = 'Google_Service_Dataflow_InstructionInput';
+  protected $inputDataType = '';
+  protected $sinkType = 'Google_Service_Dataflow_Sink';
+  protected $sinkDataType = '';
+
+
+  public function setInput(Google_Service_Dataflow_InstructionInput $input)
+  {
+    $this->input = $input;
+  }
+  public function getInput()
+  {
+    return $this->input;
+  }
+  public function setSink(Google_Service_Dataflow_Sink $sink)
+  {
+    $this->sink = $sink;
+  }
+  public function getSink()
+  {
+    return $this->sink;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Datastore.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Datastore.php
@@ -1,0 +1,1525 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Datastore (v1beta2).
+ *
+ * <p>
+ * API for accessing Google Cloud Datastore.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/datastore/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Datastore extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+  /** View and manage your Google Cloud Datastore data. */
+  const DATASTORE =
+      "https://www.googleapis.com/auth/datastore";
+  /** View your email address. */
+  const USERINFO_EMAIL =
+      "https://www.googleapis.com/auth/userinfo.email";
+
+  public $datasets;
+  
+
+  /**
+   * Constructs the internal representation of the Datastore service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'datastore/v1beta2/datasets/';
+    $this->version = 'v1beta2';
+    $this->serviceName = 'datastore';
+
+    $this->datasets = new Google_Service_Datastore_Datasets_Resource(
+        $this,
+        $this->serviceName,
+        'datasets',
+        array(
+          'methods' => array(
+            'allocateIds' => array(
+              'path' => '{datasetId}/allocateIds',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'beginTransaction' => array(
+              'path' => '{datasetId}/beginTransaction',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'commit' => array(
+              'path' => '{datasetId}/commit',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'lookup' => array(
+              'path' => '{datasetId}/lookup',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'rollback' => array(
+              'path' => '{datasetId}/rollback',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'runQuery' => array(
+              'path' => '{datasetId}/runQuery',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "datasets" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $datastoreService = new Google_Service_Datastore(...);
+ *   $datasets = $datastoreService->datasets;
+ *  </code>
+ */
+class Google_Service_Datastore_Datasets_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Allocate IDs for incomplete keys (useful for referencing an entity before it
+   * is inserted). (datasets.allocateIds)
+   *
+   * @param string $datasetId Identifies the dataset.
+   * @param Google_AllocateIdsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Datastore_AllocateIdsResponse
+   */
+  public function allocateIds($datasetId, Google_Service_Datastore_AllocateIdsRequest $postBody, $optParams = array())
+  {
+    $params = array('datasetId' => $datasetId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('allocateIds', array($params), "Google_Service_Datastore_AllocateIdsResponse");
+  }
+
+  /**
+   * Begin a new transaction. (datasets.beginTransaction)
+   *
+   * @param string $datasetId Identifies the dataset.
+   * @param Google_BeginTransactionRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Datastore_BeginTransactionResponse
+   */
+  public function beginTransaction($datasetId, Google_Service_Datastore_BeginTransactionRequest $postBody, $optParams = array())
+  {
+    $params = array('datasetId' => $datasetId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('beginTransaction', array($params), "Google_Service_Datastore_BeginTransactionResponse");
+  }
+
+  /**
+   * Commit a transaction, optionally creating, deleting or modifying some
+   * entities. (datasets.commit)
+   *
+   * @param string $datasetId Identifies the dataset.
+   * @param Google_CommitRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Datastore_CommitResponse
+   */
+  public function commit($datasetId, Google_Service_Datastore_CommitRequest $postBody, $optParams = array())
+  {
+    $params = array('datasetId' => $datasetId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('commit', array($params), "Google_Service_Datastore_CommitResponse");
+  }
+
+  /**
+   * Look up some entities by key. (datasets.lookup)
+   *
+   * @param string $datasetId Identifies the dataset.
+   * @param Google_LookupRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Datastore_LookupResponse
+   */
+  public function lookup($datasetId, Google_Service_Datastore_LookupRequest $postBody, $optParams = array())
+  {
+    $params = array('datasetId' => $datasetId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('lookup', array($params), "Google_Service_Datastore_LookupResponse");
+  }
+
+  /**
+   * Roll back a transaction. (datasets.rollback)
+   *
+   * @param string $datasetId Identifies the dataset.
+   * @param Google_RollbackRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Datastore_RollbackResponse
+   */
+  public function rollback($datasetId, Google_Service_Datastore_RollbackRequest $postBody, $optParams = array())
+  {
+    $params = array('datasetId' => $datasetId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('rollback', array($params), "Google_Service_Datastore_RollbackResponse");
+  }
+
+  /**
+   * Query for entities. (datasets.runQuery)
+   *
+   * @param string $datasetId Identifies the dataset.
+   * @param Google_RunQueryRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Datastore_RunQueryResponse
+   */
+  public function runQuery($datasetId, Google_Service_Datastore_RunQueryRequest $postBody, $optParams = array())
+  {
+    $params = array('datasetId' => $datasetId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('runQuery', array($params), "Google_Service_Datastore_RunQueryResponse");
+  }
+}
+
+
+
+
+class Google_Service_Datastore_AllocateIdsRequest extends Google_Collection
+{
+  protected $collection_key = 'keys';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $keysType = 'Google_Service_Datastore_Key';
+  protected $keysDataType = 'array';
+
+
+  public function setKeys($keys)
+  {
+    $this->keys = $keys;
+  }
+  public function getKeys()
+  {
+    return $this->keys;
+  }
+}
+
+class Google_Service_Datastore_AllocateIdsResponse extends Google_Collection
+{
+  protected $collection_key = 'keys';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $headerType = 'Google_Service_Datastore_ResponseHeader';
+  protected $headerDataType = '';
+  protected $keysType = 'Google_Service_Datastore_Key';
+  protected $keysDataType = 'array';
+
+
+  public function setHeader(Google_Service_Datastore_ResponseHeader $header)
+  {
+    $this->header = $header;
+  }
+  public function getHeader()
+  {
+    return $this->header;
+  }
+  public function setKeys($keys)
+  {
+    $this->keys = $keys;
+  }
+  public function getKeys()
+  {
+    return $this->keys;
+  }
+}
+
+class Google_Service_Datastore_BeginTransactionRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $isolationLevel;
+
+
+  public function setIsolationLevel($isolationLevel)
+  {
+    $this->isolationLevel = $isolationLevel;
+  }
+  public function getIsolationLevel()
+  {
+    return $this->isolationLevel;
+  }
+}
+
+class Google_Service_Datastore_BeginTransactionResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $headerType = 'Google_Service_Datastore_ResponseHeader';
+  protected $headerDataType = '';
+  public $transaction;
+
+
+  public function setHeader(Google_Service_Datastore_ResponseHeader $header)
+  {
+    $this->header = $header;
+  }
+  public function getHeader()
+  {
+    return $this->header;
+  }
+  public function setTransaction($transaction)
+  {
+    $this->transaction = $transaction;
+  }
+  public function getTransaction()
+  {
+    return $this->transaction;
+  }
+}
+
+class Google_Service_Datastore_CommitRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $ignoreReadOnly;
+  public $mode;
+  protected $mutationType = 'Google_Service_Datastore_Mutation';
+  protected $mutationDataType = '';
+  public $transaction;
+
+
+  public function setIgnoreReadOnly($ignoreReadOnly)
+  {
+    $this->ignoreReadOnly = $ignoreReadOnly;
+  }
+  public function getIgnoreReadOnly()
+  {
+    return $this->ignoreReadOnly;
+  }
+  public function setMode($mode)
+  {
+    $this->mode = $mode;
+  }
+  public function getMode()
+  {
+    return $this->mode;
+  }
+  public function setMutation(Google_Service_Datastore_Mutation $mutation)
+  {
+    $this->mutation = $mutation;
+  }
+  public function getMutation()
+  {
+    return $this->mutation;
+  }
+  public function setTransaction($transaction)
+  {
+    $this->transaction = $transaction;
+  }
+  public function getTransaction()
+  {
+    return $this->transaction;
+  }
+}
+
+class Google_Service_Datastore_CommitResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $headerType = 'Google_Service_Datastore_ResponseHeader';
+  protected $headerDataType = '';
+  protected $mutationResultType = 'Google_Service_Datastore_MutationResult';
+  protected $mutationResultDataType = '';
+
+
+  public function setHeader(Google_Service_Datastore_ResponseHeader $header)
+  {
+    $this->header = $header;
+  }
+  public function getHeader()
+  {
+    return $this->header;
+  }
+  public function setMutationResult(Google_Service_Datastore_MutationResult $mutationResult)
+  {
+    $this->mutationResult = $mutationResult;
+  }
+  public function getMutationResult()
+  {
+    return $this->mutationResult;
+  }
+}
+
+class Google_Service_Datastore_CompositeFilter extends Google_Collection
+{
+  protected $collection_key = 'filters';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $filtersType = 'Google_Service_Datastore_Filter';
+  protected $filtersDataType = 'array';
+  public $operator;
+
+
+  public function setFilters($filters)
+  {
+    $this->filters = $filters;
+  }
+  public function getFilters()
+  {
+    return $this->filters;
+  }
+  public function setOperator($operator)
+  {
+    $this->operator = $operator;
+  }
+  public function getOperator()
+  {
+    return $this->operator;
+  }
+}
+
+class Google_Service_Datastore_Entity extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $keyType = 'Google_Service_Datastore_Key';
+  protected $keyDataType = '';
+  protected $propertiesType = 'Google_Service_Datastore_Property';
+  protected $propertiesDataType = 'map';
+
+
+  public function setKey(Google_Service_Datastore_Key $key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setProperties($properties)
+  {
+    $this->properties = $properties;
+  }
+  public function getProperties()
+  {
+    return $this->properties;
+  }
+}
+
+class Google_Service_Datastore_EntityProperties extends Google_Model
+{
+}
+
+class Google_Service_Datastore_EntityResult extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entityType = 'Google_Service_Datastore_Entity';
+  protected $entityDataType = '';
+
+
+  public function setEntity(Google_Service_Datastore_Entity $entity)
+  {
+    $this->entity = $entity;
+  }
+  public function getEntity()
+  {
+    return $this->entity;
+  }
+}
+
+class Google_Service_Datastore_Filter extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $compositeFilterType = 'Google_Service_Datastore_CompositeFilter';
+  protected $compositeFilterDataType = '';
+  protected $propertyFilterType = 'Google_Service_Datastore_PropertyFilter';
+  protected $propertyFilterDataType = '';
+
+
+  public function setCompositeFilter(Google_Service_Datastore_CompositeFilter $compositeFilter)
+  {
+    $this->compositeFilter = $compositeFilter;
+  }
+  public function getCompositeFilter()
+  {
+    return $this->compositeFilter;
+  }
+  public function setPropertyFilter(Google_Service_Datastore_PropertyFilter $propertyFilter)
+  {
+    $this->propertyFilter = $propertyFilter;
+  }
+  public function getPropertyFilter()
+  {
+    return $this->propertyFilter;
+  }
+}
+
+class Google_Service_Datastore_GqlQuery extends Google_Collection
+{
+  protected $collection_key = 'numberArgs';
+  protected $internal_gapi_mappings = array(
+  );
+  public $allowLiteral;
+  protected $nameArgsType = 'Google_Service_Datastore_GqlQueryArg';
+  protected $nameArgsDataType = 'array';
+  protected $numberArgsType = 'Google_Service_Datastore_GqlQueryArg';
+  protected $numberArgsDataType = 'array';
+  public $queryString;
+
+
+  public function setAllowLiteral($allowLiteral)
+  {
+    $this->allowLiteral = $allowLiteral;
+  }
+  public function getAllowLiteral()
+  {
+    return $this->allowLiteral;
+  }
+  public function setNameArgs($nameArgs)
+  {
+    $this->nameArgs = $nameArgs;
+  }
+  public function getNameArgs()
+  {
+    return $this->nameArgs;
+  }
+  public function setNumberArgs($numberArgs)
+  {
+    $this->numberArgs = $numberArgs;
+  }
+  public function getNumberArgs()
+  {
+    return $this->numberArgs;
+  }
+  public function setQueryString($queryString)
+  {
+    $this->queryString = $queryString;
+  }
+  public function getQueryString()
+  {
+    return $this->queryString;
+  }
+}
+
+class Google_Service_Datastore_GqlQueryArg extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $cursor;
+  public $name;
+  protected $valueType = 'Google_Service_Datastore_Value';
+  protected $valueDataType = '';
+
+
+  public function setCursor($cursor)
+  {
+    $this->cursor = $cursor;
+  }
+  public function getCursor()
+  {
+    return $this->cursor;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setValue(Google_Service_Datastore_Value $value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Datastore_Key extends Google_Collection
+{
+  protected $collection_key = 'path';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $partitionIdType = 'Google_Service_Datastore_PartitionId';
+  protected $partitionIdDataType = '';
+  protected $pathType = 'Google_Service_Datastore_KeyPathElement';
+  protected $pathDataType = 'array';
+
+
+  public function setPartitionId(Google_Service_Datastore_PartitionId $partitionId)
+  {
+    $this->partitionId = $partitionId;
+  }
+  public function getPartitionId()
+  {
+    return $this->partitionId;
+  }
+  public function setPath($path)
+  {
+    $this->path = $path;
+  }
+  public function getPath()
+  {
+    return $this->path;
+  }
+}
+
+class Google_Service_Datastore_KeyPathElement extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Datastore_KindExpression extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Datastore_LookupRequest extends Google_Collection
+{
+  protected $collection_key = 'keys';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $keysType = 'Google_Service_Datastore_Key';
+  protected $keysDataType = 'array';
+  protected $readOptionsType = 'Google_Service_Datastore_ReadOptions';
+  protected $readOptionsDataType = '';
+
+
+  public function setKeys($keys)
+  {
+    $this->keys = $keys;
+  }
+  public function getKeys()
+  {
+    return $this->keys;
+  }
+  public function setReadOptions(Google_Service_Datastore_ReadOptions $readOptions)
+  {
+    $this->readOptions = $readOptions;
+  }
+  public function getReadOptions()
+  {
+    return $this->readOptions;
+  }
+}
+
+class Google_Service_Datastore_LookupResponse extends Google_Collection
+{
+  protected $collection_key = 'missing';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $deferredType = 'Google_Service_Datastore_Key';
+  protected $deferredDataType = 'array';
+  protected $foundType = 'Google_Service_Datastore_EntityResult';
+  protected $foundDataType = 'array';
+  protected $headerType = 'Google_Service_Datastore_ResponseHeader';
+  protected $headerDataType = '';
+  protected $missingType = 'Google_Service_Datastore_EntityResult';
+  protected $missingDataType = 'array';
+
+
+  public function setDeferred($deferred)
+  {
+    $this->deferred = $deferred;
+  }
+  public function getDeferred()
+  {
+    return $this->deferred;
+  }
+  public function setFound($found)
+  {
+    $this->found = $found;
+  }
+  public function getFound()
+  {
+    return $this->found;
+  }
+  public function setHeader(Google_Service_Datastore_ResponseHeader $header)
+  {
+    $this->header = $header;
+  }
+  public function getHeader()
+  {
+    return $this->header;
+  }
+  public function setMissing($missing)
+  {
+    $this->missing = $missing;
+  }
+  public function getMissing()
+  {
+    return $this->missing;
+  }
+}
+
+class Google_Service_Datastore_Mutation extends Google_Collection
+{
+  protected $collection_key = 'upsert';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $deleteType = 'Google_Service_Datastore_Key';
+  protected $deleteDataType = 'array';
+  public $force;
+  protected $insertType = 'Google_Service_Datastore_Entity';
+  protected $insertDataType = 'array';
+  protected $insertAutoIdType = 'Google_Service_Datastore_Entity';
+  protected $insertAutoIdDataType = 'array';
+  protected $updateType = 'Google_Service_Datastore_Entity';
+  protected $updateDataType = 'array';
+  protected $upsertType = 'Google_Service_Datastore_Entity';
+  protected $upsertDataType = 'array';
+
+
+  public function setDelete($delete)
+  {
+    $this->delete = $delete;
+  }
+  public function getDelete()
+  {
+    return $this->delete;
+  }
+  public function setForce($force)
+  {
+    $this->force = $force;
+  }
+  public function getForce()
+  {
+    return $this->force;
+  }
+  public function setInsert($insert)
+  {
+    $this->insert = $insert;
+  }
+  public function getInsert()
+  {
+    return $this->insert;
+  }
+  public function setInsertAutoId($insertAutoId)
+  {
+    $this->insertAutoId = $insertAutoId;
+  }
+  public function getInsertAutoId()
+  {
+    return $this->insertAutoId;
+  }
+  public function setUpdate($update)
+  {
+    $this->update = $update;
+  }
+  public function getUpdate()
+  {
+    return $this->update;
+  }
+  public function setUpsert($upsert)
+  {
+    $this->upsert = $upsert;
+  }
+  public function getUpsert()
+  {
+    return $this->upsert;
+  }
+}
+
+class Google_Service_Datastore_MutationResult extends Google_Collection
+{
+  protected $collection_key = 'insertAutoIdKeys';
+  protected $internal_gapi_mappings = array(
+  );
+  public $indexUpdates;
+  protected $insertAutoIdKeysType = 'Google_Service_Datastore_Key';
+  protected $insertAutoIdKeysDataType = 'array';
+
+
+  public function setIndexUpdates($indexUpdates)
+  {
+    $this->indexUpdates = $indexUpdates;
+  }
+  public function getIndexUpdates()
+  {
+    return $this->indexUpdates;
+  }
+  public function setInsertAutoIdKeys($insertAutoIdKeys)
+  {
+    $this->insertAutoIdKeys = $insertAutoIdKeys;
+  }
+  public function getInsertAutoIdKeys()
+  {
+    return $this->insertAutoIdKeys;
+  }
+}
+
+class Google_Service_Datastore_PartitionId extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $datasetId;
+  public $namespace;
+
+
+  public function setDatasetId($datasetId)
+  {
+    $this->datasetId = $datasetId;
+  }
+  public function getDatasetId()
+  {
+    return $this->datasetId;
+  }
+  public function setNamespace($namespace)
+  {
+    $this->namespace = $namespace;
+  }
+  public function getNamespace()
+  {
+    return $this->namespace;
+  }
+}
+
+class Google_Service_Datastore_Property extends Google_Collection
+{
+  protected $collection_key = 'listValue';
+  protected $internal_gapi_mappings = array(
+  );
+  public $blobKeyValue;
+  public $blobValue;
+  public $booleanValue;
+  public $dateTimeValue;
+  public $doubleValue;
+  protected $entityValueType = 'Google_Service_Datastore_Entity';
+  protected $entityValueDataType = '';
+  public $indexed;
+  public $integerValue;
+  protected $keyValueType = 'Google_Service_Datastore_Key';
+  protected $keyValueDataType = '';
+  protected $listValueType = 'Google_Service_Datastore_Value';
+  protected $listValueDataType = 'array';
+  public $meaning;
+  public $stringValue;
+
+
+  public function setBlobKeyValue($blobKeyValue)
+  {
+    $this->blobKeyValue = $blobKeyValue;
+  }
+  public function getBlobKeyValue()
+  {
+    return $this->blobKeyValue;
+  }
+  public function setBlobValue($blobValue)
+  {
+    $this->blobValue = $blobValue;
+  }
+  public function getBlobValue()
+  {
+    return $this->blobValue;
+  }
+  public function setBooleanValue($booleanValue)
+  {
+    $this->booleanValue = $booleanValue;
+  }
+  public function getBooleanValue()
+  {
+    return $this->booleanValue;
+  }
+  public function setDateTimeValue($dateTimeValue)
+  {
+    $this->dateTimeValue = $dateTimeValue;
+  }
+  public function getDateTimeValue()
+  {
+    return $this->dateTimeValue;
+  }
+  public function setDoubleValue($doubleValue)
+  {
+    $this->doubleValue = $doubleValue;
+  }
+  public function getDoubleValue()
+  {
+    return $this->doubleValue;
+  }
+  public function setEntityValue(Google_Service_Datastore_Entity $entityValue)
+  {
+    $this->entityValue = $entityValue;
+  }
+  public function getEntityValue()
+  {
+    return $this->entityValue;
+  }
+  public function setIndexed($indexed)
+  {
+    $this->indexed = $indexed;
+  }
+  public function getIndexed()
+  {
+    return $this->indexed;
+  }
+  public function setIntegerValue($integerValue)
+  {
+    $this->integerValue = $integerValue;
+  }
+  public function getIntegerValue()
+  {
+    return $this->integerValue;
+  }
+  public function setKeyValue(Google_Service_Datastore_Key $keyValue)
+  {
+    $this->keyValue = $keyValue;
+  }
+  public function getKeyValue()
+  {
+    return $this->keyValue;
+  }
+  public function setListValue($listValue)
+  {
+    $this->listValue = $listValue;
+  }
+  public function getListValue()
+  {
+    return $this->listValue;
+  }
+  public function setMeaning($meaning)
+  {
+    $this->meaning = $meaning;
+  }
+  public function getMeaning()
+  {
+    return $this->meaning;
+  }
+  public function setStringValue($stringValue)
+  {
+    $this->stringValue = $stringValue;
+  }
+  public function getStringValue()
+  {
+    return $this->stringValue;
+  }
+}
+
+class Google_Service_Datastore_PropertyExpression extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $aggregationFunction;
+  protected $propertyType = 'Google_Service_Datastore_PropertyReference';
+  protected $propertyDataType = '';
+
+
+  public function setAggregationFunction($aggregationFunction)
+  {
+    $this->aggregationFunction = $aggregationFunction;
+  }
+  public function getAggregationFunction()
+  {
+    return $this->aggregationFunction;
+  }
+  public function setProperty(Google_Service_Datastore_PropertyReference $property)
+  {
+    $this->property = $property;
+  }
+  public function getProperty()
+  {
+    return $this->property;
+  }
+}
+
+class Google_Service_Datastore_PropertyFilter extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $operator;
+  protected $propertyType = 'Google_Service_Datastore_PropertyReference';
+  protected $propertyDataType = '';
+  protected $valueType = 'Google_Service_Datastore_Value';
+  protected $valueDataType = '';
+
+
+  public function setOperator($operator)
+  {
+    $this->operator = $operator;
+  }
+  public function getOperator()
+  {
+    return $this->operator;
+  }
+  public function setProperty(Google_Service_Datastore_PropertyReference $property)
+  {
+    $this->property = $property;
+  }
+  public function getProperty()
+  {
+    return $this->property;
+  }
+  public function setValue(Google_Service_Datastore_Value $value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Datastore_PropertyOrder extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $direction;
+  protected $propertyType = 'Google_Service_Datastore_PropertyReference';
+  protected $propertyDataType = '';
+
+
+  public function setDirection($direction)
+  {
+    $this->direction = $direction;
+  }
+  public function getDirection()
+  {
+    return $this->direction;
+  }
+  public function setProperty(Google_Service_Datastore_PropertyReference $property)
+  {
+    $this->property = $property;
+  }
+  public function getProperty()
+  {
+    return $this->property;
+  }
+}
+
+class Google_Service_Datastore_PropertyReference extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Datastore_Query extends Google_Collection
+{
+  protected $collection_key = 'projection';
+  protected $internal_gapi_mappings = array(
+  );
+  public $endCursor;
+  protected $filterType = 'Google_Service_Datastore_Filter';
+  protected $filterDataType = '';
+  protected $groupByType = 'Google_Service_Datastore_PropertyReference';
+  protected $groupByDataType = 'array';
+  protected $kindsType = 'Google_Service_Datastore_KindExpression';
+  protected $kindsDataType = 'array';
+  public $limit;
+  public $offset;
+  protected $orderType = 'Google_Service_Datastore_PropertyOrder';
+  protected $orderDataType = 'array';
+  protected $projectionType = 'Google_Service_Datastore_PropertyExpression';
+  protected $projectionDataType = 'array';
+  public $startCursor;
+
+
+  public function setEndCursor($endCursor)
+  {
+    $this->endCursor = $endCursor;
+  }
+  public function getEndCursor()
+  {
+    return $this->endCursor;
+  }
+  public function setFilter(Google_Service_Datastore_Filter $filter)
+  {
+    $this->filter = $filter;
+  }
+  public function getFilter()
+  {
+    return $this->filter;
+  }
+  public function setGroupBy($groupBy)
+  {
+    $this->groupBy = $groupBy;
+  }
+  public function getGroupBy()
+  {
+    return $this->groupBy;
+  }
+  public function setKinds($kinds)
+  {
+    $this->kinds = $kinds;
+  }
+  public function getKinds()
+  {
+    return $this->kinds;
+  }
+  public function setLimit($limit)
+  {
+    $this->limit = $limit;
+  }
+  public function getLimit()
+  {
+    return $this->limit;
+  }
+  public function setOffset($offset)
+  {
+    $this->offset = $offset;
+  }
+  public function getOffset()
+  {
+    return $this->offset;
+  }
+  public function setOrder($order)
+  {
+    $this->order = $order;
+  }
+  public function getOrder()
+  {
+    return $this->order;
+  }
+  public function setProjection($projection)
+  {
+    $this->projection = $projection;
+  }
+  public function getProjection()
+  {
+    return $this->projection;
+  }
+  public function setStartCursor($startCursor)
+  {
+    $this->startCursor = $startCursor;
+  }
+  public function getStartCursor()
+  {
+    return $this->startCursor;
+  }
+}
+
+class Google_Service_Datastore_QueryResultBatch extends Google_Collection
+{
+  protected $collection_key = 'entityResults';
+  protected $internal_gapi_mappings = array(
+  );
+  public $endCursor;
+  public $entityResultType;
+  protected $entityResultsType = 'Google_Service_Datastore_EntityResult';
+  protected $entityResultsDataType = 'array';
+  public $moreResults;
+  public $skippedResults;
+
+
+  public function setEndCursor($endCursor)
+  {
+    $this->endCursor = $endCursor;
+  }
+  public function getEndCursor()
+  {
+    return $this->endCursor;
+  }
+  public function setEntityResultType($entityResultType)
+  {
+    $this->entityResultType = $entityResultType;
+  }
+  public function getEntityResultType()
+  {
+    return $this->entityResultType;
+  }
+  public function setEntityResults($entityResults)
+  {
+    $this->entityResults = $entityResults;
+  }
+  public function getEntityResults()
+  {
+    return $this->entityResults;
+  }
+  public function setMoreResults($moreResults)
+  {
+    $this->moreResults = $moreResults;
+  }
+  public function getMoreResults()
+  {
+    return $this->moreResults;
+  }
+  public function setSkippedResults($skippedResults)
+  {
+    $this->skippedResults = $skippedResults;
+  }
+  public function getSkippedResults()
+  {
+    return $this->skippedResults;
+  }
+}
+
+class Google_Service_Datastore_ReadOptions extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $readConsistency;
+  public $transaction;
+
+
+  public function setReadConsistency($readConsistency)
+  {
+    $this->readConsistency = $readConsistency;
+  }
+  public function getReadConsistency()
+  {
+    return $this->readConsistency;
+  }
+  public function setTransaction($transaction)
+  {
+    $this->transaction = $transaction;
+  }
+  public function getTransaction()
+  {
+    return $this->transaction;
+  }
+}
+
+class Google_Service_Datastore_ResponseHeader extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Datastore_RollbackRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $transaction;
+
+
+  public function setTransaction($transaction)
+  {
+    $this->transaction = $transaction;
+  }
+  public function getTransaction()
+  {
+    return $this->transaction;
+  }
+}
+
+class Google_Service_Datastore_RollbackResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $headerType = 'Google_Service_Datastore_ResponseHeader';
+  protected $headerDataType = '';
+
+
+  public function setHeader(Google_Service_Datastore_ResponseHeader $header)
+  {
+    $this->header = $header;
+  }
+  public function getHeader()
+  {
+    return $this->header;
+  }
+}
+
+class Google_Service_Datastore_RunQueryRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $gqlQueryType = 'Google_Service_Datastore_GqlQuery';
+  protected $gqlQueryDataType = '';
+  protected $partitionIdType = 'Google_Service_Datastore_PartitionId';
+  protected $partitionIdDataType = '';
+  protected $queryType = 'Google_Service_Datastore_Query';
+  protected $queryDataType = '';
+  protected $readOptionsType = 'Google_Service_Datastore_ReadOptions';
+  protected $readOptionsDataType = '';
+
+
+  public function setGqlQuery(Google_Service_Datastore_GqlQuery $gqlQuery)
+  {
+    $this->gqlQuery = $gqlQuery;
+  }
+  public function getGqlQuery()
+  {
+    return $this->gqlQuery;
+  }
+  public function setPartitionId(Google_Service_Datastore_PartitionId $partitionId)
+  {
+    $this->partitionId = $partitionId;
+  }
+  public function getPartitionId()
+  {
+    return $this->partitionId;
+  }
+  public function setQuery(Google_Service_Datastore_Query $query)
+  {
+    $this->query = $query;
+  }
+  public function getQuery()
+  {
+    return $this->query;
+  }
+  public function setReadOptions(Google_Service_Datastore_ReadOptions $readOptions)
+  {
+    $this->readOptions = $readOptions;
+  }
+  public function getReadOptions()
+  {
+    return $this->readOptions;
+  }
+}
+
+class Google_Service_Datastore_RunQueryResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $batchType = 'Google_Service_Datastore_QueryResultBatch';
+  protected $batchDataType = '';
+  protected $headerType = 'Google_Service_Datastore_ResponseHeader';
+  protected $headerDataType = '';
+
+
+  public function setBatch(Google_Service_Datastore_QueryResultBatch $batch)
+  {
+    $this->batch = $batch;
+  }
+  public function getBatch()
+  {
+    return $this->batch;
+  }
+  public function setHeader(Google_Service_Datastore_ResponseHeader $header)
+  {
+    $this->header = $header;
+  }
+  public function getHeader()
+  {
+    return $this->header;
+  }
+}
+
+class Google_Service_Datastore_Value extends Google_Collection
+{
+  protected $collection_key = 'listValue';
+  protected $internal_gapi_mappings = array(
+  );
+  public $blobKeyValue;
+  public $blobValue;
+  public $booleanValue;
+  public $dateTimeValue;
+  public $doubleValue;
+  protected $entityValueType = 'Google_Service_Datastore_Entity';
+  protected $entityValueDataType = '';
+  public $indexed;
+  public $integerValue;
+  protected $keyValueType = 'Google_Service_Datastore_Key';
+  protected $keyValueDataType = '';
+  protected $listValueType = 'Google_Service_Datastore_Value';
+  protected $listValueDataType = 'array';
+  public $meaning;
+  public $stringValue;
+
+
+  public function setBlobKeyValue($blobKeyValue)
+  {
+    $this->blobKeyValue = $blobKeyValue;
+  }
+  public function getBlobKeyValue()
+  {
+    return $this->blobKeyValue;
+  }
+  public function setBlobValue($blobValue)
+  {
+    $this->blobValue = $blobValue;
+  }
+  public function getBlobValue()
+  {
+    return $this->blobValue;
+  }
+  public function setBooleanValue($booleanValue)
+  {
+    $this->booleanValue = $booleanValue;
+  }
+  public function getBooleanValue()
+  {
+    return $this->booleanValue;
+  }
+  public function setDateTimeValue($dateTimeValue)
+  {
+    $this->dateTimeValue = $dateTimeValue;
+  }
+  public function getDateTimeValue()
+  {
+    return $this->dateTimeValue;
+  }
+  public function setDoubleValue($doubleValue)
+  {
+    $this->doubleValue = $doubleValue;
+  }
+  public function getDoubleValue()
+  {
+    return $this->doubleValue;
+  }
+  public function setEntityValue(Google_Service_Datastore_Entity $entityValue)
+  {
+    $this->entityValue = $entityValue;
+  }
+  public function getEntityValue()
+  {
+    return $this->entityValue;
+  }
+  public function setIndexed($indexed)
+  {
+    $this->indexed = $indexed;
+  }
+  public function getIndexed()
+  {
+    return $this->indexed;
+  }
+  public function setIntegerValue($integerValue)
+  {
+    $this->integerValue = $integerValue;
+  }
+  public function getIntegerValue()
+  {
+    return $this->integerValue;
+  }
+  public function setKeyValue(Google_Service_Datastore_Key $keyValue)
+  {
+    $this->keyValue = $keyValue;
+  }
+  public function getKeyValue()
+  {
+    return $this->keyValue;
+  }
+  public function setListValue($listValue)
+  {
+    $this->listValue = $listValue;
+  }
+  public function getListValue()
+  {
+    return $this->listValue;
+  }
+  public function setMeaning($meaning)
+  {
+    $this->meaning = $meaning;
+  }
+  public function getMeaning()
+  {
+    return $this->meaning;
+  }
+  public function setStringValue($stringValue)
+  {
+    $this->stringValue = $stringValue;
+  }
+  public function getStringValue()
+  {
+    return $this->stringValue;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/DeploymentManager.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/DeploymentManager.php
@@ -1,0 +1,2019 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for DeploymentManager (v2).
+ *
+ * <p>
+ * The Deployment Manager API allows users to declaratively configure, deploy
+ * and run complex solutions on the Google Cloud Platform.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://cloud.google.com/deployment-manager/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_DeploymentManager extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+  /** View your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM_READ_ONLY =
+      "https://www.googleapis.com/auth/cloud-platform.read-only";
+  /** View and manage your Google Cloud Platform management resources and deployment status information. */
+  const NDEV_CLOUDMAN =
+      "https://www.googleapis.com/auth/ndev.cloudman";
+  /** View your Google Cloud Platform management resources and deployment status information. */
+  const NDEV_CLOUDMAN_READONLY =
+      "https://www.googleapis.com/auth/ndev.cloudman.readonly";
+
+  public $deployments;
+  public $manifests;
+  public $operations;
+  public $resources;
+  public $types;
+  
+
+  /**
+   * Constructs the internal representation of the DeploymentManager service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'deploymentmanager/v2/projects/';
+    $this->version = 'v2';
+    $this->serviceName = 'deploymentmanager';
+
+    $this->deployments = new Google_Service_DeploymentManager_Deployments_Resource(
+        $this,
+        $this->serviceName,
+        'deployments',
+        array(
+          'methods' => array(
+            'cancelPreview' => array(
+              'path' => '{project}/global/deployments/{deployment}/cancelPreview',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deployment' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/global/deployments/{deployment}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deployment' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/global/deployments/{deployment}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deployment' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/global/deployments',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'preview' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/deployments',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{project}/global/deployments/{deployment}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deployment' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'preview' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'deletePolicy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'createPolicy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'stop' => array(
+              'path' => '{project}/global/deployments/{deployment}/stop',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deployment' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{project}/global/deployments/{deployment}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deployment' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'preview' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'deletePolicy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'createPolicy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->manifests = new Google_Service_DeploymentManager_Manifests_Resource(
+        $this,
+        $this->serviceName,
+        'manifests',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{project}/global/deployments/{deployment}/manifests/{manifest}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deployment' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'manifest' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/deployments/{deployment}/manifests',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deployment' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->operations = new Google_Service_DeploymentManager_Operations_Resource(
+        $this,
+        $this->serviceName,
+        'operations',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{project}/global/operations/{operation}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operation' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/operations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->resources = new Google_Service_DeploymentManager_Resources_Resource(
+        $this,
+        $this->serviceName,
+        'resources',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{project}/global/deployments/{deployment}/resources/{resource}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deployment' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'resource' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/global/deployments/{deployment}/resources',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deployment' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->types = new Google_Service_DeploymentManager_Types_Resource(
+        $this,
+        $this->serviceName,
+        'types',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => '{project}/global/types',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "deployments" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $deploymentmanagerService = new Google_Service_DeploymentManager(...);
+ *   $deployments = $deploymentmanagerService->deployments;
+ *  </code>
+ */
+class Google_Service_DeploymentManager_Deployments_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Cancels and removes the preview currently associated with the deployment.
+   * (deployments.cancelPreview)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $deployment The name of the deployment for this request.
+   * @param Google_DeploymentsCancelPreviewRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_DeploymentManager_Operation
+   */
+  public function cancelPreview($project, $deployment, Google_Service_DeploymentManager_DeploymentsCancelPreviewRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'deployment' => $deployment, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('cancelPreview', array($params), "Google_Service_DeploymentManager_Operation");
+  }
+
+  /**
+   * Deletes a deployment and all of the resources in the deployment.
+   * (deployments.delete)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $deployment The name of the deployment for this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_DeploymentManager_Operation
+   */
+  public function delete($project, $deployment, $optParams = array())
+  {
+    $params = array('project' => $project, 'deployment' => $deployment);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_DeploymentManager_Operation");
+  }
+
+  /**
+   * Gets information about a specific deployment. (deployments.get)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $deployment The name of the deployment for this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_DeploymentManager_Deployment
+   */
+  public function get($project, $deployment, $optParams = array())
+  {
+    $params = array('project' => $project, 'deployment' => $deployment);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_DeploymentManager_Deployment");
+  }
+
+  /**
+   * Creates a deployment and all of the resources described by the deployment
+   * manifest. (deployments.insert)
+   *
+   * @param string $project The project ID for this request.
+   * @param Google_Deployment $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool preview If set to true, creates a deployment and creates
+   * "shell" resources but does not actually instantiate these resources. This
+   * allows you to preview what your deployment looks like. After previewing a
+   * deployment, you can deploy your resources by making a request with the
+   * update() method or you can use the cancelPreview() method to cancel the
+   * preview altogether. Note that the deployment will still exist after you
+   * cancel the preview and you must separately delete this deployment if you want
+   * to remove it.
+   * @return Google_Service_DeploymentManager_Operation
+   */
+  public function insert($project, Google_Service_DeploymentManager_Deployment $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_DeploymentManager_Operation");
+  }
+
+  /**
+   * Lists all deployments for a given project. (deployments.listDeployments)
+   *
+   * @param string $project The project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_DeploymentManager_DeploymentsListResponse
+   */
+  public function listDeployments($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_DeploymentManager_DeploymentsListResponse");
+  }
+
+  /**
+   * Updates a deployment and all of the resources described by the deployment
+   * manifest. This method supports patch semantics. (deployments.patch)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $deployment The name of the deployment for this request.
+   * @param Google_Deployment $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool preview If set to true, updates the deployment and creates
+   * and updates the "shell" resources but does not actually alter or instantiate
+   * these resources. This allows you to preview what your deployment looks like.
+   * You can use this intent to preview how an update would affect your
+   * deployment. You must provide a target.config with a configuration if this is
+   * set to true. After previewing a deployment, you can deploy your resources by
+   * making a request with the update() or you can cancelPreview() to remove the
+   * preview altogether. Note that the deployment will still exist after you
+   * cancel the preview and you must separately delete this deployment if you want
+   * to remove it.
+   * @opt_param string deletePolicy Sets the policy to use for deleting resources.
+   * @opt_param string createPolicy Sets the policy to use for creating new
+   * resources.
+   * @return Google_Service_DeploymentManager_Operation
+   */
+  public function patch($project, $deployment, Google_Service_DeploymentManager_Deployment $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'deployment' => $deployment, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_DeploymentManager_Operation");
+  }
+
+  /**
+   * Stops an ongoing operation. This does not roll back any work that has already
+   * been completed, but prevents any new work from being started.
+   * (deployments.stop)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $deployment The name of the deployment for this request.
+   * @param Google_DeploymentsStopRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_DeploymentManager_Operation
+   */
+  public function stop($project, $deployment, Google_Service_DeploymentManager_DeploymentsStopRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'deployment' => $deployment, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('stop', array($params), "Google_Service_DeploymentManager_Operation");
+  }
+
+  /**
+   * Updates a deployment and all of the resources described by the deployment
+   * manifest. (deployments.update)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $deployment The name of the deployment for this request.
+   * @param Google_Deployment $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool preview If set to true, updates the deployment and creates
+   * and updates the "shell" resources but does not actually alter or instantiate
+   * these resources. This allows you to preview what your deployment looks like.
+   * You can use this intent to preview how an update would affect your
+   * deployment. You must provide a target.config with a configuration if this is
+   * set to true. After previewing a deployment, you can deploy your resources by
+   * making a request with the update() or you can cancelPreview() to remove the
+   * preview altogether. Note that the deployment will still exist after you
+   * cancel the preview and you must separately delete this deployment if you want
+   * to remove it.
+   * @opt_param string deletePolicy Sets the policy to use for deleting resources.
+   * @opt_param string createPolicy Sets the policy to use for creating new
+   * resources.
+   * @return Google_Service_DeploymentManager_Operation
+   */
+  public function update($project, $deployment, Google_Service_DeploymentManager_Deployment $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'deployment' => $deployment, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_DeploymentManager_Operation");
+  }
+}
+
+/**
+ * The "manifests" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $deploymentmanagerService = new Google_Service_DeploymentManager(...);
+ *   $manifests = $deploymentmanagerService->manifests;
+ *  </code>
+ */
+class Google_Service_DeploymentManager_Manifests_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets information about a specific manifest. (manifests.get)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $deployment The name of the deployment for this request.
+   * @param string $manifest The name of the manifest for this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_DeploymentManager_Manifest
+   */
+  public function get($project, $deployment, $manifest, $optParams = array())
+  {
+    $params = array('project' => $project, 'deployment' => $deployment, 'manifest' => $manifest);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_DeploymentManager_Manifest");
+  }
+
+  /**
+   * Lists all manifests for a given deployment. (manifests.listManifests)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $deployment The name of the deployment for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_DeploymentManager_ManifestsListResponse
+   */
+  public function listManifests($project, $deployment, $optParams = array())
+  {
+    $params = array('project' => $project, 'deployment' => $deployment);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_DeploymentManager_ManifestsListResponse");
+  }
+}
+
+/**
+ * The "operations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $deploymentmanagerService = new Google_Service_DeploymentManager(...);
+ *   $operations = $deploymentmanagerService->operations;
+ *  </code>
+ */
+class Google_Service_DeploymentManager_Operations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets information about a specific operation. (operations.get)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $operation The name of the operation for this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_DeploymentManager_Operation
+   */
+  public function get($project, $operation, $optParams = array())
+  {
+    $params = array('project' => $project, 'operation' => $operation);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_DeploymentManager_Operation");
+  }
+
+  /**
+   * Lists all operations for a project. (operations.listOperations)
+   *
+   * @param string $project The project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_DeploymentManager_OperationsListResponse
+   */
+  public function listOperations($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_DeploymentManager_OperationsListResponse");
+  }
+}
+
+/**
+ * The "resources" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $deploymentmanagerService = new Google_Service_DeploymentManager(...);
+ *   $resources = $deploymentmanagerService->resources;
+ *  </code>
+ */
+class Google_Service_DeploymentManager_Resources_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets information about a single resource. (resources.get)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $deployment The name of the deployment for this request.
+   * @param string $resource The name of the resource for this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_DeploymentManager_DeploymentmanagerResource
+   */
+  public function get($project, $deployment, $resource, $optParams = array())
+  {
+    $params = array('project' => $project, 'deployment' => $deployment, 'resource' => $resource);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_DeploymentManager_DeploymentmanagerResource");
+  }
+
+  /**
+   * Lists all resources in a given deployment. (resources.listResources)
+   *
+   * @param string $project The project ID for this request.
+   * @param string $deployment The name of the deployment for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_DeploymentManager_ResourcesListResponse
+   */
+  public function listResources($project, $deployment, $optParams = array())
+  {
+    $params = array('project' => $project, 'deployment' => $deployment);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_DeploymentManager_ResourcesListResponse");
+  }
+}
+
+/**
+ * The "types" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $deploymentmanagerService = new Google_Service_DeploymentManager(...);
+ *   $types = $deploymentmanagerService->types;
+ *  </code>
+ */
+class Google_Service_DeploymentManager_Types_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Lists all resource types for Deployment Manager. (types.listTypes)
+   *
+   * @param string $project The project ID for this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Sets a filter expression for filtering listed
+   * resources, in the form filter={expression}. Your {expression} must be in the
+   * format: FIELD_NAME COMPARISON_STRING LITERAL_STRING.
+   *
+   * The FIELD_NAME is the name of the field you want to compare. Only atomic
+   * field types are supported (string, number, boolean). The COMPARISON_STRING
+   * must be either eq (equals) or ne (not equals). The LITERAL_STRING is the
+   * string value to filter to. The literal value must be valid for the type of
+   * field (string, number, boolean). For string fields, the literal value is
+   * interpreted as a regular expression using RE2 syntax. The literal value must
+   * match the entire field.
+   *
+   * For example, filter=name ne example-instance.
+   * @opt_param string pageToken Specifies a page token to use. Use this parameter
+   * if you want to list the next page of results. Set pageToken to the
+   * nextPageToken returned by a previous list request.
+   * @opt_param string maxResults Maximum count of results to be returned.
+   * @return Google_Service_DeploymentManager_TypesListResponse
+   */
+  public function listTypes($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_DeploymentManager_TypesListResponse");
+  }
+}
+
+
+
+
+class Google_Service_DeploymentManager_ConfigFile extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $content;
+
+
+  public function setContent($content)
+  {
+    $this->content = $content;
+  }
+  public function getContent()
+  {
+    return $this->content;
+  }
+}
+
+class Google_Service_DeploymentManager_Deployment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $fingerprint;
+  public $id;
+  public $insertTime;
+  public $manifest;
+  public $name;
+  protected $operationType = 'Google_Service_DeploymentManager_Operation';
+  protected $operationDataType = '';
+  protected $targetType = 'Google_Service_DeploymentManager_TargetConfiguration';
+  protected $targetDataType = '';
+  protected $updateType = 'Google_Service_DeploymentManager_DeploymentUpdate';
+  protected $updateDataType = '';
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInsertTime($insertTime)
+  {
+    $this->insertTime = $insertTime;
+  }
+  public function getInsertTime()
+  {
+    return $this->insertTime;
+  }
+  public function setManifest($manifest)
+  {
+    $this->manifest = $manifest;
+  }
+  public function getManifest()
+  {
+    return $this->manifest;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOperation(Google_Service_DeploymentManager_Operation $operation)
+  {
+    $this->operation = $operation;
+  }
+  public function getOperation()
+  {
+    return $this->operation;
+  }
+  public function setTarget(Google_Service_DeploymentManager_TargetConfiguration $target)
+  {
+    $this->target = $target;
+  }
+  public function getTarget()
+  {
+    return $this->target;
+  }
+  public function setUpdate(Google_Service_DeploymentManager_DeploymentUpdate $update)
+  {
+    $this->update = $update;
+  }
+  public function getUpdate()
+  {
+    return $this->update;
+  }
+}
+
+class Google_Service_DeploymentManager_DeploymentUpdate extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $manifest;
+
+
+  public function setManifest($manifest)
+  {
+    $this->manifest = $manifest;
+  }
+  public function getManifest()
+  {
+    return $this->manifest;
+  }
+}
+
+class Google_Service_DeploymentManager_DeploymentmanagerResource extends Google_Collection
+{
+  protected $collection_key = 'warnings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $finalProperties;
+  public $id;
+  public $insertTime;
+  public $manifest;
+  public $name;
+  public $properties;
+  public $type;
+  protected $updateType = 'Google_Service_DeploymentManager_ResourceUpdate';
+  protected $updateDataType = '';
+  public $updateTime;
+  public $url;
+  protected $warningsType = 'Google_Service_DeploymentManager_DeploymentmanagerResourceWarnings';
+  protected $warningsDataType = 'array';
+
+
+  public function setFinalProperties($finalProperties)
+  {
+    $this->finalProperties = $finalProperties;
+  }
+  public function getFinalProperties()
+  {
+    return $this->finalProperties;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInsertTime($insertTime)
+  {
+    $this->insertTime = $insertTime;
+  }
+  public function getInsertTime()
+  {
+    return $this->insertTime;
+  }
+  public function setManifest($manifest)
+  {
+    $this->manifest = $manifest;
+  }
+  public function getManifest()
+  {
+    return $this->manifest;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProperties($properties)
+  {
+    $this->properties = $properties;
+  }
+  public function getProperties()
+  {
+    return $this->properties;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUpdate(Google_Service_DeploymentManager_ResourceUpdate $update)
+  {
+    $this->update = $update;
+  }
+  public function getUpdate()
+  {
+    return $this->update;
+  }
+  public function setUpdateTime($updateTime)
+  {
+    $this->updateTime = $updateTime;
+  }
+  public function getUpdateTime()
+  {
+    return $this->updateTime;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setWarnings($warnings)
+  {
+    $this->warnings = $warnings;
+  }
+  public function getWarnings()
+  {
+    return $this->warnings;
+  }
+}
+
+class Google_Service_DeploymentManager_DeploymentmanagerResourceWarnings extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_DeploymentManager_DeploymentmanagerResourceWarningsData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_DeploymentManager_DeploymentmanagerResourceWarningsData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_DeploymentManager_DeploymentsCancelPreviewRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $fingerprint;
+
+
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+}
+
+class Google_Service_DeploymentManager_DeploymentsListResponse extends Google_Collection
+{
+  protected $collection_key = 'deployments';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $deploymentsType = 'Google_Service_DeploymentManager_Deployment';
+  protected $deploymentsDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setDeployments($deployments)
+  {
+    $this->deployments = $deployments;
+  }
+  public function getDeployments()
+  {
+    return $this->deployments;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_DeploymentManager_DeploymentsStopRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $fingerprint;
+
+
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+}
+
+class Google_Service_DeploymentManager_ImportFile extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $content;
+  public $name;
+
+
+  public function setContent($content)
+  {
+    $this->content = $content;
+  }
+  public function getContent()
+  {
+    return $this->content;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_DeploymentManager_Manifest extends Google_Collection
+{
+  protected $collection_key = 'imports';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $configType = 'Google_Service_DeploymentManager_ConfigFile';
+  protected $configDataType = '';
+  public $expandedConfig;
+  public $id;
+  protected $importsType = 'Google_Service_DeploymentManager_ImportFile';
+  protected $importsDataType = 'array';
+  public $insertTime;
+  public $layout;
+  public $name;
+  public $selfLink;
+
+
+  public function setConfig(Google_Service_DeploymentManager_ConfigFile $config)
+  {
+    $this->config = $config;
+  }
+  public function getConfig()
+  {
+    return $this->config;
+  }
+  public function setExpandedConfig($expandedConfig)
+  {
+    $this->expandedConfig = $expandedConfig;
+  }
+  public function getExpandedConfig()
+  {
+    return $this->expandedConfig;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImports($imports)
+  {
+    $this->imports = $imports;
+  }
+  public function getImports()
+  {
+    return $this->imports;
+  }
+  public function setInsertTime($insertTime)
+  {
+    $this->insertTime = $insertTime;
+  }
+  public function getInsertTime()
+  {
+    return $this->insertTime;
+  }
+  public function setLayout($layout)
+  {
+    $this->layout = $layout;
+  }
+  public function getLayout()
+  {
+    return $this->layout;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_DeploymentManager_ManifestsListResponse extends Google_Collection
+{
+  protected $collection_key = 'manifests';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $manifestsType = 'Google_Service_DeploymentManager_Manifest';
+  protected $manifestsDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setManifests($manifests)
+  {
+    $this->manifests = $manifests;
+  }
+  public function getManifests()
+  {
+    return $this->manifests;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_DeploymentManager_Operation extends Google_Collection
+{
+  protected $collection_key = 'warnings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $clientOperationId;
+  public $creationTimestamp;
+  public $endTime;
+  protected $errorType = 'Google_Service_DeploymentManager_OperationError';
+  protected $errorDataType = '';
+  public $httpErrorMessage;
+  public $httpErrorStatusCode;
+  public $id;
+  public $insertTime;
+  public $kind;
+  public $name;
+  public $operationType;
+  public $progress;
+  public $region;
+  public $selfLink;
+  public $startTime;
+  public $status;
+  public $statusMessage;
+  public $targetId;
+  public $targetLink;
+  public $user;
+  protected $warningsType = 'Google_Service_DeploymentManager_OperationWarnings';
+  protected $warningsDataType = 'array';
+  public $zone;
+
+
+  public function setClientOperationId($clientOperationId)
+  {
+    $this->clientOperationId = $clientOperationId;
+  }
+  public function getClientOperationId()
+  {
+    return $this->clientOperationId;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setError(Google_Service_DeploymentManager_OperationError $error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setHttpErrorMessage($httpErrorMessage)
+  {
+    $this->httpErrorMessage = $httpErrorMessage;
+  }
+  public function getHttpErrorMessage()
+  {
+    return $this->httpErrorMessage;
+  }
+  public function setHttpErrorStatusCode($httpErrorStatusCode)
+  {
+    $this->httpErrorStatusCode = $httpErrorStatusCode;
+  }
+  public function getHttpErrorStatusCode()
+  {
+    return $this->httpErrorStatusCode;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInsertTime($insertTime)
+  {
+    $this->insertTime = $insertTime;
+  }
+  public function getInsertTime()
+  {
+    return $this->insertTime;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOperationType($operationType)
+  {
+    $this->operationType = $operationType;
+  }
+  public function getOperationType()
+  {
+    return $this->operationType;
+  }
+  public function setProgress($progress)
+  {
+    $this->progress = $progress;
+  }
+  public function getProgress()
+  {
+    return $this->progress;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setStatusMessage($statusMessage)
+  {
+    $this->statusMessage = $statusMessage;
+  }
+  public function getStatusMessage()
+  {
+    return $this->statusMessage;
+  }
+  public function setTargetId($targetId)
+  {
+    $this->targetId = $targetId;
+  }
+  public function getTargetId()
+  {
+    return $this->targetId;
+  }
+  public function setTargetLink($targetLink)
+  {
+    $this->targetLink = $targetLink;
+  }
+  public function getTargetLink()
+  {
+    return $this->targetLink;
+  }
+  public function setUser($user)
+  {
+    $this->user = $user;
+  }
+  public function getUser()
+  {
+    return $this->user;
+  }
+  public function setWarnings($warnings)
+  {
+    $this->warnings = $warnings;
+  }
+  public function getWarnings()
+  {
+    return $this->warnings;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_DeploymentManager_OperationError extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorsType = 'Google_Service_DeploymentManager_OperationErrorErrors';
+  protected $errorsDataType = 'array';
+
+
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+}
+
+class Google_Service_DeploymentManager_OperationErrorErrors extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $location;
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_DeploymentManager_OperationWarnings extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_DeploymentManager_OperationWarningsData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_DeploymentManager_OperationWarningsData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_DeploymentManager_OperationsListResponse extends Google_Collection
+{
+  protected $collection_key = 'operations';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $operationsType = 'Google_Service_DeploymentManager_Operation';
+  protected $operationsDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setOperations($operations)
+  {
+    $this->operations = $operations;
+  }
+  public function getOperations()
+  {
+    return $this->operations;
+  }
+}
+
+class Google_Service_DeploymentManager_ResourceUpdate extends Google_Collection
+{
+  protected $collection_key = 'warnings';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorType = 'Google_Service_DeploymentManager_ResourceUpdateError';
+  protected $errorDataType = '';
+  public $finalProperties;
+  public $intent;
+  public $manifest;
+  public $properties;
+  public $state;
+  protected $warningsType = 'Google_Service_DeploymentManager_ResourceUpdateWarnings';
+  protected $warningsDataType = 'array';
+
+
+  public function setError(Google_Service_DeploymentManager_ResourceUpdateError $error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setFinalProperties($finalProperties)
+  {
+    $this->finalProperties = $finalProperties;
+  }
+  public function getFinalProperties()
+  {
+    return $this->finalProperties;
+  }
+  public function setIntent($intent)
+  {
+    $this->intent = $intent;
+  }
+  public function getIntent()
+  {
+    return $this->intent;
+  }
+  public function setManifest($manifest)
+  {
+    $this->manifest = $manifest;
+  }
+  public function getManifest()
+  {
+    return $this->manifest;
+  }
+  public function setProperties($properties)
+  {
+    $this->properties = $properties;
+  }
+  public function getProperties()
+  {
+    return $this->properties;
+  }
+  public function setState($state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+  public function setWarnings($warnings)
+  {
+    $this->warnings = $warnings;
+  }
+  public function getWarnings()
+  {
+    return $this->warnings;
+  }
+}
+
+class Google_Service_DeploymentManager_ResourceUpdateError extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorsType = 'Google_Service_DeploymentManager_ResourceUpdateErrorErrors';
+  protected $errorsDataType = 'array';
+
+
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+}
+
+class Google_Service_DeploymentManager_ResourceUpdateErrorErrors extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $location;
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_DeploymentManager_ResourceUpdateWarnings extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_DeploymentManager_ResourceUpdateWarningsData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_DeploymentManager_ResourceUpdateWarningsData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_DeploymentManager_ResourcesListResponse extends Google_Collection
+{
+  protected $collection_key = 'resources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $resourcesType = 'Google_Service_DeploymentManager_DeploymentmanagerResource';
+  protected $resourcesDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setResources($resources)
+  {
+    $this->resources = $resources;
+  }
+  public function getResources()
+  {
+    return $this->resources;
+  }
+}
+
+class Google_Service_DeploymentManager_TargetConfiguration extends Google_Collection
+{
+  protected $collection_key = 'imports';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $configType = 'Google_Service_DeploymentManager_ConfigFile';
+  protected $configDataType = '';
+  protected $importsType = 'Google_Service_DeploymentManager_ImportFile';
+  protected $importsDataType = 'array';
+
+
+  public function setConfig(Google_Service_DeploymentManager_ConfigFile $config)
+  {
+    $this->config = $config;
+  }
+  public function getConfig()
+  {
+    return $this->config;
+  }
+  public function setImports($imports)
+  {
+    $this->imports = $imports;
+  }
+  public function getImports()
+  {
+    return $this->imports;
+  }
+}
+
+class Google_Service_DeploymentManager_Type extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $insertTime;
+  public $name;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInsertTime($insertTime)
+  {
+    $this->insertTime = $insertTime;
+  }
+  public function getInsertTime()
+  {
+    return $this->insertTime;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_DeploymentManager_TypesListResponse extends Google_Collection
+{
+  protected $collection_key = 'types';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $typesType = 'Google_Service_DeploymentManager_Type';
+  protected $typesDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTypes($types)
+  {
+    $this->types = $types;
+  }
+  public function getTypes()
+  {
+    return $this->types;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Dfareporting.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Dfareporting.php
@@ -1,0 +1,21443 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Dfareporting (v2.1).
+ *
+ * <p>
+ * Manage your DoubleClick Campaign Manager ad campaigns and reports.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/doubleclick-advertisers/reporting/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Dfareporting extends Google_Service
+{
+  /** View and manage DoubleClick for Advertisers reports. */
+  const DFAREPORTING =
+      "https://www.googleapis.com/auth/dfareporting";
+  /** View and manage your DoubleClick Campaign Manager's (DCM) display ad campaigns. */
+  const DFATRAFFICKING =
+      "https://www.googleapis.com/auth/dfatrafficking";
+
+  public $accountActiveAdSummaries;
+  public $accountPermissionGroups;
+  public $accountPermissions;
+  public $accountUserProfiles;
+  public $accounts;
+  public $ads;
+  public $advertiserGroups;
+  public $advertisers;
+  public $browsers;
+  public $campaignCreativeAssociations;
+  public $campaigns;
+  public $changeLogs;
+  public $cities;
+  public $connectionTypes;
+  public $contentCategories;
+  public $countries;
+  public $creativeAssets;
+  public $creativeFieldValues;
+  public $creativeFields;
+  public $creativeGroups;
+  public $creatives;
+  public $dimensionValues;
+  public $directorySiteContacts;
+  public $directorySites;
+  public $eventTags;
+  public $files;
+  public $floodlightActivities;
+  public $floodlightActivityGroups;
+  public $floodlightConfigurations;
+  public $inventoryItems;
+  public $landingPages;
+  public $metros;
+  public $mobileCarriers;
+  public $operatingSystemVersions;
+  public $operatingSystems;
+  public $orderDocuments;
+  public $orders;
+  public $placementGroups;
+  public $placementStrategies;
+  public $placements;
+  public $platformTypes;
+  public $postalCodes;
+  public $projects;
+  public $regions;
+  public $remarketingListShares;
+  public $remarketingLists;
+  public $reports;
+  public $reports_compatibleFields;
+  public $reports_files;
+  public $sites;
+  public $sizes;
+  public $subaccounts;
+  public $targetableRemarketingLists;
+  public $userProfiles;
+  public $userRolePermissionGroups;
+  public $userRolePermissions;
+  public $userRoles;
+  
+
+  /**
+   * Constructs the internal representation of the Dfareporting service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->servicePath = 'dfareporting/v2.1/';
+    $this->version = 'v2.1';
+    $this->serviceName = 'dfareporting';
+
+    $this->accountActiveAdSummaries = new Google_Service_Dfareporting_AccountActiveAdSummaries_Resource(
+        $this,
+        $this->serviceName,
+        'accountActiveAdSummaries',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/accountActiveAdSummaries/{summaryAccountId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'summaryAccountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accountPermissionGroups = new Google_Service_Dfareporting_AccountPermissionGroups_Resource(
+        $this,
+        $this->serviceName,
+        'accountPermissionGroups',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/accountPermissionGroups/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/accountPermissionGroups',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accountPermissions = new Google_Service_Dfareporting_AccountPermissions_Resource(
+        $this,
+        $this->serviceName,
+        'accountPermissions',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/accountPermissions/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/accountPermissions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accountUserProfiles = new Google_Service_Dfareporting_AccountUserProfiles_Resource(
+        $this,
+        $this->serviceName,
+        'accountUserProfiles',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/accountUserProfiles/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/accountUserProfiles',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/accountUserProfiles',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'subaccountId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'userRoleId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'active' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/accountUserProfiles',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/accountUserProfiles',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts = new Google_Service_Dfareporting_Accounts_Resource(
+        $this,
+        $this->serviceName,
+        'accounts',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/accounts/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/accounts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'active' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/accounts',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/accounts',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->ads = new Google_Service_Dfareporting_Ads_Resource(
+        $this,
+        $this->serviceName,
+        'ads',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/ads/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/ads',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/ads',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'landingPageIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'overriddenEventTagId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'campaignIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'archived' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'creativeOptimizationConfigurationIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'sslCompliant' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'sizeIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'type' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'sslRequired' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'creativeIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'creativeType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'placementIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'active' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'compatibility' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'advertiserId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'audienceSegmentIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'remarketingListIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'dynamicClickTracker' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/ads',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/ads',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->advertiserGroups = new Google_Service_Dfareporting_AdvertiserGroups_Resource(
+        $this,
+        $this->serviceName,
+        'advertiserGroups',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'userprofiles/{profileId}/advertiserGroups/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'userprofiles/{profileId}/advertiserGroups/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/advertiserGroups',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/advertiserGroups',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/advertiserGroups',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/advertiserGroups',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->advertisers = new Google_Service_Dfareporting_Advertisers_Resource(
+        $this,
+        $this->serviceName,
+        'advertisers',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/advertisers/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/advertisers',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/advertisers',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'status' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'subaccountId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'includeAdvertisersWithoutGroupsOnly' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onlyParent' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'floodlightConfigurationIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'advertiserGroupIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/advertisers',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/advertisers',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->browsers = new Google_Service_Dfareporting_Browsers_Resource(
+        $this,
+        $this->serviceName,
+        'browsers',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'userprofiles/{profileId}/browsers',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->campaignCreativeAssociations = new Google_Service_Dfareporting_CampaignCreativeAssociations_Resource(
+        $this,
+        $this->serviceName,
+        'campaignCreativeAssociations',
+        array(
+          'methods' => array(
+            'insert' => array(
+              'path' => 'userprofiles/{profileId}/campaigns/{campaignId}/campaignCreativeAssociations',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'campaignId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/campaigns/{campaignId}/campaignCreativeAssociations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'campaignId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->campaigns = new Google_Service_Dfareporting_Campaigns_Resource(
+        $this,
+        $this->serviceName,
+        'campaigns',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/campaigns/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/campaigns',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'defaultLandingPageName' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'defaultLandingPageUrl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/campaigns',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'archived' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'subaccountId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'advertiserIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'excludedIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'advertiserGroupIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'overriddenEventTagId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'atLeastOneOptimizationActivity' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/campaigns',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/campaigns',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->changeLogs = new Google_Service_Dfareporting_ChangeLogs_Resource(
+        $this,
+        $this->serviceName,
+        'changeLogs',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/changeLogs/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/changeLogs',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'minChangeTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxChangeTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'userProfileIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'objectIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'action' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'objectType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->cities = new Google_Service_Dfareporting_Cities_Resource(
+        $this,
+        $this->serviceName,
+        'cities',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'userprofiles/{profileId}/cities',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dartIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'namePrefix' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'regionDartIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'countryDartIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->connectionTypes = new Google_Service_Dfareporting_ConnectionTypes_Resource(
+        $this,
+        $this->serviceName,
+        'connectionTypes',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/connectionTypes/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/connectionTypes',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->contentCategories = new Google_Service_Dfareporting_ContentCategories_Resource(
+        $this,
+        $this->serviceName,
+        'contentCategories',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'userprofiles/{profileId}/contentCategories/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'userprofiles/{profileId}/contentCategories/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/contentCategories',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/contentCategories',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/contentCategories',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/contentCategories',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->countries = new Google_Service_Dfareporting_Countries_Resource(
+        $this,
+        $this->serviceName,
+        'countries',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/countries/{dartId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dartId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/countries',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->creativeAssets = new Google_Service_Dfareporting_CreativeAssets_Resource(
+        $this,
+        $this->serviceName,
+        'creativeAssets',
+        array(
+          'methods' => array(
+            'insert' => array(
+              'path' => 'userprofiles/{profileId}/creativeAssets/{advertiserId}/creativeAssets',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'advertiserId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->creativeFieldValues = new Google_Service_Dfareporting_CreativeFieldValues_Resource(
+        $this,
+        $this->serviceName,
+        'creativeFieldValues',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'userprofiles/{profileId}/creativeFields/{creativeFieldId}/creativeFieldValues/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'creativeFieldId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'userprofiles/{profileId}/creativeFields/{creativeFieldId}/creativeFieldValues/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'creativeFieldId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/creativeFields/{creativeFieldId}/creativeFieldValues',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'creativeFieldId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/creativeFields/{creativeFieldId}/creativeFieldValues',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'creativeFieldId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/creativeFields/{creativeFieldId}/creativeFieldValues',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'creativeFieldId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/creativeFields/{creativeFieldId}/creativeFieldValues',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'creativeFieldId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->creativeFields = new Google_Service_Dfareporting_CreativeFields_Resource(
+        $this,
+        $this->serviceName,
+        'creativeFields',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'userprofiles/{profileId}/creativeFields/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'userprofiles/{profileId}/creativeFields/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/creativeFields',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/creativeFields',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'advertiserIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/creativeFields',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/creativeFields',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->creativeGroups = new Google_Service_Dfareporting_CreativeGroups_Resource(
+        $this,
+        $this->serviceName,
+        'creativeGroups',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/creativeGroups/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/creativeGroups',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/creativeGroups',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'advertiserIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'groupNumber' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/creativeGroups',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/creativeGroups',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->creatives = new Google_Service_Dfareporting_Creatives_Resource(
+        $this,
+        $this->serviceName,
+        'creatives',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/creatives/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/creatives',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/creatives',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sizeIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'archived' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'campaignId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'renderingIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'advertiserId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'studioCreativeId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'companionCreativeIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'active' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'creativeFieldIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'types' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/creatives',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/creatives',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->dimensionValues = new Google_Service_Dfareporting_DimensionValues_Resource(
+        $this,
+        $this->serviceName,
+        'dimensionValues',
+        array(
+          'methods' => array(
+            'query' => array(
+              'path' => 'userprofiles/{profileId}/dimensionvalues/query',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->directorySiteContacts = new Google_Service_Dfareporting_DirectorySiteContacts_Resource(
+        $this,
+        $this->serviceName,
+        'directorySiteContacts',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/directorySiteContacts/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/directorySiteContacts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'directorySiteIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->directorySites = new Google_Service_Dfareporting_DirectorySites_Resource(
+        $this,
+        $this->serviceName,
+        'directorySites',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/directorySites/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/directorySites',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/directorySites',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'acceptsInterstitialPlacements' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'countryId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'acceptsInStreamVideoPlacements' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'acceptsPublisherPaidPlacements' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'parentId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'active' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'dfp_network_code' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->eventTags = new Google_Service_Dfareporting_EventTags_Resource(
+        $this,
+        $this->serviceName,
+        'eventTags',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'userprofiles/{profileId}/eventTags/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'userprofiles/{profileId}/eventTags/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/eventTags',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/eventTags',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'campaignId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'enabled' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'advertiserId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'adId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'eventTagTypes' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'definitionsOnly' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/eventTags',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/eventTags',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->files = new Google_Service_Dfareporting_Files_Resource(
+        $this,
+        $this->serviceName,
+        'files',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'reports/{reportId}/files/{fileId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'reportId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'fileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/files',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'scope' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->floodlightActivities = new Google_Service_Dfareporting_FloodlightActivities_Resource(
+        $this,
+        $this->serviceName,
+        'floodlightActivities',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'userprofiles/{profileId}/floodlightActivities/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'generatetag' => array(
+              'path' => 'userprofiles/{profileId}/floodlightActivities/generatetag',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'floodlightActivityId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'userprofiles/{profileId}/floodlightActivities/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/floodlightActivities',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/floodlightActivities',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'floodlightActivityGroupIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'floodlightConfigurationId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'floodlightActivityGroupName' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'advertiserId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'tagString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'floodlightActivityGroupTagString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'floodlightActivityGroupType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/floodlightActivities',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/floodlightActivities',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->floodlightActivityGroups = new Google_Service_Dfareporting_FloodlightActivityGroups_Resource(
+        $this,
+        $this->serviceName,
+        'floodlightActivityGroups',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'userprofiles/{profileId}/floodlightActivityGroups/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'userprofiles/{profileId}/floodlightActivityGroups/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/floodlightActivityGroups',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/floodlightActivityGroups',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'floodlightConfigurationId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'advertiserId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'type' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/floodlightActivityGroups',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/floodlightActivityGroups',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->floodlightConfigurations = new Google_Service_Dfareporting_FloodlightConfigurations_Resource(
+        $this,
+        $this->serviceName,
+        'floodlightConfigurations',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/floodlightConfigurations/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/floodlightConfigurations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/floodlightConfigurations',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/floodlightConfigurations',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->inventoryItems = new Google_Service_Dfareporting_InventoryItems_Resource(
+        $this,
+        $this->serviceName,
+        'inventoryItems',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/projects/{projectId}/inventoryItems/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/projects/{projectId}/inventoryItems',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'siteId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'inPlan' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->landingPages = new Google_Service_Dfareporting_LandingPages_Resource(
+        $this,
+        $this->serviceName,
+        'landingPages',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'userprofiles/{profileId}/campaigns/{campaignId}/landingPages/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'campaignId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'userprofiles/{profileId}/campaigns/{campaignId}/landingPages/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'campaignId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/campaigns/{campaignId}/landingPages',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'campaignId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/campaigns/{campaignId}/landingPages',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'campaignId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/campaigns/{campaignId}/landingPages',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'campaignId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/campaigns/{campaignId}/landingPages',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'campaignId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->metros = new Google_Service_Dfareporting_Metros_Resource(
+        $this,
+        $this->serviceName,
+        'metros',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'userprofiles/{profileId}/metros',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->mobileCarriers = new Google_Service_Dfareporting_MobileCarriers_Resource(
+        $this,
+        $this->serviceName,
+        'mobileCarriers',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/mobileCarriers/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/mobileCarriers',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->operatingSystemVersions = new Google_Service_Dfareporting_OperatingSystemVersions_Resource(
+        $this,
+        $this->serviceName,
+        'operatingSystemVersions',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/operatingSystemVersions/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/operatingSystemVersions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->operatingSystems = new Google_Service_Dfareporting_OperatingSystems_Resource(
+        $this,
+        $this->serviceName,
+        'operatingSystems',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/operatingSystems/{dartId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dartId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/operatingSystems',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->orderDocuments = new Google_Service_Dfareporting_OrderDocuments_Resource(
+        $this,
+        $this->serviceName,
+        'orderDocuments',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/projects/{projectId}/orderDocuments/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/projects/{projectId}/orderDocuments',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'siteId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'approved' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->orders = new Google_Service_Dfareporting_Orders_Resource(
+        $this,
+        $this->serviceName,
+        'orders',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/projects/{projectId}/orders/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/projects/{projectId}/orders',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'siteId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->placementGroups = new Google_Service_Dfareporting_PlacementGroups_Resource(
+        $this,
+        $this->serviceName,
+        'placementGroups',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/placementGroups/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/placementGroups',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/placementGroups',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'placementStrategyIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'archived' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'contentCategoryIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'directorySiteIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'advertiserIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'placementGroupType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pricingTypes' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'siteIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'campaignIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/placementGroups',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/placementGroups',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->placementStrategies = new Google_Service_Dfareporting_PlacementStrategies_Resource(
+        $this,
+        $this->serviceName,
+        'placementStrategies',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'userprofiles/{profileId}/placementStrategies/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'userprofiles/{profileId}/placementStrategies/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/placementStrategies',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/placementStrategies',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/placementStrategies',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/placementStrategies',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->placements = new Google_Service_Dfareporting_Placements_Resource(
+        $this,
+        $this->serviceName,
+        'placements',
+        array(
+          'methods' => array(
+            'generatetags' => array(
+              'path' => 'userprofiles/{profileId}/placements/generatetags',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'tagFormats' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'placementIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'campaignId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'userprofiles/{profileId}/placements/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/placements',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/placements',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'placementStrategyIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'archived' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'contentCategoryIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'directorySiteIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'advertiserIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'paymentSource' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'sizeIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'compatibilities' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'groupIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'pricingTypes' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'siteIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'campaignIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/placements',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/placements',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->platformTypes = new Google_Service_Dfareporting_PlatformTypes_Resource(
+        $this,
+        $this->serviceName,
+        'platformTypes',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/platformTypes/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/platformTypes',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->postalCodes = new Google_Service_Dfareporting_PostalCodes_Resource(
+        $this,
+        $this->serviceName,
+        'postalCodes',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/postalCodes/{code}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'code' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/postalCodes',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->projects = new Google_Service_Dfareporting_Projects_Resource(
+        $this,
+        $this->serviceName,
+        'projects',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/projects/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/projects',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'advertiserIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->regions = new Google_Service_Dfareporting_Regions_Resource(
+        $this,
+        $this->serviceName,
+        'regions',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'userprofiles/{profileId}/regions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->remarketingListShares = new Google_Service_Dfareporting_RemarketingListShares_Resource(
+        $this,
+        $this->serviceName,
+        'remarketingListShares',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/remarketingListShares/{remarketingListId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'remarketingListId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/remarketingListShares',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'remarketingListId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/remarketingListShares',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->remarketingLists = new Google_Service_Dfareporting_RemarketingLists_Resource(
+        $this,
+        $this->serviceName,
+        'remarketingLists',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/remarketingLists/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/remarketingLists',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/remarketingLists',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'advertiserId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'name' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'active' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'floodlightActivityId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/remarketingLists',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/remarketingLists',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->reports = new Google_Service_Dfareporting_Reports_Resource(
+        $this,
+        $this->serviceName,
+        'reports',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'userprofiles/{profileId}/reports/{reportId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'reportId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'userprofiles/{profileId}/reports/{reportId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'reportId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/reports',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/reports',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'scope' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/reports/{reportId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'reportId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'run' => array(
+              'path' => 'userprofiles/{profileId}/reports/{reportId}/run',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'reportId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'synchronous' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/reports/{reportId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'reportId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->reports_compatibleFields = new Google_Service_Dfareporting_ReportsCompatibleFields_Resource(
+        $this,
+        $this->serviceName,
+        'compatibleFields',
+        array(
+          'methods' => array(
+            'query' => array(
+              'path' => 'userprofiles/{profileId}/reports/compatiblefields/query',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->reports_files = new Google_Service_Dfareporting_ReportsFiles_Resource(
+        $this,
+        $this->serviceName,
+        'files',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/reports/{reportId}/files/{fileId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'reportId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'fileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/reports/{reportId}/files',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'reportId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->sites = new Google_Service_Dfareporting_Sites_Resource(
+        $this,
+        $this->serviceName,
+        'sites',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/sites/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/sites',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/sites',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'acceptsInterstitialPlacements' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'subaccountId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'directorySiteIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'acceptsInStreamVideoPlacements' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'acceptsPublisherPaidPlacements' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'adWordsSite' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'unmappedSite' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'approved' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'campaignIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/sites',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/sites',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->sizes = new Google_Service_Dfareporting_Sizes_Resource(
+        $this,
+        $this->serviceName,
+        'sizes',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/sizes/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/sizes',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/sizes',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'iabStandard' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'width' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'height' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->subaccounts = new Google_Service_Dfareporting_Subaccounts_Resource(
+        $this,
+        $this->serviceName,
+        'subaccounts',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/subaccounts/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/subaccounts',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/subaccounts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/subaccounts',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/subaccounts',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->targetableRemarketingLists = new Google_Service_Dfareporting_TargetableRemarketingLists_Resource(
+        $this,
+        $this->serviceName,
+        'targetableRemarketingLists',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/targetableRemarketingLists/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/targetableRemarketingLists',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'advertiserId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'name' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'active' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->userProfiles = new Google_Service_Dfareporting_UserProfiles_Resource(
+        $this,
+        $this->serviceName,
+        'userProfiles',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->userRolePermissionGroups = new Google_Service_Dfareporting_UserRolePermissionGroups_Resource(
+        $this,
+        $this->serviceName,
+        'userRolePermissionGroups',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/userRolePermissionGroups/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/userRolePermissionGroups',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->userRolePermissions = new Google_Service_Dfareporting_UserRolePermissions_Resource(
+        $this,
+        $this->serviceName,
+        'userRolePermissions',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userprofiles/{profileId}/userRolePermissions/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/userRolePermissions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->userRoles = new Google_Service_Dfareporting_UserRoles_Resource(
+        $this,
+        $this->serviceName,
+        'userRoles',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'userprofiles/{profileId}/userRoles/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'userprofiles/{profileId}/userRoles/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'userprofiles/{profileId}/userRoles',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'userprofiles/{profileId}/userRoles',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'searchString' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'subaccountId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortField' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'accountUserRoleOnly' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'userprofiles/{profileId}/userRoles',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'userprofiles/{profileId}/userRoles',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'profileId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "accountActiveAdSummaries" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $accountActiveAdSummaries = $dfareportingService->accountActiveAdSummaries;
+ *  </code>
+ */
+class Google_Service_Dfareporting_AccountActiveAdSummaries_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the account's active ad summary by account ID.
+   * (accountActiveAdSummaries.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $summaryAccountId Account ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_AccountActiveAdSummary
+   */
+  public function get($profileId, $summaryAccountId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'summaryAccountId' => $summaryAccountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_AccountActiveAdSummary");
+  }
+}
+
+/**
+ * The "accountPermissionGroups" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $accountPermissionGroups = $dfareportingService->accountPermissionGroups;
+ *  </code>
+ */
+class Google_Service_Dfareporting_AccountPermissionGroups_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one account permission group by ID. (accountPermissionGroups.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Account permission group ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_AccountPermissionGroup
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_AccountPermissionGroup");
+  }
+
+  /**
+   * Retrieves the list of account permission groups.
+   * (accountPermissionGroups.listAccountPermissionGroups)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_AccountPermissionGroupsListResponse
+   */
+  public function listAccountPermissionGroups($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_AccountPermissionGroupsListResponse");
+  }
+}
+
+/**
+ * The "accountPermissions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $accountPermissions = $dfareportingService->accountPermissions;
+ *  </code>
+ */
+class Google_Service_Dfareporting_AccountPermissions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one account permission by ID. (accountPermissions.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Account permission ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_AccountPermission
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_AccountPermission");
+  }
+
+  /**
+   * Retrieves the list of account permissions.
+   * (accountPermissions.listAccountPermissions)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_AccountPermissionsListResponse
+   */
+  public function listAccountPermissions($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_AccountPermissionsListResponse");
+  }
+}
+
+/**
+ * The "accountUserProfiles" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $accountUserProfiles = $dfareportingService->accountUserProfiles;
+ *  </code>
+ */
+class Google_Service_Dfareporting_AccountUserProfiles_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one account user profile by ID. (accountUserProfiles.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id User profile ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_AccountUserProfile
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_AccountUserProfile");
+  }
+
+  /**
+   * Inserts a new account user profile. (accountUserProfiles.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_AccountUserProfile $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_AccountUserProfile
+   */
+  public function insert($profileId, Google_Service_Dfareporting_AccountUserProfile $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_AccountUserProfile");
+  }
+
+  /**
+   * Retrieves a list of account user profiles, possibly filtered.
+   * (accountUserProfiles.listAccountUserProfiles)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string searchString Allows searching for objects by name, ID or
+   * email. Wildcards (*) are allowed. For example, "user profile*2015" will
+   * return objects with names like "user profile June 2015", "user profile April
+   * 2015", or simply "user profile 2015". Most of the searches also add wildcards
+   * implicitly at the start and the end of the search string. For example, a
+   * search string of "user profile" will match objects with name "my user
+   * profile", "user profile 2015", or simply "user profile".
+   * @opt_param string subaccountId Select only user profiles with the specified
+   * subaccount ID.
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string ids Select only user profiles with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string userRoleId Select only user profiles with the specified
+   * user role ID.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param bool active Select only active user profiles.
+   * @return Google_Service_Dfareporting_AccountUserProfilesListResponse
+   */
+  public function listAccountUserProfiles($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_AccountUserProfilesListResponse");
+  }
+
+  /**
+   * Updates an existing account user profile. This method supports patch
+   * semantics. (accountUserProfiles.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id User profile ID.
+   * @param Google_AccountUserProfile $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_AccountUserProfile
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_AccountUserProfile $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_AccountUserProfile");
+  }
+
+  /**
+   * Updates an existing account user profile. (accountUserProfiles.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_AccountUserProfile $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_AccountUserProfile
+   */
+  public function update($profileId, Google_Service_Dfareporting_AccountUserProfile $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_AccountUserProfile");
+  }
+}
+
+/**
+ * The "accounts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $accounts = $dfareportingService->accounts;
+ *  </code>
+ */
+class Google_Service_Dfareporting_Accounts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one account by ID. (accounts.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Account ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Account
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_Account");
+  }
+
+  /**
+   * Retrieves the list of accounts, possibly filtered. (accounts.listAccounts)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string searchString Allows searching for objects by name or ID.
+   * Wildcards (*) are allowed. For example, "account*2015" will return objects
+   * with names like "account June 2015", "account April 2015", or simply "account
+   * 2015". Most of the searches also add wildcards implicitly at the start and
+   * the end of the search string. For example, a search string of "account" will
+   * match objects with name "my account", "account 2015", or simply "account".
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string ids Select only accounts with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param bool active Select only active accounts. Don't set this field to
+   * select both active and non-active accounts.
+   * @return Google_Service_Dfareporting_AccountsListResponse
+   */
+  public function listAccounts($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_AccountsListResponse");
+  }
+
+  /**
+   * Updates an existing account. This method supports patch semantics.
+   * (accounts.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Account ID.
+   * @param Google_Account $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Account
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_Account $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_Account");
+  }
+
+  /**
+   * Updates an existing account. (accounts.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_Account $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Account
+   */
+  public function update($profileId, Google_Service_Dfareporting_Account $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_Account");
+  }
+}
+
+/**
+ * The "ads" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $ads = $dfareportingService->ads;
+ *  </code>
+ */
+class Google_Service_Dfareporting_Ads_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one ad by ID. (ads.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Ad ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Ad
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_Ad");
+  }
+
+  /**
+   * Inserts a new ad. (ads.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_Ad $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Ad
+   */
+  public function insert($profileId, Google_Service_Dfareporting_Ad $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_Ad");
+  }
+
+  /**
+   * Retrieves a list of ads, possibly filtered. (ads.listAds)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string landingPageIds Select only ads with these landing page IDs.
+   * @opt_param string overriddenEventTagId Select only ads with this event tag
+   * override ID.
+   * @opt_param string campaignIds Select only ads with these campaign IDs.
+   * @opt_param bool archived Select only archived ads.
+   * @opt_param string creativeOptimizationConfigurationIds Select only ads with
+   * these creative optimization configuration IDs.
+   * @opt_param bool sslCompliant Select only ads that are SSL-compliant.
+   * @opt_param string sizeIds Select only ads with these size IDs.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param string type Select only ads with these types.
+   * @opt_param bool sslRequired Select only ads that require SSL.
+   * @opt_param string creativeIds Select only ads with these creative IDs
+   * assigned.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string creativeType Select only ads with the specified
+   * creativeType.
+   * @opt_param string placementIds Select only ads with these placement IDs
+   * assigned.
+   * @opt_param bool active Select only active ads.
+   * @opt_param string compatibility Select default ads with the specified
+   * compatibility. Applicable when type is AD_SERVING_DEFAULT_AD. WEB and
+   * WEB_INTERSTITIAL refer to rendering either on desktop or on mobile devices
+   * for regular or interstitial ads, respectively. APP and APP_INTERSTITIAL are
+   * for rendering in mobile apps. IN_STREAM_VIDEO refers to rendering an in-
+   * stream video ads developed with the VAST standard.
+   * @opt_param string advertiserId Select only ads with this advertiser ID.
+   * @opt_param string searchString Allows searching for objects by name or ID.
+   * Wildcards (*) are allowed. For example, "ad*2015" will return objects with
+   * names like "ad June 2015", "ad April 2015", or simply "ad 2015". Most of the
+   * searches also add wildcards implicitly at the start and the end of the search
+   * string. For example, a search string of "ad" will match objects with name "my
+   * ad", "ad 2015", or simply "ad".
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string audienceSegmentIds Select only ads with these audience
+   * segment IDs.
+   * @opt_param string ids Select only ads with these IDs.
+   * @opt_param string remarketingListIds Select only ads whose list targeting
+   * expression use these remarketing list IDs.
+   * @opt_param bool dynamicClickTracker Select only dynamic click trackers.
+   * Applicable when type is AD_SERVING_CLICK_TRACKER. If true, select dynamic
+   * click trackers. If false, select static click trackers. Leave unset to select
+   * both.
+   * @return Google_Service_Dfareporting_AdsListResponse
+   */
+  public function listAds($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_AdsListResponse");
+  }
+
+  /**
+   * Updates an existing ad. This method supports patch semantics. (ads.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Ad ID.
+   * @param Google_Ad $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Ad
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_Ad $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_Ad");
+  }
+
+  /**
+   * Updates an existing ad. (ads.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_Ad $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Ad
+   */
+  public function update($profileId, Google_Service_Dfareporting_Ad $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_Ad");
+  }
+}
+
+/**
+ * The "advertiserGroups" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $advertiserGroups = $dfareportingService->advertiserGroups;
+ *  </code>
+ */
+class Google_Service_Dfareporting_AdvertiserGroups_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes an existing advertiser group. (advertiserGroups.delete)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Advertiser group ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets one advertiser group by ID. (advertiserGroups.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Advertiser group ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_AdvertiserGroup
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_AdvertiserGroup");
+  }
+
+  /**
+   * Inserts a new advertiser group. (advertiserGroups.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_AdvertiserGroup $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_AdvertiserGroup
+   */
+  public function insert($profileId, Google_Service_Dfareporting_AdvertiserGroup $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_AdvertiserGroup");
+  }
+
+  /**
+   * Retrieves a list of advertiser groups, possibly filtered.
+   * (advertiserGroups.listAdvertiserGroups)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string searchString Allows searching for objects by name or ID.
+   * Wildcards (*) are allowed. For example, "advertiser*2015" will return objects
+   * with names like "advertiser group June 2015", "advertiser group April 2015",
+   * or simply "advertiser group 2015". Most of the searches also add wildcards
+   * implicitly at the start and the end of the search string. For example, a
+   * search string of "advertisergroup" will match objects with name "my
+   * advertisergroup", "advertisergroup 2015", or simply "advertisergroup".
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string ids Select only advertiser groups with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @return Google_Service_Dfareporting_AdvertiserGroupsListResponse
+   */
+  public function listAdvertiserGroups($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_AdvertiserGroupsListResponse");
+  }
+
+  /**
+   * Updates an existing advertiser group. This method supports patch semantics.
+   * (advertiserGroups.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Advertiser group ID.
+   * @param Google_AdvertiserGroup $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_AdvertiserGroup
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_AdvertiserGroup $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_AdvertiserGroup");
+  }
+
+  /**
+   * Updates an existing advertiser group. (advertiserGroups.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_AdvertiserGroup $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_AdvertiserGroup
+   */
+  public function update($profileId, Google_Service_Dfareporting_AdvertiserGroup $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_AdvertiserGroup");
+  }
+}
+
+/**
+ * The "advertisers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $advertisers = $dfareportingService->advertisers;
+ *  </code>
+ */
+class Google_Service_Dfareporting_Advertisers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one advertiser by ID. (advertisers.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Advertiser ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Advertiser
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_Advertiser");
+  }
+
+  /**
+   * Inserts a new advertiser. (advertisers.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_Advertiser $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Advertiser
+   */
+  public function insert($profileId, Google_Service_Dfareporting_Advertiser $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_Advertiser");
+  }
+
+  /**
+   * Retrieves a list of advertisers, possibly filtered.
+   * (advertisers.listAdvertisers)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string status Select only advertisers with the specified status.
+   * @opt_param string searchString Allows searching for objects by name or ID.
+   * Wildcards (*) are allowed. For example, "advertiser*2015" will return objects
+   * with names like "advertiser June 2015", "advertiser April 2015", or simply
+   * "advertiser 2015". Most of the searches also add wildcards implicitly at the
+   * start and the end of the search string. For example, a search string of
+   * "advertiser" will match objects with name "my advertiser", "advertiser 2015",
+   * or simply "advertiser".
+   * @opt_param string subaccountId Select only advertisers with these subaccount
+   * IDs.
+   * @opt_param bool includeAdvertisersWithoutGroupsOnly Select only advertisers
+   * which do not belong to any advertiser group.
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string ids Select only advertisers with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param bool onlyParent Select only advertisers which use another
+   * advertiser's floodlight configuration.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param string floodlightConfigurationIds Select only advertisers with
+   * these floodlight configuration IDs.
+   * @opt_param string advertiserGroupIds Select only advertisers with these
+   * advertiser group IDs.
+   * @return Google_Service_Dfareporting_AdvertisersListResponse
+   */
+  public function listAdvertisers($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_AdvertisersListResponse");
+  }
+
+  /**
+   * Updates an existing advertiser. This method supports patch semantics.
+   * (advertisers.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Advertiser ID.
+   * @param Google_Advertiser $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Advertiser
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_Advertiser $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_Advertiser");
+  }
+
+  /**
+   * Updates an existing advertiser. (advertisers.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_Advertiser $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Advertiser
+   */
+  public function update($profileId, Google_Service_Dfareporting_Advertiser $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_Advertiser");
+  }
+}
+
+/**
+ * The "browsers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $browsers = $dfareportingService->browsers;
+ *  </code>
+ */
+class Google_Service_Dfareporting_Browsers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a list of browsers. (browsers.listBrowsers)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_BrowsersListResponse
+   */
+  public function listBrowsers($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_BrowsersListResponse");
+  }
+}
+
+/**
+ * The "campaignCreativeAssociations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $campaignCreativeAssociations = $dfareportingService->campaignCreativeAssociations;
+ *  </code>
+ */
+class Google_Service_Dfareporting_CampaignCreativeAssociations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Associates a creative with the specified campaign. This method creates a
+   * default ad with dimensions matching the creative in the campaign if such a
+   * default ad does not exist already. (campaignCreativeAssociations.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $campaignId Campaign ID in this association.
+   * @param Google_CampaignCreativeAssociation $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_CampaignCreativeAssociation
+   */
+  public function insert($profileId, $campaignId, Google_Service_Dfareporting_CampaignCreativeAssociation $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'campaignId' => $campaignId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_CampaignCreativeAssociation");
+  }
+
+  /**
+   * Retrieves the list of creative IDs associated with the specified campaign.
+   * (campaignCreativeAssociations.listCampaignCreativeAssociations)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $campaignId Campaign ID in this association.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @return Google_Service_Dfareporting_CampaignCreativeAssociationsListResponse
+   */
+  public function listCampaignCreativeAssociations($profileId, $campaignId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'campaignId' => $campaignId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_CampaignCreativeAssociationsListResponse");
+  }
+}
+
+/**
+ * The "campaigns" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $campaigns = $dfareportingService->campaigns;
+ *  </code>
+ */
+class Google_Service_Dfareporting_Campaigns_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one campaign by ID. (campaigns.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Campaign ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Campaign
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_Campaign");
+  }
+
+  /**
+   * Inserts a new campaign. (campaigns.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $defaultLandingPageName Default landing page name for this new
+   * campaign. Must be less than 256 characters long.
+   * @param string $defaultLandingPageUrl Default landing page URL for this new
+   * campaign.
+   * @param Google_Campaign $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Campaign
+   */
+  public function insert($profileId, $defaultLandingPageName, $defaultLandingPageUrl, Google_Service_Dfareporting_Campaign $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'defaultLandingPageName' => $defaultLandingPageName, 'defaultLandingPageUrl' => $defaultLandingPageUrl, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_Campaign");
+  }
+
+  /**
+   * Retrieves a list of campaigns, possibly filtered. (campaigns.listCampaigns)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool archived Select only archived campaigns. Don't set this field
+   * to select both archived and non-archived campaigns.
+   * @opt_param string searchString Allows searching for campaigns by name or ID.
+   * Wildcards (*) are allowed. For example, "campaign*2015" will return campaigns
+   * with names like "campaign June 2015", "campaign April 2015", or simply
+   * "campaign 2015". Most of the searches also add wildcards implicitly at the
+   * start and the end of the search string. For example, a search string of
+   * "campaign" will match campaigns with name "my campaign", "campaign 2015", or
+   * simply "campaign".
+   * @opt_param string subaccountId Select only campaigns that belong to this
+   * subaccount.
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string advertiserIds Select only campaigns that belong to these
+   * advertisers.
+   * @opt_param string ids Select only campaigns with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string excludedIds Exclude campaigns with these IDs.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string advertiserGroupIds Select only campaigns whose advertisers
+   * belong to these advertiser groups.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param string overriddenEventTagId Select only campaigns that have
+   * overridden this event tag ID.
+   * @opt_param bool atLeastOneOptimizationActivity Select only campaigns that
+   * have at least one optimization activity.
+   * @return Google_Service_Dfareporting_CampaignsListResponse
+   */
+  public function listCampaigns($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_CampaignsListResponse");
+  }
+
+  /**
+   * Updates an existing campaign. This method supports patch semantics.
+   * (campaigns.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Campaign ID.
+   * @param Google_Campaign $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Campaign
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_Campaign $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_Campaign");
+  }
+
+  /**
+   * Updates an existing campaign. (campaigns.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_Campaign $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Campaign
+   */
+  public function update($profileId, Google_Service_Dfareporting_Campaign $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_Campaign");
+  }
+}
+
+/**
+ * The "changeLogs" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $changeLogs = $dfareportingService->changeLogs;
+ *  </code>
+ */
+class Google_Service_Dfareporting_ChangeLogs_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one change log by ID. (changeLogs.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Change log ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_ChangeLog
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_ChangeLog");
+  }
+
+  /**
+   * Retrieves a list of change logs. (changeLogs.listChangeLogs)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string minChangeTime Select only change logs whose change time is
+   * before the specified minChangeTime.The time should be formatted as an RFC3339
+   * date/time string. For example, for 10:54 PM on July 18th, 2015, in the
+   * America/New York time zone, the format is "2015-07-18T22:54:00-04:00". In
+   * other words, the year, month, day, the letter T, the hour (24-hour clock
+   * system), minute, second, and then the time zone offset.
+   * @opt_param string searchString Select only change logs whose object ID, user
+   * name, old or new values match the search string.
+   * @opt_param string maxChangeTime Select only change logs whose change time is
+   * before the specified maxChangeTime.The time should be formatted as an RFC3339
+   * date/time string. For example, for 10:54 PM on July 18th, 2015, in the
+   * America/New York time zone, the format is "2015-07-18T22:54:00-04:00". In
+   * other words, the year, month, day, the letter T, the hour (24-hour clock
+   * system), minute, second, and then the time zone offset.
+   * @opt_param string userProfileIds Select only change logs with these user
+   * profile IDs.
+   * @opt_param string ids Select only change logs with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string objectIds Select only change logs with these object IDs.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string action Select only change logs with the specified action.
+   * @opt_param string objectType Select only change logs with the specified
+   * object type.
+   * @return Google_Service_Dfareporting_ChangeLogsListResponse
+   */
+  public function listChangeLogs($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_ChangeLogsListResponse");
+  }
+}
+
+/**
+ * The "cities" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $cities = $dfareportingService->cities;
+ *  </code>
+ */
+class Google_Service_Dfareporting_Cities_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a list of cities, possibly filtered. (cities.listCities)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string dartIds Select only cities with these DART IDs.
+   * @opt_param string namePrefix Select only cities with names starting with this
+   * prefix.
+   * @opt_param string regionDartIds Select only cities from these regions.
+   * @opt_param string countryDartIds Select only cities from these countries.
+   * @return Google_Service_Dfareporting_CitiesListResponse
+   */
+  public function listCities($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_CitiesListResponse");
+  }
+}
+
+/**
+ * The "connectionTypes" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $connectionTypes = $dfareportingService->connectionTypes;
+ *  </code>
+ */
+class Google_Service_Dfareporting_ConnectionTypes_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one connection type by ID. (connectionTypes.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Connection type ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_ConnectionType
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_ConnectionType");
+  }
+
+  /**
+   * Retrieves a list of connection types. (connectionTypes.listConnectionTypes)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_ConnectionTypesListResponse
+   */
+  public function listConnectionTypes($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_ConnectionTypesListResponse");
+  }
+}
+
+/**
+ * The "contentCategories" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $contentCategories = $dfareportingService->contentCategories;
+ *  </code>
+ */
+class Google_Service_Dfareporting_ContentCategories_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes an existing content category. (contentCategories.delete)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Content category ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets one content category by ID. (contentCategories.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Content category ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_ContentCategory
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_ContentCategory");
+  }
+
+  /**
+   * Inserts a new content category. (contentCategories.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_ContentCategory $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_ContentCategory
+   */
+  public function insert($profileId, Google_Service_Dfareporting_ContentCategory $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_ContentCategory");
+  }
+
+  /**
+   * Retrieves a list of content categories, possibly filtered.
+   * (contentCategories.listContentCategories)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string searchString Allows searching for objects by name or ID.
+   * Wildcards (*) are allowed. For example, "contentcategory*2015" will return
+   * objects with names like "contentcategory June 2015", "contentcategory April
+   * 2015", or simply "contentcategory 2015". Most of the searches also add
+   * wildcards implicitly at the start and the end of the search string. For
+   * example, a search string of "contentcategory" will match objects with name
+   * "my contentcategory", "contentcategory 2015", or simply "contentcategory".
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string ids Select only content categories with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @return Google_Service_Dfareporting_ContentCategoriesListResponse
+   */
+  public function listContentCategories($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_ContentCategoriesListResponse");
+  }
+
+  /**
+   * Updates an existing content category. This method supports patch semantics.
+   * (contentCategories.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Content category ID.
+   * @param Google_ContentCategory $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_ContentCategory
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_ContentCategory $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_ContentCategory");
+  }
+
+  /**
+   * Updates an existing content category. (contentCategories.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_ContentCategory $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_ContentCategory
+   */
+  public function update($profileId, Google_Service_Dfareporting_ContentCategory $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_ContentCategory");
+  }
+}
+
+/**
+ * The "countries" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $countries = $dfareportingService->countries;
+ *  </code>
+ */
+class Google_Service_Dfareporting_Countries_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one country by ID. (countries.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $dartId Country DART ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Country
+   */
+  public function get($profileId, $dartId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'dartId' => $dartId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_Country");
+  }
+
+  /**
+   * Retrieves a list of countries. (countries.listCountries)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_CountriesListResponse
+   */
+  public function listCountries($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_CountriesListResponse");
+  }
+}
+
+/**
+ * The "creativeAssets" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $creativeAssets = $dfareportingService->creativeAssets;
+ *  </code>
+ */
+class Google_Service_Dfareporting_CreativeAssets_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Inserts a new creative asset. (creativeAssets.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $advertiserId Advertiser ID of this creative. This is a
+   * required field.
+   * @param Google_CreativeAssetMetadata $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_CreativeAssetMetadata
+   */
+  public function insert($profileId, $advertiserId, Google_Service_Dfareporting_CreativeAssetMetadata $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'advertiserId' => $advertiserId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_CreativeAssetMetadata");
+  }
+}
+
+/**
+ * The "creativeFieldValues" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $creativeFieldValues = $dfareportingService->creativeFieldValues;
+ *  </code>
+ */
+class Google_Service_Dfareporting_CreativeFieldValues_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes an existing creative field value. (creativeFieldValues.delete)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $creativeFieldId Creative field ID for this creative field
+   * value.
+   * @param string $id Creative Field Value ID
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($profileId, $creativeFieldId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'creativeFieldId' => $creativeFieldId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets one creative field value by ID. (creativeFieldValues.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $creativeFieldId Creative field ID for this creative field
+   * value.
+   * @param string $id Creative Field Value ID
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_CreativeFieldValue
+   */
+  public function get($profileId, $creativeFieldId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'creativeFieldId' => $creativeFieldId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_CreativeFieldValue");
+  }
+
+  /**
+   * Inserts a new creative field value. (creativeFieldValues.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $creativeFieldId Creative field ID for this creative field
+   * value.
+   * @param Google_CreativeFieldValue $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_CreativeFieldValue
+   */
+  public function insert($profileId, $creativeFieldId, Google_Service_Dfareporting_CreativeFieldValue $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'creativeFieldId' => $creativeFieldId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_CreativeFieldValue");
+  }
+
+  /**
+   * Retrieves a list of creative field values, possibly filtered.
+   * (creativeFieldValues.listCreativeFieldValues)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $creativeFieldId Creative field ID for this creative field
+   * value.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string searchString Allows searching for creative field values by
+   * their values. Wildcards (e.g. *) are not allowed.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string ids Select only creative field values with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @return Google_Service_Dfareporting_CreativeFieldValuesListResponse
+   */
+  public function listCreativeFieldValues($profileId, $creativeFieldId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'creativeFieldId' => $creativeFieldId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_CreativeFieldValuesListResponse");
+  }
+
+  /**
+   * Updates an existing creative field value. This method supports patch
+   * semantics. (creativeFieldValues.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $creativeFieldId Creative field ID for this creative field
+   * value.
+   * @param string $id Creative Field Value ID
+   * @param Google_CreativeFieldValue $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_CreativeFieldValue
+   */
+  public function patch($profileId, $creativeFieldId, $id, Google_Service_Dfareporting_CreativeFieldValue $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'creativeFieldId' => $creativeFieldId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_CreativeFieldValue");
+  }
+
+  /**
+   * Updates an existing creative field value. (creativeFieldValues.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $creativeFieldId Creative field ID for this creative field
+   * value.
+   * @param Google_CreativeFieldValue $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_CreativeFieldValue
+   */
+  public function update($profileId, $creativeFieldId, Google_Service_Dfareporting_CreativeFieldValue $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'creativeFieldId' => $creativeFieldId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_CreativeFieldValue");
+  }
+}
+
+/**
+ * The "creativeFields" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $creativeFields = $dfareportingService->creativeFields;
+ *  </code>
+ */
+class Google_Service_Dfareporting_CreativeFields_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes an existing creative field. (creativeFields.delete)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Creative Field ID
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets one creative field by ID. (creativeFields.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Creative Field ID
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_CreativeField
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_CreativeField");
+  }
+
+  /**
+   * Inserts a new creative field. (creativeFields.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_CreativeField $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_CreativeField
+   */
+  public function insert($profileId, Google_Service_Dfareporting_CreativeField $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_CreativeField");
+  }
+
+  /**
+   * Retrieves a list of creative fields, possibly filtered.
+   * (creativeFields.listCreativeFields)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string searchString Allows searching for creative fields by name
+   * or ID. Wildcards (*) are allowed. For example, "creativefield*2015" will
+   * return creative fields with names like "creativefield June 2015",
+   * "creativefield April 2015", or simply "creativefield 2015". Most of the
+   * searches also add wild-cards implicitly at the start and the end of the
+   * search string. For example, a search string of "creativefield" will match
+   * creative fields with the name "my creativefield", "creativefield 2015", or
+   * simply "creativefield".
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string advertiserIds Select only creative fields that belong to
+   * these advertisers.
+   * @opt_param string ids Select only creative fields with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @return Google_Service_Dfareporting_CreativeFieldsListResponse
+   */
+  public function listCreativeFields($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_CreativeFieldsListResponse");
+  }
+
+  /**
+   * Updates an existing creative field. This method supports patch semantics.
+   * (creativeFields.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Creative Field ID
+   * @param Google_CreativeField $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_CreativeField
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_CreativeField $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_CreativeField");
+  }
+
+  /**
+   * Updates an existing creative field. (creativeFields.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_CreativeField $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_CreativeField
+   */
+  public function update($profileId, Google_Service_Dfareporting_CreativeField $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_CreativeField");
+  }
+}
+
+/**
+ * The "creativeGroups" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $creativeGroups = $dfareportingService->creativeGroups;
+ *  </code>
+ */
+class Google_Service_Dfareporting_CreativeGroups_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one creative group by ID. (creativeGroups.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Creative group ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_CreativeGroup
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_CreativeGroup");
+  }
+
+  /**
+   * Inserts a new creative group. (creativeGroups.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_CreativeGroup $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_CreativeGroup
+   */
+  public function insert($profileId, Google_Service_Dfareporting_CreativeGroup $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_CreativeGroup");
+  }
+
+  /**
+   * Retrieves a list of creative groups, possibly filtered.
+   * (creativeGroups.listCreativeGroups)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string searchString Allows searching for creative groups by name
+   * or ID. Wildcards (*) are allowed. For example, "creativegroup*2015" will
+   * return creative groups with names like "creativegroup June 2015",
+   * "creativegroup April 2015", or simply "creativegroup 2015". Most of the
+   * searches also add wild-cards implicitly at the start and the end of the
+   * search string. For example, a search string of "creativegroup" will match
+   * creative groups with the name "my creativegroup", "creativegroup 2015", or
+   * simply "creativegroup".
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string advertiserIds Select only creative groups that belong to
+   * these advertisers.
+   * @opt_param int groupNumber Select only creative groups that belong to this
+   * subgroup.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string ids Select only creative groups with these IDs.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @return Google_Service_Dfareporting_CreativeGroupsListResponse
+   */
+  public function listCreativeGroups($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_CreativeGroupsListResponse");
+  }
+
+  /**
+   * Updates an existing creative group. This method supports patch semantics.
+   * (creativeGroups.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Creative group ID.
+   * @param Google_CreativeGroup $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_CreativeGroup
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_CreativeGroup $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_CreativeGroup");
+  }
+
+  /**
+   * Updates an existing creative group. (creativeGroups.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_CreativeGroup $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_CreativeGroup
+   */
+  public function update($profileId, Google_Service_Dfareporting_CreativeGroup $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_CreativeGroup");
+  }
+}
+
+/**
+ * The "creatives" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $creatives = $dfareportingService->creatives;
+ *  </code>
+ */
+class Google_Service_Dfareporting_Creatives_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one creative by ID. (creatives.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Creative ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Creative
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_Creative");
+  }
+
+  /**
+   * Inserts a new creative. (creatives.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_Creative $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Creative
+   */
+  public function insert($profileId, Google_Service_Dfareporting_Creative $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_Creative");
+  }
+
+  /**
+   * Retrieves a list of creatives, possibly filtered. (creatives.listCreatives)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string sizeIds Select only creatives with these size IDs.
+   * @opt_param bool archived Select only archived creatives. Leave blank to
+   * select archived and unarchived creatives.
+   * @opt_param string searchString Allows searching for objects by name or ID.
+   * Wildcards (*) are allowed. For example, "creative*2015" will return objects
+   * with names like "creative June 2015", "creative April 2015", or simply
+   * "creative 2015". Most of the searches also add wildcards implicitly at the
+   * start and the end of the search string. For example, a search string of
+   * "creative" will match objects with name "my creative", "creative 2015", or
+   * simply "creative".
+   * @opt_param string campaignId Select only creatives with this campaign ID.
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string renderingIds Select only creatives with these rendering
+   * IDs.
+   * @opt_param string ids Select only creatives with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string advertiserId Select only creatives with this advertiser ID.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string studioCreativeId Select only creatives corresponding to
+   * this Studio creative ID.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param string companionCreativeIds Select only in-stream video creatives
+   * with these companion IDs.
+   * @opt_param bool active Select only active creatives. Leave blank to select
+   * active and inactive creatives.
+   * @opt_param string creativeFieldIds Select only creatives with these creative
+   * field IDs.
+   * @opt_param string types Select only creatives with these creative types.
+   * @return Google_Service_Dfareporting_CreativesListResponse
+   */
+  public function listCreatives($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_CreativesListResponse");
+  }
+
+  /**
+   * Updates an existing creative. This method supports patch semantics.
+   * (creatives.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Creative ID.
+   * @param Google_Creative $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Creative
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_Creative $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_Creative");
+  }
+
+  /**
+   * Updates an existing creative. (creatives.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_Creative $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Creative
+   */
+  public function update($profileId, Google_Service_Dfareporting_Creative $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_Creative");
+  }
+}
+
+/**
+ * The "dimensionValues" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $dimensionValues = $dfareportingService->dimensionValues;
+ *  </code>
+ */
+class Google_Service_Dfareporting_DimensionValues_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves list of report dimension values for a list of filters.
+   * (dimensionValues.query)
+   *
+   * @param string $profileId The DFA user profile ID.
+   * @param Google_DimensionValueRequest $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The value of the nextToken from the previous
+   * result page.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @return Google_Service_Dfareporting_DimensionValueList
+   */
+  public function query($profileId, Google_Service_Dfareporting_DimensionValueRequest $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('query', array($params), "Google_Service_Dfareporting_DimensionValueList");
+  }
+}
+
+/**
+ * The "directorySiteContacts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $directorySiteContacts = $dfareportingService->directorySiteContacts;
+ *  </code>
+ */
+class Google_Service_Dfareporting_DirectorySiteContacts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one directory site contact by ID. (directorySiteContacts.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Directory site contact ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_DirectorySiteContact
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_DirectorySiteContact");
+  }
+
+  /**
+   * Retrieves a list of directory site contacts, possibly filtered.
+   * (directorySiteContacts.listDirectorySiteContacts)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string searchString Allows searching for objects by name, ID or
+   * email. Wildcards (*) are allowed. For example, "directory site contact*2015"
+   * will return objects with names like "directory site contact June 2015",
+   * "directory site contact April 2015", or simply "directory site contact 2015".
+   * Most of the searches also add wildcards implicitly at the start and the end
+   * of the search string. For example, a search string of "directory site
+   * contact" will match objects with name "my directory site contact", "directory
+   * site contact 2015", or simply "directory site contact".
+   * @opt_param string directorySiteIds Select only directory site contacts with
+   * these directory site IDs. This is a required field.
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string ids Select only directory site contacts with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @return Google_Service_Dfareporting_DirectorySiteContactsListResponse
+   */
+  public function listDirectorySiteContacts($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_DirectorySiteContactsListResponse");
+  }
+}
+
+/**
+ * The "directorySites" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $directorySites = $dfareportingService->directorySites;
+ *  </code>
+ */
+class Google_Service_Dfareporting_DirectorySites_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one directory site by ID. (directorySites.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Directory site ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_DirectorySite
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_DirectorySite");
+  }
+
+  /**
+   * Inserts a new directory site. (directorySites.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_DirectorySite $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_DirectorySite
+   */
+  public function insert($profileId, Google_Service_Dfareporting_DirectorySite $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_DirectorySite");
+  }
+
+  /**
+   * Retrieves a list of directory sites, possibly filtered.
+   * (directorySites.listDirectorySites)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool acceptsInterstitialPlacements This search filter is no longer
+   * supported and will have no effect on the results returned.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param string searchString Allows searching for objects by name, ID or
+   * URL. Wildcards (*) are allowed. For example, "directory site*2015" will
+   * return objects with names like "directory site June 2015", "directory site
+   * April 2015", or simply "directory site 2015". Most of the searches also add
+   * wildcards implicitly at the start and the end of the search string. For
+   * example, a search string of "directory site" will match objects with name "my
+   * directory site", "directory site 2015" or simply, "directory site".
+   * @opt_param string countryId Select only directory sites with this country ID.
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param bool acceptsInStreamVideoPlacements This search filter is no
+   * longer supported and will have no effect on the results returned.
+   * @opt_param string ids Select only directory sites with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param bool acceptsPublisherPaidPlacements Select only directory sites
+   * that accept publisher paid placements. This field can be left blank.
+   * @opt_param string parentId Select only directory sites with this parent ID.
+   * @opt_param bool active Select only active directory sites. Leave blank to
+   * retrieve both active and inactive directory sites.
+   * @opt_param string dfp_network_code Select only directory sites with this DFP
+   * network code.
+   * @return Google_Service_Dfareporting_DirectorySitesListResponse
+   */
+  public function listDirectorySites($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_DirectorySitesListResponse");
+  }
+}
+
+/**
+ * The "eventTags" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $eventTags = $dfareportingService->eventTags;
+ *  </code>
+ */
+class Google_Service_Dfareporting_EventTags_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes an existing event tag. (eventTags.delete)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Event tag ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets one event tag by ID. (eventTags.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Event tag ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_EventTag
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_EventTag");
+  }
+
+  /**
+   * Inserts a new event tag. (eventTags.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_EventTag $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_EventTag
+   */
+  public function insert($profileId, Google_Service_Dfareporting_EventTag $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_EventTag");
+  }
+
+  /**
+   * Retrieves a list of event tags, possibly filtered. (eventTags.listEventTags)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string searchString Allows searching for objects by name or ID.
+   * Wildcards (*) are allowed. For example, "eventtag*2015" will return objects
+   * with names like "eventtag June 2015", "eventtag April 2015", or simply
+   * "eventtag 2015". Most of the searches also add wildcards implicitly at the
+   * start and the end of the search string. For example, a search string of
+   * "eventtag" will match objects with name "my eventtag", "eventtag 2015", or
+   * simply "eventtag".
+   * @opt_param string campaignId Select only event tags that belong to this
+   * campaign.
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param bool enabled Select only enabled event tags. When definitionsOnly
+   * is set to true, only the specified advertiser or campaign's event tags'
+   * enabledByDefault field is examined. When definitionsOnly is set to false, the
+   * specified ad or specified campaign's parent advertiser's or parent campaign's
+   * event tags' enabledByDefault and status fields are examined as well.
+   * @opt_param string ids Select only event tags with these IDs.
+   * @opt_param string advertiserId Select only event tags that belong to this
+   * advertiser.
+   * @opt_param string adId Select only event tags that belong to this ad.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param string eventTagTypes Select only event tags with the specified
+   * event tag types. Event tag types can be used to specify whether to use a
+   * third-party pixel, a third-party JavaScript URL, or a third-party click-
+   * through URL for either impression or click tracking.
+   * @opt_param bool definitionsOnly Examine only the specified ad or campaign or
+   * advertiser's event tags for matching selector criteria. When set to false,
+   * the parent advertiser and parent campaign is examined as well. In addition,
+   * when set to false, the status field is examined as well along with the
+   * enabledByDefault field.
+   * @return Google_Service_Dfareporting_EventTagsListResponse
+   */
+  public function listEventTags($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_EventTagsListResponse");
+  }
+
+  /**
+   * Updates an existing event tag. This method supports patch semantics.
+   * (eventTags.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Event tag ID.
+   * @param Google_EventTag $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_EventTag
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_EventTag $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_EventTag");
+  }
+
+  /**
+   * Updates an existing event tag. (eventTags.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_EventTag $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_EventTag
+   */
+  public function update($profileId, Google_Service_Dfareporting_EventTag $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_EventTag");
+  }
+}
+
+/**
+ * The "files" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $files = $dfareportingService->files;
+ *  </code>
+ */
+class Google_Service_Dfareporting_Files_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a report file by its report ID and file ID. (files.get)
+   *
+   * @param string $reportId The ID of the report.
+   * @param string $fileId The ID of the report file.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_DfareportingFile
+   */
+  public function get($reportId, $fileId, $optParams = array())
+  {
+    $params = array('reportId' => $reportId, 'fileId' => $fileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_DfareportingFile");
+  }
+
+  /**
+   * Lists files for a user profile. (files.listFiles)
+   *
+   * @param string $profileId The DFA profile ID.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string sortField The field by which to sort the list.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken The value of the nextToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is 'DESCENDING'.
+   * @opt_param string scope The scope that defines which results are returned,
+   * default is 'MINE'.
+   * @return Google_Service_Dfareporting_FileList
+   */
+  public function listFiles($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_FileList");
+  }
+}
+
+/**
+ * The "floodlightActivities" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $floodlightActivities = $dfareportingService->floodlightActivities;
+ *  </code>
+ */
+class Google_Service_Dfareporting_FloodlightActivities_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes an existing floodlight activity. (floodlightActivities.delete)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Floodlight activity ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Generates a tag for a floodlight activity. (floodlightActivities.generatetag)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string floodlightActivityId Floodlight activity ID for which we
+   * want to generate a tag.
+   * @return Google_Service_Dfareporting_FloodlightActivitiesGenerateTagResponse
+   */
+  public function generatetag($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('generatetag', array($params), "Google_Service_Dfareporting_FloodlightActivitiesGenerateTagResponse");
+  }
+
+  /**
+   * Gets one floodlight activity by ID. (floodlightActivities.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Floodlight activity ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_FloodlightActivity
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_FloodlightActivity");
+  }
+
+  /**
+   * Inserts a new floodlight activity. (floodlightActivities.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_FloodlightActivity $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_FloodlightActivity
+   */
+  public function insert($profileId, Google_Service_Dfareporting_FloodlightActivity $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_FloodlightActivity");
+  }
+
+  /**
+   * Retrieves a list of floodlight activities, possibly filtered.
+   * (floodlightActivities.listFloodlightActivities)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string floodlightActivityGroupIds Select only floodlight
+   * activities with the specified floodlight activity group IDs.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param string searchString Allows searching for objects by name or ID.
+   * Wildcards (*) are allowed. For example, "floodlightactivity*2015" will return
+   * objects with names like "floodlightactivity June 2015", "floodlightactivity
+   * April 2015", or simply "floodlightactivity 2015". Most of the searches also
+   * add wildcards implicitly at the start and the end of the search string. For
+   * example, a search string of "floodlightactivity" will match objects with name
+   * "my floodlightactivity activity", "floodlightactivity 2015", or simply
+   * "floodlightactivity".
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string floodlightConfigurationId Select only floodlight activities
+   * for the specified floodlight configuration ID. Must specify either ids,
+   * advertiserId, or floodlightConfigurationId for a non-empty result.
+   * @opt_param string ids Select only floodlight activities with the specified
+   * IDs. Must specify either ids, advertiserId, or floodlightConfigurationId for
+   * a non-empty result.
+   * @opt_param string floodlightActivityGroupName Select only floodlight
+   * activities with the specified floodlight activity group name.
+   * @opt_param string advertiserId Select only floodlight activities for the
+   * specified advertiser ID. Must specify either ids, advertiserId, or
+   * floodlightConfigurationId for a non-empty result.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string tagString Select only floodlight activities with the
+   * specified tag string.
+   * @opt_param string floodlightActivityGroupTagString Select only floodlight
+   * activities with the specified floodlight activity group tag string.
+   * @opt_param string floodlightActivityGroupType Select only floodlight
+   * activities with the specified floodlight activity group type.
+   * @return Google_Service_Dfareporting_FloodlightActivitiesListResponse
+   */
+  public function listFloodlightActivities($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_FloodlightActivitiesListResponse");
+  }
+
+  /**
+   * Updates an existing floodlight activity. This method supports patch
+   * semantics. (floodlightActivities.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Floodlight activity ID.
+   * @param Google_FloodlightActivity $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_FloodlightActivity
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_FloodlightActivity $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_FloodlightActivity");
+  }
+
+  /**
+   * Updates an existing floodlight activity. (floodlightActivities.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_FloodlightActivity $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_FloodlightActivity
+   */
+  public function update($profileId, Google_Service_Dfareporting_FloodlightActivity $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_FloodlightActivity");
+  }
+}
+
+/**
+ * The "floodlightActivityGroups" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $floodlightActivityGroups = $dfareportingService->floodlightActivityGroups;
+ *  </code>
+ */
+class Google_Service_Dfareporting_FloodlightActivityGroups_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes an existing floodlight activity group.
+   * (floodlightActivityGroups.delete)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Floodlight activity Group ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets one floodlight activity group by ID. (floodlightActivityGroups.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Floodlight activity Group ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_FloodlightActivityGroup
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_FloodlightActivityGroup");
+  }
+
+  /**
+   * Inserts a new floodlight activity group. (floodlightActivityGroups.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_FloodlightActivityGroup $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_FloodlightActivityGroup
+   */
+  public function insert($profileId, Google_Service_Dfareporting_FloodlightActivityGroup $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_FloodlightActivityGroup");
+  }
+
+  /**
+   * Retrieves a list of floodlight activity groups, possibly filtered.
+   * (floodlightActivityGroups.listFloodlightActivityGroups)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string searchString Allows searching for objects by name or ID.
+   * Wildcards (*) are allowed. For example, "floodlightactivitygroup*2015" will
+   * return objects with names like "floodlightactivitygroup June 2015",
+   * "floodlightactivitygroup April 2015", or simply "floodlightactivitygroup
+   * 2015". Most of the searches also add wildcards implicitly at the start and
+   * the end of the search string. For example, a search string of
+   * "floodlightactivitygroup" will match objects with name "my
+   * floodlightactivitygroup activity", "floodlightactivitygroup 2015", or simply
+   * "floodlightactivitygroup".
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string floodlightConfigurationId Select only floodlight activity
+   * groups with the specified floodlight configuration ID. Must specify either
+   * advertiserId, or floodlightConfigurationId for a non-empty result.
+   * @opt_param string ids Select only floodlight activity groups with the
+   * specified IDs. Must specify either advertiserId or floodlightConfigurationId
+   * for a non-empty result.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string advertiserId Select only floodlight activity groups with
+   * the specified advertiser ID. Must specify either advertiserId or
+   * floodlightConfigurationId for a non-empty result.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param string type Select only floodlight activity groups with the
+   * specified floodlight activity group type.
+   * @return Google_Service_Dfareporting_FloodlightActivityGroupsListResponse
+   */
+  public function listFloodlightActivityGroups($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_FloodlightActivityGroupsListResponse");
+  }
+
+  /**
+   * Updates an existing floodlight activity group. This method supports patch
+   * semantics. (floodlightActivityGroups.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Floodlight activity Group ID.
+   * @param Google_FloodlightActivityGroup $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_FloodlightActivityGroup
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_FloodlightActivityGroup $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_FloodlightActivityGroup");
+  }
+
+  /**
+   * Updates an existing floodlight activity group.
+   * (floodlightActivityGroups.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_FloodlightActivityGroup $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_FloodlightActivityGroup
+   */
+  public function update($profileId, Google_Service_Dfareporting_FloodlightActivityGroup $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_FloodlightActivityGroup");
+  }
+}
+
+/**
+ * The "floodlightConfigurations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $floodlightConfigurations = $dfareportingService->floodlightConfigurations;
+ *  </code>
+ */
+class Google_Service_Dfareporting_FloodlightConfigurations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one floodlight configuration by ID. (floodlightConfigurations.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Floodlight configuration ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_FloodlightConfiguration
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_FloodlightConfiguration");
+  }
+
+  /**
+   * Retrieves a list of floodlight configurations, possibly filtered.
+   * (floodlightConfigurations.listFloodlightConfigurations)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string ids Set of IDs of floodlight configurations to retrieve.
+   * Required field; otherwise an empty list will be returned.
+   * @return Google_Service_Dfareporting_FloodlightConfigurationsListResponse
+   */
+  public function listFloodlightConfigurations($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_FloodlightConfigurationsListResponse");
+  }
+
+  /**
+   * Updates an existing floodlight configuration. This method supports patch
+   * semantics. (floodlightConfigurations.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Floodlight configuration ID.
+   * @param Google_FloodlightConfiguration $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_FloodlightConfiguration
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_FloodlightConfiguration $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_FloodlightConfiguration");
+  }
+
+  /**
+   * Updates an existing floodlight configuration.
+   * (floodlightConfigurations.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_FloodlightConfiguration $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_FloodlightConfiguration
+   */
+  public function update($profileId, Google_Service_Dfareporting_FloodlightConfiguration $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_FloodlightConfiguration");
+  }
+}
+
+/**
+ * The "inventoryItems" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $inventoryItems = $dfareportingService->inventoryItems;
+ *  </code>
+ */
+class Google_Service_Dfareporting_InventoryItems_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one inventory item by ID. (inventoryItems.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $projectId Project ID for order documents.
+   * @param string $id Inventory item ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_InventoryItem
+   */
+  public function get($profileId, $projectId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'projectId' => $projectId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_InventoryItem");
+  }
+
+  /**
+   * Retrieves a list of inventory items, possibly filtered.
+   * (inventoryItems.listInventoryItems)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $projectId Project ID for order documents.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderId Select only inventory items that belong to
+   * specified orders.
+   * @opt_param string ids Select only inventory items with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string siteId Select only inventory items that are associated with
+   * these sites.
+   * @opt_param bool inPlan Select only inventory items that are in plan.
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @return Google_Service_Dfareporting_InventoryItemsListResponse
+   */
+  public function listInventoryItems($profileId, $projectId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'projectId' => $projectId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_InventoryItemsListResponse");
+  }
+}
+
+/**
+ * The "landingPages" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $landingPages = $dfareportingService->landingPages;
+ *  </code>
+ */
+class Google_Service_Dfareporting_LandingPages_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes an existing campaign landing page. (landingPages.delete)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $campaignId Landing page campaign ID.
+   * @param string $id Landing page ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($profileId, $campaignId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'campaignId' => $campaignId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets one campaign landing page by ID. (landingPages.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $campaignId Landing page campaign ID.
+   * @param string $id Landing page ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_LandingPage
+   */
+  public function get($profileId, $campaignId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'campaignId' => $campaignId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_LandingPage");
+  }
+
+  /**
+   * Inserts a new landing page for the specified campaign. (landingPages.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $campaignId Landing page campaign ID.
+   * @param Google_LandingPage $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_LandingPage
+   */
+  public function insert($profileId, $campaignId, Google_Service_Dfareporting_LandingPage $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'campaignId' => $campaignId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_LandingPage");
+  }
+
+  /**
+   * Retrieves the list of landing pages for the specified campaign.
+   * (landingPages.listLandingPages)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $campaignId Landing page campaign ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_LandingPagesListResponse
+   */
+  public function listLandingPages($profileId, $campaignId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'campaignId' => $campaignId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_LandingPagesListResponse");
+  }
+
+  /**
+   * Updates an existing campaign landing page. This method supports patch
+   * semantics. (landingPages.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $campaignId Landing page campaign ID.
+   * @param string $id Landing page ID.
+   * @param Google_LandingPage $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_LandingPage
+   */
+  public function patch($profileId, $campaignId, $id, Google_Service_Dfareporting_LandingPage $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'campaignId' => $campaignId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_LandingPage");
+  }
+
+  /**
+   * Updates an existing campaign landing page. (landingPages.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $campaignId Landing page campaign ID.
+   * @param Google_LandingPage $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_LandingPage
+   */
+  public function update($profileId, $campaignId, Google_Service_Dfareporting_LandingPage $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'campaignId' => $campaignId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_LandingPage");
+  }
+}
+
+/**
+ * The "metros" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $metros = $dfareportingService->metros;
+ *  </code>
+ */
+class Google_Service_Dfareporting_Metros_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a list of metros. (metros.listMetros)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_MetrosListResponse
+   */
+  public function listMetros($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_MetrosListResponse");
+  }
+}
+
+/**
+ * The "mobileCarriers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $mobileCarriers = $dfareportingService->mobileCarriers;
+ *  </code>
+ */
+class Google_Service_Dfareporting_MobileCarriers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one mobile carrier by ID. (mobileCarriers.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Mobile carrier ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_MobileCarrier
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_MobileCarrier");
+  }
+
+  /**
+   * Retrieves a list of mobile carriers. (mobileCarriers.listMobileCarriers)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_MobileCarriersListResponse
+   */
+  public function listMobileCarriers($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_MobileCarriersListResponse");
+  }
+}
+
+/**
+ * The "operatingSystemVersions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $operatingSystemVersions = $dfareportingService->operatingSystemVersions;
+ *  </code>
+ */
+class Google_Service_Dfareporting_OperatingSystemVersions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one operating system version by ID. (operatingSystemVersions.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Operating system version ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_OperatingSystemVersion
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_OperatingSystemVersion");
+  }
+
+  /**
+   * Retrieves a list of operating system versions.
+   * (operatingSystemVersions.listOperatingSystemVersions)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_OperatingSystemVersionsListResponse
+   */
+  public function listOperatingSystemVersions($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_OperatingSystemVersionsListResponse");
+  }
+}
+
+/**
+ * The "operatingSystems" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $operatingSystems = $dfareportingService->operatingSystems;
+ *  </code>
+ */
+class Google_Service_Dfareporting_OperatingSystems_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one operating system by DART ID. (operatingSystems.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $dartId Operating system DART ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_OperatingSystem
+   */
+  public function get($profileId, $dartId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'dartId' => $dartId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_OperatingSystem");
+  }
+
+  /**
+   * Retrieves a list of operating systems.
+   * (operatingSystems.listOperatingSystems)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_OperatingSystemsListResponse
+   */
+  public function listOperatingSystems($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_OperatingSystemsListResponse");
+  }
+}
+
+/**
+ * The "orderDocuments" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $orderDocuments = $dfareportingService->orderDocuments;
+ *  </code>
+ */
+class Google_Service_Dfareporting_OrderDocuments_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one order document by ID. (orderDocuments.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $projectId Project ID for order documents.
+   * @param string $id Order document ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_OrderDocument
+   */
+  public function get($profileId, $projectId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'projectId' => $projectId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_OrderDocument");
+  }
+
+  /**
+   * Retrieves a list of order documents, possibly filtered.
+   * (orderDocuments.listOrderDocuments)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $projectId Project ID for order documents.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderId Select only order documents for specified orders.
+   * @opt_param string searchString Allows searching for order documents by name
+   * or ID. Wildcards (*) are allowed. For example, "orderdocument*2015" will
+   * return order documents with names like "orderdocument June 2015",
+   * "orderdocument April 2015", or simply "orderdocument 2015". Most of the
+   * searches also add wildcards implicitly at the start and the end of the search
+   * string. For example, a search string of "orderdocument" will match order
+   * documents with name "my orderdocument", "orderdocument 2015", or simply
+   * "orderdocument".
+   * @opt_param string ids Select only order documents with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string siteId Select only order documents that are associated with
+   * these sites.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param bool approved Select only order documents that have been approved
+   * by at least one user.
+   * @return Google_Service_Dfareporting_OrderDocumentsListResponse
+   */
+  public function listOrderDocuments($profileId, $projectId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'projectId' => $projectId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_OrderDocumentsListResponse");
+  }
+}
+
+/**
+ * The "orders" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $orders = $dfareportingService->orders;
+ *  </code>
+ */
+class Google_Service_Dfareporting_Orders_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one order by ID. (orders.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $projectId Project ID for orders.
+   * @param string $id Order ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Order
+   */
+  public function get($profileId, $projectId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'projectId' => $projectId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_Order");
+  }
+
+  /**
+   * Retrieves a list of orders, possibly filtered. (orders.listOrders)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $projectId Project ID for orders.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string searchString Allows searching for orders by name or ID.
+   * Wildcards (*) are allowed. For example, "order*2015" will return orders with
+   * names like "order June 2015", "order April 2015", or simply "order 2015".
+   * Most of the searches also add wildcards implicitly at the start and the end
+   * of the search string. For example, a search string of "order" will match
+   * orders with name "my order", "order 2015", or simply "order".
+   * @opt_param string ids Select only orders with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string siteId Select only orders that are associated with these
+   * site IDs.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param string sortField Field by which to sort the list.
+   * @return Google_Service_Dfareporting_OrdersListResponse
+   */
+  public function listOrders($profileId, $projectId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'projectId' => $projectId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_OrdersListResponse");
+  }
+}
+
+/**
+ * The "placementGroups" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $placementGroups = $dfareportingService->placementGroups;
+ *  </code>
+ */
+class Google_Service_Dfareporting_PlacementGroups_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one placement group by ID. (placementGroups.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Placement group ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_PlacementGroup
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_PlacementGroup");
+  }
+
+  /**
+   * Inserts a new placement group. (placementGroups.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_PlacementGroup $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_PlacementGroup
+   */
+  public function insert($profileId, Google_Service_Dfareporting_PlacementGroup $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_PlacementGroup");
+  }
+
+  /**
+   * Retrieves a list of placement groups, possibly filtered.
+   * (placementGroups.listPlacementGroups)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string placementStrategyIds Select only placement groups that are
+   * associated with these placement strategies.
+   * @opt_param bool archived Select only archived placements. Don't set this
+   * field to select both archived and non-archived placements.
+   * @opt_param string searchString Allows searching for placement groups by name
+   * or ID. Wildcards (*) are allowed. For example, "placement*2015" will return
+   * placement groups with names like "placement group June 2015", "placement
+   * group May 2015", or simply "placements 2015". Most of the searches also add
+   * wildcards implicitly at the start and the end of the search string. For
+   * example, a search string of "placementgroup" will match placement groups with
+   * name "my placementgroup", "placementgroup 2015", or simply "placementgroup".
+   * @opt_param string contentCategoryIds Select only placement groups that are
+   * associated with these content categories.
+   * @opt_param string directorySiteIds Select only placement groups that are
+   * associated with these directory sites.
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string advertiserIds Select only placement groups that belong to
+   * these advertisers.
+   * @opt_param string ids Select only placement groups with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param string placementGroupType Select only placement groups belonging
+   * with this group type. A package is a simple group of placements that acts as
+   * a single pricing point for a group of tags. A roadblock is a group of
+   * placements that not only acts as a single pricing point but also assumes that
+   * all the tags in it will be served at the same time. A roadblock requires one
+   * of its assigned placements to be marked as primary for reporting.
+   * @opt_param string pricingTypes Select only placement groups with these
+   * pricing types.
+   * @opt_param string siteIds Select only placement groups that are associated
+   * with these sites.
+   * @opt_param string campaignIds Select only placement groups that belong to
+   * these campaigns.
+   * @return Google_Service_Dfareporting_PlacementGroupsListResponse
+   */
+  public function listPlacementGroups($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_PlacementGroupsListResponse");
+  }
+
+  /**
+   * Updates an existing placement group. This method supports patch semantics.
+   * (placementGroups.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Placement group ID.
+   * @param Google_PlacementGroup $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_PlacementGroup
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_PlacementGroup $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_PlacementGroup");
+  }
+
+  /**
+   * Updates an existing placement group. (placementGroups.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_PlacementGroup $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_PlacementGroup
+   */
+  public function update($profileId, Google_Service_Dfareporting_PlacementGroup $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_PlacementGroup");
+  }
+}
+
+/**
+ * The "placementStrategies" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $placementStrategies = $dfareportingService->placementStrategies;
+ *  </code>
+ */
+class Google_Service_Dfareporting_PlacementStrategies_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes an existing placement strategy. (placementStrategies.delete)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Placement strategy ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets one placement strategy by ID. (placementStrategies.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Placement strategy ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_PlacementStrategy
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_PlacementStrategy");
+  }
+
+  /**
+   * Inserts a new placement strategy. (placementStrategies.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_PlacementStrategy $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_PlacementStrategy
+   */
+  public function insert($profileId, Google_Service_Dfareporting_PlacementStrategy $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_PlacementStrategy");
+  }
+
+  /**
+   * Retrieves a list of placement strategies, possibly filtered.
+   * (placementStrategies.listPlacementStrategies)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string searchString Allows searching for objects by name or ID.
+   * Wildcards (*) are allowed. For example, "placementstrategy*2015" will return
+   * objects with names like "placementstrategy June 2015", "placementstrategy
+   * April 2015", or simply "placementstrategy 2015". Most of the searches also
+   * add wildcards implicitly at the start and the end of the search string. For
+   * example, a search string of "placementstrategy" will match objects with name
+   * "my placementstrategy", "placementstrategy 2015", or simply
+   * "placementstrategy".
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string ids Select only placement strategies with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @return Google_Service_Dfareporting_PlacementStrategiesListResponse
+   */
+  public function listPlacementStrategies($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_PlacementStrategiesListResponse");
+  }
+
+  /**
+   * Updates an existing placement strategy. This method supports patch semantics.
+   * (placementStrategies.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Placement strategy ID.
+   * @param Google_PlacementStrategy $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_PlacementStrategy
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_PlacementStrategy $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_PlacementStrategy");
+  }
+
+  /**
+   * Updates an existing placement strategy. (placementStrategies.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_PlacementStrategy $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_PlacementStrategy
+   */
+  public function update($profileId, Google_Service_Dfareporting_PlacementStrategy $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_PlacementStrategy");
+  }
+}
+
+/**
+ * The "placements" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $placements = $dfareportingService->placements;
+ *  </code>
+ */
+class Google_Service_Dfareporting_Placements_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Generates tags for a placement. (placements.generatetags)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string tagFormats Tag formats to generate for these placements.
+   * @opt_param string placementIds Generate tags for these placements.
+   * @opt_param string campaignId Generate placements belonging to this campaign.
+   * This is a required field.
+   * @return Google_Service_Dfareporting_PlacementsGenerateTagsResponse
+   */
+  public function generatetags($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('generatetags', array($params), "Google_Service_Dfareporting_PlacementsGenerateTagsResponse");
+  }
+
+  /**
+   * Gets one placement by ID. (placements.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Placement ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Placement
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_Placement");
+  }
+
+  /**
+   * Inserts a new placement. (placements.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_Placement $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Placement
+   */
+  public function insert($profileId, Google_Service_Dfareporting_Placement $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_Placement");
+  }
+
+  /**
+   * Retrieves a list of placements, possibly filtered.
+   * (placements.listPlacements)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string placementStrategyIds Select only placements that are
+   * associated with these placement strategies.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param bool archived Select only archived placements. Don't set this
+   * field to select both archived and non-archived placements.
+   * @opt_param string searchString Allows searching for placements by name or ID.
+   * Wildcards (*) are allowed. For example, "placement*2015" will return
+   * placements with names like "placement June 2015", "placement May 2015", or
+   * simply "placements 2015". Most of the searches also add wildcards implicitly
+   * at the start and the end of the search string. For example, a search string
+   * of "placement" will match placements with name "my placement", "placement
+   * 2015", or simply "placement".
+   * @opt_param string contentCategoryIds Select only placements that are
+   * associated with these content categories.
+   * @opt_param string directorySiteIds Select only placements that are associated
+   * with these directory sites.
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string advertiserIds Select only placements that belong to these
+   * advertisers.
+   * @opt_param string paymentSource Select only placements with this payment
+   * source.
+   * @opt_param string ids Select only placements with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string sizeIds Select only placements that are associated with
+   * these sizes.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string compatibilities Select only placements that are associated
+   * with these compatibilities. WEB and WEB_INTERSTITIAL refer to rendering
+   * either on desktop or on mobile devices for regular or interstitial ads
+   * respectively. APP and APP_INTERSTITIAL are for rendering in mobile
+   * apps.IN_STREAM_VIDEO refers to rendering in in-stream video ads developed
+   * with the VAST standard.
+   * @opt_param string groupIds Select only placements that belong to these
+   * placement groups.
+   * @opt_param string pricingTypes Select only placements with these pricing
+   * types.
+   * @opt_param string siteIds Select only placements that are associated with
+   * these sites.
+   * @opt_param string campaignIds Select only placements that belong to these
+   * campaigns.
+   * @return Google_Service_Dfareporting_PlacementsListResponse
+   */
+  public function listPlacements($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_PlacementsListResponse");
+  }
+
+  /**
+   * Updates an existing placement. This method supports patch semantics.
+   * (placements.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Placement ID.
+   * @param Google_Placement $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Placement
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_Placement $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_Placement");
+  }
+
+  /**
+   * Updates an existing placement. (placements.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_Placement $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Placement
+   */
+  public function update($profileId, Google_Service_Dfareporting_Placement $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_Placement");
+  }
+}
+
+/**
+ * The "platformTypes" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $platformTypes = $dfareportingService->platformTypes;
+ *  </code>
+ */
+class Google_Service_Dfareporting_PlatformTypes_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one platform type by ID. (platformTypes.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Platform type ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_PlatformType
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_PlatformType");
+  }
+
+  /**
+   * Retrieves a list of platform types. (platformTypes.listPlatformTypes)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_PlatformTypesListResponse
+   */
+  public function listPlatformTypes($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_PlatformTypesListResponse");
+  }
+}
+
+/**
+ * The "postalCodes" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $postalCodes = $dfareportingService->postalCodes;
+ *  </code>
+ */
+class Google_Service_Dfareporting_PostalCodes_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one postal code by ID. (postalCodes.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $code Postal code ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_PostalCode
+   */
+  public function get($profileId, $code, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'code' => $code);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_PostalCode");
+  }
+
+  /**
+   * Retrieves a list of postal codes. (postalCodes.listPostalCodes)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_PostalCodesListResponse
+   */
+  public function listPostalCodes($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_PostalCodesListResponse");
+  }
+}
+
+/**
+ * The "projects" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $projects = $dfareportingService->projects;
+ *  </code>
+ */
+class Google_Service_Dfareporting_Projects_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one project by ID. (projects.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Project ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Project
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_Project");
+  }
+
+  /**
+   * Retrieves a list of projects, possibly filtered. (projects.listProjects)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string searchString Allows searching for projects by name or ID.
+   * Wildcards (*) are allowed. For example, "project*2015" will return projects
+   * with names like "project June 2015", "project April 2015", or simply "project
+   * 2015". Most of the searches also add wildcards implicitly at the start and
+   * the end of the search string. For example, a search string of "project" will
+   * match projects with name "my project", "project 2015", or simply "project".
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string advertiserIds Select only projects with these advertiser
+   * IDs.
+   * @opt_param string ids Select only projects with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @return Google_Service_Dfareporting_ProjectsListResponse
+   */
+  public function listProjects($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_ProjectsListResponse");
+  }
+}
+
+/**
+ * The "regions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $regions = $dfareportingService->regions;
+ *  </code>
+ */
+class Google_Service_Dfareporting_Regions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a list of regions. (regions.listRegions)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_RegionsListResponse
+   */
+  public function listRegions($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_RegionsListResponse");
+  }
+}
+
+/**
+ * The "remarketingListShares" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $remarketingListShares = $dfareportingService->remarketingListShares;
+ *  </code>
+ */
+class Google_Service_Dfareporting_RemarketingListShares_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one remarketing list share by remarketing list ID.
+   * (remarketingListShares.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $remarketingListId Remarketing list ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_RemarketingListShare
+   */
+  public function get($profileId, $remarketingListId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'remarketingListId' => $remarketingListId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_RemarketingListShare");
+  }
+
+  /**
+   * Updates an existing remarketing list share. This method supports patch
+   * semantics. (remarketingListShares.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $remarketingListId Remarketing list ID.
+   * @param Google_RemarketingListShare $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_RemarketingListShare
+   */
+  public function patch($profileId, $remarketingListId, Google_Service_Dfareporting_RemarketingListShare $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'remarketingListId' => $remarketingListId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_RemarketingListShare");
+  }
+
+  /**
+   * Updates an existing remarketing list share. (remarketingListShares.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_RemarketingListShare $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_RemarketingListShare
+   */
+  public function update($profileId, Google_Service_Dfareporting_RemarketingListShare $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_RemarketingListShare");
+  }
+}
+
+/**
+ * The "remarketingLists" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $remarketingLists = $dfareportingService->remarketingLists;
+ *  </code>
+ */
+class Google_Service_Dfareporting_RemarketingLists_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one remarketing list by ID. (remarketingLists.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Remarketing list ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_RemarketingList
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_RemarketingList");
+  }
+
+  /**
+   * Inserts a new remarketing list. (remarketingLists.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_RemarketingList $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_RemarketingList
+   */
+  public function insert($profileId, Google_Service_Dfareporting_RemarketingList $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_RemarketingList");
+  }
+
+  /**
+   * Retrieves a list of remarketing lists, possibly filtered.
+   * (remarketingLists.listRemarketingLists)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $advertiserId Select only remarketing lists owned by this
+   * advertiser.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string name Allows searching for objects by name or ID. Wildcards
+   * (*) are allowed. For example, "remarketing list*2015" will return objects
+   * with names like "remarketing list June 2015", "remarketing list April 2015",
+   * or simply "remarketing list 2015". Most of the searches also add wildcards
+   * implicitly at the start and the end of the search string. For example, a
+   * search string of "remarketing list" will match objects with name "my
+   * remarketing list", "remarketing list 2015", or simply "remarketing list".
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param bool active Select only active or only inactive remarketing lists.
+   * @opt_param string floodlightActivityId Select only remarketing lists that
+   * have this floodlight activity ID.
+   * @return Google_Service_Dfareporting_RemarketingListsListResponse
+   */
+  public function listRemarketingLists($profileId, $advertiserId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'advertiserId' => $advertiserId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_RemarketingListsListResponse");
+  }
+
+  /**
+   * Updates an existing remarketing list. This method supports patch semantics.
+   * (remarketingLists.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Remarketing list ID.
+   * @param Google_RemarketingList $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_RemarketingList
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_RemarketingList $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_RemarketingList");
+  }
+
+  /**
+   * Updates an existing remarketing list. (remarketingLists.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_RemarketingList $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_RemarketingList
+   */
+  public function update($profileId, Google_Service_Dfareporting_RemarketingList $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_RemarketingList");
+  }
+}
+
+/**
+ * The "reports" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $reports = $dfareportingService->reports;
+ *  </code>
+ */
+class Google_Service_Dfareporting_Reports_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a report by its ID. (reports.delete)
+   *
+   * @param string $profileId The DFA user profile ID.
+   * @param string $reportId The ID of the report.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($profileId, $reportId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'reportId' => $reportId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves a report by its ID. (reports.get)
+   *
+   * @param string $profileId The DFA user profile ID.
+   * @param string $reportId The ID of the report.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Report
+   */
+  public function get($profileId, $reportId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'reportId' => $reportId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_Report");
+  }
+
+  /**
+   * Creates a report. (reports.insert)
+   *
+   * @param string $profileId The DFA user profile ID.
+   * @param Google_Report $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Report
+   */
+  public function insert($profileId, Google_Service_Dfareporting_Report $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_Report");
+  }
+
+  /**
+   * Retrieves list of reports. (reports.listReports)
+   *
+   * @param string $profileId The DFA user profile ID.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string sortField The field by which to sort the list.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken The value of the nextToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is 'DESCENDING'.
+   * @opt_param string scope The scope that defines which results are returned,
+   * default is 'MINE'.
+   * @return Google_Service_Dfareporting_ReportList
+   */
+  public function listReports($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_ReportList");
+  }
+
+  /**
+   * Updates a report. This method supports patch semantics. (reports.patch)
+   *
+   * @param string $profileId The DFA user profile ID.
+   * @param string $reportId The ID of the report.
+   * @param Google_Report $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Report
+   */
+  public function patch($profileId, $reportId, Google_Service_Dfareporting_Report $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'reportId' => $reportId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_Report");
+  }
+
+  /**
+   * Runs a report. (reports.run)
+   *
+   * @param string $profileId The DFA profile ID.
+   * @param string $reportId The ID of the report.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool synchronous If set and true, tries to run the report
+   * synchronously.
+   * @return Google_Service_Dfareporting_DfareportingFile
+   */
+  public function run($profileId, $reportId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'reportId' => $reportId);
+    $params = array_merge($params, $optParams);
+    return $this->call('run', array($params), "Google_Service_Dfareporting_DfareportingFile");
+  }
+
+  /**
+   * Updates a report. (reports.update)
+   *
+   * @param string $profileId The DFA user profile ID.
+   * @param string $reportId The ID of the report.
+   * @param Google_Report $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Report
+   */
+  public function update($profileId, $reportId, Google_Service_Dfareporting_Report $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'reportId' => $reportId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_Report");
+  }
+}
+
+/**
+ * The "compatibleFields" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $compatibleFields = $dfareportingService->compatibleFields;
+ *  </code>
+ */
+class Google_Service_Dfareporting_ReportsCompatibleFields_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns the fields that are compatible to be selected in the respective
+   * sections of a report criteria, given the fields already selected in the input
+   * report and user permissions. (compatibleFields.query)
+   *
+   * @param string $profileId The DFA user profile ID.
+   * @param Google_Report $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_CompatibleFields
+   */
+  public function query($profileId, Google_Service_Dfareporting_Report $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('query', array($params), "Google_Service_Dfareporting_CompatibleFields");
+  }
+}
+/**
+ * The "files" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $files = $dfareportingService->files;
+ *  </code>
+ */
+class Google_Service_Dfareporting_ReportsFiles_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a report file. (files.get)
+   *
+   * @param string $profileId The DFA profile ID.
+   * @param string $reportId The ID of the report.
+   * @param string $fileId The ID of the report file.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_DfareportingFile
+   */
+  public function get($profileId, $reportId, $fileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'reportId' => $reportId, 'fileId' => $fileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_DfareportingFile");
+  }
+
+  /**
+   * Lists files for a report. (files.listReportsFiles)
+   *
+   * @param string $profileId The DFA profile ID.
+   * @param string $reportId The ID of the parent report.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string sortField The field by which to sort the list.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken The value of the nextToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is 'DESCENDING'.
+   * @return Google_Service_Dfareporting_FileList
+   */
+  public function listReportsFiles($profileId, $reportId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'reportId' => $reportId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_FileList");
+  }
+}
+
+/**
+ * The "sites" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $sites = $dfareportingService->sites;
+ *  </code>
+ */
+class Google_Service_Dfareporting_Sites_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one site by ID. (sites.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Site ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Site
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_Site");
+  }
+
+  /**
+   * Inserts a new site. (sites.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_Site $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Site
+   */
+  public function insert($profileId, Google_Service_Dfareporting_Site $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_Site");
+  }
+
+  /**
+   * Retrieves a list of sites, possibly filtered. (sites.listSites)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool acceptsInterstitialPlacements This search filter is no longer
+   * supported and will have no effect on the results returned.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param string searchString Allows searching for objects by name, ID or
+   * keyName. Wildcards (*) are allowed. For example, "site*2015" will return
+   * objects with names like "site June 2015", "site April 2015", or simply "site
+   * 2015". Most of the searches also add wildcards implicitly at the start and
+   * the end of the search string. For example, a search string of "site" will
+   * match objects with name "my site", "site 2015", or simply "site".
+   * @opt_param string subaccountId Select only sites with this subaccount ID.
+   * @opt_param string directorySiteIds Select only sites with these directory
+   * site IDs.
+   * @opt_param bool acceptsInStreamVideoPlacements This search filter is no
+   * longer supported and will have no effect on the results returned.
+   * @opt_param string ids Select only sites with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param bool acceptsPublisherPaidPlacements Select only sites that accept
+   * publisher paid placements.
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param bool adWordsSite Select only AdWords sites.
+   * @opt_param bool unmappedSite Select only sites that have not been mapped to a
+   * directory site.
+   * @opt_param bool approved Select only approved sites.
+   * @opt_param string campaignIds Select only sites with these campaign IDs.
+   * @return Google_Service_Dfareporting_SitesListResponse
+   */
+  public function listSites($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_SitesListResponse");
+  }
+
+  /**
+   * Updates an existing site. This method supports patch semantics. (sites.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Site ID.
+   * @param Google_Site $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Site
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_Site $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_Site");
+  }
+
+  /**
+   * Updates an existing site. (sites.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_Site $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Site
+   */
+  public function update($profileId, Google_Service_Dfareporting_Site $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_Site");
+  }
+}
+
+/**
+ * The "sizes" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $sizes = $dfareportingService->sizes;
+ *  </code>
+ */
+class Google_Service_Dfareporting_Sizes_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one size by ID. (sizes.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Size ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Size
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_Size");
+  }
+
+  /**
+   * Inserts a new size. (sizes.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_Size $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Size
+   */
+  public function insert($profileId, Google_Service_Dfareporting_Size $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_Size");
+  }
+
+  /**
+   * Retrieves a list of sizes, possibly filtered. (sizes.listSizes)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool iabStandard Select only IAB standard sizes.
+   * @opt_param int width Select only sizes with this width.
+   * @opt_param string ids Select only sizes with these IDs.
+   * @opt_param int height Select only sizes with this height.
+   * @return Google_Service_Dfareporting_SizesListResponse
+   */
+  public function listSizes($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_SizesListResponse");
+  }
+}
+
+/**
+ * The "subaccounts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $subaccounts = $dfareportingService->subaccounts;
+ *  </code>
+ */
+class Google_Service_Dfareporting_Subaccounts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one subaccount by ID. (subaccounts.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Subaccount ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Subaccount
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_Subaccount");
+  }
+
+  /**
+   * Inserts a new subaccount. (subaccounts.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_Subaccount $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Subaccount
+   */
+  public function insert($profileId, Google_Service_Dfareporting_Subaccount $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_Subaccount");
+  }
+
+  /**
+   * Gets a list of subaccounts, possibly filtered. (subaccounts.listSubaccounts)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string searchString Allows searching for objects by name or ID.
+   * Wildcards (*) are allowed. For example, "subaccount*2015" will return objects
+   * with names like "subaccount June 2015", "subaccount April 2015", or simply
+   * "subaccount 2015". Most of the searches also add wildcards implicitly at the
+   * start and the end of the search string. For example, a search string of
+   * "subaccount" will match objects with name "my subaccount", "subaccount 2015",
+   * or simply "subaccount".
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string ids Select only subaccounts with these IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @return Google_Service_Dfareporting_SubaccountsListResponse
+   */
+  public function listSubaccounts($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_SubaccountsListResponse");
+  }
+
+  /**
+   * Updates an existing subaccount. This method supports patch semantics.
+   * (subaccounts.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Subaccount ID.
+   * @param Google_Subaccount $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Subaccount
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_Subaccount $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_Subaccount");
+  }
+
+  /**
+   * Updates an existing subaccount. (subaccounts.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_Subaccount $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_Subaccount
+   */
+  public function update($profileId, Google_Service_Dfareporting_Subaccount $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_Subaccount");
+  }
+}
+
+/**
+ * The "targetableRemarketingLists" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $targetableRemarketingLists = $dfareportingService->targetableRemarketingLists;
+ *  </code>
+ */
+class Google_Service_Dfareporting_TargetableRemarketingLists_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one remarketing list by ID. (targetableRemarketingLists.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id Remarketing list ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_TargetableRemarketingList
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_TargetableRemarketingList");
+  }
+
+  /**
+   * Retrieves a list of targetable remarketing lists, possibly filtered.
+   * (targetableRemarketingLists.listTargetableRemarketingLists)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $advertiserId Select only targetable remarketing lists
+   * targetable by these advertisers.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string name Allows searching for objects by name or ID. Wildcards
+   * (*) are allowed. For example, "remarketing list*2015" will return objects
+   * with names like "remarketing list June 2015", "remarketing list April 2015",
+   * or simply "remarketing list 2015". Most of the searches also add wildcards
+   * implicitly at the start and the end of the search string. For example, a
+   * search string of "remarketing list" will match objects with name "my
+   * remarketing list", "remarketing list 2015", or simply "remarketing list".
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param bool active Select only active or only inactive targetable
+   * remarketing lists.
+   * @return Google_Service_Dfareporting_TargetableRemarketingListsListResponse
+   */
+  public function listTargetableRemarketingLists($profileId, $advertiserId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'advertiserId' => $advertiserId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_TargetableRemarketingListsListResponse");
+  }
+}
+
+/**
+ * The "userProfiles" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $userProfiles = $dfareportingService->userProfiles;
+ *  </code>
+ */
+class Google_Service_Dfareporting_UserProfiles_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one user profile by ID. (userProfiles.get)
+   *
+   * @param string $profileId The user profile ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_UserProfile
+   */
+  public function get($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_UserProfile");
+  }
+
+  /**
+   * Retrieves list of user profiles for a user. (userProfiles.listUserProfiles)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_UserProfileList
+   */
+  public function listUserProfiles($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_UserProfileList");
+  }
+}
+
+/**
+ * The "userRolePermissionGroups" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $userRolePermissionGroups = $dfareportingService->userRolePermissionGroups;
+ *  </code>
+ */
+class Google_Service_Dfareporting_UserRolePermissionGroups_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one user role permission group by ID. (userRolePermissionGroups.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id User role permission group ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_UserRolePermissionGroup
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_UserRolePermissionGroup");
+  }
+
+  /**
+   * Gets a list of all supported user role permission groups.
+   * (userRolePermissionGroups.listUserRolePermissionGroups)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_UserRolePermissionGroupsListResponse
+   */
+  public function listUserRolePermissionGroups($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_UserRolePermissionGroupsListResponse");
+  }
+}
+
+/**
+ * The "userRolePermissions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $userRolePermissions = $dfareportingService->userRolePermissions;
+ *  </code>
+ */
+class Google_Service_Dfareporting_UserRolePermissions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one user role permission by ID. (userRolePermissions.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id User role permission ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_UserRolePermission
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_UserRolePermission");
+  }
+
+  /**
+   * Gets a list of user role permissions, possibly filtered.
+   * (userRolePermissions.listUserRolePermissions)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string ids Select only user role permissions with these IDs.
+   * @return Google_Service_Dfareporting_UserRolePermissionsListResponse
+   */
+  public function listUserRolePermissions($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_UserRolePermissionsListResponse");
+  }
+}
+
+/**
+ * The "userRoles" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dfareportingService = new Google_Service_Dfareporting(...);
+ *   $userRoles = $dfareportingService->userRoles;
+ *  </code>
+ */
+class Google_Service_Dfareporting_UserRoles_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes an existing user role. (userRoles.delete)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id User role ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets one user role by ID. (userRoles.get)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id User role ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_UserRole
+   */
+  public function get($profileId, $id, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dfareporting_UserRole");
+  }
+
+  /**
+   * Inserts a new user role. (userRoles.insert)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_UserRole $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_UserRole
+   */
+  public function insert($profileId, Google_Service_Dfareporting_UserRole $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Dfareporting_UserRole");
+  }
+
+  /**
+   * Retrieves a list of user roles, possibly filtered. (userRoles.listUserRoles)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string searchString Allows searching for objects by name or ID.
+   * Wildcards (*) are allowed. For example, "userrole*2015" will return objects
+   * with names like "userrole June 2015", "userrole April 2015", or simply
+   * "userrole 2015". Most of the searches also add wildcards implicitly at the
+   * start and the end of the search string. For example, a search string of
+   * "userrole" will match objects with name "my userrole", "userrole 2015", or
+   * simply "userrole".
+   * @opt_param string subaccountId Select only user roles that belong to this
+   * subaccount.
+   * @opt_param string sortField Field by which to sort the list.
+   * @opt_param string ids Select only user roles with the specified IDs.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string pageToken Value of the nextPageToken from the previous
+   * result page.
+   * @opt_param string sortOrder Order of sorted results, default is ASCENDING.
+   * @opt_param bool accountUserRoleOnly Select only account level user roles not
+   * associated with any specific subaccount.
+   * @return Google_Service_Dfareporting_UserRolesListResponse
+   */
+  public function listUserRoles($profileId, $optParams = array())
+  {
+    $params = array('profileId' => $profileId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dfareporting_UserRolesListResponse");
+  }
+
+  /**
+   * Updates an existing user role. This method supports patch semantics.
+   * (userRoles.patch)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param string $id User role ID.
+   * @param Google_UserRole $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_UserRole
+   */
+  public function patch($profileId, $id, Google_Service_Dfareporting_UserRole $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Dfareporting_UserRole");
+  }
+
+  /**
+   * Updates an existing user role. (userRoles.update)
+   *
+   * @param string $profileId User profile ID associated with this request.
+   * @param Google_UserRole $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dfareporting_UserRole
+   */
+  public function update($profileId, Google_Service_Dfareporting_UserRole $postBody, $optParams = array())
+  {
+    $params = array('profileId' => $profileId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Dfareporting_UserRole");
+  }
+}
+
+
+
+
+class Google_Service_Dfareporting_Account extends Google_Collection
+{
+  protected $collection_key = 'availablePermissionIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountPermissionIds;
+  public $accountProfile;
+  public $active;
+  public $activeAdsLimitTier;
+  public $activeViewOptOut;
+  public $availablePermissionIds;
+  public $comscoreVceEnabled;
+  public $countryId;
+  public $currencyId;
+  public $defaultCreativeSizeId;
+  public $description;
+  public $id;
+  public $kind;
+  public $locale;
+  public $maximumImageSize;
+  public $name;
+  public $nielsenOcrEnabled;
+  protected $reportsConfigurationType = 'Google_Service_Dfareporting_ReportsConfiguration';
+  protected $reportsConfigurationDataType = '';
+  public $teaserSizeLimit;
+
+
+  public function setAccountPermissionIds($accountPermissionIds)
+  {
+    $this->accountPermissionIds = $accountPermissionIds;
+  }
+  public function getAccountPermissionIds()
+  {
+    return $this->accountPermissionIds;
+  }
+  public function setAccountProfile($accountProfile)
+  {
+    $this->accountProfile = $accountProfile;
+  }
+  public function getAccountProfile()
+  {
+    return $this->accountProfile;
+  }
+  public function setActive($active)
+  {
+    $this->active = $active;
+  }
+  public function getActive()
+  {
+    return $this->active;
+  }
+  public function setActiveAdsLimitTier($activeAdsLimitTier)
+  {
+    $this->activeAdsLimitTier = $activeAdsLimitTier;
+  }
+  public function getActiveAdsLimitTier()
+  {
+    return $this->activeAdsLimitTier;
+  }
+  public function setActiveViewOptOut($activeViewOptOut)
+  {
+    $this->activeViewOptOut = $activeViewOptOut;
+  }
+  public function getActiveViewOptOut()
+  {
+    return $this->activeViewOptOut;
+  }
+  public function setAvailablePermissionIds($availablePermissionIds)
+  {
+    $this->availablePermissionIds = $availablePermissionIds;
+  }
+  public function getAvailablePermissionIds()
+  {
+    return $this->availablePermissionIds;
+  }
+  public function setComscoreVceEnabled($comscoreVceEnabled)
+  {
+    $this->comscoreVceEnabled = $comscoreVceEnabled;
+  }
+  public function getComscoreVceEnabled()
+  {
+    return $this->comscoreVceEnabled;
+  }
+  public function setCountryId($countryId)
+  {
+    $this->countryId = $countryId;
+  }
+  public function getCountryId()
+  {
+    return $this->countryId;
+  }
+  public function setCurrencyId($currencyId)
+  {
+    $this->currencyId = $currencyId;
+  }
+  public function getCurrencyId()
+  {
+    return $this->currencyId;
+  }
+  public function setDefaultCreativeSizeId($defaultCreativeSizeId)
+  {
+    $this->defaultCreativeSizeId = $defaultCreativeSizeId;
+  }
+  public function getDefaultCreativeSizeId()
+  {
+    return $this->defaultCreativeSizeId;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocale($locale)
+  {
+    $this->locale = $locale;
+  }
+  public function getLocale()
+  {
+    return $this->locale;
+  }
+  public function setMaximumImageSize($maximumImageSize)
+  {
+    $this->maximumImageSize = $maximumImageSize;
+  }
+  public function getMaximumImageSize()
+  {
+    return $this->maximumImageSize;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNielsenOcrEnabled($nielsenOcrEnabled)
+  {
+    $this->nielsenOcrEnabled = $nielsenOcrEnabled;
+  }
+  public function getNielsenOcrEnabled()
+  {
+    return $this->nielsenOcrEnabled;
+  }
+  public function setReportsConfiguration(Google_Service_Dfareporting_ReportsConfiguration $reportsConfiguration)
+  {
+    $this->reportsConfiguration = $reportsConfiguration;
+  }
+  public function getReportsConfiguration()
+  {
+    return $this->reportsConfiguration;
+  }
+  public function setTeaserSizeLimit($teaserSizeLimit)
+  {
+    $this->teaserSizeLimit = $teaserSizeLimit;
+  }
+  public function getTeaserSizeLimit()
+  {
+    return $this->teaserSizeLimit;
+  }
+}
+
+class Google_Service_Dfareporting_AccountActiveAdSummary extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $activeAds;
+  public $activeAdsLimitTier;
+  public $availableAds;
+  public $kind;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setActiveAds($activeAds)
+  {
+    $this->activeAds = $activeAds;
+  }
+  public function getActiveAds()
+  {
+    return $this->activeAds;
+  }
+  public function setActiveAdsLimitTier($activeAdsLimitTier)
+  {
+    $this->activeAdsLimitTier = $activeAdsLimitTier;
+  }
+  public function getActiveAdsLimitTier()
+  {
+    return $this->activeAdsLimitTier;
+  }
+  public function setAvailableAds($availableAds)
+  {
+    $this->availableAds = $availableAds;
+  }
+  public function getAvailableAds()
+  {
+    return $this->availableAds;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Dfareporting_AccountPermission extends Google_Collection
+{
+  protected $collection_key = 'accountProfiles';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountProfiles;
+  public $id;
+  public $kind;
+  public $level;
+  public $name;
+  public $permissionGroupId;
+
+
+  public function setAccountProfiles($accountProfiles)
+  {
+    $this->accountProfiles = $accountProfiles;
+  }
+  public function getAccountProfiles()
+  {
+    return $this->accountProfiles;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLevel($level)
+  {
+    $this->level = $level;
+  }
+  public function getLevel()
+  {
+    return $this->level;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPermissionGroupId($permissionGroupId)
+  {
+    $this->permissionGroupId = $permissionGroupId;
+  }
+  public function getPermissionGroupId()
+  {
+    return $this->permissionGroupId;
+  }
+}
+
+class Google_Service_Dfareporting_AccountPermissionGroup extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Dfareporting_AccountPermissionGroupsListResponse extends Google_Collection
+{
+  protected $collection_key = 'accountPermissionGroups';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accountPermissionGroupsType = 'Google_Service_Dfareporting_AccountPermissionGroup';
+  protected $accountPermissionGroupsDataType = 'array';
+  public $kind;
+
+
+  public function setAccountPermissionGroups($accountPermissionGroups)
+  {
+    $this->accountPermissionGroups = $accountPermissionGroups;
+  }
+  public function getAccountPermissionGroups()
+  {
+    return $this->accountPermissionGroups;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Dfareporting_AccountPermissionsListResponse extends Google_Collection
+{
+  protected $collection_key = 'accountPermissions';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accountPermissionsType = 'Google_Service_Dfareporting_AccountPermission';
+  protected $accountPermissionsDataType = 'array';
+  public $kind;
+
+
+  public function setAccountPermissions($accountPermissions)
+  {
+    $this->accountPermissions = $accountPermissions;
+  }
+  public function getAccountPermissions()
+  {
+    return $this->accountPermissions;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Dfareporting_AccountUserProfile extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $active;
+  protected $advertiserFilterType = 'Google_Service_Dfareporting_ObjectFilter';
+  protected $advertiserFilterDataType = '';
+  protected $campaignFilterType = 'Google_Service_Dfareporting_ObjectFilter';
+  protected $campaignFilterDataType = '';
+  public $comments;
+  public $email;
+  public $id;
+  public $kind;
+  public $locale;
+  public $name;
+  protected $siteFilterType = 'Google_Service_Dfareporting_ObjectFilter';
+  protected $siteFilterDataType = '';
+  public $subaccountId;
+  public $traffickerType;
+  public $userAccessType;
+  protected $userRoleFilterType = 'Google_Service_Dfareporting_ObjectFilter';
+  protected $userRoleFilterDataType = '';
+  public $userRoleId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setActive($active)
+  {
+    $this->active = $active;
+  }
+  public function getActive()
+  {
+    return $this->active;
+  }
+  public function setAdvertiserFilter(Google_Service_Dfareporting_ObjectFilter $advertiserFilter)
+  {
+    $this->advertiserFilter = $advertiserFilter;
+  }
+  public function getAdvertiserFilter()
+  {
+    return $this->advertiserFilter;
+  }
+  public function setCampaignFilter(Google_Service_Dfareporting_ObjectFilter $campaignFilter)
+  {
+    $this->campaignFilter = $campaignFilter;
+  }
+  public function getCampaignFilter()
+  {
+    return $this->campaignFilter;
+  }
+  public function setComments($comments)
+  {
+    $this->comments = $comments;
+  }
+  public function getComments()
+  {
+    return $this->comments;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocale($locale)
+  {
+    $this->locale = $locale;
+  }
+  public function getLocale()
+  {
+    return $this->locale;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSiteFilter(Google_Service_Dfareporting_ObjectFilter $siteFilter)
+  {
+    $this->siteFilter = $siteFilter;
+  }
+  public function getSiteFilter()
+  {
+    return $this->siteFilter;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+  public function setTraffickerType($traffickerType)
+  {
+    $this->traffickerType = $traffickerType;
+  }
+  public function getTraffickerType()
+  {
+    return $this->traffickerType;
+  }
+  public function setUserAccessType($userAccessType)
+  {
+    $this->userAccessType = $userAccessType;
+  }
+  public function getUserAccessType()
+  {
+    return $this->userAccessType;
+  }
+  public function setUserRoleFilter(Google_Service_Dfareporting_ObjectFilter $userRoleFilter)
+  {
+    $this->userRoleFilter = $userRoleFilter;
+  }
+  public function getUserRoleFilter()
+  {
+    return $this->userRoleFilter;
+  }
+  public function setUserRoleId($userRoleId)
+  {
+    $this->userRoleId = $userRoleId;
+  }
+  public function getUserRoleId()
+  {
+    return $this->userRoleId;
+  }
+}
+
+class Google_Service_Dfareporting_AccountUserProfilesListResponse extends Google_Collection
+{
+  protected $collection_key = 'accountUserProfiles';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accountUserProfilesType = 'Google_Service_Dfareporting_AccountUserProfile';
+  protected $accountUserProfilesDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setAccountUserProfiles($accountUserProfiles)
+  {
+    $this->accountUserProfiles = $accountUserProfiles;
+  }
+  public function getAccountUserProfiles()
+  {
+    return $this->accountUserProfiles;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_AccountsListResponse extends Google_Collection
+{
+  protected $collection_key = 'accounts';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accountsType = 'Google_Service_Dfareporting_Account';
+  protected $accountsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setAccounts($accounts)
+  {
+    $this->accounts = $accounts;
+  }
+  public function getAccounts()
+  {
+    return $this->accounts;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_Activities extends Google_Collection
+{
+  protected $collection_key = 'metricNames';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $filtersType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $filtersDataType = 'array';
+  public $kind;
+  public $metricNames;
+
+
+  public function setFilters($filters)
+  {
+    $this->filters = $filters;
+  }
+  public function getFilters()
+  {
+    return $this->filters;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMetricNames($metricNames)
+  {
+    $this->metricNames = $metricNames;
+  }
+  public function getMetricNames()
+  {
+    return $this->metricNames;
+  }
+}
+
+class Google_Service_Dfareporting_Ad extends Google_Collection
+{
+  protected $collection_key = 'placementAssignments';
+  protected $internal_gapi_mappings = array(
+        "remarketingListExpression" => "remarketing_list_expression",
+  );
+  public $accountId;
+  public $active;
+  public $advertiserId;
+  protected $advertiserIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $advertiserIdDimensionValueDataType = '';
+  public $archived;
+  public $audienceSegmentId;
+  public $campaignId;
+  protected $campaignIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $campaignIdDimensionValueDataType = '';
+  protected $clickThroughUrlType = 'Google_Service_Dfareporting_ClickThroughUrl';
+  protected $clickThroughUrlDataType = '';
+  protected $clickThroughUrlSuffixPropertiesType = 'Google_Service_Dfareporting_ClickThroughUrlSuffixProperties';
+  protected $clickThroughUrlSuffixPropertiesDataType = '';
+  public $comments;
+  public $compatibility;
+  protected $createInfoType = 'Google_Service_Dfareporting_LastModifiedInfo';
+  protected $createInfoDataType = '';
+  protected $creativeGroupAssignmentsType = 'Google_Service_Dfareporting_CreativeGroupAssignment';
+  protected $creativeGroupAssignmentsDataType = 'array';
+  protected $creativeRotationType = 'Google_Service_Dfareporting_CreativeRotation';
+  protected $creativeRotationDataType = '';
+  protected $dayPartTargetingType = 'Google_Service_Dfareporting_DayPartTargeting';
+  protected $dayPartTargetingDataType = '';
+  protected $defaultClickThroughEventTagPropertiesType = 'Google_Service_Dfareporting_DefaultClickThroughEventTagProperties';
+  protected $defaultClickThroughEventTagPropertiesDataType = '';
+  protected $deliveryScheduleType = 'Google_Service_Dfareporting_DeliverySchedule';
+  protected $deliveryScheduleDataType = '';
+  public $dynamicClickTracker;
+  public $endTime;
+  protected $eventTagOverridesType = 'Google_Service_Dfareporting_EventTagOverride';
+  protected $eventTagOverridesDataType = 'array';
+  protected $geoTargetingType = 'Google_Service_Dfareporting_GeoTargeting';
+  protected $geoTargetingDataType = '';
+  public $id;
+  protected $idDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $idDimensionValueDataType = '';
+  protected $keyValueTargetingExpressionType = 'Google_Service_Dfareporting_KeyValueTargetingExpression';
+  protected $keyValueTargetingExpressionDataType = '';
+  public $kind;
+  protected $lastModifiedInfoType = 'Google_Service_Dfareporting_LastModifiedInfo';
+  protected $lastModifiedInfoDataType = '';
+  public $name;
+  protected $placementAssignmentsType = 'Google_Service_Dfareporting_PlacementAssignment';
+  protected $placementAssignmentsDataType = 'array';
+  protected $remarketingListExpressionType = 'Google_Service_Dfareporting_ListTargetingExpression';
+  protected $remarketingListExpressionDataType = '';
+  protected $sizeType = 'Google_Service_Dfareporting_Size';
+  protected $sizeDataType = '';
+  public $sslCompliant;
+  public $sslRequired;
+  public $startTime;
+  public $subaccountId;
+  protected $technologyTargetingType = 'Google_Service_Dfareporting_TechnologyTargeting';
+  protected $technologyTargetingDataType = '';
+  public $type;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setActive($active)
+  {
+    $this->active = $active;
+  }
+  public function getActive()
+  {
+    return $this->active;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAdvertiserIdDimensionValue(Google_Service_Dfareporting_DimensionValue $advertiserIdDimensionValue)
+  {
+    $this->advertiserIdDimensionValue = $advertiserIdDimensionValue;
+  }
+  public function getAdvertiserIdDimensionValue()
+  {
+    return $this->advertiserIdDimensionValue;
+  }
+  public function setArchived($archived)
+  {
+    $this->archived = $archived;
+  }
+  public function getArchived()
+  {
+    return $this->archived;
+  }
+  public function setAudienceSegmentId($audienceSegmentId)
+  {
+    $this->audienceSegmentId = $audienceSegmentId;
+  }
+  public function getAudienceSegmentId()
+  {
+    return $this->audienceSegmentId;
+  }
+  public function setCampaignId($campaignId)
+  {
+    $this->campaignId = $campaignId;
+  }
+  public function getCampaignId()
+  {
+    return $this->campaignId;
+  }
+  public function setCampaignIdDimensionValue(Google_Service_Dfareporting_DimensionValue $campaignIdDimensionValue)
+  {
+    $this->campaignIdDimensionValue = $campaignIdDimensionValue;
+  }
+  public function getCampaignIdDimensionValue()
+  {
+    return $this->campaignIdDimensionValue;
+  }
+  public function setClickThroughUrl(Google_Service_Dfareporting_ClickThroughUrl $clickThroughUrl)
+  {
+    $this->clickThroughUrl = $clickThroughUrl;
+  }
+  public function getClickThroughUrl()
+  {
+    return $this->clickThroughUrl;
+  }
+  public function setClickThroughUrlSuffixProperties(Google_Service_Dfareporting_ClickThroughUrlSuffixProperties $clickThroughUrlSuffixProperties)
+  {
+    $this->clickThroughUrlSuffixProperties = $clickThroughUrlSuffixProperties;
+  }
+  public function getClickThroughUrlSuffixProperties()
+  {
+    return $this->clickThroughUrlSuffixProperties;
+  }
+  public function setComments($comments)
+  {
+    $this->comments = $comments;
+  }
+  public function getComments()
+  {
+    return $this->comments;
+  }
+  public function setCompatibility($compatibility)
+  {
+    $this->compatibility = $compatibility;
+  }
+  public function getCompatibility()
+  {
+    return $this->compatibility;
+  }
+  public function setCreateInfo(Google_Service_Dfareporting_LastModifiedInfo $createInfo)
+  {
+    $this->createInfo = $createInfo;
+  }
+  public function getCreateInfo()
+  {
+    return $this->createInfo;
+  }
+  public function setCreativeGroupAssignments($creativeGroupAssignments)
+  {
+    $this->creativeGroupAssignments = $creativeGroupAssignments;
+  }
+  public function getCreativeGroupAssignments()
+  {
+    return $this->creativeGroupAssignments;
+  }
+  public function setCreativeRotation(Google_Service_Dfareporting_CreativeRotation $creativeRotation)
+  {
+    $this->creativeRotation = $creativeRotation;
+  }
+  public function getCreativeRotation()
+  {
+    return $this->creativeRotation;
+  }
+  public function setDayPartTargeting(Google_Service_Dfareporting_DayPartTargeting $dayPartTargeting)
+  {
+    $this->dayPartTargeting = $dayPartTargeting;
+  }
+  public function getDayPartTargeting()
+  {
+    return $this->dayPartTargeting;
+  }
+  public function setDefaultClickThroughEventTagProperties(Google_Service_Dfareporting_DefaultClickThroughEventTagProperties $defaultClickThroughEventTagProperties)
+  {
+    $this->defaultClickThroughEventTagProperties = $defaultClickThroughEventTagProperties;
+  }
+  public function getDefaultClickThroughEventTagProperties()
+  {
+    return $this->defaultClickThroughEventTagProperties;
+  }
+  public function setDeliverySchedule(Google_Service_Dfareporting_DeliverySchedule $deliverySchedule)
+  {
+    $this->deliverySchedule = $deliverySchedule;
+  }
+  public function getDeliverySchedule()
+  {
+    return $this->deliverySchedule;
+  }
+  public function setDynamicClickTracker($dynamicClickTracker)
+  {
+    $this->dynamicClickTracker = $dynamicClickTracker;
+  }
+  public function getDynamicClickTracker()
+  {
+    return $this->dynamicClickTracker;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setEventTagOverrides($eventTagOverrides)
+  {
+    $this->eventTagOverrides = $eventTagOverrides;
+  }
+  public function getEventTagOverrides()
+  {
+    return $this->eventTagOverrides;
+  }
+  public function setGeoTargeting(Google_Service_Dfareporting_GeoTargeting $geoTargeting)
+  {
+    $this->geoTargeting = $geoTargeting;
+  }
+  public function getGeoTargeting()
+  {
+    return $this->geoTargeting;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIdDimensionValue(Google_Service_Dfareporting_DimensionValue $idDimensionValue)
+  {
+    $this->idDimensionValue = $idDimensionValue;
+  }
+  public function getIdDimensionValue()
+  {
+    return $this->idDimensionValue;
+  }
+  public function setKeyValueTargetingExpression(Google_Service_Dfareporting_KeyValueTargetingExpression $keyValueTargetingExpression)
+  {
+    $this->keyValueTargetingExpression = $keyValueTargetingExpression;
+  }
+  public function getKeyValueTargetingExpression()
+  {
+    return $this->keyValueTargetingExpression;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastModifiedInfo(Google_Service_Dfareporting_LastModifiedInfo $lastModifiedInfo)
+  {
+    $this->lastModifiedInfo = $lastModifiedInfo;
+  }
+  public function getLastModifiedInfo()
+  {
+    return $this->lastModifiedInfo;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPlacementAssignments($placementAssignments)
+  {
+    $this->placementAssignments = $placementAssignments;
+  }
+  public function getPlacementAssignments()
+  {
+    return $this->placementAssignments;
+  }
+  public function setRemarketingListExpression(Google_Service_Dfareporting_ListTargetingExpression $remarketingListExpression)
+  {
+    $this->remarketingListExpression = $remarketingListExpression;
+  }
+  public function getRemarketingListExpression()
+  {
+    return $this->remarketingListExpression;
+  }
+  public function setSize(Google_Service_Dfareporting_Size $size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+  public function setSslCompliant($sslCompliant)
+  {
+    $this->sslCompliant = $sslCompliant;
+  }
+  public function getSslCompliant()
+  {
+    return $this->sslCompliant;
+  }
+  public function setSslRequired($sslRequired)
+  {
+    $this->sslRequired = $sslRequired;
+  }
+  public function getSslRequired()
+  {
+    return $this->sslRequired;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+  public function setTechnologyTargeting(Google_Service_Dfareporting_TechnologyTargeting $technologyTargeting)
+  {
+    $this->technologyTargeting = $technologyTargeting;
+  }
+  public function getTechnologyTargeting()
+  {
+    return $this->technologyTargeting;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Dfareporting_AdSlot extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $comment;
+  public $compatibility;
+  public $height;
+  public $linkedPlacementId;
+  public $name;
+  public $paymentSourceType;
+  public $primary;
+  public $width;
+
+
+  public function setComment($comment)
+  {
+    $this->comment = $comment;
+  }
+  public function getComment()
+  {
+    return $this->comment;
+  }
+  public function setCompatibility($compatibility)
+  {
+    $this->compatibility = $compatibility;
+  }
+  public function getCompatibility()
+  {
+    return $this->compatibility;
+  }
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setLinkedPlacementId($linkedPlacementId)
+  {
+    $this->linkedPlacementId = $linkedPlacementId;
+  }
+  public function getLinkedPlacementId()
+  {
+    return $this->linkedPlacementId;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPaymentSourceType($paymentSourceType)
+  {
+    $this->paymentSourceType = $paymentSourceType;
+  }
+  public function getPaymentSourceType()
+  {
+    return $this->paymentSourceType;
+  }
+  public function setPrimary($primary)
+  {
+    $this->primary = $primary;
+  }
+  public function getPrimary()
+  {
+    return $this->primary;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_Dfareporting_AdsListResponse extends Google_Collection
+{
+  protected $collection_key = 'ads';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $adsType = 'Google_Service_Dfareporting_Ad';
+  protected $adsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setAds($ads)
+  {
+    $this->ads = $ads;
+  }
+  public function getAds()
+  {
+    return $this->ads;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_Advertiser extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $advertiserGroupId;
+  public $clickThroughUrlSuffix;
+  public $defaultClickThroughEventTagId;
+  public $defaultEmail;
+  public $floodlightConfigurationId;
+  protected $floodlightConfigurationIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $floodlightConfigurationIdDimensionValueDataType = '';
+  public $id;
+  protected $idDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $idDimensionValueDataType = '';
+  public $kind;
+  public $name;
+  public $originalFloodlightConfigurationId;
+  public $status;
+  public $subaccountId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAdvertiserGroupId($advertiserGroupId)
+  {
+    $this->advertiserGroupId = $advertiserGroupId;
+  }
+  public function getAdvertiserGroupId()
+  {
+    return $this->advertiserGroupId;
+  }
+  public function setClickThroughUrlSuffix($clickThroughUrlSuffix)
+  {
+    $this->clickThroughUrlSuffix = $clickThroughUrlSuffix;
+  }
+  public function getClickThroughUrlSuffix()
+  {
+    return $this->clickThroughUrlSuffix;
+  }
+  public function setDefaultClickThroughEventTagId($defaultClickThroughEventTagId)
+  {
+    $this->defaultClickThroughEventTagId = $defaultClickThroughEventTagId;
+  }
+  public function getDefaultClickThroughEventTagId()
+  {
+    return $this->defaultClickThroughEventTagId;
+  }
+  public function setDefaultEmail($defaultEmail)
+  {
+    $this->defaultEmail = $defaultEmail;
+  }
+  public function getDefaultEmail()
+  {
+    return $this->defaultEmail;
+  }
+  public function setFloodlightConfigurationId($floodlightConfigurationId)
+  {
+    $this->floodlightConfigurationId = $floodlightConfigurationId;
+  }
+  public function getFloodlightConfigurationId()
+  {
+    return $this->floodlightConfigurationId;
+  }
+  public function setFloodlightConfigurationIdDimensionValue(Google_Service_Dfareporting_DimensionValue $floodlightConfigurationIdDimensionValue)
+  {
+    $this->floodlightConfigurationIdDimensionValue = $floodlightConfigurationIdDimensionValue;
+  }
+  public function getFloodlightConfigurationIdDimensionValue()
+  {
+    return $this->floodlightConfigurationIdDimensionValue;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIdDimensionValue(Google_Service_Dfareporting_DimensionValue $idDimensionValue)
+  {
+    $this->idDimensionValue = $idDimensionValue;
+  }
+  public function getIdDimensionValue()
+  {
+    return $this->idDimensionValue;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOriginalFloodlightConfigurationId($originalFloodlightConfigurationId)
+  {
+    $this->originalFloodlightConfigurationId = $originalFloodlightConfigurationId;
+  }
+  public function getOriginalFloodlightConfigurationId()
+  {
+    return $this->originalFloodlightConfigurationId;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+}
+
+class Google_Service_Dfareporting_AdvertiserGroup extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Dfareporting_AdvertiserGroupsListResponse extends Google_Collection
+{
+  protected $collection_key = 'advertiserGroups';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $advertiserGroupsType = 'Google_Service_Dfareporting_AdvertiserGroup';
+  protected $advertiserGroupsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setAdvertiserGroups($advertiserGroups)
+  {
+    $this->advertiserGroups = $advertiserGroups;
+  }
+  public function getAdvertiserGroups()
+  {
+    return $this->advertiserGroups;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_AdvertisersListResponse extends Google_Collection
+{
+  protected $collection_key = 'advertisers';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $advertisersType = 'Google_Service_Dfareporting_Advertiser';
+  protected $advertisersDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setAdvertisers($advertisers)
+  {
+    $this->advertisers = $advertisers;
+  }
+  public function getAdvertisers()
+  {
+    return $this->advertisers;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_AudienceSegment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $allocation;
+  public $id;
+  public $name;
+
+
+  public function setAllocation($allocation)
+  {
+    $this->allocation = $allocation;
+  }
+  public function getAllocation()
+  {
+    return $this->allocation;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Dfareporting_AudienceSegmentGroup extends Google_Collection
+{
+  protected $collection_key = 'audienceSegments';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $audienceSegmentsType = 'Google_Service_Dfareporting_AudienceSegment';
+  protected $audienceSegmentsDataType = 'array';
+  public $id;
+  public $name;
+
+
+  public function setAudienceSegments($audienceSegments)
+  {
+    $this->audienceSegments = $audienceSegments;
+  }
+  public function getAudienceSegments()
+  {
+    return $this->audienceSegments;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Dfareporting_Browser extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $browserVersionId;
+  public $dartId;
+  public $kind;
+  public $majorVersion;
+  public $minorVersion;
+  public $name;
+
+
+  public function setBrowserVersionId($browserVersionId)
+  {
+    $this->browserVersionId = $browserVersionId;
+  }
+  public function getBrowserVersionId()
+  {
+    return $this->browserVersionId;
+  }
+  public function setDartId($dartId)
+  {
+    $this->dartId = $dartId;
+  }
+  public function getDartId()
+  {
+    return $this->dartId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMajorVersion($majorVersion)
+  {
+    $this->majorVersion = $majorVersion;
+  }
+  public function getMajorVersion()
+  {
+    return $this->majorVersion;
+  }
+  public function setMinorVersion($minorVersion)
+  {
+    $this->minorVersion = $minorVersion;
+  }
+  public function getMinorVersion()
+  {
+    return $this->minorVersion;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Dfareporting_BrowsersListResponse extends Google_Collection
+{
+  protected $collection_key = 'browsers';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $browsersType = 'Google_Service_Dfareporting_Browser';
+  protected $browsersDataType = 'array';
+  public $kind;
+
+
+  public function setBrowsers($browsers)
+  {
+    $this->browsers = $browsers;
+  }
+  public function getBrowsers()
+  {
+    return $this->browsers;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Dfareporting_Campaign extends Google_Collection
+{
+  protected $collection_key = 'traffickerEmails';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  protected $additionalCreativeOptimizationConfigurationsType = 'Google_Service_Dfareporting_CreativeOptimizationConfiguration';
+  protected $additionalCreativeOptimizationConfigurationsDataType = 'array';
+  public $advertiserGroupId;
+  public $advertiserId;
+  protected $advertiserIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $advertiserIdDimensionValueDataType = '';
+  public $archived;
+  protected $audienceSegmentGroupsType = 'Google_Service_Dfareporting_AudienceSegmentGroup';
+  protected $audienceSegmentGroupsDataType = 'array';
+  public $billingInvoiceCode;
+  protected $clickThroughUrlSuffixPropertiesType = 'Google_Service_Dfareporting_ClickThroughUrlSuffixProperties';
+  protected $clickThroughUrlSuffixPropertiesDataType = '';
+  public $comment;
+  public $comscoreVceEnabled;
+  protected $createInfoType = 'Google_Service_Dfareporting_LastModifiedInfo';
+  protected $createInfoDataType = '';
+  public $creativeGroupIds;
+  protected $creativeOptimizationConfigurationType = 'Google_Service_Dfareporting_CreativeOptimizationConfiguration';
+  protected $creativeOptimizationConfigurationDataType = '';
+  protected $defaultClickThroughEventTagPropertiesType = 'Google_Service_Dfareporting_DefaultClickThroughEventTagProperties';
+  protected $defaultClickThroughEventTagPropertiesDataType = '';
+  public $endDate;
+  protected $eventTagOverridesType = 'Google_Service_Dfareporting_EventTagOverride';
+  protected $eventTagOverridesDataType = 'array';
+  public $externalId;
+  public $id;
+  protected $idDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $idDimensionValueDataType = '';
+  public $kind;
+  protected $lastModifiedInfoType = 'Google_Service_Dfareporting_LastModifiedInfo';
+  protected $lastModifiedInfoDataType = '';
+  protected $lookbackConfigurationType = 'Google_Service_Dfareporting_LookbackConfiguration';
+  protected $lookbackConfigurationDataType = '';
+  public $name;
+  public $nielsenOcrEnabled;
+  public $startDate;
+  public $subaccountId;
+  public $traffickerEmails;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAdditionalCreativeOptimizationConfigurations($additionalCreativeOptimizationConfigurations)
+  {
+    $this->additionalCreativeOptimizationConfigurations = $additionalCreativeOptimizationConfigurations;
+  }
+  public function getAdditionalCreativeOptimizationConfigurations()
+  {
+    return $this->additionalCreativeOptimizationConfigurations;
+  }
+  public function setAdvertiserGroupId($advertiserGroupId)
+  {
+    $this->advertiserGroupId = $advertiserGroupId;
+  }
+  public function getAdvertiserGroupId()
+  {
+    return $this->advertiserGroupId;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAdvertiserIdDimensionValue(Google_Service_Dfareporting_DimensionValue $advertiserIdDimensionValue)
+  {
+    $this->advertiserIdDimensionValue = $advertiserIdDimensionValue;
+  }
+  public function getAdvertiserIdDimensionValue()
+  {
+    return $this->advertiserIdDimensionValue;
+  }
+  public function setArchived($archived)
+  {
+    $this->archived = $archived;
+  }
+  public function getArchived()
+  {
+    return $this->archived;
+  }
+  public function setAudienceSegmentGroups($audienceSegmentGroups)
+  {
+    $this->audienceSegmentGroups = $audienceSegmentGroups;
+  }
+  public function getAudienceSegmentGroups()
+  {
+    return $this->audienceSegmentGroups;
+  }
+  public function setBillingInvoiceCode($billingInvoiceCode)
+  {
+    $this->billingInvoiceCode = $billingInvoiceCode;
+  }
+  public function getBillingInvoiceCode()
+  {
+    return $this->billingInvoiceCode;
+  }
+  public function setClickThroughUrlSuffixProperties(Google_Service_Dfareporting_ClickThroughUrlSuffixProperties $clickThroughUrlSuffixProperties)
+  {
+    $this->clickThroughUrlSuffixProperties = $clickThroughUrlSuffixProperties;
+  }
+  public function getClickThroughUrlSuffixProperties()
+  {
+    return $this->clickThroughUrlSuffixProperties;
+  }
+  public function setComment($comment)
+  {
+    $this->comment = $comment;
+  }
+  public function getComment()
+  {
+    return $this->comment;
+  }
+  public function setComscoreVceEnabled($comscoreVceEnabled)
+  {
+    $this->comscoreVceEnabled = $comscoreVceEnabled;
+  }
+  public function getComscoreVceEnabled()
+  {
+    return $this->comscoreVceEnabled;
+  }
+  public function setCreateInfo(Google_Service_Dfareporting_LastModifiedInfo $createInfo)
+  {
+    $this->createInfo = $createInfo;
+  }
+  public function getCreateInfo()
+  {
+    return $this->createInfo;
+  }
+  public function setCreativeGroupIds($creativeGroupIds)
+  {
+    $this->creativeGroupIds = $creativeGroupIds;
+  }
+  public function getCreativeGroupIds()
+  {
+    return $this->creativeGroupIds;
+  }
+  public function setCreativeOptimizationConfiguration(Google_Service_Dfareporting_CreativeOptimizationConfiguration $creativeOptimizationConfiguration)
+  {
+    $this->creativeOptimizationConfiguration = $creativeOptimizationConfiguration;
+  }
+  public function getCreativeOptimizationConfiguration()
+  {
+    return $this->creativeOptimizationConfiguration;
+  }
+  public function setDefaultClickThroughEventTagProperties(Google_Service_Dfareporting_DefaultClickThroughEventTagProperties $defaultClickThroughEventTagProperties)
+  {
+    $this->defaultClickThroughEventTagProperties = $defaultClickThroughEventTagProperties;
+  }
+  public function getDefaultClickThroughEventTagProperties()
+  {
+    return $this->defaultClickThroughEventTagProperties;
+  }
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setEventTagOverrides($eventTagOverrides)
+  {
+    $this->eventTagOverrides = $eventTagOverrides;
+  }
+  public function getEventTagOverrides()
+  {
+    return $this->eventTagOverrides;
+  }
+  public function setExternalId($externalId)
+  {
+    $this->externalId = $externalId;
+  }
+  public function getExternalId()
+  {
+    return $this->externalId;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIdDimensionValue(Google_Service_Dfareporting_DimensionValue $idDimensionValue)
+  {
+    $this->idDimensionValue = $idDimensionValue;
+  }
+  public function getIdDimensionValue()
+  {
+    return $this->idDimensionValue;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastModifiedInfo(Google_Service_Dfareporting_LastModifiedInfo $lastModifiedInfo)
+  {
+    $this->lastModifiedInfo = $lastModifiedInfo;
+  }
+  public function getLastModifiedInfo()
+  {
+    return $this->lastModifiedInfo;
+  }
+  public function setLookbackConfiguration(Google_Service_Dfareporting_LookbackConfiguration $lookbackConfiguration)
+  {
+    $this->lookbackConfiguration = $lookbackConfiguration;
+  }
+  public function getLookbackConfiguration()
+  {
+    return $this->lookbackConfiguration;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNielsenOcrEnabled($nielsenOcrEnabled)
+  {
+    $this->nielsenOcrEnabled = $nielsenOcrEnabled;
+  }
+  public function getNielsenOcrEnabled()
+  {
+    return $this->nielsenOcrEnabled;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+  public function setTraffickerEmails($traffickerEmails)
+  {
+    $this->traffickerEmails = $traffickerEmails;
+  }
+  public function getTraffickerEmails()
+  {
+    return $this->traffickerEmails;
+  }
+}
+
+class Google_Service_Dfareporting_CampaignCreativeAssociation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $creativeId;
+  public $kind;
+
+
+  public function setCreativeId($creativeId)
+  {
+    $this->creativeId = $creativeId;
+  }
+  public function getCreativeId()
+  {
+    return $this->creativeId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Dfareporting_CampaignCreativeAssociationsListResponse extends Google_Collection
+{
+  protected $collection_key = 'campaignCreativeAssociations';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $campaignCreativeAssociationsType = 'Google_Service_Dfareporting_CampaignCreativeAssociation';
+  protected $campaignCreativeAssociationsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setCampaignCreativeAssociations($campaignCreativeAssociations)
+  {
+    $this->campaignCreativeAssociations = $campaignCreativeAssociations;
+  }
+  public function getCampaignCreativeAssociations()
+  {
+    return $this->campaignCreativeAssociations;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_CampaignsListResponse extends Google_Collection
+{
+  protected $collection_key = 'campaigns';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $campaignsType = 'Google_Service_Dfareporting_Campaign';
+  protected $campaignsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setCampaigns($campaigns)
+  {
+    $this->campaigns = $campaigns;
+  }
+  public function getCampaigns()
+  {
+    return $this->campaigns;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_ChangeLog extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $action;
+  public $changeTime;
+  public $fieldName;
+  public $id;
+  public $kind;
+  public $newValue;
+  public $objectId;
+  public $objectType;
+  public $oldValue;
+  public $subaccountId;
+  public $transactionId;
+  public $userProfileId;
+  public $userProfileName;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAction($action)
+  {
+    $this->action = $action;
+  }
+  public function getAction()
+  {
+    return $this->action;
+  }
+  public function setChangeTime($changeTime)
+  {
+    $this->changeTime = $changeTime;
+  }
+  public function getChangeTime()
+  {
+    return $this->changeTime;
+  }
+  public function setFieldName($fieldName)
+  {
+    $this->fieldName = $fieldName;
+  }
+  public function getFieldName()
+  {
+    return $this->fieldName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNewValue($newValue)
+  {
+    $this->newValue = $newValue;
+  }
+  public function getNewValue()
+  {
+    return $this->newValue;
+  }
+  public function setObjectId($objectId)
+  {
+    $this->objectId = $objectId;
+  }
+  public function getObjectId()
+  {
+    return $this->objectId;
+  }
+  public function setObjectType($objectType)
+  {
+    $this->objectType = $objectType;
+  }
+  public function getObjectType()
+  {
+    return $this->objectType;
+  }
+  public function setOldValue($oldValue)
+  {
+    $this->oldValue = $oldValue;
+  }
+  public function getOldValue()
+  {
+    return $this->oldValue;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+  public function setTransactionId($transactionId)
+  {
+    $this->transactionId = $transactionId;
+  }
+  public function getTransactionId()
+  {
+    return $this->transactionId;
+  }
+  public function setUserProfileId($userProfileId)
+  {
+    $this->userProfileId = $userProfileId;
+  }
+  public function getUserProfileId()
+  {
+    return $this->userProfileId;
+  }
+  public function setUserProfileName($userProfileName)
+  {
+    $this->userProfileName = $userProfileName;
+  }
+  public function getUserProfileName()
+  {
+    return $this->userProfileName;
+  }
+}
+
+class Google_Service_Dfareporting_ChangeLogsListResponse extends Google_Collection
+{
+  protected $collection_key = 'changeLogs';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $changeLogsType = 'Google_Service_Dfareporting_ChangeLog';
+  protected $changeLogsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setChangeLogs($changeLogs)
+  {
+    $this->changeLogs = $changeLogs;
+  }
+  public function getChangeLogs()
+  {
+    return $this->changeLogs;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_CitiesListResponse extends Google_Collection
+{
+  protected $collection_key = 'cities';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $citiesType = 'Google_Service_Dfareporting_City';
+  protected $citiesDataType = 'array';
+  public $kind;
+
+
+  public function setCities($cities)
+  {
+    $this->cities = $cities;
+  }
+  public function getCities()
+  {
+    return $this->cities;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Dfareporting_City extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $countryCode;
+  public $countryDartId;
+  public $dartId;
+  public $kind;
+  public $metroCode;
+  public $metroDmaId;
+  public $name;
+  public $regionCode;
+  public $regionDartId;
+
+
+  public function setCountryCode($countryCode)
+  {
+    $this->countryCode = $countryCode;
+  }
+  public function getCountryCode()
+  {
+    return $this->countryCode;
+  }
+  public function setCountryDartId($countryDartId)
+  {
+    $this->countryDartId = $countryDartId;
+  }
+  public function getCountryDartId()
+  {
+    return $this->countryDartId;
+  }
+  public function setDartId($dartId)
+  {
+    $this->dartId = $dartId;
+  }
+  public function getDartId()
+  {
+    return $this->dartId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMetroCode($metroCode)
+  {
+    $this->metroCode = $metroCode;
+  }
+  public function getMetroCode()
+  {
+    return $this->metroCode;
+  }
+  public function setMetroDmaId($metroDmaId)
+  {
+    $this->metroDmaId = $metroDmaId;
+  }
+  public function getMetroDmaId()
+  {
+    return $this->metroDmaId;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setRegionCode($regionCode)
+  {
+    $this->regionCode = $regionCode;
+  }
+  public function getRegionCode()
+  {
+    return $this->regionCode;
+  }
+  public function setRegionDartId($regionDartId)
+  {
+    $this->regionDartId = $regionDartId;
+  }
+  public function getRegionDartId()
+  {
+    return $this->regionDartId;
+  }
+}
+
+class Google_Service_Dfareporting_ClickTag extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $eventName;
+  public $name;
+  public $value;
+
+
+  public function setEventName($eventName)
+  {
+    $this->eventName = $eventName;
+  }
+  public function getEventName()
+  {
+    return $this->eventName;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Dfareporting_ClickThroughUrl extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $customClickThroughUrl;
+  public $defaultLandingPage;
+  public $landingPageId;
+
+
+  public function setCustomClickThroughUrl($customClickThroughUrl)
+  {
+    $this->customClickThroughUrl = $customClickThroughUrl;
+  }
+  public function getCustomClickThroughUrl()
+  {
+    return $this->customClickThroughUrl;
+  }
+  public function setDefaultLandingPage($defaultLandingPage)
+  {
+    $this->defaultLandingPage = $defaultLandingPage;
+  }
+  public function getDefaultLandingPage()
+  {
+    return $this->defaultLandingPage;
+  }
+  public function setLandingPageId($landingPageId)
+  {
+    $this->landingPageId = $landingPageId;
+  }
+  public function getLandingPageId()
+  {
+    return $this->landingPageId;
+  }
+}
+
+class Google_Service_Dfareporting_ClickThroughUrlSuffixProperties extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $clickThroughUrlSuffix;
+  public $overrideInheritedSuffix;
+
+
+  public function setClickThroughUrlSuffix($clickThroughUrlSuffix)
+  {
+    $this->clickThroughUrlSuffix = $clickThroughUrlSuffix;
+  }
+  public function getClickThroughUrlSuffix()
+  {
+    return $this->clickThroughUrlSuffix;
+  }
+  public function setOverrideInheritedSuffix($overrideInheritedSuffix)
+  {
+    $this->overrideInheritedSuffix = $overrideInheritedSuffix;
+  }
+  public function getOverrideInheritedSuffix()
+  {
+    return $this->overrideInheritedSuffix;
+  }
+}
+
+class Google_Service_Dfareporting_CompanionClickThroughOverride extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $clickThroughUrlType = 'Google_Service_Dfareporting_ClickThroughUrl';
+  protected $clickThroughUrlDataType = '';
+  public $creativeId;
+
+
+  public function setClickThroughUrl(Google_Service_Dfareporting_ClickThroughUrl $clickThroughUrl)
+  {
+    $this->clickThroughUrl = $clickThroughUrl;
+  }
+  public function getClickThroughUrl()
+  {
+    return $this->clickThroughUrl;
+  }
+  public function setCreativeId($creativeId)
+  {
+    $this->creativeId = $creativeId;
+  }
+  public function getCreativeId()
+  {
+    return $this->creativeId;
+  }
+}
+
+class Google_Service_Dfareporting_CompatibleFields extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $crossDimensionReachReportCompatibleFieldsType = 'Google_Service_Dfareporting_CrossDimensionReachReportCompatibleFields';
+  protected $crossDimensionReachReportCompatibleFieldsDataType = '';
+  protected $floodlightReportCompatibleFieldsType = 'Google_Service_Dfareporting_FloodlightReportCompatibleFields';
+  protected $floodlightReportCompatibleFieldsDataType = '';
+  public $kind;
+  protected $pathToConversionReportCompatibleFieldsType = 'Google_Service_Dfareporting_PathToConversionReportCompatibleFields';
+  protected $pathToConversionReportCompatibleFieldsDataType = '';
+  protected $reachReportCompatibleFieldsType = 'Google_Service_Dfareporting_ReachReportCompatibleFields';
+  protected $reachReportCompatibleFieldsDataType = '';
+  protected $reportCompatibleFieldsType = 'Google_Service_Dfareporting_ReportCompatibleFields';
+  protected $reportCompatibleFieldsDataType = '';
+
+
+  public function setCrossDimensionReachReportCompatibleFields(Google_Service_Dfareporting_CrossDimensionReachReportCompatibleFields $crossDimensionReachReportCompatibleFields)
+  {
+    $this->crossDimensionReachReportCompatibleFields = $crossDimensionReachReportCompatibleFields;
+  }
+  public function getCrossDimensionReachReportCompatibleFields()
+  {
+    return $this->crossDimensionReachReportCompatibleFields;
+  }
+  public function setFloodlightReportCompatibleFields(Google_Service_Dfareporting_FloodlightReportCompatibleFields $floodlightReportCompatibleFields)
+  {
+    $this->floodlightReportCompatibleFields = $floodlightReportCompatibleFields;
+  }
+  public function getFloodlightReportCompatibleFields()
+  {
+    return $this->floodlightReportCompatibleFields;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPathToConversionReportCompatibleFields(Google_Service_Dfareporting_PathToConversionReportCompatibleFields $pathToConversionReportCompatibleFields)
+  {
+    $this->pathToConversionReportCompatibleFields = $pathToConversionReportCompatibleFields;
+  }
+  public function getPathToConversionReportCompatibleFields()
+  {
+    return $this->pathToConversionReportCompatibleFields;
+  }
+  public function setReachReportCompatibleFields(Google_Service_Dfareporting_ReachReportCompatibleFields $reachReportCompatibleFields)
+  {
+    $this->reachReportCompatibleFields = $reachReportCompatibleFields;
+  }
+  public function getReachReportCompatibleFields()
+  {
+    return $this->reachReportCompatibleFields;
+  }
+  public function setReportCompatibleFields(Google_Service_Dfareporting_ReportCompatibleFields $reportCompatibleFields)
+  {
+    $this->reportCompatibleFields = $reportCompatibleFields;
+  }
+  public function getReportCompatibleFields()
+  {
+    return $this->reportCompatibleFields;
+  }
+}
+
+class Google_Service_Dfareporting_ConnectionType extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Dfareporting_ConnectionTypesListResponse extends Google_Collection
+{
+  protected $collection_key = 'connectionTypes';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $connectionTypesType = 'Google_Service_Dfareporting_ConnectionType';
+  protected $connectionTypesDataType = 'array';
+  public $kind;
+
+
+  public function setConnectionTypes($connectionTypes)
+  {
+    $this->connectionTypes = $connectionTypes;
+  }
+  public function getConnectionTypes()
+  {
+    return $this->connectionTypes;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Dfareporting_ContentCategoriesListResponse extends Google_Collection
+{
+  protected $collection_key = 'contentCategories';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $contentCategoriesType = 'Google_Service_Dfareporting_ContentCategory';
+  protected $contentCategoriesDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setContentCategories($contentCategories)
+  {
+    $this->contentCategories = $contentCategories;
+  }
+  public function getContentCategories()
+  {
+    return $this->contentCategories;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_ContentCategory extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Dfareporting_CountriesListResponse extends Google_Collection
+{
+  protected $collection_key = 'countries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $countriesType = 'Google_Service_Dfareporting_Country';
+  protected $countriesDataType = 'array';
+  public $kind;
+
+
+  public function setCountries($countries)
+  {
+    $this->countries = $countries;
+  }
+  public function getCountries()
+  {
+    return $this->countries;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Dfareporting_Country extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $countryCode;
+  public $dartId;
+  public $kind;
+  public $name;
+  public $sslEnabled;
+
+
+  public function setCountryCode($countryCode)
+  {
+    $this->countryCode = $countryCode;
+  }
+  public function getCountryCode()
+  {
+    return $this->countryCode;
+  }
+  public function setDartId($dartId)
+  {
+    $this->dartId = $dartId;
+  }
+  public function getDartId()
+  {
+    return $this->dartId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSslEnabled($sslEnabled)
+  {
+    $this->sslEnabled = $sslEnabled;
+  }
+  public function getSslEnabled()
+  {
+    return $this->sslEnabled;
+  }
+}
+
+class Google_Service_Dfareporting_Creative extends Google_Collection
+{
+  protected $collection_key = 'timerCustomEvents';
+  protected $internal_gapi_mappings = array(
+        "autoAdvanceImages" => "auto_advance_images",
+  );
+  public $accountId;
+  public $active;
+  public $adParameters;
+  public $adTagKeys;
+  public $advertiserId;
+  public $allowScriptAccess;
+  public $archived;
+  public $artworkType;
+  public $authoringTool;
+  public $autoAdvanceImages;
+  public $backgroundColor;
+  public $backupImageClickThroughUrl;
+  public $backupImageFeatures;
+  public $backupImageReportingLabel;
+  protected $backupImageTargetWindowType = 'Google_Service_Dfareporting_TargetWindow';
+  protected $backupImageTargetWindowDataType = '';
+  protected $clickTagsType = 'Google_Service_Dfareporting_ClickTag';
+  protected $clickTagsDataType = 'array';
+  public $commercialId;
+  public $companionCreatives;
+  public $compatibility;
+  public $convertFlashToHtml5;
+  protected $counterCustomEventsType = 'Google_Service_Dfareporting_CreativeCustomEvent';
+  protected $counterCustomEventsDataType = 'array';
+  protected $creativeAssetsType = 'Google_Service_Dfareporting_CreativeAsset';
+  protected $creativeAssetsDataType = 'array';
+  protected $creativeFieldAssignmentsType = 'Google_Service_Dfareporting_CreativeFieldAssignment';
+  protected $creativeFieldAssignmentsDataType = 'array';
+  public $customKeyValues;
+  protected $exitCustomEventsType = 'Google_Service_Dfareporting_CreativeCustomEvent';
+  protected $exitCustomEventsDataType = 'array';
+  protected $fsCommandType = 'Google_Service_Dfareporting_FsCommand';
+  protected $fsCommandDataType = '';
+  public $htmlCode;
+  public $htmlCodeLocked;
+  public $id;
+  protected $idDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $idDimensionValueDataType = '';
+  public $kind;
+  protected $lastModifiedInfoType = 'Google_Service_Dfareporting_LastModifiedInfo';
+  protected $lastModifiedInfoDataType = '';
+  public $latestTraffickedCreativeId;
+  public $name;
+  public $overrideCss;
+  public $redirectUrl;
+  public $renderingId;
+  protected $renderingIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $renderingIdDimensionValueDataType = '';
+  public $requiredFlashPluginVersion;
+  public $requiredFlashVersion;
+  protected $sizeType = 'Google_Service_Dfareporting_Size';
+  protected $sizeDataType = '';
+  public $skippable;
+  public $sslCompliant;
+  public $studioAdvertiserId;
+  public $studioCreativeId;
+  public $studioTraffickedCreativeId;
+  public $subaccountId;
+  public $thirdPartyBackupImageImpressionsUrl;
+  public $thirdPartyRichMediaImpressionsUrl;
+  protected $thirdPartyUrlsType = 'Google_Service_Dfareporting_ThirdPartyTrackingUrl';
+  protected $thirdPartyUrlsDataType = 'array';
+  protected $timerCustomEventsType = 'Google_Service_Dfareporting_CreativeCustomEvent';
+  protected $timerCustomEventsDataType = 'array';
+  public $totalFileSize;
+  public $type;
+  public $version;
+  public $videoDescription;
+  public $videoDuration;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setActive($active)
+  {
+    $this->active = $active;
+  }
+  public function getActive()
+  {
+    return $this->active;
+  }
+  public function setAdParameters($adParameters)
+  {
+    $this->adParameters = $adParameters;
+  }
+  public function getAdParameters()
+  {
+    return $this->adParameters;
+  }
+  public function setAdTagKeys($adTagKeys)
+  {
+    $this->adTagKeys = $adTagKeys;
+  }
+  public function getAdTagKeys()
+  {
+    return $this->adTagKeys;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAllowScriptAccess($allowScriptAccess)
+  {
+    $this->allowScriptAccess = $allowScriptAccess;
+  }
+  public function getAllowScriptAccess()
+  {
+    return $this->allowScriptAccess;
+  }
+  public function setArchived($archived)
+  {
+    $this->archived = $archived;
+  }
+  public function getArchived()
+  {
+    return $this->archived;
+  }
+  public function setArtworkType($artworkType)
+  {
+    $this->artworkType = $artworkType;
+  }
+  public function getArtworkType()
+  {
+    return $this->artworkType;
+  }
+  public function setAuthoringTool($authoringTool)
+  {
+    $this->authoringTool = $authoringTool;
+  }
+  public function getAuthoringTool()
+  {
+    return $this->authoringTool;
+  }
+  public function setAutoAdvanceImages($autoAdvanceImages)
+  {
+    $this->autoAdvanceImages = $autoAdvanceImages;
+  }
+  public function getAutoAdvanceImages()
+  {
+    return $this->autoAdvanceImages;
+  }
+  public function setBackgroundColor($backgroundColor)
+  {
+    $this->backgroundColor = $backgroundColor;
+  }
+  public function getBackgroundColor()
+  {
+    return $this->backgroundColor;
+  }
+  public function setBackupImageClickThroughUrl($backupImageClickThroughUrl)
+  {
+    $this->backupImageClickThroughUrl = $backupImageClickThroughUrl;
+  }
+  public function getBackupImageClickThroughUrl()
+  {
+    return $this->backupImageClickThroughUrl;
+  }
+  public function setBackupImageFeatures($backupImageFeatures)
+  {
+    $this->backupImageFeatures = $backupImageFeatures;
+  }
+  public function getBackupImageFeatures()
+  {
+    return $this->backupImageFeatures;
+  }
+  public function setBackupImageReportingLabel($backupImageReportingLabel)
+  {
+    $this->backupImageReportingLabel = $backupImageReportingLabel;
+  }
+  public function getBackupImageReportingLabel()
+  {
+    return $this->backupImageReportingLabel;
+  }
+  public function setBackupImageTargetWindow(Google_Service_Dfareporting_TargetWindow $backupImageTargetWindow)
+  {
+    $this->backupImageTargetWindow = $backupImageTargetWindow;
+  }
+  public function getBackupImageTargetWindow()
+  {
+    return $this->backupImageTargetWindow;
+  }
+  public function setClickTags($clickTags)
+  {
+    $this->clickTags = $clickTags;
+  }
+  public function getClickTags()
+  {
+    return $this->clickTags;
+  }
+  public function setCommercialId($commercialId)
+  {
+    $this->commercialId = $commercialId;
+  }
+  public function getCommercialId()
+  {
+    return $this->commercialId;
+  }
+  public function setCompanionCreatives($companionCreatives)
+  {
+    $this->companionCreatives = $companionCreatives;
+  }
+  public function getCompanionCreatives()
+  {
+    return $this->companionCreatives;
+  }
+  public function setCompatibility($compatibility)
+  {
+    $this->compatibility = $compatibility;
+  }
+  public function getCompatibility()
+  {
+    return $this->compatibility;
+  }
+  public function setConvertFlashToHtml5($convertFlashToHtml5)
+  {
+    $this->convertFlashToHtml5 = $convertFlashToHtml5;
+  }
+  public function getConvertFlashToHtml5()
+  {
+    return $this->convertFlashToHtml5;
+  }
+  public function setCounterCustomEvents($counterCustomEvents)
+  {
+    $this->counterCustomEvents = $counterCustomEvents;
+  }
+  public function getCounterCustomEvents()
+  {
+    return $this->counterCustomEvents;
+  }
+  public function setCreativeAssets($creativeAssets)
+  {
+    $this->creativeAssets = $creativeAssets;
+  }
+  public function getCreativeAssets()
+  {
+    return $this->creativeAssets;
+  }
+  public function setCreativeFieldAssignments($creativeFieldAssignments)
+  {
+    $this->creativeFieldAssignments = $creativeFieldAssignments;
+  }
+  public function getCreativeFieldAssignments()
+  {
+    return $this->creativeFieldAssignments;
+  }
+  public function setCustomKeyValues($customKeyValues)
+  {
+    $this->customKeyValues = $customKeyValues;
+  }
+  public function getCustomKeyValues()
+  {
+    return $this->customKeyValues;
+  }
+  public function setExitCustomEvents($exitCustomEvents)
+  {
+    $this->exitCustomEvents = $exitCustomEvents;
+  }
+  public function getExitCustomEvents()
+  {
+    return $this->exitCustomEvents;
+  }
+  public function setFsCommand(Google_Service_Dfareporting_FsCommand $fsCommand)
+  {
+    $this->fsCommand = $fsCommand;
+  }
+  public function getFsCommand()
+  {
+    return $this->fsCommand;
+  }
+  public function setHtmlCode($htmlCode)
+  {
+    $this->htmlCode = $htmlCode;
+  }
+  public function getHtmlCode()
+  {
+    return $this->htmlCode;
+  }
+  public function setHtmlCodeLocked($htmlCodeLocked)
+  {
+    $this->htmlCodeLocked = $htmlCodeLocked;
+  }
+  public function getHtmlCodeLocked()
+  {
+    return $this->htmlCodeLocked;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIdDimensionValue(Google_Service_Dfareporting_DimensionValue $idDimensionValue)
+  {
+    $this->idDimensionValue = $idDimensionValue;
+  }
+  public function getIdDimensionValue()
+  {
+    return $this->idDimensionValue;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastModifiedInfo(Google_Service_Dfareporting_LastModifiedInfo $lastModifiedInfo)
+  {
+    $this->lastModifiedInfo = $lastModifiedInfo;
+  }
+  public function getLastModifiedInfo()
+  {
+    return $this->lastModifiedInfo;
+  }
+  public function setLatestTraffickedCreativeId($latestTraffickedCreativeId)
+  {
+    $this->latestTraffickedCreativeId = $latestTraffickedCreativeId;
+  }
+  public function getLatestTraffickedCreativeId()
+  {
+    return $this->latestTraffickedCreativeId;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOverrideCss($overrideCss)
+  {
+    $this->overrideCss = $overrideCss;
+  }
+  public function getOverrideCss()
+  {
+    return $this->overrideCss;
+  }
+  public function setRedirectUrl($redirectUrl)
+  {
+    $this->redirectUrl = $redirectUrl;
+  }
+  public function getRedirectUrl()
+  {
+    return $this->redirectUrl;
+  }
+  public function setRenderingId($renderingId)
+  {
+    $this->renderingId = $renderingId;
+  }
+  public function getRenderingId()
+  {
+    return $this->renderingId;
+  }
+  public function setRenderingIdDimensionValue(Google_Service_Dfareporting_DimensionValue $renderingIdDimensionValue)
+  {
+    $this->renderingIdDimensionValue = $renderingIdDimensionValue;
+  }
+  public function getRenderingIdDimensionValue()
+  {
+    return $this->renderingIdDimensionValue;
+  }
+  public function setRequiredFlashPluginVersion($requiredFlashPluginVersion)
+  {
+    $this->requiredFlashPluginVersion = $requiredFlashPluginVersion;
+  }
+  public function getRequiredFlashPluginVersion()
+  {
+    return $this->requiredFlashPluginVersion;
+  }
+  public function setRequiredFlashVersion($requiredFlashVersion)
+  {
+    $this->requiredFlashVersion = $requiredFlashVersion;
+  }
+  public function getRequiredFlashVersion()
+  {
+    return $this->requiredFlashVersion;
+  }
+  public function setSize(Google_Service_Dfareporting_Size $size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+  public function setSkippable($skippable)
+  {
+    $this->skippable = $skippable;
+  }
+  public function getSkippable()
+  {
+    return $this->skippable;
+  }
+  public function setSslCompliant($sslCompliant)
+  {
+    $this->sslCompliant = $sslCompliant;
+  }
+  public function getSslCompliant()
+  {
+    return $this->sslCompliant;
+  }
+  public function setStudioAdvertiserId($studioAdvertiserId)
+  {
+    $this->studioAdvertiserId = $studioAdvertiserId;
+  }
+  public function getStudioAdvertiserId()
+  {
+    return $this->studioAdvertiserId;
+  }
+  public function setStudioCreativeId($studioCreativeId)
+  {
+    $this->studioCreativeId = $studioCreativeId;
+  }
+  public function getStudioCreativeId()
+  {
+    return $this->studioCreativeId;
+  }
+  public function setStudioTraffickedCreativeId($studioTraffickedCreativeId)
+  {
+    $this->studioTraffickedCreativeId = $studioTraffickedCreativeId;
+  }
+  public function getStudioTraffickedCreativeId()
+  {
+    return $this->studioTraffickedCreativeId;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+  public function setThirdPartyBackupImageImpressionsUrl($thirdPartyBackupImageImpressionsUrl)
+  {
+    $this->thirdPartyBackupImageImpressionsUrl = $thirdPartyBackupImageImpressionsUrl;
+  }
+  public function getThirdPartyBackupImageImpressionsUrl()
+  {
+    return $this->thirdPartyBackupImageImpressionsUrl;
+  }
+  public function setThirdPartyRichMediaImpressionsUrl($thirdPartyRichMediaImpressionsUrl)
+  {
+    $this->thirdPartyRichMediaImpressionsUrl = $thirdPartyRichMediaImpressionsUrl;
+  }
+  public function getThirdPartyRichMediaImpressionsUrl()
+  {
+    return $this->thirdPartyRichMediaImpressionsUrl;
+  }
+  public function setThirdPartyUrls($thirdPartyUrls)
+  {
+    $this->thirdPartyUrls = $thirdPartyUrls;
+  }
+  public function getThirdPartyUrls()
+  {
+    return $this->thirdPartyUrls;
+  }
+  public function setTimerCustomEvents($timerCustomEvents)
+  {
+    $this->timerCustomEvents = $timerCustomEvents;
+  }
+  public function getTimerCustomEvents()
+  {
+    return $this->timerCustomEvents;
+  }
+  public function setTotalFileSize($totalFileSize)
+  {
+    $this->totalFileSize = $totalFileSize;
+  }
+  public function getTotalFileSize()
+  {
+    return $this->totalFileSize;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+  public function setVideoDescription($videoDescription)
+  {
+    $this->videoDescription = $videoDescription;
+  }
+  public function getVideoDescription()
+  {
+    return $this->videoDescription;
+  }
+  public function setVideoDuration($videoDuration)
+  {
+    $this->videoDuration = $videoDuration;
+  }
+  public function getVideoDuration()
+  {
+    return $this->videoDuration;
+  }
+}
+
+class Google_Service_Dfareporting_CreativeAsset extends Google_Collection
+{
+  protected $collection_key = 'detectedFeatures';
+  protected $internal_gapi_mappings = array(
+  );
+  public $actionScript3;
+  public $active;
+  public $alignment;
+  public $artworkType;
+  protected $assetIdentifierType = 'Google_Service_Dfareporting_CreativeAssetId';
+  protected $assetIdentifierDataType = '';
+  protected $backupImageExitType = 'Google_Service_Dfareporting_CreativeCustomEvent';
+  protected $backupImageExitDataType = '';
+  public $bitRate;
+  public $childAssetType;
+  protected $collapsedSizeType = 'Google_Service_Dfareporting_Size';
+  protected $collapsedSizeDataType = '';
+  public $customStartTimeValue;
+  public $detectedFeatures;
+  public $displayType;
+  public $duration;
+  public $durationType;
+  protected $expandedDimensionType = 'Google_Service_Dfareporting_Size';
+  protected $expandedDimensionDataType = '';
+  public $fileSize;
+  public $flashVersion;
+  public $hideFlashObjects;
+  public $hideSelectionBoxes;
+  public $horizontallyLocked;
+  public $id;
+  public $mimeType;
+  protected $offsetType = 'Google_Service_Dfareporting_OffsetPosition';
+  protected $offsetDataType = '';
+  public $originalBackup;
+  protected $positionType = 'Google_Service_Dfareporting_OffsetPosition';
+  protected $positionDataType = '';
+  public $positionLeftUnit;
+  public $positionTopUnit;
+  public $progressiveServingUrl;
+  public $pushdown;
+  public $pushdownDuration;
+  public $role;
+  protected $sizeType = 'Google_Service_Dfareporting_Size';
+  protected $sizeDataType = '';
+  public $sslCompliant;
+  public $startTimeType;
+  public $streamingServingUrl;
+  public $transparency;
+  public $verticallyLocked;
+  public $videoDuration;
+  public $windowMode;
+  public $zIndex;
+  public $zipFilename;
+  public $zipFilesize;
+
+
+  public function setActionScript3($actionScript3)
+  {
+    $this->actionScript3 = $actionScript3;
+  }
+  public function getActionScript3()
+  {
+    return $this->actionScript3;
+  }
+  public function setActive($active)
+  {
+    $this->active = $active;
+  }
+  public function getActive()
+  {
+    return $this->active;
+  }
+  public function setAlignment($alignment)
+  {
+    $this->alignment = $alignment;
+  }
+  public function getAlignment()
+  {
+    return $this->alignment;
+  }
+  public function setArtworkType($artworkType)
+  {
+    $this->artworkType = $artworkType;
+  }
+  public function getArtworkType()
+  {
+    return $this->artworkType;
+  }
+  public function setAssetIdentifier(Google_Service_Dfareporting_CreativeAssetId $assetIdentifier)
+  {
+    $this->assetIdentifier = $assetIdentifier;
+  }
+  public function getAssetIdentifier()
+  {
+    return $this->assetIdentifier;
+  }
+  public function setBackupImageExit(Google_Service_Dfareporting_CreativeCustomEvent $backupImageExit)
+  {
+    $this->backupImageExit = $backupImageExit;
+  }
+  public function getBackupImageExit()
+  {
+    return $this->backupImageExit;
+  }
+  public function setBitRate($bitRate)
+  {
+    $this->bitRate = $bitRate;
+  }
+  public function getBitRate()
+  {
+    return $this->bitRate;
+  }
+  public function setChildAssetType($childAssetType)
+  {
+    $this->childAssetType = $childAssetType;
+  }
+  public function getChildAssetType()
+  {
+    return $this->childAssetType;
+  }
+  public function setCollapsedSize(Google_Service_Dfareporting_Size $collapsedSize)
+  {
+    $this->collapsedSize = $collapsedSize;
+  }
+  public function getCollapsedSize()
+  {
+    return $this->collapsedSize;
+  }
+  public function setCustomStartTimeValue($customStartTimeValue)
+  {
+    $this->customStartTimeValue = $customStartTimeValue;
+  }
+  public function getCustomStartTimeValue()
+  {
+    return $this->customStartTimeValue;
+  }
+  public function setDetectedFeatures($detectedFeatures)
+  {
+    $this->detectedFeatures = $detectedFeatures;
+  }
+  public function getDetectedFeatures()
+  {
+    return $this->detectedFeatures;
+  }
+  public function setDisplayType($displayType)
+  {
+    $this->displayType = $displayType;
+  }
+  public function getDisplayType()
+  {
+    return $this->displayType;
+  }
+  public function setDuration($duration)
+  {
+    $this->duration = $duration;
+  }
+  public function getDuration()
+  {
+    return $this->duration;
+  }
+  public function setDurationType($durationType)
+  {
+    $this->durationType = $durationType;
+  }
+  public function getDurationType()
+  {
+    return $this->durationType;
+  }
+  public function setExpandedDimension(Google_Service_Dfareporting_Size $expandedDimension)
+  {
+    $this->expandedDimension = $expandedDimension;
+  }
+  public function getExpandedDimension()
+  {
+    return $this->expandedDimension;
+  }
+  public function setFileSize($fileSize)
+  {
+    $this->fileSize = $fileSize;
+  }
+  public function getFileSize()
+  {
+    return $this->fileSize;
+  }
+  public function setFlashVersion($flashVersion)
+  {
+    $this->flashVersion = $flashVersion;
+  }
+  public function getFlashVersion()
+  {
+    return $this->flashVersion;
+  }
+  public function setHideFlashObjects($hideFlashObjects)
+  {
+    $this->hideFlashObjects = $hideFlashObjects;
+  }
+  public function getHideFlashObjects()
+  {
+    return $this->hideFlashObjects;
+  }
+  public function setHideSelectionBoxes($hideSelectionBoxes)
+  {
+    $this->hideSelectionBoxes = $hideSelectionBoxes;
+  }
+  public function getHideSelectionBoxes()
+  {
+    return $this->hideSelectionBoxes;
+  }
+  public function setHorizontallyLocked($horizontallyLocked)
+  {
+    $this->horizontallyLocked = $horizontallyLocked;
+  }
+  public function getHorizontallyLocked()
+  {
+    return $this->horizontallyLocked;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setMimeType($mimeType)
+  {
+    $this->mimeType = $mimeType;
+  }
+  public function getMimeType()
+  {
+    return $this->mimeType;
+  }
+  public function setOffset(Google_Service_Dfareporting_OffsetPosition $offset)
+  {
+    $this->offset = $offset;
+  }
+  public function getOffset()
+  {
+    return $this->offset;
+  }
+  public function setOriginalBackup($originalBackup)
+  {
+    $this->originalBackup = $originalBackup;
+  }
+  public function getOriginalBackup()
+  {
+    return $this->originalBackup;
+  }
+  public function setPosition(Google_Service_Dfareporting_OffsetPosition $position)
+  {
+    $this->position = $position;
+  }
+  public function getPosition()
+  {
+    return $this->position;
+  }
+  public function setPositionLeftUnit($positionLeftUnit)
+  {
+    $this->positionLeftUnit = $positionLeftUnit;
+  }
+  public function getPositionLeftUnit()
+  {
+    return $this->positionLeftUnit;
+  }
+  public function setPositionTopUnit($positionTopUnit)
+  {
+    $this->positionTopUnit = $positionTopUnit;
+  }
+  public function getPositionTopUnit()
+  {
+    return $this->positionTopUnit;
+  }
+  public function setProgressiveServingUrl($progressiveServingUrl)
+  {
+    $this->progressiveServingUrl = $progressiveServingUrl;
+  }
+  public function getProgressiveServingUrl()
+  {
+    return $this->progressiveServingUrl;
+  }
+  public function setPushdown($pushdown)
+  {
+    $this->pushdown = $pushdown;
+  }
+  public function getPushdown()
+  {
+    return $this->pushdown;
+  }
+  public function setPushdownDuration($pushdownDuration)
+  {
+    $this->pushdownDuration = $pushdownDuration;
+  }
+  public function getPushdownDuration()
+  {
+    return $this->pushdownDuration;
+  }
+  public function setRole($role)
+  {
+    $this->role = $role;
+  }
+  public function getRole()
+  {
+    return $this->role;
+  }
+  public function setSize(Google_Service_Dfareporting_Size $size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+  public function setSslCompliant($sslCompliant)
+  {
+    $this->sslCompliant = $sslCompliant;
+  }
+  public function getSslCompliant()
+  {
+    return $this->sslCompliant;
+  }
+  public function setStartTimeType($startTimeType)
+  {
+    $this->startTimeType = $startTimeType;
+  }
+  public function getStartTimeType()
+  {
+    return $this->startTimeType;
+  }
+  public function setStreamingServingUrl($streamingServingUrl)
+  {
+    $this->streamingServingUrl = $streamingServingUrl;
+  }
+  public function getStreamingServingUrl()
+  {
+    return $this->streamingServingUrl;
+  }
+  public function setTransparency($transparency)
+  {
+    $this->transparency = $transparency;
+  }
+  public function getTransparency()
+  {
+    return $this->transparency;
+  }
+  public function setVerticallyLocked($verticallyLocked)
+  {
+    $this->verticallyLocked = $verticallyLocked;
+  }
+  public function getVerticallyLocked()
+  {
+    return $this->verticallyLocked;
+  }
+  public function setVideoDuration($videoDuration)
+  {
+    $this->videoDuration = $videoDuration;
+  }
+  public function getVideoDuration()
+  {
+    return $this->videoDuration;
+  }
+  public function setWindowMode($windowMode)
+  {
+    $this->windowMode = $windowMode;
+  }
+  public function getWindowMode()
+  {
+    return $this->windowMode;
+  }
+  public function setZIndex($zIndex)
+  {
+    $this->zIndex = $zIndex;
+  }
+  public function getZIndex()
+  {
+    return $this->zIndex;
+  }
+  public function setZipFilename($zipFilename)
+  {
+    $this->zipFilename = $zipFilename;
+  }
+  public function getZipFilename()
+  {
+    return $this->zipFilename;
+  }
+  public function setZipFilesize($zipFilesize)
+  {
+    $this->zipFilesize = $zipFilesize;
+  }
+  public function getZipFilesize()
+  {
+    return $this->zipFilesize;
+  }
+}
+
+class Google_Service_Dfareporting_CreativeAssetId extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $type;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Dfareporting_CreativeAssetMetadata extends Google_Collection
+{
+  protected $collection_key = 'warnedValidationRules';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $assetIdentifierType = 'Google_Service_Dfareporting_CreativeAssetId';
+  protected $assetIdentifierDataType = '';
+  protected $clickTagsType = 'Google_Service_Dfareporting_ClickTag';
+  protected $clickTagsDataType = 'array';
+  public $detectedFeatures;
+  public $kind;
+  public $warnedValidationRules;
+
+
+  public function setAssetIdentifier(Google_Service_Dfareporting_CreativeAssetId $assetIdentifier)
+  {
+    $this->assetIdentifier = $assetIdentifier;
+  }
+  public function getAssetIdentifier()
+  {
+    return $this->assetIdentifier;
+  }
+  public function setClickTags($clickTags)
+  {
+    $this->clickTags = $clickTags;
+  }
+  public function getClickTags()
+  {
+    return $this->clickTags;
+  }
+  public function setDetectedFeatures($detectedFeatures)
+  {
+    $this->detectedFeatures = $detectedFeatures;
+  }
+  public function getDetectedFeatures()
+  {
+    return $this->detectedFeatures;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setWarnedValidationRules($warnedValidationRules)
+  {
+    $this->warnedValidationRules = $warnedValidationRules;
+  }
+  public function getWarnedValidationRules()
+  {
+    return $this->warnedValidationRules;
+  }
+}
+
+class Google_Service_Dfareporting_CreativeAssignment extends Google_Collection
+{
+  protected $collection_key = 'richMediaExitOverrides';
+  protected $internal_gapi_mappings = array(
+  );
+  public $active;
+  public $applyEventTags;
+  protected $clickThroughUrlType = 'Google_Service_Dfareporting_ClickThroughUrl';
+  protected $clickThroughUrlDataType = '';
+  protected $companionCreativeOverridesType = 'Google_Service_Dfareporting_CompanionClickThroughOverride';
+  protected $companionCreativeOverridesDataType = 'array';
+  protected $creativeGroupAssignmentsType = 'Google_Service_Dfareporting_CreativeGroupAssignment';
+  protected $creativeGroupAssignmentsDataType = 'array';
+  public $creativeId;
+  protected $creativeIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $creativeIdDimensionValueDataType = '';
+  public $endTime;
+  protected $richMediaExitOverridesType = 'Google_Service_Dfareporting_RichMediaExitOverride';
+  protected $richMediaExitOverridesDataType = 'array';
+  public $sequence;
+  public $sslCompliant;
+  public $startTime;
+  public $weight;
+
+
+  public function setActive($active)
+  {
+    $this->active = $active;
+  }
+  public function getActive()
+  {
+    return $this->active;
+  }
+  public function setApplyEventTags($applyEventTags)
+  {
+    $this->applyEventTags = $applyEventTags;
+  }
+  public function getApplyEventTags()
+  {
+    return $this->applyEventTags;
+  }
+  public function setClickThroughUrl(Google_Service_Dfareporting_ClickThroughUrl $clickThroughUrl)
+  {
+    $this->clickThroughUrl = $clickThroughUrl;
+  }
+  public function getClickThroughUrl()
+  {
+    return $this->clickThroughUrl;
+  }
+  public function setCompanionCreativeOverrides($companionCreativeOverrides)
+  {
+    $this->companionCreativeOverrides = $companionCreativeOverrides;
+  }
+  public function getCompanionCreativeOverrides()
+  {
+    return $this->companionCreativeOverrides;
+  }
+  public function setCreativeGroupAssignments($creativeGroupAssignments)
+  {
+    $this->creativeGroupAssignments = $creativeGroupAssignments;
+  }
+  public function getCreativeGroupAssignments()
+  {
+    return $this->creativeGroupAssignments;
+  }
+  public function setCreativeId($creativeId)
+  {
+    $this->creativeId = $creativeId;
+  }
+  public function getCreativeId()
+  {
+    return $this->creativeId;
+  }
+  public function setCreativeIdDimensionValue(Google_Service_Dfareporting_DimensionValue $creativeIdDimensionValue)
+  {
+    $this->creativeIdDimensionValue = $creativeIdDimensionValue;
+  }
+  public function getCreativeIdDimensionValue()
+  {
+    return $this->creativeIdDimensionValue;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setRichMediaExitOverrides($richMediaExitOverrides)
+  {
+    $this->richMediaExitOverrides = $richMediaExitOverrides;
+  }
+  public function getRichMediaExitOverrides()
+  {
+    return $this->richMediaExitOverrides;
+  }
+  public function setSequence($sequence)
+  {
+    $this->sequence = $sequence;
+  }
+  public function getSequence()
+  {
+    return $this->sequence;
+  }
+  public function setSslCompliant($sslCompliant)
+  {
+    $this->sslCompliant = $sslCompliant;
+  }
+  public function getSslCompliant()
+  {
+    return $this->sslCompliant;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+  public function setWeight($weight)
+  {
+    $this->weight = $weight;
+  }
+  public function getWeight()
+  {
+    return $this->weight;
+  }
+}
+
+class Google_Service_Dfareporting_CreativeCustomEvent extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $active;
+  public $advertiserCustomEventName;
+  public $advertiserCustomEventType;
+  public $artworkLabel;
+  public $artworkType;
+  public $exitUrl;
+  public $id;
+  protected $popupWindowPropertiesType = 'Google_Service_Dfareporting_PopupWindowProperties';
+  protected $popupWindowPropertiesDataType = '';
+  public $targetType;
+  public $videoReportingId;
+
+
+  public function setActive($active)
+  {
+    $this->active = $active;
+  }
+  public function getActive()
+  {
+    return $this->active;
+  }
+  public function setAdvertiserCustomEventName($advertiserCustomEventName)
+  {
+    $this->advertiserCustomEventName = $advertiserCustomEventName;
+  }
+  public function getAdvertiserCustomEventName()
+  {
+    return $this->advertiserCustomEventName;
+  }
+  public function setAdvertiserCustomEventType($advertiserCustomEventType)
+  {
+    $this->advertiserCustomEventType = $advertiserCustomEventType;
+  }
+  public function getAdvertiserCustomEventType()
+  {
+    return $this->advertiserCustomEventType;
+  }
+  public function setArtworkLabel($artworkLabel)
+  {
+    $this->artworkLabel = $artworkLabel;
+  }
+  public function getArtworkLabel()
+  {
+    return $this->artworkLabel;
+  }
+  public function setArtworkType($artworkType)
+  {
+    $this->artworkType = $artworkType;
+  }
+  public function getArtworkType()
+  {
+    return $this->artworkType;
+  }
+  public function setExitUrl($exitUrl)
+  {
+    $this->exitUrl = $exitUrl;
+  }
+  public function getExitUrl()
+  {
+    return $this->exitUrl;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setPopupWindowProperties(Google_Service_Dfareporting_PopupWindowProperties $popupWindowProperties)
+  {
+    $this->popupWindowProperties = $popupWindowProperties;
+  }
+  public function getPopupWindowProperties()
+  {
+    return $this->popupWindowProperties;
+  }
+  public function setTargetType($targetType)
+  {
+    $this->targetType = $targetType;
+  }
+  public function getTargetType()
+  {
+    return $this->targetType;
+  }
+  public function setVideoReportingId($videoReportingId)
+  {
+    $this->videoReportingId = $videoReportingId;
+  }
+  public function getVideoReportingId()
+  {
+    return $this->videoReportingId;
+  }
+}
+
+class Google_Service_Dfareporting_CreativeField extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $advertiserId;
+  protected $advertiserIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $advertiserIdDimensionValueDataType = '';
+  public $id;
+  public $kind;
+  public $name;
+  public $subaccountId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAdvertiserIdDimensionValue(Google_Service_Dfareporting_DimensionValue $advertiserIdDimensionValue)
+  {
+    $this->advertiserIdDimensionValue = $advertiserIdDimensionValue;
+  }
+  public function getAdvertiserIdDimensionValue()
+  {
+    return $this->advertiserIdDimensionValue;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+}
+
+class Google_Service_Dfareporting_CreativeFieldAssignment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $creativeFieldId;
+  public $creativeFieldValueId;
+
+
+  public function setCreativeFieldId($creativeFieldId)
+  {
+    $this->creativeFieldId = $creativeFieldId;
+  }
+  public function getCreativeFieldId()
+  {
+    return $this->creativeFieldId;
+  }
+  public function setCreativeFieldValueId($creativeFieldValueId)
+  {
+    $this->creativeFieldValueId = $creativeFieldValueId;
+  }
+  public function getCreativeFieldValueId()
+  {
+    return $this->creativeFieldValueId;
+  }
+}
+
+class Google_Service_Dfareporting_CreativeFieldValue extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $value;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Dfareporting_CreativeFieldValuesListResponse extends Google_Collection
+{
+  protected $collection_key = 'creativeFieldValues';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $creativeFieldValuesType = 'Google_Service_Dfareporting_CreativeFieldValue';
+  protected $creativeFieldValuesDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setCreativeFieldValues($creativeFieldValues)
+  {
+    $this->creativeFieldValues = $creativeFieldValues;
+  }
+  public function getCreativeFieldValues()
+  {
+    return $this->creativeFieldValues;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_CreativeFieldsListResponse extends Google_Collection
+{
+  protected $collection_key = 'creativeFields';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $creativeFieldsType = 'Google_Service_Dfareporting_CreativeField';
+  protected $creativeFieldsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setCreativeFields($creativeFields)
+  {
+    $this->creativeFields = $creativeFields;
+  }
+  public function getCreativeFields()
+  {
+    return $this->creativeFields;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_CreativeGroup extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $advertiserId;
+  protected $advertiserIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $advertiserIdDimensionValueDataType = '';
+  public $groupNumber;
+  public $id;
+  public $kind;
+  public $name;
+  public $subaccountId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAdvertiserIdDimensionValue(Google_Service_Dfareporting_DimensionValue $advertiserIdDimensionValue)
+  {
+    $this->advertiserIdDimensionValue = $advertiserIdDimensionValue;
+  }
+  public function getAdvertiserIdDimensionValue()
+  {
+    return $this->advertiserIdDimensionValue;
+  }
+  public function setGroupNumber($groupNumber)
+  {
+    $this->groupNumber = $groupNumber;
+  }
+  public function getGroupNumber()
+  {
+    return $this->groupNumber;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+}
+
+class Google_Service_Dfareporting_CreativeGroupAssignment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $creativeGroupId;
+  public $creativeGroupNumber;
+
+
+  public function setCreativeGroupId($creativeGroupId)
+  {
+    $this->creativeGroupId = $creativeGroupId;
+  }
+  public function getCreativeGroupId()
+  {
+    return $this->creativeGroupId;
+  }
+  public function setCreativeGroupNumber($creativeGroupNumber)
+  {
+    $this->creativeGroupNumber = $creativeGroupNumber;
+  }
+  public function getCreativeGroupNumber()
+  {
+    return $this->creativeGroupNumber;
+  }
+}
+
+class Google_Service_Dfareporting_CreativeGroupsListResponse extends Google_Collection
+{
+  protected $collection_key = 'creativeGroups';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $creativeGroupsType = 'Google_Service_Dfareporting_CreativeGroup';
+  protected $creativeGroupsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setCreativeGroups($creativeGroups)
+  {
+    $this->creativeGroups = $creativeGroups;
+  }
+  public function getCreativeGroups()
+  {
+    return $this->creativeGroups;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_CreativeOptimizationConfiguration extends Google_Collection
+{
+  protected $collection_key = 'optimizationActivitys';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $name;
+  protected $optimizationActivitysType = 'Google_Service_Dfareporting_OptimizationActivity';
+  protected $optimizationActivitysDataType = 'array';
+  public $optimizationModel;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOptimizationActivitys($optimizationActivitys)
+  {
+    $this->optimizationActivitys = $optimizationActivitys;
+  }
+  public function getOptimizationActivitys()
+  {
+    return $this->optimizationActivitys;
+  }
+  public function setOptimizationModel($optimizationModel)
+  {
+    $this->optimizationModel = $optimizationModel;
+  }
+  public function getOptimizationModel()
+  {
+    return $this->optimizationModel;
+  }
+}
+
+class Google_Service_Dfareporting_CreativeRotation extends Google_Collection
+{
+  protected $collection_key = 'creativeAssignments';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $creativeAssignmentsType = 'Google_Service_Dfareporting_CreativeAssignment';
+  protected $creativeAssignmentsDataType = 'array';
+  public $creativeOptimizationConfigurationId;
+  public $type;
+  public $weightCalculationStrategy;
+
+
+  public function setCreativeAssignments($creativeAssignments)
+  {
+    $this->creativeAssignments = $creativeAssignments;
+  }
+  public function getCreativeAssignments()
+  {
+    return $this->creativeAssignments;
+  }
+  public function setCreativeOptimizationConfigurationId($creativeOptimizationConfigurationId)
+  {
+    $this->creativeOptimizationConfigurationId = $creativeOptimizationConfigurationId;
+  }
+  public function getCreativeOptimizationConfigurationId()
+  {
+    return $this->creativeOptimizationConfigurationId;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setWeightCalculationStrategy($weightCalculationStrategy)
+  {
+    $this->weightCalculationStrategy = $weightCalculationStrategy;
+  }
+  public function getWeightCalculationStrategy()
+  {
+    return $this->weightCalculationStrategy;
+  }
+}
+
+class Google_Service_Dfareporting_CreativeSettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $iFrameFooter;
+  public $iFrameHeader;
+
+
+  public function setIFrameFooter($iFrameFooter)
+  {
+    $this->iFrameFooter = $iFrameFooter;
+  }
+  public function getIFrameFooter()
+  {
+    return $this->iFrameFooter;
+  }
+  public function setIFrameHeader($iFrameHeader)
+  {
+    $this->iFrameHeader = $iFrameHeader;
+  }
+  public function getIFrameHeader()
+  {
+    return $this->iFrameHeader;
+  }
+}
+
+class Google_Service_Dfareporting_CreativesListResponse extends Google_Collection
+{
+  protected $collection_key = 'creatives';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $creativesType = 'Google_Service_Dfareporting_Creative';
+  protected $creativesDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setCreatives($creatives)
+  {
+    $this->creatives = $creatives;
+  }
+  public function getCreatives()
+  {
+    return $this->creatives;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_CrossDimensionReachReportCompatibleFields extends Google_Collection
+{
+  protected $collection_key = 'overlapMetrics';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $breakdownType = 'Google_Service_Dfareporting_Dimension';
+  protected $breakdownDataType = 'array';
+  protected $dimensionFiltersType = 'Google_Service_Dfareporting_Dimension';
+  protected $dimensionFiltersDataType = 'array';
+  public $kind;
+  protected $metricsType = 'Google_Service_Dfareporting_Metric';
+  protected $metricsDataType = 'array';
+  protected $overlapMetricsType = 'Google_Service_Dfareporting_Metric';
+  protected $overlapMetricsDataType = 'array';
+
+
+  public function setBreakdown($breakdown)
+  {
+    $this->breakdown = $breakdown;
+  }
+  public function getBreakdown()
+  {
+    return $this->breakdown;
+  }
+  public function setDimensionFilters($dimensionFilters)
+  {
+    $this->dimensionFilters = $dimensionFilters;
+  }
+  public function getDimensionFilters()
+  {
+    return $this->dimensionFilters;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMetrics($metrics)
+  {
+    $this->metrics = $metrics;
+  }
+  public function getMetrics()
+  {
+    return $this->metrics;
+  }
+  public function setOverlapMetrics($overlapMetrics)
+  {
+    $this->overlapMetrics = $overlapMetrics;
+  }
+  public function getOverlapMetrics()
+  {
+    return $this->overlapMetrics;
+  }
+}
+
+class Google_Service_Dfareporting_CustomRichMediaEvents extends Google_Collection
+{
+  protected $collection_key = 'filteredEventIds';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $filteredEventIdsType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $filteredEventIdsDataType = 'array';
+  public $kind;
+
+
+  public function setFilteredEventIds($filteredEventIds)
+  {
+    $this->filteredEventIds = $filteredEventIds;
+  }
+  public function getFilteredEventIds()
+  {
+    return $this->filteredEventIds;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Dfareporting_DateRange extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $endDate;
+  public $kind;
+  public $relativeDateRange;
+  public $startDate;
+
+
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRelativeDateRange($relativeDateRange)
+  {
+    $this->relativeDateRange = $relativeDateRange;
+  }
+  public function getRelativeDateRange()
+  {
+    return $this->relativeDateRange;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+}
+
+class Google_Service_Dfareporting_DayPartTargeting extends Google_Collection
+{
+  protected $collection_key = 'hoursOfDay';
+  protected $internal_gapi_mappings = array(
+  );
+  public $daysOfWeek;
+  public $hoursOfDay;
+  public $userLocalTime;
+
+
+  public function setDaysOfWeek($daysOfWeek)
+  {
+    $this->daysOfWeek = $daysOfWeek;
+  }
+  public function getDaysOfWeek()
+  {
+    return $this->daysOfWeek;
+  }
+  public function setHoursOfDay($hoursOfDay)
+  {
+    $this->hoursOfDay = $hoursOfDay;
+  }
+  public function getHoursOfDay()
+  {
+    return $this->hoursOfDay;
+  }
+  public function setUserLocalTime($userLocalTime)
+  {
+    $this->userLocalTime = $userLocalTime;
+  }
+  public function getUserLocalTime()
+  {
+    return $this->userLocalTime;
+  }
+}
+
+class Google_Service_Dfareporting_DefaultClickThroughEventTagProperties extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $defaultClickThroughEventTagId;
+  public $overrideInheritedEventTag;
+
+
+  public function setDefaultClickThroughEventTagId($defaultClickThroughEventTagId)
+  {
+    $this->defaultClickThroughEventTagId = $defaultClickThroughEventTagId;
+  }
+  public function getDefaultClickThroughEventTagId()
+  {
+    return $this->defaultClickThroughEventTagId;
+  }
+  public function setOverrideInheritedEventTag($overrideInheritedEventTag)
+  {
+    $this->overrideInheritedEventTag = $overrideInheritedEventTag;
+  }
+  public function getOverrideInheritedEventTag()
+  {
+    return $this->overrideInheritedEventTag;
+  }
+}
+
+class Google_Service_Dfareporting_DeliverySchedule extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $frequencyCapType = 'Google_Service_Dfareporting_FrequencyCap';
+  protected $frequencyCapDataType = '';
+  public $hardCutoff;
+  public $impressionRatio;
+  public $priority;
+
+
+  public function setFrequencyCap(Google_Service_Dfareporting_FrequencyCap $frequencyCap)
+  {
+    $this->frequencyCap = $frequencyCap;
+  }
+  public function getFrequencyCap()
+  {
+    return $this->frequencyCap;
+  }
+  public function setHardCutoff($hardCutoff)
+  {
+    $this->hardCutoff = $hardCutoff;
+  }
+  public function getHardCutoff()
+  {
+    return $this->hardCutoff;
+  }
+  public function setImpressionRatio($impressionRatio)
+  {
+    $this->impressionRatio = $impressionRatio;
+  }
+  public function getImpressionRatio()
+  {
+    return $this->impressionRatio;
+  }
+  public function setPriority($priority)
+  {
+    $this->priority = $priority;
+  }
+  public function getPriority()
+  {
+    return $this->priority;
+  }
+}
+
+class Google_Service_Dfareporting_DfareportingFile extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $dateRangeType = 'Google_Service_Dfareporting_DateRange';
+  protected $dateRangeDataType = '';
+  public $etag;
+  public $fileName;
+  public $format;
+  public $id;
+  public $kind;
+  public $lastModifiedTime;
+  public $reportId;
+  public $status;
+  protected $urlsType = 'Google_Service_Dfareporting_DfareportingFileUrls';
+  protected $urlsDataType = '';
+
+
+  public function setDateRange(Google_Service_Dfareporting_DateRange $dateRange)
+  {
+    $this->dateRange = $dateRange;
+  }
+  public function getDateRange()
+  {
+    return $this->dateRange;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setFileName($fileName)
+  {
+    $this->fileName = $fileName;
+  }
+  public function getFileName()
+  {
+    return $this->fileName;
+  }
+  public function setFormat($format)
+  {
+    $this->format = $format;
+  }
+  public function getFormat()
+  {
+    return $this->format;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastModifiedTime($lastModifiedTime)
+  {
+    $this->lastModifiedTime = $lastModifiedTime;
+  }
+  public function getLastModifiedTime()
+  {
+    return $this->lastModifiedTime;
+  }
+  public function setReportId($reportId)
+  {
+    $this->reportId = $reportId;
+  }
+  public function getReportId()
+  {
+    return $this->reportId;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setUrls(Google_Service_Dfareporting_DfareportingFileUrls $urls)
+  {
+    $this->urls = $urls;
+  }
+  public function getUrls()
+  {
+    return $this->urls;
+  }
+}
+
+class Google_Service_Dfareporting_DfareportingFileUrls extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $apiUrl;
+  public $browserUrl;
+
+
+  public function setApiUrl($apiUrl)
+  {
+    $this->apiUrl = $apiUrl;
+  }
+  public function getApiUrl()
+  {
+    return $this->apiUrl;
+  }
+  public function setBrowserUrl($browserUrl)
+  {
+    $this->browserUrl = $browserUrl;
+  }
+  public function getBrowserUrl()
+  {
+    return $this->browserUrl;
+  }
+}
+
+class Google_Service_Dfareporting_DfpSettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "dfpNetworkCode" => "dfp_network_code",
+        "dfpNetworkName" => "dfp_network_name",
+  );
+  public $dfpNetworkCode;
+  public $dfpNetworkName;
+  public $programmaticPlacementAccepted;
+  public $pubPaidPlacementAccepted;
+  public $publisherPortalOnly;
+
+
+  public function setDfpNetworkCode($dfpNetworkCode)
+  {
+    $this->dfpNetworkCode = $dfpNetworkCode;
+  }
+  public function getDfpNetworkCode()
+  {
+    return $this->dfpNetworkCode;
+  }
+  public function setDfpNetworkName($dfpNetworkName)
+  {
+    $this->dfpNetworkName = $dfpNetworkName;
+  }
+  public function getDfpNetworkName()
+  {
+    return $this->dfpNetworkName;
+  }
+  public function setProgrammaticPlacementAccepted($programmaticPlacementAccepted)
+  {
+    $this->programmaticPlacementAccepted = $programmaticPlacementAccepted;
+  }
+  public function getProgrammaticPlacementAccepted()
+  {
+    return $this->programmaticPlacementAccepted;
+  }
+  public function setPubPaidPlacementAccepted($pubPaidPlacementAccepted)
+  {
+    $this->pubPaidPlacementAccepted = $pubPaidPlacementAccepted;
+  }
+  public function getPubPaidPlacementAccepted()
+  {
+    return $this->pubPaidPlacementAccepted;
+  }
+  public function setPublisherPortalOnly($publisherPortalOnly)
+  {
+    $this->publisherPortalOnly = $publisherPortalOnly;
+  }
+  public function getPublisherPortalOnly()
+  {
+    return $this->publisherPortalOnly;
+  }
+}
+
+class Google_Service_Dfareporting_Dimension extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $name;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Dfareporting_DimensionFilter extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $dimensionName;
+  public $kind;
+  public $value;
+
+
+  public function setDimensionName($dimensionName)
+  {
+    $this->dimensionName = $dimensionName;
+  }
+  public function getDimensionName()
+  {
+    return $this->dimensionName;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Dfareporting_DimensionValue extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $dimensionName;
+  public $etag;
+  public $id;
+  public $kind;
+  public $matchType;
+  public $value;
+
+
+  public function setDimensionName($dimensionName)
+  {
+    $this->dimensionName = $dimensionName;
+  }
+  public function getDimensionName()
+  {
+    return $this->dimensionName;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMatchType($matchType)
+  {
+    $this->matchType = $matchType;
+  }
+  public function getMatchType()
+  {
+    return $this->matchType;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Dfareporting_DimensionValueList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_DimensionValueRequest extends Google_Collection
+{
+  protected $collection_key = 'filters';
+  protected $internal_gapi_mappings = array(
+  );
+  public $dimensionName;
+  public $endDate;
+  protected $filtersType = 'Google_Service_Dfareporting_DimensionFilter';
+  protected $filtersDataType = 'array';
+  public $kind;
+  public $startDate;
+
+
+  public function setDimensionName($dimensionName)
+  {
+    $this->dimensionName = $dimensionName;
+  }
+  public function getDimensionName()
+  {
+    return $this->dimensionName;
+  }
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setFilters($filters)
+  {
+    $this->filters = $filters;
+  }
+  public function getFilters()
+  {
+    return $this->filters;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+}
+
+class Google_Service_Dfareporting_DirectorySite extends Google_Collection
+{
+  protected $collection_key = 'interstitialTagFormats';
+  protected $internal_gapi_mappings = array(
+  );
+  public $active;
+  protected $contactAssignmentsType = 'Google_Service_Dfareporting_DirectorySiteContactAssignment';
+  protected $contactAssignmentsDataType = 'array';
+  public $countryId;
+  public $currencyId;
+  public $description;
+  public $id;
+  protected $idDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $idDimensionValueDataType = '';
+  public $inpageTagFormats;
+  public $interstitialTagFormats;
+  public $kind;
+  public $name;
+  public $parentId;
+  protected $settingsType = 'Google_Service_Dfareporting_DirectorySiteSettings';
+  protected $settingsDataType = '';
+  public $url;
+
+
+  public function setActive($active)
+  {
+    $this->active = $active;
+  }
+  public function getActive()
+  {
+    return $this->active;
+  }
+  public function setContactAssignments($contactAssignments)
+  {
+    $this->contactAssignments = $contactAssignments;
+  }
+  public function getContactAssignments()
+  {
+    return $this->contactAssignments;
+  }
+  public function setCountryId($countryId)
+  {
+    $this->countryId = $countryId;
+  }
+  public function getCountryId()
+  {
+    return $this->countryId;
+  }
+  public function setCurrencyId($currencyId)
+  {
+    $this->currencyId = $currencyId;
+  }
+  public function getCurrencyId()
+  {
+    return $this->currencyId;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIdDimensionValue(Google_Service_Dfareporting_DimensionValue $idDimensionValue)
+  {
+    $this->idDimensionValue = $idDimensionValue;
+  }
+  public function getIdDimensionValue()
+  {
+    return $this->idDimensionValue;
+  }
+  public function setInpageTagFormats($inpageTagFormats)
+  {
+    $this->inpageTagFormats = $inpageTagFormats;
+  }
+  public function getInpageTagFormats()
+  {
+    return $this->inpageTagFormats;
+  }
+  public function setInterstitialTagFormats($interstitialTagFormats)
+  {
+    $this->interstitialTagFormats = $interstitialTagFormats;
+  }
+  public function getInterstitialTagFormats()
+  {
+    return $this->interstitialTagFormats;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setParentId($parentId)
+  {
+    $this->parentId = $parentId;
+  }
+  public function getParentId()
+  {
+    return $this->parentId;
+  }
+  public function setSettings(Google_Service_Dfareporting_DirectorySiteSettings $settings)
+  {
+    $this->settings = $settings;
+  }
+  public function getSettings()
+  {
+    return $this->settings;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Dfareporting_DirectorySiteContact extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $address;
+  public $email;
+  public $firstName;
+  public $id;
+  public $kind;
+  public $lastName;
+  public $phone;
+  public $role;
+  public $title;
+  public $type;
+
+
+  public function setAddress($address)
+  {
+    $this->address = $address;
+  }
+  public function getAddress()
+  {
+    return $this->address;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setFirstName($firstName)
+  {
+    $this->firstName = $firstName;
+  }
+  public function getFirstName()
+  {
+    return $this->firstName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastName($lastName)
+  {
+    $this->lastName = $lastName;
+  }
+  public function getLastName()
+  {
+    return $this->lastName;
+  }
+  public function setPhone($phone)
+  {
+    $this->phone = $phone;
+  }
+  public function getPhone()
+  {
+    return $this->phone;
+  }
+  public function setRole($role)
+  {
+    $this->role = $role;
+  }
+  public function getRole()
+  {
+    return $this->role;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Dfareporting_DirectorySiteContactAssignment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $contactId;
+  public $visibility;
+
+
+  public function setContactId($contactId)
+  {
+    $this->contactId = $contactId;
+  }
+  public function getContactId()
+  {
+    return $this->contactId;
+  }
+  public function setVisibility($visibility)
+  {
+    $this->visibility = $visibility;
+  }
+  public function getVisibility()
+  {
+    return $this->visibility;
+  }
+}
+
+class Google_Service_Dfareporting_DirectorySiteContactsListResponse extends Google_Collection
+{
+  protected $collection_key = 'directorySiteContacts';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $directorySiteContactsType = 'Google_Service_Dfareporting_DirectorySiteContact';
+  protected $directorySiteContactsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setDirectorySiteContacts($directorySiteContacts)
+  {
+    $this->directorySiteContacts = $directorySiteContacts;
+  }
+  public function getDirectorySiteContacts()
+  {
+    return $this->directorySiteContacts;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_DirectorySiteSettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "dfpSettings" => "dfp_settings",
+        "instreamVideoPlacementAccepted" => "instream_video_placement_accepted",
+  );
+  public $activeViewOptOut;
+  protected $dfpSettingsType = 'Google_Service_Dfareporting_DfpSettings';
+  protected $dfpSettingsDataType = '';
+  public $instreamVideoPlacementAccepted;
+  public $interstitialPlacementAccepted;
+  public $nielsenOcrOptOut;
+  public $verificationTagOptOut;
+  public $videoActiveViewOptOut;
+
+
+  public function setActiveViewOptOut($activeViewOptOut)
+  {
+    $this->activeViewOptOut = $activeViewOptOut;
+  }
+  public function getActiveViewOptOut()
+  {
+    return $this->activeViewOptOut;
+  }
+  public function setDfpSettings(Google_Service_Dfareporting_DfpSettings $dfpSettings)
+  {
+    $this->dfpSettings = $dfpSettings;
+  }
+  public function getDfpSettings()
+  {
+    return $this->dfpSettings;
+  }
+  public function setInstreamVideoPlacementAccepted($instreamVideoPlacementAccepted)
+  {
+    $this->instreamVideoPlacementAccepted = $instreamVideoPlacementAccepted;
+  }
+  public function getInstreamVideoPlacementAccepted()
+  {
+    return $this->instreamVideoPlacementAccepted;
+  }
+  public function setInterstitialPlacementAccepted($interstitialPlacementAccepted)
+  {
+    $this->interstitialPlacementAccepted = $interstitialPlacementAccepted;
+  }
+  public function getInterstitialPlacementAccepted()
+  {
+    return $this->interstitialPlacementAccepted;
+  }
+  public function setNielsenOcrOptOut($nielsenOcrOptOut)
+  {
+    $this->nielsenOcrOptOut = $nielsenOcrOptOut;
+  }
+  public function getNielsenOcrOptOut()
+  {
+    return $this->nielsenOcrOptOut;
+  }
+  public function setVerificationTagOptOut($verificationTagOptOut)
+  {
+    $this->verificationTagOptOut = $verificationTagOptOut;
+  }
+  public function getVerificationTagOptOut()
+  {
+    return $this->verificationTagOptOut;
+  }
+  public function setVideoActiveViewOptOut($videoActiveViewOptOut)
+  {
+    $this->videoActiveViewOptOut = $videoActiveViewOptOut;
+  }
+  public function getVideoActiveViewOptOut()
+  {
+    return $this->videoActiveViewOptOut;
+  }
+}
+
+class Google_Service_Dfareporting_DirectorySitesListResponse extends Google_Collection
+{
+  protected $collection_key = 'directorySites';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $directorySitesType = 'Google_Service_Dfareporting_DirectorySite';
+  protected $directorySitesDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setDirectorySites($directorySites)
+  {
+    $this->directorySites = $directorySites;
+  }
+  public function getDirectorySites()
+  {
+    return $this->directorySites;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_EventTag extends Google_Collection
+{
+  protected $collection_key = 'siteIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $advertiserId;
+  protected $advertiserIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $advertiserIdDimensionValueDataType = '';
+  public $campaignId;
+  protected $campaignIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $campaignIdDimensionValueDataType = '';
+  public $enabledByDefault;
+  public $id;
+  public $kind;
+  public $name;
+  public $siteFilterType;
+  public $siteIds;
+  public $sslCompliant;
+  public $status;
+  public $subaccountId;
+  public $type;
+  public $url;
+  public $urlEscapeLevels;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAdvertiserIdDimensionValue(Google_Service_Dfareporting_DimensionValue $advertiserIdDimensionValue)
+  {
+    $this->advertiserIdDimensionValue = $advertiserIdDimensionValue;
+  }
+  public function getAdvertiserIdDimensionValue()
+  {
+    return $this->advertiserIdDimensionValue;
+  }
+  public function setCampaignId($campaignId)
+  {
+    $this->campaignId = $campaignId;
+  }
+  public function getCampaignId()
+  {
+    return $this->campaignId;
+  }
+  public function setCampaignIdDimensionValue(Google_Service_Dfareporting_DimensionValue $campaignIdDimensionValue)
+  {
+    $this->campaignIdDimensionValue = $campaignIdDimensionValue;
+  }
+  public function getCampaignIdDimensionValue()
+  {
+    return $this->campaignIdDimensionValue;
+  }
+  public function setEnabledByDefault($enabledByDefault)
+  {
+    $this->enabledByDefault = $enabledByDefault;
+  }
+  public function getEnabledByDefault()
+  {
+    return $this->enabledByDefault;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSiteFilterType($siteFilterType)
+  {
+    $this->siteFilterType = $siteFilterType;
+  }
+  public function getSiteFilterType()
+  {
+    return $this->siteFilterType;
+  }
+  public function setSiteIds($siteIds)
+  {
+    $this->siteIds = $siteIds;
+  }
+  public function getSiteIds()
+  {
+    return $this->siteIds;
+  }
+  public function setSslCompliant($sslCompliant)
+  {
+    $this->sslCompliant = $sslCompliant;
+  }
+  public function getSslCompliant()
+  {
+    return $this->sslCompliant;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setUrlEscapeLevels($urlEscapeLevels)
+  {
+    $this->urlEscapeLevels = $urlEscapeLevels;
+  }
+  public function getUrlEscapeLevels()
+  {
+    return $this->urlEscapeLevels;
+  }
+}
+
+class Google_Service_Dfareporting_EventTagOverride extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $enabled;
+  public $id;
+
+
+  public function setEnabled($enabled)
+  {
+    $this->enabled = $enabled;
+  }
+  public function getEnabled()
+  {
+    return $this->enabled;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+}
+
+class Google_Service_Dfareporting_EventTagsListResponse extends Google_Collection
+{
+  protected $collection_key = 'eventTags';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $eventTagsType = 'Google_Service_Dfareporting_EventTag';
+  protected $eventTagsDataType = 'array';
+  public $kind;
+
+
+  public function setEventTags($eventTags)
+  {
+    $this->eventTags = $eventTags;
+  }
+  public function getEventTags()
+  {
+    return $this->eventTags;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Dfareporting_FileList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Dfareporting_DfareportingFile';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_Flight extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $endDate;
+  public $rateOrCost;
+  public $startDate;
+  public $units;
+
+
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setRateOrCost($rateOrCost)
+  {
+    $this->rateOrCost = $rateOrCost;
+  }
+  public function getRateOrCost()
+  {
+    return $this->rateOrCost;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+  public function setUnits($units)
+  {
+    $this->units = $units;
+  }
+  public function getUnits()
+  {
+    return $this->units;
+  }
+}
+
+class Google_Service_Dfareporting_FloodlightActivitiesGenerateTagResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $floodlightActivityTag;
+  public $kind;
+
+
+  public function setFloodlightActivityTag($floodlightActivityTag)
+  {
+    $this->floodlightActivityTag = $floodlightActivityTag;
+  }
+  public function getFloodlightActivityTag()
+  {
+    return $this->floodlightActivityTag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Dfareporting_FloodlightActivitiesListResponse extends Google_Collection
+{
+  protected $collection_key = 'floodlightActivities';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $floodlightActivitiesType = 'Google_Service_Dfareporting_FloodlightActivity';
+  protected $floodlightActivitiesDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setFloodlightActivities($floodlightActivities)
+  {
+    $this->floodlightActivities = $floodlightActivities;
+  }
+  public function getFloodlightActivities()
+  {
+    return $this->floodlightActivities;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_FloodlightActivity extends Google_Collection
+{
+  protected $collection_key = 'userDefinedVariableTypes';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $advertiserId;
+  protected $advertiserIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $advertiserIdDimensionValueDataType = '';
+  public $cacheBustingType;
+  public $countingMethod;
+  protected $defaultTagsType = 'Google_Service_Dfareporting_FloodlightActivityDynamicTag';
+  protected $defaultTagsDataType = 'array';
+  public $expectedUrl;
+  public $floodlightActivityGroupId;
+  public $floodlightActivityGroupName;
+  public $floodlightActivityGroupTagString;
+  public $floodlightActivityGroupType;
+  public $floodlightConfigurationId;
+  protected $floodlightConfigurationIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $floodlightConfigurationIdDimensionValueDataType = '';
+  public $hidden;
+  public $id;
+  protected $idDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $idDimensionValueDataType = '';
+  public $imageTagEnabled;
+  public $kind;
+  public $name;
+  public $notes;
+  protected $publisherTagsType = 'Google_Service_Dfareporting_FloodlightActivityPublisherDynamicTag';
+  protected $publisherTagsDataType = 'array';
+  public $secure;
+  public $sslCompliant;
+  public $sslRequired;
+  public $subaccountId;
+  public $tagFormat;
+  public $tagString;
+  public $userDefinedVariableTypes;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAdvertiserIdDimensionValue(Google_Service_Dfareporting_DimensionValue $advertiserIdDimensionValue)
+  {
+    $this->advertiserIdDimensionValue = $advertiserIdDimensionValue;
+  }
+  public function getAdvertiserIdDimensionValue()
+  {
+    return $this->advertiserIdDimensionValue;
+  }
+  public function setCacheBustingType($cacheBustingType)
+  {
+    $this->cacheBustingType = $cacheBustingType;
+  }
+  public function getCacheBustingType()
+  {
+    return $this->cacheBustingType;
+  }
+  public function setCountingMethod($countingMethod)
+  {
+    $this->countingMethod = $countingMethod;
+  }
+  public function getCountingMethod()
+  {
+    return $this->countingMethod;
+  }
+  public function setDefaultTags($defaultTags)
+  {
+    $this->defaultTags = $defaultTags;
+  }
+  public function getDefaultTags()
+  {
+    return $this->defaultTags;
+  }
+  public function setExpectedUrl($expectedUrl)
+  {
+    $this->expectedUrl = $expectedUrl;
+  }
+  public function getExpectedUrl()
+  {
+    return $this->expectedUrl;
+  }
+  public function setFloodlightActivityGroupId($floodlightActivityGroupId)
+  {
+    $this->floodlightActivityGroupId = $floodlightActivityGroupId;
+  }
+  public function getFloodlightActivityGroupId()
+  {
+    return $this->floodlightActivityGroupId;
+  }
+  public function setFloodlightActivityGroupName($floodlightActivityGroupName)
+  {
+    $this->floodlightActivityGroupName = $floodlightActivityGroupName;
+  }
+  public function getFloodlightActivityGroupName()
+  {
+    return $this->floodlightActivityGroupName;
+  }
+  public function setFloodlightActivityGroupTagString($floodlightActivityGroupTagString)
+  {
+    $this->floodlightActivityGroupTagString = $floodlightActivityGroupTagString;
+  }
+  public function getFloodlightActivityGroupTagString()
+  {
+    return $this->floodlightActivityGroupTagString;
+  }
+  public function setFloodlightActivityGroupType($floodlightActivityGroupType)
+  {
+    $this->floodlightActivityGroupType = $floodlightActivityGroupType;
+  }
+  public function getFloodlightActivityGroupType()
+  {
+    return $this->floodlightActivityGroupType;
+  }
+  public function setFloodlightConfigurationId($floodlightConfigurationId)
+  {
+    $this->floodlightConfigurationId = $floodlightConfigurationId;
+  }
+  public function getFloodlightConfigurationId()
+  {
+    return $this->floodlightConfigurationId;
+  }
+  public function setFloodlightConfigurationIdDimensionValue(Google_Service_Dfareporting_DimensionValue $floodlightConfigurationIdDimensionValue)
+  {
+    $this->floodlightConfigurationIdDimensionValue = $floodlightConfigurationIdDimensionValue;
+  }
+  public function getFloodlightConfigurationIdDimensionValue()
+  {
+    return $this->floodlightConfigurationIdDimensionValue;
+  }
+  public function setHidden($hidden)
+  {
+    $this->hidden = $hidden;
+  }
+  public function getHidden()
+  {
+    return $this->hidden;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIdDimensionValue(Google_Service_Dfareporting_DimensionValue $idDimensionValue)
+  {
+    $this->idDimensionValue = $idDimensionValue;
+  }
+  public function getIdDimensionValue()
+  {
+    return $this->idDimensionValue;
+  }
+  public function setImageTagEnabled($imageTagEnabled)
+  {
+    $this->imageTagEnabled = $imageTagEnabled;
+  }
+  public function getImageTagEnabled()
+  {
+    return $this->imageTagEnabled;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNotes($notes)
+  {
+    $this->notes = $notes;
+  }
+  public function getNotes()
+  {
+    return $this->notes;
+  }
+  public function setPublisherTags($publisherTags)
+  {
+    $this->publisherTags = $publisherTags;
+  }
+  public function getPublisherTags()
+  {
+    return $this->publisherTags;
+  }
+  public function setSecure($secure)
+  {
+    $this->secure = $secure;
+  }
+  public function getSecure()
+  {
+    return $this->secure;
+  }
+  public function setSslCompliant($sslCompliant)
+  {
+    $this->sslCompliant = $sslCompliant;
+  }
+  public function getSslCompliant()
+  {
+    return $this->sslCompliant;
+  }
+  public function setSslRequired($sslRequired)
+  {
+    $this->sslRequired = $sslRequired;
+  }
+  public function getSslRequired()
+  {
+    return $this->sslRequired;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+  public function setTagFormat($tagFormat)
+  {
+    $this->tagFormat = $tagFormat;
+  }
+  public function getTagFormat()
+  {
+    return $this->tagFormat;
+  }
+  public function setTagString($tagString)
+  {
+    $this->tagString = $tagString;
+  }
+  public function getTagString()
+  {
+    return $this->tagString;
+  }
+  public function setUserDefinedVariableTypes($userDefinedVariableTypes)
+  {
+    $this->userDefinedVariableTypes = $userDefinedVariableTypes;
+  }
+  public function getUserDefinedVariableTypes()
+  {
+    return $this->userDefinedVariableTypes;
+  }
+}
+
+class Google_Service_Dfareporting_FloodlightActivityDynamicTag extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $name;
+  public $tag;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setTag($tag)
+  {
+    $this->tag = $tag;
+  }
+  public function getTag()
+  {
+    return $this->tag;
+  }
+}
+
+class Google_Service_Dfareporting_FloodlightActivityGroup extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $advertiserId;
+  protected $advertiserIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $advertiserIdDimensionValueDataType = '';
+  public $floodlightConfigurationId;
+  protected $floodlightConfigurationIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $floodlightConfigurationIdDimensionValueDataType = '';
+  public $id;
+  protected $idDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $idDimensionValueDataType = '';
+  public $kind;
+  public $name;
+  public $subaccountId;
+  public $tagString;
+  public $type;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAdvertiserIdDimensionValue(Google_Service_Dfareporting_DimensionValue $advertiserIdDimensionValue)
+  {
+    $this->advertiserIdDimensionValue = $advertiserIdDimensionValue;
+  }
+  public function getAdvertiserIdDimensionValue()
+  {
+    return $this->advertiserIdDimensionValue;
+  }
+  public function setFloodlightConfigurationId($floodlightConfigurationId)
+  {
+    $this->floodlightConfigurationId = $floodlightConfigurationId;
+  }
+  public function getFloodlightConfigurationId()
+  {
+    return $this->floodlightConfigurationId;
+  }
+  public function setFloodlightConfigurationIdDimensionValue(Google_Service_Dfareporting_DimensionValue $floodlightConfigurationIdDimensionValue)
+  {
+    $this->floodlightConfigurationIdDimensionValue = $floodlightConfigurationIdDimensionValue;
+  }
+  public function getFloodlightConfigurationIdDimensionValue()
+  {
+    return $this->floodlightConfigurationIdDimensionValue;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIdDimensionValue(Google_Service_Dfareporting_DimensionValue $idDimensionValue)
+  {
+    $this->idDimensionValue = $idDimensionValue;
+  }
+  public function getIdDimensionValue()
+  {
+    return $this->idDimensionValue;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+  public function setTagString($tagString)
+  {
+    $this->tagString = $tagString;
+  }
+  public function getTagString()
+  {
+    return $this->tagString;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Dfareporting_FloodlightActivityGroupsListResponse extends Google_Collection
+{
+  protected $collection_key = 'floodlightActivityGroups';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $floodlightActivityGroupsType = 'Google_Service_Dfareporting_FloodlightActivityGroup';
+  protected $floodlightActivityGroupsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setFloodlightActivityGroups($floodlightActivityGroups)
+  {
+    $this->floodlightActivityGroups = $floodlightActivityGroups;
+  }
+  public function getFloodlightActivityGroups()
+  {
+    return $this->floodlightActivityGroups;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_FloodlightActivityPublisherDynamicTag extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $clickThrough;
+  public $directorySiteId;
+  protected $dynamicTagType = 'Google_Service_Dfareporting_FloodlightActivityDynamicTag';
+  protected $dynamicTagDataType = '';
+  public $siteId;
+  protected $siteIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $siteIdDimensionValueDataType = '';
+  public $viewThrough;
+
+
+  public function setClickThrough($clickThrough)
+  {
+    $this->clickThrough = $clickThrough;
+  }
+  public function getClickThrough()
+  {
+    return $this->clickThrough;
+  }
+  public function setDirectorySiteId($directorySiteId)
+  {
+    $this->directorySiteId = $directorySiteId;
+  }
+  public function getDirectorySiteId()
+  {
+    return $this->directorySiteId;
+  }
+  public function setDynamicTag(Google_Service_Dfareporting_FloodlightActivityDynamicTag $dynamicTag)
+  {
+    $this->dynamicTag = $dynamicTag;
+  }
+  public function getDynamicTag()
+  {
+    return $this->dynamicTag;
+  }
+  public function setSiteId($siteId)
+  {
+    $this->siteId = $siteId;
+  }
+  public function getSiteId()
+  {
+    return $this->siteId;
+  }
+  public function setSiteIdDimensionValue(Google_Service_Dfareporting_DimensionValue $siteIdDimensionValue)
+  {
+    $this->siteIdDimensionValue = $siteIdDimensionValue;
+  }
+  public function getSiteIdDimensionValue()
+  {
+    return $this->siteIdDimensionValue;
+  }
+  public function setViewThrough($viewThrough)
+  {
+    $this->viewThrough = $viewThrough;
+  }
+  public function getViewThrough()
+  {
+    return $this->viewThrough;
+  }
+}
+
+class Google_Service_Dfareporting_FloodlightConfiguration extends Google_Collection
+{
+  protected $collection_key = 'userDefinedVariableConfigurations';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $advertiserId;
+  protected $advertiserIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $advertiserIdDimensionValueDataType = '';
+  public $analyticsDataSharingEnabled;
+  public $exposureToConversionEnabled;
+  public $firstDayOfWeek;
+  public $id;
+  protected $idDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $idDimensionValueDataType = '';
+  public $kind;
+  protected $lookbackConfigurationType = 'Google_Service_Dfareporting_LookbackConfiguration';
+  protected $lookbackConfigurationDataType = '';
+  public $naturalSearchConversionAttributionOption;
+  protected $omnitureSettingsType = 'Google_Service_Dfareporting_OmnitureSettings';
+  protected $omnitureSettingsDataType = '';
+  public $sslRequired;
+  public $standardVariableTypes;
+  public $subaccountId;
+  protected $tagSettingsType = 'Google_Service_Dfareporting_TagSettings';
+  protected $tagSettingsDataType = '';
+  protected $userDefinedVariableConfigurationsType = 'Google_Service_Dfareporting_UserDefinedVariableConfiguration';
+  protected $userDefinedVariableConfigurationsDataType = 'array';
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAdvertiserIdDimensionValue(Google_Service_Dfareporting_DimensionValue $advertiserIdDimensionValue)
+  {
+    $this->advertiserIdDimensionValue = $advertiserIdDimensionValue;
+  }
+  public function getAdvertiserIdDimensionValue()
+  {
+    return $this->advertiserIdDimensionValue;
+  }
+  public function setAnalyticsDataSharingEnabled($analyticsDataSharingEnabled)
+  {
+    $this->analyticsDataSharingEnabled = $analyticsDataSharingEnabled;
+  }
+  public function getAnalyticsDataSharingEnabled()
+  {
+    return $this->analyticsDataSharingEnabled;
+  }
+  public function setExposureToConversionEnabled($exposureToConversionEnabled)
+  {
+    $this->exposureToConversionEnabled = $exposureToConversionEnabled;
+  }
+  public function getExposureToConversionEnabled()
+  {
+    return $this->exposureToConversionEnabled;
+  }
+  public function setFirstDayOfWeek($firstDayOfWeek)
+  {
+    $this->firstDayOfWeek = $firstDayOfWeek;
+  }
+  public function getFirstDayOfWeek()
+  {
+    return $this->firstDayOfWeek;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIdDimensionValue(Google_Service_Dfareporting_DimensionValue $idDimensionValue)
+  {
+    $this->idDimensionValue = $idDimensionValue;
+  }
+  public function getIdDimensionValue()
+  {
+    return $this->idDimensionValue;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLookbackConfiguration(Google_Service_Dfareporting_LookbackConfiguration $lookbackConfiguration)
+  {
+    $this->lookbackConfiguration = $lookbackConfiguration;
+  }
+  public function getLookbackConfiguration()
+  {
+    return $this->lookbackConfiguration;
+  }
+  public function setNaturalSearchConversionAttributionOption($naturalSearchConversionAttributionOption)
+  {
+    $this->naturalSearchConversionAttributionOption = $naturalSearchConversionAttributionOption;
+  }
+  public function getNaturalSearchConversionAttributionOption()
+  {
+    return $this->naturalSearchConversionAttributionOption;
+  }
+  public function setOmnitureSettings(Google_Service_Dfareporting_OmnitureSettings $omnitureSettings)
+  {
+    $this->omnitureSettings = $omnitureSettings;
+  }
+  public function getOmnitureSettings()
+  {
+    return $this->omnitureSettings;
+  }
+  public function setSslRequired($sslRequired)
+  {
+    $this->sslRequired = $sslRequired;
+  }
+  public function getSslRequired()
+  {
+    return $this->sslRequired;
+  }
+  public function setStandardVariableTypes($standardVariableTypes)
+  {
+    $this->standardVariableTypes = $standardVariableTypes;
+  }
+  public function getStandardVariableTypes()
+  {
+    return $this->standardVariableTypes;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+  public function setTagSettings(Google_Service_Dfareporting_TagSettings $tagSettings)
+  {
+    $this->tagSettings = $tagSettings;
+  }
+  public function getTagSettings()
+  {
+    return $this->tagSettings;
+  }
+  public function setUserDefinedVariableConfigurations($userDefinedVariableConfigurations)
+  {
+    $this->userDefinedVariableConfigurations = $userDefinedVariableConfigurations;
+  }
+  public function getUserDefinedVariableConfigurations()
+  {
+    return $this->userDefinedVariableConfigurations;
+  }
+}
+
+class Google_Service_Dfareporting_FloodlightConfigurationsListResponse extends Google_Collection
+{
+  protected $collection_key = 'floodlightConfigurations';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $floodlightConfigurationsType = 'Google_Service_Dfareporting_FloodlightConfiguration';
+  protected $floodlightConfigurationsDataType = 'array';
+  public $kind;
+
+
+  public function setFloodlightConfigurations($floodlightConfigurations)
+  {
+    $this->floodlightConfigurations = $floodlightConfigurations;
+  }
+  public function getFloodlightConfigurations()
+  {
+    return $this->floodlightConfigurations;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Dfareporting_FloodlightReportCompatibleFields extends Google_Collection
+{
+  protected $collection_key = 'metrics';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $dimensionFiltersType = 'Google_Service_Dfareporting_Dimension';
+  protected $dimensionFiltersDataType = 'array';
+  protected $dimensionsType = 'Google_Service_Dfareporting_Dimension';
+  protected $dimensionsDataType = 'array';
+  public $kind;
+  protected $metricsType = 'Google_Service_Dfareporting_Metric';
+  protected $metricsDataType = 'array';
+
+
+  public function setDimensionFilters($dimensionFilters)
+  {
+    $this->dimensionFilters = $dimensionFilters;
+  }
+  public function getDimensionFilters()
+  {
+    return $this->dimensionFilters;
+  }
+  public function setDimensions($dimensions)
+  {
+    $this->dimensions = $dimensions;
+  }
+  public function getDimensions()
+  {
+    return $this->dimensions;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMetrics($metrics)
+  {
+    $this->metrics = $metrics;
+  }
+  public function getMetrics()
+  {
+    return $this->metrics;
+  }
+}
+
+class Google_Service_Dfareporting_FrequencyCap extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $duration;
+  public $impressions;
+
+
+  public function setDuration($duration)
+  {
+    $this->duration = $duration;
+  }
+  public function getDuration()
+  {
+    return $this->duration;
+  }
+  public function setImpressions($impressions)
+  {
+    $this->impressions = $impressions;
+  }
+  public function getImpressions()
+  {
+    return $this->impressions;
+  }
+}
+
+class Google_Service_Dfareporting_FsCommand extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $left;
+  public $positionOption;
+  public $top;
+  public $windowHeight;
+  public $windowWidth;
+
+
+  public function setLeft($left)
+  {
+    $this->left = $left;
+  }
+  public function getLeft()
+  {
+    return $this->left;
+  }
+  public function setPositionOption($positionOption)
+  {
+    $this->positionOption = $positionOption;
+  }
+  public function getPositionOption()
+  {
+    return $this->positionOption;
+  }
+  public function setTop($top)
+  {
+    $this->top = $top;
+  }
+  public function getTop()
+  {
+    return $this->top;
+  }
+  public function setWindowHeight($windowHeight)
+  {
+    $this->windowHeight = $windowHeight;
+  }
+  public function getWindowHeight()
+  {
+    return $this->windowHeight;
+  }
+  public function setWindowWidth($windowWidth)
+  {
+    $this->windowWidth = $windowWidth;
+  }
+  public function getWindowWidth()
+  {
+    return $this->windowWidth;
+  }
+}
+
+class Google_Service_Dfareporting_GeoTargeting extends Google_Collection
+{
+  protected $collection_key = 'regions';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $citiesType = 'Google_Service_Dfareporting_City';
+  protected $citiesDataType = 'array';
+  protected $countriesType = 'Google_Service_Dfareporting_Country';
+  protected $countriesDataType = 'array';
+  public $excludeCountries;
+  protected $metrosType = 'Google_Service_Dfareporting_Metro';
+  protected $metrosDataType = 'array';
+  protected $postalCodesType = 'Google_Service_Dfareporting_PostalCode';
+  protected $postalCodesDataType = 'array';
+  protected $regionsType = 'Google_Service_Dfareporting_Region';
+  protected $regionsDataType = 'array';
+
+
+  public function setCities($cities)
+  {
+    $this->cities = $cities;
+  }
+  public function getCities()
+  {
+    return $this->cities;
+  }
+  public function setCountries($countries)
+  {
+    $this->countries = $countries;
+  }
+  public function getCountries()
+  {
+    return $this->countries;
+  }
+  public function setExcludeCountries($excludeCountries)
+  {
+    $this->excludeCountries = $excludeCountries;
+  }
+  public function getExcludeCountries()
+  {
+    return $this->excludeCountries;
+  }
+  public function setMetros($metros)
+  {
+    $this->metros = $metros;
+  }
+  public function getMetros()
+  {
+    return $this->metros;
+  }
+  public function setPostalCodes($postalCodes)
+  {
+    $this->postalCodes = $postalCodes;
+  }
+  public function getPostalCodes()
+  {
+    return $this->postalCodes;
+  }
+  public function setRegions($regions)
+  {
+    $this->regions = $regions;
+  }
+  public function getRegions()
+  {
+    return $this->regions;
+  }
+}
+
+class Google_Service_Dfareporting_InventoryItem extends Google_Collection
+{
+  protected $collection_key = 'adSlots';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  protected $adSlotsType = 'Google_Service_Dfareporting_AdSlot';
+  protected $adSlotsDataType = 'array';
+  public $advertiserId;
+  public $contentCategoryId;
+  public $estimatedClickThroughRate;
+  public $estimatedConversionRate;
+  public $id;
+  public $inPlan;
+  public $kind;
+  protected $lastModifiedInfoType = 'Google_Service_Dfareporting_LastModifiedInfo';
+  protected $lastModifiedInfoDataType = '';
+  public $name;
+  public $negotiationChannelId;
+  public $orderId;
+  public $placementStrategyId;
+  protected $pricingType = 'Google_Service_Dfareporting_Pricing';
+  protected $pricingDataType = '';
+  public $projectId;
+  public $rfpId;
+  public $siteId;
+  public $subaccountId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAdSlots($adSlots)
+  {
+    $this->adSlots = $adSlots;
+  }
+  public function getAdSlots()
+  {
+    return $this->adSlots;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setContentCategoryId($contentCategoryId)
+  {
+    $this->contentCategoryId = $contentCategoryId;
+  }
+  public function getContentCategoryId()
+  {
+    return $this->contentCategoryId;
+  }
+  public function setEstimatedClickThroughRate($estimatedClickThroughRate)
+  {
+    $this->estimatedClickThroughRate = $estimatedClickThroughRate;
+  }
+  public function getEstimatedClickThroughRate()
+  {
+    return $this->estimatedClickThroughRate;
+  }
+  public function setEstimatedConversionRate($estimatedConversionRate)
+  {
+    $this->estimatedConversionRate = $estimatedConversionRate;
+  }
+  public function getEstimatedConversionRate()
+  {
+    return $this->estimatedConversionRate;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInPlan($inPlan)
+  {
+    $this->inPlan = $inPlan;
+  }
+  public function getInPlan()
+  {
+    return $this->inPlan;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastModifiedInfo(Google_Service_Dfareporting_LastModifiedInfo $lastModifiedInfo)
+  {
+    $this->lastModifiedInfo = $lastModifiedInfo;
+  }
+  public function getLastModifiedInfo()
+  {
+    return $this->lastModifiedInfo;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNegotiationChannelId($negotiationChannelId)
+  {
+    $this->negotiationChannelId = $negotiationChannelId;
+  }
+  public function getNegotiationChannelId()
+  {
+    return $this->negotiationChannelId;
+  }
+  public function setOrderId($orderId)
+  {
+    $this->orderId = $orderId;
+  }
+  public function getOrderId()
+  {
+    return $this->orderId;
+  }
+  public function setPlacementStrategyId($placementStrategyId)
+  {
+    $this->placementStrategyId = $placementStrategyId;
+  }
+  public function getPlacementStrategyId()
+  {
+    return $this->placementStrategyId;
+  }
+  public function setPricing(Google_Service_Dfareporting_Pricing $pricing)
+  {
+    $this->pricing = $pricing;
+  }
+  public function getPricing()
+  {
+    return $this->pricing;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setRfpId($rfpId)
+  {
+    $this->rfpId = $rfpId;
+  }
+  public function getRfpId()
+  {
+    return $this->rfpId;
+  }
+  public function setSiteId($siteId)
+  {
+    $this->siteId = $siteId;
+  }
+  public function getSiteId()
+  {
+    return $this->siteId;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+}
+
+class Google_Service_Dfareporting_InventoryItemsListResponse extends Google_Collection
+{
+  protected $collection_key = 'inventoryItems';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $inventoryItemsType = 'Google_Service_Dfareporting_InventoryItem';
+  protected $inventoryItemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setInventoryItems($inventoryItems)
+  {
+    $this->inventoryItems = $inventoryItems;
+  }
+  public function getInventoryItems()
+  {
+    return $this->inventoryItems;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_KeyValueTargetingExpression extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $expression;
+
+
+  public function setExpression($expression)
+  {
+    $this->expression = $expression;
+  }
+  public function getExpression()
+  {
+    return $this->expression;
+  }
+}
+
+class Google_Service_Dfareporting_LandingPage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $default;
+  public $id;
+  public $kind;
+  public $name;
+  public $url;
+
+
+  public function setDefault($default)
+  {
+    $this->default = $default;
+  }
+  public function getDefault()
+  {
+    return $this->default;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Dfareporting_LandingPagesListResponse extends Google_Collection
+{
+  protected $collection_key = 'landingPages';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $landingPagesType = 'Google_Service_Dfareporting_LandingPage';
+  protected $landingPagesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLandingPages($landingPages)
+  {
+    $this->landingPages = $landingPages;
+  }
+  public function getLandingPages()
+  {
+    return $this->landingPages;
+  }
+}
+
+class Google_Service_Dfareporting_LastModifiedInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $time;
+
+
+  public function setTime($time)
+  {
+    $this->time = $time;
+  }
+  public function getTime()
+  {
+    return $this->time;
+  }
+}
+
+class Google_Service_Dfareporting_ListPopulationClause extends Google_Collection
+{
+  protected $collection_key = 'terms';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $termsType = 'Google_Service_Dfareporting_ListPopulationTerm';
+  protected $termsDataType = 'array';
+
+
+  public function setTerms($terms)
+  {
+    $this->terms = $terms;
+  }
+  public function getTerms()
+  {
+    return $this->terms;
+  }
+}
+
+class Google_Service_Dfareporting_ListPopulationRule extends Google_Collection
+{
+  protected $collection_key = 'listPopulationClauses';
+  protected $internal_gapi_mappings = array(
+  );
+  public $floodlightActivityId;
+  public $floodlightActivityName;
+  protected $listPopulationClausesType = 'Google_Service_Dfareporting_ListPopulationClause';
+  protected $listPopulationClausesDataType = 'array';
+
+
+  public function setFloodlightActivityId($floodlightActivityId)
+  {
+    $this->floodlightActivityId = $floodlightActivityId;
+  }
+  public function getFloodlightActivityId()
+  {
+    return $this->floodlightActivityId;
+  }
+  public function setFloodlightActivityName($floodlightActivityName)
+  {
+    $this->floodlightActivityName = $floodlightActivityName;
+  }
+  public function getFloodlightActivityName()
+  {
+    return $this->floodlightActivityName;
+  }
+  public function setListPopulationClauses($listPopulationClauses)
+  {
+    $this->listPopulationClauses = $listPopulationClauses;
+  }
+  public function getListPopulationClauses()
+  {
+    return $this->listPopulationClauses;
+  }
+}
+
+class Google_Service_Dfareporting_ListPopulationTerm extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $contains;
+  public $negation;
+  public $operator;
+  public $remarketingListId;
+  public $type;
+  public $value;
+  public $variableFriendlyName;
+  public $variableName;
+
+
+  public function setContains($contains)
+  {
+    $this->contains = $contains;
+  }
+  public function getContains()
+  {
+    return $this->contains;
+  }
+  public function setNegation($negation)
+  {
+    $this->negation = $negation;
+  }
+  public function getNegation()
+  {
+    return $this->negation;
+  }
+  public function setOperator($operator)
+  {
+    $this->operator = $operator;
+  }
+  public function getOperator()
+  {
+    return $this->operator;
+  }
+  public function setRemarketingListId($remarketingListId)
+  {
+    $this->remarketingListId = $remarketingListId;
+  }
+  public function getRemarketingListId()
+  {
+    return $this->remarketingListId;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+  public function setVariableFriendlyName($variableFriendlyName)
+  {
+    $this->variableFriendlyName = $variableFriendlyName;
+  }
+  public function getVariableFriendlyName()
+  {
+    return $this->variableFriendlyName;
+  }
+  public function setVariableName($variableName)
+  {
+    $this->variableName = $variableName;
+  }
+  public function getVariableName()
+  {
+    return $this->variableName;
+  }
+}
+
+class Google_Service_Dfareporting_ListTargetingExpression extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $expression;
+
+
+  public function setExpression($expression)
+  {
+    $this->expression = $expression;
+  }
+  public function getExpression()
+  {
+    return $this->expression;
+  }
+}
+
+class Google_Service_Dfareporting_LookbackConfiguration extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $clickDuration;
+  public $postImpressionActivitiesDuration;
+
+
+  public function setClickDuration($clickDuration)
+  {
+    $this->clickDuration = $clickDuration;
+  }
+  public function getClickDuration()
+  {
+    return $this->clickDuration;
+  }
+  public function setPostImpressionActivitiesDuration($postImpressionActivitiesDuration)
+  {
+    $this->postImpressionActivitiesDuration = $postImpressionActivitiesDuration;
+  }
+  public function getPostImpressionActivitiesDuration()
+  {
+    return $this->postImpressionActivitiesDuration;
+  }
+}
+
+class Google_Service_Dfareporting_Metric extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $name;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Dfareporting_Metro extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $countryCode;
+  public $countryDartId;
+  public $dartId;
+  public $dmaId;
+  public $kind;
+  public $metroCode;
+  public $name;
+
+
+  public function setCountryCode($countryCode)
+  {
+    $this->countryCode = $countryCode;
+  }
+  public function getCountryCode()
+  {
+    return $this->countryCode;
+  }
+  public function setCountryDartId($countryDartId)
+  {
+    $this->countryDartId = $countryDartId;
+  }
+  public function getCountryDartId()
+  {
+    return $this->countryDartId;
+  }
+  public function setDartId($dartId)
+  {
+    $this->dartId = $dartId;
+  }
+  public function getDartId()
+  {
+    return $this->dartId;
+  }
+  public function setDmaId($dmaId)
+  {
+    $this->dmaId = $dmaId;
+  }
+  public function getDmaId()
+  {
+    return $this->dmaId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMetroCode($metroCode)
+  {
+    $this->metroCode = $metroCode;
+  }
+  public function getMetroCode()
+  {
+    return $this->metroCode;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Dfareporting_MetrosListResponse extends Google_Collection
+{
+  protected $collection_key = 'metros';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $metrosType = 'Google_Service_Dfareporting_Metro';
+  protected $metrosDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMetros($metros)
+  {
+    $this->metros = $metros;
+  }
+  public function getMetros()
+  {
+    return $this->metros;
+  }
+}
+
+class Google_Service_Dfareporting_MobileCarrier extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $countryCode;
+  public $countryDartId;
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setCountryCode($countryCode)
+  {
+    $this->countryCode = $countryCode;
+  }
+  public function getCountryCode()
+  {
+    return $this->countryCode;
+  }
+  public function setCountryDartId($countryDartId)
+  {
+    $this->countryDartId = $countryDartId;
+  }
+  public function getCountryDartId()
+  {
+    return $this->countryDartId;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Dfareporting_MobileCarriersListResponse extends Google_Collection
+{
+  protected $collection_key = 'mobileCarriers';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $mobileCarriersType = 'Google_Service_Dfareporting_MobileCarrier';
+  protected $mobileCarriersDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMobileCarriers($mobileCarriers)
+  {
+    $this->mobileCarriers = $mobileCarriers;
+  }
+  public function getMobileCarriers()
+  {
+    return $this->mobileCarriers;
+  }
+}
+
+class Google_Service_Dfareporting_ObjectFilter extends Google_Collection
+{
+  protected $collection_key = 'objectIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $objectIds;
+  public $status;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setObjectIds($objectIds)
+  {
+    $this->objectIds = $objectIds;
+  }
+  public function getObjectIds()
+  {
+    return $this->objectIds;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_Dfareporting_OffsetPosition extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $left;
+  public $top;
+
+
+  public function setLeft($left)
+  {
+    $this->left = $left;
+  }
+  public function getLeft()
+  {
+    return $this->left;
+  }
+  public function setTop($top)
+  {
+    $this->top = $top;
+  }
+  public function getTop()
+  {
+    return $this->top;
+  }
+}
+
+class Google_Service_Dfareporting_OmnitureSettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $omnitureCostDataEnabled;
+  public $omnitureIntegrationEnabled;
+
+
+  public function setOmnitureCostDataEnabled($omnitureCostDataEnabled)
+  {
+    $this->omnitureCostDataEnabled = $omnitureCostDataEnabled;
+  }
+  public function getOmnitureCostDataEnabled()
+  {
+    return $this->omnitureCostDataEnabled;
+  }
+  public function setOmnitureIntegrationEnabled($omnitureIntegrationEnabled)
+  {
+    $this->omnitureIntegrationEnabled = $omnitureIntegrationEnabled;
+  }
+  public function getOmnitureIntegrationEnabled()
+  {
+    return $this->omnitureIntegrationEnabled;
+  }
+}
+
+class Google_Service_Dfareporting_OperatingSystem extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $dartId;
+  public $desktop;
+  public $kind;
+  public $mobile;
+  public $name;
+
+
+  public function setDartId($dartId)
+  {
+    $this->dartId = $dartId;
+  }
+  public function getDartId()
+  {
+    return $this->dartId;
+  }
+  public function setDesktop($desktop)
+  {
+    $this->desktop = $desktop;
+  }
+  public function getDesktop()
+  {
+    return $this->desktop;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMobile($mobile)
+  {
+    $this->mobile = $mobile;
+  }
+  public function getMobile()
+  {
+    return $this->mobile;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Dfareporting_OperatingSystemVersion extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $majorVersion;
+  public $minorVersion;
+  public $name;
+  protected $operatingSystemType = 'Google_Service_Dfareporting_OperatingSystem';
+  protected $operatingSystemDataType = '';
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMajorVersion($majorVersion)
+  {
+    $this->majorVersion = $majorVersion;
+  }
+  public function getMajorVersion()
+  {
+    return $this->majorVersion;
+  }
+  public function setMinorVersion($minorVersion)
+  {
+    $this->minorVersion = $minorVersion;
+  }
+  public function getMinorVersion()
+  {
+    return $this->minorVersion;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOperatingSystem(Google_Service_Dfareporting_OperatingSystem $operatingSystem)
+  {
+    $this->operatingSystem = $operatingSystem;
+  }
+  public function getOperatingSystem()
+  {
+    return $this->operatingSystem;
+  }
+}
+
+class Google_Service_Dfareporting_OperatingSystemVersionsListResponse extends Google_Collection
+{
+  protected $collection_key = 'operatingSystemVersions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $operatingSystemVersionsType = 'Google_Service_Dfareporting_OperatingSystemVersion';
+  protected $operatingSystemVersionsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setOperatingSystemVersions($operatingSystemVersions)
+  {
+    $this->operatingSystemVersions = $operatingSystemVersions;
+  }
+  public function getOperatingSystemVersions()
+  {
+    return $this->operatingSystemVersions;
+  }
+}
+
+class Google_Service_Dfareporting_OperatingSystemsListResponse extends Google_Collection
+{
+  protected $collection_key = 'operatingSystems';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $operatingSystemsType = 'Google_Service_Dfareporting_OperatingSystem';
+  protected $operatingSystemsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setOperatingSystems($operatingSystems)
+  {
+    $this->operatingSystems = $operatingSystems;
+  }
+  public function getOperatingSystems()
+  {
+    return $this->operatingSystems;
+  }
+}
+
+class Google_Service_Dfareporting_OptimizationActivity extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $floodlightActivityId;
+  protected $floodlightActivityIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $floodlightActivityIdDimensionValueDataType = '';
+  public $weight;
+
+
+  public function setFloodlightActivityId($floodlightActivityId)
+  {
+    $this->floodlightActivityId = $floodlightActivityId;
+  }
+  public function getFloodlightActivityId()
+  {
+    return $this->floodlightActivityId;
+  }
+  public function setFloodlightActivityIdDimensionValue(Google_Service_Dfareporting_DimensionValue $floodlightActivityIdDimensionValue)
+  {
+    $this->floodlightActivityIdDimensionValue = $floodlightActivityIdDimensionValue;
+  }
+  public function getFloodlightActivityIdDimensionValue()
+  {
+    return $this->floodlightActivityIdDimensionValue;
+  }
+  public function setWeight($weight)
+  {
+    $this->weight = $weight;
+  }
+  public function getWeight()
+  {
+    return $this->weight;
+  }
+}
+
+class Google_Service_Dfareporting_Order extends Google_Collection
+{
+  protected $collection_key = 'siteNames';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $advertiserId;
+  public $approverUserProfileIds;
+  public $buyerInvoiceId;
+  public $buyerOrganizationName;
+  public $comments;
+  protected $contactsType = 'Google_Service_Dfareporting_OrderContact';
+  protected $contactsDataType = 'array';
+  public $id;
+  public $kind;
+  protected $lastModifiedInfoType = 'Google_Service_Dfareporting_LastModifiedInfo';
+  protected $lastModifiedInfoDataType = '';
+  public $name;
+  public $notes;
+  public $planningTermId;
+  public $projectId;
+  public $sellerOrderId;
+  public $sellerOrganizationName;
+  public $siteId;
+  public $siteNames;
+  public $subaccountId;
+  public $termsAndConditions;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setApproverUserProfileIds($approverUserProfileIds)
+  {
+    $this->approverUserProfileIds = $approverUserProfileIds;
+  }
+  public function getApproverUserProfileIds()
+  {
+    return $this->approverUserProfileIds;
+  }
+  public function setBuyerInvoiceId($buyerInvoiceId)
+  {
+    $this->buyerInvoiceId = $buyerInvoiceId;
+  }
+  public function getBuyerInvoiceId()
+  {
+    return $this->buyerInvoiceId;
+  }
+  public function setBuyerOrganizationName($buyerOrganizationName)
+  {
+    $this->buyerOrganizationName = $buyerOrganizationName;
+  }
+  public function getBuyerOrganizationName()
+  {
+    return $this->buyerOrganizationName;
+  }
+  public function setComments($comments)
+  {
+    $this->comments = $comments;
+  }
+  public function getComments()
+  {
+    return $this->comments;
+  }
+  public function setContacts($contacts)
+  {
+    $this->contacts = $contacts;
+  }
+  public function getContacts()
+  {
+    return $this->contacts;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastModifiedInfo(Google_Service_Dfareporting_LastModifiedInfo $lastModifiedInfo)
+  {
+    $this->lastModifiedInfo = $lastModifiedInfo;
+  }
+  public function getLastModifiedInfo()
+  {
+    return $this->lastModifiedInfo;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNotes($notes)
+  {
+    $this->notes = $notes;
+  }
+  public function getNotes()
+  {
+    return $this->notes;
+  }
+  public function setPlanningTermId($planningTermId)
+  {
+    $this->planningTermId = $planningTermId;
+  }
+  public function getPlanningTermId()
+  {
+    return $this->planningTermId;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setSellerOrderId($sellerOrderId)
+  {
+    $this->sellerOrderId = $sellerOrderId;
+  }
+  public function getSellerOrderId()
+  {
+    return $this->sellerOrderId;
+  }
+  public function setSellerOrganizationName($sellerOrganizationName)
+  {
+    $this->sellerOrganizationName = $sellerOrganizationName;
+  }
+  public function getSellerOrganizationName()
+  {
+    return $this->sellerOrganizationName;
+  }
+  public function setSiteId($siteId)
+  {
+    $this->siteId = $siteId;
+  }
+  public function getSiteId()
+  {
+    return $this->siteId;
+  }
+  public function setSiteNames($siteNames)
+  {
+    $this->siteNames = $siteNames;
+  }
+  public function getSiteNames()
+  {
+    return $this->siteNames;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+  public function setTermsAndConditions($termsAndConditions)
+  {
+    $this->termsAndConditions = $termsAndConditions;
+  }
+  public function getTermsAndConditions()
+  {
+    return $this->termsAndConditions;
+  }
+}
+
+class Google_Service_Dfareporting_OrderContact extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $contactInfo;
+  public $contactName;
+  public $contactTitle;
+  public $contactType;
+  public $signatureUserProfileId;
+
+
+  public function setContactInfo($contactInfo)
+  {
+    $this->contactInfo = $contactInfo;
+  }
+  public function getContactInfo()
+  {
+    return $this->contactInfo;
+  }
+  public function setContactName($contactName)
+  {
+    $this->contactName = $contactName;
+  }
+  public function getContactName()
+  {
+    return $this->contactName;
+  }
+  public function setContactTitle($contactTitle)
+  {
+    $this->contactTitle = $contactTitle;
+  }
+  public function getContactTitle()
+  {
+    return $this->contactTitle;
+  }
+  public function setContactType($contactType)
+  {
+    $this->contactType = $contactType;
+  }
+  public function getContactType()
+  {
+    return $this->contactType;
+  }
+  public function setSignatureUserProfileId($signatureUserProfileId)
+  {
+    $this->signatureUserProfileId = $signatureUserProfileId;
+  }
+  public function getSignatureUserProfileId()
+  {
+    return $this->signatureUserProfileId;
+  }
+}
+
+class Google_Service_Dfareporting_OrderDocument extends Google_Collection
+{
+  protected $collection_key = 'approvedByUserProfileIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $advertiserId;
+  public $amendedOrderDocumentId;
+  public $approvedByUserProfileIds;
+  public $cancelled;
+  protected $createdInfoType = 'Google_Service_Dfareporting_LastModifiedInfo';
+  protected $createdInfoDataType = '';
+  public $effectiveDate;
+  public $id;
+  public $kind;
+  public $orderId;
+  public $projectId;
+  public $signed;
+  public $subaccountId;
+  public $title;
+  public $type;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAmendedOrderDocumentId($amendedOrderDocumentId)
+  {
+    $this->amendedOrderDocumentId = $amendedOrderDocumentId;
+  }
+  public function getAmendedOrderDocumentId()
+  {
+    return $this->amendedOrderDocumentId;
+  }
+  public function setApprovedByUserProfileIds($approvedByUserProfileIds)
+  {
+    $this->approvedByUserProfileIds = $approvedByUserProfileIds;
+  }
+  public function getApprovedByUserProfileIds()
+  {
+    return $this->approvedByUserProfileIds;
+  }
+  public function setCancelled($cancelled)
+  {
+    $this->cancelled = $cancelled;
+  }
+  public function getCancelled()
+  {
+    return $this->cancelled;
+  }
+  public function setCreatedInfo(Google_Service_Dfareporting_LastModifiedInfo $createdInfo)
+  {
+    $this->createdInfo = $createdInfo;
+  }
+  public function getCreatedInfo()
+  {
+    return $this->createdInfo;
+  }
+  public function setEffectiveDate($effectiveDate)
+  {
+    $this->effectiveDate = $effectiveDate;
+  }
+  public function getEffectiveDate()
+  {
+    return $this->effectiveDate;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setOrderId($orderId)
+  {
+    $this->orderId = $orderId;
+  }
+  public function getOrderId()
+  {
+    return $this->orderId;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setSigned($signed)
+  {
+    $this->signed = $signed;
+  }
+  public function getSigned()
+  {
+    return $this->signed;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Dfareporting_OrderDocumentsListResponse extends Google_Collection
+{
+  protected $collection_key = 'orderDocuments';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $orderDocumentsType = 'Google_Service_Dfareporting_OrderDocument';
+  protected $orderDocumentsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setOrderDocuments($orderDocuments)
+  {
+    $this->orderDocuments = $orderDocuments;
+  }
+  public function getOrderDocuments()
+  {
+    return $this->orderDocuments;
+  }
+}
+
+class Google_Service_Dfareporting_OrdersListResponse extends Google_Collection
+{
+  protected $collection_key = 'orders';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $ordersType = 'Google_Service_Dfareporting_Order';
+  protected $ordersDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setOrders($orders)
+  {
+    $this->orders = $orders;
+  }
+  public function getOrders()
+  {
+    return $this->orders;
+  }
+}
+
+class Google_Service_Dfareporting_PathToConversionReportCompatibleFields extends Google_Collection
+{
+  protected $collection_key = 'perInteractionDimensions';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $conversionDimensionsType = 'Google_Service_Dfareporting_Dimension';
+  protected $conversionDimensionsDataType = 'array';
+  protected $customFloodlightVariablesType = 'Google_Service_Dfareporting_Dimension';
+  protected $customFloodlightVariablesDataType = 'array';
+  public $kind;
+  protected $metricsType = 'Google_Service_Dfareporting_Metric';
+  protected $metricsDataType = 'array';
+  protected $perInteractionDimensionsType = 'Google_Service_Dfareporting_Dimension';
+  protected $perInteractionDimensionsDataType = 'array';
+
+
+  public function setConversionDimensions($conversionDimensions)
+  {
+    $this->conversionDimensions = $conversionDimensions;
+  }
+  public function getConversionDimensions()
+  {
+    return $this->conversionDimensions;
+  }
+  public function setCustomFloodlightVariables($customFloodlightVariables)
+  {
+    $this->customFloodlightVariables = $customFloodlightVariables;
+  }
+  public function getCustomFloodlightVariables()
+  {
+    return $this->customFloodlightVariables;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMetrics($metrics)
+  {
+    $this->metrics = $metrics;
+  }
+  public function getMetrics()
+  {
+    return $this->metrics;
+  }
+  public function setPerInteractionDimensions($perInteractionDimensions)
+  {
+    $this->perInteractionDimensions = $perInteractionDimensions;
+  }
+  public function getPerInteractionDimensions()
+  {
+    return $this->perInteractionDimensions;
+  }
+}
+
+class Google_Service_Dfareporting_Placement extends Google_Collection
+{
+  protected $collection_key = 'tagFormats';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $advertiserId;
+  protected $advertiserIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $advertiserIdDimensionValueDataType = '';
+  public $archived;
+  public $campaignId;
+  protected $campaignIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $campaignIdDimensionValueDataType = '';
+  public $comment;
+  public $compatibility;
+  public $contentCategoryId;
+  protected $createInfoType = 'Google_Service_Dfareporting_LastModifiedInfo';
+  protected $createInfoDataType = '';
+  public $directorySiteId;
+  protected $directorySiteIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $directorySiteIdDimensionValueDataType = '';
+  public $externalId;
+  public $id;
+  protected $idDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $idDimensionValueDataType = '';
+  public $keyName;
+  public $kind;
+  protected $lastModifiedInfoType = 'Google_Service_Dfareporting_LastModifiedInfo';
+  protected $lastModifiedInfoDataType = '';
+  protected $lookbackConfigurationType = 'Google_Service_Dfareporting_LookbackConfiguration';
+  protected $lookbackConfigurationDataType = '';
+  public $name;
+  public $paymentApproved;
+  public $paymentSource;
+  public $placementGroupId;
+  protected $placementGroupIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $placementGroupIdDimensionValueDataType = '';
+  public $placementStrategyId;
+  protected $pricingScheduleType = 'Google_Service_Dfareporting_PricingSchedule';
+  protected $pricingScheduleDataType = '';
+  public $primary;
+  protected $publisherUpdateInfoType = 'Google_Service_Dfareporting_LastModifiedInfo';
+  protected $publisherUpdateInfoDataType = '';
+  public $siteId;
+  protected $siteIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $siteIdDimensionValueDataType = '';
+  protected $sizeType = 'Google_Service_Dfareporting_Size';
+  protected $sizeDataType = '';
+  public $sslRequired;
+  public $status;
+  public $subaccountId;
+  public $tagFormats;
+  protected $tagSettingType = 'Google_Service_Dfareporting_TagSetting';
+  protected $tagSettingDataType = '';
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAdvertiserIdDimensionValue(Google_Service_Dfareporting_DimensionValue $advertiserIdDimensionValue)
+  {
+    $this->advertiserIdDimensionValue = $advertiserIdDimensionValue;
+  }
+  public function getAdvertiserIdDimensionValue()
+  {
+    return $this->advertiserIdDimensionValue;
+  }
+  public function setArchived($archived)
+  {
+    $this->archived = $archived;
+  }
+  public function getArchived()
+  {
+    return $this->archived;
+  }
+  public function setCampaignId($campaignId)
+  {
+    $this->campaignId = $campaignId;
+  }
+  public function getCampaignId()
+  {
+    return $this->campaignId;
+  }
+  public function setCampaignIdDimensionValue(Google_Service_Dfareporting_DimensionValue $campaignIdDimensionValue)
+  {
+    $this->campaignIdDimensionValue = $campaignIdDimensionValue;
+  }
+  public function getCampaignIdDimensionValue()
+  {
+    return $this->campaignIdDimensionValue;
+  }
+  public function setComment($comment)
+  {
+    $this->comment = $comment;
+  }
+  public function getComment()
+  {
+    return $this->comment;
+  }
+  public function setCompatibility($compatibility)
+  {
+    $this->compatibility = $compatibility;
+  }
+  public function getCompatibility()
+  {
+    return $this->compatibility;
+  }
+  public function setContentCategoryId($contentCategoryId)
+  {
+    $this->contentCategoryId = $contentCategoryId;
+  }
+  public function getContentCategoryId()
+  {
+    return $this->contentCategoryId;
+  }
+  public function setCreateInfo(Google_Service_Dfareporting_LastModifiedInfo $createInfo)
+  {
+    $this->createInfo = $createInfo;
+  }
+  public function getCreateInfo()
+  {
+    return $this->createInfo;
+  }
+  public function setDirectorySiteId($directorySiteId)
+  {
+    $this->directorySiteId = $directorySiteId;
+  }
+  public function getDirectorySiteId()
+  {
+    return $this->directorySiteId;
+  }
+  public function setDirectorySiteIdDimensionValue(Google_Service_Dfareporting_DimensionValue $directorySiteIdDimensionValue)
+  {
+    $this->directorySiteIdDimensionValue = $directorySiteIdDimensionValue;
+  }
+  public function getDirectorySiteIdDimensionValue()
+  {
+    return $this->directorySiteIdDimensionValue;
+  }
+  public function setExternalId($externalId)
+  {
+    $this->externalId = $externalId;
+  }
+  public function getExternalId()
+  {
+    return $this->externalId;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIdDimensionValue(Google_Service_Dfareporting_DimensionValue $idDimensionValue)
+  {
+    $this->idDimensionValue = $idDimensionValue;
+  }
+  public function getIdDimensionValue()
+  {
+    return $this->idDimensionValue;
+  }
+  public function setKeyName($keyName)
+  {
+    $this->keyName = $keyName;
+  }
+  public function getKeyName()
+  {
+    return $this->keyName;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastModifiedInfo(Google_Service_Dfareporting_LastModifiedInfo $lastModifiedInfo)
+  {
+    $this->lastModifiedInfo = $lastModifiedInfo;
+  }
+  public function getLastModifiedInfo()
+  {
+    return $this->lastModifiedInfo;
+  }
+  public function setLookbackConfiguration(Google_Service_Dfareporting_LookbackConfiguration $lookbackConfiguration)
+  {
+    $this->lookbackConfiguration = $lookbackConfiguration;
+  }
+  public function getLookbackConfiguration()
+  {
+    return $this->lookbackConfiguration;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPaymentApproved($paymentApproved)
+  {
+    $this->paymentApproved = $paymentApproved;
+  }
+  public function getPaymentApproved()
+  {
+    return $this->paymentApproved;
+  }
+  public function setPaymentSource($paymentSource)
+  {
+    $this->paymentSource = $paymentSource;
+  }
+  public function getPaymentSource()
+  {
+    return $this->paymentSource;
+  }
+  public function setPlacementGroupId($placementGroupId)
+  {
+    $this->placementGroupId = $placementGroupId;
+  }
+  public function getPlacementGroupId()
+  {
+    return $this->placementGroupId;
+  }
+  public function setPlacementGroupIdDimensionValue(Google_Service_Dfareporting_DimensionValue $placementGroupIdDimensionValue)
+  {
+    $this->placementGroupIdDimensionValue = $placementGroupIdDimensionValue;
+  }
+  public function getPlacementGroupIdDimensionValue()
+  {
+    return $this->placementGroupIdDimensionValue;
+  }
+  public function setPlacementStrategyId($placementStrategyId)
+  {
+    $this->placementStrategyId = $placementStrategyId;
+  }
+  public function getPlacementStrategyId()
+  {
+    return $this->placementStrategyId;
+  }
+  public function setPricingSchedule(Google_Service_Dfareporting_PricingSchedule $pricingSchedule)
+  {
+    $this->pricingSchedule = $pricingSchedule;
+  }
+  public function getPricingSchedule()
+  {
+    return $this->pricingSchedule;
+  }
+  public function setPrimary($primary)
+  {
+    $this->primary = $primary;
+  }
+  public function getPrimary()
+  {
+    return $this->primary;
+  }
+  public function setPublisherUpdateInfo(Google_Service_Dfareporting_LastModifiedInfo $publisherUpdateInfo)
+  {
+    $this->publisherUpdateInfo = $publisherUpdateInfo;
+  }
+  public function getPublisherUpdateInfo()
+  {
+    return $this->publisherUpdateInfo;
+  }
+  public function setSiteId($siteId)
+  {
+    $this->siteId = $siteId;
+  }
+  public function getSiteId()
+  {
+    return $this->siteId;
+  }
+  public function setSiteIdDimensionValue(Google_Service_Dfareporting_DimensionValue $siteIdDimensionValue)
+  {
+    $this->siteIdDimensionValue = $siteIdDimensionValue;
+  }
+  public function getSiteIdDimensionValue()
+  {
+    return $this->siteIdDimensionValue;
+  }
+  public function setSize(Google_Service_Dfareporting_Size $size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+  public function setSslRequired($sslRequired)
+  {
+    $this->sslRequired = $sslRequired;
+  }
+  public function getSslRequired()
+  {
+    return $this->sslRequired;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+  public function setTagFormats($tagFormats)
+  {
+    $this->tagFormats = $tagFormats;
+  }
+  public function getTagFormats()
+  {
+    return $this->tagFormats;
+  }
+  public function setTagSetting(Google_Service_Dfareporting_TagSetting $tagSetting)
+  {
+    $this->tagSetting = $tagSetting;
+  }
+  public function getTagSetting()
+  {
+    return $this->tagSetting;
+  }
+}
+
+class Google_Service_Dfareporting_PlacementAssignment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $active;
+  public $placementId;
+  protected $placementIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $placementIdDimensionValueDataType = '';
+  public $sslRequired;
+
+
+  public function setActive($active)
+  {
+    $this->active = $active;
+  }
+  public function getActive()
+  {
+    return $this->active;
+  }
+  public function setPlacementId($placementId)
+  {
+    $this->placementId = $placementId;
+  }
+  public function getPlacementId()
+  {
+    return $this->placementId;
+  }
+  public function setPlacementIdDimensionValue(Google_Service_Dfareporting_DimensionValue $placementIdDimensionValue)
+  {
+    $this->placementIdDimensionValue = $placementIdDimensionValue;
+  }
+  public function getPlacementIdDimensionValue()
+  {
+    return $this->placementIdDimensionValue;
+  }
+  public function setSslRequired($sslRequired)
+  {
+    $this->sslRequired = $sslRequired;
+  }
+  public function getSslRequired()
+  {
+    return $this->sslRequired;
+  }
+}
+
+class Google_Service_Dfareporting_PlacementGroup extends Google_Collection
+{
+  protected $collection_key = 'childPlacementIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $advertiserId;
+  protected $advertiserIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $advertiserIdDimensionValueDataType = '';
+  public $archived;
+  public $campaignId;
+  protected $campaignIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $campaignIdDimensionValueDataType = '';
+  public $childPlacementIds;
+  public $comment;
+  public $contentCategoryId;
+  protected $createInfoType = 'Google_Service_Dfareporting_LastModifiedInfo';
+  protected $createInfoDataType = '';
+  public $directorySiteId;
+  protected $directorySiteIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $directorySiteIdDimensionValueDataType = '';
+  public $externalId;
+  public $id;
+  protected $idDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $idDimensionValueDataType = '';
+  public $kind;
+  protected $lastModifiedInfoType = 'Google_Service_Dfareporting_LastModifiedInfo';
+  protected $lastModifiedInfoDataType = '';
+  public $name;
+  public $placementGroupType;
+  public $placementStrategyId;
+  protected $pricingScheduleType = 'Google_Service_Dfareporting_PricingSchedule';
+  protected $pricingScheduleDataType = '';
+  public $primaryPlacementId;
+  protected $primaryPlacementIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $primaryPlacementIdDimensionValueDataType = '';
+  protected $programmaticSettingType = 'Google_Service_Dfareporting_ProgrammaticSetting';
+  protected $programmaticSettingDataType = '';
+  public $siteId;
+  protected $siteIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $siteIdDimensionValueDataType = '';
+  public $subaccountId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAdvertiserIdDimensionValue(Google_Service_Dfareporting_DimensionValue $advertiserIdDimensionValue)
+  {
+    $this->advertiserIdDimensionValue = $advertiserIdDimensionValue;
+  }
+  public function getAdvertiserIdDimensionValue()
+  {
+    return $this->advertiserIdDimensionValue;
+  }
+  public function setArchived($archived)
+  {
+    $this->archived = $archived;
+  }
+  public function getArchived()
+  {
+    return $this->archived;
+  }
+  public function setCampaignId($campaignId)
+  {
+    $this->campaignId = $campaignId;
+  }
+  public function getCampaignId()
+  {
+    return $this->campaignId;
+  }
+  public function setCampaignIdDimensionValue(Google_Service_Dfareporting_DimensionValue $campaignIdDimensionValue)
+  {
+    $this->campaignIdDimensionValue = $campaignIdDimensionValue;
+  }
+  public function getCampaignIdDimensionValue()
+  {
+    return $this->campaignIdDimensionValue;
+  }
+  public function setChildPlacementIds($childPlacementIds)
+  {
+    $this->childPlacementIds = $childPlacementIds;
+  }
+  public function getChildPlacementIds()
+  {
+    return $this->childPlacementIds;
+  }
+  public function setComment($comment)
+  {
+    $this->comment = $comment;
+  }
+  public function getComment()
+  {
+    return $this->comment;
+  }
+  public function setContentCategoryId($contentCategoryId)
+  {
+    $this->contentCategoryId = $contentCategoryId;
+  }
+  public function getContentCategoryId()
+  {
+    return $this->contentCategoryId;
+  }
+  public function setCreateInfo(Google_Service_Dfareporting_LastModifiedInfo $createInfo)
+  {
+    $this->createInfo = $createInfo;
+  }
+  public function getCreateInfo()
+  {
+    return $this->createInfo;
+  }
+  public function setDirectorySiteId($directorySiteId)
+  {
+    $this->directorySiteId = $directorySiteId;
+  }
+  public function getDirectorySiteId()
+  {
+    return $this->directorySiteId;
+  }
+  public function setDirectorySiteIdDimensionValue(Google_Service_Dfareporting_DimensionValue $directorySiteIdDimensionValue)
+  {
+    $this->directorySiteIdDimensionValue = $directorySiteIdDimensionValue;
+  }
+  public function getDirectorySiteIdDimensionValue()
+  {
+    return $this->directorySiteIdDimensionValue;
+  }
+  public function setExternalId($externalId)
+  {
+    $this->externalId = $externalId;
+  }
+  public function getExternalId()
+  {
+    return $this->externalId;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIdDimensionValue(Google_Service_Dfareporting_DimensionValue $idDimensionValue)
+  {
+    $this->idDimensionValue = $idDimensionValue;
+  }
+  public function getIdDimensionValue()
+  {
+    return $this->idDimensionValue;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastModifiedInfo(Google_Service_Dfareporting_LastModifiedInfo $lastModifiedInfo)
+  {
+    $this->lastModifiedInfo = $lastModifiedInfo;
+  }
+  public function getLastModifiedInfo()
+  {
+    return $this->lastModifiedInfo;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPlacementGroupType($placementGroupType)
+  {
+    $this->placementGroupType = $placementGroupType;
+  }
+  public function getPlacementGroupType()
+  {
+    return $this->placementGroupType;
+  }
+  public function setPlacementStrategyId($placementStrategyId)
+  {
+    $this->placementStrategyId = $placementStrategyId;
+  }
+  public function getPlacementStrategyId()
+  {
+    return $this->placementStrategyId;
+  }
+  public function setPricingSchedule(Google_Service_Dfareporting_PricingSchedule $pricingSchedule)
+  {
+    $this->pricingSchedule = $pricingSchedule;
+  }
+  public function getPricingSchedule()
+  {
+    return $this->pricingSchedule;
+  }
+  public function setPrimaryPlacementId($primaryPlacementId)
+  {
+    $this->primaryPlacementId = $primaryPlacementId;
+  }
+  public function getPrimaryPlacementId()
+  {
+    return $this->primaryPlacementId;
+  }
+  public function setPrimaryPlacementIdDimensionValue(Google_Service_Dfareporting_DimensionValue $primaryPlacementIdDimensionValue)
+  {
+    $this->primaryPlacementIdDimensionValue = $primaryPlacementIdDimensionValue;
+  }
+  public function getPrimaryPlacementIdDimensionValue()
+  {
+    return $this->primaryPlacementIdDimensionValue;
+  }
+  public function setProgrammaticSetting(Google_Service_Dfareporting_ProgrammaticSetting $programmaticSetting)
+  {
+    $this->programmaticSetting = $programmaticSetting;
+  }
+  public function getProgrammaticSetting()
+  {
+    return $this->programmaticSetting;
+  }
+  public function setSiteId($siteId)
+  {
+    $this->siteId = $siteId;
+  }
+  public function getSiteId()
+  {
+    return $this->siteId;
+  }
+  public function setSiteIdDimensionValue(Google_Service_Dfareporting_DimensionValue $siteIdDimensionValue)
+  {
+    $this->siteIdDimensionValue = $siteIdDimensionValue;
+  }
+  public function getSiteIdDimensionValue()
+  {
+    return $this->siteIdDimensionValue;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+}
+
+class Google_Service_Dfareporting_PlacementGroupsListResponse extends Google_Collection
+{
+  protected $collection_key = 'placementGroups';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $placementGroupsType = 'Google_Service_Dfareporting_PlacementGroup';
+  protected $placementGroupsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPlacementGroups($placementGroups)
+  {
+    $this->placementGroups = $placementGroups;
+  }
+  public function getPlacementGroups()
+  {
+    return $this->placementGroups;
+  }
+}
+
+class Google_Service_Dfareporting_PlacementStrategiesListResponse extends Google_Collection
+{
+  protected $collection_key = 'placementStrategies';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $placementStrategiesType = 'Google_Service_Dfareporting_PlacementStrategy';
+  protected $placementStrategiesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPlacementStrategies($placementStrategies)
+  {
+    $this->placementStrategies = $placementStrategies;
+  }
+  public function getPlacementStrategies()
+  {
+    return $this->placementStrategies;
+  }
+}
+
+class Google_Service_Dfareporting_PlacementStrategy extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Dfareporting_PlacementTag extends Google_Collection
+{
+  protected $collection_key = 'tagDatas';
+  protected $internal_gapi_mappings = array(
+  );
+  public $placementId;
+  protected $tagDatasType = 'Google_Service_Dfareporting_TagData';
+  protected $tagDatasDataType = 'array';
+
+
+  public function setPlacementId($placementId)
+  {
+    $this->placementId = $placementId;
+  }
+  public function getPlacementId()
+  {
+    return $this->placementId;
+  }
+  public function setTagDatas($tagDatas)
+  {
+    $this->tagDatas = $tagDatas;
+  }
+  public function getTagDatas()
+  {
+    return $this->tagDatas;
+  }
+}
+
+class Google_Service_Dfareporting_PlacementsGenerateTagsResponse extends Google_Collection
+{
+  protected $collection_key = 'placementTags';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $placementTagsType = 'Google_Service_Dfareporting_PlacementTag';
+  protected $placementTagsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPlacementTags($placementTags)
+  {
+    $this->placementTags = $placementTags;
+  }
+  public function getPlacementTags()
+  {
+    return $this->placementTags;
+  }
+}
+
+class Google_Service_Dfareporting_PlacementsListResponse extends Google_Collection
+{
+  protected $collection_key = 'placements';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $placementsType = 'Google_Service_Dfareporting_Placement';
+  protected $placementsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPlacements($placements)
+  {
+    $this->placements = $placements;
+  }
+  public function getPlacements()
+  {
+    return $this->placements;
+  }
+}
+
+class Google_Service_Dfareporting_PlatformType extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Dfareporting_PlatformTypesListResponse extends Google_Collection
+{
+  protected $collection_key = 'platformTypes';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $platformTypesType = 'Google_Service_Dfareporting_PlatformType';
+  protected $platformTypesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPlatformTypes($platformTypes)
+  {
+    $this->platformTypes = $platformTypes;
+  }
+  public function getPlatformTypes()
+  {
+    return $this->platformTypes;
+  }
+}
+
+class Google_Service_Dfareporting_PopupWindowProperties extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $dimensionType = 'Google_Service_Dfareporting_Size';
+  protected $dimensionDataType = '';
+  protected $offsetType = 'Google_Service_Dfareporting_OffsetPosition';
+  protected $offsetDataType = '';
+  public $positionType;
+  public $showAddressBar;
+  public $showMenuBar;
+  public $showScrollBar;
+  public $showStatusBar;
+  public $showToolBar;
+  public $title;
+
+
+  public function setDimension(Google_Service_Dfareporting_Size $dimension)
+  {
+    $this->dimension = $dimension;
+  }
+  public function getDimension()
+  {
+    return $this->dimension;
+  }
+  public function setOffset(Google_Service_Dfareporting_OffsetPosition $offset)
+  {
+    $this->offset = $offset;
+  }
+  public function getOffset()
+  {
+    return $this->offset;
+  }
+  public function setPositionType($positionType)
+  {
+    $this->positionType = $positionType;
+  }
+  public function getPositionType()
+  {
+    return $this->positionType;
+  }
+  public function setShowAddressBar($showAddressBar)
+  {
+    $this->showAddressBar = $showAddressBar;
+  }
+  public function getShowAddressBar()
+  {
+    return $this->showAddressBar;
+  }
+  public function setShowMenuBar($showMenuBar)
+  {
+    $this->showMenuBar = $showMenuBar;
+  }
+  public function getShowMenuBar()
+  {
+    return $this->showMenuBar;
+  }
+  public function setShowScrollBar($showScrollBar)
+  {
+    $this->showScrollBar = $showScrollBar;
+  }
+  public function getShowScrollBar()
+  {
+    return $this->showScrollBar;
+  }
+  public function setShowStatusBar($showStatusBar)
+  {
+    $this->showStatusBar = $showStatusBar;
+  }
+  public function getShowStatusBar()
+  {
+    return $this->showStatusBar;
+  }
+  public function setShowToolBar($showToolBar)
+  {
+    $this->showToolBar = $showToolBar;
+  }
+  public function getShowToolBar()
+  {
+    return $this->showToolBar;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_Dfareporting_PostalCode extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $countryCode;
+  public $countryDartId;
+  public $id;
+  public $kind;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setCountryCode($countryCode)
+  {
+    $this->countryCode = $countryCode;
+  }
+  public function getCountryCode()
+  {
+    return $this->countryCode;
+  }
+  public function setCountryDartId($countryDartId)
+  {
+    $this->countryDartId = $countryDartId;
+  }
+  public function getCountryDartId()
+  {
+    return $this->countryDartId;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Dfareporting_PostalCodesListResponse extends Google_Collection
+{
+  protected $collection_key = 'postalCodes';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $postalCodesType = 'Google_Service_Dfareporting_PostalCode';
+  protected $postalCodesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPostalCodes($postalCodes)
+  {
+    $this->postalCodes = $postalCodes;
+  }
+  public function getPostalCodes()
+  {
+    return $this->postalCodes;
+  }
+}
+
+class Google_Service_Dfareporting_Pricing extends Google_Collection
+{
+  protected $collection_key = 'flights';
+  protected $internal_gapi_mappings = array(
+  );
+  public $capCostType;
+  public $endDate;
+  protected $flightsType = 'Google_Service_Dfareporting_Flight';
+  protected $flightsDataType = 'array';
+  public $groupType;
+  public $pricingType;
+  public $startDate;
+
+
+  public function setCapCostType($capCostType)
+  {
+    $this->capCostType = $capCostType;
+  }
+  public function getCapCostType()
+  {
+    return $this->capCostType;
+  }
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setFlights($flights)
+  {
+    $this->flights = $flights;
+  }
+  public function getFlights()
+  {
+    return $this->flights;
+  }
+  public function setGroupType($groupType)
+  {
+    $this->groupType = $groupType;
+  }
+  public function getGroupType()
+  {
+    return $this->groupType;
+  }
+  public function setPricingType($pricingType)
+  {
+    $this->pricingType = $pricingType;
+  }
+  public function getPricingType()
+  {
+    return $this->pricingType;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+}
+
+class Google_Service_Dfareporting_PricingSchedule extends Google_Collection
+{
+  protected $collection_key = 'pricingPeriods';
+  protected $internal_gapi_mappings = array(
+  );
+  public $capCostOption;
+  public $disregardOverdelivery;
+  public $endDate;
+  public $flighted;
+  public $floodlightActivityId;
+  protected $pricingPeriodsType = 'Google_Service_Dfareporting_PricingSchedulePricingPeriod';
+  protected $pricingPeriodsDataType = 'array';
+  public $pricingType;
+  public $startDate;
+  public $testingStartDate;
+
+
+  public function setCapCostOption($capCostOption)
+  {
+    $this->capCostOption = $capCostOption;
+  }
+  public function getCapCostOption()
+  {
+    return $this->capCostOption;
+  }
+  public function setDisregardOverdelivery($disregardOverdelivery)
+  {
+    $this->disregardOverdelivery = $disregardOverdelivery;
+  }
+  public function getDisregardOverdelivery()
+  {
+    return $this->disregardOverdelivery;
+  }
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setFlighted($flighted)
+  {
+    $this->flighted = $flighted;
+  }
+  public function getFlighted()
+  {
+    return $this->flighted;
+  }
+  public function setFloodlightActivityId($floodlightActivityId)
+  {
+    $this->floodlightActivityId = $floodlightActivityId;
+  }
+  public function getFloodlightActivityId()
+  {
+    return $this->floodlightActivityId;
+  }
+  public function setPricingPeriods($pricingPeriods)
+  {
+    $this->pricingPeriods = $pricingPeriods;
+  }
+  public function getPricingPeriods()
+  {
+    return $this->pricingPeriods;
+  }
+  public function setPricingType($pricingType)
+  {
+    $this->pricingType = $pricingType;
+  }
+  public function getPricingType()
+  {
+    return $this->pricingType;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+  public function setTestingStartDate($testingStartDate)
+  {
+    $this->testingStartDate = $testingStartDate;
+  }
+  public function getTestingStartDate()
+  {
+    return $this->testingStartDate;
+  }
+}
+
+class Google_Service_Dfareporting_PricingSchedulePricingPeriod extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $endDate;
+  public $pricingComment;
+  public $rateOrCostNanos;
+  public $startDate;
+  public $units;
+
+
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setPricingComment($pricingComment)
+  {
+    $this->pricingComment = $pricingComment;
+  }
+  public function getPricingComment()
+  {
+    return $this->pricingComment;
+  }
+  public function setRateOrCostNanos($rateOrCostNanos)
+  {
+    $this->rateOrCostNanos = $rateOrCostNanos;
+  }
+  public function getRateOrCostNanos()
+  {
+    return $this->rateOrCostNanos;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+  public function setUnits($units)
+  {
+    $this->units = $units;
+  }
+  public function getUnits()
+  {
+    return $this->units;
+  }
+}
+
+class Google_Service_Dfareporting_ProgrammaticSetting extends Google_Collection
+{
+  protected $collection_key = 'traffickerEmails';
+  protected $internal_gapi_mappings = array(
+  );
+  public $adxDealIds;
+  public $insertionOrderId;
+  public $insertionOrderIdStatus;
+  public $mediaCostNanos;
+  public $programmatic;
+  public $traffickerEmails;
+
+
+  public function setAdxDealIds($adxDealIds)
+  {
+    $this->adxDealIds = $adxDealIds;
+  }
+  public function getAdxDealIds()
+  {
+    return $this->adxDealIds;
+  }
+  public function setInsertionOrderId($insertionOrderId)
+  {
+    $this->insertionOrderId = $insertionOrderId;
+  }
+  public function getInsertionOrderId()
+  {
+    return $this->insertionOrderId;
+  }
+  public function setInsertionOrderIdStatus($insertionOrderIdStatus)
+  {
+    $this->insertionOrderIdStatus = $insertionOrderIdStatus;
+  }
+  public function getInsertionOrderIdStatus()
+  {
+    return $this->insertionOrderIdStatus;
+  }
+  public function setMediaCostNanos($mediaCostNanos)
+  {
+    $this->mediaCostNanos = $mediaCostNanos;
+  }
+  public function getMediaCostNanos()
+  {
+    return $this->mediaCostNanos;
+  }
+  public function setProgrammatic($programmatic)
+  {
+    $this->programmatic = $programmatic;
+  }
+  public function getProgrammatic()
+  {
+    return $this->programmatic;
+  }
+  public function setTraffickerEmails($traffickerEmails)
+  {
+    $this->traffickerEmails = $traffickerEmails;
+  }
+  public function getTraffickerEmails()
+  {
+    return $this->traffickerEmails;
+  }
+}
+
+class Google_Service_Dfareporting_Project extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $advertiserId;
+  public $audienceAgeGroup;
+  public $audienceGender;
+  public $budget;
+  public $clientBillingCode;
+  public $clientName;
+  public $endDate;
+  public $id;
+  public $kind;
+  protected $lastModifiedInfoType = 'Google_Service_Dfareporting_LastModifiedInfo';
+  protected $lastModifiedInfoDataType = '';
+  public $name;
+  public $overview;
+  public $startDate;
+  public $subaccountId;
+  public $targetClicks;
+  public $targetConversions;
+  public $targetCpaNanos;
+  public $targetCpcNanos;
+  public $targetCpmNanos;
+  public $targetImpressions;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAudienceAgeGroup($audienceAgeGroup)
+  {
+    $this->audienceAgeGroup = $audienceAgeGroup;
+  }
+  public function getAudienceAgeGroup()
+  {
+    return $this->audienceAgeGroup;
+  }
+  public function setAudienceGender($audienceGender)
+  {
+    $this->audienceGender = $audienceGender;
+  }
+  public function getAudienceGender()
+  {
+    return $this->audienceGender;
+  }
+  public function setBudget($budget)
+  {
+    $this->budget = $budget;
+  }
+  public function getBudget()
+  {
+    return $this->budget;
+  }
+  public function setClientBillingCode($clientBillingCode)
+  {
+    $this->clientBillingCode = $clientBillingCode;
+  }
+  public function getClientBillingCode()
+  {
+    return $this->clientBillingCode;
+  }
+  public function setClientName($clientName)
+  {
+    $this->clientName = $clientName;
+  }
+  public function getClientName()
+  {
+    return $this->clientName;
+  }
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastModifiedInfo(Google_Service_Dfareporting_LastModifiedInfo $lastModifiedInfo)
+  {
+    $this->lastModifiedInfo = $lastModifiedInfo;
+  }
+  public function getLastModifiedInfo()
+  {
+    return $this->lastModifiedInfo;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOverview($overview)
+  {
+    $this->overview = $overview;
+  }
+  public function getOverview()
+  {
+    return $this->overview;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+  public function setTargetClicks($targetClicks)
+  {
+    $this->targetClicks = $targetClicks;
+  }
+  public function getTargetClicks()
+  {
+    return $this->targetClicks;
+  }
+  public function setTargetConversions($targetConversions)
+  {
+    $this->targetConversions = $targetConversions;
+  }
+  public function getTargetConversions()
+  {
+    return $this->targetConversions;
+  }
+  public function setTargetCpaNanos($targetCpaNanos)
+  {
+    $this->targetCpaNanos = $targetCpaNanos;
+  }
+  public function getTargetCpaNanos()
+  {
+    return $this->targetCpaNanos;
+  }
+  public function setTargetCpcNanos($targetCpcNanos)
+  {
+    $this->targetCpcNanos = $targetCpcNanos;
+  }
+  public function getTargetCpcNanos()
+  {
+    return $this->targetCpcNanos;
+  }
+  public function setTargetCpmNanos($targetCpmNanos)
+  {
+    $this->targetCpmNanos = $targetCpmNanos;
+  }
+  public function getTargetCpmNanos()
+  {
+    return $this->targetCpmNanos;
+  }
+  public function setTargetImpressions($targetImpressions)
+  {
+    $this->targetImpressions = $targetImpressions;
+  }
+  public function getTargetImpressions()
+  {
+    return $this->targetImpressions;
+  }
+}
+
+class Google_Service_Dfareporting_ProjectsListResponse extends Google_Collection
+{
+  protected $collection_key = 'projects';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $projectsType = 'Google_Service_Dfareporting_Project';
+  protected $projectsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setProjects($projects)
+  {
+    $this->projects = $projects;
+  }
+  public function getProjects()
+  {
+    return $this->projects;
+  }
+}
+
+class Google_Service_Dfareporting_ReachReportCompatibleFields extends Google_Collection
+{
+  protected $collection_key = 'reachByFrequencyMetrics';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $dimensionFiltersType = 'Google_Service_Dfareporting_Dimension';
+  protected $dimensionFiltersDataType = 'array';
+  protected $dimensionsType = 'Google_Service_Dfareporting_Dimension';
+  protected $dimensionsDataType = 'array';
+  public $kind;
+  protected $metricsType = 'Google_Service_Dfareporting_Metric';
+  protected $metricsDataType = 'array';
+  protected $pivotedActivityMetricsType = 'Google_Service_Dfareporting_Metric';
+  protected $pivotedActivityMetricsDataType = 'array';
+  protected $reachByFrequencyMetricsType = 'Google_Service_Dfareporting_Metric';
+  protected $reachByFrequencyMetricsDataType = 'array';
+
+
+  public function setDimensionFilters($dimensionFilters)
+  {
+    $this->dimensionFilters = $dimensionFilters;
+  }
+  public function getDimensionFilters()
+  {
+    return $this->dimensionFilters;
+  }
+  public function setDimensions($dimensions)
+  {
+    $this->dimensions = $dimensions;
+  }
+  public function getDimensions()
+  {
+    return $this->dimensions;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMetrics($metrics)
+  {
+    $this->metrics = $metrics;
+  }
+  public function getMetrics()
+  {
+    return $this->metrics;
+  }
+  public function setPivotedActivityMetrics($pivotedActivityMetrics)
+  {
+    $this->pivotedActivityMetrics = $pivotedActivityMetrics;
+  }
+  public function getPivotedActivityMetrics()
+  {
+    return $this->pivotedActivityMetrics;
+  }
+  public function setReachByFrequencyMetrics($reachByFrequencyMetrics)
+  {
+    $this->reachByFrequencyMetrics = $reachByFrequencyMetrics;
+  }
+  public function getReachByFrequencyMetrics()
+  {
+    return $this->reachByFrequencyMetrics;
+  }
+}
+
+class Google_Service_Dfareporting_Recipient extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $deliveryType;
+  public $email;
+  public $kind;
+
+
+  public function setDeliveryType($deliveryType)
+  {
+    $this->deliveryType = $deliveryType;
+  }
+  public function getDeliveryType()
+  {
+    return $this->deliveryType;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Dfareporting_Region extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $countryCode;
+  public $countryDartId;
+  public $dartId;
+  public $kind;
+  public $name;
+  public $regionCode;
+
+
+  public function setCountryCode($countryCode)
+  {
+    $this->countryCode = $countryCode;
+  }
+  public function getCountryCode()
+  {
+    return $this->countryCode;
+  }
+  public function setCountryDartId($countryDartId)
+  {
+    $this->countryDartId = $countryDartId;
+  }
+  public function getCountryDartId()
+  {
+    return $this->countryDartId;
+  }
+  public function setDartId($dartId)
+  {
+    $this->dartId = $dartId;
+  }
+  public function getDartId()
+  {
+    return $this->dartId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setRegionCode($regionCode)
+  {
+    $this->regionCode = $regionCode;
+  }
+  public function getRegionCode()
+  {
+    return $this->regionCode;
+  }
+}
+
+class Google_Service_Dfareporting_RegionsListResponse extends Google_Collection
+{
+  protected $collection_key = 'regions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $regionsType = 'Google_Service_Dfareporting_Region';
+  protected $regionsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRegions($regions)
+  {
+    $this->regions = $regions;
+  }
+  public function getRegions()
+  {
+    return $this->regions;
+  }
+}
+
+class Google_Service_Dfareporting_RemarketingList extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $active;
+  public $advertiserId;
+  protected $advertiserIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $advertiserIdDimensionValueDataType = '';
+  public $description;
+  public $id;
+  public $kind;
+  public $lifeSpan;
+  protected $listPopulationRuleType = 'Google_Service_Dfareporting_ListPopulationRule';
+  protected $listPopulationRuleDataType = '';
+  public $listSize;
+  public $listSource;
+  public $name;
+  public $subaccountId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setActive($active)
+  {
+    $this->active = $active;
+  }
+  public function getActive()
+  {
+    return $this->active;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAdvertiserIdDimensionValue(Google_Service_Dfareporting_DimensionValue $advertiserIdDimensionValue)
+  {
+    $this->advertiserIdDimensionValue = $advertiserIdDimensionValue;
+  }
+  public function getAdvertiserIdDimensionValue()
+  {
+    return $this->advertiserIdDimensionValue;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLifeSpan($lifeSpan)
+  {
+    $this->lifeSpan = $lifeSpan;
+  }
+  public function getLifeSpan()
+  {
+    return $this->lifeSpan;
+  }
+  public function setListPopulationRule(Google_Service_Dfareporting_ListPopulationRule $listPopulationRule)
+  {
+    $this->listPopulationRule = $listPopulationRule;
+  }
+  public function getListPopulationRule()
+  {
+    return $this->listPopulationRule;
+  }
+  public function setListSize($listSize)
+  {
+    $this->listSize = $listSize;
+  }
+  public function getListSize()
+  {
+    return $this->listSize;
+  }
+  public function setListSource($listSource)
+  {
+    $this->listSource = $listSource;
+  }
+  public function getListSource()
+  {
+    return $this->listSource;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+}
+
+class Google_Service_Dfareporting_RemarketingListShare extends Google_Collection
+{
+  protected $collection_key = 'sharedAdvertiserIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $remarketingListId;
+  public $sharedAccountIds;
+  public $sharedAdvertiserIds;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRemarketingListId($remarketingListId)
+  {
+    $this->remarketingListId = $remarketingListId;
+  }
+  public function getRemarketingListId()
+  {
+    return $this->remarketingListId;
+  }
+  public function setSharedAccountIds($sharedAccountIds)
+  {
+    $this->sharedAccountIds = $sharedAccountIds;
+  }
+  public function getSharedAccountIds()
+  {
+    return $this->sharedAccountIds;
+  }
+  public function setSharedAdvertiserIds($sharedAdvertiserIds)
+  {
+    $this->sharedAdvertiserIds = $sharedAdvertiserIds;
+  }
+  public function getSharedAdvertiserIds()
+  {
+    return $this->sharedAdvertiserIds;
+  }
+}
+
+class Google_Service_Dfareporting_RemarketingListsListResponse extends Google_Collection
+{
+  protected $collection_key = 'remarketingLists';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $remarketingListsType = 'Google_Service_Dfareporting_RemarketingList';
+  protected $remarketingListsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setRemarketingLists($remarketingLists)
+  {
+    $this->remarketingLists = $remarketingLists;
+  }
+  public function getRemarketingLists()
+  {
+    return $this->remarketingLists;
+  }
+}
+
+class Google_Service_Dfareporting_Report extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  protected $criteriaType = 'Google_Service_Dfareporting_ReportCriteria';
+  protected $criteriaDataType = '';
+  protected $crossDimensionReachCriteriaType = 'Google_Service_Dfareporting_ReportCrossDimensionReachCriteria';
+  protected $crossDimensionReachCriteriaDataType = '';
+  protected $deliveryType = 'Google_Service_Dfareporting_ReportDelivery';
+  protected $deliveryDataType = '';
+  public $etag;
+  public $fileName;
+  protected $floodlightCriteriaType = 'Google_Service_Dfareporting_ReportFloodlightCriteria';
+  protected $floodlightCriteriaDataType = '';
+  public $format;
+  public $id;
+  public $kind;
+  public $lastModifiedTime;
+  public $name;
+  public $ownerProfileId;
+  protected $pathToConversionCriteriaType = 'Google_Service_Dfareporting_ReportPathToConversionCriteria';
+  protected $pathToConversionCriteriaDataType = '';
+  protected $reachCriteriaType = 'Google_Service_Dfareporting_ReportReachCriteria';
+  protected $reachCriteriaDataType = '';
+  protected $scheduleType = 'Google_Service_Dfareporting_ReportSchedule';
+  protected $scheduleDataType = '';
+  public $subAccountId;
+  public $type;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setCriteria(Google_Service_Dfareporting_ReportCriteria $criteria)
+  {
+    $this->criteria = $criteria;
+  }
+  public function getCriteria()
+  {
+    return $this->criteria;
+  }
+  public function setCrossDimensionReachCriteria(Google_Service_Dfareporting_ReportCrossDimensionReachCriteria $crossDimensionReachCriteria)
+  {
+    $this->crossDimensionReachCriteria = $crossDimensionReachCriteria;
+  }
+  public function getCrossDimensionReachCriteria()
+  {
+    return $this->crossDimensionReachCriteria;
+  }
+  public function setDelivery(Google_Service_Dfareporting_ReportDelivery $delivery)
+  {
+    $this->delivery = $delivery;
+  }
+  public function getDelivery()
+  {
+    return $this->delivery;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setFileName($fileName)
+  {
+    $this->fileName = $fileName;
+  }
+  public function getFileName()
+  {
+    return $this->fileName;
+  }
+  public function setFloodlightCriteria(Google_Service_Dfareporting_ReportFloodlightCriteria $floodlightCriteria)
+  {
+    $this->floodlightCriteria = $floodlightCriteria;
+  }
+  public function getFloodlightCriteria()
+  {
+    return $this->floodlightCriteria;
+  }
+  public function setFormat($format)
+  {
+    $this->format = $format;
+  }
+  public function getFormat()
+  {
+    return $this->format;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastModifiedTime($lastModifiedTime)
+  {
+    $this->lastModifiedTime = $lastModifiedTime;
+  }
+  public function getLastModifiedTime()
+  {
+    return $this->lastModifiedTime;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOwnerProfileId($ownerProfileId)
+  {
+    $this->ownerProfileId = $ownerProfileId;
+  }
+  public function getOwnerProfileId()
+  {
+    return $this->ownerProfileId;
+  }
+  public function setPathToConversionCriteria(Google_Service_Dfareporting_ReportPathToConversionCriteria $pathToConversionCriteria)
+  {
+    $this->pathToConversionCriteria = $pathToConversionCriteria;
+  }
+  public function getPathToConversionCriteria()
+  {
+    return $this->pathToConversionCriteria;
+  }
+  public function setReachCriteria(Google_Service_Dfareporting_ReportReachCriteria $reachCriteria)
+  {
+    $this->reachCriteria = $reachCriteria;
+  }
+  public function getReachCriteria()
+  {
+    return $this->reachCriteria;
+  }
+  public function setSchedule(Google_Service_Dfareporting_ReportSchedule $schedule)
+  {
+    $this->schedule = $schedule;
+  }
+  public function getSchedule()
+  {
+    return $this->schedule;
+  }
+  public function setSubAccountId($subAccountId)
+  {
+    $this->subAccountId = $subAccountId;
+  }
+  public function getSubAccountId()
+  {
+    return $this->subAccountId;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Dfareporting_ReportCompatibleFields extends Google_Collection
+{
+  protected $collection_key = 'pivotedActivityMetrics';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $dimensionFiltersType = 'Google_Service_Dfareporting_Dimension';
+  protected $dimensionFiltersDataType = 'array';
+  protected $dimensionsType = 'Google_Service_Dfareporting_Dimension';
+  protected $dimensionsDataType = 'array';
+  public $kind;
+  protected $metricsType = 'Google_Service_Dfareporting_Metric';
+  protected $metricsDataType = 'array';
+  protected $pivotedActivityMetricsType = 'Google_Service_Dfareporting_Metric';
+  protected $pivotedActivityMetricsDataType = 'array';
+
+
+  public function setDimensionFilters($dimensionFilters)
+  {
+    $this->dimensionFilters = $dimensionFilters;
+  }
+  public function getDimensionFilters()
+  {
+    return $this->dimensionFilters;
+  }
+  public function setDimensions($dimensions)
+  {
+    $this->dimensions = $dimensions;
+  }
+  public function getDimensions()
+  {
+    return $this->dimensions;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMetrics($metrics)
+  {
+    $this->metrics = $metrics;
+  }
+  public function getMetrics()
+  {
+    return $this->metrics;
+  }
+  public function setPivotedActivityMetrics($pivotedActivityMetrics)
+  {
+    $this->pivotedActivityMetrics = $pivotedActivityMetrics;
+  }
+  public function getPivotedActivityMetrics()
+  {
+    return $this->pivotedActivityMetrics;
+  }
+}
+
+class Google_Service_Dfareporting_ReportCriteria extends Google_Collection
+{
+  protected $collection_key = 'metricNames';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $activitiesType = 'Google_Service_Dfareporting_Activities';
+  protected $activitiesDataType = '';
+  protected $customRichMediaEventsType = 'Google_Service_Dfareporting_CustomRichMediaEvents';
+  protected $customRichMediaEventsDataType = '';
+  protected $dateRangeType = 'Google_Service_Dfareporting_DateRange';
+  protected $dateRangeDataType = '';
+  protected $dimensionFiltersType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $dimensionFiltersDataType = 'array';
+  protected $dimensionsType = 'Google_Service_Dfareporting_SortedDimension';
+  protected $dimensionsDataType = 'array';
+  public $metricNames;
+
+
+  public function setActivities(Google_Service_Dfareporting_Activities $activities)
+  {
+    $this->activities = $activities;
+  }
+  public function getActivities()
+  {
+    return $this->activities;
+  }
+  public function setCustomRichMediaEvents(Google_Service_Dfareporting_CustomRichMediaEvents $customRichMediaEvents)
+  {
+    $this->customRichMediaEvents = $customRichMediaEvents;
+  }
+  public function getCustomRichMediaEvents()
+  {
+    return $this->customRichMediaEvents;
+  }
+  public function setDateRange(Google_Service_Dfareporting_DateRange $dateRange)
+  {
+    $this->dateRange = $dateRange;
+  }
+  public function getDateRange()
+  {
+    return $this->dateRange;
+  }
+  public function setDimensionFilters($dimensionFilters)
+  {
+    $this->dimensionFilters = $dimensionFilters;
+  }
+  public function getDimensionFilters()
+  {
+    return $this->dimensionFilters;
+  }
+  public function setDimensions($dimensions)
+  {
+    $this->dimensions = $dimensions;
+  }
+  public function getDimensions()
+  {
+    return $this->dimensions;
+  }
+  public function setMetricNames($metricNames)
+  {
+    $this->metricNames = $metricNames;
+  }
+  public function getMetricNames()
+  {
+    return $this->metricNames;
+  }
+}
+
+class Google_Service_Dfareporting_ReportCrossDimensionReachCriteria extends Google_Collection
+{
+  protected $collection_key = 'overlapMetricNames';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $breakdownType = 'Google_Service_Dfareporting_SortedDimension';
+  protected $breakdownDataType = 'array';
+  protected $dateRangeType = 'Google_Service_Dfareporting_DateRange';
+  protected $dateRangeDataType = '';
+  public $dimension;
+  protected $dimensionFiltersType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $dimensionFiltersDataType = 'array';
+  public $metricNames;
+  public $overlapMetricNames;
+  public $pivoted;
+
+
+  public function setBreakdown($breakdown)
+  {
+    $this->breakdown = $breakdown;
+  }
+  public function getBreakdown()
+  {
+    return $this->breakdown;
+  }
+  public function setDateRange(Google_Service_Dfareporting_DateRange $dateRange)
+  {
+    $this->dateRange = $dateRange;
+  }
+  public function getDateRange()
+  {
+    return $this->dateRange;
+  }
+  public function setDimension($dimension)
+  {
+    $this->dimension = $dimension;
+  }
+  public function getDimension()
+  {
+    return $this->dimension;
+  }
+  public function setDimensionFilters($dimensionFilters)
+  {
+    $this->dimensionFilters = $dimensionFilters;
+  }
+  public function getDimensionFilters()
+  {
+    return $this->dimensionFilters;
+  }
+  public function setMetricNames($metricNames)
+  {
+    $this->metricNames = $metricNames;
+  }
+  public function getMetricNames()
+  {
+    return $this->metricNames;
+  }
+  public function setOverlapMetricNames($overlapMetricNames)
+  {
+    $this->overlapMetricNames = $overlapMetricNames;
+  }
+  public function getOverlapMetricNames()
+  {
+    return $this->overlapMetricNames;
+  }
+  public function setPivoted($pivoted)
+  {
+    $this->pivoted = $pivoted;
+  }
+  public function getPivoted()
+  {
+    return $this->pivoted;
+  }
+}
+
+class Google_Service_Dfareporting_ReportDelivery extends Google_Collection
+{
+  protected $collection_key = 'recipients';
+  protected $internal_gapi_mappings = array(
+  );
+  public $emailOwner;
+  public $emailOwnerDeliveryType;
+  public $message;
+  protected $recipientsType = 'Google_Service_Dfareporting_Recipient';
+  protected $recipientsDataType = 'array';
+
+
+  public function setEmailOwner($emailOwner)
+  {
+    $this->emailOwner = $emailOwner;
+  }
+  public function getEmailOwner()
+  {
+    return $this->emailOwner;
+  }
+  public function setEmailOwnerDeliveryType($emailOwnerDeliveryType)
+  {
+    $this->emailOwnerDeliveryType = $emailOwnerDeliveryType;
+  }
+  public function getEmailOwnerDeliveryType()
+  {
+    return $this->emailOwnerDeliveryType;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+  public function setRecipients($recipients)
+  {
+    $this->recipients = $recipients;
+  }
+  public function getRecipients()
+  {
+    return $this->recipients;
+  }
+}
+
+class Google_Service_Dfareporting_ReportFloodlightCriteria extends Google_Collection
+{
+  protected $collection_key = 'metricNames';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $customRichMediaEventsType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $customRichMediaEventsDataType = 'array';
+  protected $dateRangeType = 'Google_Service_Dfareporting_DateRange';
+  protected $dateRangeDataType = '';
+  protected $dimensionFiltersType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $dimensionFiltersDataType = 'array';
+  protected $dimensionsType = 'Google_Service_Dfareporting_SortedDimension';
+  protected $dimensionsDataType = 'array';
+  protected $floodlightConfigIdType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $floodlightConfigIdDataType = '';
+  public $metricNames;
+  protected $reportPropertiesType = 'Google_Service_Dfareporting_ReportFloodlightCriteriaReportProperties';
+  protected $reportPropertiesDataType = '';
+
+
+  public function setCustomRichMediaEvents($customRichMediaEvents)
+  {
+    $this->customRichMediaEvents = $customRichMediaEvents;
+  }
+  public function getCustomRichMediaEvents()
+  {
+    return $this->customRichMediaEvents;
+  }
+  public function setDateRange(Google_Service_Dfareporting_DateRange $dateRange)
+  {
+    $this->dateRange = $dateRange;
+  }
+  public function getDateRange()
+  {
+    return $this->dateRange;
+  }
+  public function setDimensionFilters($dimensionFilters)
+  {
+    $this->dimensionFilters = $dimensionFilters;
+  }
+  public function getDimensionFilters()
+  {
+    return $this->dimensionFilters;
+  }
+  public function setDimensions($dimensions)
+  {
+    $this->dimensions = $dimensions;
+  }
+  public function getDimensions()
+  {
+    return $this->dimensions;
+  }
+  public function setFloodlightConfigId(Google_Service_Dfareporting_DimensionValue $floodlightConfigId)
+  {
+    $this->floodlightConfigId = $floodlightConfigId;
+  }
+  public function getFloodlightConfigId()
+  {
+    return $this->floodlightConfigId;
+  }
+  public function setMetricNames($metricNames)
+  {
+    $this->metricNames = $metricNames;
+  }
+  public function getMetricNames()
+  {
+    return $this->metricNames;
+  }
+  public function setReportProperties(Google_Service_Dfareporting_ReportFloodlightCriteriaReportProperties $reportProperties)
+  {
+    $this->reportProperties = $reportProperties;
+  }
+  public function getReportProperties()
+  {
+    return $this->reportProperties;
+  }
+}
+
+class Google_Service_Dfareporting_ReportFloodlightCriteriaReportProperties extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $includeAttributedIPConversions;
+  public $includeUnattributedCookieConversions;
+  public $includeUnattributedIPConversions;
+
+
+  public function setIncludeAttributedIPConversions($includeAttributedIPConversions)
+  {
+    $this->includeAttributedIPConversions = $includeAttributedIPConversions;
+  }
+  public function getIncludeAttributedIPConversions()
+  {
+    return $this->includeAttributedIPConversions;
+  }
+  public function setIncludeUnattributedCookieConversions($includeUnattributedCookieConversions)
+  {
+    $this->includeUnattributedCookieConversions = $includeUnattributedCookieConversions;
+  }
+  public function getIncludeUnattributedCookieConversions()
+  {
+    return $this->includeUnattributedCookieConversions;
+  }
+  public function setIncludeUnattributedIPConversions($includeUnattributedIPConversions)
+  {
+    $this->includeUnattributedIPConversions = $includeUnattributedIPConversions;
+  }
+  public function getIncludeUnattributedIPConversions()
+  {
+    return $this->includeUnattributedIPConversions;
+  }
+}
+
+class Google_Service_Dfareporting_ReportList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Dfareporting_Report';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dfareporting_ReportPathToConversionCriteria extends Google_Collection
+{
+  protected $collection_key = 'perInteractionDimensions';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $activityFiltersType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $activityFiltersDataType = 'array';
+  protected $conversionDimensionsType = 'Google_Service_Dfareporting_SortedDimension';
+  protected $conversionDimensionsDataType = 'array';
+  protected $customFloodlightVariablesType = 'Google_Service_Dfareporting_SortedDimension';
+  protected $customFloodlightVariablesDataType = 'array';
+  protected $customRichMediaEventsType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $customRichMediaEventsDataType = 'array';
+  protected $dateRangeType = 'Google_Service_Dfareporting_DateRange';
+  protected $dateRangeDataType = '';
+  protected $floodlightConfigIdType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $floodlightConfigIdDataType = '';
+  public $metricNames;
+  protected $perInteractionDimensionsType = 'Google_Service_Dfareporting_SortedDimension';
+  protected $perInteractionDimensionsDataType = 'array';
+  protected $reportPropertiesType = 'Google_Service_Dfareporting_ReportPathToConversionCriteriaReportProperties';
+  protected $reportPropertiesDataType = '';
+
+
+  public function setActivityFilters($activityFilters)
+  {
+    $this->activityFilters = $activityFilters;
+  }
+  public function getActivityFilters()
+  {
+    return $this->activityFilters;
+  }
+  public function setConversionDimensions($conversionDimensions)
+  {
+    $this->conversionDimensions = $conversionDimensions;
+  }
+  public function getConversionDimensions()
+  {
+    return $this->conversionDimensions;
+  }
+  public function setCustomFloodlightVariables($customFloodlightVariables)
+  {
+    $this->customFloodlightVariables = $customFloodlightVariables;
+  }
+  public function getCustomFloodlightVariables()
+  {
+    return $this->customFloodlightVariables;
+  }
+  public function setCustomRichMediaEvents($customRichMediaEvents)
+  {
+    $this->customRichMediaEvents = $customRichMediaEvents;
+  }
+  public function getCustomRichMediaEvents()
+  {
+    return $this->customRichMediaEvents;
+  }
+  public function setDateRange(Google_Service_Dfareporting_DateRange $dateRange)
+  {
+    $this->dateRange = $dateRange;
+  }
+  public function getDateRange()
+  {
+    return $this->dateRange;
+  }
+  public function setFloodlightConfigId(Google_Service_Dfareporting_DimensionValue $floodlightConfigId)
+  {
+    $this->floodlightConfigId = $floodlightConfigId;
+  }
+  public function getFloodlightConfigId()
+  {
+    return $this->floodlightConfigId;
+  }
+  public function setMetricNames($metricNames)
+  {
+    $this->metricNames = $metricNames;
+  }
+  public function getMetricNames()
+  {
+    return $this->metricNames;
+  }
+  public function setPerInteractionDimensions($perInteractionDimensions)
+  {
+    $this->perInteractionDimensions = $perInteractionDimensions;
+  }
+  public function getPerInteractionDimensions()
+  {
+    return $this->perInteractionDimensions;
+  }
+  public function setReportProperties(Google_Service_Dfareporting_ReportPathToConversionCriteriaReportProperties $reportProperties)
+  {
+    $this->reportProperties = $reportProperties;
+  }
+  public function getReportProperties()
+  {
+    return $this->reportProperties;
+  }
+}
+
+class Google_Service_Dfareporting_ReportPathToConversionCriteriaReportProperties extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $clicksLookbackWindow;
+  public $impressionsLookbackWindow;
+  public $includeAttributedIPConversions;
+  public $includeUnattributedCookieConversions;
+  public $includeUnattributedIPConversions;
+  public $maximumClickInteractions;
+  public $maximumImpressionInteractions;
+  public $maximumInteractionGap;
+  public $pivotOnInteractionPath;
+
+
+  public function setClicksLookbackWindow($clicksLookbackWindow)
+  {
+    $this->clicksLookbackWindow = $clicksLookbackWindow;
+  }
+  public function getClicksLookbackWindow()
+  {
+    return $this->clicksLookbackWindow;
+  }
+  public function setImpressionsLookbackWindow($impressionsLookbackWindow)
+  {
+    $this->impressionsLookbackWindow = $impressionsLookbackWindow;
+  }
+  public function getImpressionsLookbackWindow()
+  {
+    return $this->impressionsLookbackWindow;
+  }
+  public function setIncludeAttributedIPConversions($includeAttributedIPConversions)
+  {
+    $this->includeAttributedIPConversions = $includeAttributedIPConversions;
+  }
+  public function getIncludeAttributedIPConversions()
+  {
+    return $this->includeAttributedIPConversions;
+  }
+  public function setIncludeUnattributedCookieConversions($includeUnattributedCookieConversions)
+  {
+    $this->includeUnattributedCookieConversions = $includeUnattributedCookieConversions;
+  }
+  public function getIncludeUnattributedCookieConversions()
+  {
+    return $this->includeUnattributedCookieConversions;
+  }
+  public function setIncludeUnattributedIPConversions($includeUnattributedIPConversions)
+  {
+    $this->includeUnattributedIPConversions = $includeUnattributedIPConversions;
+  }
+  public function getIncludeUnattributedIPConversions()
+  {
+    return $this->includeUnattributedIPConversions;
+  }
+  public function setMaximumClickInteractions($maximumClickInteractions)
+  {
+    $this->maximumClickInteractions = $maximumClickInteractions;
+  }
+  public function getMaximumClickInteractions()
+  {
+    return $this->maximumClickInteractions;
+  }
+  public function setMaximumImpressionInteractions($maximumImpressionInteractions)
+  {
+    $this->maximumImpressionInteractions = $maximumImpressionInteractions;
+  }
+  public function getMaximumImpressionInteractions()
+  {
+    return $this->maximumImpressionInteractions;
+  }
+  public function setMaximumInteractionGap($maximumInteractionGap)
+  {
+    $this->maximumInteractionGap = $maximumInteractionGap;
+  }
+  public function getMaximumInteractionGap()
+  {
+    return $this->maximumInteractionGap;
+  }
+  public function setPivotOnInteractionPath($pivotOnInteractionPath)
+  {
+    $this->pivotOnInteractionPath = $pivotOnInteractionPath;
+  }
+  public function getPivotOnInteractionPath()
+  {
+    return $this->pivotOnInteractionPath;
+  }
+}
+
+class Google_Service_Dfareporting_ReportReachCriteria extends Google_Collection
+{
+  protected $collection_key = 'reachByFrequencyMetricNames';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $activitiesType = 'Google_Service_Dfareporting_Activities';
+  protected $activitiesDataType = '';
+  protected $customRichMediaEventsType = 'Google_Service_Dfareporting_CustomRichMediaEvents';
+  protected $customRichMediaEventsDataType = '';
+  protected $dateRangeType = 'Google_Service_Dfareporting_DateRange';
+  protected $dateRangeDataType = '';
+  protected $dimensionFiltersType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $dimensionFiltersDataType = 'array';
+  protected $dimensionsType = 'Google_Service_Dfareporting_SortedDimension';
+  protected $dimensionsDataType = 'array';
+  public $enableAllDimensionCombinations;
+  public $metricNames;
+  public $reachByFrequencyMetricNames;
+
+
+  public function setActivities(Google_Service_Dfareporting_Activities $activities)
+  {
+    $this->activities = $activities;
+  }
+  public function getActivities()
+  {
+    return $this->activities;
+  }
+  public function setCustomRichMediaEvents(Google_Service_Dfareporting_CustomRichMediaEvents $customRichMediaEvents)
+  {
+    $this->customRichMediaEvents = $customRichMediaEvents;
+  }
+  public function getCustomRichMediaEvents()
+  {
+    return $this->customRichMediaEvents;
+  }
+  public function setDateRange(Google_Service_Dfareporting_DateRange $dateRange)
+  {
+    $this->dateRange = $dateRange;
+  }
+  public function getDateRange()
+  {
+    return $this->dateRange;
+  }
+  public function setDimensionFilters($dimensionFilters)
+  {
+    $this->dimensionFilters = $dimensionFilters;
+  }
+  public function getDimensionFilters()
+  {
+    return $this->dimensionFilters;
+  }
+  public function setDimensions($dimensions)
+  {
+    $this->dimensions = $dimensions;
+  }
+  public function getDimensions()
+  {
+    return $this->dimensions;
+  }
+  public function setEnableAllDimensionCombinations($enableAllDimensionCombinations)
+  {
+    $this->enableAllDimensionCombinations = $enableAllDimensionCombinations;
+  }
+  public function getEnableAllDimensionCombinations()
+  {
+    return $this->enableAllDimensionCombinations;
+  }
+  public function setMetricNames($metricNames)
+  {
+    $this->metricNames = $metricNames;
+  }
+  public function getMetricNames()
+  {
+    return $this->metricNames;
+  }
+  public function setReachByFrequencyMetricNames($reachByFrequencyMetricNames)
+  {
+    $this->reachByFrequencyMetricNames = $reachByFrequencyMetricNames;
+  }
+  public function getReachByFrequencyMetricNames()
+  {
+    return $this->reachByFrequencyMetricNames;
+  }
+}
+
+class Google_Service_Dfareporting_ReportSchedule extends Google_Collection
+{
+  protected $collection_key = 'repeatsOnWeekDays';
+  protected $internal_gapi_mappings = array(
+  );
+  public $active;
+  public $every;
+  public $expirationDate;
+  public $repeats;
+  public $repeatsOnWeekDays;
+  public $runsOnDayOfMonth;
+  public $startDate;
+
+
+  public function setActive($active)
+  {
+    $this->active = $active;
+  }
+  public function getActive()
+  {
+    return $this->active;
+  }
+  public function setEvery($every)
+  {
+    $this->every = $every;
+  }
+  public function getEvery()
+  {
+    return $this->every;
+  }
+  public function setExpirationDate($expirationDate)
+  {
+    $this->expirationDate = $expirationDate;
+  }
+  public function getExpirationDate()
+  {
+    return $this->expirationDate;
+  }
+  public function setRepeats($repeats)
+  {
+    $this->repeats = $repeats;
+  }
+  public function getRepeats()
+  {
+    return $this->repeats;
+  }
+  public function setRepeatsOnWeekDays($repeatsOnWeekDays)
+  {
+    $this->repeatsOnWeekDays = $repeatsOnWeekDays;
+  }
+  public function getRepeatsOnWeekDays()
+  {
+    return $this->repeatsOnWeekDays;
+  }
+  public function setRunsOnDayOfMonth($runsOnDayOfMonth)
+  {
+    $this->runsOnDayOfMonth = $runsOnDayOfMonth;
+  }
+  public function getRunsOnDayOfMonth()
+  {
+    return $this->runsOnDayOfMonth;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+}
+
+class Google_Service_Dfareporting_ReportsConfiguration extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $exposureToConversionEnabled;
+  protected $lookbackConfigurationType = 'Google_Service_Dfareporting_LookbackConfiguration';
+  protected $lookbackConfigurationDataType = '';
+  public $reportGenerationTimeZoneId;
+
+
+  public function setExposureToConversionEnabled($exposureToConversionEnabled)
+  {
+    $this->exposureToConversionEnabled = $exposureToConversionEnabled;
+  }
+  public function getExposureToConversionEnabled()
+  {
+    return $this->exposureToConversionEnabled;
+  }
+  public function setLookbackConfiguration(Google_Service_Dfareporting_LookbackConfiguration $lookbackConfiguration)
+  {
+    $this->lookbackConfiguration = $lookbackConfiguration;
+  }
+  public function getLookbackConfiguration()
+  {
+    return $this->lookbackConfiguration;
+  }
+  public function setReportGenerationTimeZoneId($reportGenerationTimeZoneId)
+  {
+    $this->reportGenerationTimeZoneId = $reportGenerationTimeZoneId;
+  }
+  public function getReportGenerationTimeZoneId()
+  {
+    return $this->reportGenerationTimeZoneId;
+  }
+}
+
+class Google_Service_Dfareporting_RichMediaExitOverride extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $customExitUrl;
+  public $exitId;
+  public $useCustomExitUrl;
+
+
+  public function setCustomExitUrl($customExitUrl)
+  {
+    $this->customExitUrl = $customExitUrl;
+  }
+  public function getCustomExitUrl()
+  {
+    return $this->customExitUrl;
+  }
+  public function setExitId($exitId)
+  {
+    $this->exitId = $exitId;
+  }
+  public function getExitId()
+  {
+    return $this->exitId;
+  }
+  public function setUseCustomExitUrl($useCustomExitUrl)
+  {
+    $this->useCustomExitUrl = $useCustomExitUrl;
+  }
+  public function getUseCustomExitUrl()
+  {
+    return $this->useCustomExitUrl;
+  }
+}
+
+class Google_Service_Dfareporting_Site extends Google_Collection
+{
+  protected $collection_key = 'siteContacts';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $approved;
+  public $directorySiteId;
+  protected $directorySiteIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $directorySiteIdDimensionValueDataType = '';
+  public $id;
+  protected $idDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $idDimensionValueDataType = '';
+  public $keyName;
+  public $kind;
+  public $name;
+  protected $siteContactsType = 'Google_Service_Dfareporting_SiteContact';
+  protected $siteContactsDataType = 'array';
+  protected $siteSettingsType = 'Google_Service_Dfareporting_SiteSettings';
+  protected $siteSettingsDataType = '';
+  public $subaccountId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setApproved($approved)
+  {
+    $this->approved = $approved;
+  }
+  public function getApproved()
+  {
+    return $this->approved;
+  }
+  public function setDirectorySiteId($directorySiteId)
+  {
+    $this->directorySiteId = $directorySiteId;
+  }
+  public function getDirectorySiteId()
+  {
+    return $this->directorySiteId;
+  }
+  public function setDirectorySiteIdDimensionValue(Google_Service_Dfareporting_DimensionValue $directorySiteIdDimensionValue)
+  {
+    $this->directorySiteIdDimensionValue = $directorySiteIdDimensionValue;
+  }
+  public function getDirectorySiteIdDimensionValue()
+  {
+    return $this->directorySiteIdDimensionValue;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIdDimensionValue(Google_Service_Dfareporting_DimensionValue $idDimensionValue)
+  {
+    $this->idDimensionValue = $idDimensionValue;
+  }
+  public function getIdDimensionValue()
+  {
+    return $this->idDimensionValue;
+  }
+  public function setKeyName($keyName)
+  {
+    $this->keyName = $keyName;
+  }
+  public function getKeyName()
+  {
+    return $this->keyName;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSiteContacts($siteContacts)
+  {
+    $this->siteContacts = $siteContacts;
+  }
+  public function getSiteContacts()
+  {
+    return $this->siteContacts;
+  }
+  public function setSiteSettings(Google_Service_Dfareporting_SiteSettings $siteSettings)
+  {
+    $this->siteSettings = $siteSettings;
+  }
+  public function getSiteSettings()
+  {
+    return $this->siteSettings;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+}
+
+class Google_Service_Dfareporting_SiteContact extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $address;
+  public $contactType;
+  public $email;
+  public $firstName;
+  public $id;
+  public $lastName;
+  public $phone;
+  public $title;
+
+
+  public function setAddress($address)
+  {
+    $this->address = $address;
+  }
+  public function getAddress()
+  {
+    return $this->address;
+  }
+  public function setContactType($contactType)
+  {
+    $this->contactType = $contactType;
+  }
+  public function getContactType()
+  {
+    return $this->contactType;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setFirstName($firstName)
+  {
+    $this->firstName = $firstName;
+  }
+  public function getFirstName()
+  {
+    return $this->firstName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLastName($lastName)
+  {
+    $this->lastName = $lastName;
+  }
+  public function getLastName()
+  {
+    return $this->lastName;
+  }
+  public function setPhone($phone)
+  {
+    $this->phone = $phone;
+  }
+  public function getPhone()
+  {
+    return $this->phone;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_Dfareporting_SiteSettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $activeViewOptOut;
+  protected $creativeSettingsType = 'Google_Service_Dfareporting_CreativeSettings';
+  protected $creativeSettingsDataType = '';
+  public $disableBrandSafeAds;
+  public $disableNewCookie;
+  protected $lookbackConfigurationType = 'Google_Service_Dfareporting_LookbackConfiguration';
+  protected $lookbackConfigurationDataType = '';
+  protected $tagSettingType = 'Google_Service_Dfareporting_TagSetting';
+  protected $tagSettingDataType = '';
+
+
+  public function setActiveViewOptOut($activeViewOptOut)
+  {
+    $this->activeViewOptOut = $activeViewOptOut;
+  }
+  public function getActiveViewOptOut()
+  {
+    return $this->activeViewOptOut;
+  }
+  public function setCreativeSettings(Google_Service_Dfareporting_CreativeSettings $creativeSettings)
+  {
+    $this->creativeSettings = $creativeSettings;
+  }
+  public function getCreativeSettings()
+  {
+    return $this->creativeSettings;
+  }
+  public function setDisableBrandSafeAds($disableBrandSafeAds)
+  {
+    $this->disableBrandSafeAds = $disableBrandSafeAds;
+  }
+  public function getDisableBrandSafeAds()
+  {
+    return $this->disableBrandSafeAds;
+  }
+  public function setDisableNewCookie($disableNewCookie)
+  {
+    $this->disableNewCookie = $disableNewCookie;
+  }
+  public function getDisableNewCookie()
+  {
+    return $this->disableNewCookie;
+  }
+  public function setLookbackConfiguration(Google_Service_Dfareporting_LookbackConfiguration $lookbackConfiguration)
+  {
+    $this->lookbackConfiguration = $lookbackConfiguration;
+  }
+  public function getLookbackConfiguration()
+  {
+    return $this->lookbackConfiguration;
+  }
+  public function setTagSetting(Google_Service_Dfareporting_TagSetting $tagSetting)
+  {
+    $this->tagSetting = $tagSetting;
+  }
+  public function getTagSetting()
+  {
+    return $this->tagSetting;
+  }
+}
+
+class Google_Service_Dfareporting_SitesListResponse extends Google_Collection
+{
+  protected $collection_key = 'sites';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $sitesType = 'Google_Service_Dfareporting_Site';
+  protected $sitesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSites($sites)
+  {
+    $this->sites = $sites;
+  }
+  public function getSites()
+  {
+    return $this->sites;
+  }
+}
+
+class Google_Service_Dfareporting_Size extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $iab;
+  public $id;
+  public $kind;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setIab($iab)
+  {
+    $this->iab = $iab;
+  }
+  public function getIab()
+  {
+    return $this->iab;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_Dfareporting_SizesListResponse extends Google_Collection
+{
+  protected $collection_key = 'sizes';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $sizesType = 'Google_Service_Dfareporting_Size';
+  protected $sizesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSizes($sizes)
+  {
+    $this->sizes = $sizes;
+  }
+  public function getSizes()
+  {
+    return $this->sizes;
+  }
+}
+
+class Google_Service_Dfareporting_SortedDimension extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $name;
+  public $sortOrder;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSortOrder($sortOrder)
+  {
+    $this->sortOrder = $sortOrder;
+  }
+  public function getSortOrder()
+  {
+    return $this->sortOrder;
+  }
+}
+
+class Google_Service_Dfareporting_Subaccount extends Google_Collection
+{
+  protected $collection_key = 'availablePermissionIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $availablePermissionIds;
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAvailablePermissionIds($availablePermissionIds)
+  {
+    $this->availablePermissionIds = $availablePermissionIds;
+  }
+  public function getAvailablePermissionIds()
+  {
+    return $this->availablePermissionIds;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Dfareporting_SubaccountsListResponse extends Google_Collection
+{
+  protected $collection_key = 'subaccounts';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $subaccountsType = 'Google_Service_Dfareporting_Subaccount';
+  protected $subaccountsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSubaccounts($subaccounts)
+  {
+    $this->subaccounts = $subaccounts;
+  }
+  public function getSubaccounts()
+  {
+    return $this->subaccounts;
+  }
+}
+
+class Google_Service_Dfareporting_TagData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $adId;
+  public $clickTag;
+  public $creativeId;
+  public $format;
+  public $impressionTag;
+
+
+  public function setAdId($adId)
+  {
+    $this->adId = $adId;
+  }
+  public function getAdId()
+  {
+    return $this->adId;
+  }
+  public function setClickTag($clickTag)
+  {
+    $this->clickTag = $clickTag;
+  }
+  public function getClickTag()
+  {
+    return $this->clickTag;
+  }
+  public function setCreativeId($creativeId)
+  {
+    $this->creativeId = $creativeId;
+  }
+  public function getCreativeId()
+  {
+    return $this->creativeId;
+  }
+  public function setFormat($format)
+  {
+    $this->format = $format;
+  }
+  public function getFormat()
+  {
+    return $this->format;
+  }
+  public function setImpressionTag($impressionTag)
+  {
+    $this->impressionTag = $impressionTag;
+  }
+  public function getImpressionTag()
+  {
+    return $this->impressionTag;
+  }
+}
+
+class Google_Service_Dfareporting_TagSetting extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $additionalKeyValues;
+  public $includeClickThroughUrls;
+  public $includeClickTracking;
+  public $keywordOption;
+
+
+  public function setAdditionalKeyValues($additionalKeyValues)
+  {
+    $this->additionalKeyValues = $additionalKeyValues;
+  }
+  public function getAdditionalKeyValues()
+  {
+    return $this->additionalKeyValues;
+  }
+  public function setIncludeClickThroughUrls($includeClickThroughUrls)
+  {
+    $this->includeClickThroughUrls = $includeClickThroughUrls;
+  }
+  public function getIncludeClickThroughUrls()
+  {
+    return $this->includeClickThroughUrls;
+  }
+  public function setIncludeClickTracking($includeClickTracking)
+  {
+    $this->includeClickTracking = $includeClickTracking;
+  }
+  public function getIncludeClickTracking()
+  {
+    return $this->includeClickTracking;
+  }
+  public function setKeywordOption($keywordOption)
+  {
+    $this->keywordOption = $keywordOption;
+  }
+  public function getKeywordOption()
+  {
+    return $this->keywordOption;
+  }
+}
+
+class Google_Service_Dfareporting_TagSettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $dynamicTagEnabled;
+  public $imageTagEnabled;
+
+
+  public function setDynamicTagEnabled($dynamicTagEnabled)
+  {
+    $this->dynamicTagEnabled = $dynamicTagEnabled;
+  }
+  public function getDynamicTagEnabled()
+  {
+    return $this->dynamicTagEnabled;
+  }
+  public function setImageTagEnabled($imageTagEnabled)
+  {
+    $this->imageTagEnabled = $imageTagEnabled;
+  }
+  public function getImageTagEnabled()
+  {
+    return $this->imageTagEnabled;
+  }
+}
+
+class Google_Service_Dfareporting_TargetWindow extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $customHtml;
+  public $targetWindowOption;
+
+
+  public function setCustomHtml($customHtml)
+  {
+    $this->customHtml = $customHtml;
+  }
+  public function getCustomHtml()
+  {
+    return $this->customHtml;
+  }
+  public function setTargetWindowOption($targetWindowOption)
+  {
+    $this->targetWindowOption = $targetWindowOption;
+  }
+  public function getTargetWindowOption()
+  {
+    return $this->targetWindowOption;
+  }
+}
+
+class Google_Service_Dfareporting_TargetableRemarketingList extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $active;
+  public $advertiserId;
+  protected $advertiserIdDimensionValueType = 'Google_Service_Dfareporting_DimensionValue';
+  protected $advertiserIdDimensionValueDataType = '';
+  public $description;
+  public $id;
+  public $kind;
+  public $lifeSpan;
+  public $listSize;
+  public $listSource;
+  public $name;
+  public $subaccountId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setActive($active)
+  {
+    $this->active = $active;
+  }
+  public function getActive()
+  {
+    return $this->active;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAdvertiserIdDimensionValue(Google_Service_Dfareporting_DimensionValue $advertiserIdDimensionValue)
+  {
+    $this->advertiserIdDimensionValue = $advertiserIdDimensionValue;
+  }
+  public function getAdvertiserIdDimensionValue()
+  {
+    return $this->advertiserIdDimensionValue;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLifeSpan($lifeSpan)
+  {
+    $this->lifeSpan = $lifeSpan;
+  }
+  public function getLifeSpan()
+  {
+    return $this->lifeSpan;
+  }
+  public function setListSize($listSize)
+  {
+    $this->listSize = $listSize;
+  }
+  public function getListSize()
+  {
+    return $this->listSize;
+  }
+  public function setListSource($listSource)
+  {
+    $this->listSource = $listSource;
+  }
+  public function getListSource()
+  {
+    return $this->listSource;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+}
+
+class Google_Service_Dfareporting_TargetableRemarketingListsListResponse extends Google_Collection
+{
+  protected $collection_key = 'targetableRemarketingLists';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $targetableRemarketingListsType = 'Google_Service_Dfareporting_TargetableRemarketingList';
+  protected $targetableRemarketingListsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTargetableRemarketingLists($targetableRemarketingLists)
+  {
+    $this->targetableRemarketingLists = $targetableRemarketingLists;
+  }
+  public function getTargetableRemarketingLists()
+  {
+    return $this->targetableRemarketingLists;
+  }
+}
+
+class Google_Service_Dfareporting_TechnologyTargeting extends Google_Collection
+{
+  protected $collection_key = 'platformTypes';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $browsersType = 'Google_Service_Dfareporting_Browser';
+  protected $browsersDataType = 'array';
+  protected $connectionTypesType = 'Google_Service_Dfareporting_ConnectionType';
+  protected $connectionTypesDataType = 'array';
+  protected $mobileCarriersType = 'Google_Service_Dfareporting_MobileCarrier';
+  protected $mobileCarriersDataType = 'array';
+  protected $operatingSystemVersionsType = 'Google_Service_Dfareporting_OperatingSystemVersion';
+  protected $operatingSystemVersionsDataType = 'array';
+  protected $operatingSystemsType = 'Google_Service_Dfareporting_OperatingSystem';
+  protected $operatingSystemsDataType = 'array';
+  protected $platformTypesType = 'Google_Service_Dfareporting_PlatformType';
+  protected $platformTypesDataType = 'array';
+
+
+  public function setBrowsers($browsers)
+  {
+    $this->browsers = $browsers;
+  }
+  public function getBrowsers()
+  {
+    return $this->browsers;
+  }
+  public function setConnectionTypes($connectionTypes)
+  {
+    $this->connectionTypes = $connectionTypes;
+  }
+  public function getConnectionTypes()
+  {
+    return $this->connectionTypes;
+  }
+  public function setMobileCarriers($mobileCarriers)
+  {
+    $this->mobileCarriers = $mobileCarriers;
+  }
+  public function getMobileCarriers()
+  {
+    return $this->mobileCarriers;
+  }
+  public function setOperatingSystemVersions($operatingSystemVersions)
+  {
+    $this->operatingSystemVersions = $operatingSystemVersions;
+  }
+  public function getOperatingSystemVersions()
+  {
+    return $this->operatingSystemVersions;
+  }
+  public function setOperatingSystems($operatingSystems)
+  {
+    $this->operatingSystems = $operatingSystems;
+  }
+  public function getOperatingSystems()
+  {
+    return $this->operatingSystems;
+  }
+  public function setPlatformTypes($platformTypes)
+  {
+    $this->platformTypes = $platformTypes;
+  }
+  public function getPlatformTypes()
+  {
+    return $this->platformTypes;
+  }
+}
+
+class Google_Service_Dfareporting_ThirdPartyTrackingUrl extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $thirdPartyUrlType;
+  public $url;
+
+
+  public function setThirdPartyUrlType($thirdPartyUrlType)
+  {
+    $this->thirdPartyUrlType = $thirdPartyUrlType;
+  }
+  public function getThirdPartyUrlType()
+  {
+    return $this->thirdPartyUrlType;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Dfareporting_UserDefinedVariableConfiguration extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $dataType;
+  public $reportName;
+  public $variableType;
+
+
+  public function setDataType($dataType)
+  {
+    $this->dataType = $dataType;
+  }
+  public function getDataType()
+  {
+    return $this->dataType;
+  }
+  public function setReportName($reportName)
+  {
+    $this->reportName = $reportName;
+  }
+  public function getReportName()
+  {
+    return $this->reportName;
+  }
+  public function setVariableType($variableType)
+  {
+    $this->variableType = $variableType;
+  }
+  public function getVariableType()
+  {
+    return $this->variableType;
+  }
+}
+
+class Google_Service_Dfareporting_UserProfile extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $accountName;
+  public $etag;
+  public $kind;
+  public $profileId;
+  public $subAccountId;
+  public $subAccountName;
+  public $userName;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAccountName($accountName)
+  {
+    $this->accountName = $accountName;
+  }
+  public function getAccountName()
+  {
+    return $this->accountName;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProfileId($profileId)
+  {
+    $this->profileId = $profileId;
+  }
+  public function getProfileId()
+  {
+    return $this->profileId;
+  }
+  public function setSubAccountId($subAccountId)
+  {
+    $this->subAccountId = $subAccountId;
+  }
+  public function getSubAccountId()
+  {
+    return $this->subAccountId;
+  }
+  public function setSubAccountName($subAccountName)
+  {
+    $this->subAccountName = $subAccountName;
+  }
+  public function getSubAccountName()
+  {
+    return $this->subAccountName;
+  }
+  public function setUserName($userName)
+  {
+    $this->userName = $userName;
+  }
+  public function getUserName()
+  {
+    return $this->userName;
+  }
+}
+
+class Google_Service_Dfareporting_UserProfileList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Dfareporting_UserProfile';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Dfareporting_UserRole extends Google_Collection
+{
+  protected $collection_key = 'permissions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $defaultUserRole;
+  public $id;
+  public $kind;
+  public $name;
+  public $parentUserRoleId;
+  protected $permissionsType = 'Google_Service_Dfareporting_UserRolePermission';
+  protected $permissionsDataType = 'array';
+  public $subaccountId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setDefaultUserRole($defaultUserRole)
+  {
+    $this->defaultUserRole = $defaultUserRole;
+  }
+  public function getDefaultUserRole()
+  {
+    return $this->defaultUserRole;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setParentUserRoleId($parentUserRoleId)
+  {
+    $this->parentUserRoleId = $parentUserRoleId;
+  }
+  public function getParentUserRoleId()
+  {
+    return $this->parentUserRoleId;
+  }
+  public function setPermissions($permissions)
+  {
+    $this->permissions = $permissions;
+  }
+  public function getPermissions()
+  {
+    return $this->permissions;
+  }
+  public function setSubaccountId($subaccountId)
+  {
+    $this->subaccountId = $subaccountId;
+  }
+  public function getSubaccountId()
+  {
+    return $this->subaccountId;
+  }
+}
+
+class Google_Service_Dfareporting_UserRolePermission extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $availability;
+  public $id;
+  public $kind;
+  public $name;
+  public $permissionGroupId;
+
+
+  public function setAvailability($availability)
+  {
+    $this->availability = $availability;
+  }
+  public function getAvailability()
+  {
+    return $this->availability;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPermissionGroupId($permissionGroupId)
+  {
+    $this->permissionGroupId = $permissionGroupId;
+  }
+  public function getPermissionGroupId()
+  {
+    return $this->permissionGroupId;
+  }
+}
+
+class Google_Service_Dfareporting_UserRolePermissionGroup extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Dfareporting_UserRolePermissionGroupsListResponse extends Google_Collection
+{
+  protected $collection_key = 'userRolePermissionGroups';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $userRolePermissionGroupsType = 'Google_Service_Dfareporting_UserRolePermissionGroup';
+  protected $userRolePermissionGroupsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUserRolePermissionGroups($userRolePermissionGroups)
+  {
+    $this->userRolePermissionGroups = $userRolePermissionGroups;
+  }
+  public function getUserRolePermissionGroups()
+  {
+    return $this->userRolePermissionGroups;
+  }
+}
+
+class Google_Service_Dfareporting_UserRolePermissionsListResponse extends Google_Collection
+{
+  protected $collection_key = 'userRolePermissions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $userRolePermissionsType = 'Google_Service_Dfareporting_UserRolePermission';
+  protected $userRolePermissionsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUserRolePermissions($userRolePermissions)
+  {
+    $this->userRolePermissions = $userRolePermissions;
+  }
+  public function getUserRolePermissions()
+  {
+    return $this->userRolePermissions;
+  }
+}
+
+class Google_Service_Dfareporting_UserRolesListResponse extends Google_Collection
+{
+  protected $collection_key = 'userRoles';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $userRolesType = 'Google_Service_Dfareporting_UserRole';
+  protected $userRolesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setUserRoles($userRoles)
+  {
+    $this->userRoles = $userRoles;
+  }
+  public function getUserRoles()
+  {
+    return $this->userRoles;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Directory.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Directory.php
@@ -1,0 +1,7180 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Directory (directory_v1).
+ *
+ * <p>
+ * The Admin SDK Directory API lets you view and manage enterprise resources
+ * such as users and groups, administrative notifications, security features,
+ * and more.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/admin-sdk/directory/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Directory extends Google_Service
+{
+  /** View and manage customer related information. */
+  const ADMIN_DIRECTORY_CUSTOMER =
+      "https://www.googleapis.com/auth/admin.directory.customer";
+  /** View customer related information. */
+  const ADMIN_DIRECTORY_CUSTOMER_READONLY =
+      "https://www.googleapis.com/auth/admin.directory.customer.readonly";
+  /** View and manage your Chrome OS devices' metadata. */
+  const ADMIN_DIRECTORY_DEVICE_CHROMEOS =
+      "https://www.googleapis.com/auth/admin.directory.device.chromeos";
+  /** View your Chrome OS devices' metadata. */
+  const ADMIN_DIRECTORY_DEVICE_CHROMEOS_READONLY =
+      "https://www.googleapis.com/auth/admin.directory.device.chromeos.readonly";
+  /** View and manage your mobile devices' metadata. */
+  const ADMIN_DIRECTORY_DEVICE_MOBILE =
+      "https://www.googleapis.com/auth/admin.directory.device.mobile";
+  /** Manage your mobile devices by performing administrative tasks. */
+  const ADMIN_DIRECTORY_DEVICE_MOBILE_ACTION =
+      "https://www.googleapis.com/auth/admin.directory.device.mobile.action";
+  /** View your mobile devices' metadata. */
+  const ADMIN_DIRECTORY_DEVICE_MOBILE_READONLY =
+      "https://www.googleapis.com/auth/admin.directory.device.mobile.readonly";
+  /** View and manage the provisioning of domains for your customers. */
+  const ADMIN_DIRECTORY_DOMAIN =
+      "https://www.googleapis.com/auth/admin.directory.domain";
+  /** View domains related to your customers. */
+  const ADMIN_DIRECTORY_DOMAIN_READONLY =
+      "https://www.googleapis.com/auth/admin.directory.domain.readonly";
+  /** View and manage the provisioning of groups on your domain. */
+  const ADMIN_DIRECTORY_GROUP =
+      "https://www.googleapis.com/auth/admin.directory.group";
+  /** View and manage group subscriptions on your domain. */
+  const ADMIN_DIRECTORY_GROUP_MEMBER =
+      "https://www.googleapis.com/auth/admin.directory.group.member";
+  /** View group subscriptions on your domain. */
+  const ADMIN_DIRECTORY_GROUP_MEMBER_READONLY =
+      "https://www.googleapis.com/auth/admin.directory.group.member.readonly";
+  /** View groups on your domain. */
+  const ADMIN_DIRECTORY_GROUP_READONLY =
+      "https://www.googleapis.com/auth/admin.directory.group.readonly";
+  /** View and manage notifications received on your domain. */
+  const ADMIN_DIRECTORY_NOTIFICATIONS =
+      "https://www.googleapis.com/auth/admin.directory.notifications";
+  /** View and manage organization units on your domain. */
+  const ADMIN_DIRECTORY_ORGUNIT =
+      "https://www.googleapis.com/auth/admin.directory.orgunit";
+  /** View organization units on your domain. */
+  const ADMIN_DIRECTORY_ORGUNIT_READONLY =
+      "https://www.googleapis.com/auth/admin.directory.orgunit.readonly";
+  /** Manage delegated admin roles for your domain. */
+  const ADMIN_DIRECTORY_ROLEMANAGEMENT =
+      "https://www.googleapis.com/auth/admin.directory.rolemanagement";
+  /** View delegated admin roles for your domain. */
+  const ADMIN_DIRECTORY_ROLEMANAGEMENT_READONLY =
+      "https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly";
+  /** View and manage the provisioning of users on your domain. */
+  const ADMIN_DIRECTORY_USER =
+      "https://www.googleapis.com/auth/admin.directory.user";
+  /** View and manage user aliases on your domain. */
+  const ADMIN_DIRECTORY_USER_ALIAS =
+      "https://www.googleapis.com/auth/admin.directory.user.alias";
+  /** View user aliases on your domain. */
+  const ADMIN_DIRECTORY_USER_ALIAS_READONLY =
+      "https://www.googleapis.com/auth/admin.directory.user.alias.readonly";
+  /** View users on your domain. */
+  const ADMIN_DIRECTORY_USER_READONLY =
+      "https://www.googleapis.com/auth/admin.directory.user.readonly";
+  /** Manage data access permissions for users on your domain. */
+  const ADMIN_DIRECTORY_USER_SECURITY =
+      "https://www.googleapis.com/auth/admin.directory.user.security";
+  /** View and manage the provisioning of user schemas on your domain. */
+  const ADMIN_DIRECTORY_USERSCHEMA =
+      "https://www.googleapis.com/auth/admin.directory.userschema";
+  /** View user schemas on your domain. */
+  const ADMIN_DIRECTORY_USERSCHEMA_READONLY =
+      "https://www.googleapis.com/auth/admin.directory.userschema.readonly";
+
+  public $asps;
+  public $channels;
+  public $chromeosdevices;
+  public $customers;
+  public $domainAliases;
+  public $domains;
+  public $groups;
+  public $groups_aliases;
+  public $members;
+  public $mobiledevices;
+  public $notifications;
+  public $orgunits;
+  public $privileges;
+  public $roleAssignments;
+  public $roles;
+  public $schemas;
+  public $tokens;
+  public $users;
+  public $users_aliases;
+  public $users_photos;
+  public $verificationCodes;
+  
+
+  /**
+   * Constructs the internal representation of the Directory service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'admin/directory/v1/';
+    $this->version = 'directory_v1';
+    $this->serviceName = 'admin';
+
+    $this->asps = new Google_Service_Directory_Asps_Resource(
+        $this,
+        $this->serviceName,
+        'asps',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'users/{userKey}/asps/{codeId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'codeId' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'users/{userKey}/asps/{codeId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'codeId' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'users/{userKey}/asps',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->channels = new Google_Service_Directory_Channels_Resource(
+        $this,
+        $this->serviceName,
+        'channels',
+        array(
+          'methods' => array(
+            'stop' => array(
+              'path' => '/admin/directory_v1/channels/stop',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->chromeosdevices = new Google_Service_Directory_Chromeosdevices_Resource(
+        $this,
+        $this->serviceName,
+        'chromeosdevices',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'customer/{customerId}/devices/chromeos/{deviceId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deviceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'customer/{customerId}/devices/chromeos',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'query' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'customer/{customerId}/devices/chromeos/{deviceId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deviceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'customer/{customerId}/devices/chromeos/{deviceId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deviceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->customers = new Google_Service_Directory_Customers_Resource(
+        $this,
+        $this->serviceName,
+        'customers',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'customers/{customerKey}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customerKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'customers/{customerKey}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'customerKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'customers/{customerKey}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'customerKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->domainAliases = new Google_Service_Directory_DomainAliases_Resource(
+        $this,
+        $this->serviceName,
+        'domainAliases',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'customer/{customer}/domainaliases/{domainAliasName}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'domainAliasName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'customer/{customer}/domainaliases/{domainAliasName}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'domainAliasName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'customer/{customer}/domainaliases',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'customer/{customer}/domainaliases',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'parentDomainName' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->domains = new Google_Service_Directory_Domains_Resource(
+        $this,
+        $this->serviceName,
+        'domains',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'customer/{customer}/domains/{domainName}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'domainName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'customer/{customer}/domains/{domainName}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'domainName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'customer/{customer}/domains',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'customer/{customer}/domains',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->groups = new Google_Service_Directory_Groups_Resource(
+        $this,
+        $this->serviceName,
+        'groups',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'groups/{groupKey}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'groupKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'groups/{groupKey}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'groupKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'groups',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'list' => array(
+              'path' => 'groups',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'domain' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'userKey' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'groups/{groupKey}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'groupKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'groups/{groupKey}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'groupKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->groups_aliases = new Google_Service_Directory_GroupsAliases_Resource(
+        $this,
+        $this->serviceName,
+        'aliases',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'groups/{groupKey}/aliases/{alias}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'groupKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'alias' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'groups/{groupKey}/aliases',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'groupKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'groups/{groupKey}/aliases',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'groupKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->members = new Google_Service_Directory_Members_Resource(
+        $this,
+        $this->serviceName,
+        'members',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'groups/{groupKey}/members/{memberKey}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'groupKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'memberKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'groups/{groupKey}/members/{memberKey}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'groupKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'memberKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'groups/{groupKey}/members',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'groupKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'groups/{groupKey}/members',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'groupKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'roles' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'groups/{groupKey}/members/{memberKey}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'groupKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'memberKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'groups/{groupKey}/members/{memberKey}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'groupKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'memberKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->mobiledevices = new Google_Service_Directory_Mobiledevices_Resource(
+        $this,
+        $this->serviceName,
+        'mobiledevices',
+        array(
+          'methods' => array(
+            'action' => array(
+              'path' => 'customer/{customerId}/devices/mobile/{resourceId}/action',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'resourceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'customer/{customerId}/devices/mobile/{resourceId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'resourceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'customer/{customerId}/devices/mobile/{resourceId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'resourceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'customer/{customerId}/devices/mobile',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'query' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->notifications = new Google_Service_Directory_Notifications_Resource(
+        $this,
+        $this->serviceName,
+        'notifications',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'customer/{customer}/notifications/{notificationId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'notificationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'customer/{customer}/notifications/{notificationId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'notificationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'customer/{customer}/notifications',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'customer/{customer}/notifications/{notificationId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'notificationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'customer/{customer}/notifications/{notificationId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'notificationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->orgunits = new Google_Service_Directory_Orgunits_Resource(
+        $this,
+        $this->serviceName,
+        'orgunits',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'customer/{customerId}/orgunits{/orgUnitPath*}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orgUnitPath' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'repeated' => true,
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'customer/{customerId}/orgunits{/orgUnitPath*}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orgUnitPath' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'repeated' => true,
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'customer/{customerId}/orgunits',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'customer/{customerId}/orgunits',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'type' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'orgUnitPath' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'customer/{customerId}/orgunits{/orgUnitPath*}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orgUnitPath' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'repeated' => true,
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'customer/{customerId}/orgunits{/orgUnitPath*}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orgUnitPath' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'repeated' => true,
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->privileges = new Google_Service_Directory_Privileges_Resource(
+        $this,
+        $this->serviceName,
+        'privileges',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'customer/{customer}/roles/ALL/privileges',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->roleAssignments = new Google_Service_Directory_RoleAssignments_Resource(
+        $this,
+        $this->serviceName,
+        'roleAssignments',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'customer/{customer}/roleassignments/{roleAssignmentId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'roleAssignmentId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'customer/{customer}/roleassignments/{roleAssignmentId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'roleAssignmentId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'customer/{customer}/roleassignments',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'customer/{customer}/roleassignments',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'userKey' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'roleId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->roles = new Google_Service_Directory_Roles_Resource(
+        $this,
+        $this->serviceName,
+        'roles',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'customer/{customer}/roles/{roleId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'roleId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'customer/{customer}/roles/{roleId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'roleId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'customer/{customer}/roles',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'customer/{customer}/roles',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'customer/{customer}/roles/{roleId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'roleId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'customer/{customer}/roles/{roleId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'roleId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->schemas = new Google_Service_Directory_Schemas_Resource(
+        $this,
+        $this->serviceName,
+        'schemas',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'customer/{customerId}/schemas/{schemaKey}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'schemaKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'customer/{customerId}/schemas/{schemaKey}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'schemaKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'customer/{customerId}/schemas',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'customer/{customerId}/schemas',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'customer/{customerId}/schemas/{schemaKey}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'schemaKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'customer/{customerId}/schemas/{schemaKey}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'schemaKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->tokens = new Google_Service_Directory_Tokens_Resource(
+        $this,
+        $this->serviceName,
+        'tokens',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'users/{userKey}/tokens/{clientId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'clientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'users/{userKey}/tokens/{clientId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'clientId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'users/{userKey}/tokens',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->users = new Google_Service_Directory_Users_Resource(
+        $this,
+        $this->serviceName,
+        'users',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'users/{userKey}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'users/{userKey}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'viewType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'customFieldMask' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'users',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'list' => array(
+              'path' => 'users',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'domain' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'showDeleted' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'customFieldMask' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'query' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'viewType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'event' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'makeAdmin' => array(
+              'path' => 'users/{userKey}/makeAdmin',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'users/{userKey}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'undelete' => array(
+              'path' => 'users/{userKey}/undelete',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'users/{userKey}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'watch' => array(
+              'path' => 'users/watch',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'customer' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'domain' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'showDeleted' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'customFieldMask' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'query' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'viewType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'event' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->users_aliases = new Google_Service_Directory_UsersAliases_Resource(
+        $this,
+        $this->serviceName,
+        'aliases',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'users/{userKey}/aliases/{alias}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'alias' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'users/{userKey}/aliases',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'users/{userKey}/aliases',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'event' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'watch' => array(
+              'path' => 'users/{userKey}/aliases/watch',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'event' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->users_photos = new Google_Service_Directory_UsersPhotos_Resource(
+        $this,
+        $this->serviceName,
+        'photos',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'users/{userKey}/photos/thumbnail',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'users/{userKey}/photos/thumbnail',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'users/{userKey}/photos/thumbnail',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'users/{userKey}/photos/thumbnail',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->verificationCodes = new Google_Service_Directory_VerificationCodes_Resource(
+        $this,
+        $this->serviceName,
+        'verificationCodes',
+        array(
+          'methods' => array(
+            'generate' => array(
+              'path' => 'users/{userKey}/verificationCodes/generate',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'invalidate' => array(
+              'path' => 'users/{userKey}/verificationCodes/invalidate',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'users/{userKey}/verificationCodes',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "asps" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $asps = $adminService->asps;
+ *  </code>
+ */
+class Google_Service_Directory_Asps_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete an ASP issued by a user. (asps.delete)
+   *
+   * @param string $userKey Identifies the user in the API request. The value can
+   * be the user's primary email address, alias email address, or unique user ID.
+   * @param int $codeId The unique ID of the ASP to be deleted.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($userKey, $codeId, $optParams = array())
+  {
+    $params = array('userKey' => $userKey, 'codeId' => $codeId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Get information about an ASP issued by a user. (asps.get)
+   *
+   * @param string $userKey Identifies the user in the API request. The value can
+   * be the user's primary email address, alias email address, or unique user ID.
+   * @param int $codeId The unique ID of the ASP.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Asp
+   */
+  public function get($userKey, $codeId, $optParams = array())
+  {
+    $params = array('userKey' => $userKey, 'codeId' => $codeId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Directory_Asp");
+  }
+
+  /**
+   * List the ASPs issued by a user. (asps.listAsps)
+   *
+   * @param string $userKey Identifies the user in the API request. The value can
+   * be the user's primary email address, alias email address, or unique user ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Asps
+   */
+  public function listAsps($userKey, $optParams = array())
+  {
+    $params = array('userKey' => $userKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Directory_Asps");
+  }
+}
+
+/**
+ * The "channels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $channels = $adminService->channels;
+ *  </code>
+ */
+class Google_Service_Directory_Channels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Stop watching resources through this channel (channels.stop)
+   *
+   * @param Google_Channel $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function stop(Google_Service_Directory_Channel $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('stop', array($params));
+  }
+}
+
+/**
+ * The "chromeosdevices" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $chromeosdevices = $adminService->chromeosdevices;
+ *  </code>
+ */
+class Google_Service_Directory_Chromeosdevices_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieve Chrome OS Device (chromeosdevices.get)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param string $deviceId Immutable id of Chrome OS Device
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string projection Restrict information returned to a set of
+   * selected fields.
+   * @return Google_Service_Directory_ChromeOsDevice
+   */
+  public function get($customerId, $deviceId, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'deviceId' => $deviceId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Directory_ChromeOsDevice");
+  }
+
+  /**
+   * Retrieve all Chrome OS Devices of a customer (paginated)
+   * (chromeosdevices.listChromeosdevices)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderBy Column to use for sorting results
+   * @opt_param string projection Restrict information returned to a set of
+   * selected fields.
+   * @opt_param int maxResults Maximum number of results to return. Default is 100
+   * @opt_param string pageToken Token to specify next page in the list
+   * @opt_param string sortOrder Whether to return results in ascending or
+   * descending order. Only of use when orderBy is also used
+   * @opt_param string query Search string in the format given at
+   * http://support.google.com/chromeos/a/bin/answer.py?hl=en=1698333
+   * @return Google_Service_Directory_ChromeOsDevices
+   */
+  public function listChromeosdevices($customerId, $optParams = array())
+  {
+    $params = array('customerId' => $customerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Directory_ChromeOsDevices");
+  }
+
+  /**
+   * Update Chrome OS Device. This method supports patch semantics.
+   * (chromeosdevices.patch)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param string $deviceId Immutable id of Chrome OS Device
+   * @param Google_ChromeOsDevice $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string projection Restrict information returned to a set of
+   * selected fields.
+   * @return Google_Service_Directory_ChromeOsDevice
+   */
+  public function patch($customerId, $deviceId, Google_Service_Directory_ChromeOsDevice $postBody, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'deviceId' => $deviceId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Directory_ChromeOsDevice");
+  }
+
+  /**
+   * Update Chrome OS Device (chromeosdevices.update)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param string $deviceId Immutable id of Chrome OS Device
+   * @param Google_ChromeOsDevice $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string projection Restrict information returned to a set of
+   * selected fields.
+   * @return Google_Service_Directory_ChromeOsDevice
+   */
+  public function update($customerId, $deviceId, Google_Service_Directory_ChromeOsDevice $postBody, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'deviceId' => $deviceId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Directory_ChromeOsDevice");
+  }
+}
+
+/**
+ * The "customers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $customers = $adminService->customers;
+ *  </code>
+ */
+class Google_Service_Directory_Customers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrives a customer. (customers.get)
+   *
+   * @param string $customerKey Id of the customer to be retrieved
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Customer
+   */
+  public function get($customerKey, $optParams = array())
+  {
+    $params = array('customerKey' => $customerKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Directory_Customer");
+  }
+
+  /**
+   * Updates a customer. This method supports patch semantics. (customers.patch)
+   *
+   * @param string $customerKey Id of the customer to be updated
+   * @param Google_Customer $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Customer
+   */
+  public function patch($customerKey, Google_Service_Directory_Customer $postBody, $optParams = array())
+  {
+    $params = array('customerKey' => $customerKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Directory_Customer");
+  }
+
+  /**
+   * Updates a customer. (customers.update)
+   *
+   * @param string $customerKey Id of the customer to be updated
+   * @param Google_Customer $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Customer
+   */
+  public function update($customerKey, Google_Service_Directory_Customer $postBody, $optParams = array())
+  {
+    $params = array('customerKey' => $customerKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Directory_Customer");
+  }
+}
+
+/**
+ * The "domainAliases" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $domainAliases = $adminService->domainAliases;
+ *  </code>
+ */
+class Google_Service_Directory_DomainAliases_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a Domain Alias of the customer. (domainAliases.delete)
+   *
+   * @param string $customer Immutable id of the Google Apps account.
+   * @param string $domainAliasName Name of domain alias to be retrieved.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($customer, $domainAliasName, $optParams = array())
+  {
+    $params = array('customer' => $customer, 'domainAliasName' => $domainAliasName);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves a domain alias of the customer. (domainAliases.get)
+   *
+   * @param string $customer Immutable id of the Google Apps account.
+   * @param string $domainAliasName Name of domain alias to be retrieved.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_DomainAlias
+   */
+  public function get($customer, $domainAliasName, $optParams = array())
+  {
+    $params = array('customer' => $customer, 'domainAliasName' => $domainAliasName);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Directory_DomainAlias");
+  }
+
+  /**
+   * Inserts a Domain alias of the customer. (domainAliases.insert)
+   *
+   * @param string $customer Immutable id of the Google Apps account.
+   * @param Google_DomainAlias $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_DomainAlias
+   */
+  public function insert($customer, Google_Service_Directory_DomainAlias $postBody, $optParams = array())
+  {
+    $params = array('customer' => $customer, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Directory_DomainAlias");
+  }
+
+  /**
+   * Lists the domain aliases of the customer. (domainAliases.listDomainAliases)
+   *
+   * @param string $customer Immutable id of the Google Apps account.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string parentDomainName Name of the parent domain for which domain
+   * aliases are to be fetched.
+   * @return Google_Service_Directory_DomainAliases
+   */
+  public function listDomainAliases($customer, $optParams = array())
+  {
+    $params = array('customer' => $customer);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Directory_DomainAliases");
+  }
+}
+
+/**
+ * The "domains" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $domains = $adminService->domains;
+ *  </code>
+ */
+class Google_Service_Directory_Domains_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a domain of the customer. (domains.delete)
+   *
+   * @param string $customer Immutable id of the Google Apps account.
+   * @param string $domainName Name of domain to be deleted
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($customer, $domainName, $optParams = array())
+  {
+    $params = array('customer' => $customer, 'domainName' => $domainName);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrives a domain of the customer. (domains.get)
+   *
+   * @param string $customer Immutable id of the Google Apps account.
+   * @param string $domainName Name of domain to be retrieved
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Domains
+   */
+  public function get($customer, $domainName, $optParams = array())
+  {
+    $params = array('customer' => $customer, 'domainName' => $domainName);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Directory_Domains");
+  }
+
+  /**
+   * Inserts a domain of the customer. (domains.insert)
+   *
+   * @param string $customer Immutable id of the Google Apps account.
+   * @param Google_Domains $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Domains
+   */
+  public function insert($customer, Google_Service_Directory_Domains $postBody, $optParams = array())
+  {
+    $params = array('customer' => $customer, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Directory_Domains");
+  }
+
+  /**
+   * Lists the domains of the customer. (domains.listDomains)
+   *
+   * @param string $customer Immutable id of the Google Apps account.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Domains2
+   */
+  public function listDomains($customer, $optParams = array())
+  {
+    $params = array('customer' => $customer);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Directory_Domains2");
+  }
+}
+
+/**
+ * The "groups" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $groups = $adminService->groups;
+ *  </code>
+ */
+class Google_Service_Directory_Groups_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete Group (groups.delete)
+   *
+   * @param string $groupKey Email or immutable Id of the group
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($groupKey, $optParams = array())
+  {
+    $params = array('groupKey' => $groupKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieve Group (groups.get)
+   *
+   * @param string $groupKey Email or immutable Id of the group
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Group
+   */
+  public function get($groupKey, $optParams = array())
+  {
+    $params = array('groupKey' => $groupKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Directory_Group");
+  }
+
+  /**
+   * Create Group (groups.insert)
+   *
+   * @param Google_Group $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Group
+   */
+  public function insert(Google_Service_Directory_Group $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Directory_Group");
+  }
+
+  /**
+   * Retrieve all groups in a domain (paginated) (groups.listGroups)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string customer Immutable id of the Google Apps account. In case
+   * of multi-domain, to fetch all groups for a customer, fill this field instead
+   * of domain.
+   * @opt_param string pageToken Token to specify next page in the list
+   * @opt_param string domain Name of the domain. Fill this field to get groups
+   * from only this domain. To return all groups in a multi-domain fill customer
+   * field instead.
+   * @opt_param int maxResults Maximum number of results to return. Default is 200
+   * @opt_param string userKey Email or immutable Id of the user if only those
+   * groups are to be listed, the given user is a member of. If Id, it should
+   * match with id of user object
+   * @return Google_Service_Directory_Groups
+   */
+  public function listGroups($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Directory_Groups");
+  }
+
+  /**
+   * Update Group. This method supports patch semantics. (groups.patch)
+   *
+   * @param string $groupKey Email or immutable Id of the group. If Id, it should
+   * match with id of group object
+   * @param Google_Group $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Group
+   */
+  public function patch($groupKey, Google_Service_Directory_Group $postBody, $optParams = array())
+  {
+    $params = array('groupKey' => $groupKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Directory_Group");
+  }
+
+  /**
+   * Update Group (groups.update)
+   *
+   * @param string $groupKey Email or immutable Id of the group. If Id, it should
+   * match with id of group object
+   * @param Google_Group $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Group
+   */
+  public function update($groupKey, Google_Service_Directory_Group $postBody, $optParams = array())
+  {
+    $params = array('groupKey' => $groupKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Directory_Group");
+  }
+}
+
+/**
+ * The "aliases" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $aliases = $adminService->aliases;
+ *  </code>
+ */
+class Google_Service_Directory_GroupsAliases_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Remove a alias for the group (aliases.delete)
+   *
+   * @param string $groupKey Email or immutable Id of the group
+   * @param string $alias The alias to be removed
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($groupKey, $alias, $optParams = array())
+  {
+    $params = array('groupKey' => $groupKey, 'alias' => $alias);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Add a alias for the group (aliases.insert)
+   *
+   * @param string $groupKey Email or immutable Id of the group
+   * @param Google_Alias $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Alias
+   */
+  public function insert($groupKey, Google_Service_Directory_Alias $postBody, $optParams = array())
+  {
+    $params = array('groupKey' => $groupKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Directory_Alias");
+  }
+
+  /**
+   * List all aliases for a group (aliases.listGroupsAliases)
+   *
+   * @param string $groupKey Email or immutable Id of the group
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Aliases
+   */
+  public function listGroupsAliases($groupKey, $optParams = array())
+  {
+    $params = array('groupKey' => $groupKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Directory_Aliases");
+  }
+}
+
+/**
+ * The "members" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $members = $adminService->members;
+ *  </code>
+ */
+class Google_Service_Directory_Members_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Remove membership. (members.delete)
+   *
+   * @param string $groupKey Email or immutable Id of the group
+   * @param string $memberKey Email or immutable Id of the member
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($groupKey, $memberKey, $optParams = array())
+  {
+    $params = array('groupKey' => $groupKey, 'memberKey' => $memberKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieve Group Member (members.get)
+   *
+   * @param string $groupKey Email or immutable Id of the group
+   * @param string $memberKey Email or immutable Id of the member
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Member
+   */
+  public function get($groupKey, $memberKey, $optParams = array())
+  {
+    $params = array('groupKey' => $groupKey, 'memberKey' => $memberKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Directory_Member");
+  }
+
+  /**
+   * Add user to the specified group. (members.insert)
+   *
+   * @param string $groupKey Email or immutable Id of the group
+   * @param Google_Member $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Member
+   */
+  public function insert($groupKey, Google_Service_Directory_Member $postBody, $optParams = array())
+  {
+    $params = array('groupKey' => $groupKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Directory_Member");
+  }
+
+  /**
+   * Retrieve all members in a group (paginated) (members.listMembers)
+   *
+   * @param string $groupKey Email or immutable Id of the group
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Token to specify next page in the list
+   * @opt_param string roles Comma separated role values to filter list results
+   * on.
+   * @opt_param int maxResults Maximum number of results to return. Default is 200
+   * @return Google_Service_Directory_Members
+   */
+  public function listMembers($groupKey, $optParams = array())
+  {
+    $params = array('groupKey' => $groupKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Directory_Members");
+  }
+
+  /**
+   * Update membership of a user in the specified group. This method supports
+   * patch semantics. (members.patch)
+   *
+   * @param string $groupKey Email or immutable Id of the group. If Id, it should
+   * match with id of group object
+   * @param string $memberKey Email or immutable Id of the user. If Id, it should
+   * match with id of member object
+   * @param Google_Member $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Member
+   */
+  public function patch($groupKey, $memberKey, Google_Service_Directory_Member $postBody, $optParams = array())
+  {
+    $params = array('groupKey' => $groupKey, 'memberKey' => $memberKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Directory_Member");
+  }
+
+  /**
+   * Update membership of a user in the specified group. (members.update)
+   *
+   * @param string $groupKey Email or immutable Id of the group. If Id, it should
+   * match with id of group object
+   * @param string $memberKey Email or immutable Id of the user. If Id, it should
+   * match with id of member object
+   * @param Google_Member $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Member
+   */
+  public function update($groupKey, $memberKey, Google_Service_Directory_Member $postBody, $optParams = array())
+  {
+    $params = array('groupKey' => $groupKey, 'memberKey' => $memberKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Directory_Member");
+  }
+}
+
+/**
+ * The "mobiledevices" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $mobiledevices = $adminService->mobiledevices;
+ *  </code>
+ */
+class Google_Service_Directory_Mobiledevices_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Take action on Mobile Device (mobiledevices.action)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param string $resourceId Immutable id of Mobile Device
+   * @param Google_MobileDeviceAction $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function action($customerId, $resourceId, Google_Service_Directory_MobileDeviceAction $postBody, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'resourceId' => $resourceId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('action', array($params));
+  }
+
+  /**
+   * Delete Mobile Device (mobiledevices.delete)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param string $resourceId Immutable id of Mobile Device
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($customerId, $resourceId, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'resourceId' => $resourceId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieve Mobile Device (mobiledevices.get)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param string $resourceId Immutable id of Mobile Device
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string projection Restrict information returned to a set of
+   * selected fields.
+   * @return Google_Service_Directory_MobileDevice
+   */
+  public function get($customerId, $resourceId, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'resourceId' => $resourceId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Directory_MobileDevice");
+  }
+
+  /**
+   * Retrieve all Mobile Devices of a customer (paginated)
+   * (mobiledevices.listMobiledevices)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderBy Column to use for sorting results
+   * @opt_param string projection Restrict information returned to a set of
+   * selected fields.
+   * @opt_param int maxResults Maximum number of results to return. Default is 100
+   * @opt_param string pageToken Token to specify next page in the list
+   * @opt_param string sortOrder Whether to return results in ascending or
+   * descending order. Only of use when orderBy is also used
+   * @opt_param string query Search string in the format given at
+   * http://support.google.com/a/bin/answer.py?hl=en=1408863#search
+   * @return Google_Service_Directory_MobileDevices
+   */
+  public function listMobiledevices($customerId, $optParams = array())
+  {
+    $params = array('customerId' => $customerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Directory_MobileDevices");
+  }
+}
+
+/**
+ * The "notifications" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $notifications = $adminService->notifications;
+ *  </code>
+ */
+class Google_Service_Directory_Notifications_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a notification (notifications.delete)
+   *
+   * @param string $customer The unique ID for the customer's Google account. The
+   * customerId is also returned as part of the Users resource.
+   * @param string $notificationId The unique ID of the notification.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($customer, $notificationId, $optParams = array())
+  {
+    $params = array('customer' => $customer, 'notificationId' => $notificationId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves a notification. (notifications.get)
+   *
+   * @param string $customer The unique ID for the customer's Google account. The
+   * customerId is also returned as part of the Users resource.
+   * @param string $notificationId The unique ID of the notification.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Notification
+   */
+  public function get($customer, $notificationId, $optParams = array())
+  {
+    $params = array('customer' => $customer, 'notificationId' => $notificationId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Directory_Notification");
+  }
+
+  /**
+   * Retrieves a list of notifications. (notifications.listNotifications)
+   *
+   * @param string $customer The unique ID for the customer's Google account.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token to specify the page of results to
+   * retrieve.
+   * @opt_param string maxResults Maximum number of notifications to return per
+   * page. The default is 100.
+   * @opt_param string language The ISO 639-1 code of the language notifications
+   * are returned in. The default is English (en).
+   * @return Google_Service_Directory_Notifications
+   */
+  public function listNotifications($customer, $optParams = array())
+  {
+    $params = array('customer' => $customer);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Directory_Notifications");
+  }
+
+  /**
+   * Updates a notification. This method supports patch semantics.
+   * (notifications.patch)
+   *
+   * @param string $customer The unique ID for the customer's Google account.
+   * @param string $notificationId The unique ID of the notification.
+   * @param Google_Notification $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Notification
+   */
+  public function patch($customer, $notificationId, Google_Service_Directory_Notification $postBody, $optParams = array())
+  {
+    $params = array('customer' => $customer, 'notificationId' => $notificationId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Directory_Notification");
+  }
+
+  /**
+   * Updates a notification. (notifications.update)
+   *
+   * @param string $customer The unique ID for the customer's Google account.
+   * @param string $notificationId The unique ID of the notification.
+   * @param Google_Notification $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Notification
+   */
+  public function update($customer, $notificationId, Google_Service_Directory_Notification $postBody, $optParams = array())
+  {
+    $params = array('customer' => $customer, 'notificationId' => $notificationId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Directory_Notification");
+  }
+}
+
+/**
+ * The "orgunits" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $orgunits = $adminService->orgunits;
+ *  </code>
+ */
+class Google_Service_Directory_Orgunits_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Remove Organization Unit (orgunits.delete)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param string $orgUnitPath Full path of the organization unit or its Id
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($customerId, $orgUnitPath, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'orgUnitPath' => $orgUnitPath);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieve Organization Unit (orgunits.get)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param string $orgUnitPath Full path of the organization unit or its Id
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_OrgUnit
+   */
+  public function get($customerId, $orgUnitPath, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'orgUnitPath' => $orgUnitPath);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Directory_OrgUnit");
+  }
+
+  /**
+   * Add Organization Unit (orgunits.insert)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param Google_OrgUnit $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_OrgUnit
+   */
+  public function insert($customerId, Google_Service_Directory_OrgUnit $postBody, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Directory_OrgUnit");
+  }
+
+  /**
+   * Retrieve all Organization Units (orgunits.listOrgunits)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string type Whether to return all sub-organizations or just
+   * immediate children
+   * @opt_param string orgUnitPath the URL-encoded organization unit's path or its
+   * Id
+   * @return Google_Service_Directory_OrgUnits
+   */
+  public function listOrgunits($customerId, $optParams = array())
+  {
+    $params = array('customerId' => $customerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Directory_OrgUnits");
+  }
+
+  /**
+   * Update Organization Unit. This method supports patch semantics.
+   * (orgunits.patch)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param string $orgUnitPath Full path of the organization unit or its Id
+   * @param Google_OrgUnit $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_OrgUnit
+   */
+  public function patch($customerId, $orgUnitPath, Google_Service_Directory_OrgUnit $postBody, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'orgUnitPath' => $orgUnitPath, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Directory_OrgUnit");
+  }
+
+  /**
+   * Update Organization Unit (orgunits.update)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param string $orgUnitPath Full path of the organization unit or its Id
+   * @param Google_OrgUnit $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_OrgUnit
+   */
+  public function update($customerId, $orgUnitPath, Google_Service_Directory_OrgUnit $postBody, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'orgUnitPath' => $orgUnitPath, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Directory_OrgUnit");
+  }
+}
+
+/**
+ * The "privileges" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $privileges = $adminService->privileges;
+ *  </code>
+ */
+class Google_Service_Directory_Privileges_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a paginated list of all privileges for a customer.
+   * (privileges.listPrivileges)
+   *
+   * @param string $customer Immutable ID of the Google Apps account.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Privileges
+   */
+  public function listPrivileges($customer, $optParams = array())
+  {
+    $params = array('customer' => $customer);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Directory_Privileges");
+  }
+}
+
+/**
+ * The "roleAssignments" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $roleAssignments = $adminService->roleAssignments;
+ *  </code>
+ */
+class Google_Service_Directory_RoleAssignments_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a role assignment. (roleAssignments.delete)
+   *
+   * @param string $customer Immutable ID of the Google Apps account.
+   * @param string $roleAssignmentId Immutable ID of the role assignment.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($customer, $roleAssignmentId, $optParams = array())
+  {
+    $params = array('customer' => $customer, 'roleAssignmentId' => $roleAssignmentId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieve a role assignment. (roleAssignments.get)
+   *
+   * @param string $customer Immutable ID of the Google Apps account.
+   * @param string $roleAssignmentId Immutable ID of the role assignment.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_RoleAssignment
+   */
+  public function get($customer, $roleAssignmentId, $optParams = array())
+  {
+    $params = array('customer' => $customer, 'roleAssignmentId' => $roleAssignmentId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Directory_RoleAssignment");
+  }
+
+  /**
+   * Creates a role assignment. (roleAssignments.insert)
+   *
+   * @param string $customer Immutable ID of the Google Apps account.
+   * @param Google_RoleAssignment $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_RoleAssignment
+   */
+  public function insert($customer, Google_Service_Directory_RoleAssignment $postBody, $optParams = array())
+  {
+    $params = array('customer' => $customer, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Directory_RoleAssignment");
+  }
+
+  /**
+   * Retrieves a paginated list of all roleAssignments.
+   * (roleAssignments.listRoleAssignments)
+   *
+   * @param string $customer Immutable ID of the Google Apps account.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Token to specify the next page in the list.
+   * @opt_param string userKey The user's primary email address, alias email
+   * address, or unique user ID. If included in the request, returns role
+   * assignments only for this user.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @opt_param string roleId Immutable ID of a role. If included in the request,
+   * returns only role assignments containing this role ID.
+   * @return Google_Service_Directory_RoleAssignments
+   */
+  public function listRoleAssignments($customer, $optParams = array())
+  {
+    $params = array('customer' => $customer);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Directory_RoleAssignments");
+  }
+}
+
+/**
+ * The "roles" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $roles = $adminService->roles;
+ *  </code>
+ */
+class Google_Service_Directory_Roles_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a role. (roles.delete)
+   *
+   * @param string $customer Immutable ID of the Google Apps account.
+   * @param string $roleId Immutable ID of the role.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($customer, $roleId, $optParams = array())
+  {
+    $params = array('customer' => $customer, 'roleId' => $roleId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves a role. (roles.get)
+   *
+   * @param string $customer Immutable ID of the Google Apps account.
+   * @param string $roleId Immutable ID of the role.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Role
+   */
+  public function get($customer, $roleId, $optParams = array())
+  {
+    $params = array('customer' => $customer, 'roleId' => $roleId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Directory_Role");
+  }
+
+  /**
+   * Creates a role. (roles.insert)
+   *
+   * @param string $customer Immutable ID of the Google Apps account.
+   * @param Google_Role $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Role
+   */
+  public function insert($customer, Google_Service_Directory_Role $postBody, $optParams = array())
+  {
+    $params = array('customer' => $customer, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Directory_Role");
+  }
+
+  /**
+   * Retrieves a paginated list of all the roles in a domain. (roles.listRoles)
+   *
+   * @param string $customer Immutable id of the Google Apps account.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Token to specify the next page in the list.
+   * @opt_param int maxResults Maximum number of results to return.
+   * @return Google_Service_Directory_Roles
+   */
+  public function listRoles($customer, $optParams = array())
+  {
+    $params = array('customer' => $customer);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Directory_Roles");
+  }
+
+  /**
+   * Updates a role. This method supports patch semantics. (roles.patch)
+   *
+   * @param string $customer Immutable ID of the Google Apps account.
+   * @param string $roleId Immutable ID of the role.
+   * @param Google_Role $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Role
+   */
+  public function patch($customer, $roleId, Google_Service_Directory_Role $postBody, $optParams = array())
+  {
+    $params = array('customer' => $customer, 'roleId' => $roleId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Directory_Role");
+  }
+
+  /**
+   * Updates a role. (roles.update)
+   *
+   * @param string $customer Immutable ID of the Google Apps account.
+   * @param string $roleId Immutable ID of the role.
+   * @param Google_Role $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Role
+   */
+  public function update($customer, $roleId, Google_Service_Directory_Role $postBody, $optParams = array())
+  {
+    $params = array('customer' => $customer, 'roleId' => $roleId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Directory_Role");
+  }
+}
+
+/**
+ * The "schemas" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $schemas = $adminService->schemas;
+ *  </code>
+ */
+class Google_Service_Directory_Schemas_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete schema (schemas.delete)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param string $schemaKey Name or immutable Id of the schema
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($customerId, $schemaKey, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'schemaKey' => $schemaKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieve schema (schemas.get)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param string $schemaKey Name or immutable Id of the schema
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Schema
+   */
+  public function get($customerId, $schemaKey, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'schemaKey' => $schemaKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Directory_Schema");
+  }
+
+  /**
+   * Create schema. (schemas.insert)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param Google_Schema $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Schema
+   */
+  public function insert($customerId, Google_Service_Directory_Schema $postBody, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Directory_Schema");
+  }
+
+  /**
+   * Retrieve all schemas for a customer (schemas.listSchemas)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Schemas
+   */
+  public function listSchemas($customerId, $optParams = array())
+  {
+    $params = array('customerId' => $customerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Directory_Schemas");
+  }
+
+  /**
+   * Update schema. This method supports patch semantics. (schemas.patch)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param string $schemaKey Name or immutable Id of the schema.
+   * @param Google_Schema $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Schema
+   */
+  public function patch($customerId, $schemaKey, Google_Service_Directory_Schema $postBody, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'schemaKey' => $schemaKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Directory_Schema");
+  }
+
+  /**
+   * Update schema (schemas.update)
+   *
+   * @param string $customerId Immutable id of the Google Apps account
+   * @param string $schemaKey Name or immutable Id of the schema.
+   * @param Google_Schema $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Schema
+   */
+  public function update($customerId, $schemaKey, Google_Service_Directory_Schema $postBody, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'schemaKey' => $schemaKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Directory_Schema");
+  }
+}
+
+/**
+ * The "tokens" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $tokens = $adminService->tokens;
+ *  </code>
+ */
+class Google_Service_Directory_Tokens_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete all access tokens issued by a user for an application. (tokens.delete)
+   *
+   * @param string $userKey Identifies the user in the API request. The value can
+   * be the user's primary email address, alias email address, or unique user ID.
+   * @param string $clientId The Client ID of the application the token is issued
+   * to.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($userKey, $clientId, $optParams = array())
+  {
+    $params = array('userKey' => $userKey, 'clientId' => $clientId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Get information about an access token issued by a user. (tokens.get)
+   *
+   * @param string $userKey Identifies the user in the API request. The value can
+   * be the user's primary email address, alias email address, or unique user ID.
+   * @param string $clientId The Client ID of the application the token is issued
+   * to.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Token
+   */
+  public function get($userKey, $clientId, $optParams = array())
+  {
+    $params = array('userKey' => $userKey, 'clientId' => $clientId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Directory_Token");
+  }
+
+  /**
+   * Returns the set of tokens specified user has issued to 3rd party
+   * applications. (tokens.listTokens)
+   *
+   * @param string $userKey Identifies the user in the API request. The value can
+   * be the user's primary email address, alias email address, or unique user ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Tokens
+   */
+  public function listTokens($userKey, $optParams = array())
+  {
+    $params = array('userKey' => $userKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Directory_Tokens");
+  }
+}
+
+/**
+ * The "users" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $users = $adminService->users;
+ *  </code>
+ */
+class Google_Service_Directory_Users_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete user (users.delete)
+   *
+   * @param string $userKey Email or immutable Id of the user
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($userKey, $optParams = array())
+  {
+    $params = array('userKey' => $userKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * retrieve user (users.get)
+   *
+   * @param string $userKey Email or immutable Id of the user
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string viewType Whether to fetch the ADMIN_VIEW or DOMAIN_PUBLIC
+   * view of the user.
+   * @opt_param string customFieldMask Comma-separated list of schema names. All
+   * fields from these schemas are fetched. This should only be set when
+   * projection=custom.
+   * @opt_param string projection What subset of fields to fetch for this user.
+   * @return Google_Service_Directory_User
+   */
+  public function get($userKey, $optParams = array())
+  {
+    $params = array('userKey' => $userKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Directory_User");
+  }
+
+  /**
+   * create user. (users.insert)
+   *
+   * @param Google_User $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_User
+   */
+  public function insert(Google_Service_Directory_User $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Directory_User");
+  }
+
+  /**
+   * Retrieve either deleted users or all users in a domain (paginated)
+   * (users.listUsers)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string customer Immutable id of the Google Apps account. In case
+   * of multi-domain, to fetch all users for a customer, fill this field instead
+   * of domain.
+   * @opt_param string orderBy Column to use for sorting results
+   * @opt_param string domain Name of the domain. Fill this field to get users
+   * from only this domain. To return all users in a multi-domain fill customer
+   * field instead.
+   * @opt_param string projection What subset of fields to fetch for this user.
+   * @opt_param string showDeleted If set to true retrieves the list of deleted
+   * users. Default is false
+   * @opt_param string customFieldMask Comma-separated list of schema names. All
+   * fields from these schemas are fetched. This should only be set when
+   * projection=custom.
+   * @opt_param int maxResults Maximum number of results to return. Default is
+   * 100. Max allowed is 500
+   * @opt_param string pageToken Token to specify next page in the list
+   * @opt_param string sortOrder Whether to return results in ascending or
+   * descending order.
+   * @opt_param string query Query string search. Should be of the form "".
+   * Complete documentation is at https://developers.google.com/admin-
+   * sdk/directory/v1/guides/search-users
+   * @opt_param string viewType Whether to fetch the ADMIN_VIEW or DOMAIN_PUBLIC
+   * view of the user.
+   * @opt_param string event Event on which subscription is intended (if
+   * subscribing)
+   * @return Google_Service_Directory_Users
+   */
+  public function listUsers($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Directory_Users");
+  }
+
+  /**
+   * change admin status of a user (users.makeAdmin)
+   *
+   * @param string $userKey Email or immutable Id of the user as admin
+   * @param Google_UserMakeAdmin $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function makeAdmin($userKey, Google_Service_Directory_UserMakeAdmin $postBody, $optParams = array())
+  {
+    $params = array('userKey' => $userKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('makeAdmin', array($params));
+  }
+
+  /**
+   * update user. This method supports patch semantics. (users.patch)
+   *
+   * @param string $userKey Email or immutable Id of the user. If Id, it should
+   * match with id of user object
+   * @param Google_User $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_User
+   */
+  public function patch($userKey, Google_Service_Directory_User $postBody, $optParams = array())
+  {
+    $params = array('userKey' => $userKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Directory_User");
+  }
+
+  /**
+   * Undelete a deleted user (users.undelete)
+   *
+   * @param string $userKey The immutable id of the user
+   * @param Google_UserUndelete $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function undelete($userKey, Google_Service_Directory_UserUndelete $postBody, $optParams = array())
+  {
+    $params = array('userKey' => $userKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('undelete', array($params));
+  }
+
+  /**
+   * update user (users.update)
+   *
+   * @param string $userKey Email or immutable Id of the user. If Id, it should
+   * match with id of user object
+   * @param Google_User $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_User
+   */
+  public function update($userKey, Google_Service_Directory_User $postBody, $optParams = array())
+  {
+    $params = array('userKey' => $userKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Directory_User");
+  }
+
+  /**
+   * Watch for changes in users list (users.watch)
+   *
+   * @param Google_Channel $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string customer Immutable id of the Google Apps account. In case
+   * of multi-domain, to fetch all users for a customer, fill this field instead
+   * of domain.
+   * @opt_param string orderBy Column to use for sorting results
+   * @opt_param string domain Name of the domain. Fill this field to get users
+   * from only this domain. To return all users in a multi-domain fill customer
+   * field instead.
+   * @opt_param string projection What subset of fields to fetch for this user.
+   * @opt_param string showDeleted If set to true retrieves the list of deleted
+   * users. Default is false
+   * @opt_param string customFieldMask Comma-separated list of schema names. All
+   * fields from these schemas are fetched. This should only be set when
+   * projection=custom.
+   * @opt_param int maxResults Maximum number of results to return. Default is
+   * 100. Max allowed is 500
+   * @opt_param string pageToken Token to specify next page in the list
+   * @opt_param string sortOrder Whether to return results in ascending or
+   * descending order.
+   * @opt_param string query Query string search. Should be of the form "".
+   * Complete documentation is at https://developers.google.com/admin-
+   * sdk/directory/v1/guides/search-users
+   * @opt_param string viewType Whether to fetch the ADMIN_VIEW or DOMAIN_PUBLIC
+   * view of the user.
+   * @opt_param string event Event on which subscription is intended (if
+   * subscribing)
+   * @return Google_Service_Directory_Channel
+   */
+  public function watch(Google_Service_Directory_Channel $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('watch', array($params), "Google_Service_Directory_Channel");
+  }
+}
+
+/**
+ * The "aliases" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $aliases = $adminService->aliases;
+ *  </code>
+ */
+class Google_Service_Directory_UsersAliases_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Remove a alias for the user (aliases.delete)
+   *
+   * @param string $userKey Email or immutable Id of the user
+   * @param string $alias The alias to be removed
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($userKey, $alias, $optParams = array())
+  {
+    $params = array('userKey' => $userKey, 'alias' => $alias);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Add a alias for the user (aliases.insert)
+   *
+   * @param string $userKey Email or immutable Id of the user
+   * @param Google_Alias $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_Alias
+   */
+  public function insert($userKey, Google_Service_Directory_Alias $postBody, $optParams = array())
+  {
+    $params = array('userKey' => $userKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Directory_Alias");
+  }
+
+  /**
+   * List all aliases for a user (aliases.listUsersAliases)
+   *
+   * @param string $userKey Email or immutable Id of the user
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string event Event on which subscription is intended (if
+   * subscribing)
+   * @return Google_Service_Directory_Aliases
+   */
+  public function listUsersAliases($userKey, $optParams = array())
+  {
+    $params = array('userKey' => $userKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Directory_Aliases");
+  }
+
+  /**
+   * Watch for changes in user aliases list (aliases.watch)
+   *
+   * @param string $userKey Email or immutable Id of the user
+   * @param Google_Channel $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string event Event on which subscription is intended (if
+   * subscribing)
+   * @return Google_Service_Directory_Channel
+   */
+  public function watch($userKey, Google_Service_Directory_Channel $postBody, $optParams = array())
+  {
+    $params = array('userKey' => $userKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('watch', array($params), "Google_Service_Directory_Channel");
+  }
+}
+/**
+ * The "photos" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $photos = $adminService->photos;
+ *  </code>
+ */
+class Google_Service_Directory_UsersPhotos_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Remove photos for the user (photos.delete)
+   *
+   * @param string $userKey Email or immutable Id of the user
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($userKey, $optParams = array())
+  {
+    $params = array('userKey' => $userKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieve photo of a user (photos.get)
+   *
+   * @param string $userKey Email or immutable Id of the user
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_UserPhoto
+   */
+  public function get($userKey, $optParams = array())
+  {
+    $params = array('userKey' => $userKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Directory_UserPhoto");
+  }
+
+  /**
+   * Add a photo for the user. This method supports patch semantics.
+   * (photos.patch)
+   *
+   * @param string $userKey Email or immutable Id of the user
+   * @param Google_UserPhoto $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_UserPhoto
+   */
+  public function patch($userKey, Google_Service_Directory_UserPhoto $postBody, $optParams = array())
+  {
+    $params = array('userKey' => $userKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Directory_UserPhoto");
+  }
+
+  /**
+   * Add a photo for the user (photos.update)
+   *
+   * @param string $userKey Email or immutable Id of the user
+   * @param Google_UserPhoto $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_UserPhoto
+   */
+  public function update($userKey, Google_Service_Directory_UserPhoto $postBody, $optParams = array())
+  {
+    $params = array('userKey' => $userKey, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Directory_UserPhoto");
+  }
+}
+
+/**
+ * The "verificationCodes" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Directory(...);
+ *   $verificationCodes = $adminService->verificationCodes;
+ *  </code>
+ */
+class Google_Service_Directory_VerificationCodes_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Generate new backup verification codes for the user.
+   * (verificationCodes.generate)
+   *
+   * @param string $userKey Email or immutable Id of the user
+   * @param array $optParams Optional parameters.
+   */
+  public function generate($userKey, $optParams = array())
+  {
+    $params = array('userKey' => $userKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('generate', array($params));
+  }
+
+  /**
+   * Invalidate the current backup verification codes for the user.
+   * (verificationCodes.invalidate)
+   *
+   * @param string $userKey Email or immutable Id of the user
+   * @param array $optParams Optional parameters.
+   */
+  public function invalidate($userKey, $optParams = array())
+  {
+    $params = array('userKey' => $userKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('invalidate', array($params));
+  }
+
+  /**
+   * Returns the current set of valid backup verification codes for the specified
+   * user. (verificationCodes.listVerificationCodes)
+   *
+   * @param string $userKey Identifies the user in the API request. The value can
+   * be the user's primary email address, alias email address, or unique user ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Directory_VerificationCodes
+   */
+  public function listVerificationCodes($userKey, $optParams = array())
+  {
+    $params = array('userKey' => $userKey);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Directory_VerificationCodes");
+  }
+}
+
+
+
+
+class Google_Service_Directory_Alias extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $alias;
+  public $etag;
+  public $id;
+  public $kind;
+  public $primaryEmail;
+
+
+  public function setAlias($alias)
+  {
+    $this->alias = $alias;
+  }
+  public function getAlias()
+  {
+    return $this->alias;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPrimaryEmail($primaryEmail)
+  {
+    $this->primaryEmail = $primaryEmail;
+  }
+  public function getPrimaryEmail()
+  {
+    return $this->primaryEmail;
+  }
+}
+
+class Google_Service_Directory_Aliases extends Google_Collection
+{
+  protected $collection_key = 'aliases';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $aliasesType = 'Google_Service_Directory_Alias';
+  protected $aliasesDataType = 'array';
+  public $etag;
+  public $kind;
+
+
+  public function setAliases($aliases)
+  {
+    $this->aliases = $aliases;
+  }
+  public function getAliases()
+  {
+    return $this->aliases;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Directory_Asp extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $codeId;
+  public $creationTime;
+  public $etag;
+  public $kind;
+  public $lastTimeUsed;
+  public $name;
+  public $userKey;
+
+
+  public function setCodeId($codeId)
+  {
+    $this->codeId = $codeId;
+  }
+  public function getCodeId()
+  {
+    return $this->codeId;
+  }
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastTimeUsed($lastTimeUsed)
+  {
+    $this->lastTimeUsed = $lastTimeUsed;
+  }
+  public function getLastTimeUsed()
+  {
+    return $this->lastTimeUsed;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setUserKey($userKey)
+  {
+    $this->userKey = $userKey;
+  }
+  public function getUserKey()
+  {
+    return $this->userKey;
+  }
+}
+
+class Google_Service_Directory_Asps extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Directory_Asp';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Directory_Channel extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $address;
+  public $expiration;
+  public $id;
+  public $kind;
+  public $params;
+  public $payload;
+  public $resourceId;
+  public $resourceUri;
+  public $token;
+  public $type;
+
+
+  public function setAddress($address)
+  {
+    $this->address = $address;
+  }
+  public function getAddress()
+  {
+    return $this->address;
+  }
+  public function setExpiration($expiration)
+  {
+    $this->expiration = $expiration;
+  }
+  public function getExpiration()
+  {
+    return $this->expiration;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setParams($params)
+  {
+    $this->params = $params;
+  }
+  public function getParams()
+  {
+    return $this->params;
+  }
+  public function setPayload($payload)
+  {
+    $this->payload = $payload;
+  }
+  public function getPayload()
+  {
+    return $this->payload;
+  }
+  public function setResourceId($resourceId)
+  {
+    $this->resourceId = $resourceId;
+  }
+  public function getResourceId()
+  {
+    return $this->resourceId;
+  }
+  public function setResourceUri($resourceUri)
+  {
+    $this->resourceUri = $resourceUri;
+  }
+  public function getResourceUri()
+  {
+    return $this->resourceUri;
+  }
+  public function setToken($token)
+  {
+    $this->token = $token;
+  }
+  public function getToken()
+  {
+    return $this->token;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Directory_ChannelParams extends Google_Model
+{
+}
+
+class Google_Service_Directory_ChromeOsDevice extends Google_Collection
+{
+  protected $collection_key = 'recentUsers';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $activeTimeRangesType = 'Google_Service_Directory_ChromeOsDeviceActiveTimeRanges';
+  protected $activeTimeRangesDataType = 'array';
+  public $annotatedAssetId;
+  public $annotatedLocation;
+  public $annotatedUser;
+  public $bootMode;
+  public $deviceId;
+  public $etag;
+  public $ethernetMacAddress;
+  public $firmwareVersion;
+  public $kind;
+  public $lastEnrollmentTime;
+  public $lastSync;
+  public $macAddress;
+  public $meid;
+  public $model;
+  public $notes;
+  public $orderNumber;
+  public $orgUnitPath;
+  public $osVersion;
+  public $platformVersion;
+  protected $recentUsersType = 'Google_Service_Directory_ChromeOsDeviceRecentUsers';
+  protected $recentUsersDataType = 'array';
+  public $serialNumber;
+  public $status;
+  public $supportEndDate;
+  public $willAutoRenew;
+
+
+  public function setActiveTimeRanges($activeTimeRanges)
+  {
+    $this->activeTimeRanges = $activeTimeRanges;
+  }
+  public function getActiveTimeRanges()
+  {
+    return $this->activeTimeRanges;
+  }
+  public function setAnnotatedAssetId($annotatedAssetId)
+  {
+    $this->annotatedAssetId = $annotatedAssetId;
+  }
+  public function getAnnotatedAssetId()
+  {
+    return $this->annotatedAssetId;
+  }
+  public function setAnnotatedLocation($annotatedLocation)
+  {
+    $this->annotatedLocation = $annotatedLocation;
+  }
+  public function getAnnotatedLocation()
+  {
+    return $this->annotatedLocation;
+  }
+  public function setAnnotatedUser($annotatedUser)
+  {
+    $this->annotatedUser = $annotatedUser;
+  }
+  public function getAnnotatedUser()
+  {
+    return $this->annotatedUser;
+  }
+  public function setBootMode($bootMode)
+  {
+    $this->bootMode = $bootMode;
+  }
+  public function getBootMode()
+  {
+    return $this->bootMode;
+  }
+  public function setDeviceId($deviceId)
+  {
+    $this->deviceId = $deviceId;
+  }
+  public function getDeviceId()
+  {
+    return $this->deviceId;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEthernetMacAddress($ethernetMacAddress)
+  {
+    $this->ethernetMacAddress = $ethernetMacAddress;
+  }
+  public function getEthernetMacAddress()
+  {
+    return $this->ethernetMacAddress;
+  }
+  public function setFirmwareVersion($firmwareVersion)
+  {
+    $this->firmwareVersion = $firmwareVersion;
+  }
+  public function getFirmwareVersion()
+  {
+    return $this->firmwareVersion;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastEnrollmentTime($lastEnrollmentTime)
+  {
+    $this->lastEnrollmentTime = $lastEnrollmentTime;
+  }
+  public function getLastEnrollmentTime()
+  {
+    return $this->lastEnrollmentTime;
+  }
+  public function setLastSync($lastSync)
+  {
+    $this->lastSync = $lastSync;
+  }
+  public function getLastSync()
+  {
+    return $this->lastSync;
+  }
+  public function setMacAddress($macAddress)
+  {
+    $this->macAddress = $macAddress;
+  }
+  public function getMacAddress()
+  {
+    return $this->macAddress;
+  }
+  public function setMeid($meid)
+  {
+    $this->meid = $meid;
+  }
+  public function getMeid()
+  {
+    return $this->meid;
+  }
+  public function setModel($model)
+  {
+    $this->model = $model;
+  }
+  public function getModel()
+  {
+    return $this->model;
+  }
+  public function setNotes($notes)
+  {
+    $this->notes = $notes;
+  }
+  public function getNotes()
+  {
+    return $this->notes;
+  }
+  public function setOrderNumber($orderNumber)
+  {
+    $this->orderNumber = $orderNumber;
+  }
+  public function getOrderNumber()
+  {
+    return $this->orderNumber;
+  }
+  public function setOrgUnitPath($orgUnitPath)
+  {
+    $this->orgUnitPath = $orgUnitPath;
+  }
+  public function getOrgUnitPath()
+  {
+    return $this->orgUnitPath;
+  }
+  public function setOsVersion($osVersion)
+  {
+    $this->osVersion = $osVersion;
+  }
+  public function getOsVersion()
+  {
+    return $this->osVersion;
+  }
+  public function setPlatformVersion($platformVersion)
+  {
+    $this->platformVersion = $platformVersion;
+  }
+  public function getPlatformVersion()
+  {
+    return $this->platformVersion;
+  }
+  public function setRecentUsers($recentUsers)
+  {
+    $this->recentUsers = $recentUsers;
+  }
+  public function getRecentUsers()
+  {
+    return $this->recentUsers;
+  }
+  public function setSerialNumber($serialNumber)
+  {
+    $this->serialNumber = $serialNumber;
+  }
+  public function getSerialNumber()
+  {
+    return $this->serialNumber;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setSupportEndDate($supportEndDate)
+  {
+    $this->supportEndDate = $supportEndDate;
+  }
+  public function getSupportEndDate()
+  {
+    return $this->supportEndDate;
+  }
+  public function setWillAutoRenew($willAutoRenew)
+  {
+    $this->willAutoRenew = $willAutoRenew;
+  }
+  public function getWillAutoRenew()
+  {
+    return $this->willAutoRenew;
+  }
+}
+
+class Google_Service_Directory_ChromeOsDeviceActiveTimeRanges extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $activeTime;
+  public $date;
+
+
+  public function setActiveTime($activeTime)
+  {
+    $this->activeTime = $activeTime;
+  }
+  public function getActiveTime()
+  {
+    return $this->activeTime;
+  }
+  public function setDate($date)
+  {
+    $this->date = $date;
+  }
+  public function getDate()
+  {
+    return $this->date;
+  }
+}
+
+class Google_Service_Directory_ChromeOsDeviceRecentUsers extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $email;
+  public $type;
+
+
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Directory_ChromeOsDevices extends Google_Collection
+{
+  protected $collection_key = 'chromeosdevices';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $chromeosdevicesType = 'Google_Service_Directory_ChromeOsDevice';
+  protected $chromeosdevicesDataType = 'array';
+  public $etag;
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setChromeosdevices($chromeosdevices)
+  {
+    $this->chromeosdevices = $chromeosdevices;
+  }
+  public function getChromeosdevices()
+  {
+    return $this->chromeosdevices;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Directory_Customer extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $alternateEmail;
+  public $customerCreationTime;
+  public $customerDomain;
+  public $etag;
+  public $id;
+  public $kind;
+  public $language;
+  public $phoneNumber;
+  protected $postalAddressType = 'Google_Service_Directory_CustomerPostalAddress';
+  protected $postalAddressDataType = '';
+
+
+  public function setAlternateEmail($alternateEmail)
+  {
+    $this->alternateEmail = $alternateEmail;
+  }
+  public function getAlternateEmail()
+  {
+    return $this->alternateEmail;
+  }
+  public function setCustomerCreationTime($customerCreationTime)
+  {
+    $this->customerCreationTime = $customerCreationTime;
+  }
+  public function getCustomerCreationTime()
+  {
+    return $this->customerCreationTime;
+  }
+  public function setCustomerDomain($customerDomain)
+  {
+    $this->customerDomain = $customerDomain;
+  }
+  public function getCustomerDomain()
+  {
+    return $this->customerDomain;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLanguage($language)
+  {
+    $this->language = $language;
+  }
+  public function getLanguage()
+  {
+    return $this->language;
+  }
+  public function setPhoneNumber($phoneNumber)
+  {
+    $this->phoneNumber = $phoneNumber;
+  }
+  public function getPhoneNumber()
+  {
+    return $this->phoneNumber;
+  }
+  public function setPostalAddress(Google_Service_Directory_CustomerPostalAddress $postalAddress)
+  {
+    $this->postalAddress = $postalAddress;
+  }
+  public function getPostalAddress()
+  {
+    return $this->postalAddress;
+  }
+}
+
+class Google_Service_Directory_CustomerPostalAddress extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $addressLine1;
+  public $addressLine2;
+  public $addressLine3;
+  public $contactName;
+  public $countryCode;
+  public $locality;
+  public $organizationName;
+  public $postalCode;
+  public $region;
+
+
+  public function setAddressLine1($addressLine1)
+  {
+    $this->addressLine1 = $addressLine1;
+  }
+  public function getAddressLine1()
+  {
+    return $this->addressLine1;
+  }
+  public function setAddressLine2($addressLine2)
+  {
+    $this->addressLine2 = $addressLine2;
+  }
+  public function getAddressLine2()
+  {
+    return $this->addressLine2;
+  }
+  public function setAddressLine3($addressLine3)
+  {
+    $this->addressLine3 = $addressLine3;
+  }
+  public function getAddressLine3()
+  {
+    return $this->addressLine3;
+  }
+  public function setContactName($contactName)
+  {
+    $this->contactName = $contactName;
+  }
+  public function getContactName()
+  {
+    return $this->contactName;
+  }
+  public function setCountryCode($countryCode)
+  {
+    $this->countryCode = $countryCode;
+  }
+  public function getCountryCode()
+  {
+    return $this->countryCode;
+  }
+  public function setLocality($locality)
+  {
+    $this->locality = $locality;
+  }
+  public function getLocality()
+  {
+    return $this->locality;
+  }
+  public function setOrganizationName($organizationName)
+  {
+    $this->organizationName = $organizationName;
+  }
+  public function getOrganizationName()
+  {
+    return $this->organizationName;
+  }
+  public function setPostalCode($postalCode)
+  {
+    $this->postalCode = $postalCode;
+  }
+  public function getPostalCode()
+  {
+    return $this->postalCode;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+}
+
+class Google_Service_Directory_DomainAlias extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTime;
+  public $domainAliasName;
+  public $etag;
+  public $kind;
+  public $parentDomainName;
+  public $verified;
+
+
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setDomainAliasName($domainAliasName)
+  {
+    $this->domainAliasName = $domainAliasName;
+  }
+  public function getDomainAliasName()
+  {
+    return $this->domainAliasName;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setParentDomainName($parentDomainName)
+  {
+    $this->parentDomainName = $parentDomainName;
+  }
+  public function getParentDomainName()
+  {
+    return $this->parentDomainName;
+  }
+  public function setVerified($verified)
+  {
+    $this->verified = $verified;
+  }
+  public function getVerified()
+  {
+    return $this->verified;
+  }
+}
+
+class Google_Service_Directory_DomainAliases extends Google_Collection
+{
+  protected $collection_key = 'domainAliases';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $domainAliasesType = 'Google_Service_Directory_DomainAlias';
+  protected $domainAliasesDataType = 'array';
+  public $etag;
+  public $kind;
+
+
+  public function setDomainAliases($domainAliases)
+  {
+    $this->domainAliases = $domainAliases;
+  }
+  public function getDomainAliases()
+  {
+    return $this->domainAliases;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Directory_Domains extends Google_Collection
+{
+  protected $collection_key = 'domainAliases';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTime;
+  protected $domainAliasesType = 'Google_Service_Directory_DomainAlias';
+  protected $domainAliasesDataType = 'array';
+  public $domainName;
+  public $etag;
+  public $isPrimary;
+  public $kind;
+  public $verified;
+
+
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setDomainAliases($domainAliases)
+  {
+    $this->domainAliases = $domainAliases;
+  }
+  public function getDomainAliases()
+  {
+    return $this->domainAliases;
+  }
+  public function setDomainName($domainName)
+  {
+    $this->domainName = $domainName;
+  }
+  public function getDomainName()
+  {
+    return $this->domainName;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setIsPrimary($isPrimary)
+  {
+    $this->isPrimary = $isPrimary;
+  }
+  public function getIsPrimary()
+  {
+    return $this->isPrimary;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setVerified($verified)
+  {
+    $this->verified = $verified;
+  }
+  public function getVerified()
+  {
+    return $this->verified;
+  }
+}
+
+class Google_Service_Directory_Domains2 extends Google_Collection
+{
+  protected $collection_key = 'domains';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $domainsType = 'Google_Service_Directory_Domains';
+  protected $domainsDataType = 'array';
+  public $etag;
+  public $kind;
+
+
+  public function setDomains($domains)
+  {
+    $this->domains = $domains;
+  }
+  public function getDomains()
+  {
+    return $this->domains;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Directory_Group extends Google_Collection
+{
+  protected $collection_key = 'nonEditableAliases';
+  protected $internal_gapi_mappings = array(
+  );
+  public $adminCreated;
+  public $aliases;
+  public $description;
+  public $directMembersCount;
+  public $email;
+  public $etag;
+  public $id;
+  public $kind;
+  public $name;
+  public $nonEditableAliases;
+
+
+  public function setAdminCreated($adminCreated)
+  {
+    $this->adminCreated = $adminCreated;
+  }
+  public function getAdminCreated()
+  {
+    return $this->adminCreated;
+  }
+  public function setAliases($aliases)
+  {
+    $this->aliases = $aliases;
+  }
+  public function getAliases()
+  {
+    return $this->aliases;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDirectMembersCount($directMembersCount)
+  {
+    $this->directMembersCount = $directMembersCount;
+  }
+  public function getDirectMembersCount()
+  {
+    return $this->directMembersCount;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNonEditableAliases($nonEditableAliases)
+  {
+    $this->nonEditableAliases = $nonEditableAliases;
+  }
+  public function getNonEditableAliases()
+  {
+    return $this->nonEditableAliases;
+  }
+}
+
+class Google_Service_Directory_Groups extends Google_Collection
+{
+  protected $collection_key = 'groups';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $groupsType = 'Google_Service_Directory_Group';
+  protected $groupsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setGroups($groups)
+  {
+    $this->groups = $groups;
+  }
+  public function getGroups()
+  {
+    return $this->groups;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Directory_Member extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $email;
+  public $etag;
+  public $id;
+  public $kind;
+  public $role;
+  public $type;
+
+
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRole($role)
+  {
+    $this->role = $role;
+  }
+  public function getRole()
+  {
+    return $this->role;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Directory_Members extends Google_Collection
+{
+  protected $collection_key = 'members';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $kind;
+  protected $membersType = 'Google_Service_Directory_Member';
+  protected $membersDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMembers($members)
+  {
+    $this->members = $members;
+  }
+  public function getMembers()
+  {
+    return $this->members;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Directory_MobileDevice extends Google_Collection
+{
+  protected $collection_key = 'otherAccountsInfo';
+  protected $internal_gapi_mappings = array(
+  );
+  public $adbStatus;
+  protected $applicationsType = 'Google_Service_Directory_MobileDeviceApplications';
+  protected $applicationsDataType = 'array';
+  public $basebandVersion;
+  public $buildNumber;
+  public $defaultLanguage;
+  public $developerOptionsStatus;
+  public $deviceCompromisedStatus;
+  public $deviceId;
+  public $email;
+  public $etag;
+  public $firstSync;
+  public $hardwareId;
+  public $imei;
+  public $kernelVersion;
+  public $kind;
+  public $lastSync;
+  public $managedAccountIsOnOwnerProfile;
+  public $meid;
+  public $model;
+  public $name;
+  public $networkOperator;
+  public $os;
+  public $otherAccountsInfo;
+  public $resourceId;
+  public $serialNumber;
+  public $status;
+  public $supportsWorkProfile;
+  public $type;
+  public $unknownSourcesStatus;
+  public $userAgent;
+  public $wifiMacAddress;
+
+
+  public function setAdbStatus($adbStatus)
+  {
+    $this->adbStatus = $adbStatus;
+  }
+  public function getAdbStatus()
+  {
+    return $this->adbStatus;
+  }
+  public function setApplications($applications)
+  {
+    $this->applications = $applications;
+  }
+  public function getApplications()
+  {
+    return $this->applications;
+  }
+  public function setBasebandVersion($basebandVersion)
+  {
+    $this->basebandVersion = $basebandVersion;
+  }
+  public function getBasebandVersion()
+  {
+    return $this->basebandVersion;
+  }
+  public function setBuildNumber($buildNumber)
+  {
+    $this->buildNumber = $buildNumber;
+  }
+  public function getBuildNumber()
+  {
+    return $this->buildNumber;
+  }
+  public function setDefaultLanguage($defaultLanguage)
+  {
+    $this->defaultLanguage = $defaultLanguage;
+  }
+  public function getDefaultLanguage()
+  {
+    return $this->defaultLanguage;
+  }
+  public function setDeveloperOptionsStatus($developerOptionsStatus)
+  {
+    $this->developerOptionsStatus = $developerOptionsStatus;
+  }
+  public function getDeveloperOptionsStatus()
+  {
+    return $this->developerOptionsStatus;
+  }
+  public function setDeviceCompromisedStatus($deviceCompromisedStatus)
+  {
+    $this->deviceCompromisedStatus = $deviceCompromisedStatus;
+  }
+  public function getDeviceCompromisedStatus()
+  {
+    return $this->deviceCompromisedStatus;
+  }
+  public function setDeviceId($deviceId)
+  {
+    $this->deviceId = $deviceId;
+  }
+  public function getDeviceId()
+  {
+    return $this->deviceId;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setFirstSync($firstSync)
+  {
+    $this->firstSync = $firstSync;
+  }
+  public function getFirstSync()
+  {
+    return $this->firstSync;
+  }
+  public function setHardwareId($hardwareId)
+  {
+    $this->hardwareId = $hardwareId;
+  }
+  public function getHardwareId()
+  {
+    return $this->hardwareId;
+  }
+  public function setImei($imei)
+  {
+    $this->imei = $imei;
+  }
+  public function getImei()
+  {
+    return $this->imei;
+  }
+  public function setKernelVersion($kernelVersion)
+  {
+    $this->kernelVersion = $kernelVersion;
+  }
+  public function getKernelVersion()
+  {
+    return $this->kernelVersion;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastSync($lastSync)
+  {
+    $this->lastSync = $lastSync;
+  }
+  public function getLastSync()
+  {
+    return $this->lastSync;
+  }
+  public function setManagedAccountIsOnOwnerProfile($managedAccountIsOnOwnerProfile)
+  {
+    $this->managedAccountIsOnOwnerProfile = $managedAccountIsOnOwnerProfile;
+  }
+  public function getManagedAccountIsOnOwnerProfile()
+  {
+    return $this->managedAccountIsOnOwnerProfile;
+  }
+  public function setMeid($meid)
+  {
+    $this->meid = $meid;
+  }
+  public function getMeid()
+  {
+    return $this->meid;
+  }
+  public function setModel($model)
+  {
+    $this->model = $model;
+  }
+  public function getModel()
+  {
+    return $this->model;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNetworkOperator($networkOperator)
+  {
+    $this->networkOperator = $networkOperator;
+  }
+  public function getNetworkOperator()
+  {
+    return $this->networkOperator;
+  }
+  public function setOs($os)
+  {
+    $this->os = $os;
+  }
+  public function getOs()
+  {
+    return $this->os;
+  }
+  public function setOtherAccountsInfo($otherAccountsInfo)
+  {
+    $this->otherAccountsInfo = $otherAccountsInfo;
+  }
+  public function getOtherAccountsInfo()
+  {
+    return $this->otherAccountsInfo;
+  }
+  public function setResourceId($resourceId)
+  {
+    $this->resourceId = $resourceId;
+  }
+  public function getResourceId()
+  {
+    return $this->resourceId;
+  }
+  public function setSerialNumber($serialNumber)
+  {
+    $this->serialNumber = $serialNumber;
+  }
+  public function getSerialNumber()
+  {
+    return $this->serialNumber;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setSupportsWorkProfile($supportsWorkProfile)
+  {
+    $this->supportsWorkProfile = $supportsWorkProfile;
+  }
+  public function getSupportsWorkProfile()
+  {
+    return $this->supportsWorkProfile;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUnknownSourcesStatus($unknownSourcesStatus)
+  {
+    $this->unknownSourcesStatus = $unknownSourcesStatus;
+  }
+  public function getUnknownSourcesStatus()
+  {
+    return $this->unknownSourcesStatus;
+  }
+  public function setUserAgent($userAgent)
+  {
+    $this->userAgent = $userAgent;
+  }
+  public function getUserAgent()
+  {
+    return $this->userAgent;
+  }
+  public function setWifiMacAddress($wifiMacAddress)
+  {
+    $this->wifiMacAddress = $wifiMacAddress;
+  }
+  public function getWifiMacAddress()
+  {
+    return $this->wifiMacAddress;
+  }
+}
+
+class Google_Service_Directory_MobileDeviceAction extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $action;
+
+
+  public function setAction($action)
+  {
+    $this->action = $action;
+  }
+  public function getAction()
+  {
+    return $this->action;
+  }
+}
+
+class Google_Service_Directory_MobileDeviceApplications extends Google_Collection
+{
+  protected $collection_key = 'permission';
+  protected $internal_gapi_mappings = array(
+  );
+  public $displayName;
+  public $packageName;
+  public $permission;
+  public $versionCode;
+  public $versionName;
+
+
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setPackageName($packageName)
+  {
+    $this->packageName = $packageName;
+  }
+  public function getPackageName()
+  {
+    return $this->packageName;
+  }
+  public function setPermission($permission)
+  {
+    $this->permission = $permission;
+  }
+  public function getPermission()
+  {
+    return $this->permission;
+  }
+  public function setVersionCode($versionCode)
+  {
+    $this->versionCode = $versionCode;
+  }
+  public function getVersionCode()
+  {
+    return $this->versionCode;
+  }
+  public function setVersionName($versionName)
+  {
+    $this->versionName = $versionName;
+  }
+  public function getVersionName()
+  {
+    return $this->versionName;
+  }
+}
+
+class Google_Service_Directory_MobileDevices extends Google_Collection
+{
+  protected $collection_key = 'mobiledevices';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $kind;
+  protected $mobiledevicesType = 'Google_Service_Directory_MobileDevice';
+  protected $mobiledevicesDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMobiledevices($mobiledevices)
+  {
+    $this->mobiledevices = $mobiledevices;
+  }
+  public function getMobiledevices()
+  {
+    return $this->mobiledevices;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Directory_Notification extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $body;
+  public $etag;
+  public $fromAddress;
+  public $isUnread;
+  public $kind;
+  public $notificationId;
+  public $sendTime;
+  public $subject;
+
+
+  public function setBody($body)
+  {
+    $this->body = $body;
+  }
+  public function getBody()
+  {
+    return $this->body;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setFromAddress($fromAddress)
+  {
+    $this->fromAddress = $fromAddress;
+  }
+  public function getFromAddress()
+  {
+    return $this->fromAddress;
+  }
+  public function setIsUnread($isUnread)
+  {
+    $this->isUnread = $isUnread;
+  }
+  public function getIsUnread()
+  {
+    return $this->isUnread;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNotificationId($notificationId)
+  {
+    $this->notificationId = $notificationId;
+  }
+  public function getNotificationId()
+  {
+    return $this->notificationId;
+  }
+  public function setSendTime($sendTime)
+  {
+    $this->sendTime = $sendTime;
+  }
+  public function getSendTime()
+  {
+    return $this->sendTime;
+  }
+  public function setSubject($subject)
+  {
+    $this->subject = $subject;
+  }
+  public function getSubject()
+  {
+    return $this->subject;
+  }
+}
+
+class Google_Service_Directory_Notifications extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Directory_Notification';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $unreadNotificationsCount;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setUnreadNotificationsCount($unreadNotificationsCount)
+  {
+    $this->unreadNotificationsCount = $unreadNotificationsCount;
+  }
+  public function getUnreadNotificationsCount()
+  {
+    return $this->unreadNotificationsCount;
+  }
+}
+
+class Google_Service_Directory_OrgUnit extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $blockInheritance;
+  public $description;
+  public $etag;
+  public $kind;
+  public $name;
+  public $orgUnitId;
+  public $orgUnitPath;
+  public $parentOrgUnitId;
+  public $parentOrgUnitPath;
+
+
+  public function setBlockInheritance($blockInheritance)
+  {
+    $this->blockInheritance = $blockInheritance;
+  }
+  public function getBlockInheritance()
+  {
+    return $this->blockInheritance;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOrgUnitId($orgUnitId)
+  {
+    $this->orgUnitId = $orgUnitId;
+  }
+  public function getOrgUnitId()
+  {
+    return $this->orgUnitId;
+  }
+  public function setOrgUnitPath($orgUnitPath)
+  {
+    $this->orgUnitPath = $orgUnitPath;
+  }
+  public function getOrgUnitPath()
+  {
+    return $this->orgUnitPath;
+  }
+  public function setParentOrgUnitId($parentOrgUnitId)
+  {
+    $this->parentOrgUnitId = $parentOrgUnitId;
+  }
+  public function getParentOrgUnitId()
+  {
+    return $this->parentOrgUnitId;
+  }
+  public function setParentOrgUnitPath($parentOrgUnitPath)
+  {
+    $this->parentOrgUnitPath = $parentOrgUnitPath;
+  }
+  public function getParentOrgUnitPath()
+  {
+    return $this->parentOrgUnitPath;
+  }
+}
+
+class Google_Service_Directory_OrgUnits extends Google_Collection
+{
+  protected $collection_key = 'organizationUnits';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $kind;
+  protected $organizationUnitsType = 'Google_Service_Directory_OrgUnit';
+  protected $organizationUnitsDataType = 'array';
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setOrganizationUnits($organizationUnits)
+  {
+    $this->organizationUnits = $organizationUnits;
+  }
+  public function getOrganizationUnits()
+  {
+    return $this->organizationUnits;
+  }
+}
+
+class Google_Service_Directory_Privilege extends Google_Collection
+{
+  protected $collection_key = 'childPrivileges';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $childPrivilegesType = 'Google_Service_Directory_Privilege';
+  protected $childPrivilegesDataType = 'array';
+  public $etag;
+  public $isOuScopable;
+  public $kind;
+  public $privilegeName;
+  public $serviceId;
+  public $serviceName;
+
+
+  public function setChildPrivileges($childPrivileges)
+  {
+    $this->childPrivileges = $childPrivileges;
+  }
+  public function getChildPrivileges()
+  {
+    return $this->childPrivileges;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setIsOuScopable($isOuScopable)
+  {
+    $this->isOuScopable = $isOuScopable;
+  }
+  public function getIsOuScopable()
+  {
+    return $this->isOuScopable;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPrivilegeName($privilegeName)
+  {
+    $this->privilegeName = $privilegeName;
+  }
+  public function getPrivilegeName()
+  {
+    return $this->privilegeName;
+  }
+  public function setServiceId($serviceId)
+  {
+    $this->serviceId = $serviceId;
+  }
+  public function getServiceId()
+  {
+    return $this->serviceId;
+  }
+  public function setServiceName($serviceName)
+  {
+    $this->serviceName = $serviceName;
+  }
+  public function getServiceName()
+  {
+    return $this->serviceName;
+  }
+}
+
+class Google_Service_Directory_Privileges extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Directory_Privilege';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Directory_Role extends Google_Collection
+{
+  protected $collection_key = 'rolePrivileges';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $isSuperAdminRole;
+  public $isSystemRole;
+  public $kind;
+  public $roleDescription;
+  public $roleId;
+  public $roleName;
+  protected $rolePrivilegesType = 'Google_Service_Directory_RoleRolePrivileges';
+  protected $rolePrivilegesDataType = 'array';
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setIsSuperAdminRole($isSuperAdminRole)
+  {
+    $this->isSuperAdminRole = $isSuperAdminRole;
+  }
+  public function getIsSuperAdminRole()
+  {
+    return $this->isSuperAdminRole;
+  }
+  public function setIsSystemRole($isSystemRole)
+  {
+    $this->isSystemRole = $isSystemRole;
+  }
+  public function getIsSystemRole()
+  {
+    return $this->isSystemRole;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRoleDescription($roleDescription)
+  {
+    $this->roleDescription = $roleDescription;
+  }
+  public function getRoleDescription()
+  {
+    return $this->roleDescription;
+  }
+  public function setRoleId($roleId)
+  {
+    $this->roleId = $roleId;
+  }
+  public function getRoleId()
+  {
+    return $this->roleId;
+  }
+  public function setRoleName($roleName)
+  {
+    $this->roleName = $roleName;
+  }
+  public function getRoleName()
+  {
+    return $this->roleName;
+  }
+  public function setRolePrivileges($rolePrivileges)
+  {
+    $this->rolePrivileges = $rolePrivileges;
+  }
+  public function getRolePrivileges()
+  {
+    return $this->rolePrivileges;
+  }
+}
+
+class Google_Service_Directory_RoleAssignment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $assignedTo;
+  public $etag;
+  public $kind;
+  public $orgUnitId;
+  public $roleAssignmentId;
+  public $roleId;
+  public $scopeType;
+
+
+  public function setAssignedTo($assignedTo)
+  {
+    $this->assignedTo = $assignedTo;
+  }
+  public function getAssignedTo()
+  {
+    return $this->assignedTo;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setOrgUnitId($orgUnitId)
+  {
+    $this->orgUnitId = $orgUnitId;
+  }
+  public function getOrgUnitId()
+  {
+    return $this->orgUnitId;
+  }
+  public function setRoleAssignmentId($roleAssignmentId)
+  {
+    $this->roleAssignmentId = $roleAssignmentId;
+  }
+  public function getRoleAssignmentId()
+  {
+    return $this->roleAssignmentId;
+  }
+  public function setRoleId($roleId)
+  {
+    $this->roleId = $roleId;
+  }
+  public function getRoleId()
+  {
+    return $this->roleId;
+  }
+  public function setScopeType($scopeType)
+  {
+    $this->scopeType = $scopeType;
+  }
+  public function getScopeType()
+  {
+    return $this->scopeType;
+  }
+}
+
+class Google_Service_Directory_RoleAssignments extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Directory_RoleAssignment';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Directory_RoleRolePrivileges extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $privilegeName;
+  public $serviceId;
+
+
+  public function setPrivilegeName($privilegeName)
+  {
+    $this->privilegeName = $privilegeName;
+  }
+  public function getPrivilegeName()
+  {
+    return $this->privilegeName;
+  }
+  public function setServiceId($serviceId)
+  {
+    $this->serviceId = $serviceId;
+  }
+  public function getServiceId()
+  {
+    return $this->serviceId;
+  }
+}
+
+class Google_Service_Directory_Roles extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Directory_Role';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Directory_Schema extends Google_Collection
+{
+  protected $collection_key = 'fields';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $fieldsType = 'Google_Service_Directory_SchemaFieldSpec';
+  protected $fieldsDataType = 'array';
+  public $kind;
+  public $schemaId;
+  public $schemaName;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setFields($fields)
+  {
+    $this->fields = $fields;
+  }
+  public function getFields()
+  {
+    return $this->fields;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSchemaId($schemaId)
+  {
+    $this->schemaId = $schemaId;
+  }
+  public function getSchemaId()
+  {
+    return $this->schemaId;
+  }
+  public function setSchemaName($schemaName)
+  {
+    $this->schemaName = $schemaName;
+  }
+  public function getSchemaName()
+  {
+    return $this->schemaName;
+  }
+}
+
+class Google_Service_Directory_SchemaFieldSpec extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $fieldId;
+  public $fieldName;
+  public $fieldType;
+  public $indexed;
+  public $kind;
+  public $multiValued;
+  protected $numericIndexingSpecType = 'Google_Service_Directory_SchemaFieldSpecNumericIndexingSpec';
+  protected $numericIndexingSpecDataType = '';
+  public $readAccessType;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setFieldId($fieldId)
+  {
+    $this->fieldId = $fieldId;
+  }
+  public function getFieldId()
+  {
+    return $this->fieldId;
+  }
+  public function setFieldName($fieldName)
+  {
+    $this->fieldName = $fieldName;
+  }
+  public function getFieldName()
+  {
+    return $this->fieldName;
+  }
+  public function setFieldType($fieldType)
+  {
+    $this->fieldType = $fieldType;
+  }
+  public function getFieldType()
+  {
+    return $this->fieldType;
+  }
+  public function setIndexed($indexed)
+  {
+    $this->indexed = $indexed;
+  }
+  public function getIndexed()
+  {
+    return $this->indexed;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMultiValued($multiValued)
+  {
+    $this->multiValued = $multiValued;
+  }
+  public function getMultiValued()
+  {
+    return $this->multiValued;
+  }
+  public function setNumericIndexingSpec(Google_Service_Directory_SchemaFieldSpecNumericIndexingSpec $numericIndexingSpec)
+  {
+    $this->numericIndexingSpec = $numericIndexingSpec;
+  }
+  public function getNumericIndexingSpec()
+  {
+    return $this->numericIndexingSpec;
+  }
+  public function setReadAccessType($readAccessType)
+  {
+    $this->readAccessType = $readAccessType;
+  }
+  public function getReadAccessType()
+  {
+    return $this->readAccessType;
+  }
+}
+
+class Google_Service_Directory_SchemaFieldSpecNumericIndexingSpec extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $maxValue;
+  public $minValue;
+
+
+  public function setMaxValue($maxValue)
+  {
+    $this->maxValue = $maxValue;
+  }
+  public function getMaxValue()
+  {
+    return $this->maxValue;
+  }
+  public function setMinValue($minValue)
+  {
+    $this->minValue = $minValue;
+  }
+  public function getMinValue()
+  {
+    return $this->minValue;
+  }
+}
+
+class Google_Service_Directory_Schemas extends Google_Collection
+{
+  protected $collection_key = 'schemas';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $kind;
+  protected $schemasType = 'Google_Service_Directory_Schema';
+  protected $schemasDataType = 'array';
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSchemas($schemas)
+  {
+    $this->schemas = $schemas;
+  }
+  public function getSchemas()
+  {
+    return $this->schemas;
+  }
+}
+
+class Google_Service_Directory_Token extends Google_Collection
+{
+  protected $collection_key = 'scopes';
+  protected $internal_gapi_mappings = array(
+  );
+  public $anonymous;
+  public $clientId;
+  public $displayText;
+  public $etag;
+  public $kind;
+  public $nativeApp;
+  public $scopes;
+  public $userKey;
+
+
+  public function setAnonymous($anonymous)
+  {
+    $this->anonymous = $anonymous;
+  }
+  public function getAnonymous()
+  {
+    return $this->anonymous;
+  }
+  public function setClientId($clientId)
+  {
+    $this->clientId = $clientId;
+  }
+  public function getClientId()
+  {
+    return $this->clientId;
+  }
+  public function setDisplayText($displayText)
+  {
+    $this->displayText = $displayText;
+  }
+  public function getDisplayText()
+  {
+    return $this->displayText;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNativeApp($nativeApp)
+  {
+    $this->nativeApp = $nativeApp;
+  }
+  public function getNativeApp()
+  {
+    return $this->nativeApp;
+  }
+  public function setScopes($scopes)
+  {
+    $this->scopes = $scopes;
+  }
+  public function getScopes()
+  {
+    return $this->scopes;
+  }
+  public function setUserKey($userKey)
+  {
+    $this->userKey = $userKey;
+  }
+  public function getUserKey()
+  {
+    return $this->userKey;
+  }
+}
+
+class Google_Service_Directory_Tokens extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Directory_Token';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Directory_User extends Google_Collection
+{
+  protected $collection_key = 'nonEditableAliases';
+  protected $internal_gapi_mappings = array(
+  );
+  public $addresses;
+  public $agreedToTerms;
+  public $aliases;
+  public $changePasswordAtNextLogin;
+  public $creationTime;
+  public $customSchemas;
+  public $customerId;
+  public $deletionTime;
+  public $emails;
+  public $etag;
+  public $externalIds;
+  public $hashFunction;
+  public $id;
+  public $ims;
+  public $includeInGlobalAddressList;
+  public $ipWhitelisted;
+  public $isAdmin;
+  public $isDelegatedAdmin;
+  public $isMailboxSetup;
+  public $kind;
+  public $lastLoginTime;
+  protected $nameType = 'Google_Service_Directory_UserName';
+  protected $nameDataType = '';
+  public $nonEditableAliases;
+  public $notes;
+  public $orgUnitPath;
+  public $organizations;
+  public $password;
+  public $phones;
+  public $primaryEmail;
+  public $relations;
+  public $suspended;
+  public $suspensionReason;
+  public $thumbnailPhotoEtag;
+  public $thumbnailPhotoUrl;
+  public $websites;
+
+
+  public function setAddresses($addresses)
+  {
+    $this->addresses = $addresses;
+  }
+  public function getAddresses()
+  {
+    return $this->addresses;
+  }
+  public function setAgreedToTerms($agreedToTerms)
+  {
+    $this->agreedToTerms = $agreedToTerms;
+  }
+  public function getAgreedToTerms()
+  {
+    return $this->agreedToTerms;
+  }
+  public function setAliases($aliases)
+  {
+    $this->aliases = $aliases;
+  }
+  public function getAliases()
+  {
+    return $this->aliases;
+  }
+  public function setChangePasswordAtNextLogin($changePasswordAtNextLogin)
+  {
+    $this->changePasswordAtNextLogin = $changePasswordAtNextLogin;
+  }
+  public function getChangePasswordAtNextLogin()
+  {
+    return $this->changePasswordAtNextLogin;
+  }
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setCustomSchemas($customSchemas)
+  {
+    $this->customSchemas = $customSchemas;
+  }
+  public function getCustomSchemas()
+  {
+    return $this->customSchemas;
+  }
+  public function setCustomerId($customerId)
+  {
+    $this->customerId = $customerId;
+  }
+  public function getCustomerId()
+  {
+    return $this->customerId;
+  }
+  public function setDeletionTime($deletionTime)
+  {
+    $this->deletionTime = $deletionTime;
+  }
+  public function getDeletionTime()
+  {
+    return $this->deletionTime;
+  }
+  public function setEmails($emails)
+  {
+    $this->emails = $emails;
+  }
+  public function getEmails()
+  {
+    return $this->emails;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setExternalIds($externalIds)
+  {
+    $this->externalIds = $externalIds;
+  }
+  public function getExternalIds()
+  {
+    return $this->externalIds;
+  }
+  public function setHashFunction($hashFunction)
+  {
+    $this->hashFunction = $hashFunction;
+  }
+  public function getHashFunction()
+  {
+    return $this->hashFunction;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIms($ims)
+  {
+    $this->ims = $ims;
+  }
+  public function getIms()
+  {
+    return $this->ims;
+  }
+  public function setIncludeInGlobalAddressList($includeInGlobalAddressList)
+  {
+    $this->includeInGlobalAddressList = $includeInGlobalAddressList;
+  }
+  public function getIncludeInGlobalAddressList()
+  {
+    return $this->includeInGlobalAddressList;
+  }
+  public function setIpWhitelisted($ipWhitelisted)
+  {
+    $this->ipWhitelisted = $ipWhitelisted;
+  }
+  public function getIpWhitelisted()
+  {
+    return $this->ipWhitelisted;
+  }
+  public function setIsAdmin($isAdmin)
+  {
+    $this->isAdmin = $isAdmin;
+  }
+  public function getIsAdmin()
+  {
+    return $this->isAdmin;
+  }
+  public function setIsDelegatedAdmin($isDelegatedAdmin)
+  {
+    $this->isDelegatedAdmin = $isDelegatedAdmin;
+  }
+  public function getIsDelegatedAdmin()
+  {
+    return $this->isDelegatedAdmin;
+  }
+  public function setIsMailboxSetup($isMailboxSetup)
+  {
+    $this->isMailboxSetup = $isMailboxSetup;
+  }
+  public function getIsMailboxSetup()
+  {
+    return $this->isMailboxSetup;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastLoginTime($lastLoginTime)
+  {
+    $this->lastLoginTime = $lastLoginTime;
+  }
+  public function getLastLoginTime()
+  {
+    return $this->lastLoginTime;
+  }
+  public function setName(Google_Service_Directory_UserName $name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNonEditableAliases($nonEditableAliases)
+  {
+    $this->nonEditableAliases = $nonEditableAliases;
+  }
+  public function getNonEditableAliases()
+  {
+    return $this->nonEditableAliases;
+  }
+  public function setNotes($notes)
+  {
+    $this->notes = $notes;
+  }
+  public function getNotes()
+  {
+    return $this->notes;
+  }
+  public function setOrgUnitPath($orgUnitPath)
+  {
+    $this->orgUnitPath = $orgUnitPath;
+  }
+  public function getOrgUnitPath()
+  {
+    return $this->orgUnitPath;
+  }
+  public function setOrganizations($organizations)
+  {
+    $this->organizations = $organizations;
+  }
+  public function getOrganizations()
+  {
+    return $this->organizations;
+  }
+  public function setPassword($password)
+  {
+    $this->password = $password;
+  }
+  public function getPassword()
+  {
+    return $this->password;
+  }
+  public function setPhones($phones)
+  {
+    $this->phones = $phones;
+  }
+  public function getPhones()
+  {
+    return $this->phones;
+  }
+  public function setPrimaryEmail($primaryEmail)
+  {
+    $this->primaryEmail = $primaryEmail;
+  }
+  public function getPrimaryEmail()
+  {
+    return $this->primaryEmail;
+  }
+  public function setRelations($relations)
+  {
+    $this->relations = $relations;
+  }
+  public function getRelations()
+  {
+    return $this->relations;
+  }
+  public function setSuspended($suspended)
+  {
+    $this->suspended = $suspended;
+  }
+  public function getSuspended()
+  {
+    return $this->suspended;
+  }
+  public function setSuspensionReason($suspensionReason)
+  {
+    $this->suspensionReason = $suspensionReason;
+  }
+  public function getSuspensionReason()
+  {
+    return $this->suspensionReason;
+  }
+  public function setThumbnailPhotoEtag($thumbnailPhotoEtag)
+  {
+    $this->thumbnailPhotoEtag = $thumbnailPhotoEtag;
+  }
+  public function getThumbnailPhotoEtag()
+  {
+    return $this->thumbnailPhotoEtag;
+  }
+  public function setThumbnailPhotoUrl($thumbnailPhotoUrl)
+  {
+    $this->thumbnailPhotoUrl = $thumbnailPhotoUrl;
+  }
+  public function getThumbnailPhotoUrl()
+  {
+    return $this->thumbnailPhotoUrl;
+  }
+  public function setWebsites($websites)
+  {
+    $this->websites = $websites;
+  }
+  public function getWebsites()
+  {
+    return $this->websites;
+  }
+}
+
+class Google_Service_Directory_UserAbout extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $contentType;
+  public $value;
+
+
+  public function setContentType($contentType)
+  {
+    $this->contentType = $contentType;
+  }
+  public function getContentType()
+  {
+    return $this->contentType;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Directory_UserAddress extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $country;
+  public $countryCode;
+  public $customType;
+  public $extendedAddress;
+  public $formatted;
+  public $locality;
+  public $poBox;
+  public $postalCode;
+  public $primary;
+  public $region;
+  public $sourceIsStructured;
+  public $streetAddress;
+  public $type;
+
+
+  public function setCountry($country)
+  {
+    $this->country = $country;
+  }
+  public function getCountry()
+  {
+    return $this->country;
+  }
+  public function setCountryCode($countryCode)
+  {
+    $this->countryCode = $countryCode;
+  }
+  public function getCountryCode()
+  {
+    return $this->countryCode;
+  }
+  public function setCustomType($customType)
+  {
+    $this->customType = $customType;
+  }
+  public function getCustomType()
+  {
+    return $this->customType;
+  }
+  public function setExtendedAddress($extendedAddress)
+  {
+    $this->extendedAddress = $extendedAddress;
+  }
+  public function getExtendedAddress()
+  {
+    return $this->extendedAddress;
+  }
+  public function setFormatted($formatted)
+  {
+    $this->formatted = $formatted;
+  }
+  public function getFormatted()
+  {
+    return $this->formatted;
+  }
+  public function setLocality($locality)
+  {
+    $this->locality = $locality;
+  }
+  public function getLocality()
+  {
+    return $this->locality;
+  }
+  public function setPoBox($poBox)
+  {
+    $this->poBox = $poBox;
+  }
+  public function getPoBox()
+  {
+    return $this->poBox;
+  }
+  public function setPostalCode($postalCode)
+  {
+    $this->postalCode = $postalCode;
+  }
+  public function getPostalCode()
+  {
+    return $this->postalCode;
+  }
+  public function setPrimary($primary)
+  {
+    $this->primary = $primary;
+  }
+  public function getPrimary()
+  {
+    return $this->primary;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setSourceIsStructured($sourceIsStructured)
+  {
+    $this->sourceIsStructured = $sourceIsStructured;
+  }
+  public function getSourceIsStructured()
+  {
+    return $this->sourceIsStructured;
+  }
+  public function setStreetAddress($streetAddress)
+  {
+    $this->streetAddress = $streetAddress;
+  }
+  public function getStreetAddress()
+  {
+    return $this->streetAddress;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Directory_UserCustomProperties extends Google_Model
+{
+}
+
+class Google_Service_Directory_UserCustomSchemas extends Google_Model
+{
+}
+
+class Google_Service_Directory_UserEmail extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $address;
+  public $customType;
+  public $primary;
+  public $type;
+
+
+  public function setAddress($address)
+  {
+    $this->address = $address;
+  }
+  public function getAddress()
+  {
+    return $this->address;
+  }
+  public function setCustomType($customType)
+  {
+    $this->customType = $customType;
+  }
+  public function getCustomType()
+  {
+    return $this->customType;
+  }
+  public function setPrimary($primary)
+  {
+    $this->primary = $primary;
+  }
+  public function getPrimary()
+  {
+    return $this->primary;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Directory_UserExternalId extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $customType;
+  public $type;
+  public $value;
+
+
+  public function setCustomType($customType)
+  {
+    $this->customType = $customType;
+  }
+  public function getCustomType()
+  {
+    return $this->customType;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Directory_UserIm extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $customProtocol;
+  public $customType;
+  public $im;
+  public $primary;
+  public $protocol;
+  public $type;
+
+
+  public function setCustomProtocol($customProtocol)
+  {
+    $this->customProtocol = $customProtocol;
+  }
+  public function getCustomProtocol()
+  {
+    return $this->customProtocol;
+  }
+  public function setCustomType($customType)
+  {
+    $this->customType = $customType;
+  }
+  public function getCustomType()
+  {
+    return $this->customType;
+  }
+  public function setIm($im)
+  {
+    $this->im = $im;
+  }
+  public function getIm()
+  {
+    return $this->im;
+  }
+  public function setPrimary($primary)
+  {
+    $this->primary = $primary;
+  }
+  public function getPrimary()
+  {
+    return $this->primary;
+  }
+  public function setProtocol($protocol)
+  {
+    $this->protocol = $protocol;
+  }
+  public function getProtocol()
+  {
+    return $this->protocol;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Directory_UserMakeAdmin extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $status;
+
+
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_Directory_UserName extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $familyName;
+  public $fullName;
+  public $givenName;
+
+
+  public function setFamilyName($familyName)
+  {
+    $this->familyName = $familyName;
+  }
+  public function getFamilyName()
+  {
+    return $this->familyName;
+  }
+  public function setFullName($fullName)
+  {
+    $this->fullName = $fullName;
+  }
+  public function getFullName()
+  {
+    return $this->fullName;
+  }
+  public function setGivenName($givenName)
+  {
+    $this->givenName = $givenName;
+  }
+  public function getGivenName()
+  {
+    return $this->givenName;
+  }
+}
+
+class Google_Service_Directory_UserOrganization extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $costCenter;
+  public $customType;
+  public $department;
+  public $description;
+  public $domain;
+  public $location;
+  public $name;
+  public $primary;
+  public $symbol;
+  public $title;
+  public $type;
+
+
+  public function setCostCenter($costCenter)
+  {
+    $this->costCenter = $costCenter;
+  }
+  public function getCostCenter()
+  {
+    return $this->costCenter;
+  }
+  public function setCustomType($customType)
+  {
+    $this->customType = $customType;
+  }
+  public function getCustomType()
+  {
+    return $this->customType;
+  }
+  public function setDepartment($department)
+  {
+    $this->department = $department;
+  }
+  public function getDepartment()
+  {
+    return $this->department;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDomain($domain)
+  {
+    $this->domain = $domain;
+  }
+  public function getDomain()
+  {
+    return $this->domain;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPrimary($primary)
+  {
+    $this->primary = $primary;
+  }
+  public function getPrimary()
+  {
+    return $this->primary;
+  }
+  public function setSymbol($symbol)
+  {
+    $this->symbol = $symbol;
+  }
+  public function getSymbol()
+  {
+    return $this->symbol;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Directory_UserPhone extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $customType;
+  public $primary;
+  public $type;
+  public $value;
+
+
+  public function setCustomType($customType)
+  {
+    $this->customType = $customType;
+  }
+  public function getCustomType()
+  {
+    return $this->customType;
+  }
+  public function setPrimary($primary)
+  {
+    $this->primary = $primary;
+  }
+  public function getPrimary()
+  {
+    return $this->primary;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Directory_UserPhoto extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $height;
+  public $id;
+  public $kind;
+  public $mimeType;
+  public $photoData;
+  public $primaryEmail;
+  public $width;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMimeType($mimeType)
+  {
+    $this->mimeType = $mimeType;
+  }
+  public function getMimeType()
+  {
+    return $this->mimeType;
+  }
+  public function setPhotoData($photoData)
+  {
+    $this->photoData = $photoData;
+  }
+  public function getPhotoData()
+  {
+    return $this->photoData;
+  }
+  public function setPrimaryEmail($primaryEmail)
+  {
+    $this->primaryEmail = $primaryEmail;
+  }
+  public function getPrimaryEmail()
+  {
+    return $this->primaryEmail;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_Directory_UserRelation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $customType;
+  public $type;
+  public $value;
+
+
+  public function setCustomType($customType)
+  {
+    $this->customType = $customType;
+  }
+  public function getCustomType()
+  {
+    return $this->customType;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Directory_UserUndelete extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $orgUnitPath;
+
+
+  public function setOrgUnitPath($orgUnitPath)
+  {
+    $this->orgUnitPath = $orgUnitPath;
+  }
+  public function getOrgUnitPath()
+  {
+    return $this->orgUnitPath;
+  }
+}
+
+class Google_Service_Directory_UserWebsite extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $customType;
+  public $primary;
+  public $type;
+  public $value;
+
+
+  public function setCustomType($customType)
+  {
+    $this->customType = $customType;
+  }
+  public function getCustomType()
+  {
+    return $this->customType;
+  }
+  public function setPrimary($primary)
+  {
+    $this->primary = $primary;
+  }
+  public function getPrimary()
+  {
+    return $this->primary;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Directory_Users extends Google_Collection
+{
+  protected $collection_key = 'users';
+  protected $internal_gapi_mappings = array(
+        "triggerEvent" => "trigger_event",
+  );
+  public $etag;
+  public $kind;
+  public $nextPageToken;
+  public $triggerEvent;
+  protected $usersType = 'Google_Service_Directory_User';
+  protected $usersDataType = 'array';
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTriggerEvent($triggerEvent)
+  {
+    $this->triggerEvent = $triggerEvent;
+  }
+  public function getTriggerEvent()
+  {
+    return $this->triggerEvent;
+  }
+  public function setUsers($users)
+  {
+    $this->users = $users;
+  }
+  public function getUsers()
+  {
+    return $this->users;
+  }
+}
+
+class Google_Service_Directory_VerificationCode extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $kind;
+  public $userId;
+  public $verificationCode;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUserId($userId)
+  {
+    $this->userId = $userId;
+  }
+  public function getUserId()
+  {
+    return $this->userId;
+  }
+  public function setVerificationCode($verificationCode)
+  {
+    $this->verificationCode = $verificationCode;
+  }
+  public function getVerificationCode()
+  {
+    return $this->verificationCode;
+  }
+}
+
+class Google_Service_Directory_VerificationCodes extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Directory_VerificationCode';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Dns.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Dns.php
@@ -1,0 +1,926 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Dns (v1).
+ *
+ * <p>
+ * The Google Cloud DNS API provides services for configuring and serving
+ * authoritative DNS records.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/cloud-dns" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Dns extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+  /** View your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM_READ_ONLY =
+      "https://www.googleapis.com/auth/cloud-platform.read-only";
+  /** View your DNS records hosted by Google Cloud DNS. */
+  const NDEV_CLOUDDNS_READONLY =
+      "https://www.googleapis.com/auth/ndev.clouddns.readonly";
+  /** View and manage your DNS records hosted by Google Cloud DNS. */
+  const NDEV_CLOUDDNS_READWRITE =
+      "https://www.googleapis.com/auth/ndev.clouddns.readwrite";
+
+  public $changes;
+  public $managedZones;
+  public $projects;
+  public $resourceRecordSets;
+  
+
+  /**
+   * Constructs the internal representation of the Dns service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'dns/v1/projects/';
+    $this->version = 'v1';
+    $this->serviceName = 'dns';
+
+    $this->changes = new Google_Service_Dns_Changes_Resource(
+        $this,
+        $this->serviceName,
+        'changes',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => '{project}/managedZones/{managedZone}/changes',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'managedZone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/managedZones/{managedZone}/changes/{changeId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'managedZone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'changeId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/managedZones/{managedZone}/changes',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'managedZone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->managedZones = new Google_Service_Dns_ManagedZones_Resource(
+        $this,
+        $this->serviceName,
+        'managedZones',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => '{project}/managedZones',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/managedZones/{managedZone}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'managedZone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/managedZones/{managedZone}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'managedZone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/managedZones',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'dnsName' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->projects = new Google_Service_Dns_Projects_Resource(
+        $this,
+        $this->serviceName,
+        'projects',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{project}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->resourceRecordSets = new Google_Service_Dns_ResourceRecordSets_Resource(
+        $this,
+        $this->serviceName,
+        'resourceRecordSets',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => '{project}/managedZones/{managedZone}/rrsets',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'managedZone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'name' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'type' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "changes" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dnsService = new Google_Service_Dns(...);
+ *   $changes = $dnsService->changes;
+ *  </code>
+ */
+class Google_Service_Dns_Changes_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Atomically update the ResourceRecordSet collection. (changes.create)
+   *
+   * @param string $project Identifies the project addressed by this request.
+   * @param string $managedZone Identifies the managed zone addressed by this
+   * request. Can be the managed zone name or id.
+   * @param Google_Change $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dns_Change
+   */
+  public function create($project, $managedZone, Google_Service_Dns_Change $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'managedZone' => $managedZone, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Dns_Change");
+  }
+
+  /**
+   * Fetch the representation of an existing Change. (changes.get)
+   *
+   * @param string $project Identifies the project addressed by this request.
+   * @param string $managedZone Identifies the managed zone addressed by this
+   * request. Can be the managed zone name or id.
+   * @param string $changeId The identifier of the requested change, from a
+   * previous ResourceRecordSetsChangeResponse.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dns_Change
+   */
+  public function get($project, $managedZone, $changeId, $optParams = array())
+  {
+    $params = array('project' => $project, 'managedZone' => $managedZone, 'changeId' => $changeId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dns_Change");
+  }
+
+  /**
+   * Enumerate Changes to a ResourceRecordSet collection. (changes.listChanges)
+   *
+   * @param string $project Identifies the project addressed by this request.
+   * @param string $managedZone Identifies the managed zone addressed by this
+   * request. Can be the managed zone name or id.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int maxResults Optional. Maximum number of results to be returned.
+   * If unspecified, the server will decide how many results to return.
+   * @opt_param string pageToken Optional. A tag returned by a previous list
+   * request that was truncated. Use this parameter to continue a previous list
+   * request.
+   * @opt_param string sortBy Sorting criterion. The only supported value is
+   * change sequence.
+   * @opt_param string sortOrder Sorting order direction: 'ascending' or
+   * 'descending'.
+   * @return Google_Service_Dns_ChangesListResponse
+   */
+  public function listChanges($project, $managedZone, $optParams = array())
+  {
+    $params = array('project' => $project, 'managedZone' => $managedZone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dns_ChangesListResponse");
+  }
+}
+
+/**
+ * The "managedZones" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dnsService = new Google_Service_Dns(...);
+ *   $managedZones = $dnsService->managedZones;
+ *  </code>
+ */
+class Google_Service_Dns_ManagedZones_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Create a new ManagedZone. (managedZones.create)
+   *
+   * @param string $project Identifies the project addressed by this request.
+   * @param Google_ManagedZone $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dns_ManagedZone
+   */
+  public function create($project, Google_Service_Dns_ManagedZone $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Dns_ManagedZone");
+  }
+
+  /**
+   * Delete a previously created ManagedZone. (managedZones.delete)
+   *
+   * @param string $project Identifies the project addressed by this request.
+   * @param string $managedZone Identifies the managed zone addressed by this
+   * request. Can be the managed zone name or id.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($project, $managedZone, $optParams = array())
+  {
+    $params = array('project' => $project, 'managedZone' => $managedZone);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Fetch the representation of an existing ManagedZone. (managedZones.get)
+   *
+   * @param string $project Identifies the project addressed by this request.
+   * @param string $managedZone Identifies the managed zone addressed by this
+   * request. Can be the managed zone name or id.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dns_ManagedZone
+   */
+  public function get($project, $managedZone, $optParams = array())
+  {
+    $params = array('project' => $project, 'managedZone' => $managedZone);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dns_ManagedZone");
+  }
+
+  /**
+   * Enumerate ManagedZones that have been created but not yet deleted.
+   * (managedZones.listManagedZones)
+   *
+   * @param string $project Identifies the project addressed by this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Optional. A tag returned by a previous list
+   * request that was truncated. Use this parameter to continue a previous list
+   * request.
+   * @opt_param string dnsName Restricts the list to return only zones with this
+   * domain name.
+   * @opt_param int maxResults Optional. Maximum number of results to be returned.
+   * If unspecified, the server will decide how many results to return.
+   * @return Google_Service_Dns_ManagedZonesListResponse
+   */
+  public function listManagedZones($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dns_ManagedZonesListResponse");
+  }
+}
+
+/**
+ * The "projects" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dnsService = new Google_Service_Dns(...);
+ *   $projects = $dnsService->projects;
+ *  </code>
+ */
+class Google_Service_Dns_Projects_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Fetch the representation of an existing Project. (projects.get)
+   *
+   * @param string $project Identifies the project addressed by this request.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Dns_Project
+   */
+  public function get($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Dns_Project");
+  }
+}
+
+/**
+ * The "resourceRecordSets" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $dnsService = new Google_Service_Dns(...);
+ *   $resourceRecordSets = $dnsService->resourceRecordSets;
+ *  </code>
+ */
+class Google_Service_Dns_ResourceRecordSets_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Enumerate ResourceRecordSets that have been created but not yet deleted.
+   * (resourceRecordSets.listResourceRecordSets)
+   *
+   * @param string $project Identifies the project addressed by this request.
+   * @param string $managedZone Identifies the managed zone addressed by this
+   * request. Can be the managed zone name or id.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string name Restricts the list to return only records with this
+   * fully qualified domain name.
+   * @opt_param int maxResults Optional. Maximum number of results to be returned.
+   * If unspecified, the server will decide how many results to return.
+   * @opt_param string pageToken Optional. A tag returned by a previous list
+   * request that was truncated. Use this parameter to continue a previous list
+   * request.
+   * @opt_param string type Restricts the list to return only records of this
+   * type. If present, the "name" parameter must also be present.
+   * @return Google_Service_Dns_ResourceRecordSetsListResponse
+   */
+  public function listResourceRecordSets($project, $managedZone, $optParams = array())
+  {
+    $params = array('project' => $project, 'managedZone' => $managedZone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Dns_ResourceRecordSetsListResponse");
+  }
+}
+
+
+
+
+class Google_Service_Dns_Change extends Google_Collection
+{
+  protected $collection_key = 'deletions';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $additionsType = 'Google_Service_Dns_ResourceRecordSet';
+  protected $additionsDataType = 'array';
+  protected $deletionsType = 'Google_Service_Dns_ResourceRecordSet';
+  protected $deletionsDataType = 'array';
+  public $id;
+  public $kind;
+  public $startTime;
+  public $status;
+
+
+  public function setAdditions($additions)
+  {
+    $this->additions = $additions;
+  }
+  public function getAdditions()
+  {
+    return $this->additions;
+  }
+  public function setDeletions($deletions)
+  {
+    $this->deletions = $deletions;
+  }
+  public function getDeletions()
+  {
+    return $this->deletions;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_Dns_ChangesListResponse extends Google_Collection
+{
+  protected $collection_key = 'changes';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $changesType = 'Google_Service_Dns_Change';
+  protected $changesDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setChanges($changes)
+  {
+    $this->changes = $changes;
+  }
+  public function getChanges()
+  {
+    return $this->changes;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dns_ManagedZone extends Google_Collection
+{
+  protected $collection_key = 'nameServers';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTime;
+  public $description;
+  public $dnsName;
+  public $id;
+  public $kind;
+  public $name;
+  public $nameServerSet;
+  public $nameServers;
+
+
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDnsName($dnsName)
+  {
+    $this->dnsName = $dnsName;
+  }
+  public function getDnsName()
+  {
+    return $this->dnsName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNameServerSet($nameServerSet)
+  {
+    $this->nameServerSet = $nameServerSet;
+  }
+  public function getNameServerSet()
+  {
+    return $this->nameServerSet;
+  }
+  public function setNameServers($nameServers)
+  {
+    $this->nameServers = $nameServers;
+  }
+  public function getNameServers()
+  {
+    return $this->nameServers;
+  }
+}
+
+class Google_Service_Dns_ManagedZonesListResponse extends Google_Collection
+{
+  protected $collection_key = 'managedZones';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $managedZonesType = 'Google_Service_Dns_ManagedZone';
+  protected $managedZonesDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setManagedZones($managedZones)
+  {
+    $this->managedZones = $managedZones;
+  }
+  public function getManagedZones()
+  {
+    return $this->managedZones;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Dns_Project extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $number;
+  protected $quotaType = 'Google_Service_Dns_Quota';
+  protected $quotaDataType = '';
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNumber($number)
+  {
+    $this->number = $number;
+  }
+  public function getNumber()
+  {
+    return $this->number;
+  }
+  public function setQuota(Google_Service_Dns_Quota $quota)
+  {
+    $this->quota = $quota;
+  }
+  public function getQuota()
+  {
+    return $this->quota;
+  }
+}
+
+class Google_Service_Dns_Quota extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $managedZones;
+  public $resourceRecordsPerRrset;
+  public $rrsetAdditionsPerChange;
+  public $rrsetDeletionsPerChange;
+  public $rrsetsPerManagedZone;
+  public $totalRrdataSizePerChange;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setManagedZones($managedZones)
+  {
+    $this->managedZones = $managedZones;
+  }
+  public function getManagedZones()
+  {
+    return $this->managedZones;
+  }
+  public function setResourceRecordsPerRrset($resourceRecordsPerRrset)
+  {
+    $this->resourceRecordsPerRrset = $resourceRecordsPerRrset;
+  }
+  public function getResourceRecordsPerRrset()
+  {
+    return $this->resourceRecordsPerRrset;
+  }
+  public function setRrsetAdditionsPerChange($rrsetAdditionsPerChange)
+  {
+    $this->rrsetAdditionsPerChange = $rrsetAdditionsPerChange;
+  }
+  public function getRrsetAdditionsPerChange()
+  {
+    return $this->rrsetAdditionsPerChange;
+  }
+  public function setRrsetDeletionsPerChange($rrsetDeletionsPerChange)
+  {
+    $this->rrsetDeletionsPerChange = $rrsetDeletionsPerChange;
+  }
+  public function getRrsetDeletionsPerChange()
+  {
+    return $this->rrsetDeletionsPerChange;
+  }
+  public function setRrsetsPerManagedZone($rrsetsPerManagedZone)
+  {
+    $this->rrsetsPerManagedZone = $rrsetsPerManagedZone;
+  }
+  public function getRrsetsPerManagedZone()
+  {
+    return $this->rrsetsPerManagedZone;
+  }
+  public function setTotalRrdataSizePerChange($totalRrdataSizePerChange)
+  {
+    $this->totalRrdataSizePerChange = $totalRrdataSizePerChange;
+  }
+  public function getTotalRrdataSizePerChange()
+  {
+    return $this->totalRrdataSizePerChange;
+  }
+}
+
+class Google_Service_Dns_ResourceRecordSet extends Google_Collection
+{
+  protected $collection_key = 'rrdatas';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $name;
+  public $rrdatas;
+  public $ttl;
+  public $type;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setRrdatas($rrdatas)
+  {
+    $this->rrdatas = $rrdatas;
+  }
+  public function getRrdatas()
+  {
+    return $this->rrdatas;
+  }
+  public function setTtl($ttl)
+  {
+    $this->ttl = $ttl;
+  }
+  public function getTtl()
+  {
+    return $this->ttl;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Dns_ResourceRecordSetsListResponse extends Google_Collection
+{
+  protected $collection_key = 'rrsets';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $rrsetsType = 'Google_Service_Dns_ResourceRecordSet';
+  protected $rrsetsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setRrsets($rrsets)
+  {
+    $this->rrsets = $rrsets;
+  }
+  public function getRrsets()
+  {
+    return $this->rrsets;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/DoubleClickBidManager.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/DoubleClickBidManager.php
@@ -1,0 +1,1085 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for DoubleClickBidManager (v1).
+ *
+ * <p>
+ * API for viewing and managing your reports in DoubleClick Bid Manager.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/bid-manager/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_DoubleClickBidManager extends Google_Service
+{
+
+
+  public $lineitems;
+  public $queries;
+  public $reports;
+  
+
+  /**
+   * Constructs the internal representation of the DoubleClickBidManager
+   * service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'doubleclickbidmanager/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'doubleclickbidmanager';
+
+    $this->lineitems = new Google_Service_DoubleClickBidManager_Lineitems_Resource(
+        $this,
+        $this->serviceName,
+        'lineitems',
+        array(
+          'methods' => array(
+            'downloadlineitems' => array(
+              'path' => 'lineitems/downloadlineitems',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'uploadlineitems' => array(
+              'path' => 'lineitems/uploadlineitems',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->queries = new Google_Service_DoubleClickBidManager_Queries_Resource(
+        $this,
+        $this->serviceName,
+        'queries',
+        array(
+          'methods' => array(
+            'createquery' => array(
+              'path' => 'query',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'deletequery' => array(
+              'path' => 'query/{queryId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'queryId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getquery' => array(
+              'path' => 'query/{queryId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'queryId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'listqueries' => array(
+              'path' => 'queries',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),'runquery' => array(
+              'path' => 'query/{queryId}',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'queryId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->reports = new Google_Service_DoubleClickBidManager_Reports_Resource(
+        $this,
+        $this->serviceName,
+        'reports',
+        array(
+          'methods' => array(
+            'listreports' => array(
+              'path' => 'queries/{queryId}/reports',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'queryId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "lineitems" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $doubleclickbidmanagerService = new Google_Service_DoubleClickBidManager(...);
+ *   $lineitems = $doubleclickbidmanagerService->lineitems;
+ *  </code>
+ */
+class Google_Service_DoubleClickBidManager_Lineitems_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves line items in CSV format. (lineitems.downloadlineitems)
+   *
+   * @param Google_DownloadLineItemsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_DoubleClickBidManager_DownloadLineItemsResponse
+   */
+  public function downloadlineitems(Google_Service_DoubleClickBidManager_DownloadLineItemsRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('downloadlineitems', array($params), "Google_Service_DoubleClickBidManager_DownloadLineItemsResponse");
+  }
+
+  /**
+   * Uploads line items in CSV format. (lineitems.uploadlineitems)
+   *
+   * @param Google_UploadLineItemsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_DoubleClickBidManager_UploadLineItemsResponse
+   */
+  public function uploadlineitems(Google_Service_DoubleClickBidManager_UploadLineItemsRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('uploadlineitems', array($params), "Google_Service_DoubleClickBidManager_UploadLineItemsResponse");
+  }
+}
+
+/**
+ * The "queries" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $doubleclickbidmanagerService = new Google_Service_DoubleClickBidManager(...);
+ *   $queries = $doubleclickbidmanagerService->queries;
+ *  </code>
+ */
+class Google_Service_DoubleClickBidManager_Queries_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a query. (queries.createquery)
+   *
+   * @param Google_Query $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_DoubleClickBidManager_Query
+   */
+  public function createquery(Google_Service_DoubleClickBidManager_Query $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('createquery', array($params), "Google_Service_DoubleClickBidManager_Query");
+  }
+
+  /**
+   * Deletes a stored query as well as the associated stored reports.
+   * (queries.deletequery)
+   *
+   * @param string $queryId Query ID to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function deletequery($queryId, $optParams = array())
+  {
+    $params = array('queryId' => $queryId);
+    $params = array_merge($params, $optParams);
+    return $this->call('deletequery', array($params));
+  }
+
+  /**
+   * Retrieves a stored query. (queries.getquery)
+   *
+   * @param string $queryId Query ID to retrieve.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_DoubleClickBidManager_Query
+   */
+  public function getquery($queryId, $optParams = array())
+  {
+    $params = array('queryId' => $queryId);
+    $params = array_merge($params, $optParams);
+    return $this->call('getquery', array($params), "Google_Service_DoubleClickBidManager_Query");
+  }
+
+  /**
+   * Retrieves stored queries. (queries.listqueries)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_DoubleClickBidManager_ListQueriesResponse
+   */
+  public function listqueries($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('listqueries', array($params), "Google_Service_DoubleClickBidManager_ListQueriesResponse");
+  }
+
+  /**
+   * Runs a stored query to generate a report. (queries.runquery)
+   *
+   * @param string $queryId Query ID to run.
+   * @param Google_RunQueryRequest $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function runquery($queryId, Google_Service_DoubleClickBidManager_RunQueryRequest $postBody, $optParams = array())
+  {
+    $params = array('queryId' => $queryId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('runquery', array($params));
+  }
+}
+
+/**
+ * The "reports" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $doubleclickbidmanagerService = new Google_Service_DoubleClickBidManager(...);
+ *   $reports = $doubleclickbidmanagerService->reports;
+ *  </code>
+ */
+class Google_Service_DoubleClickBidManager_Reports_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves stored reports. (reports.listreports)
+   *
+   * @param string $queryId Query ID with which the reports are associated.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_DoubleClickBidManager_ListReportsResponse
+   */
+  public function listreports($queryId, $optParams = array())
+  {
+    $params = array('queryId' => $queryId);
+    $params = array_merge($params, $optParams);
+    return $this->call('listreports', array($params), "Google_Service_DoubleClickBidManager_ListReportsResponse");
+  }
+}
+
+
+
+
+class Google_Service_DoubleClickBidManager_DownloadLineItemsRequest extends Google_Collection
+{
+  protected $collection_key = 'filterIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $fileSpec;
+  public $filterIds;
+  public $filterType;
+  public $format;
+
+
+  public function setFileSpec($fileSpec)
+  {
+    $this->fileSpec = $fileSpec;
+  }
+  public function getFileSpec()
+  {
+    return $this->fileSpec;
+  }
+  public function setFilterIds($filterIds)
+  {
+    $this->filterIds = $filterIds;
+  }
+  public function getFilterIds()
+  {
+    return $this->filterIds;
+  }
+  public function setFilterType($filterType)
+  {
+    $this->filterType = $filterType;
+  }
+  public function getFilterType()
+  {
+    return $this->filterType;
+  }
+  public function setFormat($format)
+  {
+    $this->format = $format;
+  }
+  public function getFormat()
+  {
+    return $this->format;
+  }
+}
+
+class Google_Service_DoubleClickBidManager_DownloadLineItemsResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $lineItems;
+
+
+  public function setLineItems($lineItems)
+  {
+    $this->lineItems = $lineItems;
+  }
+  public function getLineItems()
+  {
+    return $this->lineItems;
+  }
+}
+
+class Google_Service_DoubleClickBidManager_FilterPair extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $type;
+  public $value;
+
+
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_DoubleClickBidManager_ListQueriesResponse extends Google_Collection
+{
+  protected $collection_key = 'queries';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $queriesType = 'Google_Service_DoubleClickBidManager_Query';
+  protected $queriesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setQueries($queries)
+  {
+    $this->queries = $queries;
+  }
+  public function getQueries()
+  {
+    return $this->queries;
+  }
+}
+
+class Google_Service_DoubleClickBidManager_ListReportsResponse extends Google_Collection
+{
+  protected $collection_key = 'reports';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $reportsType = 'Google_Service_DoubleClickBidManager_Report';
+  protected $reportsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setReports($reports)
+  {
+    $this->reports = $reports;
+  }
+  public function getReports()
+  {
+    return $this->reports;
+  }
+}
+
+class Google_Service_DoubleClickBidManager_Parameters extends Google_Collection
+{
+  protected $collection_key = 'metrics';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $filtersType = 'Google_Service_DoubleClickBidManager_FilterPair';
+  protected $filtersDataType = 'array';
+  public $groupBys;
+  public $includeInviteData;
+  public $metrics;
+  public $type;
+
+
+  public function setFilters($filters)
+  {
+    $this->filters = $filters;
+  }
+  public function getFilters()
+  {
+    return $this->filters;
+  }
+  public function setGroupBys($groupBys)
+  {
+    $this->groupBys = $groupBys;
+  }
+  public function getGroupBys()
+  {
+    return $this->groupBys;
+  }
+  public function setIncludeInviteData($includeInviteData)
+  {
+    $this->includeInviteData = $includeInviteData;
+  }
+  public function getIncludeInviteData()
+  {
+    return $this->includeInviteData;
+  }
+  public function setMetrics($metrics)
+  {
+    $this->metrics = $metrics;
+  }
+  public function getMetrics()
+  {
+    return $this->metrics;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_DoubleClickBidManager_Query extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $metadataType = 'Google_Service_DoubleClickBidManager_QueryMetadata';
+  protected $metadataDataType = '';
+  protected $paramsType = 'Google_Service_DoubleClickBidManager_Parameters';
+  protected $paramsDataType = '';
+  public $queryId;
+  public $reportDataEndTimeMs;
+  public $reportDataStartTimeMs;
+  protected $scheduleType = 'Google_Service_DoubleClickBidManager_QuerySchedule';
+  protected $scheduleDataType = '';
+  public $timezoneCode;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMetadata(Google_Service_DoubleClickBidManager_QueryMetadata $metadata)
+  {
+    $this->metadata = $metadata;
+  }
+  public function getMetadata()
+  {
+    return $this->metadata;
+  }
+  public function setParams(Google_Service_DoubleClickBidManager_Parameters $params)
+  {
+    $this->params = $params;
+  }
+  public function getParams()
+  {
+    return $this->params;
+  }
+  public function setQueryId($queryId)
+  {
+    $this->queryId = $queryId;
+  }
+  public function getQueryId()
+  {
+    return $this->queryId;
+  }
+  public function setReportDataEndTimeMs($reportDataEndTimeMs)
+  {
+    $this->reportDataEndTimeMs = $reportDataEndTimeMs;
+  }
+  public function getReportDataEndTimeMs()
+  {
+    return $this->reportDataEndTimeMs;
+  }
+  public function setReportDataStartTimeMs($reportDataStartTimeMs)
+  {
+    $this->reportDataStartTimeMs = $reportDataStartTimeMs;
+  }
+  public function getReportDataStartTimeMs()
+  {
+    return $this->reportDataStartTimeMs;
+  }
+  public function setSchedule(Google_Service_DoubleClickBidManager_QuerySchedule $schedule)
+  {
+    $this->schedule = $schedule;
+  }
+  public function getSchedule()
+  {
+    return $this->schedule;
+  }
+  public function setTimezoneCode($timezoneCode)
+  {
+    $this->timezoneCode = $timezoneCode;
+  }
+  public function getTimezoneCode()
+  {
+    return $this->timezoneCode;
+  }
+}
+
+class Google_Service_DoubleClickBidManager_QueryMetadata extends Google_Collection
+{
+  protected $collection_key = 'shareEmailAddress';
+  protected $internal_gapi_mappings = array(
+  );
+  public $dataRange;
+  public $format;
+  public $googleCloudStoragePathForLatestReport;
+  public $googleDrivePathForLatestReport;
+  public $latestReportRunTimeMs;
+  public $locale;
+  public $reportCount;
+  public $running;
+  public $sendNotification;
+  public $shareEmailAddress;
+  public $title;
+
+
+  public function setDataRange($dataRange)
+  {
+    $this->dataRange = $dataRange;
+  }
+  public function getDataRange()
+  {
+    return $this->dataRange;
+  }
+  public function setFormat($format)
+  {
+    $this->format = $format;
+  }
+  public function getFormat()
+  {
+    return $this->format;
+  }
+  public function setGoogleCloudStoragePathForLatestReport($googleCloudStoragePathForLatestReport)
+  {
+    $this->googleCloudStoragePathForLatestReport = $googleCloudStoragePathForLatestReport;
+  }
+  public function getGoogleCloudStoragePathForLatestReport()
+  {
+    return $this->googleCloudStoragePathForLatestReport;
+  }
+  public function setGoogleDrivePathForLatestReport($googleDrivePathForLatestReport)
+  {
+    $this->googleDrivePathForLatestReport = $googleDrivePathForLatestReport;
+  }
+  public function getGoogleDrivePathForLatestReport()
+  {
+    return $this->googleDrivePathForLatestReport;
+  }
+  public function setLatestReportRunTimeMs($latestReportRunTimeMs)
+  {
+    $this->latestReportRunTimeMs = $latestReportRunTimeMs;
+  }
+  public function getLatestReportRunTimeMs()
+  {
+    return $this->latestReportRunTimeMs;
+  }
+  public function setLocale($locale)
+  {
+    $this->locale = $locale;
+  }
+  public function getLocale()
+  {
+    return $this->locale;
+  }
+  public function setReportCount($reportCount)
+  {
+    $this->reportCount = $reportCount;
+  }
+  public function getReportCount()
+  {
+    return $this->reportCount;
+  }
+  public function setRunning($running)
+  {
+    $this->running = $running;
+  }
+  public function getRunning()
+  {
+    return $this->running;
+  }
+  public function setSendNotification($sendNotification)
+  {
+    $this->sendNotification = $sendNotification;
+  }
+  public function getSendNotification()
+  {
+    return $this->sendNotification;
+  }
+  public function setShareEmailAddress($shareEmailAddress)
+  {
+    $this->shareEmailAddress = $shareEmailAddress;
+  }
+  public function getShareEmailAddress()
+  {
+    return $this->shareEmailAddress;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_DoubleClickBidManager_QuerySchedule extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $endTimeMs;
+  public $frequency;
+  public $nextRunMinuteOfDay;
+  public $nextRunTimezoneCode;
+
+
+  public function setEndTimeMs($endTimeMs)
+  {
+    $this->endTimeMs = $endTimeMs;
+  }
+  public function getEndTimeMs()
+  {
+    return $this->endTimeMs;
+  }
+  public function setFrequency($frequency)
+  {
+    $this->frequency = $frequency;
+  }
+  public function getFrequency()
+  {
+    return $this->frequency;
+  }
+  public function setNextRunMinuteOfDay($nextRunMinuteOfDay)
+  {
+    $this->nextRunMinuteOfDay = $nextRunMinuteOfDay;
+  }
+  public function getNextRunMinuteOfDay()
+  {
+    return $this->nextRunMinuteOfDay;
+  }
+  public function setNextRunTimezoneCode($nextRunTimezoneCode)
+  {
+    $this->nextRunTimezoneCode = $nextRunTimezoneCode;
+  }
+  public function getNextRunTimezoneCode()
+  {
+    return $this->nextRunTimezoneCode;
+  }
+}
+
+class Google_Service_DoubleClickBidManager_Report extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $keyType = 'Google_Service_DoubleClickBidManager_ReportKey';
+  protected $keyDataType = '';
+  protected $metadataType = 'Google_Service_DoubleClickBidManager_ReportMetadata';
+  protected $metadataDataType = '';
+  protected $paramsType = 'Google_Service_DoubleClickBidManager_Parameters';
+  protected $paramsDataType = '';
+
+
+  public function setKey(Google_Service_DoubleClickBidManager_ReportKey $key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setMetadata(Google_Service_DoubleClickBidManager_ReportMetadata $metadata)
+  {
+    $this->metadata = $metadata;
+  }
+  public function getMetadata()
+  {
+    return $this->metadata;
+  }
+  public function setParams(Google_Service_DoubleClickBidManager_Parameters $params)
+  {
+    $this->params = $params;
+  }
+  public function getParams()
+  {
+    return $this->params;
+  }
+}
+
+class Google_Service_DoubleClickBidManager_ReportFailure extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $errorCode;
+
+
+  public function setErrorCode($errorCode)
+  {
+    $this->errorCode = $errorCode;
+  }
+  public function getErrorCode()
+  {
+    return $this->errorCode;
+  }
+}
+
+class Google_Service_DoubleClickBidManager_ReportKey extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $queryId;
+  public $reportId;
+
+
+  public function setQueryId($queryId)
+  {
+    $this->queryId = $queryId;
+  }
+  public function getQueryId()
+  {
+    return $this->queryId;
+  }
+  public function setReportId($reportId)
+  {
+    $this->reportId = $reportId;
+  }
+  public function getReportId()
+  {
+    return $this->reportId;
+  }
+}
+
+class Google_Service_DoubleClickBidManager_ReportMetadata extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $googleCloudStoragePath;
+  public $reportDataEndTimeMs;
+  public $reportDataStartTimeMs;
+  protected $statusType = 'Google_Service_DoubleClickBidManager_ReportStatus';
+  protected $statusDataType = '';
+
+
+  public function setGoogleCloudStoragePath($googleCloudStoragePath)
+  {
+    $this->googleCloudStoragePath = $googleCloudStoragePath;
+  }
+  public function getGoogleCloudStoragePath()
+  {
+    return $this->googleCloudStoragePath;
+  }
+  public function setReportDataEndTimeMs($reportDataEndTimeMs)
+  {
+    $this->reportDataEndTimeMs = $reportDataEndTimeMs;
+  }
+  public function getReportDataEndTimeMs()
+  {
+    return $this->reportDataEndTimeMs;
+  }
+  public function setReportDataStartTimeMs($reportDataStartTimeMs)
+  {
+    $this->reportDataStartTimeMs = $reportDataStartTimeMs;
+  }
+  public function getReportDataStartTimeMs()
+  {
+    return $this->reportDataStartTimeMs;
+  }
+  public function setStatus(Google_Service_DoubleClickBidManager_ReportStatus $status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_DoubleClickBidManager_ReportStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $failureType = 'Google_Service_DoubleClickBidManager_ReportFailure';
+  protected $failureDataType = '';
+  public $finishTimeMs;
+  public $format;
+  public $state;
+
+
+  public function setFailure(Google_Service_DoubleClickBidManager_ReportFailure $failure)
+  {
+    $this->failure = $failure;
+  }
+  public function getFailure()
+  {
+    return $this->failure;
+  }
+  public function setFinishTimeMs($finishTimeMs)
+  {
+    $this->finishTimeMs = $finishTimeMs;
+  }
+  public function getFinishTimeMs()
+  {
+    return $this->finishTimeMs;
+  }
+  public function setFormat($format)
+  {
+    $this->format = $format;
+  }
+  public function getFormat()
+  {
+    return $this->format;
+  }
+  public function setState($state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+}
+
+class Google_Service_DoubleClickBidManager_RowStatus extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  public $changed;
+  public $entityId;
+  public $entityName;
+  public $errors;
+  public $persisted;
+  public $rowNumber;
+
+
+  public function setChanged($changed)
+  {
+    $this->changed = $changed;
+  }
+  public function getChanged()
+  {
+    return $this->changed;
+  }
+  public function setEntityId($entityId)
+  {
+    $this->entityId = $entityId;
+  }
+  public function getEntityId()
+  {
+    return $this->entityId;
+  }
+  public function setEntityName($entityName)
+  {
+    $this->entityName = $entityName;
+  }
+  public function getEntityName()
+  {
+    return $this->entityName;
+  }
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setPersisted($persisted)
+  {
+    $this->persisted = $persisted;
+  }
+  public function getPersisted()
+  {
+    return $this->persisted;
+  }
+  public function setRowNumber($rowNumber)
+  {
+    $this->rowNumber = $rowNumber;
+  }
+  public function getRowNumber()
+  {
+    return $this->rowNumber;
+  }
+}
+
+class Google_Service_DoubleClickBidManager_RunQueryRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $dataRange;
+  public $reportDataEndTimeMs;
+  public $reportDataStartTimeMs;
+  public $timezoneCode;
+
+
+  public function setDataRange($dataRange)
+  {
+    $this->dataRange = $dataRange;
+  }
+  public function getDataRange()
+  {
+    return $this->dataRange;
+  }
+  public function setReportDataEndTimeMs($reportDataEndTimeMs)
+  {
+    $this->reportDataEndTimeMs = $reportDataEndTimeMs;
+  }
+  public function getReportDataEndTimeMs()
+  {
+    return $this->reportDataEndTimeMs;
+  }
+  public function setReportDataStartTimeMs($reportDataStartTimeMs)
+  {
+    $this->reportDataStartTimeMs = $reportDataStartTimeMs;
+  }
+  public function getReportDataStartTimeMs()
+  {
+    return $this->reportDataStartTimeMs;
+  }
+  public function setTimezoneCode($timezoneCode)
+  {
+    $this->timezoneCode = $timezoneCode;
+  }
+  public function getTimezoneCode()
+  {
+    return $this->timezoneCode;
+  }
+}
+
+class Google_Service_DoubleClickBidManager_UploadLineItemsRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $dryRun;
+  public $format;
+  public $lineItems;
+
+
+  public function setDryRun($dryRun)
+  {
+    $this->dryRun = $dryRun;
+  }
+  public function getDryRun()
+  {
+    return $this->dryRun;
+  }
+  public function setFormat($format)
+  {
+    $this->format = $format;
+  }
+  public function getFormat()
+  {
+    return $this->format;
+  }
+  public function setLineItems($lineItems)
+  {
+    $this->lineItems = $lineItems;
+  }
+  public function getLineItems()
+  {
+    return $this->lineItems;
+  }
+}
+
+class Google_Service_DoubleClickBidManager_UploadLineItemsResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $uploadStatusType = 'Google_Service_DoubleClickBidManager_UploadStatus';
+  protected $uploadStatusDataType = '';
+
+
+  public function setUploadStatus(Google_Service_DoubleClickBidManager_UploadStatus $uploadStatus)
+  {
+    $this->uploadStatus = $uploadStatus;
+  }
+  public function getUploadStatus()
+  {
+    return $this->uploadStatus;
+  }
+}
+
+class Google_Service_DoubleClickBidManager_UploadStatus extends Google_Collection
+{
+  protected $collection_key = 'rowStatus';
+  protected $internal_gapi_mappings = array(
+  );
+  public $errors;
+  protected $rowStatusType = 'Google_Service_DoubleClickBidManager_RowStatus';
+  protected $rowStatusDataType = 'array';
+
+
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setRowStatus($rowStatus)
+  {
+    $this->rowStatus = $rowStatus;
+  }
+  public function getRowStatus()
+  {
+    return $this->rowStatus;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Doubleclicksearch.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Doubleclicksearch.php
@@ -1,0 +1,1543 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Doubleclicksearch (v2).
+ *
+ * <p>
+ * Report and modify your advertising data in DoubleClick Search (for example,
+ * campaigns, ad groups, keywords, and conversions).</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/doubleclick-search/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Doubleclicksearch extends Google_Service
+{
+  /** View and manage your advertising data in DoubleClick Search. */
+  const DOUBLECLICKSEARCH =
+      "https://www.googleapis.com/auth/doubleclicksearch";
+
+  public $conversion;
+  public $reports;
+  public $savedColumns;
+  
+
+  /**
+   * Constructs the internal representation of the Doubleclicksearch service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'doubleclicksearch/v2/';
+    $this->version = 'v2';
+    $this->serviceName = 'doubleclicksearch';
+
+    $this->conversion = new Google_Service_Doubleclicksearch_Conversion_Resource(
+        $this,
+        $this->serviceName,
+        'conversion',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'agency/{agencyId}/advertiser/{advertiserId}/engine/{engineAccountId}/conversion',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'agencyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'advertiserId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'engineAccountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'endDate' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'rowCount' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'startDate' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'startRow' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'adGroupId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'campaignId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'adId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'criterionId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'conversion',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'patch' => array(
+              'path' => 'conversion',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'advertiserId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'agencyId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'endDate' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'engineAccountId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'rowCount' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'startDate' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'startRow' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'conversion',
+              'httpMethod' => 'PUT',
+              'parameters' => array(),
+            ),'updateAvailability' => array(
+              'path' => 'conversion/updateAvailability',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->reports = new Google_Service_Doubleclicksearch_Reports_Resource(
+        $this,
+        $this->serviceName,
+        'reports',
+        array(
+          'methods' => array(
+            'generate' => array(
+              'path' => 'reports/generate',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'get' => array(
+              'path' => 'reports/{reportId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'reportId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getFile' => array(
+              'path' => 'reports/{reportId}/files/{reportFragment}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'reportId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'reportFragment' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'request' => array(
+              'path' => 'reports',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->savedColumns = new Google_Service_Doubleclicksearch_SavedColumns_Resource(
+        $this,
+        $this->serviceName,
+        'savedColumns',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'agency/{agencyId}/advertiser/{advertiserId}/savedcolumns',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'agencyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'advertiserId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "conversion" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $doubleclicksearchService = new Google_Service_Doubleclicksearch(...);
+ *   $conversion = $doubleclicksearchService->conversion;
+ *  </code>
+ */
+class Google_Service_Doubleclicksearch_Conversion_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a list of conversions from a DoubleClick Search engine account.
+   * (conversion.get)
+   *
+   * @param string $agencyId Numeric ID of the agency.
+   * @param string $advertiserId Numeric ID of the advertiser.
+   * @param string $engineAccountId Numeric ID of the engine account.
+   * @param int $endDate Last date (inclusive) on which to retrieve conversions.
+   * Format is yyyymmdd.
+   * @param int $rowCount The number of conversions to return per call.
+   * @param int $startDate First date (inclusive) on which to retrieve
+   * conversions. Format is yyyymmdd.
+   * @param string $startRow The 0-based starting index for retrieving conversions
+   * results.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string adGroupId Numeric ID of the ad group.
+   * @opt_param string campaignId Numeric ID of the campaign.
+   * @opt_param string adId Numeric ID of the ad.
+   * @opt_param string criterionId Numeric ID of the criterion.
+   * @return Google_Service_Doubleclicksearch_ConversionList
+   */
+  public function get($agencyId, $advertiserId, $engineAccountId, $endDate, $rowCount, $startDate, $startRow, $optParams = array())
+  {
+    $params = array('agencyId' => $agencyId, 'advertiserId' => $advertiserId, 'engineAccountId' => $engineAccountId, 'endDate' => $endDate, 'rowCount' => $rowCount, 'startDate' => $startDate, 'startRow' => $startRow);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Doubleclicksearch_ConversionList");
+  }
+
+  /**
+   * Inserts a batch of new conversions into DoubleClick Search.
+   * (conversion.insert)
+   *
+   * @param Google_ConversionList $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Doubleclicksearch_ConversionList
+   */
+  public function insert(Google_Service_Doubleclicksearch_ConversionList $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Doubleclicksearch_ConversionList");
+  }
+
+  /**
+   * Updates a batch of conversions in DoubleClick Search. This method supports
+   * patch semantics. (conversion.patch)
+   *
+   * @param string $advertiserId Numeric ID of the advertiser.
+   * @param string $agencyId Numeric ID of the agency.
+   * @param int $endDate Last date (inclusive) on which to retrieve conversions.
+   * Format is yyyymmdd.
+   * @param string $engineAccountId Numeric ID of the engine account.
+   * @param int $rowCount The number of conversions to return per call.
+   * @param int $startDate First date (inclusive) on which to retrieve
+   * conversions. Format is yyyymmdd.
+   * @param string $startRow The 0-based starting index for retrieving conversions
+   * results.
+   * @param Google_ConversionList $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Doubleclicksearch_ConversionList
+   */
+  public function patch($advertiserId, $agencyId, $endDate, $engineAccountId, $rowCount, $startDate, $startRow, Google_Service_Doubleclicksearch_ConversionList $postBody, $optParams = array())
+  {
+    $params = array('advertiserId' => $advertiserId, 'agencyId' => $agencyId, 'endDate' => $endDate, 'engineAccountId' => $engineAccountId, 'rowCount' => $rowCount, 'startDate' => $startDate, 'startRow' => $startRow, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Doubleclicksearch_ConversionList");
+  }
+
+  /**
+   * Updates a batch of conversions in DoubleClick Search. (conversion.update)
+   *
+   * @param Google_ConversionList $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Doubleclicksearch_ConversionList
+   */
+  public function update(Google_Service_Doubleclicksearch_ConversionList $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Doubleclicksearch_ConversionList");
+  }
+
+  /**
+   * Updates the availabilities of a batch of floodlight activities in DoubleClick
+   * Search. (conversion.updateAvailability)
+   *
+   * @param Google_UpdateAvailabilityRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Doubleclicksearch_UpdateAvailabilityResponse
+   */
+  public function updateAvailability(Google_Service_Doubleclicksearch_UpdateAvailabilityRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('updateAvailability', array($params), "Google_Service_Doubleclicksearch_UpdateAvailabilityResponse");
+  }
+}
+
+/**
+ * The "reports" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $doubleclicksearchService = new Google_Service_Doubleclicksearch(...);
+ *   $reports = $doubleclicksearchService->reports;
+ *  </code>
+ */
+class Google_Service_Doubleclicksearch_Reports_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Generates and returns a report immediately. (reports.generate)
+   *
+   * @param Google_ReportRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Doubleclicksearch_Report
+   */
+  public function generate(Google_Service_Doubleclicksearch_ReportRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('generate', array($params), "Google_Service_Doubleclicksearch_Report");
+  }
+
+  /**
+   * Polls for the status of a report request. (reports.get)
+   *
+   * @param string $reportId ID of the report request being polled.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Doubleclicksearch_Report
+   */
+  public function get($reportId, $optParams = array())
+  {
+    $params = array('reportId' => $reportId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Doubleclicksearch_Report");
+  }
+
+  /**
+   * Downloads a report file encoded in UTF-8. (reports.getFile)
+   *
+   * @param string $reportId ID of the report.
+   * @param int $reportFragment The index of the report fragment to download.
+   * @param array $optParams Optional parameters.
+   */
+  public function getFile($reportId, $reportFragment, $optParams = array())
+  {
+    $params = array('reportId' => $reportId, 'reportFragment' => $reportFragment);
+    $params = array_merge($params, $optParams);
+    return $this->call('getFile', array($params));
+  }
+
+  /**
+   * Inserts a report request into the reporting system. (reports.request)
+   *
+   * @param Google_ReportRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Doubleclicksearch_Report
+   */
+  public function request(Google_Service_Doubleclicksearch_ReportRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('request', array($params), "Google_Service_Doubleclicksearch_Report");
+  }
+}
+
+/**
+ * The "savedColumns" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $doubleclicksearchService = new Google_Service_Doubleclicksearch(...);
+ *   $savedColumns = $doubleclicksearchService->savedColumns;
+ *  </code>
+ */
+class Google_Service_Doubleclicksearch_SavedColumns_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieve the list of saved columns for a specified advertiser.
+   * (savedColumns.listSavedColumns)
+   *
+   * @param string $agencyId DS ID of the agency.
+   * @param string $advertiserId DS ID of the advertiser.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Doubleclicksearch_SavedColumnList
+   */
+  public function listSavedColumns($agencyId, $advertiserId, $optParams = array())
+  {
+    $params = array('agencyId' => $agencyId, 'advertiserId' => $advertiserId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Doubleclicksearch_SavedColumnList");
+  }
+}
+
+
+
+
+class Google_Service_Doubleclicksearch_Availability extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $advertiserId;
+  public $agencyId;
+  public $availabilityTimestamp;
+  public $segmentationId;
+  public $segmentationName;
+  public $segmentationType;
+
+
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAgencyId($agencyId)
+  {
+    $this->agencyId = $agencyId;
+  }
+  public function getAgencyId()
+  {
+    return $this->agencyId;
+  }
+  public function setAvailabilityTimestamp($availabilityTimestamp)
+  {
+    $this->availabilityTimestamp = $availabilityTimestamp;
+  }
+  public function getAvailabilityTimestamp()
+  {
+    return $this->availabilityTimestamp;
+  }
+  public function setSegmentationId($segmentationId)
+  {
+    $this->segmentationId = $segmentationId;
+  }
+  public function getSegmentationId()
+  {
+    return $this->segmentationId;
+  }
+  public function setSegmentationName($segmentationName)
+  {
+    $this->segmentationName = $segmentationName;
+  }
+  public function getSegmentationName()
+  {
+    return $this->segmentationName;
+  }
+  public function setSegmentationType($segmentationType)
+  {
+    $this->segmentationType = $segmentationType;
+  }
+  public function getSegmentationType()
+  {
+    return $this->segmentationType;
+  }
+}
+
+class Google_Service_Doubleclicksearch_Conversion extends Google_Collection
+{
+  protected $collection_key = 'customMetric';
+  protected $internal_gapi_mappings = array(
+  );
+  public $adGroupId;
+  public $adId;
+  public $advertiserId;
+  public $agencyId;
+  public $attributionModel;
+  public $campaignId;
+  public $channel;
+  public $clickId;
+  public $conversionId;
+  public $conversionModifiedTimestamp;
+  public $conversionTimestamp;
+  public $countMillis;
+  public $criterionId;
+  public $currencyCode;
+  protected $customDimensionType = 'Google_Service_Doubleclicksearch_CustomDimension';
+  protected $customDimensionDataType = 'array';
+  protected $customMetricType = 'Google_Service_Doubleclicksearch_CustomMetric';
+  protected $customMetricDataType = 'array';
+  public $deviceType;
+  public $dsConversionId;
+  public $engineAccountId;
+  public $floodlightOrderId;
+  public $inventoryAccountId;
+  public $productCountry;
+  public $productGroupId;
+  public $productId;
+  public $productLanguage;
+  public $quantityMillis;
+  public $revenueMicros;
+  public $segmentationId;
+  public $segmentationName;
+  public $segmentationType;
+  public $state;
+  public $storeId;
+  public $type;
+
+
+  public function setAdGroupId($adGroupId)
+  {
+    $this->adGroupId = $adGroupId;
+  }
+  public function getAdGroupId()
+  {
+    return $this->adGroupId;
+  }
+  public function setAdId($adId)
+  {
+    $this->adId = $adId;
+  }
+  public function getAdId()
+  {
+    return $this->adId;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAgencyId($agencyId)
+  {
+    $this->agencyId = $agencyId;
+  }
+  public function getAgencyId()
+  {
+    return $this->agencyId;
+  }
+  public function setAttributionModel($attributionModel)
+  {
+    $this->attributionModel = $attributionModel;
+  }
+  public function getAttributionModel()
+  {
+    return $this->attributionModel;
+  }
+  public function setCampaignId($campaignId)
+  {
+    $this->campaignId = $campaignId;
+  }
+  public function getCampaignId()
+  {
+    return $this->campaignId;
+  }
+  public function setChannel($channel)
+  {
+    $this->channel = $channel;
+  }
+  public function getChannel()
+  {
+    return $this->channel;
+  }
+  public function setClickId($clickId)
+  {
+    $this->clickId = $clickId;
+  }
+  public function getClickId()
+  {
+    return $this->clickId;
+  }
+  public function setConversionId($conversionId)
+  {
+    $this->conversionId = $conversionId;
+  }
+  public function getConversionId()
+  {
+    return $this->conversionId;
+  }
+  public function setConversionModifiedTimestamp($conversionModifiedTimestamp)
+  {
+    $this->conversionModifiedTimestamp = $conversionModifiedTimestamp;
+  }
+  public function getConversionModifiedTimestamp()
+  {
+    return $this->conversionModifiedTimestamp;
+  }
+  public function setConversionTimestamp($conversionTimestamp)
+  {
+    $this->conversionTimestamp = $conversionTimestamp;
+  }
+  public function getConversionTimestamp()
+  {
+    return $this->conversionTimestamp;
+  }
+  public function setCountMillis($countMillis)
+  {
+    $this->countMillis = $countMillis;
+  }
+  public function getCountMillis()
+  {
+    return $this->countMillis;
+  }
+  public function setCriterionId($criterionId)
+  {
+    $this->criterionId = $criterionId;
+  }
+  public function getCriterionId()
+  {
+    return $this->criterionId;
+  }
+  public function setCurrencyCode($currencyCode)
+  {
+    $this->currencyCode = $currencyCode;
+  }
+  public function getCurrencyCode()
+  {
+    return $this->currencyCode;
+  }
+  public function setCustomDimension($customDimension)
+  {
+    $this->customDimension = $customDimension;
+  }
+  public function getCustomDimension()
+  {
+    return $this->customDimension;
+  }
+  public function setCustomMetric($customMetric)
+  {
+    $this->customMetric = $customMetric;
+  }
+  public function getCustomMetric()
+  {
+    return $this->customMetric;
+  }
+  public function setDeviceType($deviceType)
+  {
+    $this->deviceType = $deviceType;
+  }
+  public function getDeviceType()
+  {
+    return $this->deviceType;
+  }
+  public function setDsConversionId($dsConversionId)
+  {
+    $this->dsConversionId = $dsConversionId;
+  }
+  public function getDsConversionId()
+  {
+    return $this->dsConversionId;
+  }
+  public function setEngineAccountId($engineAccountId)
+  {
+    $this->engineAccountId = $engineAccountId;
+  }
+  public function getEngineAccountId()
+  {
+    return $this->engineAccountId;
+  }
+  public function setFloodlightOrderId($floodlightOrderId)
+  {
+    $this->floodlightOrderId = $floodlightOrderId;
+  }
+  public function getFloodlightOrderId()
+  {
+    return $this->floodlightOrderId;
+  }
+  public function setInventoryAccountId($inventoryAccountId)
+  {
+    $this->inventoryAccountId = $inventoryAccountId;
+  }
+  public function getInventoryAccountId()
+  {
+    return $this->inventoryAccountId;
+  }
+  public function setProductCountry($productCountry)
+  {
+    $this->productCountry = $productCountry;
+  }
+  public function getProductCountry()
+  {
+    return $this->productCountry;
+  }
+  public function setProductGroupId($productGroupId)
+  {
+    $this->productGroupId = $productGroupId;
+  }
+  public function getProductGroupId()
+  {
+    return $this->productGroupId;
+  }
+  public function setProductId($productId)
+  {
+    $this->productId = $productId;
+  }
+  public function getProductId()
+  {
+    return $this->productId;
+  }
+  public function setProductLanguage($productLanguage)
+  {
+    $this->productLanguage = $productLanguage;
+  }
+  public function getProductLanguage()
+  {
+    return $this->productLanguage;
+  }
+  public function setQuantityMillis($quantityMillis)
+  {
+    $this->quantityMillis = $quantityMillis;
+  }
+  public function getQuantityMillis()
+  {
+    return $this->quantityMillis;
+  }
+  public function setRevenueMicros($revenueMicros)
+  {
+    $this->revenueMicros = $revenueMicros;
+  }
+  public function getRevenueMicros()
+  {
+    return $this->revenueMicros;
+  }
+  public function setSegmentationId($segmentationId)
+  {
+    $this->segmentationId = $segmentationId;
+  }
+  public function getSegmentationId()
+  {
+    return $this->segmentationId;
+  }
+  public function setSegmentationName($segmentationName)
+  {
+    $this->segmentationName = $segmentationName;
+  }
+  public function getSegmentationName()
+  {
+    return $this->segmentationName;
+  }
+  public function setSegmentationType($segmentationType)
+  {
+    $this->segmentationType = $segmentationType;
+  }
+  public function getSegmentationType()
+  {
+    return $this->segmentationType;
+  }
+  public function setState($state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+  public function setStoreId($storeId)
+  {
+    $this->storeId = $storeId;
+  }
+  public function getStoreId()
+  {
+    return $this->storeId;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Doubleclicksearch_ConversionList extends Google_Collection
+{
+  protected $collection_key = 'conversion';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $conversionType = 'Google_Service_Doubleclicksearch_Conversion';
+  protected $conversionDataType = 'array';
+  public $kind;
+
+
+  public function setConversion($conversion)
+  {
+    $this->conversion = $conversion;
+  }
+  public function getConversion()
+  {
+    return $this->conversion;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Doubleclicksearch_CustomDimension extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $value;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Doubleclicksearch_CustomMetric extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $value;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Doubleclicksearch_Report extends Google_Collection
+{
+  protected $collection_key = 'rows';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $filesType = 'Google_Service_Doubleclicksearch_ReportFiles';
+  protected $filesDataType = 'array';
+  public $id;
+  public $isReportReady;
+  public $kind;
+  protected $requestType = 'Google_Service_Doubleclicksearch_ReportRequest';
+  protected $requestDataType = '';
+  public $rowCount;
+  public $rows;
+  public $statisticsCurrencyCode;
+  public $statisticsTimeZone;
+
+
+  public function setFiles($files)
+  {
+    $this->files = $files;
+  }
+  public function getFiles()
+  {
+    return $this->files;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIsReportReady($isReportReady)
+  {
+    $this->isReportReady = $isReportReady;
+  }
+  public function getIsReportReady()
+  {
+    return $this->isReportReady;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRequest(Google_Service_Doubleclicksearch_ReportRequest $request)
+  {
+    $this->request = $request;
+  }
+  public function getRequest()
+  {
+    return $this->request;
+  }
+  public function setRowCount($rowCount)
+  {
+    $this->rowCount = $rowCount;
+  }
+  public function getRowCount()
+  {
+    return $this->rowCount;
+  }
+  public function setRows($rows)
+  {
+    $this->rows = $rows;
+  }
+  public function getRows()
+  {
+    return $this->rows;
+  }
+  public function setStatisticsCurrencyCode($statisticsCurrencyCode)
+  {
+    $this->statisticsCurrencyCode = $statisticsCurrencyCode;
+  }
+  public function getStatisticsCurrencyCode()
+  {
+    return $this->statisticsCurrencyCode;
+  }
+  public function setStatisticsTimeZone($statisticsTimeZone)
+  {
+    $this->statisticsTimeZone = $statisticsTimeZone;
+  }
+  public function getStatisticsTimeZone()
+  {
+    return $this->statisticsTimeZone;
+  }
+}
+
+class Google_Service_Doubleclicksearch_ReportApiColumnSpec extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $columnName;
+  public $customDimensionName;
+  public $customMetricName;
+  public $endDate;
+  public $groupByColumn;
+  public $headerText;
+  public $platformSource;
+  public $productReportPerspective;
+  public $savedColumnName;
+  public $startDate;
+
+
+  public function setColumnName($columnName)
+  {
+    $this->columnName = $columnName;
+  }
+  public function getColumnName()
+  {
+    return $this->columnName;
+  }
+  public function setCustomDimensionName($customDimensionName)
+  {
+    $this->customDimensionName = $customDimensionName;
+  }
+  public function getCustomDimensionName()
+  {
+    return $this->customDimensionName;
+  }
+  public function setCustomMetricName($customMetricName)
+  {
+    $this->customMetricName = $customMetricName;
+  }
+  public function getCustomMetricName()
+  {
+    return $this->customMetricName;
+  }
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setGroupByColumn($groupByColumn)
+  {
+    $this->groupByColumn = $groupByColumn;
+  }
+  public function getGroupByColumn()
+  {
+    return $this->groupByColumn;
+  }
+  public function setHeaderText($headerText)
+  {
+    $this->headerText = $headerText;
+  }
+  public function getHeaderText()
+  {
+    return $this->headerText;
+  }
+  public function setPlatformSource($platformSource)
+  {
+    $this->platformSource = $platformSource;
+  }
+  public function getPlatformSource()
+  {
+    return $this->platformSource;
+  }
+  public function setProductReportPerspective($productReportPerspective)
+  {
+    $this->productReportPerspective = $productReportPerspective;
+  }
+  public function getProductReportPerspective()
+  {
+    return $this->productReportPerspective;
+  }
+  public function setSavedColumnName($savedColumnName)
+  {
+    $this->savedColumnName = $savedColumnName;
+  }
+  public function getSavedColumnName()
+  {
+    return $this->savedColumnName;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+}
+
+class Google_Service_Doubleclicksearch_ReportFiles extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $byteCount;
+  public $url;
+
+
+  public function setByteCount($byteCount)
+  {
+    $this->byteCount = $byteCount;
+  }
+  public function getByteCount()
+  {
+    return $this->byteCount;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Doubleclicksearch_ReportRequest extends Google_Collection
+{
+  protected $collection_key = 'orderBy';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $columnsType = 'Google_Service_Doubleclicksearch_ReportApiColumnSpec';
+  protected $columnsDataType = 'array';
+  public $downloadFormat;
+  protected $filtersType = 'Google_Service_Doubleclicksearch_ReportRequestFilters';
+  protected $filtersDataType = 'array';
+  public $includeDeletedEntities;
+  public $includeRemovedEntities;
+  public $maxRowsPerFile;
+  protected $orderByType = 'Google_Service_Doubleclicksearch_ReportRequestOrderBy';
+  protected $orderByDataType = 'array';
+  protected $reportScopeType = 'Google_Service_Doubleclicksearch_ReportRequestReportScope';
+  protected $reportScopeDataType = '';
+  public $reportType;
+  public $rowCount;
+  public $startRow;
+  public $statisticsCurrency;
+  protected $timeRangeType = 'Google_Service_Doubleclicksearch_ReportRequestTimeRange';
+  protected $timeRangeDataType = '';
+  public $verifySingleTimeZone;
+
+
+  public function setColumns($columns)
+  {
+    $this->columns = $columns;
+  }
+  public function getColumns()
+  {
+    return $this->columns;
+  }
+  public function setDownloadFormat($downloadFormat)
+  {
+    $this->downloadFormat = $downloadFormat;
+  }
+  public function getDownloadFormat()
+  {
+    return $this->downloadFormat;
+  }
+  public function setFilters($filters)
+  {
+    $this->filters = $filters;
+  }
+  public function getFilters()
+  {
+    return $this->filters;
+  }
+  public function setIncludeDeletedEntities($includeDeletedEntities)
+  {
+    $this->includeDeletedEntities = $includeDeletedEntities;
+  }
+  public function getIncludeDeletedEntities()
+  {
+    return $this->includeDeletedEntities;
+  }
+  public function setIncludeRemovedEntities($includeRemovedEntities)
+  {
+    $this->includeRemovedEntities = $includeRemovedEntities;
+  }
+  public function getIncludeRemovedEntities()
+  {
+    return $this->includeRemovedEntities;
+  }
+  public function setMaxRowsPerFile($maxRowsPerFile)
+  {
+    $this->maxRowsPerFile = $maxRowsPerFile;
+  }
+  public function getMaxRowsPerFile()
+  {
+    return $this->maxRowsPerFile;
+  }
+  public function setOrderBy($orderBy)
+  {
+    $this->orderBy = $orderBy;
+  }
+  public function getOrderBy()
+  {
+    return $this->orderBy;
+  }
+  public function setReportScope(Google_Service_Doubleclicksearch_ReportRequestReportScope $reportScope)
+  {
+    $this->reportScope = $reportScope;
+  }
+  public function getReportScope()
+  {
+    return $this->reportScope;
+  }
+  public function setReportType($reportType)
+  {
+    $this->reportType = $reportType;
+  }
+  public function getReportType()
+  {
+    return $this->reportType;
+  }
+  public function setRowCount($rowCount)
+  {
+    $this->rowCount = $rowCount;
+  }
+  public function getRowCount()
+  {
+    return $this->rowCount;
+  }
+  public function setStartRow($startRow)
+  {
+    $this->startRow = $startRow;
+  }
+  public function getStartRow()
+  {
+    return $this->startRow;
+  }
+  public function setStatisticsCurrency($statisticsCurrency)
+  {
+    $this->statisticsCurrency = $statisticsCurrency;
+  }
+  public function getStatisticsCurrency()
+  {
+    return $this->statisticsCurrency;
+  }
+  public function setTimeRange(Google_Service_Doubleclicksearch_ReportRequestTimeRange $timeRange)
+  {
+    $this->timeRange = $timeRange;
+  }
+  public function getTimeRange()
+  {
+    return $this->timeRange;
+  }
+  public function setVerifySingleTimeZone($verifySingleTimeZone)
+  {
+    $this->verifySingleTimeZone = $verifySingleTimeZone;
+  }
+  public function getVerifySingleTimeZone()
+  {
+    return $this->verifySingleTimeZone;
+  }
+}
+
+class Google_Service_Doubleclicksearch_ReportRequestFilters extends Google_Collection
+{
+  protected $collection_key = 'values';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $columnType = 'Google_Service_Doubleclicksearch_ReportApiColumnSpec';
+  protected $columnDataType = '';
+  public $operator;
+  public $values;
+
+
+  public function setColumn(Google_Service_Doubleclicksearch_ReportApiColumnSpec $column)
+  {
+    $this->column = $column;
+  }
+  public function getColumn()
+  {
+    return $this->column;
+  }
+  public function setOperator($operator)
+  {
+    $this->operator = $operator;
+  }
+  public function getOperator()
+  {
+    return $this->operator;
+  }
+  public function setValues($values)
+  {
+    $this->values = $values;
+  }
+  public function getValues()
+  {
+    return $this->values;
+  }
+}
+
+class Google_Service_Doubleclicksearch_ReportRequestOrderBy extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $columnType = 'Google_Service_Doubleclicksearch_ReportApiColumnSpec';
+  protected $columnDataType = '';
+  public $sortOrder;
+
+
+  public function setColumn(Google_Service_Doubleclicksearch_ReportApiColumnSpec $column)
+  {
+    $this->column = $column;
+  }
+  public function getColumn()
+  {
+    return $this->column;
+  }
+  public function setSortOrder($sortOrder)
+  {
+    $this->sortOrder = $sortOrder;
+  }
+  public function getSortOrder()
+  {
+    return $this->sortOrder;
+  }
+}
+
+class Google_Service_Doubleclicksearch_ReportRequestReportScope extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $adGroupId;
+  public $adId;
+  public $advertiserId;
+  public $agencyId;
+  public $campaignId;
+  public $engineAccountId;
+  public $keywordId;
+
+
+  public function setAdGroupId($adGroupId)
+  {
+    $this->adGroupId = $adGroupId;
+  }
+  public function getAdGroupId()
+  {
+    return $this->adGroupId;
+  }
+  public function setAdId($adId)
+  {
+    $this->adId = $adId;
+  }
+  public function getAdId()
+  {
+    return $this->adId;
+  }
+  public function setAdvertiserId($advertiserId)
+  {
+    $this->advertiserId = $advertiserId;
+  }
+  public function getAdvertiserId()
+  {
+    return $this->advertiserId;
+  }
+  public function setAgencyId($agencyId)
+  {
+    $this->agencyId = $agencyId;
+  }
+  public function getAgencyId()
+  {
+    return $this->agencyId;
+  }
+  public function setCampaignId($campaignId)
+  {
+    $this->campaignId = $campaignId;
+  }
+  public function getCampaignId()
+  {
+    return $this->campaignId;
+  }
+  public function setEngineAccountId($engineAccountId)
+  {
+    $this->engineAccountId = $engineAccountId;
+  }
+  public function getEngineAccountId()
+  {
+    return $this->engineAccountId;
+  }
+  public function setKeywordId($keywordId)
+  {
+    $this->keywordId = $keywordId;
+  }
+  public function getKeywordId()
+  {
+    return $this->keywordId;
+  }
+}
+
+class Google_Service_Doubleclicksearch_ReportRequestTimeRange extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $changedAttributesSinceTimestamp;
+  public $changedMetricsSinceTimestamp;
+  public $endDate;
+  public $startDate;
+
+
+  public function setChangedAttributesSinceTimestamp($changedAttributesSinceTimestamp)
+  {
+    $this->changedAttributesSinceTimestamp = $changedAttributesSinceTimestamp;
+  }
+  public function getChangedAttributesSinceTimestamp()
+  {
+    return $this->changedAttributesSinceTimestamp;
+  }
+  public function setChangedMetricsSinceTimestamp($changedMetricsSinceTimestamp)
+  {
+    $this->changedMetricsSinceTimestamp = $changedMetricsSinceTimestamp;
+  }
+  public function getChangedMetricsSinceTimestamp()
+  {
+    return $this->changedMetricsSinceTimestamp;
+  }
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+}
+
+class Google_Service_Doubleclicksearch_ReportRow extends Google_Model
+{
+}
+
+class Google_Service_Doubleclicksearch_SavedColumn extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $savedColumnName;
+  public $type;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSavedColumnName($savedColumnName)
+  {
+    $this->savedColumnName = $savedColumnName;
+  }
+  public function getSavedColumnName()
+  {
+    return $this->savedColumnName;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Doubleclicksearch_SavedColumnList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Doubleclicksearch_SavedColumn';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Doubleclicksearch_UpdateAvailabilityRequest extends Google_Collection
+{
+  protected $collection_key = 'availabilities';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $availabilitiesType = 'Google_Service_Doubleclicksearch_Availability';
+  protected $availabilitiesDataType = 'array';
+
+
+  public function setAvailabilities($availabilities)
+  {
+    $this->availabilities = $availabilities;
+  }
+  public function getAvailabilities()
+  {
+    return $this->availabilities;
+  }
+}
+
+class Google_Service_Doubleclicksearch_UpdateAvailabilityResponse extends Google_Collection
+{
+  protected $collection_key = 'availabilities';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $availabilitiesType = 'Google_Service_Doubleclicksearch_Availability';
+  protected $availabilitiesDataType = 'array';
+
+
+  public function setAvailabilities($availabilities)
+  {
+    $this->availabilities = $availabilities;
+  }
+  public function getAvailabilities()
+  {
+    return $this->availabilities;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Drive.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Drive.php
@@ -19,8 +19,7 @@
  * Service definition for Drive (v2).
  *
  * <p>
- * The API to interact with Drive.
- * </p>
+ * The API to interact with Drive.</p>
  *
  * <p>
  * For more information about this service, see the API
@@ -31,20 +30,33 @@
  */
 class Google_Service_Drive extends Google_Service
 {
-  /** View and manage the files and documents in your Google Drive. */
-  const DRIVE = "https://www.googleapis.com/auth/drive";
+  /** View and manage the files in your Google Drive. */
+  const DRIVE =
+      "https://www.googleapis.com/auth/drive";
   /** View and manage its own configuration data in your Google Drive. */
-  const DRIVE_APPDATA = "https://www.googleapis.com/auth/drive.appdata";
+  const DRIVE_APPDATA =
+      "https://www.googleapis.com/auth/drive.appdata";
   /** View your Google Drive apps. */
-  const DRIVE_APPS_READONLY = "https://www.googleapis.com/auth/drive.apps.readonly";
-  /** View and manage Google Drive files that you have opened or created with this app. */
-  const DRIVE_FILE = "https://www.googleapis.com/auth/drive.file";
-  /** View metadata for files and documents in your Google Drive. */
-  const DRIVE_METADATA_READONLY = "https://www.googleapis.com/auth/drive.metadata.readonly";
-  /** View the files and documents in your Google Drive. */
-  const DRIVE_READONLY = "https://www.googleapis.com/auth/drive.readonly";
+  const DRIVE_APPS_READONLY =
+      "https://www.googleapis.com/auth/drive.apps.readonly";
+  /** View and manage Google Drive files and folders that you have opened or created with this app. */
+  const DRIVE_FILE =
+      "https://www.googleapis.com/auth/drive.file";
+  /** View and manage metadata of files in your Google Drive. */
+  const DRIVE_METADATA =
+      "https://www.googleapis.com/auth/drive.metadata";
+  /** View metadata for files in your Google Drive. */
+  const DRIVE_METADATA_READONLY =
+      "https://www.googleapis.com/auth/drive.metadata.readonly";
+  /** View the photos, videos and albums in your Google Photos. */
+  const DRIVE_PHOTOS_READONLY =
+      "https://www.googleapis.com/auth/drive.photos.readonly";
+  /** View the files in your Google Drive. */
+  const DRIVE_READONLY =
+      "https://www.googleapis.com/auth/drive.readonly";
   /** Modify your Google Apps Script scripts' behavior. */
-  const DRIVE_SCRIPTS = "https://www.googleapis.com/auth/drive.scripts";
+  const DRIVE_SCRIPTS =
+      "https://www.googleapis.com/auth/drive.scripts";
 
   public $about;
   public $apps;
@@ -69,6 +81,7 @@ class Google_Service_Drive extends Google_Service
   public function __construct(Google_Client $client)
   {
     parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
     $this->servicePath = 'drive/v2/';
     $this->version = 'v2';
     $this->serviceName = 'drive';
@@ -161,10 +174,6 @@ class Google_Service_Drive extends Google_Service
                   'location' => 'query',
                   'type' => 'boolean',
                 ),
-                'startChangeId' => array(
-                  'location' => 'query',
-                  'type' => 'string',
-                ),
                 'includeDeleted' => array(
                   'location' => 'query',
                   'type' => 'boolean',
@@ -174,6 +183,14 @@ class Google_Service_Drive extends Google_Service
                   'type' => 'integer',
                 ),
                 'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'spaces' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startChangeId' => array(
                   'location' => 'query',
                   'type' => 'string',
                 ),
@@ -186,10 +203,6 @@ class Google_Service_Drive extends Google_Service
                   'location' => 'query',
                   'type' => 'boolean',
                 ),
-                'startChangeId' => array(
-                  'location' => 'query',
-                  'type' => 'string',
-                ),
                 'includeDeleted' => array(
                   'location' => 'query',
                   'type' => 'boolean',
@@ -199,6 +212,14 @@ class Google_Service_Drive extends Google_Service
                   'type' => 'integer',
                 ),
                 'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'spaces' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startChangeId' => array(
                   'location' => 'query',
                   'type' => 'string',
                 ),
@@ -276,11 +297,15 @@ class Google_Service_Drive extends Google_Service
                   'type' => 'string',
                   'required' => true,
                 ),
-                'q' => array(
+                'orderBy' => array(
                   'location' => 'query',
                   'type' => 'string',
                 ),
                 'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'q' => array(
                   'location' => 'query',
                   'type' => 'string',
                 ),
@@ -461,6 +486,19 @@ class Google_Service_Drive extends Google_Service
               'path' => 'files/trash',
               'httpMethod' => 'DELETE',
               'parameters' => array(),
+            ),'generateIds' => array(
+              'path' => 'files/generateIds',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'space' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
             ),'get' => array(
               'path' => 'files/{fileId}',
               'httpMethod' => 'GET',
@@ -470,9 +508,17 @@ class Google_Service_Drive extends Google_Service
                   'type' => 'string',
                   'required' => true,
                 ),
+                'acknowledgeAbuse' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
                 'updateViewedDate' => array(
                   'location' => 'query',
                   'type' => 'boolean',
+                ),
+                'revisionId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
                 ),
                 'projection' => array(
                   'location' => 'query',
@@ -520,15 +566,7 @@ class Google_Service_Drive extends Google_Service
               'path' => 'files',
               'httpMethod' => 'GET',
               'parameters' => array(
-                'q' => array(
-                  'location' => 'query',
-                  'type' => 'string',
-                ),
-                'pageToken' => array(
-                  'location' => 'query',
-                  'type' => 'string',
-                ),
-                'corpus' => array(
+                'orderBy' => array(
                   'location' => 'query',
                   'type' => 'string',
                 ),
@@ -539,6 +577,22 @@ class Google_Service_Drive extends Google_Service
                 'maxResults' => array(
                   'location' => 'query',
                   'type' => 'integer',
+                ),
+                'q' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'spaces' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'corpus' => array(
+                  'location' => 'query',
+                  'type' => 'string',
                 ),
               ),
             ),'patch' => array(
@@ -554,23 +608,27 @@ class Google_Service_Drive extends Google_Service
                   'location' => 'query',
                   'type' => 'string',
                 ),
-                'updateViewedDate' => array(
+                'modifiedDateBehavior' => array(
                   'location' => 'query',
-                  'type' => 'boolean',
+                  'type' => 'string',
                 ),
                 'removeParents' => array(
                   'location' => 'query',
                   'type' => 'string',
                 ),
+                'updateViewedDate' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
                 'setModifiedDate' => array(
                   'location' => 'query',
                   'type' => 'boolean',
                 ),
-                'convert' => array(
+                'useContentAsIndexableText' => array(
                   'location' => 'query',
                   'type' => 'boolean',
                 ),
-                'useContentAsIndexableText' => array(
+                'convert' => array(
                   'location' => 'query',
                   'type' => 'boolean',
                 ),
@@ -642,23 +700,27 @@ class Google_Service_Drive extends Google_Service
                   'location' => 'query',
                   'type' => 'string',
                 ),
-                'updateViewedDate' => array(
+                'modifiedDateBehavior' => array(
                   'location' => 'query',
-                  'type' => 'boolean',
+                  'type' => 'string',
                 ),
                 'removeParents' => array(
                   'location' => 'query',
                   'type' => 'string',
                 ),
+                'updateViewedDate' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
                 'setModifiedDate' => array(
                   'location' => 'query',
                   'type' => 'boolean',
                 ),
-                'convert' => array(
+                'useContentAsIndexableText' => array(
                   'location' => 'query',
                   'type' => 'boolean',
                 ),
-                'useContentAsIndexableText' => array(
+                'convert' => array(
                   'location' => 'query',
                   'type' => 'boolean',
                 ),
@@ -696,9 +758,17 @@ class Google_Service_Drive extends Google_Service
                   'type' => 'string',
                   'required' => true,
                 ),
+                'acknowledgeAbuse' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
                 'updateViewedDate' => array(
                   'location' => 'query',
                   'type' => 'boolean',
+                ),
+                'revisionId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
                 ),
                 'projection' => array(
                   'location' => 'query',
@@ -1266,14 +1336,15 @@ class Google_Service_Drive_About_Resource extends Google_Service_Resource
    *
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool includeSubscribed
-   * When calculating the number of remaining change IDs, whether to include public files the user
-    * has opened and shared files. When set to false, this counts only change IDs for owned files and
-    * any shared or public files that the user has explicitly added to a folder they own.
-   * @opt_param string maxChangeIdCount
-   * Maximum number of remaining change IDs to count
-   * @opt_param string startChangeId
-   * Change ID to start counting from when calculating number of remaining change IDs
+   * @opt_param bool includeSubscribed When calculating the number of remaining
+   * change IDs, whether to include public files the user has opened and shared
+   * files. When set to false, this counts only change IDs for owned files and any
+   * shared or public files that the user has explicitly added to a folder they
+   * own.
+   * @opt_param string maxChangeIdCount Maximum number of remaining change IDs to
+   * count
+   * @opt_param string startChangeId Change ID to start counting from when
+   * calculating number of remaining change IDs
    * @return Google_Service_Drive_About
    */
   public function get($optParams = array())
@@ -1298,8 +1369,7 @@ class Google_Service_Drive_Apps_Resource extends Google_Service_Resource
   /**
    * Gets a specific app. (apps.get)
    *
-   * @param string $appId
-   * The ID of the app.
+   * @param string $appId The ID of the app.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_App
    */
@@ -1309,22 +1379,25 @@ class Google_Service_Drive_Apps_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_App");
   }
+
   /**
    * Lists a user's installed apps. (apps.listApps)
    *
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string languageCode
-   * A language or locale code, as defined by BCP 47, with some extensions from Unicode's LDML format
-    * (http://www.unicode.org/reports/tr35/).
-   * @opt_param string appFilterExtensions
-   * A comma-separated list of file extensions for open with filtering. All apps within the given app
-    * query scope which can open any of the given file extensions will be included in the response. If
-    * appFilterMimeTypes are provided as well, the result is a union of the two resulting app lists.
-   * @opt_param string appFilterMimeTypes
-   * A comma-separated list of MIME types for open with filtering. All apps within the given app
-    * query scope which can open any of the given MIME types will be included in the response. If
-    * appFilterExtensions are provided as well, the result is a union of the two resulting app lists.
+   * @opt_param string languageCode A language or locale code, as defined by BCP
+   * 47, with some extensions from Unicode's LDML format
+   * (http://www.unicode.org/reports/tr35/).
+   * @opt_param string appFilterExtensions A comma-separated list of file
+   * extensions for open with filtering. All apps within the given app query scope
+   * which can open any of the given file extensions will be included in the
+   * response. If appFilterMimeTypes are provided as well, the result is a union
+   * of the two resulting app lists.
+   * @opt_param string appFilterMimeTypes A comma-separated list of MIME types for
+   * open with filtering. All apps within the given app query scope which can open
+   * any of the given MIME types will be included in the response. If
+   * appFilterExtensions are provided as well, the result is a union of the two
+   * resulting app lists.
    * @return Google_Service_Drive_AppList
    */
   public function listApps($optParams = array())
@@ -1349,8 +1422,7 @@ class Google_Service_Drive_Changes_Resource extends Google_Service_Resource
   /**
    * Gets a specific change. (changes.get)
    *
-   * @param string $changeId
-   * The ID of the change.
+   * @param string $changeId The ID of the change.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_Change
    */
@@ -1360,23 +1432,22 @@ class Google_Service_Drive_Changes_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_Change");
   }
+
   /**
    * Lists the changes for a user. (changes.listChanges)
    *
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool includeSubscribed
-   * Whether to include public files the user has opened and shared files. When set to false, the
-    * list only includes owned files plus any shared or public files the user has explicitly added to
-    * a folder they own.
-   * @opt_param string startChangeId
-   * Change ID to start listing changes from.
-   * @opt_param bool includeDeleted
-   * Whether to include deleted items.
-   * @opt_param int maxResults
-   * Maximum number of changes to return.
-   * @opt_param string pageToken
-   * Page token for changes.
+   * @opt_param bool includeSubscribed Whether to include public files the user
+   * has opened and shared files. When set to false, the list only includes owned
+   * files plus any shared or public files the user has explicitly added to a
+   * folder they own.
+   * @opt_param bool includeDeleted Whether to include deleted items.
+   * @opt_param int maxResults Maximum number of changes to return.
+   * @opt_param string pageToken Page token for changes.
+   * @opt_param string spaces A comma-separated list of spaces to query. Supported
+   * values are 'drive', 'appDataFolder' and 'photos'.
+   * @opt_param string startChangeId Change ID to start listing changes from.
    * @return Google_Service_Drive_ChangeList
    */
   public function listChanges($optParams = array())
@@ -1385,24 +1456,23 @@ class Google_Service_Drive_Changes_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('list', array($params), "Google_Service_Drive_ChangeList");
   }
+
   /**
    * Subscribe to changes for a user. (changes.watch)
    *
    * @param Google_Channel $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool includeSubscribed
-   * Whether to include public files the user has opened and shared files. When set to false, the
-    * list only includes owned files plus any shared or public files the user has explicitly added to
-    * a folder they own.
-   * @opt_param string startChangeId
-   * Change ID to start listing changes from.
-   * @opt_param bool includeDeleted
-   * Whether to include deleted items.
-   * @opt_param int maxResults
-   * Maximum number of changes to return.
-   * @opt_param string pageToken
-   * Page token for changes.
+   * @opt_param bool includeSubscribed Whether to include public files the user
+   * has opened and shared files. When set to false, the list only includes owned
+   * files plus any shared or public files the user has explicitly added to a
+   * folder they own.
+   * @opt_param bool includeDeleted Whether to include deleted items.
+   * @opt_param int maxResults Maximum number of changes to return.
+   * @opt_param string pageToken Page token for changes.
+   * @opt_param string spaces A comma-separated list of spaces to query. Supported
+   * values are 'drive', 'appDataFolder' and 'photos'.
+   * @opt_param string startChangeId Change ID to start listing changes from.
    * @return Google_Service_Drive_Channel
    */
   public function watch(Google_Service_Drive_Channel $postBody, $optParams = array())
@@ -1452,10 +1522,8 @@ class Google_Service_Drive_Children_Resource extends Google_Service_Resource
   /**
    * Removes a child from a folder. (children.delete)
    *
-   * @param string $folderId
-   * The ID of the folder.
-   * @param string $childId
-   * The ID of the child.
+   * @param string $folderId The ID of the folder.
+   * @param string $childId The ID of the child.
    * @param array $optParams Optional parameters.
    */
   public function delete($folderId, $childId, $optParams = array())
@@ -1464,13 +1532,12 @@ class Google_Service_Drive_Children_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('delete', array($params));
   }
+
   /**
    * Gets a specific child reference. (children.get)
    *
-   * @param string $folderId
-   * The ID of the folder.
-   * @param string $childId
-   * The ID of the child.
+   * @param string $folderId The ID of the folder.
+   * @param string $childId The ID of the child.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_ChildReference
    */
@@ -1480,11 +1547,11 @@ class Google_Service_Drive_Children_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_ChildReference");
   }
+
   /**
    * Inserts a file into a folder. (children.insert)
    *
-   * @param string $folderId
-   * The ID of the folder.
+   * @param string $folderId The ID of the folder.
    * @param Google_ChildReference $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_ChildReference
@@ -1495,19 +1562,23 @@ class Google_Service_Drive_Children_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('insert', array($params), "Google_Service_Drive_ChildReference");
   }
+
   /**
    * Lists a folder's children. (children.listChildren)
    *
-   * @param string $folderId
-   * The ID of the folder.
+   * @param string $folderId The ID of the folder.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string q
-   * Query string for searching children.
-   * @opt_param string pageToken
-   * Page token for children.
-   * @opt_param int maxResults
-   * Maximum number of children to return.
+   * @opt_param string orderBy A comma-separated list of sort keys. Valid keys are
+   * 'createdDate', 'folder', 'lastViewedByMeDate', 'modifiedByMeDate',
+   * 'modifiedDate', 'quotaBytesUsed', 'recency', 'sharedWithMeDate', 'starred',
+   * and 'title'. Each key sorts ascending by default, but may be reversed with
+   * the 'desc' modifier. Example usage: ?orderBy=folder,modifiedDate desc,title.
+   * Please note that there is a current limitation for users with approximately
+   * one million files in which the requested sort order is ignored.
+   * @opt_param string pageToken Page token for children.
+   * @opt_param string q Query string for searching children.
+   * @opt_param int maxResults Maximum number of children to return.
    * @return Google_Service_Drive_ChildList
    */
   public function listChildren($folderId, $optParams = array())
@@ -1532,10 +1603,8 @@ class Google_Service_Drive_Comments_Resource extends Google_Service_Resource
   /**
    * Deletes a comment. (comments.delete)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
    * @param array $optParams Optional parameters.
    */
   public function delete($fileId, $commentId, $optParams = array())
@@ -1544,18 +1613,16 @@ class Google_Service_Drive_Comments_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('delete', array($params));
   }
+
   /**
    * Gets a comment by ID. (comments.get)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool includeDeleted
-   * If set, this will succeed when retrieving a deleted comment, and will include any deleted
-    * replies.
+   * @opt_param bool includeDeleted If set, this will succeed when retrieving a
+   * deleted comment, and will include any deleted replies.
    * @return Google_Service_Drive_Comment
    */
   public function get($fileId, $commentId, $optParams = array())
@@ -1564,11 +1631,11 @@ class Google_Service_Drive_Comments_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_Comment");
   }
+
   /**
    * Creates a new comment on the given file. (comments.insert)
    *
-   * @param string $fileId
-   * The ID of the file.
+   * @param string $fileId The ID of the file.
    * @param Google_Comment $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_Comment
@@ -1579,24 +1646,22 @@ class Google_Service_Drive_Comments_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('insert', array($params), "Google_Service_Drive_Comment");
   }
+
   /**
    * Lists a file's comments. (comments.listComments)
    *
-   * @param string $fileId
-   * The ID of the file.
+   * @param string $fileId The ID of the file.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string pageToken
-   * The continuation token, used to page through large result sets. To get the next page of results,
-    * set this parameter to the value of "nextPageToken" from the previous response.
-   * @opt_param string updatedMin
-   * Only discussions that were updated after this timestamp will be returned. Formatted as an RFC
-    * 3339 timestamp.
-   * @opt_param bool includeDeleted
-   * If set, all comments and replies, including deleted comments and replies (with content stripped)
-    * will be returned.
-   * @opt_param int maxResults
-   * The maximum number of discussions to include in the response, used for paging.
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of "nextPageToken" from the previous response.
+   * @opt_param string updatedMin Only discussions that were updated after this
+   * timestamp will be returned. Formatted as an RFC 3339 timestamp.
+   * @opt_param bool includeDeleted If set, all comments and replies, including
+   * deleted comments and replies (with content stripped) will be returned.
+   * @opt_param int maxResults The maximum number of discussions to include in the
+   * response, used for paging.
    * @return Google_Service_Drive_CommentList
    */
   public function listComments($fileId, $optParams = array())
@@ -1605,14 +1670,13 @@ class Google_Service_Drive_Comments_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('list', array($params), "Google_Service_Drive_CommentList");
   }
+
   /**
    * Updates an existing comment. This method supports patch semantics.
    * (comments.patch)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
    * @param Google_Comment $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_Comment
@@ -1623,13 +1687,12 @@ class Google_Service_Drive_Comments_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('patch', array($params), "Google_Service_Drive_Comment");
   }
+
   /**
    * Updates an existing comment. (comments.update)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
    * @param Google_Comment $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_Comment
@@ -1656,27 +1719,23 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
   /**
    * Creates a copy of the specified file. (files.copy)
    *
-   * @param string $fileId
-   * The ID of the file to copy.
+   * @param string $fileId The ID of the file to copy.
    * @param Google_DriveFile $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool convert
-   * Whether to convert this file to the corresponding Google Docs format.
-   * @opt_param string ocrLanguage
-   * If ocr is true, hints at the language to use. Valid values are ISO 639-1 codes.
-   * @opt_param string visibility
-   * The visibility of the new file. This parameter is only relevant when the source is not a native
-    * Google Doc and convert=false.
-   * @opt_param bool pinned
-   * Whether to pin the head revision of the new copy. A file can have a maximum of 200 pinned
-    * revisions.
-   * @opt_param bool ocr
-   * Whether to attempt OCR on .jpg, .png, .gif, or .pdf uploads.
-   * @opt_param string timedTextTrackName
-   * The timed text track name.
-   * @opt_param string timedTextLanguage
-   * The language of the timed text.
+   * @opt_param bool convert Whether to convert this file to the corresponding
+   * Google Docs format.
+   * @opt_param string ocrLanguage If ocr is true, hints at the language to use.
+   * Valid values are BCP 47 codes.
+   * @opt_param string visibility The visibility of the new file. This parameter
+   * is only relevant when the source is not a native Google Doc and
+   * convert=false.
+   * @opt_param bool pinned Whether to pin the head revision of the new copy. A
+   * file can have a maximum of 200 pinned revisions.
+   * @opt_param bool ocr Whether to attempt OCR on .jpg, .png, .gif, or .pdf
+   * uploads.
+   * @opt_param string timedTextTrackName The timed text track name.
+   * @opt_param string timedTextLanguage The language of the timed text.
    * @return Google_Service_Drive_DriveFile
    */
   public function copy($fileId, Google_Service_Drive_DriveFile $postBody, $optParams = array())
@@ -1685,11 +1744,12 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('copy', array($params), "Google_Service_Drive_DriveFile");
   }
+
   /**
-   * Permanently deletes a file by ID. Skips the trash. (files.delete)
+   * Permanently deletes a file by ID. Skips the trash. The currently
+   * authenticated user must own the file. (files.delete)
    *
-   * @param string $fileId
-   * The ID of the file to delete.
+   * @param string $fileId The ID of the file to delete.
    * @param array $optParams Optional parameters.
    */
   public function delete($fileId, $optParams = array())
@@ -1698,6 +1758,7 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('delete', array($params));
   }
+
   /**
    * Permanently deletes all of the user's trashed files. (files.emptyTrash)
    *
@@ -1709,17 +1770,40 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('emptyTrash', array($params));
   }
+
+  /**
+   * Generates a set of file IDs which can be provided in insert requests.
+   * (files.generateIds)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int maxResults Maximum number of IDs to return.
+   * @opt_param string space The space in which the IDs can be used to create new
+   * files. Supported values are 'drive' and 'appDataFolder'.
+   * @return Google_Service_Drive_GeneratedIds
+   */
+  public function generateIds($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('generateIds', array($params), "Google_Service_Drive_GeneratedIds");
+  }
+
   /**
    * Gets a file's metadata by ID. (files.get)
    *
-   * @param string $fileId
-   * The ID for the file in question.
+   * @param string $fileId The ID for the file in question.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool updateViewedDate
-   * Whether to update the view date after successfully retrieving the file.
-   * @opt_param string projection
-   * This parameter is deprecated and has no function.
+   * @opt_param bool acknowledgeAbuse Whether the user is acknowledging the risk
+   * of downloading known malware or other abusive files.
+   * @opt_param bool updateViewedDate Deprecated: Use files.update with
+   * modifiedDateBehavior=noChange, updateViewedDate=true and an empty request
+   * body.
+   * @opt_param string revisionId Specifies the Revision ID that should be
+   * downloaded. Ignored unless alt=media is specified.
+   * @opt_param string projection This parameter is deprecated and has no
+   * function.
    * @return Google_Service_Drive_DriveFile
    */
   public function get($fileId, $optParams = array())
@@ -1728,29 +1812,27 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_DriveFile");
   }
+
   /**
    * Insert a new file. (files.insert)
    *
    * @param Google_DriveFile $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool convert
-   * Whether to convert this file to the corresponding Google Docs format.
-   * @opt_param bool useContentAsIndexableText
-   * Whether to use the content as indexable text.
-   * @opt_param string ocrLanguage
-   * If ocr is true, hints at the language to use. Valid values are ISO 639-1 codes.
-   * @opt_param string visibility
-   * The visibility of the new file. This parameter is only relevant when convert=false.
-   * @opt_param bool pinned
-   * Whether to pin the head revision of the uploaded file. A file can have a maximum of 200 pinned
-    * revisions.
-   * @opt_param bool ocr
-   * Whether to attempt OCR on .jpg, .png, .gif, or .pdf uploads.
-   * @opt_param string timedTextTrackName
-   * The timed text track name.
-   * @opt_param string timedTextLanguage
-   * The language of the timed text.
+   * @opt_param bool convert Whether to convert this file to the corresponding
+   * Google Docs format.
+   * @opt_param bool useContentAsIndexableText Whether to use the content as
+   * indexable text.
+   * @opt_param string ocrLanguage If ocr is true, hints at the language to use.
+   * Valid values are BCP 47 codes.
+   * @opt_param string visibility The visibility of the new file. This parameter
+   * is only relevant when convert=false.
+   * @opt_param bool pinned Whether to pin the head revision of the uploaded file.
+   * A file can have a maximum of 200 pinned revisions.
+   * @opt_param bool ocr Whether to attempt OCR on .jpg, .png, .gif, or .pdf
+   * uploads.
+   * @opt_param string timedTextTrackName The timed text track name.
+   * @opt_param string timedTextLanguage The language of the timed text.
    * @return Google_Service_Drive_DriveFile
    */
   public function insert(Google_Service_Drive_DriveFile $postBody, $optParams = array())
@@ -1759,21 +1841,28 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('insert', array($params), "Google_Service_Drive_DriveFile");
   }
+
   /**
    * Lists the user's files. (files.listFiles)
    *
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string q
-   * Query string for searching files.
-   * @opt_param string pageToken
-   * Page token for files.
-   * @opt_param string corpus
-   * The body of items (files/documents) to which the query applies.
-   * @opt_param string projection
-   * This parameter is deprecated and has no function.
-   * @opt_param int maxResults
-   * Maximum number of files to return.
+   * @opt_param string orderBy A comma-separated list of sort keys. Valid keys are
+   * 'createdDate', 'folder', 'lastViewedByMeDate', 'modifiedByMeDate',
+   * 'modifiedDate', 'quotaBytesUsed', 'recency', 'sharedWithMeDate', 'starred',
+   * and 'title'. Each key sorts ascending by default, but may be reversed with
+   * the 'desc' modifier. Example usage: ?orderBy=folder,modifiedDate desc,title.
+   * Please note that there is a current limitation for users with approximately
+   * one million files in which the requested sort order is ignored.
+   * @opt_param string projection This parameter is deprecated and has no
+   * function.
+   * @opt_param int maxResults Maximum number of files to return.
+   * @opt_param string q Query string for searching files.
+   * @opt_param string pageToken Page token for files.
+   * @opt_param string spaces A comma-separated list of spaces to query. Supported
+   * values are 'drive', 'appDataFolder' and 'photos'.
+   * @opt_param string corpus The body of items (files/documents) to which the
+   * query applies.
    * @return Google_Service_Drive_FileList
    */
   public function listFiles($optParams = array())
@@ -1782,41 +1871,41 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('list', array($params), "Google_Service_Drive_FileList");
   }
+
   /**
    * Updates file metadata and/or content. This method supports patch semantics.
    * (files.patch)
    *
-   * @param string $fileId
-   * The ID of the file to update.
+   * @param string $fileId The ID of the file to update.
    * @param Google_DriveFile $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string addParents
-   * Comma-separated list of parent IDs to add.
-   * @opt_param bool updateViewedDate
-   * Whether to update the view date after successfully updating the file.
-   * @opt_param string removeParents
-   * Comma-separated list of parent IDs to remove.
-   * @opt_param bool setModifiedDate
-   * Whether to set the modified date with the supplied modified date.
-   * @opt_param bool convert
-   * Whether to convert this file to the corresponding Google Docs format.
-   * @opt_param bool useContentAsIndexableText
-   * Whether to use the content as indexable text.
-   * @opt_param string ocrLanguage
-   * If ocr is true, hints at the language to use. Valid values are ISO 639-1 codes.
-   * @opt_param bool pinned
-   * Whether to pin the new revision. A file can have a maximum of 200 pinned revisions.
-   * @opt_param bool newRevision
-   * Whether a blob upload should create a new revision. If false, the blob data in the current head
-    * revision is replaced. If true or not set, a new blob is created as head revision, and previous
-    * revisions are preserved (causing increased use of the user's data storage quota).
-   * @opt_param bool ocr
-   * Whether to attempt OCR on .jpg, .png, .gif, or .pdf uploads.
-   * @opt_param string timedTextLanguage
-   * The language of the timed text.
-   * @opt_param string timedTextTrackName
-   * The timed text track name.
+   * @opt_param string addParents Comma-separated list of parent IDs to add.
+   * @opt_param string modifiedDateBehavior Determines the behavior in which
+   * modifiedDate is updated. This overrides setModifiedDate.
+   * @opt_param string removeParents Comma-separated list of parent IDs to remove.
+   * @opt_param bool updateViewedDate Whether to update the view date after
+   * successfully updating the file.
+   * @opt_param bool setModifiedDate Whether to set the modified date with the
+   * supplied modified date.
+   * @opt_param bool useContentAsIndexableText Whether to use the content as
+   * indexable text.
+   * @opt_param bool convert This parameter is deprecated and has no function.
+   * @opt_param string ocrLanguage If ocr is true, hints at the language to use.
+   * Valid values are BCP 47 codes.
+   * @opt_param bool pinned Whether to pin the new revision. A file can have a
+   * maximum of 200 pinned revisions.
+   * @opt_param bool newRevision Whether a blob upload should create a new
+   * revision. If false, the blob data in the current head revision is replaced.
+   * If true or not set, a new blob is created as head revision, and previous
+   * unpinned revisions are preserved for a short period of time. Pinned revisions
+   * are stored indefinitely, using additional storage quota, up to a maximum of
+   * 200 revisions. For details on how revisions are retained, see the Drive Help
+   * Center.
+   * @opt_param bool ocr Whether to attempt OCR on .jpg, .png, .gif, or .pdf
+   * uploads.
+   * @opt_param string timedTextLanguage The language of the timed text.
+   * @opt_param string timedTextTrackName The timed text track name.
    * @return Google_Service_Drive_DriveFile
    */
   public function patch($fileId, Google_Service_Drive_DriveFile $postBody, $optParams = array())
@@ -1825,11 +1914,11 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('patch', array($params), "Google_Service_Drive_DriveFile");
   }
+
   /**
    * Set the file's updated time to the current server time. (files.touch)
    *
-   * @param string $fileId
-   * The ID of the file to update.
+   * @param string $fileId The ID of the file to update.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_DriveFile
    */
@@ -1839,11 +1928,12 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('touch', array($params), "Google_Service_Drive_DriveFile");
   }
+
   /**
-   * Moves a file to the trash. (files.trash)
+   * Moves a file to the trash. The currently authenticated user must own the
+   * file. (files.trash)
    *
-   * @param string $fileId
-   * The ID of the file to trash.
+   * @param string $fileId The ID of the file to trash.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_DriveFile
    */
@@ -1853,11 +1943,11 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('trash', array($params), "Google_Service_Drive_DriveFile");
   }
+
   /**
    * Restores a file from the trash. (files.untrash)
    *
-   * @param string $fileId
-   * The ID of the file to untrash.
+   * @param string $fileId The ID of the file to untrash.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_DriveFile
    */
@@ -1867,40 +1957,40 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('untrash', array($params), "Google_Service_Drive_DriveFile");
   }
+
   /**
    * Updates file metadata and/or content. (files.update)
    *
-   * @param string $fileId
-   * The ID of the file to update.
+   * @param string $fileId The ID of the file to update.
    * @param Google_DriveFile $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string addParents
-   * Comma-separated list of parent IDs to add.
-   * @opt_param bool updateViewedDate
-   * Whether to update the view date after successfully updating the file.
-   * @opt_param string removeParents
-   * Comma-separated list of parent IDs to remove.
-   * @opt_param bool setModifiedDate
-   * Whether to set the modified date with the supplied modified date.
-   * @opt_param bool convert
-   * Whether to convert this file to the corresponding Google Docs format.
-   * @opt_param bool useContentAsIndexableText
-   * Whether to use the content as indexable text.
-   * @opt_param string ocrLanguage
-   * If ocr is true, hints at the language to use. Valid values are ISO 639-1 codes.
-   * @opt_param bool pinned
-   * Whether to pin the new revision. A file can have a maximum of 200 pinned revisions.
-   * @opt_param bool newRevision
-   * Whether a blob upload should create a new revision. If false, the blob data in the current head
-    * revision is replaced. If true or not set, a new blob is created as head revision, and previous
-    * revisions are preserved (causing increased use of the user's data storage quota).
-   * @opt_param bool ocr
-   * Whether to attempt OCR on .jpg, .png, .gif, or .pdf uploads.
-   * @opt_param string timedTextLanguage
-   * The language of the timed text.
-   * @opt_param string timedTextTrackName
-   * The timed text track name.
+   * @opt_param string addParents Comma-separated list of parent IDs to add.
+   * @opt_param string modifiedDateBehavior Determines the behavior in which
+   * modifiedDate is updated. This overrides setModifiedDate.
+   * @opt_param string removeParents Comma-separated list of parent IDs to remove.
+   * @opt_param bool updateViewedDate Whether to update the view date after
+   * successfully updating the file.
+   * @opt_param bool setModifiedDate Whether to set the modified date with the
+   * supplied modified date.
+   * @opt_param bool useContentAsIndexableText Whether to use the content as
+   * indexable text.
+   * @opt_param bool convert This parameter is deprecated and has no function.
+   * @opt_param string ocrLanguage If ocr is true, hints at the language to use.
+   * Valid values are BCP 47 codes.
+   * @opt_param bool pinned Whether to pin the new revision. A file can have a
+   * maximum of 200 pinned revisions.
+   * @opt_param bool newRevision Whether a blob upload should create a new
+   * revision. If false, the blob data in the current head revision is replaced.
+   * If true or not set, a new blob is created as head revision, and previous
+   * unpinned revisions are preserved for a short period of time. Pinned revisions
+   * are stored indefinitely, using additional storage quota, up to a maximum of
+   * 200 revisions. For details on how revisions are retained, see the Drive Help
+   * Center.
+   * @opt_param bool ocr Whether to attempt OCR on .jpg, .png, .gif, or .pdf
+   * uploads.
+   * @opt_param string timedTextLanguage The language of the timed text.
+   * @opt_param string timedTextTrackName The timed text track name.
    * @return Google_Service_Drive_DriveFile
    */
   public function update($fileId, Google_Service_Drive_DriveFile $postBody, $optParams = array())
@@ -1909,18 +1999,23 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('update', array($params), "Google_Service_Drive_DriveFile");
   }
+
   /**
    * Subscribe to changes on a file (files.watch)
    *
-   * @param string $fileId
-   * The ID for the file in question.
+   * @param string $fileId The ID for the file in question.
    * @param Google_Channel $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool updateViewedDate
-   * Whether to update the view date after successfully retrieving the file.
-   * @opt_param string projection
-   * This parameter is deprecated and has no function.
+   * @opt_param bool acknowledgeAbuse Whether the user is acknowledging the risk
+   * of downloading known malware or other abusive files.
+   * @opt_param bool updateViewedDate Deprecated: Use files.update with
+   * modifiedDateBehavior=noChange, updateViewedDate=true and an empty request
+   * body.
+   * @opt_param string revisionId Specifies the Revision ID that should be
+   * downloaded. Ignored unless alt=media is specified.
+   * @opt_param string projection This parameter is deprecated and has no
+   * function.
    * @return Google_Service_Drive_Channel
    */
   public function watch($fileId, Google_Service_Drive_Channel $postBody, $optParams = array())
@@ -1945,10 +2040,8 @@ class Google_Service_Drive_Parents_Resource extends Google_Service_Resource
   /**
    * Removes a parent from a file. (parents.delete)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $parentId
-   * The ID of the parent.
+   * @param string $fileId The ID of the file.
+   * @param string $parentId The ID of the parent.
    * @param array $optParams Optional parameters.
    */
   public function delete($fileId, $parentId, $optParams = array())
@@ -1957,13 +2050,12 @@ class Google_Service_Drive_Parents_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('delete', array($params));
   }
+
   /**
    * Gets a specific parent reference. (parents.get)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $parentId
-   * The ID of the parent.
+   * @param string $fileId The ID of the file.
+   * @param string $parentId The ID of the parent.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_ParentReference
    */
@@ -1973,11 +2065,11 @@ class Google_Service_Drive_Parents_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_ParentReference");
   }
+
   /**
    * Adds a parent folder for a file. (parents.insert)
    *
-   * @param string $fileId
-   * The ID of the file.
+   * @param string $fileId The ID of the file.
    * @param Google_ParentReference $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_ParentReference
@@ -1988,11 +2080,11 @@ class Google_Service_Drive_Parents_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('insert', array($params), "Google_Service_Drive_ParentReference");
   }
+
   /**
    * Lists a file's parents. (parents.listParents)
    *
-   * @param string $fileId
-   * The ID of the file.
+   * @param string $fileId The ID of the file.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_ParentList
    */
@@ -2018,10 +2110,8 @@ class Google_Service_Drive_Permissions_Resource extends Google_Service_Resource
   /**
    * Deletes a permission from a file. (permissions.delete)
    *
-   * @param string $fileId
-   * The ID for the file.
-   * @param string $permissionId
-   * The ID for the permission.
+   * @param string $fileId The ID for the file.
+   * @param string $permissionId The ID for the permission.
    * @param array $optParams Optional parameters.
    */
   public function delete($fileId, $permissionId, $optParams = array())
@@ -2030,13 +2120,12 @@ class Google_Service_Drive_Permissions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('delete', array($params));
   }
+
   /**
    * Gets a permission by ID. (permissions.get)
    *
-   * @param string $fileId
-   * The ID for the file.
-   * @param string $permissionId
-   * The ID for the permission.
+   * @param string $fileId The ID for the file.
+   * @param string $permissionId The ID for the permission.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_Permission
    */
@@ -2046,11 +2135,11 @@ class Google_Service_Drive_Permissions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_Permission");
   }
+
   /**
    * Returns the permission ID for an email address. (permissions.getIdForEmail)
    *
-   * @param string $email
-   * The email address for which to return a permission ID
+   * @param string $email The email address for which to return a permission ID
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_PermissionId
    */
@@ -2060,19 +2149,19 @@ class Google_Service_Drive_Permissions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('getIdForEmail', array($params), "Google_Service_Drive_PermissionId");
   }
+
   /**
    * Inserts a permission for a file. (permissions.insert)
    *
-   * @param string $fileId
-   * The ID for the file.
+   * @param string $fileId The ID for the file.
    * @param Google_Permission $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string emailMessage
-   * A custom message to include in notification emails.
-   * @opt_param bool sendNotificationEmails
-   * Whether to send notification emails when sharing to users or groups. This parameter is ignored
-    * and an email is sent if the role is owner.
+   * @opt_param string emailMessage A custom message to include in notification
+   * emails.
+   * @opt_param bool sendNotificationEmails Whether to send notification emails
+   * when sharing to users or groups. This parameter is ignored and an email is
+   * sent if the role is owner.
    * @return Google_Service_Drive_Permission
    */
   public function insert($fileId, Google_Service_Drive_Permission $postBody, $optParams = array())
@@ -2081,11 +2170,11 @@ class Google_Service_Drive_Permissions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('insert', array($params), "Google_Service_Drive_Permission");
   }
+
   /**
    * Lists a file's permissions. (permissions.listPermissions)
    *
-   * @param string $fileId
-   * The ID for the file.
+   * @param string $fileId The ID for the file.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_PermissionList
    */
@@ -2095,19 +2184,18 @@ class Google_Service_Drive_Permissions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('list', array($params), "Google_Service_Drive_PermissionList");
   }
+
   /**
-   * Updates a permission. This method supports patch semantics.
-   * (permissions.patch)
+   * Updates a permission using patch semantics. (permissions.patch)
    *
-   * @param string $fileId
-   * The ID for the file.
-   * @param string $permissionId
-   * The ID for the permission.
+   * @param string $fileId The ID for the file.
+   * @param string $permissionId The ID for the permission.
    * @param Google_Permission $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool transferOwnership
-   * Whether changing a role to 'owner' should also downgrade the current owners to writers.
+   * @opt_param bool transferOwnership Whether changing a role to 'owner'
+   * downgrades the current owners to writers. Does nothing if the specified role
+   * is not 'owner'.
    * @return Google_Service_Drive_Permission
    */
   public function patch($fileId, $permissionId, Google_Service_Drive_Permission $postBody, $optParams = array())
@@ -2116,18 +2204,18 @@ class Google_Service_Drive_Permissions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('patch', array($params), "Google_Service_Drive_Permission");
   }
+
   /**
    * Updates a permission. (permissions.update)
    *
-   * @param string $fileId
-   * The ID for the file.
-   * @param string $permissionId
-   * The ID for the permission.
+   * @param string $fileId The ID for the file.
+   * @param string $permissionId The ID for the permission.
    * @param Google_Permission $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool transferOwnership
-   * Whether changing a role to 'owner' should also downgrade the current owners to writers.
+   * @opt_param bool transferOwnership Whether changing a role to 'owner'
+   * downgrades the current owners to writers. Does nothing if the specified role
+   * is not 'owner'.
    * @return Google_Service_Drive_Permission
    */
   public function update($fileId, $permissionId, Google_Service_Drive_Permission $postBody, $optParams = array())
@@ -2152,14 +2240,11 @@ class Google_Service_Drive_Properties_Resource extends Google_Service_Resource
   /**
    * Deletes a property. (properties.delete)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $propertyKey
-   * The key of the property.
+   * @param string $fileId The ID of the file.
+   * @param string $propertyKey The key of the property.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string visibility
-   * The visibility of the property.
+   * @opt_param string visibility The visibility of the property.
    */
   public function delete($fileId, $propertyKey, $optParams = array())
   {
@@ -2167,17 +2252,15 @@ class Google_Service_Drive_Properties_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('delete', array($params));
   }
+
   /**
    * Gets a property by its key. (properties.get)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $propertyKey
-   * The key of the property.
+   * @param string $fileId The ID of the file.
+   * @param string $propertyKey The key of the property.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string visibility
-   * The visibility of the property.
+   * @opt_param string visibility The visibility of the property.
    * @return Google_Service_Drive_Property
    */
   public function get($fileId, $propertyKey, $optParams = array())
@@ -2186,11 +2269,11 @@ class Google_Service_Drive_Properties_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_Property");
   }
+
   /**
    * Adds a property to a file. (properties.insert)
    *
-   * @param string $fileId
-   * The ID of the file.
+   * @param string $fileId The ID of the file.
    * @param Google_Property $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_Property
@@ -2201,11 +2284,11 @@ class Google_Service_Drive_Properties_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('insert', array($params), "Google_Service_Drive_Property");
   }
+
   /**
    * Lists a file's properties. (properties.listProperties)
    *
-   * @param string $fileId
-   * The ID of the file.
+   * @param string $fileId The ID of the file.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_PropertyList
    */
@@ -2215,18 +2298,16 @@ class Google_Service_Drive_Properties_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('list', array($params), "Google_Service_Drive_PropertyList");
   }
+
   /**
    * Updates a property. This method supports patch semantics. (properties.patch)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $propertyKey
-   * The key of the property.
+   * @param string $fileId The ID of the file.
+   * @param string $propertyKey The key of the property.
    * @param Google_Property $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string visibility
-   * The visibility of the property.
+   * @opt_param string visibility The visibility of the property.
    * @return Google_Service_Drive_Property
    */
   public function patch($fileId, $propertyKey, Google_Service_Drive_Property $postBody, $optParams = array())
@@ -2235,18 +2316,16 @@ class Google_Service_Drive_Properties_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('patch', array($params), "Google_Service_Drive_Property");
   }
+
   /**
    * Updates a property. (properties.update)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $propertyKey
-   * The key of the property.
+   * @param string $fileId The ID of the file.
+   * @param string $propertyKey The key of the property.
    * @param Google_Property $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string visibility
-   * The visibility of the property.
+   * @opt_param string visibility The visibility of the property.
    * @return Google_Service_Drive_Property
    */
   public function update($fileId, $propertyKey, Google_Service_Drive_Property $postBody, $optParams = array())
@@ -2272,14 +2351,14 @@ class Google_Service_Drive_Realtime_Resource extends Google_Service_Resource
    * Exports the contents of the Realtime API data model associated with this file
    * as JSON. (realtime.get)
    *
-   * @param string $fileId
-   * The ID of the file that the Realtime API data model is associated with.
+   * @param string $fileId The ID of the file that the Realtime API data model is
+   * associated with.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param int revision
-   * The revision of the Realtime API data model to export. Revisions start at 1 (the initial empty
-    * data model) and are incremented with each change. If this parameter is excluded, the most recent
-    * data model will be returned.
+   * @opt_param int revision The revision of the Realtime API data model to
+   * export. Revisions start at 1 (the initial empty data model) and are
+   * incremented with each change. If this parameter is excluded, the most recent
+   * data model will be returned.
    */
   public function get($fileId, $optParams = array())
   {
@@ -2287,19 +2366,20 @@ class Google_Service_Drive_Realtime_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params));
   }
+
   /**
    * Overwrites the Realtime API data model associated with this file with the
    * provided JSON data model. (realtime.update)
    *
-   * @param string $fileId
-   * The ID of the file that the Realtime API data model is associated with.
+   * @param string $fileId The ID of the file that the Realtime API data model is
+   * associated with.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string baseRevision
-   * The revision of the model to diff the uploaded model against. If set, the uploaded model is
-    * diffed against the provided revision and those differences are merged with any changes made to
-    * the model after the provided revision. If not set, the uploaded model replaces the current model
-    * on the server.
+   * @opt_param string baseRevision The revision of the model to diff the uploaded
+   * model against. If set, the uploaded model is diffed against the provided
+   * revision and those differences are merged with any changes made to the model
+   * after the provided revision. If not set, the uploaded model replaces the
+   * current model on the server.
    */
   public function update($fileId, $optParams = array())
   {
@@ -2323,12 +2403,9 @@ class Google_Service_Drive_Replies_Resource extends Google_Service_Resource
   /**
    * Deletes a reply. (replies.delete)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
-   * @param string $replyId
-   * The ID of the reply.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
+   * @param string $replyId The ID of the reply.
    * @param array $optParams Optional parameters.
    */
   public function delete($fileId, $commentId, $replyId, $optParams = array())
@@ -2337,19 +2414,17 @@ class Google_Service_Drive_Replies_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('delete', array($params));
   }
+
   /**
    * Gets a reply. (replies.get)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
-   * @param string $replyId
-   * The ID of the reply.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
+   * @param string $replyId The ID of the reply.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool includeDeleted
-   * If set, this will succeed when retrieving a deleted reply.
+   * @opt_param bool includeDeleted If set, this will succeed when retrieving a
+   * deleted reply.
    * @return Google_Service_Drive_CommentReply
    */
   public function get($fileId, $commentId, $replyId, $optParams = array())
@@ -2358,13 +2433,12 @@ class Google_Service_Drive_Replies_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_CommentReply");
   }
+
   /**
    * Creates a new reply to the given comment. (replies.insert)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
    * @param Google_CommentReply $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_CommentReply
@@ -2375,22 +2449,21 @@ class Google_Service_Drive_Replies_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('insert', array($params), "Google_Service_Drive_CommentReply");
   }
+
   /**
    * Lists all of the replies to a comment. (replies.listReplies)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string pageToken
-   * The continuation token, used to page through large result sets. To get the next page of results,
-    * set this parameter to the value of "nextPageToken" from the previous response.
-   * @opt_param bool includeDeleted
-   * If set, all replies, including deleted replies (with content stripped) will be returned.
-   * @opt_param int maxResults
-   * The maximum number of replies to include in the response, used for paging.
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of "nextPageToken" from the previous response.
+   * @opt_param bool includeDeleted If set, all replies, including deleted replies
+   * (with content stripped) will be returned.
+   * @opt_param int maxResults The maximum number of replies to include in the
+   * response, used for paging.
    * @return Google_Service_Drive_CommentReplyList
    */
   public function listReplies($fileId, $commentId, $optParams = array())
@@ -2399,16 +2472,14 @@ class Google_Service_Drive_Replies_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('list', array($params), "Google_Service_Drive_CommentReplyList");
   }
+
   /**
    * Updates an existing reply. This method supports patch semantics.
    * (replies.patch)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
-   * @param string $replyId
-   * The ID of the reply.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
+   * @param string $replyId The ID of the reply.
    * @param Google_CommentReply $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_CommentReply
@@ -2419,15 +2490,13 @@ class Google_Service_Drive_Replies_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('patch', array($params), "Google_Service_Drive_CommentReply");
   }
+
   /**
    * Updates an existing reply. (replies.update)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
-   * @param string $replyId
-   * The ID of the reply.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
+   * @param string $replyId The ID of the reply.
    * @param Google_CommentReply $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_CommentReply
@@ -2454,10 +2523,8 @@ class Google_Service_Drive_Revisions_Resource extends Google_Service_Resource
   /**
    * Removes a revision. (revisions.delete)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $revisionId
-   * The ID of the revision.
+   * @param string $fileId The ID of the file.
+   * @param string $revisionId The ID of the revision.
    * @param array $optParams Optional parameters.
    */
   public function delete($fileId, $revisionId, $optParams = array())
@@ -2466,13 +2533,12 @@ class Google_Service_Drive_Revisions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('delete', array($params));
   }
+
   /**
    * Gets a specific revision. (revisions.get)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $revisionId
-   * The ID of the revision.
+   * @param string $fileId The ID of the file.
+   * @param string $revisionId The ID of the revision.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_Revision
    */
@@ -2482,11 +2548,11 @@ class Google_Service_Drive_Revisions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_Revision");
   }
+
   /**
    * Lists a file's revisions. (revisions.listRevisions)
    *
-   * @param string $fileId
-   * The ID of the file.
+   * @param string $fileId The ID of the file.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_RevisionList
    */
@@ -2496,13 +2562,12 @@ class Google_Service_Drive_Revisions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('list', array($params), "Google_Service_Drive_RevisionList");
   }
+
   /**
    * Updates a revision. This method supports patch semantics. (revisions.patch)
    *
-   * @param string $fileId
-   * The ID for the file.
-   * @param string $revisionId
-   * The ID for the revision.
+   * @param string $fileId The ID for the file.
+   * @param string $revisionId The ID for the revision.
    * @param Google_Revision $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_Revision
@@ -2513,13 +2578,12 @@ class Google_Service_Drive_Revisions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('patch', array($params), "Google_Service_Drive_Revision");
   }
+
   /**
    * Updates a revision. (revisions.update)
    *
-   * @param string $fileId
-   * The ID for the file.
-   * @param string $revisionId
-   * The ID for the revision.
+   * @param string $fileId The ID for the file.
+   * @param string $revisionId The ID for the revision.
    * @param Google_Revision $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_Revision
@@ -2548,6 +2612,7 @@ class Google_Service_Drive_About extends Google_Collection
   protected $exportFormatsDataType = 'array';
   protected $featuresType = 'Google_Service_Drive_AboutFeatures';
   protected $featuresDataType = 'array';
+  public $folderColorPalette;
   protected $importFormatsType = 'Google_Service_Drive_AboutImportFormats';
   protected $importFormatsDataType = 'array';
   public $isCurrentAppInstalled;
@@ -2571,231 +2636,195 @@ class Google_Service_Drive_About extends Google_Collection
   protected $userType = 'Google_Service_Drive_User';
   protected $userDataType = '';
 
+
   public function setAdditionalRoleInfo($additionalRoleInfo)
   {
     $this->additionalRoleInfo = $additionalRoleInfo;
   }
-
   public function getAdditionalRoleInfo()
   {
     return $this->additionalRoleInfo;
   }
-
   public function setDomainSharingPolicy($domainSharingPolicy)
   {
     $this->domainSharingPolicy = $domainSharingPolicy;
   }
-
   public function getDomainSharingPolicy()
   {
     return $this->domainSharingPolicy;
   }
-
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setExportFormats($exportFormats)
   {
     $this->exportFormats = $exportFormats;
   }
-
   public function getExportFormats()
   {
     return $this->exportFormats;
   }
-
   public function setFeatures($features)
   {
     $this->features = $features;
   }
-
   public function getFeatures()
   {
     return $this->features;
   }
-
+  public function setFolderColorPalette($folderColorPalette)
+  {
+    $this->folderColorPalette = $folderColorPalette;
+  }
+  public function getFolderColorPalette()
+  {
+    return $this->folderColorPalette;
+  }
   public function setImportFormats($importFormats)
   {
     $this->importFormats = $importFormats;
   }
-
   public function getImportFormats()
   {
     return $this->importFormats;
   }
-
   public function setIsCurrentAppInstalled($isCurrentAppInstalled)
   {
     $this->isCurrentAppInstalled = $isCurrentAppInstalled;
   }
-
   public function getIsCurrentAppInstalled()
   {
     return $this->isCurrentAppInstalled;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setLanguageCode($languageCode)
   {
     $this->languageCode = $languageCode;
   }
-
   public function getLanguageCode()
   {
     return $this->languageCode;
   }
-
   public function setLargestChangeId($largestChangeId)
   {
     $this->largestChangeId = $largestChangeId;
   }
-
   public function getLargestChangeId()
   {
     return $this->largestChangeId;
   }
-
   public function setMaxUploadSizes($maxUploadSizes)
   {
     $this->maxUploadSizes = $maxUploadSizes;
   }
-
   public function getMaxUploadSizes()
   {
     return $this->maxUploadSizes;
   }
-
   public function setName($name)
   {
     $this->name = $name;
   }
-
   public function getName()
   {
     return $this->name;
   }
-
   public function setPermissionId($permissionId)
   {
     $this->permissionId = $permissionId;
   }
-
   public function getPermissionId()
   {
     return $this->permissionId;
   }
-
   public function setQuotaBytesByService($quotaBytesByService)
   {
     $this->quotaBytesByService = $quotaBytesByService;
   }
-
   public function getQuotaBytesByService()
   {
     return $this->quotaBytesByService;
   }
-
   public function setQuotaBytesTotal($quotaBytesTotal)
   {
     $this->quotaBytesTotal = $quotaBytesTotal;
   }
-
   public function getQuotaBytesTotal()
   {
     return $this->quotaBytesTotal;
   }
-
   public function setQuotaBytesUsed($quotaBytesUsed)
   {
     $this->quotaBytesUsed = $quotaBytesUsed;
   }
-
   public function getQuotaBytesUsed()
   {
     return $this->quotaBytesUsed;
   }
-
   public function setQuotaBytesUsedAggregate($quotaBytesUsedAggregate)
   {
     $this->quotaBytesUsedAggregate = $quotaBytesUsedAggregate;
   }
-
   public function getQuotaBytesUsedAggregate()
   {
     return $this->quotaBytesUsedAggregate;
   }
-
   public function setQuotaBytesUsedInTrash($quotaBytesUsedInTrash)
   {
     $this->quotaBytesUsedInTrash = $quotaBytesUsedInTrash;
   }
-
   public function getQuotaBytesUsedInTrash()
   {
     return $this->quotaBytesUsedInTrash;
   }
-
   public function setQuotaType($quotaType)
   {
     $this->quotaType = $quotaType;
   }
-
   public function getQuotaType()
   {
     return $this->quotaType;
   }
-
   public function setRemainingChangeIds($remainingChangeIds)
   {
     $this->remainingChangeIds = $remainingChangeIds;
   }
-
   public function getRemainingChangeIds()
   {
     return $this->remainingChangeIds;
   }
-
   public function setRootFolderId($rootFolderId)
   {
     $this->rootFolderId = $rootFolderId;
   }
-
   public function getRootFolderId()
   {
     return $this->rootFolderId;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
   }
-
   public function setUser(Google_Service_Drive_User $user)
   {
     $this->user = $user;
   }
-
   public function getUser()
   {
     return $this->user;
@@ -2811,21 +2840,19 @@ class Google_Service_Drive_AboutAdditionalRoleInfo extends Google_Collection
   protected $roleSetsDataType = 'array';
   public $type;
 
+
   public function setRoleSets($roleSets)
   {
     $this->roleSets = $roleSets;
   }
-
   public function getRoleSets()
   {
     return $this->roleSets;
   }
-
   public function setType($type)
   {
     $this->type = $type;
   }
-
   public function getType()
   {
     return $this->type;
@@ -2840,21 +2867,19 @@ class Google_Service_Drive_AboutAdditionalRoleInfoRoleSets extends Google_Collec
   public $additionalRoles;
   public $primaryRole;
 
+
   public function setAdditionalRoles($additionalRoles)
   {
     $this->additionalRoles = $additionalRoles;
   }
-
   public function getAdditionalRoles()
   {
     return $this->additionalRoles;
   }
-
   public function setPrimaryRole($primaryRole)
   {
     $this->primaryRole = $primaryRole;
   }
-
   public function getPrimaryRole()
   {
     return $this->primaryRole;
@@ -2869,21 +2894,19 @@ class Google_Service_Drive_AboutExportFormats extends Google_Collection
   public $source;
   public $targets;
 
+
   public function setSource($source)
   {
     $this->source = $source;
   }
-
   public function getSource()
   {
     return $this->source;
   }
-
   public function setTargets($targets)
   {
     $this->targets = $targets;
   }
-
   public function getTargets()
   {
     return $this->targets;
@@ -2897,21 +2920,19 @@ class Google_Service_Drive_AboutFeatures extends Google_Model
   public $featureName;
   public $featureRate;
 
+
   public function setFeatureName($featureName)
   {
     $this->featureName = $featureName;
   }
-
   public function getFeatureName()
   {
     return $this->featureName;
   }
-
   public function setFeatureRate($featureRate)
   {
     $this->featureRate = $featureRate;
   }
-
   public function getFeatureRate()
   {
     return $this->featureRate;
@@ -2926,21 +2947,19 @@ class Google_Service_Drive_AboutImportFormats extends Google_Collection
   public $source;
   public $targets;
 
+
   public function setSource($source)
   {
     $this->source = $source;
   }
-
   public function getSource()
   {
     return $this->source;
   }
-
   public function setTargets($targets)
   {
     $this->targets = $targets;
   }
-
   public function getTargets()
   {
     return $this->targets;
@@ -2954,21 +2973,19 @@ class Google_Service_Drive_AboutMaxUploadSizes extends Google_Model
   public $size;
   public $type;
 
+
   public function setSize($size)
   {
     $this->size = $size;
   }
-
   public function getSize()
   {
     return $this->size;
   }
-
   public function setType($type)
   {
     $this->type = $type;
   }
-
   public function getType()
   {
     return $this->type;
@@ -2982,21 +2999,19 @@ class Google_Service_Drive_AboutQuotaBytesByService extends Google_Model
   public $bytesUsed;
   public $serviceName;
 
+
   public function setBytesUsed($bytesUsed)
   {
     $this->bytesUsed = $bytesUsed;
   }
-
   public function getBytesUsed()
   {
     return $this->bytesUsed;
   }
-
   public function setServiceName($serviceName)
   {
     $this->serviceName = $serviceName;
   }
-
   public function getServiceName()
   {
     return $this->serviceName;
@@ -3034,241 +3049,195 @@ class Google_Service_Drive_App extends Google_Collection
   public $supportsOfflineCreate;
   public $useByDefault;
 
+
   public function setAuthorized($authorized)
   {
     $this->authorized = $authorized;
   }
-
   public function getAuthorized()
   {
     return $this->authorized;
   }
-
   public function setCreateInFolderTemplate($createInFolderTemplate)
   {
     $this->createInFolderTemplate = $createInFolderTemplate;
   }
-
   public function getCreateInFolderTemplate()
   {
     return $this->createInFolderTemplate;
   }
-
   public function setCreateUrl($createUrl)
   {
     $this->createUrl = $createUrl;
   }
-
   public function getCreateUrl()
   {
     return $this->createUrl;
   }
-
   public function setHasDriveWideScope($hasDriveWideScope)
   {
     $this->hasDriveWideScope = $hasDriveWideScope;
   }
-
   public function getHasDriveWideScope()
   {
     return $this->hasDriveWideScope;
   }
-
   public function setIcons($icons)
   {
     $this->icons = $icons;
   }
-
   public function getIcons()
   {
     return $this->icons;
   }
-
   public function setId($id)
   {
     $this->id = $id;
   }
-
   public function getId()
   {
     return $this->id;
   }
-
   public function setInstalled($installed)
   {
     $this->installed = $installed;
   }
-
   public function getInstalled()
   {
     return $this->installed;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setLongDescription($longDescription)
   {
     $this->longDescription = $longDescription;
   }
-
   public function getLongDescription()
   {
     return $this->longDescription;
   }
-
   public function setName($name)
   {
     $this->name = $name;
   }
-
   public function getName()
   {
     return $this->name;
   }
-
   public function setObjectType($objectType)
   {
     $this->objectType = $objectType;
   }
-
   public function getObjectType()
   {
     return $this->objectType;
   }
-
   public function setOpenUrlTemplate($openUrlTemplate)
   {
     $this->openUrlTemplate = $openUrlTemplate;
   }
-
   public function getOpenUrlTemplate()
   {
     return $this->openUrlTemplate;
   }
-
   public function setPrimaryFileExtensions($primaryFileExtensions)
   {
     $this->primaryFileExtensions = $primaryFileExtensions;
   }
-
   public function getPrimaryFileExtensions()
   {
     return $this->primaryFileExtensions;
   }
-
   public function setPrimaryMimeTypes($primaryMimeTypes)
   {
     $this->primaryMimeTypes = $primaryMimeTypes;
   }
-
   public function getPrimaryMimeTypes()
   {
     return $this->primaryMimeTypes;
   }
-
   public function setProductId($productId)
   {
     $this->productId = $productId;
   }
-
   public function getProductId()
   {
     return $this->productId;
   }
-
   public function setProductUrl($productUrl)
   {
     $this->productUrl = $productUrl;
   }
-
   public function getProductUrl()
   {
     return $this->productUrl;
   }
-
   public function setSecondaryFileExtensions($secondaryFileExtensions)
   {
     $this->secondaryFileExtensions = $secondaryFileExtensions;
   }
-
   public function getSecondaryFileExtensions()
   {
     return $this->secondaryFileExtensions;
   }
-
   public function setSecondaryMimeTypes($secondaryMimeTypes)
   {
     $this->secondaryMimeTypes = $secondaryMimeTypes;
   }
-
   public function getSecondaryMimeTypes()
   {
     return $this->secondaryMimeTypes;
   }
-
   public function setShortDescription($shortDescription)
   {
     $this->shortDescription = $shortDescription;
   }
-
   public function getShortDescription()
   {
     return $this->shortDescription;
   }
-
   public function setSupportsCreate($supportsCreate)
   {
     $this->supportsCreate = $supportsCreate;
   }
-
   public function getSupportsCreate()
   {
     return $this->supportsCreate;
   }
-
   public function setSupportsImport($supportsImport)
   {
     $this->supportsImport = $supportsImport;
   }
-
   public function getSupportsImport()
   {
     return $this->supportsImport;
   }
-
   public function setSupportsMultiOpen($supportsMultiOpen)
   {
     $this->supportsMultiOpen = $supportsMultiOpen;
   }
-
   public function getSupportsMultiOpen()
   {
     return $this->supportsMultiOpen;
   }
-
   public function setSupportsOfflineCreate($supportsOfflineCreate)
   {
     $this->supportsOfflineCreate = $supportsOfflineCreate;
   }
-
   public function getSupportsOfflineCreate()
   {
     return $this->supportsOfflineCreate;
   }
-
   public function setUseByDefault($useByDefault)
   {
     $this->useByDefault = $useByDefault;
   }
-
   public function getUseByDefault()
   {
     return $this->useByDefault;
@@ -3283,31 +3252,27 @@ class Google_Service_Drive_AppIcons extends Google_Model
   public $iconUrl;
   public $size;
 
+
   public function setCategory($category)
   {
     $this->category = $category;
   }
-
   public function getCategory()
   {
     return $this->category;
   }
-
   public function setIconUrl($iconUrl)
   {
     $this->iconUrl = $iconUrl;
   }
-
   public function getIconUrl()
   {
     return $this->iconUrl;
   }
-
   public function setSize($size)
   {
     $this->size = $size;
   }
-
   public function getSize()
   {
     return $this->size;
@@ -3326,51 +3291,43 @@ class Google_Service_Drive_AppList extends Google_Collection
   public $kind;
   public $selfLink;
 
+
   public function setDefaultAppIds($defaultAppIds)
   {
     $this->defaultAppIds = $defaultAppIds;
   }
-
   public function getDefaultAppIds()
   {
     return $this->defaultAppIds;
   }
-
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -3390,71 +3347,59 @@ class Google_Service_Drive_Change extends Google_Model
   public $modificationDate;
   public $selfLink;
 
+
   public function setDeleted($deleted)
   {
     $this->deleted = $deleted;
   }
-
   public function getDeleted()
   {
     return $this->deleted;
   }
-
   public function setFile(Google_Service_Drive_DriveFile $file)
   {
     $this->file = $file;
   }
-
   public function getFile()
   {
     return $this->file;
   }
-
   public function setFileId($fileId)
   {
     $this->fileId = $fileId;
   }
-
   public function getFileId()
   {
     return $this->fileId;
   }
-
   public function setId($id)
   {
     $this->id = $id;
   }
-
   public function getId()
   {
     return $this->id;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setModificationDate($modificationDate)
   {
     $this->modificationDate = $modificationDate;
   }
-
   public function getModificationDate()
   {
     return $this->modificationDate;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -3475,71 +3420,59 @@ class Google_Service_Drive_ChangeList extends Google_Collection
   public $nextPageToken;
   public $selfLink;
 
+
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setLargestChangeId($largestChangeId)
   {
     $this->largestChangeId = $largestChangeId;
   }
-
   public function getLargestChangeId()
   {
     return $this->largestChangeId;
   }
-
   public function setNextLink($nextLink)
   {
     $this->nextLink = $nextLink;
   }
-
   public function getNextLink()
   {
     return $this->nextLink;
   }
-
   public function setNextPageToken($nextPageToken)
   {
     $this->nextPageToken = $nextPageToken;
   }
-
   public function getNextPageToken()
   {
     return $this->nextPageToken;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -3561,101 +3494,83 @@ class Google_Service_Drive_Channel extends Google_Model
   public $token;
   public $type;
 
+
   public function setAddress($address)
   {
     $this->address = $address;
   }
-
   public function getAddress()
   {
     return $this->address;
   }
-
   public function setExpiration($expiration)
   {
     $this->expiration = $expiration;
   }
-
   public function getExpiration()
   {
     return $this->expiration;
   }
-
   public function setId($id)
   {
     $this->id = $id;
   }
-
   public function getId()
   {
     return $this->id;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setParams($params)
   {
     $this->params = $params;
   }
-
   public function getParams()
   {
     return $this->params;
   }
-
   public function setPayload($payload)
   {
     $this->payload = $payload;
   }
-
   public function getPayload()
   {
     return $this->payload;
   }
-
   public function setResourceId($resourceId)
   {
     $this->resourceId = $resourceId;
   }
-
   public function getResourceId()
   {
     return $this->resourceId;
   }
-
   public function setResourceUri($resourceUri)
   {
     $this->resourceUri = $resourceUri;
   }
-
   public function getResourceUri()
   {
     return $this->resourceUri;
   }
-
   public function setToken($token)
   {
     $this->token = $token;
   }
-
   public function getToken()
   {
     return $this->token;
   }
-
   public function setType($type)
   {
     $this->type = $type;
   }
-
   public function getType()
   {
     return $this->type;
@@ -3664,8 +3579,6 @@ class Google_Service_Drive_Channel extends Google_Model
 
 class Google_Service_Drive_ChannelParams extends Google_Model
 {
-  protected $internal_gapi_mappings = array(
-  );
 }
 
 class Google_Service_Drive_ChildList extends Google_Collection
@@ -3681,61 +3594,51 @@ class Google_Service_Drive_ChildList extends Google_Collection
   public $nextPageToken;
   public $selfLink;
 
+
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setNextLink($nextLink)
   {
     $this->nextLink = $nextLink;
   }
-
   public function getNextLink()
   {
     return $this->nextLink;
   }
-
   public function setNextPageToken($nextPageToken)
   {
     $this->nextPageToken = $nextPageToken;
   }
-
   public function getNextPageToken()
   {
     return $this->nextPageToken;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -3751,41 +3654,35 @@ class Google_Service_Drive_ChildReference extends Google_Model
   public $kind;
   public $selfLink;
 
+
   public function setChildLink($childLink)
   {
     $this->childLink = $childLink;
   }
-
   public function getChildLink()
   {
     return $this->childLink;
   }
-
   public function setId($id)
   {
     $this->id = $id;
   }
-
   public function getId()
   {
     return $this->id;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -3816,151 +3713,123 @@ class Google_Service_Drive_Comment extends Google_Collection
   public $selfLink;
   public $status;
 
+
   public function setAnchor($anchor)
   {
     $this->anchor = $anchor;
   }
-
   public function getAnchor()
   {
     return $this->anchor;
   }
-
   public function setAuthor(Google_Service_Drive_User $author)
   {
     $this->author = $author;
   }
-
   public function getAuthor()
   {
     return $this->author;
   }
-
   public function setCommentId($commentId)
   {
     $this->commentId = $commentId;
   }
-
   public function getCommentId()
   {
     return $this->commentId;
   }
-
   public function setContent($content)
   {
     $this->content = $content;
   }
-
   public function getContent()
   {
     return $this->content;
   }
-
   public function setContext(Google_Service_Drive_CommentContext $context)
   {
     $this->context = $context;
   }
-
   public function getContext()
   {
     return $this->context;
   }
-
   public function setCreatedDate($createdDate)
   {
     $this->createdDate = $createdDate;
   }
-
   public function getCreatedDate()
   {
     return $this->createdDate;
   }
-
   public function setDeleted($deleted)
   {
     $this->deleted = $deleted;
   }
-
   public function getDeleted()
   {
     return $this->deleted;
   }
-
   public function setFileId($fileId)
   {
     $this->fileId = $fileId;
   }
-
   public function getFileId()
   {
     return $this->fileId;
   }
-
   public function setFileTitle($fileTitle)
   {
     $this->fileTitle = $fileTitle;
   }
-
   public function getFileTitle()
   {
     return $this->fileTitle;
   }
-
   public function setHtmlContent($htmlContent)
   {
     $this->htmlContent = $htmlContent;
   }
-
   public function getHtmlContent()
   {
     return $this->htmlContent;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setModifiedDate($modifiedDate)
   {
     $this->modifiedDate = $modifiedDate;
   }
-
   public function getModifiedDate()
   {
     return $this->modifiedDate;
   }
-
   public function setReplies($replies)
   {
     $this->replies = $replies;
   }
-
   public function getReplies()
   {
     return $this->replies;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
   }
-
   public function setStatus($status)
   {
     $this->status = $status;
   }
-
   public function getStatus()
   {
     return $this->status;
@@ -3974,21 +3843,19 @@ class Google_Service_Drive_CommentContext extends Google_Model
   public $type;
   public $value;
 
+
   public function setType($type)
   {
     $this->type = $type;
   }
-
   public function getType()
   {
     return $this->type;
   }
-
   public function setValue($value)
   {
     $this->value = $value;
   }
-
   public function getValue()
   {
     return $this->value;
@@ -4007,51 +3874,43 @@ class Google_Service_Drive_CommentList extends Google_Collection
   public $nextPageToken;
   public $selfLink;
 
+
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setNextLink($nextLink)
   {
     $this->nextLink = $nextLink;
   }
-
   public function getNextLink()
   {
     return $this->nextLink;
   }
-
   public function setNextPageToken($nextPageToken)
   {
     $this->nextPageToken = $nextPageToken;
   }
-
   public function getNextPageToken()
   {
     return $this->nextPageToken;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -4073,91 +3932,75 @@ class Google_Service_Drive_CommentReply extends Google_Model
   public $replyId;
   public $verb;
 
+
   public function setAuthor(Google_Service_Drive_User $author)
   {
     $this->author = $author;
   }
-
   public function getAuthor()
   {
     return $this->author;
   }
-
   public function setContent($content)
   {
     $this->content = $content;
   }
-
   public function getContent()
   {
     return $this->content;
   }
-
   public function setCreatedDate($createdDate)
   {
     $this->createdDate = $createdDate;
   }
-
   public function getCreatedDate()
   {
     return $this->createdDate;
   }
-
   public function setDeleted($deleted)
   {
     $this->deleted = $deleted;
   }
-
   public function getDeleted()
   {
     return $this->deleted;
   }
-
   public function setHtmlContent($htmlContent)
   {
     $this->htmlContent = $htmlContent;
   }
-
   public function getHtmlContent()
   {
     return $this->htmlContent;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setModifiedDate($modifiedDate)
   {
     $this->modifiedDate = $modifiedDate;
   }
-
   public function getModifiedDate()
   {
     return $this->modifiedDate;
   }
-
   public function setReplyId($replyId)
   {
     $this->replyId = $replyId;
   }
-
   public function getReplyId()
   {
     return $this->replyId;
   }
-
   public function setVerb($verb)
   {
     $this->verb = $verb;
   }
-
   public function getVerb()
   {
     return $this->verb;
@@ -4176,51 +4019,43 @@ class Google_Service_Drive_CommentReplyList extends Google_Collection
   public $nextPageToken;
   public $selfLink;
 
+
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setNextLink($nextLink)
   {
     $this->nextLink = $nextLink;
   }
-
   public function getNextLink()
   {
     return $this->nextLink;
   }
-
   public function setNextPageToken($nextPageToken)
   {
     $this->nextPageToken = $nextPageToken;
   }
-
   public function getNextPageToken()
   {
     return $this->nextPageToken;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -4229,11 +4064,12 @@ class Google_Service_Drive_CommentReplyList extends Google_Collection
 
 class Google_Service_Drive_DriveFile extends Google_Collection
 {
-  protected $collection_key = 'properties';
+  protected $collection_key = 'spaces';
   protected $internal_gapi_mappings = array(
   );
   public $alternateLink;
   public $appDataContents;
+  public $canComment;
   public $copyable;
   public $createdDate;
   public $defaultOpenWithLink;
@@ -4246,6 +4082,8 @@ class Google_Service_Drive_DriveFile extends Google_Collection
   public $exportLinks;
   public $fileExtension;
   public $fileSize;
+  public $folderColorRgb;
+  public $fullFileExtension;
   public $headRevisionId;
   public $iconLink;
   public $id;
@@ -4267,6 +4105,7 @@ class Google_Service_Drive_DriveFile extends Google_Collection
   public $modifiedDate;
   public $openWithLinks;
   public $originalFilename;
+  public $ownedByMe;
   public $ownerNames;
   protected $ownersType = 'Google_Service_Drive_User';
   protected $ownersDataType = 'array';
@@ -4278,10 +4117,12 @@ class Google_Service_Drive_DriveFile extends Google_Collection
   protected $propertiesDataType = 'array';
   public $quotaBytesUsed;
   public $selfLink;
+  public $shareable;
   public $shared;
   public $sharedWithMeDate;
   protected $sharingUserType = 'Google_Service_Drive_User';
   protected $sharingUserDataType = '';
+  public $spaces;
   protected $thumbnailType = 'Google_Service_Drive_DriveFileThumbnail';
   protected $thumbnailDataType = '';
   public $thumbnailLink;
@@ -4295,501 +4136,451 @@ class Google_Service_Drive_DriveFile extends Google_Collection
   public $webViewLink;
   public $writersCanShare;
 
+
   public function setAlternateLink($alternateLink)
   {
     $this->alternateLink = $alternateLink;
   }
-
   public function getAlternateLink()
   {
     return $this->alternateLink;
   }
-
   public function setAppDataContents($appDataContents)
   {
     $this->appDataContents = $appDataContents;
   }
-
   public function getAppDataContents()
   {
     return $this->appDataContents;
   }
-
+  public function setCanComment($canComment)
+  {
+    $this->canComment = $canComment;
+  }
+  public function getCanComment()
+  {
+    return $this->canComment;
+  }
   public function setCopyable($copyable)
   {
     $this->copyable = $copyable;
   }
-
   public function getCopyable()
   {
     return $this->copyable;
   }
-
   public function setCreatedDate($createdDate)
   {
     $this->createdDate = $createdDate;
   }
-
   public function getCreatedDate()
   {
     return $this->createdDate;
   }
-
   public function setDefaultOpenWithLink($defaultOpenWithLink)
   {
     $this->defaultOpenWithLink = $defaultOpenWithLink;
   }
-
   public function getDefaultOpenWithLink()
   {
     return $this->defaultOpenWithLink;
   }
-
   public function setDescription($description)
   {
     $this->description = $description;
   }
-
   public function getDescription()
   {
     return $this->description;
   }
-
   public function setDownloadUrl($downloadUrl)
   {
     $this->downloadUrl = $downloadUrl;
   }
-
   public function getDownloadUrl()
   {
     return $this->downloadUrl;
   }
-
   public function setEditable($editable)
   {
     $this->editable = $editable;
   }
-
   public function getEditable()
   {
     return $this->editable;
   }
-
   public function setEmbedLink($embedLink)
   {
     $this->embedLink = $embedLink;
   }
-
   public function getEmbedLink()
   {
     return $this->embedLink;
   }
-
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setExplicitlyTrashed($explicitlyTrashed)
   {
     $this->explicitlyTrashed = $explicitlyTrashed;
   }
-
   public function getExplicitlyTrashed()
   {
     return $this->explicitlyTrashed;
   }
-
   public function setExportLinks($exportLinks)
   {
     $this->exportLinks = $exportLinks;
   }
-
   public function getExportLinks()
   {
     return $this->exportLinks;
   }
-
   public function setFileExtension($fileExtension)
   {
     $this->fileExtension = $fileExtension;
   }
-
   public function getFileExtension()
   {
     return $this->fileExtension;
   }
-
   public function setFileSize($fileSize)
   {
     $this->fileSize = $fileSize;
   }
-
   public function getFileSize()
   {
     return $this->fileSize;
   }
-
+  public function setFolderColorRgb($folderColorRgb)
+  {
+    $this->folderColorRgb = $folderColorRgb;
+  }
+  public function getFolderColorRgb()
+  {
+    return $this->folderColorRgb;
+  }
+  public function setFullFileExtension($fullFileExtension)
+  {
+    $this->fullFileExtension = $fullFileExtension;
+  }
+  public function getFullFileExtension()
+  {
+    return $this->fullFileExtension;
+  }
   public function setHeadRevisionId($headRevisionId)
   {
     $this->headRevisionId = $headRevisionId;
   }
-
   public function getHeadRevisionId()
   {
     return $this->headRevisionId;
   }
-
   public function setIconLink($iconLink)
   {
     $this->iconLink = $iconLink;
   }
-
   public function getIconLink()
   {
     return $this->iconLink;
   }
-
   public function setId($id)
   {
     $this->id = $id;
   }
-
   public function getId()
   {
     return $this->id;
   }
-
   public function setImageMediaMetadata(Google_Service_Drive_DriveFileImageMediaMetadata $imageMediaMetadata)
   {
     $this->imageMediaMetadata = $imageMediaMetadata;
   }
-
   public function getImageMediaMetadata()
   {
     return $this->imageMediaMetadata;
   }
-
   public function setIndexableText(Google_Service_Drive_DriveFileIndexableText $indexableText)
   {
     $this->indexableText = $indexableText;
   }
-
   public function getIndexableText()
   {
     return $this->indexableText;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setLabels(Google_Service_Drive_DriveFileLabels $labels)
   {
     $this->labels = $labels;
   }
-
   public function getLabels()
   {
     return $this->labels;
   }
-
   public function setLastModifyingUser(Google_Service_Drive_User $lastModifyingUser)
   {
     $this->lastModifyingUser = $lastModifyingUser;
   }
-
   public function getLastModifyingUser()
   {
     return $this->lastModifyingUser;
   }
-
   public function setLastModifyingUserName($lastModifyingUserName)
   {
     $this->lastModifyingUserName = $lastModifyingUserName;
   }
-
   public function getLastModifyingUserName()
   {
     return $this->lastModifyingUserName;
   }
-
   public function setLastViewedByMeDate($lastViewedByMeDate)
   {
     $this->lastViewedByMeDate = $lastViewedByMeDate;
   }
-
   public function getLastViewedByMeDate()
   {
     return $this->lastViewedByMeDate;
   }
-
   public function setMarkedViewedByMeDate($markedViewedByMeDate)
   {
     $this->markedViewedByMeDate = $markedViewedByMeDate;
   }
-
   public function getMarkedViewedByMeDate()
   {
     return $this->markedViewedByMeDate;
   }
-
   public function setMd5Checksum($md5Checksum)
   {
     $this->md5Checksum = $md5Checksum;
   }
-
   public function getMd5Checksum()
   {
     return $this->md5Checksum;
   }
-
   public function setMimeType($mimeType)
   {
     $this->mimeType = $mimeType;
   }
-
   public function getMimeType()
   {
     return $this->mimeType;
   }
-
   public function setModifiedByMeDate($modifiedByMeDate)
   {
     $this->modifiedByMeDate = $modifiedByMeDate;
   }
-
   public function getModifiedByMeDate()
   {
     return $this->modifiedByMeDate;
   }
-
   public function setModifiedDate($modifiedDate)
   {
     $this->modifiedDate = $modifiedDate;
   }
-
   public function getModifiedDate()
   {
     return $this->modifiedDate;
   }
-
   public function setOpenWithLinks($openWithLinks)
   {
     $this->openWithLinks = $openWithLinks;
   }
-
   public function getOpenWithLinks()
   {
     return $this->openWithLinks;
   }
-
   public function setOriginalFilename($originalFilename)
   {
     $this->originalFilename = $originalFilename;
   }
-
   public function getOriginalFilename()
   {
     return $this->originalFilename;
   }
-
+  public function setOwnedByMe($ownedByMe)
+  {
+    $this->ownedByMe = $ownedByMe;
+  }
+  public function getOwnedByMe()
+  {
+    return $this->ownedByMe;
+  }
   public function setOwnerNames($ownerNames)
   {
     $this->ownerNames = $ownerNames;
   }
-
   public function getOwnerNames()
   {
     return $this->ownerNames;
   }
-
   public function setOwners($owners)
   {
     $this->owners = $owners;
   }
-
   public function getOwners()
   {
     return $this->owners;
   }
-
   public function setParents($parents)
   {
     $this->parents = $parents;
   }
-
   public function getParents()
   {
     return $this->parents;
   }
-
   public function setPermissions($permissions)
   {
     $this->permissions = $permissions;
   }
-
   public function getPermissions()
   {
     return $this->permissions;
   }
-
   public function setProperties($properties)
   {
     $this->properties = $properties;
   }
-
   public function getProperties()
   {
     return $this->properties;
   }
-
   public function setQuotaBytesUsed($quotaBytesUsed)
   {
     $this->quotaBytesUsed = $quotaBytesUsed;
   }
-
   public function getQuotaBytesUsed()
   {
     return $this->quotaBytesUsed;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
   }
-
+  public function setShareable($shareable)
+  {
+    $this->shareable = $shareable;
+  }
+  public function getShareable()
+  {
+    return $this->shareable;
+  }
   public function setShared($shared)
   {
     $this->shared = $shared;
   }
-
   public function getShared()
   {
     return $this->shared;
   }
-
   public function setSharedWithMeDate($sharedWithMeDate)
   {
     $this->sharedWithMeDate = $sharedWithMeDate;
   }
-
   public function getSharedWithMeDate()
   {
     return $this->sharedWithMeDate;
   }
-
   public function setSharingUser(Google_Service_Drive_User $sharingUser)
   {
     $this->sharingUser = $sharingUser;
   }
-
   public function getSharingUser()
   {
     return $this->sharingUser;
   }
-
+  public function setSpaces($spaces)
+  {
+    $this->spaces = $spaces;
+  }
+  public function getSpaces()
+  {
+    return $this->spaces;
+  }
   public function setThumbnail(Google_Service_Drive_DriveFileThumbnail $thumbnail)
   {
     $this->thumbnail = $thumbnail;
   }
-
   public function getThumbnail()
   {
     return $this->thumbnail;
   }
-
   public function setThumbnailLink($thumbnailLink)
   {
     $this->thumbnailLink = $thumbnailLink;
   }
-
   public function getThumbnailLink()
   {
     return $this->thumbnailLink;
   }
-
   public function setTitle($title)
   {
     $this->title = $title;
   }
-
   public function getTitle()
   {
     return $this->title;
   }
-
   public function setUserPermission(Google_Service_Drive_Permission $userPermission)
   {
     $this->userPermission = $userPermission;
   }
-
   public function getUserPermission()
   {
     return $this->userPermission;
   }
-
   public function setVersion($version)
   {
     $this->version = $version;
   }
-
   public function getVersion()
   {
     return $this->version;
   }
-
   public function setVideoMediaMetadata(Google_Service_Drive_DriveFileVideoMediaMetadata $videoMediaMetadata)
   {
     $this->videoMediaMetadata = $videoMediaMetadata;
   }
-
   public function getVideoMediaMetadata()
   {
     return $this->videoMediaMetadata;
   }
-
   public function setWebContentLink($webContentLink)
   {
     $this->webContentLink = $webContentLink;
   }
-
   public function getWebContentLink()
   {
     return $this->webContentLink;
   }
-
   public function setWebViewLink($webViewLink)
   {
     $this->webViewLink = $webViewLink;
   }
-
   public function getWebViewLink()
   {
     return $this->webViewLink;
   }
-
   public function setWritersCanShare($writersCanShare)
   {
     $this->writersCanShare = $writersCanShare;
   }
-
   public function getWritersCanShare()
   {
     return $this->writersCanShare;
@@ -4798,8 +4589,6 @@ class Google_Service_Drive_DriveFile extends Google_Collection
 
 class Google_Service_Drive_DriveFileExportLinks extends Google_Model
 {
-  protected $internal_gapi_mappings = array(
-  );
 }
 
 class Google_Service_Drive_DriveFileImageMediaMetadata extends Google_Model
@@ -4829,211 +4618,171 @@ class Google_Service_Drive_DriveFileImageMediaMetadata extends Google_Model
   public $whiteBalance;
   public $width;
 
+
   public function setAperture($aperture)
   {
     $this->aperture = $aperture;
   }
-
   public function getAperture()
   {
     return $this->aperture;
   }
-
   public function setCameraMake($cameraMake)
   {
     $this->cameraMake = $cameraMake;
   }
-
   public function getCameraMake()
   {
     return $this->cameraMake;
   }
-
   public function setCameraModel($cameraModel)
   {
     $this->cameraModel = $cameraModel;
   }
-
   public function getCameraModel()
   {
     return $this->cameraModel;
   }
-
   public function setColorSpace($colorSpace)
   {
     $this->colorSpace = $colorSpace;
   }
-
   public function getColorSpace()
   {
     return $this->colorSpace;
   }
-
   public function setDate($date)
   {
     $this->date = $date;
   }
-
   public function getDate()
   {
     return $this->date;
   }
-
   public function setExposureBias($exposureBias)
   {
     $this->exposureBias = $exposureBias;
   }
-
   public function getExposureBias()
   {
     return $this->exposureBias;
   }
-
   public function setExposureMode($exposureMode)
   {
     $this->exposureMode = $exposureMode;
   }
-
   public function getExposureMode()
   {
     return $this->exposureMode;
   }
-
   public function setExposureTime($exposureTime)
   {
     $this->exposureTime = $exposureTime;
   }
-
   public function getExposureTime()
   {
     return $this->exposureTime;
   }
-
   public function setFlashUsed($flashUsed)
   {
     $this->flashUsed = $flashUsed;
   }
-
   public function getFlashUsed()
   {
     return $this->flashUsed;
   }
-
   public function setFocalLength($focalLength)
   {
     $this->focalLength = $focalLength;
   }
-
   public function getFocalLength()
   {
     return $this->focalLength;
   }
-
   public function setHeight($height)
   {
     $this->height = $height;
   }
-
   public function getHeight()
   {
     return $this->height;
   }
-
   public function setIsoSpeed($isoSpeed)
   {
     $this->isoSpeed = $isoSpeed;
   }
-
   public function getIsoSpeed()
   {
     return $this->isoSpeed;
   }
-
   public function setLens($lens)
   {
     $this->lens = $lens;
   }
-
   public function getLens()
   {
     return $this->lens;
   }
-
   public function setLocation(Google_Service_Drive_DriveFileImageMediaMetadataLocation $location)
   {
     $this->location = $location;
   }
-
   public function getLocation()
   {
     return $this->location;
   }
-
   public function setMaxApertureValue($maxApertureValue)
   {
     $this->maxApertureValue = $maxApertureValue;
   }
-
   public function getMaxApertureValue()
   {
     return $this->maxApertureValue;
   }
-
   public function setMeteringMode($meteringMode)
   {
     $this->meteringMode = $meteringMode;
   }
-
   public function getMeteringMode()
   {
     return $this->meteringMode;
   }
-
   public function setRotation($rotation)
   {
     $this->rotation = $rotation;
   }
-
   public function getRotation()
   {
     return $this->rotation;
   }
-
   public function setSensor($sensor)
   {
     $this->sensor = $sensor;
   }
-
   public function getSensor()
   {
     return $this->sensor;
   }
-
   public function setSubjectDistance($subjectDistance)
   {
     $this->subjectDistance = $subjectDistance;
   }
-
   public function getSubjectDistance()
   {
     return $this->subjectDistance;
   }
-
   public function setWhiteBalance($whiteBalance)
   {
     $this->whiteBalance = $whiteBalance;
   }
-
   public function getWhiteBalance()
   {
     return $this->whiteBalance;
   }
-
   public function setWidth($width)
   {
     $this->width = $width;
   }
-
   public function getWidth()
   {
     return $this->width;
@@ -5048,31 +4797,27 @@ class Google_Service_Drive_DriveFileImageMediaMetadataLocation extends Google_Mo
   public $latitude;
   public $longitude;
 
+
   public function setAltitude($altitude)
   {
     $this->altitude = $altitude;
   }
-
   public function getAltitude()
   {
     return $this->altitude;
   }
-
   public function setLatitude($latitude)
   {
     $this->latitude = $latitude;
   }
-
   public function getLatitude()
   {
     return $this->latitude;
   }
-
   public function setLongitude($longitude)
   {
     $this->longitude = $longitude;
   }
-
   public function getLongitude()
   {
     return $this->longitude;
@@ -5085,11 +4830,11 @@ class Google_Service_Drive_DriveFileIndexableText extends Google_Model
   );
   public $text;
 
+
   public function setText($text)
   {
     $this->text = $text;
   }
-
   public function getText()
   {
     return $this->text;
@@ -5106,51 +4851,43 @@ class Google_Service_Drive_DriveFileLabels extends Google_Model
   public $trashed;
   public $viewed;
 
+
   public function setHidden($hidden)
   {
     $this->hidden = $hidden;
   }
-
   public function getHidden()
   {
     return $this->hidden;
   }
-
   public function setRestricted($restricted)
   {
     $this->restricted = $restricted;
   }
-
   public function getRestricted()
   {
     return $this->restricted;
   }
-
   public function setStarred($starred)
   {
     $this->starred = $starred;
   }
-
   public function getStarred()
   {
     return $this->starred;
   }
-
   public function setTrashed($trashed)
   {
     $this->trashed = $trashed;
   }
-
   public function getTrashed()
   {
     return $this->trashed;
   }
-
   public function setViewed($viewed)
   {
     $this->viewed = $viewed;
   }
-
   public function getViewed()
   {
     return $this->viewed;
@@ -5159,8 +4896,6 @@ class Google_Service_Drive_DriveFileLabels extends Google_Model
 
 class Google_Service_Drive_DriveFileOpenWithLinks extends Google_Model
 {
-  protected $internal_gapi_mappings = array(
-  );
 }
 
 class Google_Service_Drive_DriveFileThumbnail extends Google_Model
@@ -5170,21 +4905,19 @@ class Google_Service_Drive_DriveFileThumbnail extends Google_Model
   public $image;
   public $mimeType;
 
+
   public function setImage($image)
   {
     $this->image = $image;
   }
-
   public function getImage()
   {
     return $this->image;
   }
-
   public function setMimeType($mimeType)
   {
     $this->mimeType = $mimeType;
   }
-
   public function getMimeType()
   {
     return $this->mimeType;
@@ -5199,31 +4932,27 @@ class Google_Service_Drive_DriveFileVideoMediaMetadata extends Google_Model
   public $height;
   public $width;
 
+
   public function setDurationMillis($durationMillis)
   {
     $this->durationMillis = $durationMillis;
   }
-
   public function getDurationMillis()
   {
     return $this->durationMillis;
   }
-
   public function setHeight($height)
   {
     $this->height = $height;
   }
-
   public function getHeight()
   {
     return $this->height;
   }
-
   public function setWidth($width)
   {
     $this->width = $width;
   }
-
   public function getWidth()
   {
     return $this->width;
@@ -5243,64 +4972,90 @@ class Google_Service_Drive_FileList extends Google_Collection
   public $nextPageToken;
   public $selfLink;
 
+
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setNextLink($nextLink)
   {
     $this->nextLink = $nextLink;
   }
-
   public function getNextLink()
   {
     return $this->nextLink;
   }
-
   public function setNextPageToken($nextPageToken)
   {
     $this->nextPageToken = $nextPageToken;
   }
-
   public function getNextPageToken()
   {
     return $this->nextPageToken;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
+  }
+}
+
+class Google_Service_Drive_GeneratedIds extends Google_Collection
+{
+  protected $collection_key = 'ids';
+  protected $internal_gapi_mappings = array(
+  );
+  public $ids;
+  public $kind;
+  public $space;
+
+
+  public function setIds($ids)
+  {
+    $this->ids = $ids;
+  }
+  public function getIds()
+  {
+    return $this->ids;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSpace($space)
+  {
+    $this->space = $space;
+  }
+  public function getSpace()
+  {
+    return $this->space;
   }
 }
 
@@ -5315,41 +5070,35 @@ class Google_Service_Drive_ParentList extends Google_Collection
   public $kind;
   public $selfLink;
 
+
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -5366,51 +5115,43 @@ class Google_Service_Drive_ParentReference extends Google_Model
   public $parentLink;
   public $selfLink;
 
+
   public function setId($id)
   {
     $this->id = $id;
   }
-
   public function getId()
   {
     return $this->id;
   }
-
   public function setIsRoot($isRoot)
   {
     $this->isRoot = $isRoot;
   }
-
   public function getIsRoot()
   {
     return $this->isRoot;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setParentLink($parentLink)
   {
     $this->parentLink = $parentLink;
   }
-
   public function getParentLink()
   {
     return $this->parentLink;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -5437,141 +5178,115 @@ class Google_Service_Drive_Permission extends Google_Collection
   public $value;
   public $withLink;
 
+
   public function setAdditionalRoles($additionalRoles)
   {
     $this->additionalRoles = $additionalRoles;
   }
-
   public function getAdditionalRoles()
   {
     return $this->additionalRoles;
   }
-
   public function setAuthKey($authKey)
   {
     $this->authKey = $authKey;
   }
-
   public function getAuthKey()
   {
     return $this->authKey;
   }
-
   public function setDomain($domain)
   {
     $this->domain = $domain;
   }
-
   public function getDomain()
   {
     return $this->domain;
   }
-
   public function setEmailAddress($emailAddress)
   {
     $this->emailAddress = $emailAddress;
   }
-
   public function getEmailAddress()
   {
     return $this->emailAddress;
   }
-
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setId($id)
   {
     $this->id = $id;
   }
-
   public function getId()
   {
     return $this->id;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setName($name)
   {
     $this->name = $name;
   }
-
   public function getName()
   {
     return $this->name;
   }
-
   public function setPhotoLink($photoLink)
   {
     $this->photoLink = $photoLink;
   }
-
   public function getPhotoLink()
   {
     return $this->photoLink;
   }
-
   public function setRole($role)
   {
     $this->role = $role;
   }
-
   public function getRole()
   {
     return $this->role;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
   }
-
   public function setType($type)
   {
     $this->type = $type;
   }
-
   public function getType()
   {
     return $this->type;
   }
-
   public function setValue($value)
   {
     $this->value = $value;
   }
-
   public function getValue()
   {
     return $this->value;
   }
-
   public function setWithLink($withLink)
   {
     $this->withLink = $withLink;
   }
-
   public function getWithLink()
   {
     return $this->withLink;
@@ -5585,21 +5300,19 @@ class Google_Service_Drive_PermissionId extends Google_Model
   public $id;
   public $kind;
 
+
   public function setId($id)
   {
     $this->id = $id;
   }
-
   public function getId()
   {
     return $this->id;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
@@ -5617,41 +5330,35 @@ class Google_Service_Drive_PermissionList extends Google_Collection
   public $kind;
   public $selfLink;
 
+
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -5669,61 +5376,51 @@ class Google_Service_Drive_Property extends Google_Model
   public $value;
   public $visibility;
 
+
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setKey($key)
   {
     $this->key = $key;
   }
-
   public function getKey()
   {
     return $this->key;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
   }
-
   public function setValue($value)
   {
     $this->value = $value;
   }
-
   public function getValue()
   {
     return $this->value;
   }
-
   public function setVisibility($visibility)
   {
     $this->visibility = $visibility;
   }
-
   public function getVisibility()
   {
     return $this->visibility;
@@ -5741,41 +5438,35 @@ class Google_Service_Drive_PropertyList extends Google_Collection
   public $kind;
   public $selfLink;
 
+
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -5806,181 +5497,147 @@ class Google_Service_Drive_Revision extends Google_Model
   public $publishedOutsideDomain;
   public $selfLink;
 
+
   public function setDownloadUrl($downloadUrl)
   {
     $this->downloadUrl = $downloadUrl;
   }
-
   public function getDownloadUrl()
   {
     return $this->downloadUrl;
   }
-
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setExportLinks($exportLinks)
   {
     $this->exportLinks = $exportLinks;
   }
-
   public function getExportLinks()
   {
     return $this->exportLinks;
   }
-
   public function setFileSize($fileSize)
   {
     $this->fileSize = $fileSize;
   }
-
   public function getFileSize()
   {
     return $this->fileSize;
   }
-
   public function setId($id)
   {
     $this->id = $id;
   }
-
   public function getId()
   {
     return $this->id;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setLastModifyingUser(Google_Service_Drive_User $lastModifyingUser)
   {
     $this->lastModifyingUser = $lastModifyingUser;
   }
-
   public function getLastModifyingUser()
   {
     return $this->lastModifyingUser;
   }
-
   public function setLastModifyingUserName($lastModifyingUserName)
   {
     $this->lastModifyingUserName = $lastModifyingUserName;
   }
-
   public function getLastModifyingUserName()
   {
     return $this->lastModifyingUserName;
   }
-
   public function setMd5Checksum($md5Checksum)
   {
     $this->md5Checksum = $md5Checksum;
   }
-
   public function getMd5Checksum()
   {
     return $this->md5Checksum;
   }
-
   public function setMimeType($mimeType)
   {
     $this->mimeType = $mimeType;
   }
-
   public function getMimeType()
   {
     return $this->mimeType;
   }
-
   public function setModifiedDate($modifiedDate)
   {
     $this->modifiedDate = $modifiedDate;
   }
-
   public function getModifiedDate()
   {
     return $this->modifiedDate;
   }
-
   public function setOriginalFilename($originalFilename)
   {
     $this->originalFilename = $originalFilename;
   }
-
   public function getOriginalFilename()
   {
     return $this->originalFilename;
   }
-
   public function setPinned($pinned)
   {
     $this->pinned = $pinned;
   }
-
   public function getPinned()
   {
     return $this->pinned;
   }
-
   public function setPublishAuto($publishAuto)
   {
     $this->publishAuto = $publishAuto;
   }
-
   public function getPublishAuto()
   {
     return $this->publishAuto;
   }
-
   public function setPublished($published)
   {
     $this->published = $published;
   }
-
   public function getPublished()
   {
     return $this->published;
   }
-
   public function setPublishedLink($publishedLink)
   {
     $this->publishedLink = $publishedLink;
   }
-
   public function getPublishedLink()
   {
     return $this->publishedLink;
   }
-
   public function setPublishedOutsideDomain($publishedOutsideDomain)
   {
     $this->publishedOutsideDomain = $publishedOutsideDomain;
   }
-
   public function getPublishedOutsideDomain()
   {
     return $this->publishedOutsideDomain;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -5989,8 +5646,6 @@ class Google_Service_Drive_Revision extends Google_Model
 
 class Google_Service_Drive_RevisionExportLinks extends Google_Model
 {
-  protected $internal_gapi_mappings = array(
-  );
 }
 
 class Google_Service_Drive_RevisionList extends Google_Collection
@@ -6004,41 +5659,35 @@ class Google_Service_Drive_RevisionList extends Google_Collection
   public $kind;
   public $selfLink;
 
+
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -6057,61 +5706,51 @@ class Google_Service_Drive_User extends Google_Model
   protected $pictureType = 'Google_Service_Drive_UserPicture';
   protected $pictureDataType = '';
 
+
   public function setDisplayName($displayName)
   {
     $this->displayName = $displayName;
   }
-
   public function getDisplayName()
   {
     return $this->displayName;
   }
-
   public function setEmailAddress($emailAddress)
   {
     $this->emailAddress = $emailAddress;
   }
-
   public function getEmailAddress()
   {
     return $this->emailAddress;
   }
-
   public function setIsAuthenticatedUser($isAuthenticatedUser)
   {
     $this->isAuthenticatedUser = $isAuthenticatedUser;
   }
-
   public function getIsAuthenticatedUser()
   {
     return $this->isAuthenticatedUser;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setPermissionId($permissionId)
   {
     $this->permissionId = $permissionId;
   }
-
   public function getPermissionId()
   {
     return $this->permissionId;
   }
-
   public function setPicture(Google_Service_Drive_UserPicture $picture)
   {
     $this->picture = $picture;
   }
-
   public function getPicture()
   {
     return $this->picture;
@@ -6124,11 +5763,11 @@ class Google_Service_Drive_UserPicture extends Google_Model
   );
   public $url;
 
+
   public function setUrl($url)
   {
     $this->url = $url;
   }
-
   public function getUrl()
   {
     return $this->url;

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Fitness.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Fitness.php
@@ -1,0 +1,1568 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Fitness (v1).
+ *
+ * <p>
+ * Google Fit API</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/fit/rest/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Fitness extends Google_Service
+{
+  /** View your activity information in Google Fit. */
+  const FITNESS_ACTIVITY_READ =
+      "https://www.googleapis.com/auth/fitness.activity.read";
+  /** View and store your activity information in Google Fit. */
+  const FITNESS_ACTIVITY_WRITE =
+      "https://www.googleapis.com/auth/fitness.activity.write";
+  /** View body sensor information in Google Fit. */
+  const FITNESS_BODY_READ =
+      "https://www.googleapis.com/auth/fitness.body.read";
+  /** View and store body sensor data in Google Fit. */
+  const FITNESS_BODY_WRITE =
+      "https://www.googleapis.com/auth/fitness.body.write";
+  /** View your stored location data in Google Fit. */
+  const FITNESS_LOCATION_READ =
+      "https://www.googleapis.com/auth/fitness.location.read";
+  /** View and store your location data in Google Fit. */
+  const FITNESS_LOCATION_WRITE =
+      "https://www.googleapis.com/auth/fitness.location.write";
+
+  public $users_dataSources;
+  public $users_dataSources_datasets;
+  public $users_dataset;
+  public $users_sessions;
+  
+
+  /**
+   * Constructs the internal representation of the Fitness service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'fitness/v1/users/';
+    $this->version = 'v1';
+    $this->serviceName = 'fitness';
+
+    $this->users_dataSources = new Google_Service_Fitness_UsersDataSources_Resource(
+        $this,
+        $this->serviceName,
+        'dataSources',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => '{userId}/dataSources',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{userId}/dataSources/{dataSourceId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dataSourceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{userId}/dataSources/{dataSourceId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dataSourceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{userId}/dataSources',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dataTypeName' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{userId}/dataSources/{dataSourceId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dataSourceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{userId}/dataSources/{dataSourceId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dataSourceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->users_dataSources_datasets = new Google_Service_Fitness_UsersDataSourcesDatasets_Resource(
+        $this,
+        $this->serviceName,
+        'datasets',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{userId}/dataSources/{dataSourceId}/datasets/{datasetId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dataSourceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'modifiedTimeMillis' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'currentTimeMillis' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{userId}/dataSources/{dataSourceId}/datasets/{datasetId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dataSourceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'limit' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{userId}/dataSources/{dataSourceId}/datasets/{datasetId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dataSourceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'currentTimeMillis' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->users_dataset = new Google_Service_Fitness_UsersDataset_Resource(
+        $this,
+        $this->serviceName,
+        'dataset',
+        array(
+          'methods' => array(
+            'aggregate' => array(
+              'path' => '{userId}/dataset:aggregate',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->users_sessions = new Google_Service_Fitness_UsersSessions_Resource(
+        $this,
+        $this->serviceName,
+        'sessions',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{userId}/sessions/{sessionId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sessionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'currentTimeMillis' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{userId}/sessions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'endTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'includeDeleted' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'startTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{userId}/sessions/{sessionId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sessionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'currentTimeMillis' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "users" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $fitnessService = new Google_Service_Fitness(...);
+ *   $users = $fitnessService->users;
+ *  </code>
+ */
+class Google_Service_Fitness_Users_Resource extends Google_Service_Resource
+{
+}
+
+/**
+ * The "dataSources" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $fitnessService = new Google_Service_Fitness(...);
+ *   $dataSources = $fitnessService->dataSources;
+ *  </code>
+ */
+class Google_Service_Fitness_UsersDataSources_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a new data source that is unique across all data sources belonging to
+   * this user. The data stream ID field can be omitted and will be generated by
+   * the server with the correct format. The data stream ID is an ordered
+   * combination of some fields from the data source. In addition to the data
+   * source fields reflected into the data source ID, the developer project number
+   * that is authenticated when creating the data source is included. This
+   * developer project number is obfuscated when read by any other developer
+   * reading public data types. (dataSources.create)
+   *
+   * @param string $userId Create the data source for the person identified. Use
+   * me to indicate the authenticated user. Only me is supported at this time.
+   * @param Google_DataSource $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fitness_DataSource
+   */
+  public function create($userId, Google_Service_Fitness_DataSource $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Fitness_DataSource");
+  }
+
+  /**
+   * Delete the data source if there are no datapoints associated with it
+   * (dataSources.delete)
+   *
+   * @param string $userId Retrieve a data source for the person identified. Use
+   * me to indicate the authenticated user. Only me is supported at this time.
+   * @param string $dataSourceId The data stream ID of the data source to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fitness_DataSource
+   */
+  public function delete($userId, $dataSourceId, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'dataSourceId' => $dataSourceId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Fitness_DataSource");
+  }
+
+  /**
+   * Returns a data source identified by a data stream ID. (dataSources.get)
+   *
+   * @param string $userId Retrieve a data source for the person identified. Use
+   * me to indicate the authenticated user. Only me is supported at this time.
+   * @param string $dataSourceId The data stream ID of the data source to
+   * retrieve.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fitness_DataSource
+   */
+  public function get($userId, $dataSourceId, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'dataSourceId' => $dataSourceId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Fitness_DataSource");
+  }
+
+  /**
+   * Lists all data sources that are visible to the developer, using the OAuth
+   * scopes provided. The list is not exhaustive: the user may have private data
+   * sources that are only visible to other developers or calls using other
+   * scopes. (dataSources.listUsersDataSources)
+   *
+   * @param string $userId List data sources for the person identified. Use me to
+   * indicate the authenticated user. Only me is supported at this time.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string dataTypeName The names of data types to include in the
+   * list. If not specified, all data sources will be returned.
+   * @return Google_Service_Fitness_ListDataSourcesResponse
+   */
+  public function listUsersDataSources($userId, $optParams = array())
+  {
+    $params = array('userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Fitness_ListDataSourcesResponse");
+  }
+
+  /**
+   * Updates a given data source. It is an error to modify the data source's data
+   * stream ID, data type, type, stream name or device information apart from the
+   * device version. Changing these fields would require a new unique data stream
+   * ID and separate data source.
+   *
+   * Data sources are identified by their data stream ID. This method supports
+   * patch semantics. (dataSources.patch)
+   *
+   * @param string $userId Update the data source for the person identified. Use
+   * me to indicate the authenticated user. Only me is supported at this time.
+   * @param string $dataSourceId The data stream ID of the data source to update.
+   * @param Google_DataSource $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fitness_DataSource
+   */
+  public function patch($userId, $dataSourceId, Google_Service_Fitness_DataSource $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'dataSourceId' => $dataSourceId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Fitness_DataSource");
+  }
+
+  /**
+   * Updates a given data source. It is an error to modify the data source's data
+   * stream ID, data type, type, stream name or device information apart from the
+   * device version. Changing these fields would require a new unique data stream
+   * ID and separate data source.
+   *
+   * Data sources are identified by their data stream ID. (dataSources.update)
+   *
+   * @param string $userId Update the data source for the person identified. Use
+   * me to indicate the authenticated user. Only me is supported at this time.
+   * @param string $dataSourceId The data stream ID of the data source to update.
+   * @param Google_DataSource $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fitness_DataSource
+   */
+  public function update($userId, $dataSourceId, Google_Service_Fitness_DataSource $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'dataSourceId' => $dataSourceId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Fitness_DataSource");
+  }
+}
+
+/**
+ * The "datasets" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $fitnessService = new Google_Service_Fitness(...);
+ *   $datasets = $fitnessService->datasets;
+ *  </code>
+ */
+class Google_Service_Fitness_UsersDataSourcesDatasets_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Performs an inclusive delete of all data points whose start and end times
+   * have any overlap with the time range specified by the dataset ID. For most
+   * data types, the entire data point will be deleted. For data types where the
+   * time span represents a consistent value (such as
+   * com.google.activity.segment), and a data point straddles either end point of
+   * the dataset, only the overlapping portion of the data point will be deleted.
+   * (datasets.delete)
+   *
+   * @param string $userId Delete a dataset for the person identified. Use me to
+   * indicate the authenticated user. Only me is supported at this time.
+   * @param string $dataSourceId The data stream ID of the data source that
+   * created the dataset.
+   * @param string $datasetId Dataset identifier that is a composite of the
+   * minimum data point start time and maximum data point end time represented as
+   * nanoseconds from the epoch. The ID is formatted like: "startTime-endTime"
+   * where startTime and endTime are 64 bit integers.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string modifiedTimeMillis When the operation was performed on the
+   * client.
+   * @opt_param string currentTimeMillis The client's current time in milliseconds
+   * since epoch.
+   */
+  public function delete($userId, $dataSourceId, $datasetId, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'dataSourceId' => $dataSourceId, 'datasetId' => $datasetId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Returns a dataset containing all data points whose start and end times
+   * overlap with the specified range of the dataset minimum start time and
+   * maximum end time. Specifically, any data point whose start time is less than
+   * or equal to the dataset end time and whose end time is greater than or equal
+   * to the dataset start time. (datasets.get)
+   *
+   * @param string $userId Retrieve a dataset for the person identified. Use me to
+   * indicate the authenticated user. Only me is supported at this time.
+   * @param string $dataSourceId The data stream ID of the data source that
+   * created the dataset.
+   * @param string $datasetId Dataset identifier that is a composite of the
+   * minimum data point start time and maximum data point end time represented as
+   * nanoseconds from the epoch. The ID is formatted like: "startTime-endTime"
+   * where startTime and endTime are 64 bit integers.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int limit If specified, no more than this many data points will be
+   * included in the dataset. If the there are more data points in the dataset,
+   * nextPageToken will be set in the dataset response.
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large datasets. To get the next page of a dataset, set this parameter
+   * to the value of nextPageToken from the previous response. Each subsequent
+   * call will yield a partial dataset with data point end timestamps that are
+   * strictly smaller than those in the previous partial response.
+   * @return Google_Service_Fitness_Dataset
+   */
+  public function get($userId, $dataSourceId, $datasetId, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'dataSourceId' => $dataSourceId, 'datasetId' => $datasetId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Fitness_Dataset");
+  }
+
+  /**
+   * Adds data points to a dataset. The dataset need not be previously created.
+   * All points within the given dataset will be returned with subsquent calls to
+   * retrieve this dataset. Data points can belong to more than one dataset. This
+   * method does not use patch semantics. (datasets.patch)
+   *
+   * @param string $userId Patch a dataset for the person identified. Use me to
+   * indicate the authenticated user. Only me is supported at this time.
+   * @param string $dataSourceId The data stream ID of the data source that
+   * created the dataset.
+   * @param string $datasetId Dataset identifier that is a composite of the
+   * minimum data point start time and maximum data point end time represented as
+   * nanoseconds from the epoch. The ID is formatted like: "startTime-endTime"
+   * where startTime and endTime are 64 bit integers.
+   * @param Google_Dataset $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string currentTimeMillis The client's current time in milliseconds
+   * since epoch. Note that the minStartTimeNs and maxEndTimeNs properties in the
+   * request body are in nanoseconds instead of milliseconds.
+   * @return Google_Service_Fitness_Dataset
+   */
+  public function patch($userId, $dataSourceId, $datasetId, Google_Service_Fitness_Dataset $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'dataSourceId' => $dataSourceId, 'datasetId' => $datasetId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Fitness_Dataset");
+  }
+}
+/**
+ * The "dataset" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $fitnessService = new Google_Service_Fitness(...);
+ *   $dataset = $fitnessService->dataset;
+ *  </code>
+ */
+class Google_Service_Fitness_UsersDataset_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Aggregates data of a certain type or stream into buckets divided by a given
+   * type of boundary. Multiple data sets of multiple types and from multiple
+   * sources can be aggreated into exactly one bucket type per request.
+   * (dataset.aggregate)
+   *
+   * @param string $userId Aggregate data for the person identified. Use me to
+   * indicate the authenticated user. Only me is supported at this time.
+   * @param Google_AggregateRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fitness_AggregateResponse
+   */
+  public function aggregate($userId, Google_Service_Fitness_AggregateRequest $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('aggregate', array($params), "Google_Service_Fitness_AggregateResponse");
+  }
+}
+/**
+ * The "sessions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $fitnessService = new Google_Service_Fitness(...);
+ *   $sessions = $fitnessService->sessions;
+ *  </code>
+ */
+class Google_Service_Fitness_UsersSessions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a session specified by the given session ID. (sessions.delete)
+   *
+   * @param string $userId Delete a session for the person identified. Use me to
+   * indicate the authenticated user. Only me is supported at this time.
+   * @param string $sessionId The ID of the session to be deleted.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string currentTimeMillis The client's current time in milliseconds
+   * since epoch.
+   */
+  public function delete($userId, $sessionId, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'sessionId' => $sessionId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Lists sessions previously created. (sessions.listUsersSessions)
+   *
+   * @param string $userId List sessions for the person identified. Use me to
+   * indicate the authenticated user. Only me is supported at this time.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large result sets. To get the next page of results, set this
+   * parameter to the value of nextPageToken from the previous response.
+   * @opt_param string endTime An RFC3339 timestamp. Only sessions ending between
+   * the start and end times will be included in the response.
+   * @opt_param bool includeDeleted If true, deleted sessions will be returned.
+   * When set to true, sessions returned in this response will only have an ID and
+   * will not have any other fields.
+   * @opt_param string startTime An RFC3339 timestamp. Only sessions ending
+   * between the start and end times will be included in the response.
+   * @return Google_Service_Fitness_ListSessionsResponse
+   */
+  public function listUsersSessions($userId, $optParams = array())
+  {
+    $params = array('userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Fitness_ListSessionsResponse");
+  }
+
+  /**
+   * Updates or insert a given session. (sessions.update)
+   *
+   * @param string $userId Create sessions for the person identified. Use me to
+   * indicate the authenticated user. Only me is supported at this time.
+   * @param string $sessionId The ID of the session to be created.
+   * @param Google_Session $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string currentTimeMillis The client's current time in milliseconds
+   * since epoch.
+   * @return Google_Service_Fitness_Session
+   */
+  public function update($userId, $sessionId, Google_Service_Fitness_Session $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'sessionId' => $sessionId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Fitness_Session");
+  }
+}
+
+
+
+
+class Google_Service_Fitness_AggregateBucket extends Google_Collection
+{
+  protected $collection_key = 'dataset';
+  protected $internal_gapi_mappings = array(
+  );
+  public $activity;
+  protected $datasetType = 'Google_Service_Fitness_Dataset';
+  protected $datasetDataType = 'array';
+  public $endTimeMillis;
+  protected $sessionType = 'Google_Service_Fitness_Session';
+  protected $sessionDataType = '';
+  public $startTimeMillis;
+  public $type;
+
+
+  public function setActivity($activity)
+  {
+    $this->activity = $activity;
+  }
+  public function getActivity()
+  {
+    return $this->activity;
+  }
+  public function setDataset($dataset)
+  {
+    $this->dataset = $dataset;
+  }
+  public function getDataset()
+  {
+    return $this->dataset;
+  }
+  public function setEndTimeMillis($endTimeMillis)
+  {
+    $this->endTimeMillis = $endTimeMillis;
+  }
+  public function getEndTimeMillis()
+  {
+    return $this->endTimeMillis;
+  }
+  public function setSession(Google_Service_Fitness_Session $session)
+  {
+    $this->session = $session;
+  }
+  public function getSession()
+  {
+    return $this->session;
+  }
+  public function setStartTimeMillis($startTimeMillis)
+  {
+    $this->startTimeMillis = $startTimeMillis;
+  }
+  public function getStartTimeMillis()
+  {
+    return $this->startTimeMillis;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Fitness_AggregateBy extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $dataSourceId;
+  public $dataTypeName;
+
+
+  public function setDataSourceId($dataSourceId)
+  {
+    $this->dataSourceId = $dataSourceId;
+  }
+  public function getDataSourceId()
+  {
+    return $this->dataSourceId;
+  }
+  public function setDataTypeName($dataTypeName)
+  {
+    $this->dataTypeName = $dataTypeName;
+  }
+  public function getDataTypeName()
+  {
+    return $this->dataTypeName;
+  }
+}
+
+class Google_Service_Fitness_AggregateRequest extends Google_Collection
+{
+  protected $collection_key = 'aggregateBy';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $aggregateByType = 'Google_Service_Fitness_AggregateBy';
+  protected $aggregateByDataType = 'array';
+  protected $bucketByActivitySegmentType = 'Google_Service_Fitness_BucketByActivity';
+  protected $bucketByActivitySegmentDataType = '';
+  protected $bucketByActivityTypeType = 'Google_Service_Fitness_BucketByActivity';
+  protected $bucketByActivityTypeDataType = '';
+  protected $bucketBySessionType = 'Google_Service_Fitness_BucketBySession';
+  protected $bucketBySessionDataType = '';
+  protected $bucketByTimeType = 'Google_Service_Fitness_BucketByTime';
+  protected $bucketByTimeDataType = '';
+  public $endTimeMillis;
+  public $startTimeMillis;
+
+
+  public function setAggregateBy($aggregateBy)
+  {
+    $this->aggregateBy = $aggregateBy;
+  }
+  public function getAggregateBy()
+  {
+    return $this->aggregateBy;
+  }
+  public function setBucketByActivitySegment(Google_Service_Fitness_BucketByActivity $bucketByActivitySegment)
+  {
+    $this->bucketByActivitySegment = $bucketByActivitySegment;
+  }
+  public function getBucketByActivitySegment()
+  {
+    return $this->bucketByActivitySegment;
+  }
+  public function setBucketByActivityType(Google_Service_Fitness_BucketByActivity $bucketByActivityType)
+  {
+    $this->bucketByActivityType = $bucketByActivityType;
+  }
+  public function getBucketByActivityType()
+  {
+    return $this->bucketByActivityType;
+  }
+  public function setBucketBySession(Google_Service_Fitness_BucketBySession $bucketBySession)
+  {
+    $this->bucketBySession = $bucketBySession;
+  }
+  public function getBucketBySession()
+  {
+    return $this->bucketBySession;
+  }
+  public function setBucketByTime(Google_Service_Fitness_BucketByTime $bucketByTime)
+  {
+    $this->bucketByTime = $bucketByTime;
+  }
+  public function getBucketByTime()
+  {
+    return $this->bucketByTime;
+  }
+  public function setEndTimeMillis($endTimeMillis)
+  {
+    $this->endTimeMillis = $endTimeMillis;
+  }
+  public function getEndTimeMillis()
+  {
+    return $this->endTimeMillis;
+  }
+  public function setStartTimeMillis($startTimeMillis)
+  {
+    $this->startTimeMillis = $startTimeMillis;
+  }
+  public function getStartTimeMillis()
+  {
+    return $this->startTimeMillis;
+  }
+}
+
+class Google_Service_Fitness_AggregateResponse extends Google_Collection
+{
+  protected $collection_key = 'bucket';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $bucketType = 'Google_Service_Fitness_AggregateBucket';
+  protected $bucketDataType = 'array';
+
+
+  public function setBucket($bucket)
+  {
+    $this->bucket = $bucket;
+  }
+  public function getBucket()
+  {
+    return $this->bucket;
+  }
+}
+
+class Google_Service_Fitness_Application extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $detailsUrl;
+  public $name;
+  public $packageName;
+  public $version;
+
+
+  public function setDetailsUrl($detailsUrl)
+  {
+    $this->detailsUrl = $detailsUrl;
+  }
+  public function getDetailsUrl()
+  {
+    return $this->detailsUrl;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPackageName($packageName)
+  {
+    $this->packageName = $packageName;
+  }
+  public function getPackageName()
+  {
+    return $this->packageName;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Fitness_BucketByActivity extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $activityDataSourceId;
+  public $minDurationMillis;
+
+
+  public function setActivityDataSourceId($activityDataSourceId)
+  {
+    $this->activityDataSourceId = $activityDataSourceId;
+  }
+  public function getActivityDataSourceId()
+  {
+    return $this->activityDataSourceId;
+  }
+  public function setMinDurationMillis($minDurationMillis)
+  {
+    $this->minDurationMillis = $minDurationMillis;
+  }
+  public function getMinDurationMillis()
+  {
+    return $this->minDurationMillis;
+  }
+}
+
+class Google_Service_Fitness_BucketBySession extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $minDurationMillis;
+
+
+  public function setMinDurationMillis($minDurationMillis)
+  {
+    $this->minDurationMillis = $minDurationMillis;
+  }
+  public function getMinDurationMillis()
+  {
+    return $this->minDurationMillis;
+  }
+}
+
+class Google_Service_Fitness_BucketByTime extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $durationMillis;
+
+
+  public function setDurationMillis($durationMillis)
+  {
+    $this->durationMillis = $durationMillis;
+  }
+  public function getDurationMillis()
+  {
+    return $this->durationMillis;
+  }
+}
+
+class Google_Service_Fitness_DataPoint extends Google_Collection
+{
+  protected $collection_key = 'value';
+  protected $internal_gapi_mappings = array(
+  );
+  public $computationTimeMillis;
+  public $dataTypeName;
+  public $endTimeNanos;
+  public $modifiedTimeMillis;
+  public $originDataSourceId;
+  public $rawTimestampNanos;
+  public $startTimeNanos;
+  protected $valueType = 'Google_Service_Fitness_Value';
+  protected $valueDataType = 'array';
+
+
+  public function setComputationTimeMillis($computationTimeMillis)
+  {
+    $this->computationTimeMillis = $computationTimeMillis;
+  }
+  public function getComputationTimeMillis()
+  {
+    return $this->computationTimeMillis;
+  }
+  public function setDataTypeName($dataTypeName)
+  {
+    $this->dataTypeName = $dataTypeName;
+  }
+  public function getDataTypeName()
+  {
+    return $this->dataTypeName;
+  }
+  public function setEndTimeNanos($endTimeNanos)
+  {
+    $this->endTimeNanos = $endTimeNanos;
+  }
+  public function getEndTimeNanos()
+  {
+    return $this->endTimeNanos;
+  }
+  public function setModifiedTimeMillis($modifiedTimeMillis)
+  {
+    $this->modifiedTimeMillis = $modifiedTimeMillis;
+  }
+  public function getModifiedTimeMillis()
+  {
+    return $this->modifiedTimeMillis;
+  }
+  public function setOriginDataSourceId($originDataSourceId)
+  {
+    $this->originDataSourceId = $originDataSourceId;
+  }
+  public function getOriginDataSourceId()
+  {
+    return $this->originDataSourceId;
+  }
+  public function setRawTimestampNanos($rawTimestampNanos)
+  {
+    $this->rawTimestampNanos = $rawTimestampNanos;
+  }
+  public function getRawTimestampNanos()
+  {
+    return $this->rawTimestampNanos;
+  }
+  public function setStartTimeNanos($startTimeNanos)
+  {
+    $this->startTimeNanos = $startTimeNanos;
+  }
+  public function getStartTimeNanos()
+  {
+    return $this->startTimeNanos;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Fitness_DataSource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $applicationType = 'Google_Service_Fitness_Application';
+  protected $applicationDataType = '';
+  public $dataStreamId;
+  public $dataStreamName;
+  protected $dataTypeType = 'Google_Service_Fitness_DataType';
+  protected $dataTypeDataType = '';
+  protected $deviceType = 'Google_Service_Fitness_Device';
+  protected $deviceDataType = '';
+  public $name;
+  public $type;
+
+
+  public function setApplication(Google_Service_Fitness_Application $application)
+  {
+    $this->application = $application;
+  }
+  public function getApplication()
+  {
+    return $this->application;
+  }
+  public function setDataStreamId($dataStreamId)
+  {
+    $this->dataStreamId = $dataStreamId;
+  }
+  public function getDataStreamId()
+  {
+    return $this->dataStreamId;
+  }
+  public function setDataStreamName($dataStreamName)
+  {
+    $this->dataStreamName = $dataStreamName;
+  }
+  public function getDataStreamName()
+  {
+    return $this->dataStreamName;
+  }
+  public function setDataType(Google_Service_Fitness_DataType $dataType)
+  {
+    $this->dataType = $dataType;
+  }
+  public function getDataType()
+  {
+    return $this->dataType;
+  }
+  public function setDevice(Google_Service_Fitness_Device $device)
+  {
+    $this->device = $device;
+  }
+  public function getDevice()
+  {
+    return $this->device;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Fitness_DataType extends Google_Collection
+{
+  protected $collection_key = 'field';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $fieldType = 'Google_Service_Fitness_DataTypeField';
+  protected $fieldDataType = 'array';
+  public $name;
+
+
+  public function setField($field)
+  {
+    $this->field = $field;
+  }
+  public function getField()
+  {
+    return $this->field;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Fitness_DataTypeField extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $format;
+  public $name;
+  public $optional;
+
+
+  public function setFormat($format)
+  {
+    $this->format = $format;
+  }
+  public function getFormat()
+  {
+    return $this->format;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOptional($optional)
+  {
+    $this->optional = $optional;
+  }
+  public function getOptional()
+  {
+    return $this->optional;
+  }
+}
+
+class Google_Service_Fitness_Dataset extends Google_Collection
+{
+  protected $collection_key = 'point';
+  protected $internal_gapi_mappings = array(
+  );
+  public $dataSourceId;
+  public $maxEndTimeNs;
+  public $minStartTimeNs;
+  public $nextPageToken;
+  protected $pointType = 'Google_Service_Fitness_DataPoint';
+  protected $pointDataType = 'array';
+
+
+  public function setDataSourceId($dataSourceId)
+  {
+    $this->dataSourceId = $dataSourceId;
+  }
+  public function getDataSourceId()
+  {
+    return $this->dataSourceId;
+  }
+  public function setMaxEndTimeNs($maxEndTimeNs)
+  {
+    $this->maxEndTimeNs = $maxEndTimeNs;
+  }
+  public function getMaxEndTimeNs()
+  {
+    return $this->maxEndTimeNs;
+  }
+  public function setMinStartTimeNs($minStartTimeNs)
+  {
+    $this->minStartTimeNs = $minStartTimeNs;
+  }
+  public function getMinStartTimeNs()
+  {
+    return $this->minStartTimeNs;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPoint($point)
+  {
+    $this->point = $point;
+  }
+  public function getPoint()
+  {
+    return $this->point;
+  }
+}
+
+class Google_Service_Fitness_Device extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $manufacturer;
+  public $model;
+  public $type;
+  public $uid;
+  public $version;
+
+
+  public function setManufacturer($manufacturer)
+  {
+    $this->manufacturer = $manufacturer;
+  }
+  public function getManufacturer()
+  {
+    return $this->manufacturer;
+  }
+  public function setModel($model)
+  {
+    $this->model = $model;
+  }
+  public function getModel()
+  {
+    return $this->model;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUid($uid)
+  {
+    $this->uid = $uid;
+  }
+  public function getUid()
+  {
+    return $this->uid;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Fitness_ListDataSourcesResponse extends Google_Collection
+{
+  protected $collection_key = 'dataSource';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $dataSourceType = 'Google_Service_Fitness_DataSource';
+  protected $dataSourceDataType = 'array';
+
+
+  public function setDataSource($dataSource)
+  {
+    $this->dataSource = $dataSource;
+  }
+  public function getDataSource()
+  {
+    return $this->dataSource;
+  }
+}
+
+class Google_Service_Fitness_ListSessionsResponse extends Google_Collection
+{
+  protected $collection_key = 'session';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $deletedSessionType = 'Google_Service_Fitness_Session';
+  protected $deletedSessionDataType = 'array';
+  public $nextPageToken;
+  protected $sessionType = 'Google_Service_Fitness_Session';
+  protected $sessionDataType = 'array';
+
+
+  public function setDeletedSession($deletedSession)
+  {
+    $this->deletedSession = $deletedSession;
+  }
+  public function getDeletedSession()
+  {
+    return $this->deletedSession;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSession($session)
+  {
+    $this->session = $session;
+  }
+  public function getSession()
+  {
+    return $this->session;
+  }
+}
+
+class Google_Service_Fitness_MapValue extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $fpVal;
+
+
+  public function setFpVal($fpVal)
+  {
+    $this->fpVal = $fpVal;
+  }
+  public function getFpVal()
+  {
+    return $this->fpVal;
+  }
+}
+
+class Google_Service_Fitness_Session extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $activeTimeMillis;
+  public $activityType;
+  protected $applicationType = 'Google_Service_Fitness_Application';
+  protected $applicationDataType = '';
+  public $description;
+  public $endTimeMillis;
+  public $id;
+  public $modifiedTimeMillis;
+  public $name;
+  public $startTimeMillis;
+
+
+  public function setActiveTimeMillis($activeTimeMillis)
+  {
+    $this->activeTimeMillis = $activeTimeMillis;
+  }
+  public function getActiveTimeMillis()
+  {
+    return $this->activeTimeMillis;
+  }
+  public function setActivityType($activityType)
+  {
+    $this->activityType = $activityType;
+  }
+  public function getActivityType()
+  {
+    return $this->activityType;
+  }
+  public function setApplication(Google_Service_Fitness_Application $application)
+  {
+    $this->application = $application;
+  }
+  public function getApplication()
+  {
+    return $this->application;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEndTimeMillis($endTimeMillis)
+  {
+    $this->endTimeMillis = $endTimeMillis;
+  }
+  public function getEndTimeMillis()
+  {
+    return $this->endTimeMillis;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setModifiedTimeMillis($modifiedTimeMillis)
+  {
+    $this->modifiedTimeMillis = $modifiedTimeMillis;
+  }
+  public function getModifiedTimeMillis()
+  {
+    return $this->modifiedTimeMillis;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setStartTimeMillis($startTimeMillis)
+  {
+    $this->startTimeMillis = $startTimeMillis;
+  }
+  public function getStartTimeMillis()
+  {
+    return $this->startTimeMillis;
+  }
+}
+
+class Google_Service_Fitness_Value extends Google_Collection
+{
+  protected $collection_key = 'mapVal';
+  protected $internal_gapi_mappings = array(
+  );
+  public $fpVal;
+  public $intVal;
+  protected $mapValType = 'Google_Service_Fitness_ValueMapValEntry';
+  protected $mapValDataType = 'array';
+  public $stringVal;
+
+
+  public function setFpVal($fpVal)
+  {
+    $this->fpVal = $fpVal;
+  }
+  public function getFpVal()
+  {
+    return $this->fpVal;
+  }
+  public function setIntVal($intVal)
+  {
+    $this->intVal = $intVal;
+  }
+  public function getIntVal()
+  {
+    return $this->intVal;
+  }
+  public function setMapVal($mapVal)
+  {
+    $this->mapVal = $mapVal;
+  }
+  public function getMapVal()
+  {
+    return $this->mapVal;
+  }
+  public function setStringVal($stringVal)
+  {
+    $this->stringVal = $stringVal;
+  }
+  public function getStringVal()
+  {
+    return $this->stringVal;
+  }
+}
+
+class Google_Service_Fitness_ValueMapValEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  protected $valueType = 'Google_Service_Fitness_MapValue';
+  protected $valueDataType = '';
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue(Google_Service_Fitness_MapValue $value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Freebase.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Freebase.php
@@ -1,0 +1,453 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Freebase (v1).
+ *
+ * <p>
+ * Find Freebase entities using textual queries and other constraints.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/freebase/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Freebase extends Google_Service
+{
+
+
+
+  private $base_methods;
+
+  /**
+   * Constructs the internal representation of the Freebase service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'freebase/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'freebase';
+
+    $this->base_methods = new Google_Service_Resource(
+        $this,
+        $this->serviceName,
+        '',
+        array(
+          'methods' => array(
+            'reconcile' => array(
+              'path' => 'reconcile',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'lang' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'confidence' => array(
+                  'location' => 'query',
+                  'type' => 'number',
+                ),
+                'name' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'kind' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'prop' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'limit' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'search' => array(
+              'path' => 'search',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'domain' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'help' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'query' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'scoring' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'cursor' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'prefixed' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'exact' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'mid' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'encode' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'type' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'as_of_time' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'stemmed' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'format' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'spell' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'with' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'lang' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'indent' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'callback' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'without' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'limit' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'output' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'mql_output' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+  /**
+   * Reconcile entities to Freebase open data. (reconcile)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string lang Languages for names and values. First language is used
+   * for display. Default is 'en'.
+   * @opt_param float confidence Required confidence for a candidate to match.
+   * Must be between .5 and 1.0
+   * @opt_param string name Name of entity.
+   * @opt_param string kind Classifications of entity e.g. type, category, title.
+   * @opt_param string prop Property values for entity formatted as :
+   * @opt_param int limit Maximum number of candidates to return.
+   * @return Google_Service_Freebase_ReconcileGet
+   */
+  public function reconcile($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->base_methods->call('reconcile', array($params), "Google_Service_Freebase_ReconcileGet");
+  }
+  /**
+   * Search Freebase open data. (search)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string domain Restrict to topics with this Freebase domain id.
+   * @opt_param string help The keyword to request help on.
+   * @opt_param string query Query term to search for.
+   * @opt_param string scoring Relevance scoring algorithm to use.
+   * @opt_param int cursor The cursor value to use for the next page of results.
+   * @opt_param bool prefixed Prefix match against names and aliases.
+   * @opt_param bool exact Query on exact name and keys only.
+   * @opt_param string mid A mid to use instead of a query.
+   * @opt_param string encode The encoding of the response. You can use this
+   * parameter to enable html encoding.
+   * @opt_param string type Restrict to topics with this Freebase type id.
+   * @opt_param string as_of_time A mql as_of_time value to use with mql_output
+   * queries.
+   * @opt_param bool stemmed Query on stemmed names and aliases. May not be used
+   * with prefixed.
+   * @opt_param string format Structural format of the json response.
+   * @opt_param string spell Request 'did you mean' suggestions
+   * @opt_param string with A rule to match against.
+   * @opt_param string lang The code of the language to run the query with.
+   * Default is 'en'.
+   * @opt_param bool indent Whether to indent the json results or not.
+   * @opt_param string filter A filter to apply to the query.
+   * @opt_param string callback JS method name for JSONP callbacks.
+   * @opt_param string without A rule to not match against.
+   * @opt_param int limit Maximum number of results to return.
+   * @opt_param string output An output expression to request data from matches.
+   * @opt_param string mql_output The MQL query to run againist the results to
+   * extract more data.
+   */
+  public function search($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->base_methods->call('search', array($params));
+  }
+}
+
+
+
+
+
+class Google_Service_Freebase_ReconcileCandidate extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $confidence;
+  public $lang;
+  public $mid;
+  public $name;
+  protected $notableType = 'Google_Service_Freebase_ReconcileCandidateNotable';
+  protected $notableDataType = '';
+
+
+  public function setConfidence($confidence)
+  {
+    $this->confidence = $confidence;
+  }
+  public function getConfidence()
+  {
+    return $this->confidence;
+  }
+  public function setLang($lang)
+  {
+    $this->lang = $lang;
+  }
+  public function getLang()
+  {
+    return $this->lang;
+  }
+  public function setMid($mid)
+  {
+    $this->mid = $mid;
+  }
+  public function getMid()
+  {
+    return $this->mid;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNotable(Google_Service_Freebase_ReconcileCandidateNotable $notable)
+  {
+    $this->notable = $notable;
+  }
+  public function getNotable()
+  {
+    return $this->notable;
+  }
+}
+
+class Google_Service_Freebase_ReconcileCandidateNotable extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $name;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Freebase_ReconcileGet extends Google_Collection
+{
+  protected $collection_key = 'warning';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $candidateType = 'Google_Service_Freebase_ReconcileCandidate';
+  protected $candidateDataType = 'array';
+  protected $costsType = 'Google_Service_Freebase_ReconcileGetCosts';
+  protected $costsDataType = '';
+  protected $matchType = 'Google_Service_Freebase_ReconcileCandidate';
+  protected $matchDataType = '';
+  protected $warningType = 'Google_Service_Freebase_ReconcileGetWarning';
+  protected $warningDataType = 'array';
+
+
+  public function setCandidate($candidate)
+  {
+    $this->candidate = $candidate;
+  }
+  public function getCandidate()
+  {
+    return $this->candidate;
+  }
+  public function setCosts(Google_Service_Freebase_ReconcileGetCosts $costs)
+  {
+    $this->costs = $costs;
+  }
+  public function getCosts()
+  {
+    return $this->costs;
+  }
+  public function setMatch(Google_Service_Freebase_ReconcileCandidate $match)
+  {
+    $this->match = $match;
+  }
+  public function getMatch()
+  {
+    return $this->match;
+  }
+  public function setWarning($warning)
+  {
+    $this->warning = $warning;
+  }
+  public function getWarning()
+  {
+    return $this->warning;
+  }
+}
+
+class Google_Service_Freebase_ReconcileGetCosts extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $hits;
+  public $ms;
+
+
+  public function setHits($hits)
+  {
+    $this->hits = $hits;
+  }
+  public function getHits()
+  {
+    return $this->hits;
+  }
+  public function setMs($ms)
+  {
+    $this->ms = $ms;
+  }
+  public function getMs()
+  {
+    return $this->ms;
+  }
+}
+
+class Google_Service_Freebase_ReconcileGetWarning extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $location;
+  public $message;
+  public $reason;
+
+
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Fusiontables.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Fusiontables.php
@@ -1,0 +1,2485 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Fusiontables (v2).
+ *
+ * <p>
+ * API for working with Fusion Tables data.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/fusiontables" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Fusiontables extends Google_Service
+{
+  /** Manage your Fusion Tables. */
+  const FUSIONTABLES =
+      "https://www.googleapis.com/auth/fusiontables";
+  /** View your Fusion Tables. */
+  const FUSIONTABLES_READONLY =
+      "https://www.googleapis.com/auth/fusiontables.readonly";
+
+  public $column;
+  public $query;
+  public $style;
+  public $table;
+  public $task;
+  public $template;
+  
+
+  /**
+   * Constructs the internal representation of the Fusiontables service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'fusiontables/v2/';
+    $this->version = 'v2';
+    $this->serviceName = 'fusiontables';
+
+    $this->column = new Google_Service_Fusiontables_Column_Resource(
+        $this,
+        $this->serviceName,
+        'column',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'tables/{tableId}/columns/{columnId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'columnId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'tables/{tableId}/columns/{columnId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'columnId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'tables/{tableId}/columns',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'tables/{tableId}/columns',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'tables/{tableId}/columns/{columnId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'columnId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'tables/{tableId}/columns/{columnId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'columnId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->query = new Google_Service_Fusiontables_Query_Resource(
+        $this,
+        $this->serviceName,
+        'query',
+        array(
+          'methods' => array(
+            'sql' => array(
+              'path' => 'query',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'sql' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'typed' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'hdrs' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'sqlGet' => array(
+              'path' => 'query',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'sql' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'typed' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'hdrs' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->style = new Google_Service_Fusiontables_Style_Resource(
+        $this,
+        $this->serviceName,
+        'style',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'tables/{tableId}/styles/{styleId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'styleId' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'tables/{tableId}/styles/{styleId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'styleId' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'tables/{tableId}/styles',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'tables/{tableId}/styles',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'tables/{tableId}/styles/{styleId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'styleId' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'tables/{tableId}/styles/{styleId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'styleId' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->table = new Google_Service_Fusiontables_Table_Resource(
+        $this,
+        $this->serviceName,
+        'table',
+        array(
+          'methods' => array(
+            'copy' => array(
+              'path' => 'tables/{tableId}/copy',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'copyPresentation' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'tables/{tableId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'tables/{tableId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'importRows' => array(
+              'path' => 'tables/{tableId}/import',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'startLine' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'isStrict' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'encoding' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'delimiter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'endLine' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'importTable' => array(
+              'path' => 'tables/import',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'name' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'delimiter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'encoding' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'tables',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'list' => array(
+              'path' => 'tables',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'tables/{tableId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'replaceViewDefinition' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'replaceRows' => array(
+              'path' => 'tables/{tableId}/replace',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'startLine' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'isStrict' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'encoding' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'delimiter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'endLine' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'tables/{tableId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'replaceViewDefinition' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->task = new Google_Service_Fusiontables_Task_Resource(
+        $this,
+        $this->serviceName,
+        'task',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'tables/{tableId}/tasks/{taskId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'taskId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'tables/{tableId}/tasks/{taskId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'taskId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'tables/{tableId}/tasks',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startIndex' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->template = new Google_Service_Fusiontables_Template_Resource(
+        $this,
+        $this->serviceName,
+        'template',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'tables/{tableId}/templates/{templateId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'templateId' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'tables/{tableId}/templates/{templateId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'templateId' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'tables/{tableId}/templates',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'tables/{tableId}/templates',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'tables/{tableId}/templates/{templateId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'templateId' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'tables/{tableId}/templates/{templateId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'templateId' => array(
+                  'location' => 'path',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "column" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $fusiontablesService = new Google_Service_Fusiontables(...);
+ *   $column = $fusiontablesService->column;
+ *  </code>
+ */
+class Google_Service_Fusiontables_Column_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the specified column. (column.delete)
+   *
+   * @param string $tableId Table from which the column is being deleted.
+   * @param string $columnId Name or identifier for the column being deleted.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($tableId, $columnId, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'columnId' => $columnId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves a specific column by its ID. (column.get)
+   *
+   * @param string $tableId Table to which the column belongs.
+   * @param string $columnId Name or identifier for the column that is being
+   * requested.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fusiontables_Column
+   */
+  public function get($tableId, $columnId, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'columnId' => $columnId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Fusiontables_Column");
+  }
+
+  /**
+   * Adds a new column to the table. (column.insert)
+   *
+   * @param string $tableId Table for which a new column is being added.
+   * @param Google_Column $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fusiontables_Column
+   */
+  public function insert($tableId, Google_Service_Fusiontables_Column $postBody, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Fusiontables_Column");
+  }
+
+  /**
+   * Retrieves a list of columns. (column.listColumn)
+   *
+   * @param string $tableId Table whose columns are being listed.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Continuation token specifying which result page
+   * to return.
+   * @opt_param string maxResults Maximum number of columns to return. Default is
+   * 5.
+   * @return Google_Service_Fusiontables_ColumnList
+   */
+  public function listColumn($tableId, $optParams = array())
+  {
+    $params = array('tableId' => $tableId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Fusiontables_ColumnList");
+  }
+
+  /**
+   * Updates the name or type of an existing column. This method supports patch
+   * semantics. (column.patch)
+   *
+   * @param string $tableId Table for which the column is being updated.
+   * @param string $columnId Name or identifier for the column that is being
+   * updated.
+   * @param Google_Column $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fusiontables_Column
+   */
+  public function patch($tableId, $columnId, Google_Service_Fusiontables_Column $postBody, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'columnId' => $columnId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Fusiontables_Column");
+  }
+
+  /**
+   * Updates the name or type of an existing column. (column.update)
+   *
+   * @param string $tableId Table for which the column is being updated.
+   * @param string $columnId Name or identifier for the column that is being
+   * updated.
+   * @param Google_Column $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fusiontables_Column
+   */
+  public function update($tableId, $columnId, Google_Service_Fusiontables_Column $postBody, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'columnId' => $columnId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Fusiontables_Column");
+  }
+}
+
+/**
+ * The "query" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $fusiontablesService = new Google_Service_Fusiontables(...);
+ *   $query = $fusiontablesService->query;
+ *  </code>
+ */
+class Google_Service_Fusiontables_Query_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Executes a Fusion Tables SQL statement, which can be any of - SELECT - INSERT
+   * - UPDATE - DELETE - SHOW - DESCRIBE - CREATE statement. (query.sql)
+   *
+   * @param string $sql A Fusion Tables SQL statement, which can be any of -
+   * SELECT - INSERT - UPDATE - DELETE - SHOW - DESCRIBE - CREATE
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool typed Whether typed values are returned in the (JSON)
+   * response: numbers for numeric values and parsed geometries for KML values.
+   * Default is true.
+   * @opt_param bool hdrs Whether column names are included in the first row.
+   * Default is true.
+   * @return Google_Service_Fusiontables_Sqlresponse
+   */
+  public function sql($sql, $optParams = array())
+  {
+    $params = array('sql' => $sql);
+    $params = array_merge($params, $optParams);
+    return $this->call('sql', array($params), "Google_Service_Fusiontables_Sqlresponse");
+  }
+
+  /**
+   * Executes a SQL statement which can be any of - SELECT - SHOW - DESCRIBE
+   * (query.sqlGet)
+   *
+   * @param string $sql A SQL statement which can be any of - SELECT - SHOW -
+   * DESCRIBE
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool typed Whether typed values are returned in the (JSON)
+   * response: numbers for numeric values and parsed geometries for KML values.
+   * Default is true.
+   * @opt_param bool hdrs Whether column names are included (in the first row).
+   * Default is true.
+   * @return Google_Service_Fusiontables_Sqlresponse
+   */
+  public function sqlGet($sql, $optParams = array())
+  {
+    $params = array('sql' => $sql);
+    $params = array_merge($params, $optParams);
+    return $this->call('sqlGet', array($params), "Google_Service_Fusiontables_Sqlresponse");
+  }
+}
+
+/**
+ * The "style" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $fusiontablesService = new Google_Service_Fusiontables(...);
+ *   $style = $fusiontablesService->style;
+ *  </code>
+ */
+class Google_Service_Fusiontables_Style_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a style. (style.delete)
+   *
+   * @param string $tableId Table from which the style is being deleted
+   * @param int $styleId Identifier (within a table) for the style being deleted
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($tableId, $styleId, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'styleId' => $styleId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets a specific style. (style.get)
+   *
+   * @param string $tableId Table to which the requested style belongs
+   * @param int $styleId Identifier (integer) for a specific style in a table
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fusiontables_StyleSetting
+   */
+  public function get($tableId, $styleId, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'styleId' => $styleId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Fusiontables_StyleSetting");
+  }
+
+  /**
+   * Adds a new style for the table. (style.insert)
+   *
+   * @param string $tableId Table for which a new style is being added
+   * @param Google_StyleSetting $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fusiontables_StyleSetting
+   */
+  public function insert($tableId, Google_Service_Fusiontables_StyleSetting $postBody, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Fusiontables_StyleSetting");
+  }
+
+  /**
+   * Retrieves a list of styles. (style.listStyle)
+   *
+   * @param string $tableId Table whose styles are being listed
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Continuation token specifying which result page
+   * to return. Optional.
+   * @opt_param string maxResults Maximum number of styles to return. Optional.
+   * Default is 5.
+   * @return Google_Service_Fusiontables_StyleSettingList
+   */
+  public function listStyle($tableId, $optParams = array())
+  {
+    $params = array('tableId' => $tableId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Fusiontables_StyleSettingList");
+  }
+
+  /**
+   * Updates an existing style. This method supports patch semantics.
+   * (style.patch)
+   *
+   * @param string $tableId Table whose style is being updated.
+   * @param int $styleId Identifier (within a table) for the style being updated.
+   * @param Google_StyleSetting $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fusiontables_StyleSetting
+   */
+  public function patch($tableId, $styleId, Google_Service_Fusiontables_StyleSetting $postBody, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'styleId' => $styleId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Fusiontables_StyleSetting");
+  }
+
+  /**
+   * Updates an existing style. (style.update)
+   *
+   * @param string $tableId Table whose style is being updated.
+   * @param int $styleId Identifier (within a table) for the style being updated.
+   * @param Google_StyleSetting $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fusiontables_StyleSetting
+   */
+  public function update($tableId, $styleId, Google_Service_Fusiontables_StyleSetting $postBody, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'styleId' => $styleId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Fusiontables_StyleSetting");
+  }
+}
+
+/**
+ * The "table" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $fusiontablesService = new Google_Service_Fusiontables(...);
+ *   $table = $fusiontablesService->table;
+ *  </code>
+ */
+class Google_Service_Fusiontables_Table_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Copies a table. (table.copy)
+   *
+   * @param string $tableId ID of the table that is being copied.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool copyPresentation Whether to also copy tabs, styles, and
+   * templates. Default is false.
+   * @return Google_Service_Fusiontables_Table
+   */
+  public function copy($tableId, $optParams = array())
+  {
+    $params = array('tableId' => $tableId);
+    $params = array_merge($params, $optParams);
+    return $this->call('copy', array($params), "Google_Service_Fusiontables_Table");
+  }
+
+  /**
+   * Deletes a table. (table.delete)
+   *
+   * @param string $tableId ID of the table to be deleted.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($tableId, $optParams = array())
+  {
+    $params = array('tableId' => $tableId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves a specific table by its ID. (table.get)
+   *
+   * @param string $tableId Identifier for the table being requested.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fusiontables_Table
+   */
+  public function get($tableId, $optParams = array())
+  {
+    $params = array('tableId' => $tableId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Fusiontables_Table");
+  }
+
+  /**
+   * Imports more rows into a table. (table.importRows)
+   *
+   * @param string $tableId The table into which new rows are being imported.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int startLine The index of the first line from which to start
+   * importing, inclusive. Default is 0.
+   * @opt_param bool isStrict Whether the imported CSV must have the same number
+   * of values for each row. If false, rows with fewer values will be padded with
+   * empty values. Default is true.
+   * @opt_param string encoding The encoding of the content. Default is UTF-8. Use
+   * auto-detect if you are unsure of the encoding.
+   * @opt_param string delimiter The delimiter used to separate cell values. This
+   * can only consist of a single character. Default is ,.
+   * @opt_param int endLine The index of the line up to which data will be
+   * imported. Default is to import the entire file. If endLine is negative, it is
+   * an offset from the end of the file; the imported content will exclude the
+   * last endLine lines.
+   * @return Google_Service_Fusiontables_Import
+   */
+  public function importRows($tableId, $optParams = array())
+  {
+    $params = array('tableId' => $tableId);
+    $params = array_merge($params, $optParams);
+    return $this->call('importRows', array($params), "Google_Service_Fusiontables_Import");
+  }
+
+  /**
+   * Imports a new table. (table.importTable)
+   *
+   * @param string $name The name to be assigned to the new table.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string delimiter The delimiter used to separate cell values. This
+   * can only consist of a single character. Default is ,.
+   * @opt_param string encoding The encoding of the content. Default is UTF-8. Use
+   * auto-detect if you are unsure of the encoding.
+   * @return Google_Service_Fusiontables_Table
+   */
+  public function importTable($name, $optParams = array())
+  {
+    $params = array('name' => $name);
+    $params = array_merge($params, $optParams);
+    return $this->call('importTable', array($params), "Google_Service_Fusiontables_Table");
+  }
+
+  /**
+   * Creates a new table. (table.insert)
+   *
+   * @param Google_Table $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fusiontables_Table
+   */
+  public function insert(Google_Service_Fusiontables_Table $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Fusiontables_Table");
+  }
+
+  /**
+   * Retrieves a list of tables a user owns. (table.listTable)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Continuation token specifying which result page
+   * to return.
+   * @opt_param string maxResults Maximum number of tables to return. Default is
+   * 5.
+   * @return Google_Service_Fusiontables_TableList
+   */
+  public function listTable($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Fusiontables_TableList");
+  }
+
+  /**
+   * Updates an existing table. Unless explicitly requested, only the name,
+   * description, and attribution will be updated. This method supports patch
+   * semantics. (table.patch)
+   *
+   * @param string $tableId ID of the table that is being updated.
+   * @param Google_Table $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool replaceViewDefinition Whether the view definition is also
+   * updated. The specified view definition replaces the existing one. Only a view
+   * can be updated with a new definition.
+   * @return Google_Service_Fusiontables_Table
+   */
+  public function patch($tableId, Google_Service_Fusiontables_Table $postBody, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Fusiontables_Table");
+  }
+
+  /**
+   * Replaces rows of an existing table. Current rows remain visible until all
+   * replacement rows are ready. (table.replaceRows)
+   *
+   * @param string $tableId Table whose rows will be replaced.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int startLine The index of the first line from which to start
+   * importing, inclusive. Default is 0.
+   * @opt_param bool isStrict Whether the imported CSV must have the same number
+   * of column values for each row. If true, throws an exception if the CSV does
+   * not have the same number of columns. If false, rows with fewer column values
+   * will be padded with empty values. Default is true.
+   * @opt_param string encoding The encoding of the content. Default is UTF-8. Use
+   * 'auto-detect' if you are unsure of the encoding.
+   * @opt_param string delimiter The delimiter used to separate cell values. This
+   * can only consist of a single character. Default is ,.
+   * @opt_param int endLine The index of the line up to which data will be
+   * imported. Default is to import the entire file. If endLine is negative, it is
+   * an offset from the end of the file; the imported content will exclude the
+   * last endLine lines.
+   * @return Google_Service_Fusiontables_Task
+   */
+  public function replaceRows($tableId, $optParams = array())
+  {
+    $params = array('tableId' => $tableId);
+    $params = array_merge($params, $optParams);
+    return $this->call('replaceRows', array($params), "Google_Service_Fusiontables_Task");
+  }
+
+  /**
+   * Updates an existing table. Unless explicitly requested, only the name,
+   * description, and attribution will be updated. (table.update)
+   *
+   * @param string $tableId ID of the table that is being updated.
+   * @param Google_Table $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool replaceViewDefinition Whether the view definition is also
+   * updated. The specified view definition replaces the existing one. Only a view
+   * can be updated with a new definition.
+   * @return Google_Service_Fusiontables_Table
+   */
+  public function update($tableId, Google_Service_Fusiontables_Table $postBody, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Fusiontables_Table");
+  }
+}
+
+/**
+ * The "task" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $fusiontablesService = new Google_Service_Fusiontables(...);
+ *   $task = $fusiontablesService->task;
+ *  </code>
+ */
+class Google_Service_Fusiontables_Task_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a specific task by its ID, unless that task has already started
+   * running. (task.delete)
+   *
+   * @param string $tableId Table from which the task is being deleted.
+   * @param string $taskId The identifier of the task to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($tableId, $taskId, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'taskId' => $taskId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves a specific task by its ID. (task.get)
+   *
+   * @param string $tableId Table to which the task belongs.
+   * @param string $taskId The identifier of the task to get.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fusiontables_Task
+   */
+  public function get($tableId, $taskId, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'taskId' => $taskId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Fusiontables_Task");
+  }
+
+  /**
+   * Retrieves a list of tasks. (task.listTask)
+   *
+   * @param string $tableId Table whose tasks are being listed.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Continuation token specifying which result page
+   * to return.
+   * @opt_param string startIndex Index of the first result returned in the
+   * current page.
+   * @opt_param string maxResults Maximum number of tasks to return. Default is 5.
+   * @return Google_Service_Fusiontables_TaskList
+   */
+  public function listTask($tableId, $optParams = array())
+  {
+    $params = array('tableId' => $tableId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Fusiontables_TaskList");
+  }
+}
+
+/**
+ * The "template" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $fusiontablesService = new Google_Service_Fusiontables(...);
+ *   $template = $fusiontablesService->template;
+ *  </code>
+ */
+class Google_Service_Fusiontables_Template_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a template (template.delete)
+   *
+   * @param string $tableId Table from which the template is being deleted
+   * @param int $templateId Identifier for the template which is being deleted
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($tableId, $templateId, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'templateId' => $templateId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves a specific template by its id (template.get)
+   *
+   * @param string $tableId Table to which the template belongs
+   * @param int $templateId Identifier for the template that is being requested
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fusiontables_Template
+   */
+  public function get($tableId, $templateId, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'templateId' => $templateId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Fusiontables_Template");
+  }
+
+  /**
+   * Creates a new template for the table. (template.insert)
+   *
+   * @param string $tableId Table for which a new template is being created
+   * @param Google_Template $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fusiontables_Template
+   */
+  public function insert($tableId, Google_Service_Fusiontables_Template $postBody, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Fusiontables_Template");
+  }
+
+  /**
+   * Retrieves a list of templates. (template.listTemplate)
+   *
+   * @param string $tableId Identifier for the table whose templates are being
+   * requested
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Continuation token specifying which results page
+   * to return. Optional.
+   * @opt_param string maxResults Maximum number of templates to return. Optional.
+   * Default is 5.
+   * @return Google_Service_Fusiontables_TemplateList
+   */
+  public function listTemplate($tableId, $optParams = array())
+  {
+    $params = array('tableId' => $tableId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Fusiontables_TemplateList");
+  }
+
+  /**
+   * Updates an existing template. This method supports patch semantics.
+   * (template.patch)
+   *
+   * @param string $tableId Table to which the updated template belongs
+   * @param int $templateId Identifier for the template that is being updated
+   * @param Google_Template $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fusiontables_Template
+   */
+  public function patch($tableId, $templateId, Google_Service_Fusiontables_Template $postBody, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'templateId' => $templateId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Fusiontables_Template");
+  }
+
+  /**
+   * Updates an existing template (template.update)
+   *
+   * @param string $tableId Table to which the updated template belongs
+   * @param int $templateId Identifier for the template that is being updated
+   * @param Google_Template $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Fusiontables_Template
+   */
+  public function update($tableId, $templateId, Google_Service_Fusiontables_Template $postBody, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'templateId' => $templateId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Fusiontables_Template");
+  }
+}
+
+
+
+
+class Google_Service_Fusiontables_Bucket extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $color;
+  public $icon;
+  public $max;
+  public $min;
+  public $opacity;
+  public $weight;
+
+
+  public function setColor($color)
+  {
+    $this->color = $color;
+  }
+  public function getColor()
+  {
+    return $this->color;
+  }
+  public function setIcon($icon)
+  {
+    $this->icon = $icon;
+  }
+  public function getIcon()
+  {
+    return $this->icon;
+  }
+  public function setMax($max)
+  {
+    $this->max = $max;
+  }
+  public function getMax()
+  {
+    return $this->max;
+  }
+  public function setMin($min)
+  {
+    $this->min = $min;
+  }
+  public function getMin()
+  {
+    return $this->min;
+  }
+  public function setOpacity($opacity)
+  {
+    $this->opacity = $opacity;
+  }
+  public function getOpacity()
+  {
+    return $this->opacity;
+  }
+  public function setWeight($weight)
+  {
+    $this->weight = $weight;
+  }
+  public function getWeight()
+  {
+    return $this->weight;
+  }
+}
+
+class Google_Service_Fusiontables_Column extends Google_Collection
+{
+  protected $collection_key = 'validValues';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $baseColumnType = 'Google_Service_Fusiontables_ColumnBaseColumn';
+  protected $baseColumnDataType = '';
+  public $columnId;
+  public $columnJsonSchema;
+  public $columnPropertiesJson;
+  public $description;
+  public $formatPattern;
+  public $graphPredicate;
+  public $kind;
+  public $name;
+  public $type;
+  public $validValues;
+  public $validateData;
+
+
+  public function setBaseColumn(Google_Service_Fusiontables_ColumnBaseColumn $baseColumn)
+  {
+    $this->baseColumn = $baseColumn;
+  }
+  public function getBaseColumn()
+  {
+    return $this->baseColumn;
+  }
+  public function setColumnId($columnId)
+  {
+    $this->columnId = $columnId;
+  }
+  public function getColumnId()
+  {
+    return $this->columnId;
+  }
+  public function setColumnJsonSchema($columnJsonSchema)
+  {
+    $this->columnJsonSchema = $columnJsonSchema;
+  }
+  public function getColumnJsonSchema()
+  {
+    return $this->columnJsonSchema;
+  }
+  public function setColumnPropertiesJson($columnPropertiesJson)
+  {
+    $this->columnPropertiesJson = $columnPropertiesJson;
+  }
+  public function getColumnPropertiesJson()
+  {
+    return $this->columnPropertiesJson;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setFormatPattern($formatPattern)
+  {
+    $this->formatPattern = $formatPattern;
+  }
+  public function getFormatPattern()
+  {
+    return $this->formatPattern;
+  }
+  public function setGraphPredicate($graphPredicate)
+  {
+    $this->graphPredicate = $graphPredicate;
+  }
+  public function getGraphPredicate()
+  {
+    return $this->graphPredicate;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setValidValues($validValues)
+  {
+    $this->validValues = $validValues;
+  }
+  public function getValidValues()
+  {
+    return $this->validValues;
+  }
+  public function setValidateData($validateData)
+  {
+    $this->validateData = $validateData;
+  }
+  public function getValidateData()
+  {
+    return $this->validateData;
+  }
+}
+
+class Google_Service_Fusiontables_ColumnBaseColumn extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $columnId;
+  public $tableIndex;
+
+
+  public function setColumnId($columnId)
+  {
+    $this->columnId = $columnId;
+  }
+  public function getColumnId()
+  {
+    return $this->columnId;
+  }
+  public function setTableIndex($tableIndex)
+  {
+    $this->tableIndex = $tableIndex;
+  }
+  public function getTableIndex()
+  {
+    return $this->tableIndex;
+  }
+}
+
+class Google_Service_Fusiontables_ColumnList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Fusiontables_Column';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $totalItems;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_Fusiontables_Geometry extends Google_Collection
+{
+  protected $collection_key = 'geometries';
+  protected $internal_gapi_mappings = array(
+  );
+  public $geometries;
+  public $geometry;
+  public $type;
+
+
+  public function setGeometries($geometries)
+  {
+    $this->geometries = $geometries;
+  }
+  public function getGeometries()
+  {
+    return $this->geometries;
+  }
+  public function setGeometry($geometry)
+  {
+    $this->geometry = $geometry;
+  }
+  public function getGeometry()
+  {
+    return $this->geometry;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Fusiontables_Import extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $numRowsReceived;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNumRowsReceived($numRowsReceived)
+  {
+    $this->numRowsReceived = $numRowsReceived;
+  }
+  public function getNumRowsReceived()
+  {
+    return $this->numRowsReceived;
+  }
+}
+
+class Google_Service_Fusiontables_Line extends Google_Collection
+{
+  protected $collection_key = 'coordinates';
+  protected $internal_gapi_mappings = array(
+  );
+  public $coordinates;
+  public $type;
+
+
+  public function setCoordinates($coordinates)
+  {
+    $this->coordinates = $coordinates;
+  }
+  public function getCoordinates()
+  {
+    return $this->coordinates;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Fusiontables_LineStyle extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $strokeColor;
+  protected $strokeColorStylerType = 'Google_Service_Fusiontables_StyleFunction';
+  protected $strokeColorStylerDataType = '';
+  public $strokeOpacity;
+  public $strokeWeight;
+  protected $strokeWeightStylerType = 'Google_Service_Fusiontables_StyleFunction';
+  protected $strokeWeightStylerDataType = '';
+
+
+  public function setStrokeColor($strokeColor)
+  {
+    $this->strokeColor = $strokeColor;
+  }
+  public function getStrokeColor()
+  {
+    return $this->strokeColor;
+  }
+  public function setStrokeColorStyler(Google_Service_Fusiontables_StyleFunction $strokeColorStyler)
+  {
+    $this->strokeColorStyler = $strokeColorStyler;
+  }
+  public function getStrokeColorStyler()
+  {
+    return $this->strokeColorStyler;
+  }
+  public function setStrokeOpacity($strokeOpacity)
+  {
+    $this->strokeOpacity = $strokeOpacity;
+  }
+  public function getStrokeOpacity()
+  {
+    return $this->strokeOpacity;
+  }
+  public function setStrokeWeight($strokeWeight)
+  {
+    $this->strokeWeight = $strokeWeight;
+  }
+  public function getStrokeWeight()
+  {
+    return $this->strokeWeight;
+  }
+  public function setStrokeWeightStyler(Google_Service_Fusiontables_StyleFunction $strokeWeightStyler)
+  {
+    $this->strokeWeightStyler = $strokeWeightStyler;
+  }
+  public function getStrokeWeightStyler()
+  {
+    return $this->strokeWeightStyler;
+  }
+}
+
+class Google_Service_Fusiontables_Point extends Google_Collection
+{
+  protected $collection_key = 'coordinates';
+  protected $internal_gapi_mappings = array(
+  );
+  public $coordinates;
+  public $type;
+
+
+  public function setCoordinates($coordinates)
+  {
+    $this->coordinates = $coordinates;
+  }
+  public function getCoordinates()
+  {
+    return $this->coordinates;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Fusiontables_PointStyle extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $iconName;
+  protected $iconStylerType = 'Google_Service_Fusiontables_StyleFunction';
+  protected $iconStylerDataType = '';
+
+
+  public function setIconName($iconName)
+  {
+    $this->iconName = $iconName;
+  }
+  public function getIconName()
+  {
+    return $this->iconName;
+  }
+  public function setIconStyler(Google_Service_Fusiontables_StyleFunction $iconStyler)
+  {
+    $this->iconStyler = $iconStyler;
+  }
+  public function getIconStyler()
+  {
+    return $this->iconStyler;
+  }
+}
+
+class Google_Service_Fusiontables_Polygon extends Google_Collection
+{
+  protected $collection_key = 'coordinates';
+  protected $internal_gapi_mappings = array(
+  );
+  public $coordinates;
+  public $type;
+
+
+  public function setCoordinates($coordinates)
+  {
+    $this->coordinates = $coordinates;
+  }
+  public function getCoordinates()
+  {
+    return $this->coordinates;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Fusiontables_PolygonStyle extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $fillColor;
+  protected $fillColorStylerType = 'Google_Service_Fusiontables_StyleFunction';
+  protected $fillColorStylerDataType = '';
+  public $fillOpacity;
+  public $strokeColor;
+  protected $strokeColorStylerType = 'Google_Service_Fusiontables_StyleFunction';
+  protected $strokeColorStylerDataType = '';
+  public $strokeOpacity;
+  public $strokeWeight;
+  protected $strokeWeightStylerType = 'Google_Service_Fusiontables_StyleFunction';
+  protected $strokeWeightStylerDataType = '';
+
+
+  public function setFillColor($fillColor)
+  {
+    $this->fillColor = $fillColor;
+  }
+  public function getFillColor()
+  {
+    return $this->fillColor;
+  }
+  public function setFillColorStyler(Google_Service_Fusiontables_StyleFunction $fillColorStyler)
+  {
+    $this->fillColorStyler = $fillColorStyler;
+  }
+  public function getFillColorStyler()
+  {
+    return $this->fillColorStyler;
+  }
+  public function setFillOpacity($fillOpacity)
+  {
+    $this->fillOpacity = $fillOpacity;
+  }
+  public function getFillOpacity()
+  {
+    return $this->fillOpacity;
+  }
+  public function setStrokeColor($strokeColor)
+  {
+    $this->strokeColor = $strokeColor;
+  }
+  public function getStrokeColor()
+  {
+    return $this->strokeColor;
+  }
+  public function setStrokeColorStyler(Google_Service_Fusiontables_StyleFunction $strokeColorStyler)
+  {
+    $this->strokeColorStyler = $strokeColorStyler;
+  }
+  public function getStrokeColorStyler()
+  {
+    return $this->strokeColorStyler;
+  }
+  public function setStrokeOpacity($strokeOpacity)
+  {
+    $this->strokeOpacity = $strokeOpacity;
+  }
+  public function getStrokeOpacity()
+  {
+    return $this->strokeOpacity;
+  }
+  public function setStrokeWeight($strokeWeight)
+  {
+    $this->strokeWeight = $strokeWeight;
+  }
+  public function getStrokeWeight()
+  {
+    return $this->strokeWeight;
+  }
+  public function setStrokeWeightStyler(Google_Service_Fusiontables_StyleFunction $strokeWeightStyler)
+  {
+    $this->strokeWeightStyler = $strokeWeightStyler;
+  }
+  public function getStrokeWeightStyler()
+  {
+    return $this->strokeWeightStyler;
+  }
+}
+
+class Google_Service_Fusiontables_Sqlresponse extends Google_Collection
+{
+  protected $collection_key = 'rows';
+  protected $internal_gapi_mappings = array(
+  );
+  public $columns;
+  public $kind;
+  public $rows;
+
+
+  public function setColumns($columns)
+  {
+    $this->columns = $columns;
+  }
+  public function getColumns()
+  {
+    return $this->columns;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRows($rows)
+  {
+    $this->rows = $rows;
+  }
+  public function getRows()
+  {
+    return $this->rows;
+  }
+}
+
+class Google_Service_Fusiontables_StyleFunction extends Google_Collection
+{
+  protected $collection_key = 'buckets';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $bucketsType = 'Google_Service_Fusiontables_Bucket';
+  protected $bucketsDataType = 'array';
+  public $columnName;
+  protected $gradientType = 'Google_Service_Fusiontables_StyleFunctionGradient';
+  protected $gradientDataType = '';
+  public $kind;
+
+
+  public function setBuckets($buckets)
+  {
+    $this->buckets = $buckets;
+  }
+  public function getBuckets()
+  {
+    return $this->buckets;
+  }
+  public function setColumnName($columnName)
+  {
+    $this->columnName = $columnName;
+  }
+  public function getColumnName()
+  {
+    return $this->columnName;
+  }
+  public function setGradient(Google_Service_Fusiontables_StyleFunctionGradient $gradient)
+  {
+    $this->gradient = $gradient;
+  }
+  public function getGradient()
+  {
+    return $this->gradient;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Fusiontables_StyleFunctionGradient extends Google_Collection
+{
+  protected $collection_key = 'colors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $colorsType = 'Google_Service_Fusiontables_StyleFunctionGradientColors';
+  protected $colorsDataType = 'array';
+  public $max;
+  public $min;
+
+
+  public function setColors($colors)
+  {
+    $this->colors = $colors;
+  }
+  public function getColors()
+  {
+    return $this->colors;
+  }
+  public function setMax($max)
+  {
+    $this->max = $max;
+  }
+  public function getMax()
+  {
+    return $this->max;
+  }
+  public function setMin($min)
+  {
+    $this->min = $min;
+  }
+  public function getMin()
+  {
+    return $this->min;
+  }
+}
+
+class Google_Service_Fusiontables_StyleFunctionGradientColors extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $color;
+  public $opacity;
+
+
+  public function setColor($color)
+  {
+    $this->color = $color;
+  }
+  public function getColor()
+  {
+    return $this->color;
+  }
+  public function setOpacity($opacity)
+  {
+    $this->opacity = $opacity;
+  }
+  public function getOpacity()
+  {
+    return $this->opacity;
+  }
+}
+
+class Google_Service_Fusiontables_StyleSetting extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $markerOptionsType = 'Google_Service_Fusiontables_PointStyle';
+  protected $markerOptionsDataType = '';
+  public $name;
+  protected $polygonOptionsType = 'Google_Service_Fusiontables_PolygonStyle';
+  protected $polygonOptionsDataType = '';
+  protected $polylineOptionsType = 'Google_Service_Fusiontables_LineStyle';
+  protected $polylineOptionsDataType = '';
+  public $styleId;
+  public $tableId;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMarkerOptions(Google_Service_Fusiontables_PointStyle $markerOptions)
+  {
+    $this->markerOptions = $markerOptions;
+  }
+  public function getMarkerOptions()
+  {
+    return $this->markerOptions;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPolygonOptions(Google_Service_Fusiontables_PolygonStyle $polygonOptions)
+  {
+    $this->polygonOptions = $polygonOptions;
+  }
+  public function getPolygonOptions()
+  {
+    return $this->polygonOptions;
+  }
+  public function setPolylineOptions(Google_Service_Fusiontables_LineStyle $polylineOptions)
+  {
+    $this->polylineOptions = $polylineOptions;
+  }
+  public function getPolylineOptions()
+  {
+    return $this->polylineOptions;
+  }
+  public function setStyleId($styleId)
+  {
+    $this->styleId = $styleId;
+  }
+  public function getStyleId()
+  {
+    return $this->styleId;
+  }
+  public function setTableId($tableId)
+  {
+    $this->tableId = $tableId;
+  }
+  public function getTableId()
+  {
+    return $this->tableId;
+  }
+}
+
+class Google_Service_Fusiontables_StyleSettingList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Fusiontables_StyleSetting';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $totalItems;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_Fusiontables_Table extends Google_Collection
+{
+  protected $collection_key = 'columns';
+  protected $internal_gapi_mappings = array(
+  );
+  public $attribution;
+  public $attributionLink;
+  public $baseTableIds;
+  public $columnPropertiesJsonSchema;
+  protected $columnsType = 'Google_Service_Fusiontables_Column';
+  protected $columnsDataType = 'array';
+  public $description;
+  public $isExportable;
+  public $kind;
+  public $name;
+  public $sql;
+  public $tableId;
+  public $tablePropertiesJson;
+  public $tablePropertiesJsonSchema;
+
+
+  public function setAttribution($attribution)
+  {
+    $this->attribution = $attribution;
+  }
+  public function getAttribution()
+  {
+    return $this->attribution;
+  }
+  public function setAttributionLink($attributionLink)
+  {
+    $this->attributionLink = $attributionLink;
+  }
+  public function getAttributionLink()
+  {
+    return $this->attributionLink;
+  }
+  public function setBaseTableIds($baseTableIds)
+  {
+    $this->baseTableIds = $baseTableIds;
+  }
+  public function getBaseTableIds()
+  {
+    return $this->baseTableIds;
+  }
+  public function setColumnPropertiesJsonSchema($columnPropertiesJsonSchema)
+  {
+    $this->columnPropertiesJsonSchema = $columnPropertiesJsonSchema;
+  }
+  public function getColumnPropertiesJsonSchema()
+  {
+    return $this->columnPropertiesJsonSchema;
+  }
+  public function setColumns($columns)
+  {
+    $this->columns = $columns;
+  }
+  public function getColumns()
+  {
+    return $this->columns;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setIsExportable($isExportable)
+  {
+    $this->isExportable = $isExportable;
+  }
+  public function getIsExportable()
+  {
+    return $this->isExportable;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSql($sql)
+  {
+    $this->sql = $sql;
+  }
+  public function getSql()
+  {
+    return $this->sql;
+  }
+  public function setTableId($tableId)
+  {
+    $this->tableId = $tableId;
+  }
+  public function getTableId()
+  {
+    return $this->tableId;
+  }
+  public function setTablePropertiesJson($tablePropertiesJson)
+  {
+    $this->tablePropertiesJson = $tablePropertiesJson;
+  }
+  public function getTablePropertiesJson()
+  {
+    return $this->tablePropertiesJson;
+  }
+  public function setTablePropertiesJsonSchema($tablePropertiesJsonSchema)
+  {
+    $this->tablePropertiesJsonSchema = $tablePropertiesJsonSchema;
+  }
+  public function getTablePropertiesJsonSchema()
+  {
+    return $this->tablePropertiesJsonSchema;
+  }
+}
+
+class Google_Service_Fusiontables_TableList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Fusiontables_Table';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Fusiontables_Task extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $progress;
+  public $started;
+  public $taskId;
+  public $type;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProgress($progress)
+  {
+    $this->progress = $progress;
+  }
+  public function getProgress()
+  {
+    return $this->progress;
+  }
+  public function setStarted($started)
+  {
+    $this->started = $started;
+  }
+  public function getStarted()
+  {
+    return $this->started;
+  }
+  public function setTaskId($taskId)
+  {
+    $this->taskId = $taskId;
+  }
+  public function getTaskId()
+  {
+    return $this->taskId;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Fusiontables_TaskList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Fusiontables_Task';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $totalItems;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_Fusiontables_Template extends Google_Collection
+{
+  protected $collection_key = 'automaticColumnNames';
+  protected $internal_gapi_mappings = array(
+  );
+  public $automaticColumnNames;
+  public $body;
+  public $kind;
+  public $name;
+  public $tableId;
+  public $templateId;
+
+
+  public function setAutomaticColumnNames($automaticColumnNames)
+  {
+    $this->automaticColumnNames = $automaticColumnNames;
+  }
+  public function getAutomaticColumnNames()
+  {
+    return $this->automaticColumnNames;
+  }
+  public function setBody($body)
+  {
+    $this->body = $body;
+  }
+  public function getBody()
+  {
+    return $this->body;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setTableId($tableId)
+  {
+    $this->tableId = $tableId;
+  }
+  public function getTableId()
+  {
+    return $this->tableId;
+  }
+  public function setTemplateId($templateId)
+  {
+    $this->templateId = $templateId;
+  }
+  public function getTemplateId()
+  {
+    return $this->templateId;
+  }
+}
+
+class Google_Service_Fusiontables_TemplateList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Fusiontables_Template';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $totalItems;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Games.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Games.php
@@ -1,0 +1,7440 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Games (v1).
+ *
+ * <p>
+ * The API for Google Play Game Services.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/games/services/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Games extends Google_Service
+{
+  /** View and manage its own configuration data in your Google Drive. */
+  const DRIVE_APPDATA =
+      "https://www.googleapis.com/auth/drive.appdata";
+  /** Share your Google+ profile information and view and manage your game activity. */
+  const GAMES =
+      "https://www.googleapis.com/auth/games";
+  /** Know your basic profile info and list of people in your circles.. */
+  const PLUS_LOGIN =
+      "https://www.googleapis.com/auth/plus.login";
+
+  public $achievementDefinitions;
+  public $achievements;
+  public $applications;
+  public $events;
+  public $leaderboards;
+  public $metagame;
+  public $players;
+  public $pushtokens;
+  public $questMilestones;
+  public $quests;
+  public $revisions;
+  public $rooms;
+  public $scores;
+  public $snapshots;
+  public $turnBasedMatches;
+  
+
+  /**
+   * Constructs the internal representation of the Games service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'games/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'games';
+
+    $this->achievementDefinitions = new Google_Service_Games_AchievementDefinitions_Resource(
+        $this,
+        $this->serviceName,
+        'achievementDefinitions',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'achievements',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->achievements = new Google_Service_Games_Achievements_Resource(
+        $this,
+        $this->serviceName,
+        'achievements',
+        array(
+          'methods' => array(
+            'increment' => array(
+              'path' => 'achievements/{achievementId}/increment',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'achievementId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'stepsToIncrement' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'requestId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'players/{playerId}/achievements',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'playerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'state' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'reveal' => array(
+              'path' => 'achievements/{achievementId}/reveal',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'achievementId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setStepsAtLeast' => array(
+              'path' => 'achievements/{achievementId}/setStepsAtLeast',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'achievementId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'steps' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'unlock' => array(
+              'path' => 'achievements/{achievementId}/unlock',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'achievementId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'updateMultiple' => array(
+              'path' => 'achievements/updateMultiple',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->applications = new Google_Service_Games_Applications_Resource(
+        $this,
+        $this->serviceName,
+        'applications',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'applications/{applicationId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'applicationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'platformType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'played' => array(
+              'path' => 'applications/played',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->events = new Google_Service_Games_Events_Resource(
+        $this,
+        $this->serviceName,
+        'events',
+        array(
+          'methods' => array(
+            'listByPlayer' => array(
+              'path' => 'events',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'listDefinitions' => array(
+              'path' => 'eventDefinitions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'record' => array(
+              'path' => 'events',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->leaderboards = new Google_Service_Games_Leaderboards_Resource(
+        $this,
+        $this->serviceName,
+        'leaderboards',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'leaderboards/{leaderboardId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'leaderboardId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'leaderboards',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->metagame = new Google_Service_Games_Metagame_Resource(
+        $this,
+        $this->serviceName,
+        'metagame',
+        array(
+          'methods' => array(
+            'getMetagameConfig' => array(
+              'path' => 'metagameConfig',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),'listCategoriesByPlayer' => array(
+              'path' => 'players/{playerId}/categories/{collection}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'playerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collection' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->players = new Google_Service_Games_Players_Resource(
+        $this,
+        $this->serviceName,
+        'players',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'players/{playerId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'playerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'players/me/players/{collection}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'collection' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->pushtokens = new Google_Service_Games_Pushtokens_Resource(
+        $this,
+        $this->serviceName,
+        'pushtokens',
+        array(
+          'methods' => array(
+            'remove' => array(
+              'path' => 'pushtokens/remove',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'update' => array(
+              'path' => 'pushtokens',
+              'httpMethod' => 'PUT',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->questMilestones = new Google_Service_Games_QuestMilestones_Resource(
+        $this,
+        $this->serviceName,
+        'questMilestones',
+        array(
+          'methods' => array(
+            'claim' => array(
+              'path' => 'quests/{questId}/milestones/{milestoneId}/claim',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'questId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'milestoneId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'requestId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->quests = new Google_Service_Games_Quests_Resource(
+        $this,
+        $this->serviceName,
+        'quests',
+        array(
+          'methods' => array(
+            'accept' => array(
+              'path' => 'quests/{questId}/accept',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'questId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'players/{playerId}/quests',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'playerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->revisions = new Google_Service_Games_Revisions_Resource(
+        $this,
+        $this->serviceName,
+        'revisions',
+        array(
+          'methods' => array(
+            'check' => array(
+              'path' => 'revisions/check',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'clientRevision' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->rooms = new Google_Service_Games_Rooms_Resource(
+        $this,
+        $this->serviceName,
+        'rooms',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'rooms/create',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'decline' => array(
+              'path' => 'rooms/{roomId}/decline',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'roomId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'dismiss' => array(
+              'path' => 'rooms/{roomId}/dismiss',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'roomId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'rooms/{roomId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'roomId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'join' => array(
+              'path' => 'rooms/{roomId}/join',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'roomId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'leave' => array(
+              'path' => 'rooms/{roomId}/leave',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'roomId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'rooms',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'reportStatus' => array(
+              'path' => 'rooms/{roomId}/reportstatus',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'roomId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->scores = new Google_Service_Games_Scores_Resource(
+        $this,
+        $this->serviceName,
+        'scores',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'players/{playerId}/leaderboards/{leaderboardId}/scores/{timeSpan}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'playerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'leaderboardId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'timeSpan' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'includeRankType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'leaderboards/{leaderboardId}/scores/{collection}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'leaderboardId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collection' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'timeSpan' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'listWindow' => array(
+              'path' => 'leaderboards/{leaderboardId}/window/{collection}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'leaderboardId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collection' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'timeSpan' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'returnTopIfAbsent' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'resultsAbove' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'submit' => array(
+              'path' => 'leaderboards/{leaderboardId}/scores',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'leaderboardId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'score' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'scoreTag' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'submitMultiple' => array(
+              'path' => 'leaderboards/scores',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->snapshots = new Google_Service_Games_Snapshots_Resource(
+        $this,
+        $this->serviceName,
+        'snapshots',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'snapshots/{snapshotId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'snapshotId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'players/{playerId}/snapshots',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'playerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->turnBasedMatches = new Google_Service_Games_TurnBasedMatches_Resource(
+        $this,
+        $this->serviceName,
+        'turnBasedMatches',
+        array(
+          'methods' => array(
+            'cancel' => array(
+              'path' => 'turnbasedmatches/{matchId}/cancel',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'matchId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'create' => array(
+              'path' => 'turnbasedmatches/create',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'decline' => array(
+              'path' => 'turnbasedmatches/{matchId}/decline',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'matchId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'dismiss' => array(
+              'path' => 'turnbasedmatches/{matchId}/dismiss',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'matchId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'finish' => array(
+              'path' => 'turnbasedmatches/{matchId}/finish',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'matchId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'turnbasedmatches/{matchId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'matchId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'includeMatchData' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'join' => array(
+              'path' => 'turnbasedmatches/{matchId}/join',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'matchId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'leave' => array(
+              'path' => 'turnbasedmatches/{matchId}/leave',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'matchId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'leaveTurn' => array(
+              'path' => 'turnbasedmatches/{matchId}/leaveTurn',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'matchId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'matchVersion' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pendingParticipantId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'turnbasedmatches',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxCompletedMatches' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'includeMatchData' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'rematch' => array(
+              'path' => 'turnbasedmatches/{matchId}/rematch',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'matchId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'requestId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'sync' => array(
+              'path' => 'turnbasedmatches/sync',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxCompletedMatches' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'includeMatchData' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'takeTurn' => array(
+              'path' => 'turnbasedmatches/{matchId}/turn',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'matchId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "achievementDefinitions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesService = new Google_Service_Games(...);
+ *   $achievementDefinitions = $gamesService->achievementDefinitions;
+ *  </code>
+ */
+class Google_Service_Games_AchievementDefinitions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Lists all the achievement definitions for your application.
+   * (achievementDefinitions.listAchievementDefinitions)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param int maxResults The maximum number of achievement resources to
+   * return in the response, used for paging. For any response, the actual number
+   * of achievement resources returned may be less than the specified maxResults.
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_AchievementDefinitionsListResponse
+   */
+  public function listAchievementDefinitions($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Games_AchievementDefinitionsListResponse");
+  }
+}
+
+/**
+ * The "achievements" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesService = new Google_Service_Games(...);
+ *   $achievements = $gamesService->achievements;
+ *  </code>
+ */
+class Google_Service_Games_Achievements_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Increments the steps of the achievement with the given ID for the currently
+   * authenticated player. (achievements.increment)
+   *
+   * @param string $achievementId The ID of the achievement used by this method.
+   * @param int $stepsToIncrement The number of steps to increment.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string requestId A randomly generated numeric ID for each request
+   * specified by the caller. This number is used at the server to ensure that the
+   * request is handled correctly across retries.
+   * @return Google_Service_Games_AchievementIncrementResponse
+   */
+  public function increment($achievementId, $stepsToIncrement, $optParams = array())
+  {
+    $params = array('achievementId' => $achievementId, 'stepsToIncrement' => $stepsToIncrement);
+    $params = array_merge($params, $optParams);
+    return $this->call('increment', array($params), "Google_Service_Games_AchievementIncrementResponse");
+  }
+
+  /**
+   * Lists the progress for all your application's achievements for the currently
+   * authenticated player. (achievements.listAchievements)
+   *
+   * @param string $playerId A player ID. A value of me may be used in place of
+   * the authenticated player's ID.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param string state Tells the server to return only achievements with the
+   * specified state. If this parameter isn't specified, all achievements are
+   * returned.
+   * @opt_param int maxResults The maximum number of achievement resources to
+   * return in the response, used for paging. For any response, the actual number
+   * of achievement resources returned may be less than the specified maxResults.
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_PlayerAchievementListResponse
+   */
+  public function listAchievements($playerId, $optParams = array())
+  {
+    $params = array('playerId' => $playerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Games_PlayerAchievementListResponse");
+  }
+
+  /**
+   * Sets the state of the achievement with the given ID to REVEALED for the
+   * currently authenticated player. (achievements.reveal)
+   *
+   * @param string $achievementId The ID of the achievement used by this method.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Games_AchievementRevealResponse
+   */
+  public function reveal($achievementId, $optParams = array())
+  {
+    $params = array('achievementId' => $achievementId);
+    $params = array_merge($params, $optParams);
+    return $this->call('reveal', array($params), "Google_Service_Games_AchievementRevealResponse");
+  }
+
+  /**
+   * Sets the steps for the currently authenticated player towards unlocking an
+   * achievement. If the steps parameter is less than the current number of steps
+   * that the player already gained for the achievement, the achievement is not
+   * modified. (achievements.setStepsAtLeast)
+   *
+   * @param string $achievementId The ID of the achievement used by this method.
+   * @param int $steps The minimum value to set the steps to.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Games_AchievementSetStepsAtLeastResponse
+   */
+  public function setStepsAtLeast($achievementId, $steps, $optParams = array())
+  {
+    $params = array('achievementId' => $achievementId, 'steps' => $steps);
+    $params = array_merge($params, $optParams);
+    return $this->call('setStepsAtLeast', array($params), "Google_Service_Games_AchievementSetStepsAtLeastResponse");
+  }
+
+  /**
+   * Unlocks this achievement for the currently authenticated player.
+   * (achievements.unlock)
+   *
+   * @param string $achievementId The ID of the achievement used by this method.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Games_AchievementUnlockResponse
+   */
+  public function unlock($achievementId, $optParams = array())
+  {
+    $params = array('achievementId' => $achievementId);
+    $params = array_merge($params, $optParams);
+    return $this->call('unlock', array($params), "Google_Service_Games_AchievementUnlockResponse");
+  }
+
+  /**
+   * Updates multiple achievements for the currently authenticated player.
+   * (achievements.updateMultiple)
+   *
+   * @param Google_AchievementUpdateMultipleRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Games_AchievementUpdateMultipleResponse
+   */
+  public function updateMultiple(Google_Service_Games_AchievementUpdateMultipleRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('updateMultiple', array($params), "Google_Service_Games_AchievementUpdateMultipleResponse");
+  }
+}
+
+/**
+ * The "applications" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesService = new Google_Service_Games(...);
+ *   $applications = $gamesService->applications;
+ *  </code>
+ */
+class Google_Service_Games_Applications_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the metadata of the application with the given ID. If the requested
+   * application is not available for the specified platformType, the returned
+   * response will not include any instance data. (applications.get)
+   *
+   * @param string $applicationId The application ID from the Google Play
+   * developer console.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string platformType Restrict application details returned to the
+   * specific platform.
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_Application
+   */
+  public function get($applicationId, $optParams = array())
+  {
+    $params = array('applicationId' => $applicationId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Games_Application");
+  }
+
+  /**
+   * Indicate that the the currently authenticated user is playing your
+   * application. (applications.played)
+   *
+   * @param array $optParams Optional parameters.
+   */
+  public function played($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('played', array($params));
+  }
+}
+
+/**
+ * The "events" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesService = new Google_Service_Games(...);
+ *   $events = $gamesService->events;
+ *  </code>
+ */
+class Google_Service_Games_Events_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns a list showing the current progress on events in this application for
+   * the currently authenticated user. (events.listByPlayer)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param int maxResults The maximum number of events to return in the
+   * response, used for paging. For any response, the actual number of events to
+   * return may be less than the specified maxResults.
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_PlayerEventListResponse
+   */
+  public function listByPlayer($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('listByPlayer', array($params), "Google_Service_Games_PlayerEventListResponse");
+  }
+
+  /**
+   * Returns a list of the event definitions in this application.
+   * (events.listDefinitions)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param int maxResults The maximum number of event definitions to return
+   * in the response, used for paging. For any response, the actual number of
+   * event definitions to return may be less than the specified maxResults.
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_EventDefinitionListResponse
+   */
+  public function listDefinitions($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('listDefinitions', array($params), "Google_Service_Games_EventDefinitionListResponse");
+  }
+
+  /**
+   * Records a batch of changes to the number of times events have occurred for
+   * the currently authenticated user of this application. (events.record)
+   *
+   * @param Google_EventRecordRequest $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_EventUpdateResponse
+   */
+  public function record(Google_Service_Games_EventRecordRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('record', array($params), "Google_Service_Games_EventUpdateResponse");
+  }
+}
+
+/**
+ * The "leaderboards" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesService = new Google_Service_Games(...);
+ *   $leaderboards = $gamesService->leaderboards;
+ *  </code>
+ */
+class Google_Service_Games_Leaderboards_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the metadata of the leaderboard with the given ID.
+   * (leaderboards.get)
+   *
+   * @param string $leaderboardId The ID of the leaderboard.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_Leaderboard
+   */
+  public function get($leaderboardId, $optParams = array())
+  {
+    $params = array('leaderboardId' => $leaderboardId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Games_Leaderboard");
+  }
+
+  /**
+   * Lists all the leaderboard metadata for your application.
+   * (leaderboards.listLeaderboards)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param int maxResults The maximum number of leaderboards to return in the
+   * response. For any response, the actual number of leaderboards returned may be
+   * less than the specified maxResults.
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_LeaderboardListResponse
+   */
+  public function listLeaderboards($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Games_LeaderboardListResponse");
+  }
+}
+
+/**
+ * The "metagame" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesService = new Google_Service_Games(...);
+ *   $metagame = $gamesService->metagame;
+ *  </code>
+ */
+class Google_Service_Games_Metagame_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Return the metagame configuration data for the calling application.
+   * (metagame.getMetagameConfig)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Games_MetagameConfig
+   */
+  public function getMetagameConfig($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('getMetagameConfig', array($params), "Google_Service_Games_MetagameConfig");
+  }
+
+  /**
+   * List play data aggregated per category for the player corresponding to
+   * playerId. (metagame.listCategoriesByPlayer)
+   *
+   * @param string $playerId A player ID. A value of me may be used in place of
+   * the authenticated player's ID.
+   * @param string $collection The collection of categories for which data will be
+   * returned.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param int maxResults The maximum number of category resources to return
+   * in the response, used for paging. For any response, the actual number of
+   * category resources returned may be less than the specified maxResults.
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_CategoryListResponse
+   */
+  public function listCategoriesByPlayer($playerId, $collection, $optParams = array())
+  {
+    $params = array('playerId' => $playerId, 'collection' => $collection);
+    $params = array_merge($params, $optParams);
+    return $this->call('listCategoriesByPlayer', array($params), "Google_Service_Games_CategoryListResponse");
+  }
+}
+
+/**
+ * The "players" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesService = new Google_Service_Games(...);
+ *   $players = $gamesService->players;
+ *  </code>
+ */
+class Google_Service_Games_Players_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the Player resource with the given ID. To retrieve the player for
+   * the currently authenticated user, set playerId to me. (players.get)
+   *
+   * @param string $playerId A player ID. A value of me may be used in place of
+   * the authenticated player's ID.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_Player
+   */
+  public function get($playerId, $optParams = array())
+  {
+    $params = array('playerId' => $playerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Games_Player");
+  }
+
+  /**
+   * Get the collection of players for the currently authenticated user.
+   * (players.listPlayers)
+   *
+   * @param string $collection Collection of players being retrieved
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param int maxResults The maximum number of player resources to return in
+   * the response, used for paging. For any response, the actual number of player
+   * resources returned may be less than the specified maxResults.
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_PlayerListResponse
+   */
+  public function listPlayers($collection, $optParams = array())
+  {
+    $params = array('collection' => $collection);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Games_PlayerListResponse");
+  }
+}
+
+/**
+ * The "pushtokens" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesService = new Google_Service_Games(...);
+ *   $pushtokens = $gamesService->pushtokens;
+ *  </code>
+ */
+class Google_Service_Games_Pushtokens_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Removes a push token for the current user and application. Removing a non-
+   * existent push token will report success. (pushtokens.remove)
+   *
+   * @param Google_PushTokenId $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function remove(Google_Service_Games_PushTokenId $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('remove', array($params));
+  }
+
+  /**
+   * Registers a push token for the current user and application.
+   * (pushtokens.update)
+   *
+   * @param Google_PushToken $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function update(Google_Service_Games_PushToken $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params));
+  }
+}
+
+/**
+ * The "questMilestones" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesService = new Google_Service_Games(...);
+ *   $questMilestones = $gamesService->questMilestones;
+ *  </code>
+ */
+class Google_Service_Games_QuestMilestones_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Report that a reward for the milestone corresponding to milestoneId for the
+   * quest corresponding to questId has been claimed by the currently authorized
+   * user. (questMilestones.claim)
+   *
+   * @param string $questId The ID of the quest.
+   * @param string $milestoneId The ID of the milestone.
+   * @param string $requestId A numeric ID to ensure that the request is handled
+   * correctly across retries. Your client application must generate this ID
+   * randomly.
+   * @param array $optParams Optional parameters.
+   */
+  public function claim($questId, $milestoneId, $requestId, $optParams = array())
+  {
+    $params = array('questId' => $questId, 'milestoneId' => $milestoneId, 'requestId' => $requestId);
+    $params = array_merge($params, $optParams);
+    return $this->call('claim', array($params));
+  }
+}
+
+/**
+ * The "quests" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesService = new Google_Service_Games(...);
+ *   $quests = $gamesService->quests;
+ *  </code>
+ */
+class Google_Service_Games_Quests_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Indicates that the currently authorized user will participate in the quest.
+   * (quests.accept)
+   *
+   * @param string $questId The ID of the quest.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_Quest
+   */
+  public function accept($questId, $optParams = array())
+  {
+    $params = array('questId' => $questId);
+    $params = array_merge($params, $optParams);
+    return $this->call('accept', array($params), "Google_Service_Games_Quest");
+  }
+
+  /**
+   * Get a list of quests for your application and the currently authenticated
+   * player. (quests.listQuests)
+   *
+   * @param string $playerId A player ID. A value of me may be used in place of
+   * the authenticated player's ID.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param int maxResults The maximum number of quest resources to return in
+   * the response, used for paging. For any response, the actual number of quest
+   * resources returned may be less than the specified maxResults. Acceptable
+   * values are 1 to 50, inclusive. (Default: 50).
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_QuestListResponse
+   */
+  public function listQuests($playerId, $optParams = array())
+  {
+    $params = array('playerId' => $playerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Games_QuestListResponse");
+  }
+}
+
+/**
+ * The "revisions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesService = new Google_Service_Games(...);
+ *   $revisions = $gamesService->revisions;
+ *  </code>
+ */
+class Google_Service_Games_Revisions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Checks whether the games client is out of date. (revisions.check)
+   *
+   * @param string $clientRevision The revision of the client SDK used by your
+   * application. Format: [PLATFORM_TYPE]:[VERSION_NUMBER]. Possible values of
+   * PLATFORM_TYPE are:   - "ANDROID" - Client is running the Android SDK.  -
+   * "IOS" - Client is running the iOS SDK.  - "WEB_APP" - Client is running as a
+   * Web App.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Games_RevisionCheckResponse
+   */
+  public function check($clientRevision, $optParams = array())
+  {
+    $params = array('clientRevision' => $clientRevision);
+    $params = array_merge($params, $optParams);
+    return $this->call('check', array($params), "Google_Service_Games_RevisionCheckResponse");
+  }
+}
+
+/**
+ * The "rooms" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesService = new Google_Service_Games(...);
+ *   $rooms = $gamesService->rooms;
+ *  </code>
+ */
+class Google_Service_Games_Rooms_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Create a room. For internal use by the Games SDK only. Calling this method
+   * directly is unsupported. (rooms.create)
+   *
+   * @param Google_RoomCreateRequest $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_Room
+   */
+  public function create(Google_Service_Games_RoomCreateRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Games_Room");
+  }
+
+  /**
+   * Decline an invitation to join a room. For internal use by the Games SDK only.
+   * Calling this method directly is unsupported. (rooms.decline)
+   *
+   * @param string $roomId The ID of the room.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_Room
+   */
+  public function decline($roomId, $optParams = array())
+  {
+    $params = array('roomId' => $roomId);
+    $params = array_merge($params, $optParams);
+    return $this->call('decline', array($params), "Google_Service_Games_Room");
+  }
+
+  /**
+   * Dismiss an invitation to join a room. For internal use by the Games SDK only.
+   * Calling this method directly is unsupported. (rooms.dismiss)
+   *
+   * @param string $roomId The ID of the room.
+   * @param array $optParams Optional parameters.
+   */
+  public function dismiss($roomId, $optParams = array())
+  {
+    $params = array('roomId' => $roomId);
+    $params = array_merge($params, $optParams);
+    return $this->call('dismiss', array($params));
+  }
+
+  /**
+   * Get the data for a room. (rooms.get)
+   *
+   * @param string $roomId The ID of the room.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_Room
+   */
+  public function get($roomId, $optParams = array())
+  {
+    $params = array('roomId' => $roomId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Games_Room");
+  }
+
+  /**
+   * Join a room. For internal use by the Games SDK only. Calling this method
+   * directly is unsupported. (rooms.join)
+   *
+   * @param string $roomId The ID of the room.
+   * @param Google_RoomJoinRequest $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_Room
+   */
+  public function join($roomId, Google_Service_Games_RoomJoinRequest $postBody, $optParams = array())
+  {
+    $params = array('roomId' => $roomId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('join', array($params), "Google_Service_Games_Room");
+  }
+
+  /**
+   * Leave a room. For internal use by the Games SDK only. Calling this method
+   * directly is unsupported. (rooms.leave)
+   *
+   * @param string $roomId The ID of the room.
+   * @param Google_RoomLeaveRequest $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_Room
+   */
+  public function leave($roomId, Google_Service_Games_RoomLeaveRequest $postBody, $optParams = array())
+  {
+    $params = array('roomId' => $roomId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('leave', array($params), "Google_Service_Games_Room");
+  }
+
+  /**
+   * Returns invitations to join rooms. (rooms.listRooms)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param int maxResults The maximum number of rooms to return in the
+   * response, used for paging. For any response, the actual number of rooms to
+   * return may be less than the specified maxResults.
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_RoomList
+   */
+  public function listRooms($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Games_RoomList");
+  }
+
+  /**
+   * Updates sent by a client reporting the status of peers in a room. For
+   * internal use by the Games SDK only. Calling this method directly is
+   * unsupported. (rooms.reportStatus)
+   *
+   * @param string $roomId The ID of the room.
+   * @param Google_RoomP2PStatuses $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_RoomStatus
+   */
+  public function reportStatus($roomId, Google_Service_Games_RoomP2PStatuses $postBody, $optParams = array())
+  {
+    $params = array('roomId' => $roomId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('reportStatus', array($params), "Google_Service_Games_RoomStatus");
+  }
+}
+
+/**
+ * The "scores" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesService = new Google_Service_Games(...);
+ *   $scores = $gamesService->scores;
+ *  </code>
+ */
+class Google_Service_Games_Scores_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get high scores, and optionally ranks, in leaderboards for the currently
+   * authenticated player. For a specific time span, leaderboardId can be set to
+   * ALL to retrieve data for all leaderboards in a given time span. NOTE: You
+   * cannot ask for 'ALL' leaderboards and 'ALL' timeSpans in the same request;
+   * only one parameter may be set to 'ALL'. (scores.get)
+   *
+   * @param string $playerId A player ID. A value of me may be used in place of
+   * the authenticated player's ID.
+   * @param string $leaderboardId The ID of the leaderboard. Can be set to 'ALL'
+   * to retrieve data for all leaderboards for this application.
+   * @param string $timeSpan The time span for the scores and ranks you're
+   * requesting.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string includeRankType The types of ranks to return. If the
+   * parameter is omitted, no ranks will be returned.
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @opt_param int maxResults The maximum number of leaderboard scores to return
+   * in the response. For any response, the actual number of leaderboard scores
+   * returned may be less than the specified maxResults.
+   * @opt_param string pageToken The token returned by the previous request.
+   * @return Google_Service_Games_PlayerLeaderboardScoreListResponse
+   */
+  public function get($playerId, $leaderboardId, $timeSpan, $optParams = array())
+  {
+    $params = array('playerId' => $playerId, 'leaderboardId' => $leaderboardId, 'timeSpan' => $timeSpan);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Games_PlayerLeaderboardScoreListResponse");
+  }
+
+  /**
+   * Lists the scores in a leaderboard, starting from the top. (scores.listScores)
+   *
+   * @param string $leaderboardId The ID of the leaderboard.
+   * @param string $collection The collection of scores you're requesting.
+   * @param string $timeSpan The time span for the scores and ranks you're
+   * requesting.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @opt_param int maxResults The maximum number of leaderboard scores to return
+   * in the response. For any response, the actual number of leaderboard scores
+   * returned may be less than the specified maxResults.
+   * @opt_param string pageToken The token returned by the previous request.
+   * @return Google_Service_Games_LeaderboardScores
+   */
+  public function listScores($leaderboardId, $collection, $timeSpan, $optParams = array())
+  {
+    $params = array('leaderboardId' => $leaderboardId, 'collection' => $collection, 'timeSpan' => $timeSpan);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Games_LeaderboardScores");
+  }
+
+  /**
+   * Lists the scores in a leaderboard around (and including) a player's score.
+   * (scores.listWindow)
+   *
+   * @param string $leaderboardId The ID of the leaderboard.
+   * @param string $collection The collection of scores you're requesting.
+   * @param string $timeSpan The time span for the scores and ranks you're
+   * requesting.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @opt_param bool returnTopIfAbsent True if the top scores should be returned
+   * when the player is not in the leaderboard. Defaults to true.
+   * @opt_param int resultsAbove The preferred number of scores to return above
+   * the player's score. More scores may be returned if the player is at the
+   * bottom of the leaderboard; fewer may be returned if the player is at the top.
+   * Must be less than or equal to maxResults.
+   * @opt_param int maxResults The maximum number of leaderboard scores to return
+   * in the response. For any response, the actual number of leaderboard scores
+   * returned may be less than the specified maxResults.
+   * @opt_param string pageToken The token returned by the previous request.
+   * @return Google_Service_Games_LeaderboardScores
+   */
+  public function listWindow($leaderboardId, $collection, $timeSpan, $optParams = array())
+  {
+    $params = array('leaderboardId' => $leaderboardId, 'collection' => $collection, 'timeSpan' => $timeSpan);
+    $params = array_merge($params, $optParams);
+    return $this->call('listWindow', array($params), "Google_Service_Games_LeaderboardScores");
+  }
+
+  /**
+   * Submits a score to the specified leaderboard. (scores.submit)
+   *
+   * @param string $leaderboardId The ID of the leaderboard.
+   * @param string $score The score you're submitting. The submitted score is
+   * ignored if it is worse than a previously submitted score, where worse depends
+   * on the leaderboard sort order. The meaning of the score value depends on the
+   * leaderboard format type. For fixed-point, the score represents the raw value.
+   * For time, the score represents elapsed time in milliseconds. For currency,
+   * the score represents a value in micro units.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @opt_param string scoreTag Additional information about the score you're
+   * submitting. Values must contain no more than 64 URI-safe characters as
+   * defined by section 2.3 of RFC 3986.
+   * @return Google_Service_Games_PlayerScoreResponse
+   */
+  public function submit($leaderboardId, $score, $optParams = array())
+  {
+    $params = array('leaderboardId' => $leaderboardId, 'score' => $score);
+    $params = array_merge($params, $optParams);
+    return $this->call('submit', array($params), "Google_Service_Games_PlayerScoreResponse");
+  }
+
+  /**
+   * Submits multiple scores to leaderboards. (scores.submitMultiple)
+   *
+   * @param Google_PlayerScoreSubmissionList $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_PlayerScoreListResponse
+   */
+  public function submitMultiple(Google_Service_Games_PlayerScoreSubmissionList $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('submitMultiple', array($params), "Google_Service_Games_PlayerScoreListResponse");
+  }
+}
+
+/**
+ * The "snapshots" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesService = new Google_Service_Games(...);
+ *   $snapshots = $gamesService->snapshots;
+ *  </code>
+ */
+class Google_Service_Games_Snapshots_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the metadata for a given snapshot ID. (snapshots.get)
+   *
+   * @param string $snapshotId The ID of the snapshot.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_Snapshot
+   */
+  public function get($snapshotId, $optParams = array())
+  {
+    $params = array('snapshotId' => $snapshotId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Games_Snapshot");
+  }
+
+  /**
+   * Retrieves a list of snapshots created by your application for the player
+   * corresponding to the player ID. (snapshots.listSnapshots)
+   *
+   * @param string $playerId A player ID. A value of me may be used in place of
+   * the authenticated player's ID.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param int maxResults The maximum number of snapshot resources to return
+   * in the response, used for paging. For any response, the actual number of
+   * snapshot resources returned may be less than the specified maxResults.
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_SnapshotListResponse
+   */
+  public function listSnapshots($playerId, $optParams = array())
+  {
+    $params = array('playerId' => $playerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Games_SnapshotListResponse");
+  }
+}
+
+/**
+ * The "turnBasedMatches" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesService = new Google_Service_Games(...);
+ *   $turnBasedMatches = $gamesService->turnBasedMatches;
+ *  </code>
+ */
+class Google_Service_Games_TurnBasedMatches_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Cancel a turn-based match. (turnBasedMatches.cancel)
+   *
+   * @param string $matchId The ID of the match.
+   * @param array $optParams Optional parameters.
+   */
+  public function cancel($matchId, $optParams = array())
+  {
+    $params = array('matchId' => $matchId);
+    $params = array_merge($params, $optParams);
+    return $this->call('cancel', array($params));
+  }
+
+  /**
+   * Create a turn-based match. (turnBasedMatches.create)
+   *
+   * @param Google_TurnBasedMatchCreateRequest $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_TurnBasedMatch
+   */
+  public function create(Google_Service_Games_TurnBasedMatchCreateRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Games_TurnBasedMatch");
+  }
+
+  /**
+   * Decline an invitation to play a turn-based match. (turnBasedMatches.decline)
+   *
+   * @param string $matchId The ID of the match.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_TurnBasedMatch
+   */
+  public function decline($matchId, $optParams = array())
+  {
+    $params = array('matchId' => $matchId);
+    $params = array_merge($params, $optParams);
+    return $this->call('decline', array($params), "Google_Service_Games_TurnBasedMatch");
+  }
+
+  /**
+   * Dismiss a turn-based match from the match list. The match will no longer show
+   * up in the list and will not generate notifications.
+   * (turnBasedMatches.dismiss)
+   *
+   * @param string $matchId The ID of the match.
+   * @param array $optParams Optional parameters.
+   */
+  public function dismiss($matchId, $optParams = array())
+  {
+    $params = array('matchId' => $matchId);
+    $params = array_merge($params, $optParams);
+    return $this->call('dismiss', array($params));
+  }
+
+  /**
+   * Finish a turn-based match. Each player should make this call once, after all
+   * results are in. Only the player whose turn it is may make the first call to
+   * Finish, and can pass in the final match state. (turnBasedMatches.finish)
+   *
+   * @param string $matchId The ID of the match.
+   * @param Google_TurnBasedMatchResults $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_TurnBasedMatch
+   */
+  public function finish($matchId, Google_Service_Games_TurnBasedMatchResults $postBody, $optParams = array())
+  {
+    $params = array('matchId' => $matchId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('finish', array($params), "Google_Service_Games_TurnBasedMatch");
+  }
+
+  /**
+   * Get the data for a turn-based match. (turnBasedMatches.get)
+   *
+   * @param string $matchId The ID of the match.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @opt_param bool includeMatchData Get match data along with metadata.
+   * @return Google_Service_Games_TurnBasedMatch
+   */
+  public function get($matchId, $optParams = array())
+  {
+    $params = array('matchId' => $matchId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Games_TurnBasedMatch");
+  }
+
+  /**
+   * Join a turn-based match. (turnBasedMatches.join)
+   *
+   * @param string $matchId The ID of the match.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_TurnBasedMatch
+   */
+  public function join($matchId, $optParams = array())
+  {
+    $params = array('matchId' => $matchId);
+    $params = array_merge($params, $optParams);
+    return $this->call('join', array($params), "Google_Service_Games_TurnBasedMatch");
+  }
+
+  /**
+   * Leave a turn-based match when it is not the current player's turn, without
+   * canceling the match. (turnBasedMatches.leave)
+   *
+   * @param string $matchId The ID of the match.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_TurnBasedMatch
+   */
+  public function leave($matchId, $optParams = array())
+  {
+    $params = array('matchId' => $matchId);
+    $params = array_merge($params, $optParams);
+    return $this->call('leave', array($params), "Google_Service_Games_TurnBasedMatch");
+  }
+
+  /**
+   * Leave a turn-based match during the current player's turn, without canceling
+   * the match. (turnBasedMatches.leaveTurn)
+   *
+   * @param string $matchId The ID of the match.
+   * @param int $matchVersion The version of the match being updated.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @opt_param string pendingParticipantId The ID of another participant who
+   * should take their turn next. If not set, the match will wait for other
+   * player(s) to join via automatching; this is only valid if automatch criteria
+   * is set on the match with remaining slots for automatched players.
+   * @return Google_Service_Games_TurnBasedMatch
+   */
+  public function leaveTurn($matchId, $matchVersion, $optParams = array())
+  {
+    $params = array('matchId' => $matchId, 'matchVersion' => $matchVersion);
+    $params = array_merge($params, $optParams);
+    return $this->call('leaveTurn', array($params), "Google_Service_Games_TurnBasedMatch");
+  }
+
+  /**
+   * Returns turn-based matches the player is or was involved in.
+   * (turnBasedMatches.listTurnBasedMatches)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param int maxCompletedMatches The maximum number of completed or
+   * canceled matches to return in the response. If not set, all matches returned
+   * could be completed or canceled.
+   * @opt_param int maxResults The maximum number of matches to return in the
+   * response, used for paging. For any response, the actual number of matches to
+   * return may be less than the specified maxResults.
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @opt_param bool includeMatchData True if match data should be returned in the
+   * response. Note that not all data will necessarily be returned if
+   * include_match_data is true; the server may decide to only return data for
+   * some of the matches to limit download size for the client. The remainder of
+   * the data for these matches will be retrievable on request.
+   * @return Google_Service_Games_TurnBasedMatchList
+   */
+  public function listTurnBasedMatches($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Games_TurnBasedMatchList");
+  }
+
+  /**
+   * Create a rematch of a match that was previously completed, with the same
+   * participants. This can be called by only one player on a match still in their
+   * list; the player must have called Finish first. Returns the newly created
+   * match; it will be the caller's turn. (turnBasedMatches.rematch)
+   *
+   * @param string $matchId The ID of the match.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string requestId A randomly generated numeric ID for each request
+   * specified by the caller. This number is used at the server to ensure that the
+   * request is handled correctly across retries.
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_TurnBasedMatchRematch
+   */
+  public function rematch($matchId, $optParams = array())
+  {
+    $params = array('matchId' => $matchId);
+    $params = array_merge($params, $optParams);
+    return $this->call('rematch', array($params), "Google_Service_Games_TurnBasedMatchRematch");
+  }
+
+  /**
+   * Returns turn-based matches the player is or was involved in that changed
+   * since the last sync call, with the least recent changes coming first. Matches
+   * that should be removed from the local cache will have a status of
+   * MATCH_DELETED. (turnBasedMatches.sync)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param int maxCompletedMatches The maximum number of completed or
+   * canceled matches to return in the response. If not set, all matches returned
+   * could be completed or canceled.
+   * @opt_param int maxResults The maximum number of matches to return in the
+   * response, used for paging. For any response, the actual number of matches to
+   * return may be less than the specified maxResults.
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @opt_param bool includeMatchData True if match data should be returned in the
+   * response. Note that not all data will necessarily be returned if
+   * include_match_data is true; the server may decide to only return data for
+   * some of the matches to limit download size for the client. The remainder of
+   * the data for these matches will be retrievable on request.
+   * @return Google_Service_Games_TurnBasedMatchSync
+   */
+  public function sync($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('sync', array($params), "Google_Service_Games_TurnBasedMatchSync");
+  }
+
+  /**
+   * Commit the results of a player turn. (turnBasedMatches.takeTurn)
+   *
+   * @param string $matchId The ID of the match.
+   * @param Google_TurnBasedMatchTurn $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string language The preferred language to use for strings returned
+   * by this method.
+   * @return Google_Service_Games_TurnBasedMatch
+   */
+  public function takeTurn($matchId, Google_Service_Games_TurnBasedMatchTurn $postBody, $optParams = array())
+  {
+    $params = array('matchId' => $matchId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('takeTurn', array($params), "Google_Service_Games_TurnBasedMatch");
+  }
+}
+
+
+
+
+class Google_Service_Games_AchievementDefinition extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $achievementType;
+  public $description;
+  public $experiencePoints;
+  public $formattedTotalSteps;
+  public $id;
+  public $initialState;
+  public $isRevealedIconUrlDefault;
+  public $isUnlockedIconUrlDefault;
+  public $kind;
+  public $name;
+  public $revealedIconUrl;
+  public $totalSteps;
+  public $unlockedIconUrl;
+
+
+  public function setAchievementType($achievementType)
+  {
+    $this->achievementType = $achievementType;
+  }
+  public function getAchievementType()
+  {
+    return $this->achievementType;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setExperiencePoints($experiencePoints)
+  {
+    $this->experiencePoints = $experiencePoints;
+  }
+  public function getExperiencePoints()
+  {
+    return $this->experiencePoints;
+  }
+  public function setFormattedTotalSteps($formattedTotalSteps)
+  {
+    $this->formattedTotalSteps = $formattedTotalSteps;
+  }
+  public function getFormattedTotalSteps()
+  {
+    return $this->formattedTotalSteps;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInitialState($initialState)
+  {
+    $this->initialState = $initialState;
+  }
+  public function getInitialState()
+  {
+    return $this->initialState;
+  }
+  public function setIsRevealedIconUrlDefault($isRevealedIconUrlDefault)
+  {
+    $this->isRevealedIconUrlDefault = $isRevealedIconUrlDefault;
+  }
+  public function getIsRevealedIconUrlDefault()
+  {
+    return $this->isRevealedIconUrlDefault;
+  }
+  public function setIsUnlockedIconUrlDefault($isUnlockedIconUrlDefault)
+  {
+    $this->isUnlockedIconUrlDefault = $isUnlockedIconUrlDefault;
+  }
+  public function getIsUnlockedIconUrlDefault()
+  {
+    return $this->isUnlockedIconUrlDefault;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setRevealedIconUrl($revealedIconUrl)
+  {
+    $this->revealedIconUrl = $revealedIconUrl;
+  }
+  public function getRevealedIconUrl()
+  {
+    return $this->revealedIconUrl;
+  }
+  public function setTotalSteps($totalSteps)
+  {
+    $this->totalSteps = $totalSteps;
+  }
+  public function getTotalSteps()
+  {
+    return $this->totalSteps;
+  }
+  public function setUnlockedIconUrl($unlockedIconUrl)
+  {
+    $this->unlockedIconUrl = $unlockedIconUrl;
+  }
+  public function getUnlockedIconUrl()
+  {
+    return $this->unlockedIconUrl;
+  }
+}
+
+class Google_Service_Games_AchievementDefinitionsListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Games_AchievementDefinition';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Games_AchievementIncrementResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $currentSteps;
+  public $kind;
+  public $newlyUnlocked;
+
+
+  public function setCurrentSteps($currentSteps)
+  {
+    $this->currentSteps = $currentSteps;
+  }
+  public function getCurrentSteps()
+  {
+    return $this->currentSteps;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNewlyUnlocked($newlyUnlocked)
+  {
+    $this->newlyUnlocked = $newlyUnlocked;
+  }
+  public function getNewlyUnlocked()
+  {
+    return $this->newlyUnlocked;
+  }
+}
+
+class Google_Service_Games_AchievementRevealResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $currentState;
+  public $kind;
+
+
+  public function setCurrentState($currentState)
+  {
+    $this->currentState = $currentState;
+  }
+  public function getCurrentState()
+  {
+    return $this->currentState;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Games_AchievementSetStepsAtLeastResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $currentSteps;
+  public $kind;
+  public $newlyUnlocked;
+
+
+  public function setCurrentSteps($currentSteps)
+  {
+    $this->currentSteps = $currentSteps;
+  }
+  public function getCurrentSteps()
+  {
+    return $this->currentSteps;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNewlyUnlocked($newlyUnlocked)
+  {
+    $this->newlyUnlocked = $newlyUnlocked;
+  }
+  public function getNewlyUnlocked()
+  {
+    return $this->newlyUnlocked;
+  }
+}
+
+class Google_Service_Games_AchievementUnlockResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $newlyUnlocked;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNewlyUnlocked($newlyUnlocked)
+  {
+    $this->newlyUnlocked = $newlyUnlocked;
+  }
+  public function getNewlyUnlocked()
+  {
+    return $this->newlyUnlocked;
+  }
+}
+
+class Google_Service_Games_AchievementUpdateMultipleRequest extends Google_Collection
+{
+  protected $collection_key = 'updates';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $updatesType = 'Google_Service_Games_AchievementUpdateRequest';
+  protected $updatesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUpdates($updates)
+  {
+    $this->updates = $updates;
+  }
+  public function getUpdates()
+  {
+    return $this->updates;
+  }
+}
+
+class Google_Service_Games_AchievementUpdateMultipleResponse extends Google_Collection
+{
+  protected $collection_key = 'updatedAchievements';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $updatedAchievementsType = 'Google_Service_Games_AchievementUpdateResponse';
+  protected $updatedAchievementsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUpdatedAchievements($updatedAchievements)
+  {
+    $this->updatedAchievements = $updatedAchievements;
+  }
+  public function getUpdatedAchievements()
+  {
+    return $this->updatedAchievements;
+  }
+}
+
+class Google_Service_Games_AchievementUpdateRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $achievementId;
+  protected $incrementPayloadType = 'Google_Service_Games_GamesAchievementIncrement';
+  protected $incrementPayloadDataType = '';
+  public $kind;
+  protected $setStepsAtLeastPayloadType = 'Google_Service_Games_GamesAchievementSetStepsAtLeast';
+  protected $setStepsAtLeastPayloadDataType = '';
+  public $updateType;
+
+
+  public function setAchievementId($achievementId)
+  {
+    $this->achievementId = $achievementId;
+  }
+  public function getAchievementId()
+  {
+    return $this->achievementId;
+  }
+  public function setIncrementPayload(Google_Service_Games_GamesAchievementIncrement $incrementPayload)
+  {
+    $this->incrementPayload = $incrementPayload;
+  }
+  public function getIncrementPayload()
+  {
+    return $this->incrementPayload;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSetStepsAtLeastPayload(Google_Service_Games_GamesAchievementSetStepsAtLeast $setStepsAtLeastPayload)
+  {
+    $this->setStepsAtLeastPayload = $setStepsAtLeastPayload;
+  }
+  public function getSetStepsAtLeastPayload()
+  {
+    return $this->setStepsAtLeastPayload;
+  }
+  public function setUpdateType($updateType)
+  {
+    $this->updateType = $updateType;
+  }
+  public function getUpdateType()
+  {
+    return $this->updateType;
+  }
+}
+
+class Google_Service_Games_AchievementUpdateResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $achievementId;
+  public $currentState;
+  public $currentSteps;
+  public $kind;
+  public $newlyUnlocked;
+  public $updateOccurred;
+
+
+  public function setAchievementId($achievementId)
+  {
+    $this->achievementId = $achievementId;
+  }
+  public function getAchievementId()
+  {
+    return $this->achievementId;
+  }
+  public function setCurrentState($currentState)
+  {
+    $this->currentState = $currentState;
+  }
+  public function getCurrentState()
+  {
+    return $this->currentState;
+  }
+  public function setCurrentSteps($currentSteps)
+  {
+    $this->currentSteps = $currentSteps;
+  }
+  public function getCurrentSteps()
+  {
+    return $this->currentSteps;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNewlyUnlocked($newlyUnlocked)
+  {
+    $this->newlyUnlocked = $newlyUnlocked;
+  }
+  public function getNewlyUnlocked()
+  {
+    return $this->newlyUnlocked;
+  }
+  public function setUpdateOccurred($updateOccurred)
+  {
+    $this->updateOccurred = $updateOccurred;
+  }
+  public function getUpdateOccurred()
+  {
+    return $this->updateOccurred;
+  }
+}
+
+class Google_Service_Games_AggregateStats extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $count;
+  public $kind;
+  public $max;
+  public $min;
+  public $sum;
+
+
+  public function setCount($count)
+  {
+    $this->count = $count;
+  }
+  public function getCount()
+  {
+    return $this->count;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMax($max)
+  {
+    $this->max = $max;
+  }
+  public function getMax()
+  {
+    return $this->max;
+  }
+  public function setMin($min)
+  {
+    $this->min = $min;
+  }
+  public function getMin()
+  {
+    return $this->min;
+  }
+  public function setSum($sum)
+  {
+    $this->sum = $sum;
+  }
+  public function getSum()
+  {
+    return $this->sum;
+  }
+}
+
+class Google_Service_Games_AnonymousPlayer extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $avatarImageUrl;
+  public $displayName;
+  public $kind;
+
+
+  public function setAvatarImageUrl($avatarImageUrl)
+  {
+    $this->avatarImageUrl = $avatarImageUrl;
+  }
+  public function getAvatarImageUrl()
+  {
+    return $this->avatarImageUrl;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Games_Application extends Google_Collection
+{
+  protected $collection_key = 'instances';
+  protected $internal_gapi_mappings = array(
+        "achievementCount" => "achievement_count",
+        "leaderboardCount" => "leaderboard_count",
+  );
+  public $achievementCount;
+  protected $assetsType = 'Google_Service_Games_ImageAsset';
+  protected $assetsDataType = 'array';
+  public $author;
+  protected $categoryType = 'Google_Service_Games_ApplicationCategory';
+  protected $categoryDataType = '';
+  public $description;
+  public $enabledFeatures;
+  public $id;
+  protected $instancesType = 'Google_Service_Games_Instance';
+  protected $instancesDataType = 'array';
+  public $kind;
+  public $lastUpdatedTimestamp;
+  public $leaderboardCount;
+  public $name;
+  public $themeColor;
+
+
+  public function setAchievementCount($achievementCount)
+  {
+    $this->achievementCount = $achievementCount;
+  }
+  public function getAchievementCount()
+  {
+    return $this->achievementCount;
+  }
+  public function setAssets($assets)
+  {
+    $this->assets = $assets;
+  }
+  public function getAssets()
+  {
+    return $this->assets;
+  }
+  public function setAuthor($author)
+  {
+    $this->author = $author;
+  }
+  public function getAuthor()
+  {
+    return $this->author;
+  }
+  public function setCategory(Google_Service_Games_ApplicationCategory $category)
+  {
+    $this->category = $category;
+  }
+  public function getCategory()
+  {
+    return $this->category;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEnabledFeatures($enabledFeatures)
+  {
+    $this->enabledFeatures = $enabledFeatures;
+  }
+  public function getEnabledFeatures()
+  {
+    return $this->enabledFeatures;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInstances($instances)
+  {
+    $this->instances = $instances;
+  }
+  public function getInstances()
+  {
+    return $this->instances;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastUpdatedTimestamp($lastUpdatedTimestamp)
+  {
+    $this->lastUpdatedTimestamp = $lastUpdatedTimestamp;
+  }
+  public function getLastUpdatedTimestamp()
+  {
+    return $this->lastUpdatedTimestamp;
+  }
+  public function setLeaderboardCount($leaderboardCount)
+  {
+    $this->leaderboardCount = $leaderboardCount;
+  }
+  public function getLeaderboardCount()
+  {
+    return $this->leaderboardCount;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setThemeColor($themeColor)
+  {
+    $this->themeColor = $themeColor;
+  }
+  public function getThemeColor()
+  {
+    return $this->themeColor;
+  }
+}
+
+class Google_Service_Games_ApplicationCategory extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $primary;
+  public $secondary;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPrimary($primary)
+  {
+    $this->primary = $primary;
+  }
+  public function getPrimary()
+  {
+    return $this->primary;
+  }
+  public function setSecondary($secondary)
+  {
+    $this->secondary = $secondary;
+  }
+  public function getSecondary()
+  {
+    return $this->secondary;
+  }
+}
+
+class Google_Service_Games_Category extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $category;
+  public $experiencePoints;
+  public $kind;
+
+
+  public function setCategory($category)
+  {
+    $this->category = $category;
+  }
+  public function getCategory()
+  {
+    return $this->category;
+  }
+  public function setExperiencePoints($experiencePoints)
+  {
+    $this->experiencePoints = $experiencePoints;
+  }
+  public function getExperiencePoints()
+  {
+    return $this->experiencePoints;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Games_CategoryListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Games_Category';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Games_EventBatchRecordFailure extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $failureCause;
+  public $kind;
+  protected $rangeType = 'Google_Service_Games_EventPeriodRange';
+  protected $rangeDataType = '';
+
+
+  public function setFailureCause($failureCause)
+  {
+    $this->failureCause = $failureCause;
+  }
+  public function getFailureCause()
+  {
+    return $this->failureCause;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRange(Google_Service_Games_EventPeriodRange $range)
+  {
+    $this->range = $range;
+  }
+  public function getRange()
+  {
+    return $this->range;
+  }
+}
+
+class Google_Service_Games_EventChild extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $childId;
+  public $kind;
+
+
+  public function setChildId($childId)
+  {
+    $this->childId = $childId;
+  }
+  public function getChildId()
+  {
+    return $this->childId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Games_EventDefinition extends Google_Collection
+{
+  protected $collection_key = 'childEvents';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $childEventsType = 'Google_Service_Games_EventChild';
+  protected $childEventsDataType = 'array';
+  public $description;
+  public $displayName;
+  public $id;
+  public $imageUrl;
+  public $isDefaultImageUrl;
+  public $kind;
+  public $visibility;
+
+
+  public function setChildEvents($childEvents)
+  {
+    $this->childEvents = $childEvents;
+  }
+  public function getChildEvents()
+  {
+    return $this->childEvents;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImageUrl($imageUrl)
+  {
+    $this->imageUrl = $imageUrl;
+  }
+  public function getImageUrl()
+  {
+    return $this->imageUrl;
+  }
+  public function setIsDefaultImageUrl($isDefaultImageUrl)
+  {
+    $this->isDefaultImageUrl = $isDefaultImageUrl;
+  }
+  public function getIsDefaultImageUrl()
+  {
+    return $this->isDefaultImageUrl;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setVisibility($visibility)
+  {
+    $this->visibility = $visibility;
+  }
+  public function getVisibility()
+  {
+    return $this->visibility;
+  }
+}
+
+class Google_Service_Games_EventDefinitionListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Games_EventDefinition';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Games_EventPeriodRange extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $periodEndMillis;
+  public $periodStartMillis;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPeriodEndMillis($periodEndMillis)
+  {
+    $this->periodEndMillis = $periodEndMillis;
+  }
+  public function getPeriodEndMillis()
+  {
+    return $this->periodEndMillis;
+  }
+  public function setPeriodStartMillis($periodStartMillis)
+  {
+    $this->periodStartMillis = $periodStartMillis;
+  }
+  public function getPeriodStartMillis()
+  {
+    return $this->periodStartMillis;
+  }
+}
+
+class Google_Service_Games_EventPeriodUpdate extends Google_Collection
+{
+  protected $collection_key = 'updates';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $timePeriodType = 'Google_Service_Games_EventPeriodRange';
+  protected $timePeriodDataType = '';
+  protected $updatesType = 'Google_Service_Games_EventUpdateRequest';
+  protected $updatesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setTimePeriod(Google_Service_Games_EventPeriodRange $timePeriod)
+  {
+    $this->timePeriod = $timePeriod;
+  }
+  public function getTimePeriod()
+  {
+    return $this->timePeriod;
+  }
+  public function setUpdates($updates)
+  {
+    $this->updates = $updates;
+  }
+  public function getUpdates()
+  {
+    return $this->updates;
+  }
+}
+
+class Google_Service_Games_EventRecordFailure extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $eventId;
+  public $failureCause;
+  public $kind;
+
+
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setFailureCause($failureCause)
+  {
+    $this->failureCause = $failureCause;
+  }
+  public function getFailureCause()
+  {
+    return $this->failureCause;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Games_EventRecordRequest extends Google_Collection
+{
+  protected $collection_key = 'timePeriods';
+  protected $internal_gapi_mappings = array(
+  );
+  public $currentTimeMillis;
+  public $kind;
+  public $requestId;
+  protected $timePeriodsType = 'Google_Service_Games_EventPeriodUpdate';
+  protected $timePeriodsDataType = 'array';
+
+
+  public function setCurrentTimeMillis($currentTimeMillis)
+  {
+    $this->currentTimeMillis = $currentTimeMillis;
+  }
+  public function getCurrentTimeMillis()
+  {
+    return $this->currentTimeMillis;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRequestId($requestId)
+  {
+    $this->requestId = $requestId;
+  }
+  public function getRequestId()
+  {
+    return $this->requestId;
+  }
+  public function setTimePeriods($timePeriods)
+  {
+    $this->timePeriods = $timePeriods;
+  }
+  public function getTimePeriods()
+  {
+    return $this->timePeriods;
+  }
+}
+
+class Google_Service_Games_EventUpdateRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $definitionId;
+  public $kind;
+  public $updateCount;
+
+
+  public function setDefinitionId($definitionId)
+  {
+    $this->definitionId = $definitionId;
+  }
+  public function getDefinitionId()
+  {
+    return $this->definitionId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUpdateCount($updateCount)
+  {
+    $this->updateCount = $updateCount;
+  }
+  public function getUpdateCount()
+  {
+    return $this->updateCount;
+  }
+}
+
+class Google_Service_Games_EventUpdateResponse extends Google_Collection
+{
+  protected $collection_key = 'playerEvents';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $batchFailuresType = 'Google_Service_Games_EventBatchRecordFailure';
+  protected $batchFailuresDataType = 'array';
+  protected $eventFailuresType = 'Google_Service_Games_EventRecordFailure';
+  protected $eventFailuresDataType = 'array';
+  public $kind;
+  protected $playerEventsType = 'Google_Service_Games_PlayerEvent';
+  protected $playerEventsDataType = 'array';
+
+
+  public function setBatchFailures($batchFailures)
+  {
+    $this->batchFailures = $batchFailures;
+  }
+  public function getBatchFailures()
+  {
+    return $this->batchFailures;
+  }
+  public function setEventFailures($eventFailures)
+  {
+    $this->eventFailures = $eventFailures;
+  }
+  public function getEventFailures()
+  {
+    return $this->eventFailures;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPlayerEvents($playerEvents)
+  {
+    $this->playerEvents = $playerEvents;
+  }
+  public function getPlayerEvents()
+  {
+    return $this->playerEvents;
+  }
+}
+
+class Google_Service_Games_GamesAchievementIncrement extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $requestId;
+  public $steps;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRequestId($requestId)
+  {
+    $this->requestId = $requestId;
+  }
+  public function getRequestId()
+  {
+    return $this->requestId;
+  }
+  public function setSteps($steps)
+  {
+    $this->steps = $steps;
+  }
+  public function getSteps()
+  {
+    return $this->steps;
+  }
+}
+
+class Google_Service_Games_GamesAchievementSetStepsAtLeast extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $steps;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSteps($steps)
+  {
+    $this->steps = $steps;
+  }
+  public function getSteps()
+  {
+    return $this->steps;
+  }
+}
+
+class Google_Service_Games_ImageAsset extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $kind;
+  public $name;
+  public $url;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_Games_Instance extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $acquisitionUri;
+  protected $androidInstanceType = 'Google_Service_Games_InstanceAndroidDetails';
+  protected $androidInstanceDataType = '';
+  protected $iosInstanceType = 'Google_Service_Games_InstanceIosDetails';
+  protected $iosInstanceDataType = '';
+  public $kind;
+  public $name;
+  public $platformType;
+  public $realtimePlay;
+  public $turnBasedPlay;
+  protected $webInstanceType = 'Google_Service_Games_InstanceWebDetails';
+  protected $webInstanceDataType = '';
+
+
+  public function setAcquisitionUri($acquisitionUri)
+  {
+    $this->acquisitionUri = $acquisitionUri;
+  }
+  public function getAcquisitionUri()
+  {
+    return $this->acquisitionUri;
+  }
+  public function setAndroidInstance(Google_Service_Games_InstanceAndroidDetails $androidInstance)
+  {
+    $this->androidInstance = $androidInstance;
+  }
+  public function getAndroidInstance()
+  {
+    return $this->androidInstance;
+  }
+  public function setIosInstance(Google_Service_Games_InstanceIosDetails $iosInstance)
+  {
+    $this->iosInstance = $iosInstance;
+  }
+  public function getIosInstance()
+  {
+    return $this->iosInstance;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPlatformType($platformType)
+  {
+    $this->platformType = $platformType;
+  }
+  public function getPlatformType()
+  {
+    return $this->platformType;
+  }
+  public function setRealtimePlay($realtimePlay)
+  {
+    $this->realtimePlay = $realtimePlay;
+  }
+  public function getRealtimePlay()
+  {
+    return $this->realtimePlay;
+  }
+  public function setTurnBasedPlay($turnBasedPlay)
+  {
+    $this->turnBasedPlay = $turnBasedPlay;
+  }
+  public function getTurnBasedPlay()
+  {
+    return $this->turnBasedPlay;
+  }
+  public function setWebInstance(Google_Service_Games_InstanceWebDetails $webInstance)
+  {
+    $this->webInstance = $webInstance;
+  }
+  public function getWebInstance()
+  {
+    return $this->webInstance;
+  }
+}
+
+class Google_Service_Games_InstanceAndroidDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $enablePiracyCheck;
+  public $kind;
+  public $packageName;
+  public $preferred;
+
+
+  public function setEnablePiracyCheck($enablePiracyCheck)
+  {
+    $this->enablePiracyCheck = $enablePiracyCheck;
+  }
+  public function getEnablePiracyCheck()
+  {
+    return $this->enablePiracyCheck;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPackageName($packageName)
+  {
+    $this->packageName = $packageName;
+  }
+  public function getPackageName()
+  {
+    return $this->packageName;
+  }
+  public function setPreferred($preferred)
+  {
+    $this->preferred = $preferred;
+  }
+  public function getPreferred()
+  {
+    return $this->preferred;
+  }
+}
+
+class Google_Service_Games_InstanceIosDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $bundleIdentifier;
+  public $itunesAppId;
+  public $kind;
+  public $preferredForIpad;
+  public $preferredForIphone;
+  public $supportIpad;
+  public $supportIphone;
+
+
+  public function setBundleIdentifier($bundleIdentifier)
+  {
+    $this->bundleIdentifier = $bundleIdentifier;
+  }
+  public function getBundleIdentifier()
+  {
+    return $this->bundleIdentifier;
+  }
+  public function setItunesAppId($itunesAppId)
+  {
+    $this->itunesAppId = $itunesAppId;
+  }
+  public function getItunesAppId()
+  {
+    return $this->itunesAppId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPreferredForIpad($preferredForIpad)
+  {
+    $this->preferredForIpad = $preferredForIpad;
+  }
+  public function getPreferredForIpad()
+  {
+    return $this->preferredForIpad;
+  }
+  public function setPreferredForIphone($preferredForIphone)
+  {
+    $this->preferredForIphone = $preferredForIphone;
+  }
+  public function getPreferredForIphone()
+  {
+    return $this->preferredForIphone;
+  }
+  public function setSupportIpad($supportIpad)
+  {
+    $this->supportIpad = $supportIpad;
+  }
+  public function getSupportIpad()
+  {
+    return $this->supportIpad;
+  }
+  public function setSupportIphone($supportIphone)
+  {
+    $this->supportIphone = $supportIphone;
+  }
+  public function getSupportIphone()
+  {
+    return $this->supportIphone;
+  }
+}
+
+class Google_Service_Games_InstanceWebDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $launchUrl;
+  public $preferred;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLaunchUrl($launchUrl)
+  {
+    $this->launchUrl = $launchUrl;
+  }
+  public function getLaunchUrl()
+  {
+    return $this->launchUrl;
+  }
+  public function setPreferred($preferred)
+  {
+    $this->preferred = $preferred;
+  }
+  public function getPreferred()
+  {
+    return $this->preferred;
+  }
+}
+
+class Google_Service_Games_Leaderboard extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $iconUrl;
+  public $id;
+  public $isIconUrlDefault;
+  public $kind;
+  public $name;
+  public $order;
+
+
+  public function setIconUrl($iconUrl)
+  {
+    $this->iconUrl = $iconUrl;
+  }
+  public function getIconUrl()
+  {
+    return $this->iconUrl;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIsIconUrlDefault($isIconUrlDefault)
+  {
+    $this->isIconUrlDefault = $isIconUrlDefault;
+  }
+  public function getIsIconUrlDefault()
+  {
+    return $this->isIconUrlDefault;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOrder($order)
+  {
+    $this->order = $order;
+  }
+  public function getOrder()
+  {
+    return $this->order;
+  }
+}
+
+class Google_Service_Games_LeaderboardEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $formattedScore;
+  public $formattedScoreRank;
+  public $kind;
+  protected $playerType = 'Google_Service_Games_Player';
+  protected $playerDataType = '';
+  public $scoreRank;
+  public $scoreTag;
+  public $scoreValue;
+  public $timeSpan;
+  public $writeTimestampMillis;
+
+
+  public function setFormattedScore($formattedScore)
+  {
+    $this->formattedScore = $formattedScore;
+  }
+  public function getFormattedScore()
+  {
+    return $this->formattedScore;
+  }
+  public function setFormattedScoreRank($formattedScoreRank)
+  {
+    $this->formattedScoreRank = $formattedScoreRank;
+  }
+  public function getFormattedScoreRank()
+  {
+    return $this->formattedScoreRank;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPlayer(Google_Service_Games_Player $player)
+  {
+    $this->player = $player;
+  }
+  public function getPlayer()
+  {
+    return $this->player;
+  }
+  public function setScoreRank($scoreRank)
+  {
+    $this->scoreRank = $scoreRank;
+  }
+  public function getScoreRank()
+  {
+    return $this->scoreRank;
+  }
+  public function setScoreTag($scoreTag)
+  {
+    $this->scoreTag = $scoreTag;
+  }
+  public function getScoreTag()
+  {
+    return $this->scoreTag;
+  }
+  public function setScoreValue($scoreValue)
+  {
+    $this->scoreValue = $scoreValue;
+  }
+  public function getScoreValue()
+  {
+    return $this->scoreValue;
+  }
+  public function setTimeSpan($timeSpan)
+  {
+    $this->timeSpan = $timeSpan;
+  }
+  public function getTimeSpan()
+  {
+    return $this->timeSpan;
+  }
+  public function setWriteTimestampMillis($writeTimestampMillis)
+  {
+    $this->writeTimestampMillis = $writeTimestampMillis;
+  }
+  public function getWriteTimestampMillis()
+  {
+    return $this->writeTimestampMillis;
+  }
+}
+
+class Google_Service_Games_LeaderboardListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Games_Leaderboard';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Games_LeaderboardScoreRank extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $formattedNumScores;
+  public $formattedRank;
+  public $kind;
+  public $numScores;
+  public $rank;
+
+
+  public function setFormattedNumScores($formattedNumScores)
+  {
+    $this->formattedNumScores = $formattedNumScores;
+  }
+  public function getFormattedNumScores()
+  {
+    return $this->formattedNumScores;
+  }
+  public function setFormattedRank($formattedRank)
+  {
+    $this->formattedRank = $formattedRank;
+  }
+  public function getFormattedRank()
+  {
+    return $this->formattedRank;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNumScores($numScores)
+  {
+    $this->numScores = $numScores;
+  }
+  public function getNumScores()
+  {
+    return $this->numScores;
+  }
+  public function setRank($rank)
+  {
+    $this->rank = $rank;
+  }
+  public function getRank()
+  {
+    return $this->rank;
+  }
+}
+
+class Google_Service_Games_LeaderboardScores extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Games_LeaderboardEntry';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $numScores;
+  protected $playerScoreType = 'Google_Service_Games_LeaderboardEntry';
+  protected $playerScoreDataType = '';
+  public $prevPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setNumScores($numScores)
+  {
+    $this->numScores = $numScores;
+  }
+  public function getNumScores()
+  {
+    return $this->numScores;
+  }
+  public function setPlayerScore(Google_Service_Games_LeaderboardEntry $playerScore)
+  {
+    $this->playerScore = $playerScore;
+  }
+  public function getPlayerScore()
+  {
+    return $this->playerScore;
+  }
+  public function setPrevPageToken($prevPageToken)
+  {
+    $this->prevPageToken = $prevPageToken;
+  }
+  public function getPrevPageToken()
+  {
+    return $this->prevPageToken;
+  }
+}
+
+class Google_Service_Games_MetagameConfig extends Google_Collection
+{
+  protected $collection_key = 'playerLevels';
+  protected $internal_gapi_mappings = array(
+  );
+  public $currentVersion;
+  public $kind;
+  protected $playerLevelsType = 'Google_Service_Games_PlayerLevel';
+  protected $playerLevelsDataType = 'array';
+
+
+  public function setCurrentVersion($currentVersion)
+  {
+    $this->currentVersion = $currentVersion;
+  }
+  public function getCurrentVersion()
+  {
+    return $this->currentVersion;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPlayerLevels($playerLevels)
+  {
+    $this->playerLevels = $playerLevels;
+  }
+  public function getPlayerLevels()
+  {
+    return $this->playerLevels;
+  }
+}
+
+class Google_Service_Games_NetworkDiagnostics extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $androidNetworkSubtype;
+  public $androidNetworkType;
+  public $iosNetworkType;
+  public $kind;
+  public $networkOperatorCode;
+  public $networkOperatorName;
+  public $registrationLatencyMillis;
+
+
+  public function setAndroidNetworkSubtype($androidNetworkSubtype)
+  {
+    $this->androidNetworkSubtype = $androidNetworkSubtype;
+  }
+  public function getAndroidNetworkSubtype()
+  {
+    return $this->androidNetworkSubtype;
+  }
+  public function setAndroidNetworkType($androidNetworkType)
+  {
+    $this->androidNetworkType = $androidNetworkType;
+  }
+  public function getAndroidNetworkType()
+  {
+    return $this->androidNetworkType;
+  }
+  public function setIosNetworkType($iosNetworkType)
+  {
+    $this->iosNetworkType = $iosNetworkType;
+  }
+  public function getIosNetworkType()
+  {
+    return $this->iosNetworkType;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNetworkOperatorCode($networkOperatorCode)
+  {
+    $this->networkOperatorCode = $networkOperatorCode;
+  }
+  public function getNetworkOperatorCode()
+  {
+    return $this->networkOperatorCode;
+  }
+  public function setNetworkOperatorName($networkOperatorName)
+  {
+    $this->networkOperatorName = $networkOperatorName;
+  }
+  public function getNetworkOperatorName()
+  {
+    return $this->networkOperatorName;
+  }
+  public function setRegistrationLatencyMillis($registrationLatencyMillis)
+  {
+    $this->registrationLatencyMillis = $registrationLatencyMillis;
+  }
+  public function getRegistrationLatencyMillis()
+  {
+    return $this->registrationLatencyMillis;
+  }
+}
+
+class Google_Service_Games_ParticipantResult extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $participantId;
+  public $placing;
+  public $result;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setParticipantId($participantId)
+  {
+    $this->participantId = $participantId;
+  }
+  public function getParticipantId()
+  {
+    return $this->participantId;
+  }
+  public function setPlacing($placing)
+  {
+    $this->placing = $placing;
+  }
+  public function getPlacing()
+  {
+    return $this->placing;
+  }
+  public function setResult($result)
+  {
+    $this->result = $result;
+  }
+  public function getResult()
+  {
+    return $this->result;
+  }
+}
+
+class Google_Service_Games_PeerChannelDiagnostics extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $bytesReceivedType = 'Google_Service_Games_AggregateStats';
+  protected $bytesReceivedDataType = '';
+  protected $bytesSentType = 'Google_Service_Games_AggregateStats';
+  protected $bytesSentDataType = '';
+  public $kind;
+  public $numMessagesLost;
+  public $numMessagesReceived;
+  public $numMessagesSent;
+  public $numSendFailures;
+  protected $roundtripLatencyMillisType = 'Google_Service_Games_AggregateStats';
+  protected $roundtripLatencyMillisDataType = '';
+
+
+  public function setBytesReceived(Google_Service_Games_AggregateStats $bytesReceived)
+  {
+    $this->bytesReceived = $bytesReceived;
+  }
+  public function getBytesReceived()
+  {
+    return $this->bytesReceived;
+  }
+  public function setBytesSent(Google_Service_Games_AggregateStats $bytesSent)
+  {
+    $this->bytesSent = $bytesSent;
+  }
+  public function getBytesSent()
+  {
+    return $this->bytesSent;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNumMessagesLost($numMessagesLost)
+  {
+    $this->numMessagesLost = $numMessagesLost;
+  }
+  public function getNumMessagesLost()
+  {
+    return $this->numMessagesLost;
+  }
+  public function setNumMessagesReceived($numMessagesReceived)
+  {
+    $this->numMessagesReceived = $numMessagesReceived;
+  }
+  public function getNumMessagesReceived()
+  {
+    return $this->numMessagesReceived;
+  }
+  public function setNumMessagesSent($numMessagesSent)
+  {
+    $this->numMessagesSent = $numMessagesSent;
+  }
+  public function getNumMessagesSent()
+  {
+    return $this->numMessagesSent;
+  }
+  public function setNumSendFailures($numSendFailures)
+  {
+    $this->numSendFailures = $numSendFailures;
+  }
+  public function getNumSendFailures()
+  {
+    return $this->numSendFailures;
+  }
+  public function setRoundtripLatencyMillis(Google_Service_Games_AggregateStats $roundtripLatencyMillis)
+  {
+    $this->roundtripLatencyMillis = $roundtripLatencyMillis;
+  }
+  public function getRoundtripLatencyMillis()
+  {
+    return $this->roundtripLatencyMillis;
+  }
+}
+
+class Google_Service_Games_PeerSessionDiagnostics extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $connectedTimestampMillis;
+  public $kind;
+  public $participantId;
+  protected $reliableChannelType = 'Google_Service_Games_PeerChannelDiagnostics';
+  protected $reliableChannelDataType = '';
+  protected $unreliableChannelType = 'Google_Service_Games_PeerChannelDiagnostics';
+  protected $unreliableChannelDataType = '';
+
+
+  public function setConnectedTimestampMillis($connectedTimestampMillis)
+  {
+    $this->connectedTimestampMillis = $connectedTimestampMillis;
+  }
+  public function getConnectedTimestampMillis()
+  {
+    return $this->connectedTimestampMillis;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setParticipantId($participantId)
+  {
+    $this->participantId = $participantId;
+  }
+  public function getParticipantId()
+  {
+    return $this->participantId;
+  }
+  public function setReliableChannel(Google_Service_Games_PeerChannelDiagnostics $reliableChannel)
+  {
+    $this->reliableChannel = $reliableChannel;
+  }
+  public function getReliableChannel()
+  {
+    return $this->reliableChannel;
+  }
+  public function setUnreliableChannel(Google_Service_Games_PeerChannelDiagnostics $unreliableChannel)
+  {
+    $this->unreliableChannel = $unreliableChannel;
+  }
+  public function getUnreliableChannel()
+  {
+    return $this->unreliableChannel;
+  }
+}
+
+class Google_Service_Games_Played extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $autoMatched;
+  public $kind;
+  public $timeMillis;
+
+
+  public function setAutoMatched($autoMatched)
+  {
+    $this->autoMatched = $autoMatched;
+  }
+  public function getAutoMatched()
+  {
+    return $this->autoMatched;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setTimeMillis($timeMillis)
+  {
+    $this->timeMillis = $timeMillis;
+  }
+  public function getTimeMillis()
+  {
+    return $this->timeMillis;
+  }
+}
+
+class Google_Service_Games_Player extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $avatarImageUrl;
+  public $bannerUrlLandscape;
+  public $bannerUrlPortrait;
+  public $displayName;
+  protected $experienceInfoType = 'Google_Service_Games_PlayerExperienceInfo';
+  protected $experienceInfoDataType = '';
+  public $kind;
+  protected $lastPlayedWithType = 'Google_Service_Games_Played';
+  protected $lastPlayedWithDataType = '';
+  protected $nameType = 'Google_Service_Games_PlayerName';
+  protected $nameDataType = '';
+  public $playerId;
+  public $title;
+
+
+  public function setAvatarImageUrl($avatarImageUrl)
+  {
+    $this->avatarImageUrl = $avatarImageUrl;
+  }
+  public function getAvatarImageUrl()
+  {
+    return $this->avatarImageUrl;
+  }
+  public function setBannerUrlLandscape($bannerUrlLandscape)
+  {
+    $this->bannerUrlLandscape = $bannerUrlLandscape;
+  }
+  public function getBannerUrlLandscape()
+  {
+    return $this->bannerUrlLandscape;
+  }
+  public function setBannerUrlPortrait($bannerUrlPortrait)
+  {
+    $this->bannerUrlPortrait = $bannerUrlPortrait;
+  }
+  public function getBannerUrlPortrait()
+  {
+    return $this->bannerUrlPortrait;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setExperienceInfo(Google_Service_Games_PlayerExperienceInfo $experienceInfo)
+  {
+    $this->experienceInfo = $experienceInfo;
+  }
+  public function getExperienceInfo()
+  {
+    return $this->experienceInfo;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastPlayedWith(Google_Service_Games_Played $lastPlayedWith)
+  {
+    $this->lastPlayedWith = $lastPlayedWith;
+  }
+  public function getLastPlayedWith()
+  {
+    return $this->lastPlayedWith;
+  }
+  public function setName(Google_Service_Games_PlayerName $name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPlayerId($playerId)
+  {
+    $this->playerId = $playerId;
+  }
+  public function getPlayerId()
+  {
+    return $this->playerId;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_Games_PlayerAchievement extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $achievementState;
+  public $currentSteps;
+  public $experiencePoints;
+  public $formattedCurrentStepsString;
+  public $id;
+  public $kind;
+  public $lastUpdatedTimestamp;
+
+
+  public function setAchievementState($achievementState)
+  {
+    $this->achievementState = $achievementState;
+  }
+  public function getAchievementState()
+  {
+    return $this->achievementState;
+  }
+  public function setCurrentSteps($currentSteps)
+  {
+    $this->currentSteps = $currentSteps;
+  }
+  public function getCurrentSteps()
+  {
+    return $this->currentSteps;
+  }
+  public function setExperiencePoints($experiencePoints)
+  {
+    $this->experiencePoints = $experiencePoints;
+  }
+  public function getExperiencePoints()
+  {
+    return $this->experiencePoints;
+  }
+  public function setFormattedCurrentStepsString($formattedCurrentStepsString)
+  {
+    $this->formattedCurrentStepsString = $formattedCurrentStepsString;
+  }
+  public function getFormattedCurrentStepsString()
+  {
+    return $this->formattedCurrentStepsString;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastUpdatedTimestamp($lastUpdatedTimestamp)
+  {
+    $this->lastUpdatedTimestamp = $lastUpdatedTimestamp;
+  }
+  public function getLastUpdatedTimestamp()
+  {
+    return $this->lastUpdatedTimestamp;
+  }
+}
+
+class Google_Service_Games_PlayerAchievementListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Games_PlayerAchievement';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Games_PlayerEvent extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $definitionId;
+  public $formattedNumEvents;
+  public $kind;
+  public $numEvents;
+  public $playerId;
+
+
+  public function setDefinitionId($definitionId)
+  {
+    $this->definitionId = $definitionId;
+  }
+  public function getDefinitionId()
+  {
+    return $this->definitionId;
+  }
+  public function setFormattedNumEvents($formattedNumEvents)
+  {
+    $this->formattedNumEvents = $formattedNumEvents;
+  }
+  public function getFormattedNumEvents()
+  {
+    return $this->formattedNumEvents;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNumEvents($numEvents)
+  {
+    $this->numEvents = $numEvents;
+  }
+  public function getNumEvents()
+  {
+    return $this->numEvents;
+  }
+  public function setPlayerId($playerId)
+  {
+    $this->playerId = $playerId;
+  }
+  public function getPlayerId()
+  {
+    return $this->playerId;
+  }
+}
+
+class Google_Service_Games_PlayerEventListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Games_PlayerEvent';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Games_PlayerExperienceInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $currentExperiencePoints;
+  protected $currentLevelType = 'Google_Service_Games_PlayerLevel';
+  protected $currentLevelDataType = '';
+  public $kind;
+  public $lastLevelUpTimestampMillis;
+  protected $nextLevelType = 'Google_Service_Games_PlayerLevel';
+  protected $nextLevelDataType = '';
+
+
+  public function setCurrentExperiencePoints($currentExperiencePoints)
+  {
+    $this->currentExperiencePoints = $currentExperiencePoints;
+  }
+  public function getCurrentExperiencePoints()
+  {
+    return $this->currentExperiencePoints;
+  }
+  public function setCurrentLevel(Google_Service_Games_PlayerLevel $currentLevel)
+  {
+    $this->currentLevel = $currentLevel;
+  }
+  public function getCurrentLevel()
+  {
+    return $this->currentLevel;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastLevelUpTimestampMillis($lastLevelUpTimestampMillis)
+  {
+    $this->lastLevelUpTimestampMillis = $lastLevelUpTimestampMillis;
+  }
+  public function getLastLevelUpTimestampMillis()
+  {
+    return $this->lastLevelUpTimestampMillis;
+  }
+  public function setNextLevel(Google_Service_Games_PlayerLevel $nextLevel)
+  {
+    $this->nextLevel = $nextLevel;
+  }
+  public function getNextLevel()
+  {
+    return $this->nextLevel;
+  }
+}
+
+class Google_Service_Games_PlayerLeaderboardScore extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "leaderboardId" => "leaderboard_id",
+  );
+  public $kind;
+  public $leaderboardId;
+  protected $publicRankType = 'Google_Service_Games_LeaderboardScoreRank';
+  protected $publicRankDataType = '';
+  public $scoreString;
+  public $scoreTag;
+  public $scoreValue;
+  protected $socialRankType = 'Google_Service_Games_LeaderboardScoreRank';
+  protected $socialRankDataType = '';
+  public $timeSpan;
+  public $writeTimestamp;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLeaderboardId($leaderboardId)
+  {
+    $this->leaderboardId = $leaderboardId;
+  }
+  public function getLeaderboardId()
+  {
+    return $this->leaderboardId;
+  }
+  public function setPublicRank(Google_Service_Games_LeaderboardScoreRank $publicRank)
+  {
+    $this->publicRank = $publicRank;
+  }
+  public function getPublicRank()
+  {
+    return $this->publicRank;
+  }
+  public function setScoreString($scoreString)
+  {
+    $this->scoreString = $scoreString;
+  }
+  public function getScoreString()
+  {
+    return $this->scoreString;
+  }
+  public function setScoreTag($scoreTag)
+  {
+    $this->scoreTag = $scoreTag;
+  }
+  public function getScoreTag()
+  {
+    return $this->scoreTag;
+  }
+  public function setScoreValue($scoreValue)
+  {
+    $this->scoreValue = $scoreValue;
+  }
+  public function getScoreValue()
+  {
+    return $this->scoreValue;
+  }
+  public function setSocialRank(Google_Service_Games_LeaderboardScoreRank $socialRank)
+  {
+    $this->socialRank = $socialRank;
+  }
+  public function getSocialRank()
+  {
+    return $this->socialRank;
+  }
+  public function setTimeSpan($timeSpan)
+  {
+    $this->timeSpan = $timeSpan;
+  }
+  public function getTimeSpan()
+  {
+    return $this->timeSpan;
+  }
+  public function setWriteTimestamp($writeTimestamp)
+  {
+    $this->writeTimestamp = $writeTimestamp;
+  }
+  public function getWriteTimestamp()
+  {
+    return $this->writeTimestamp;
+  }
+}
+
+class Google_Service_Games_PlayerLeaderboardScoreListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Games_PlayerLeaderboardScore';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  protected $playerType = 'Google_Service_Games_Player';
+  protected $playerDataType = '';
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPlayer(Google_Service_Games_Player $player)
+  {
+    $this->player = $player;
+  }
+  public function getPlayer()
+  {
+    return $this->player;
+  }
+}
+
+class Google_Service_Games_PlayerLevel extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $level;
+  public $maxExperiencePoints;
+  public $minExperiencePoints;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLevel($level)
+  {
+    $this->level = $level;
+  }
+  public function getLevel()
+  {
+    return $this->level;
+  }
+  public function setMaxExperiencePoints($maxExperiencePoints)
+  {
+    $this->maxExperiencePoints = $maxExperiencePoints;
+  }
+  public function getMaxExperiencePoints()
+  {
+    return $this->maxExperiencePoints;
+  }
+  public function setMinExperiencePoints($minExperiencePoints)
+  {
+    $this->minExperiencePoints = $minExperiencePoints;
+  }
+  public function getMinExperiencePoints()
+  {
+    return $this->minExperiencePoints;
+  }
+}
+
+class Google_Service_Games_PlayerListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Games_Player';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Games_PlayerName extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $familyName;
+  public $givenName;
+
+
+  public function setFamilyName($familyName)
+  {
+    $this->familyName = $familyName;
+  }
+  public function getFamilyName()
+  {
+    return $this->familyName;
+  }
+  public function setGivenName($givenName)
+  {
+    $this->givenName = $givenName;
+  }
+  public function getGivenName()
+  {
+    return $this->givenName;
+  }
+}
+
+class Google_Service_Games_PlayerScore extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $formattedScore;
+  public $kind;
+  public $score;
+  public $scoreTag;
+  public $timeSpan;
+
+
+  public function setFormattedScore($formattedScore)
+  {
+    $this->formattedScore = $formattedScore;
+  }
+  public function getFormattedScore()
+  {
+    return $this->formattedScore;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setScore($score)
+  {
+    $this->score = $score;
+  }
+  public function getScore()
+  {
+    return $this->score;
+  }
+  public function setScoreTag($scoreTag)
+  {
+    $this->scoreTag = $scoreTag;
+  }
+  public function getScoreTag()
+  {
+    return $this->scoreTag;
+  }
+  public function setTimeSpan($timeSpan)
+  {
+    $this->timeSpan = $timeSpan;
+  }
+  public function getTimeSpan()
+  {
+    return $this->timeSpan;
+  }
+}
+
+class Google_Service_Games_PlayerScoreListResponse extends Google_Collection
+{
+  protected $collection_key = 'submittedScores';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $submittedScoresType = 'Google_Service_Games_PlayerScoreResponse';
+  protected $submittedScoresDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSubmittedScores($submittedScores)
+  {
+    $this->submittedScores = $submittedScores;
+  }
+  public function getSubmittedScores()
+  {
+    return $this->submittedScores;
+  }
+}
+
+class Google_Service_Games_PlayerScoreResponse extends Google_Collection
+{
+  protected $collection_key = 'unbeatenScores';
+  protected $internal_gapi_mappings = array(
+  );
+  public $beatenScoreTimeSpans;
+  public $formattedScore;
+  public $kind;
+  public $leaderboardId;
+  public $scoreTag;
+  protected $unbeatenScoresType = 'Google_Service_Games_PlayerScore';
+  protected $unbeatenScoresDataType = 'array';
+
+
+  public function setBeatenScoreTimeSpans($beatenScoreTimeSpans)
+  {
+    $this->beatenScoreTimeSpans = $beatenScoreTimeSpans;
+  }
+  public function getBeatenScoreTimeSpans()
+  {
+    return $this->beatenScoreTimeSpans;
+  }
+  public function setFormattedScore($formattedScore)
+  {
+    $this->formattedScore = $formattedScore;
+  }
+  public function getFormattedScore()
+  {
+    return $this->formattedScore;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLeaderboardId($leaderboardId)
+  {
+    $this->leaderboardId = $leaderboardId;
+  }
+  public function getLeaderboardId()
+  {
+    return $this->leaderboardId;
+  }
+  public function setScoreTag($scoreTag)
+  {
+    $this->scoreTag = $scoreTag;
+  }
+  public function getScoreTag()
+  {
+    return $this->scoreTag;
+  }
+  public function setUnbeatenScores($unbeatenScores)
+  {
+    $this->unbeatenScores = $unbeatenScores;
+  }
+  public function getUnbeatenScores()
+  {
+    return $this->unbeatenScores;
+  }
+}
+
+class Google_Service_Games_PlayerScoreSubmissionList extends Google_Collection
+{
+  protected $collection_key = 'scores';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $scoresType = 'Google_Service_Games_ScoreSubmission';
+  protected $scoresDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setScores($scores)
+  {
+    $this->scores = $scores;
+  }
+  public function getScores()
+  {
+    return $this->scores;
+  }
+}
+
+class Google_Service_Games_PushToken extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $clientRevision;
+  protected $idType = 'Google_Service_Games_PushTokenId';
+  protected $idDataType = '';
+  public $kind;
+  public $language;
+
+
+  public function setClientRevision($clientRevision)
+  {
+    $this->clientRevision = $clientRevision;
+  }
+  public function getClientRevision()
+  {
+    return $this->clientRevision;
+  }
+  public function setId(Google_Service_Games_PushTokenId $id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLanguage($language)
+  {
+    $this->language = $language;
+  }
+  public function getLanguage()
+  {
+    return $this->language;
+  }
+}
+
+class Google_Service_Games_PushTokenId extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $iosType = 'Google_Service_Games_PushTokenIdIos';
+  protected $iosDataType = '';
+  public $kind;
+
+
+  public function setIos(Google_Service_Games_PushTokenIdIos $ios)
+  {
+    $this->ios = $ios;
+  }
+  public function getIos()
+  {
+    return $this->ios;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Games_PushTokenIdIos extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "apnsDeviceToken" => "apns_device_token",
+        "apnsEnvironment" => "apns_environment",
+  );
+  public $apnsDeviceToken;
+  public $apnsEnvironment;
+
+
+  public function setApnsDeviceToken($apnsDeviceToken)
+  {
+    $this->apnsDeviceToken = $apnsDeviceToken;
+  }
+  public function getApnsDeviceToken()
+  {
+    return $this->apnsDeviceToken;
+  }
+  public function setApnsEnvironment($apnsEnvironment)
+  {
+    $this->apnsEnvironment = $apnsEnvironment;
+  }
+  public function getApnsEnvironment()
+  {
+    return $this->apnsEnvironment;
+  }
+}
+
+class Google_Service_Games_Quest extends Google_Collection
+{
+  protected $collection_key = 'milestones';
+  protected $internal_gapi_mappings = array(
+  );
+  public $acceptedTimestampMillis;
+  public $applicationId;
+  public $bannerUrl;
+  public $description;
+  public $endTimestampMillis;
+  public $iconUrl;
+  public $id;
+  public $isDefaultBannerUrl;
+  public $isDefaultIconUrl;
+  public $kind;
+  public $lastUpdatedTimestampMillis;
+  protected $milestonesType = 'Google_Service_Games_QuestMilestone';
+  protected $milestonesDataType = 'array';
+  public $name;
+  public $notifyTimestampMillis;
+  public $startTimestampMillis;
+  public $state;
+
+
+  public function setAcceptedTimestampMillis($acceptedTimestampMillis)
+  {
+    $this->acceptedTimestampMillis = $acceptedTimestampMillis;
+  }
+  public function getAcceptedTimestampMillis()
+  {
+    return $this->acceptedTimestampMillis;
+  }
+  public function setApplicationId($applicationId)
+  {
+    $this->applicationId = $applicationId;
+  }
+  public function getApplicationId()
+  {
+    return $this->applicationId;
+  }
+  public function setBannerUrl($bannerUrl)
+  {
+    $this->bannerUrl = $bannerUrl;
+  }
+  public function getBannerUrl()
+  {
+    return $this->bannerUrl;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEndTimestampMillis($endTimestampMillis)
+  {
+    $this->endTimestampMillis = $endTimestampMillis;
+  }
+  public function getEndTimestampMillis()
+  {
+    return $this->endTimestampMillis;
+  }
+  public function setIconUrl($iconUrl)
+  {
+    $this->iconUrl = $iconUrl;
+  }
+  public function getIconUrl()
+  {
+    return $this->iconUrl;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIsDefaultBannerUrl($isDefaultBannerUrl)
+  {
+    $this->isDefaultBannerUrl = $isDefaultBannerUrl;
+  }
+  public function getIsDefaultBannerUrl()
+  {
+    return $this->isDefaultBannerUrl;
+  }
+  public function setIsDefaultIconUrl($isDefaultIconUrl)
+  {
+    $this->isDefaultIconUrl = $isDefaultIconUrl;
+  }
+  public function getIsDefaultIconUrl()
+  {
+    return $this->isDefaultIconUrl;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastUpdatedTimestampMillis($lastUpdatedTimestampMillis)
+  {
+    $this->lastUpdatedTimestampMillis = $lastUpdatedTimestampMillis;
+  }
+  public function getLastUpdatedTimestampMillis()
+  {
+    return $this->lastUpdatedTimestampMillis;
+  }
+  public function setMilestones($milestones)
+  {
+    $this->milestones = $milestones;
+  }
+  public function getMilestones()
+  {
+    return $this->milestones;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNotifyTimestampMillis($notifyTimestampMillis)
+  {
+    $this->notifyTimestampMillis = $notifyTimestampMillis;
+  }
+  public function getNotifyTimestampMillis()
+  {
+    return $this->notifyTimestampMillis;
+  }
+  public function setStartTimestampMillis($startTimestampMillis)
+  {
+    $this->startTimestampMillis = $startTimestampMillis;
+  }
+  public function getStartTimestampMillis()
+  {
+    return $this->startTimestampMillis;
+  }
+  public function setState($state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+}
+
+class Google_Service_Games_QuestContribution extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $formattedValue;
+  public $kind;
+  public $value;
+
+
+  public function setFormattedValue($formattedValue)
+  {
+    $this->formattedValue = $formattedValue;
+  }
+  public function getFormattedValue()
+  {
+    return $this->formattedValue;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Games_QuestCriterion extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $completionContributionType = 'Google_Service_Games_QuestContribution';
+  protected $completionContributionDataType = '';
+  protected $currentContributionType = 'Google_Service_Games_QuestContribution';
+  protected $currentContributionDataType = '';
+  public $eventId;
+  protected $initialPlayerProgressType = 'Google_Service_Games_QuestContribution';
+  protected $initialPlayerProgressDataType = '';
+  public $kind;
+
+
+  public function setCompletionContribution(Google_Service_Games_QuestContribution $completionContribution)
+  {
+    $this->completionContribution = $completionContribution;
+  }
+  public function getCompletionContribution()
+  {
+    return $this->completionContribution;
+  }
+  public function setCurrentContribution(Google_Service_Games_QuestContribution $currentContribution)
+  {
+    $this->currentContribution = $currentContribution;
+  }
+  public function getCurrentContribution()
+  {
+    return $this->currentContribution;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setInitialPlayerProgress(Google_Service_Games_QuestContribution $initialPlayerProgress)
+  {
+    $this->initialPlayerProgress = $initialPlayerProgress;
+  }
+  public function getInitialPlayerProgress()
+  {
+    return $this->initialPlayerProgress;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Games_QuestListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Games_Quest';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Games_QuestMilestone extends Google_Collection
+{
+  protected $collection_key = 'criteria';
+  protected $internal_gapi_mappings = array(
+  );
+  public $completionRewardData;
+  protected $criteriaType = 'Google_Service_Games_QuestCriterion';
+  protected $criteriaDataType = 'array';
+  public $id;
+  public $kind;
+  public $state;
+
+
+  public function setCompletionRewardData($completionRewardData)
+  {
+    $this->completionRewardData = $completionRewardData;
+  }
+  public function getCompletionRewardData()
+  {
+    return $this->completionRewardData;
+  }
+  public function setCriteria($criteria)
+  {
+    $this->criteria = $criteria;
+  }
+  public function getCriteria()
+  {
+    return $this->criteria;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setState($state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+}
+
+class Google_Service_Games_RevisionCheckResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $apiVersion;
+  public $kind;
+  public $revisionStatus;
+
+
+  public function setApiVersion($apiVersion)
+  {
+    $this->apiVersion = $apiVersion;
+  }
+  public function getApiVersion()
+  {
+    return $this->apiVersion;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRevisionStatus($revisionStatus)
+  {
+    $this->revisionStatus = $revisionStatus;
+  }
+  public function getRevisionStatus()
+  {
+    return $this->revisionStatus;
+  }
+}
+
+class Google_Service_Games_Room extends Google_Collection
+{
+  protected $collection_key = 'participants';
+  protected $internal_gapi_mappings = array(
+  );
+  public $applicationId;
+  protected $autoMatchingCriteriaType = 'Google_Service_Games_RoomAutoMatchingCriteria';
+  protected $autoMatchingCriteriaDataType = '';
+  protected $autoMatchingStatusType = 'Google_Service_Games_RoomAutoMatchStatus';
+  protected $autoMatchingStatusDataType = '';
+  protected $creationDetailsType = 'Google_Service_Games_RoomModification';
+  protected $creationDetailsDataType = '';
+  public $description;
+  public $inviterId;
+  public $kind;
+  protected $lastUpdateDetailsType = 'Google_Service_Games_RoomModification';
+  protected $lastUpdateDetailsDataType = '';
+  protected $participantsType = 'Google_Service_Games_RoomParticipant';
+  protected $participantsDataType = 'array';
+  public $roomId;
+  public $roomStatusVersion;
+  public $status;
+  public $variant;
+
+
+  public function setApplicationId($applicationId)
+  {
+    $this->applicationId = $applicationId;
+  }
+  public function getApplicationId()
+  {
+    return $this->applicationId;
+  }
+  public function setAutoMatchingCriteria(Google_Service_Games_RoomAutoMatchingCriteria $autoMatchingCriteria)
+  {
+    $this->autoMatchingCriteria = $autoMatchingCriteria;
+  }
+  public function getAutoMatchingCriteria()
+  {
+    return $this->autoMatchingCriteria;
+  }
+  public function setAutoMatchingStatus(Google_Service_Games_RoomAutoMatchStatus $autoMatchingStatus)
+  {
+    $this->autoMatchingStatus = $autoMatchingStatus;
+  }
+  public function getAutoMatchingStatus()
+  {
+    return $this->autoMatchingStatus;
+  }
+  public function setCreationDetails(Google_Service_Games_RoomModification $creationDetails)
+  {
+    $this->creationDetails = $creationDetails;
+  }
+  public function getCreationDetails()
+  {
+    return $this->creationDetails;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setInviterId($inviterId)
+  {
+    $this->inviterId = $inviterId;
+  }
+  public function getInviterId()
+  {
+    return $this->inviterId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastUpdateDetails(Google_Service_Games_RoomModification $lastUpdateDetails)
+  {
+    $this->lastUpdateDetails = $lastUpdateDetails;
+  }
+  public function getLastUpdateDetails()
+  {
+    return $this->lastUpdateDetails;
+  }
+  public function setParticipants($participants)
+  {
+    $this->participants = $participants;
+  }
+  public function getParticipants()
+  {
+    return $this->participants;
+  }
+  public function setRoomId($roomId)
+  {
+    $this->roomId = $roomId;
+  }
+  public function getRoomId()
+  {
+    return $this->roomId;
+  }
+  public function setRoomStatusVersion($roomStatusVersion)
+  {
+    $this->roomStatusVersion = $roomStatusVersion;
+  }
+  public function getRoomStatusVersion()
+  {
+    return $this->roomStatusVersion;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setVariant($variant)
+  {
+    $this->variant = $variant;
+  }
+  public function getVariant()
+  {
+    return $this->variant;
+  }
+}
+
+class Google_Service_Games_RoomAutoMatchStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $waitEstimateSeconds;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setWaitEstimateSeconds($waitEstimateSeconds)
+  {
+    $this->waitEstimateSeconds = $waitEstimateSeconds;
+  }
+  public function getWaitEstimateSeconds()
+  {
+    return $this->waitEstimateSeconds;
+  }
+}
+
+class Google_Service_Games_RoomAutoMatchingCriteria extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $exclusiveBitmask;
+  public $kind;
+  public $maxAutoMatchingPlayers;
+  public $minAutoMatchingPlayers;
+
+
+  public function setExclusiveBitmask($exclusiveBitmask)
+  {
+    $this->exclusiveBitmask = $exclusiveBitmask;
+  }
+  public function getExclusiveBitmask()
+  {
+    return $this->exclusiveBitmask;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMaxAutoMatchingPlayers($maxAutoMatchingPlayers)
+  {
+    $this->maxAutoMatchingPlayers = $maxAutoMatchingPlayers;
+  }
+  public function getMaxAutoMatchingPlayers()
+  {
+    return $this->maxAutoMatchingPlayers;
+  }
+  public function setMinAutoMatchingPlayers($minAutoMatchingPlayers)
+  {
+    $this->minAutoMatchingPlayers = $minAutoMatchingPlayers;
+  }
+  public function getMinAutoMatchingPlayers()
+  {
+    return $this->minAutoMatchingPlayers;
+  }
+}
+
+class Google_Service_Games_RoomClientAddress extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $xmppAddress;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setXmppAddress($xmppAddress)
+  {
+    $this->xmppAddress = $xmppAddress;
+  }
+  public function getXmppAddress()
+  {
+    return $this->xmppAddress;
+  }
+}
+
+class Google_Service_Games_RoomCreateRequest extends Google_Collection
+{
+  protected $collection_key = 'invitedPlayerIds';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $autoMatchingCriteriaType = 'Google_Service_Games_RoomAutoMatchingCriteria';
+  protected $autoMatchingCriteriaDataType = '';
+  public $capabilities;
+  protected $clientAddressType = 'Google_Service_Games_RoomClientAddress';
+  protected $clientAddressDataType = '';
+  public $invitedPlayerIds;
+  public $kind;
+  protected $networkDiagnosticsType = 'Google_Service_Games_NetworkDiagnostics';
+  protected $networkDiagnosticsDataType = '';
+  public $requestId;
+  public $variant;
+
+
+  public function setAutoMatchingCriteria(Google_Service_Games_RoomAutoMatchingCriteria $autoMatchingCriteria)
+  {
+    $this->autoMatchingCriteria = $autoMatchingCriteria;
+  }
+  public function getAutoMatchingCriteria()
+  {
+    return $this->autoMatchingCriteria;
+  }
+  public function setCapabilities($capabilities)
+  {
+    $this->capabilities = $capabilities;
+  }
+  public function getCapabilities()
+  {
+    return $this->capabilities;
+  }
+  public function setClientAddress(Google_Service_Games_RoomClientAddress $clientAddress)
+  {
+    $this->clientAddress = $clientAddress;
+  }
+  public function getClientAddress()
+  {
+    return $this->clientAddress;
+  }
+  public function setInvitedPlayerIds($invitedPlayerIds)
+  {
+    $this->invitedPlayerIds = $invitedPlayerIds;
+  }
+  public function getInvitedPlayerIds()
+  {
+    return $this->invitedPlayerIds;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNetworkDiagnostics(Google_Service_Games_NetworkDiagnostics $networkDiagnostics)
+  {
+    $this->networkDiagnostics = $networkDiagnostics;
+  }
+  public function getNetworkDiagnostics()
+  {
+    return $this->networkDiagnostics;
+  }
+  public function setRequestId($requestId)
+  {
+    $this->requestId = $requestId;
+  }
+  public function getRequestId()
+  {
+    return $this->requestId;
+  }
+  public function setVariant($variant)
+  {
+    $this->variant = $variant;
+  }
+  public function getVariant()
+  {
+    return $this->variant;
+  }
+}
+
+class Google_Service_Games_RoomJoinRequest extends Google_Collection
+{
+  protected $collection_key = 'capabilities';
+  protected $internal_gapi_mappings = array(
+  );
+  public $capabilities;
+  protected $clientAddressType = 'Google_Service_Games_RoomClientAddress';
+  protected $clientAddressDataType = '';
+  public $kind;
+  protected $networkDiagnosticsType = 'Google_Service_Games_NetworkDiagnostics';
+  protected $networkDiagnosticsDataType = '';
+
+
+  public function setCapabilities($capabilities)
+  {
+    $this->capabilities = $capabilities;
+  }
+  public function getCapabilities()
+  {
+    return $this->capabilities;
+  }
+  public function setClientAddress(Google_Service_Games_RoomClientAddress $clientAddress)
+  {
+    $this->clientAddress = $clientAddress;
+  }
+  public function getClientAddress()
+  {
+    return $this->clientAddress;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNetworkDiagnostics(Google_Service_Games_NetworkDiagnostics $networkDiagnostics)
+  {
+    $this->networkDiagnostics = $networkDiagnostics;
+  }
+  public function getNetworkDiagnostics()
+  {
+    return $this->networkDiagnostics;
+  }
+}
+
+class Google_Service_Games_RoomLeaveDiagnostics extends Google_Collection
+{
+  protected $collection_key = 'peerSession';
+  protected $internal_gapi_mappings = array(
+  );
+  public $androidNetworkSubtype;
+  public $androidNetworkType;
+  public $iosNetworkType;
+  public $kind;
+  public $networkOperatorCode;
+  public $networkOperatorName;
+  protected $peerSessionType = 'Google_Service_Games_PeerSessionDiagnostics';
+  protected $peerSessionDataType = 'array';
+  public $socketsUsed;
+
+
+  public function setAndroidNetworkSubtype($androidNetworkSubtype)
+  {
+    $this->androidNetworkSubtype = $androidNetworkSubtype;
+  }
+  public function getAndroidNetworkSubtype()
+  {
+    return $this->androidNetworkSubtype;
+  }
+  public function setAndroidNetworkType($androidNetworkType)
+  {
+    $this->androidNetworkType = $androidNetworkType;
+  }
+  public function getAndroidNetworkType()
+  {
+    return $this->androidNetworkType;
+  }
+  public function setIosNetworkType($iosNetworkType)
+  {
+    $this->iosNetworkType = $iosNetworkType;
+  }
+  public function getIosNetworkType()
+  {
+    return $this->iosNetworkType;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNetworkOperatorCode($networkOperatorCode)
+  {
+    $this->networkOperatorCode = $networkOperatorCode;
+  }
+  public function getNetworkOperatorCode()
+  {
+    return $this->networkOperatorCode;
+  }
+  public function setNetworkOperatorName($networkOperatorName)
+  {
+    $this->networkOperatorName = $networkOperatorName;
+  }
+  public function getNetworkOperatorName()
+  {
+    return $this->networkOperatorName;
+  }
+  public function setPeerSession($peerSession)
+  {
+    $this->peerSession = $peerSession;
+  }
+  public function getPeerSession()
+  {
+    return $this->peerSession;
+  }
+  public function setSocketsUsed($socketsUsed)
+  {
+    $this->socketsUsed = $socketsUsed;
+  }
+  public function getSocketsUsed()
+  {
+    return $this->socketsUsed;
+  }
+}
+
+class Google_Service_Games_RoomLeaveRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $leaveDiagnosticsType = 'Google_Service_Games_RoomLeaveDiagnostics';
+  protected $leaveDiagnosticsDataType = '';
+  public $reason;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLeaveDiagnostics(Google_Service_Games_RoomLeaveDiagnostics $leaveDiagnostics)
+  {
+    $this->leaveDiagnostics = $leaveDiagnostics;
+  }
+  public function getLeaveDiagnostics()
+  {
+    return $this->leaveDiagnostics;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+}
+
+class Google_Service_Games_RoomList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Games_Room';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Games_RoomModification extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $modifiedTimestampMillis;
+  public $participantId;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setModifiedTimestampMillis($modifiedTimestampMillis)
+  {
+    $this->modifiedTimestampMillis = $modifiedTimestampMillis;
+  }
+  public function getModifiedTimestampMillis()
+  {
+    return $this->modifiedTimestampMillis;
+  }
+  public function setParticipantId($participantId)
+  {
+    $this->participantId = $participantId;
+  }
+  public function getParticipantId()
+  {
+    return $this->participantId;
+  }
+}
+
+class Google_Service_Games_RoomP2PStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "errorReason" => "error_reason",
+  );
+  public $connectionSetupLatencyMillis;
+  public $error;
+  public $errorReason;
+  public $kind;
+  public $participantId;
+  public $status;
+  public $unreliableRoundtripLatencyMillis;
+
+
+  public function setConnectionSetupLatencyMillis($connectionSetupLatencyMillis)
+  {
+    $this->connectionSetupLatencyMillis = $connectionSetupLatencyMillis;
+  }
+  public function getConnectionSetupLatencyMillis()
+  {
+    return $this->connectionSetupLatencyMillis;
+  }
+  public function setError($error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setErrorReason($errorReason)
+  {
+    $this->errorReason = $errorReason;
+  }
+  public function getErrorReason()
+  {
+    return $this->errorReason;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setParticipantId($participantId)
+  {
+    $this->participantId = $participantId;
+  }
+  public function getParticipantId()
+  {
+    return $this->participantId;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setUnreliableRoundtripLatencyMillis($unreliableRoundtripLatencyMillis)
+  {
+    $this->unreliableRoundtripLatencyMillis = $unreliableRoundtripLatencyMillis;
+  }
+  public function getUnreliableRoundtripLatencyMillis()
+  {
+    return $this->unreliableRoundtripLatencyMillis;
+  }
+}
+
+class Google_Service_Games_RoomP2PStatuses extends Google_Collection
+{
+  protected $collection_key = 'updates';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $updatesType = 'Google_Service_Games_RoomP2PStatus';
+  protected $updatesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUpdates($updates)
+  {
+    $this->updates = $updates;
+  }
+  public function getUpdates()
+  {
+    return $this->updates;
+  }
+}
+
+class Google_Service_Games_RoomParticipant extends Google_Collection
+{
+  protected $collection_key = 'capabilities';
+  protected $internal_gapi_mappings = array(
+  );
+  public $autoMatched;
+  protected $autoMatchedPlayerType = 'Google_Service_Games_AnonymousPlayer';
+  protected $autoMatchedPlayerDataType = '';
+  public $capabilities;
+  protected $clientAddressType = 'Google_Service_Games_RoomClientAddress';
+  protected $clientAddressDataType = '';
+  public $connected;
+  public $id;
+  public $kind;
+  public $leaveReason;
+  protected $playerType = 'Google_Service_Games_Player';
+  protected $playerDataType = '';
+  public $status;
+
+
+  public function setAutoMatched($autoMatched)
+  {
+    $this->autoMatched = $autoMatched;
+  }
+  public function getAutoMatched()
+  {
+    return $this->autoMatched;
+  }
+  public function setAutoMatchedPlayer(Google_Service_Games_AnonymousPlayer $autoMatchedPlayer)
+  {
+    $this->autoMatchedPlayer = $autoMatchedPlayer;
+  }
+  public function getAutoMatchedPlayer()
+  {
+    return $this->autoMatchedPlayer;
+  }
+  public function setCapabilities($capabilities)
+  {
+    $this->capabilities = $capabilities;
+  }
+  public function getCapabilities()
+  {
+    return $this->capabilities;
+  }
+  public function setClientAddress(Google_Service_Games_RoomClientAddress $clientAddress)
+  {
+    $this->clientAddress = $clientAddress;
+  }
+  public function getClientAddress()
+  {
+    return $this->clientAddress;
+  }
+  public function setConnected($connected)
+  {
+    $this->connected = $connected;
+  }
+  public function getConnected()
+  {
+    return $this->connected;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLeaveReason($leaveReason)
+  {
+    $this->leaveReason = $leaveReason;
+  }
+  public function getLeaveReason()
+  {
+    return $this->leaveReason;
+  }
+  public function setPlayer(Google_Service_Games_Player $player)
+  {
+    $this->player = $player;
+  }
+  public function getPlayer()
+  {
+    return $this->player;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_Games_RoomStatus extends Google_Collection
+{
+  protected $collection_key = 'participants';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $autoMatchingStatusType = 'Google_Service_Games_RoomAutoMatchStatus';
+  protected $autoMatchingStatusDataType = '';
+  public $kind;
+  protected $participantsType = 'Google_Service_Games_RoomParticipant';
+  protected $participantsDataType = 'array';
+  public $roomId;
+  public $status;
+  public $statusVersion;
+
+
+  public function setAutoMatchingStatus(Google_Service_Games_RoomAutoMatchStatus $autoMatchingStatus)
+  {
+    $this->autoMatchingStatus = $autoMatchingStatus;
+  }
+  public function getAutoMatchingStatus()
+  {
+    return $this->autoMatchingStatus;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setParticipants($participants)
+  {
+    $this->participants = $participants;
+  }
+  public function getParticipants()
+  {
+    return $this->participants;
+  }
+  public function setRoomId($roomId)
+  {
+    $this->roomId = $roomId;
+  }
+  public function getRoomId()
+  {
+    return $this->roomId;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setStatusVersion($statusVersion)
+  {
+    $this->statusVersion = $statusVersion;
+  }
+  public function getStatusVersion()
+  {
+    return $this->statusVersion;
+  }
+}
+
+class Google_Service_Games_ScoreSubmission extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $leaderboardId;
+  public $score;
+  public $scoreTag;
+  public $signature;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLeaderboardId($leaderboardId)
+  {
+    $this->leaderboardId = $leaderboardId;
+  }
+  public function getLeaderboardId()
+  {
+    return $this->leaderboardId;
+  }
+  public function setScore($score)
+  {
+    $this->score = $score;
+  }
+  public function getScore()
+  {
+    return $this->score;
+  }
+  public function setScoreTag($scoreTag)
+  {
+    $this->scoreTag = $scoreTag;
+  }
+  public function getScoreTag()
+  {
+    return $this->scoreTag;
+  }
+  public function setSignature($signature)
+  {
+    $this->signature = $signature;
+  }
+  public function getSignature()
+  {
+    return $this->signature;
+  }
+}
+
+class Google_Service_Games_Snapshot extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $coverImageType = 'Google_Service_Games_SnapshotImage';
+  protected $coverImageDataType = '';
+  public $description;
+  public $driveId;
+  public $durationMillis;
+  public $id;
+  public $kind;
+  public $lastModifiedMillis;
+  public $progressValue;
+  public $title;
+  public $type;
+  public $uniqueName;
+
+
+  public function setCoverImage(Google_Service_Games_SnapshotImage $coverImage)
+  {
+    $this->coverImage = $coverImage;
+  }
+  public function getCoverImage()
+  {
+    return $this->coverImage;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDriveId($driveId)
+  {
+    $this->driveId = $driveId;
+  }
+  public function getDriveId()
+  {
+    return $this->driveId;
+  }
+  public function setDurationMillis($durationMillis)
+  {
+    $this->durationMillis = $durationMillis;
+  }
+  public function getDurationMillis()
+  {
+    return $this->durationMillis;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastModifiedMillis($lastModifiedMillis)
+  {
+    $this->lastModifiedMillis = $lastModifiedMillis;
+  }
+  public function getLastModifiedMillis()
+  {
+    return $this->lastModifiedMillis;
+  }
+  public function setProgressValue($progressValue)
+  {
+    $this->progressValue = $progressValue;
+  }
+  public function getProgressValue()
+  {
+    return $this->progressValue;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUniqueName($uniqueName)
+  {
+    $this->uniqueName = $uniqueName;
+  }
+  public function getUniqueName()
+  {
+    return $this->uniqueName;
+  }
+}
+
+class Google_Service_Games_SnapshotImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "mimeType" => "mime_type",
+  );
+  public $height;
+  public $kind;
+  public $mimeType;
+  public $url;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMimeType($mimeType)
+  {
+    $this->mimeType = $mimeType;
+  }
+  public function getMimeType()
+  {
+    return $this->mimeType;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_Games_SnapshotListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Games_Snapshot';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Games_TurnBasedAutoMatchingCriteria extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $exclusiveBitmask;
+  public $kind;
+  public $maxAutoMatchingPlayers;
+  public $minAutoMatchingPlayers;
+
+
+  public function setExclusiveBitmask($exclusiveBitmask)
+  {
+    $this->exclusiveBitmask = $exclusiveBitmask;
+  }
+  public function getExclusiveBitmask()
+  {
+    return $this->exclusiveBitmask;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMaxAutoMatchingPlayers($maxAutoMatchingPlayers)
+  {
+    $this->maxAutoMatchingPlayers = $maxAutoMatchingPlayers;
+  }
+  public function getMaxAutoMatchingPlayers()
+  {
+    return $this->maxAutoMatchingPlayers;
+  }
+  public function setMinAutoMatchingPlayers($minAutoMatchingPlayers)
+  {
+    $this->minAutoMatchingPlayers = $minAutoMatchingPlayers;
+  }
+  public function getMinAutoMatchingPlayers()
+  {
+    return $this->minAutoMatchingPlayers;
+  }
+}
+
+class Google_Service_Games_TurnBasedMatch extends Google_Collection
+{
+  protected $collection_key = 'results';
+  protected $internal_gapi_mappings = array(
+  );
+  public $applicationId;
+  protected $autoMatchingCriteriaType = 'Google_Service_Games_TurnBasedAutoMatchingCriteria';
+  protected $autoMatchingCriteriaDataType = '';
+  protected $creationDetailsType = 'Google_Service_Games_TurnBasedMatchModification';
+  protected $creationDetailsDataType = '';
+  protected $dataType = 'Google_Service_Games_TurnBasedMatchData';
+  protected $dataDataType = '';
+  public $description;
+  public $inviterId;
+  public $kind;
+  protected $lastUpdateDetailsType = 'Google_Service_Games_TurnBasedMatchModification';
+  protected $lastUpdateDetailsDataType = '';
+  public $matchId;
+  public $matchNumber;
+  public $matchVersion;
+  protected $participantsType = 'Google_Service_Games_TurnBasedMatchParticipant';
+  protected $participantsDataType = 'array';
+  public $pendingParticipantId;
+  protected $previousMatchDataType = 'Google_Service_Games_TurnBasedMatchData';
+  protected $previousMatchDataDataType = '';
+  public $rematchId;
+  protected $resultsType = 'Google_Service_Games_ParticipantResult';
+  protected $resultsDataType = 'array';
+  public $status;
+  public $userMatchStatus;
+  public $variant;
+  public $withParticipantId;
+
+
+  public function setApplicationId($applicationId)
+  {
+    $this->applicationId = $applicationId;
+  }
+  public function getApplicationId()
+  {
+    return $this->applicationId;
+  }
+  public function setAutoMatchingCriteria(Google_Service_Games_TurnBasedAutoMatchingCriteria $autoMatchingCriteria)
+  {
+    $this->autoMatchingCriteria = $autoMatchingCriteria;
+  }
+  public function getAutoMatchingCriteria()
+  {
+    return $this->autoMatchingCriteria;
+  }
+  public function setCreationDetails(Google_Service_Games_TurnBasedMatchModification $creationDetails)
+  {
+    $this->creationDetails = $creationDetails;
+  }
+  public function getCreationDetails()
+  {
+    return $this->creationDetails;
+  }
+  public function setData(Google_Service_Games_TurnBasedMatchData $data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setInviterId($inviterId)
+  {
+    $this->inviterId = $inviterId;
+  }
+  public function getInviterId()
+  {
+    return $this->inviterId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastUpdateDetails(Google_Service_Games_TurnBasedMatchModification $lastUpdateDetails)
+  {
+    $this->lastUpdateDetails = $lastUpdateDetails;
+  }
+  public function getLastUpdateDetails()
+  {
+    return $this->lastUpdateDetails;
+  }
+  public function setMatchId($matchId)
+  {
+    $this->matchId = $matchId;
+  }
+  public function getMatchId()
+  {
+    return $this->matchId;
+  }
+  public function setMatchNumber($matchNumber)
+  {
+    $this->matchNumber = $matchNumber;
+  }
+  public function getMatchNumber()
+  {
+    return $this->matchNumber;
+  }
+  public function setMatchVersion($matchVersion)
+  {
+    $this->matchVersion = $matchVersion;
+  }
+  public function getMatchVersion()
+  {
+    return $this->matchVersion;
+  }
+  public function setParticipants($participants)
+  {
+    $this->participants = $participants;
+  }
+  public function getParticipants()
+  {
+    return $this->participants;
+  }
+  public function setPendingParticipantId($pendingParticipantId)
+  {
+    $this->pendingParticipantId = $pendingParticipantId;
+  }
+  public function getPendingParticipantId()
+  {
+    return $this->pendingParticipantId;
+  }
+  public function setPreviousMatchData(Google_Service_Games_TurnBasedMatchData $previousMatchData)
+  {
+    $this->previousMatchData = $previousMatchData;
+  }
+  public function getPreviousMatchData()
+  {
+    return $this->previousMatchData;
+  }
+  public function setRematchId($rematchId)
+  {
+    $this->rematchId = $rematchId;
+  }
+  public function getRematchId()
+  {
+    return $this->rematchId;
+  }
+  public function setResults($results)
+  {
+    $this->results = $results;
+  }
+  public function getResults()
+  {
+    return $this->results;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setUserMatchStatus($userMatchStatus)
+  {
+    $this->userMatchStatus = $userMatchStatus;
+  }
+  public function getUserMatchStatus()
+  {
+    return $this->userMatchStatus;
+  }
+  public function setVariant($variant)
+  {
+    $this->variant = $variant;
+  }
+  public function getVariant()
+  {
+    return $this->variant;
+  }
+  public function setWithParticipantId($withParticipantId)
+  {
+    $this->withParticipantId = $withParticipantId;
+  }
+  public function getWithParticipantId()
+  {
+    return $this->withParticipantId;
+  }
+}
+
+class Google_Service_Games_TurnBasedMatchCreateRequest extends Google_Collection
+{
+  protected $collection_key = 'invitedPlayerIds';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $autoMatchingCriteriaType = 'Google_Service_Games_TurnBasedAutoMatchingCriteria';
+  protected $autoMatchingCriteriaDataType = '';
+  public $invitedPlayerIds;
+  public $kind;
+  public $requestId;
+  public $variant;
+
+
+  public function setAutoMatchingCriteria(Google_Service_Games_TurnBasedAutoMatchingCriteria $autoMatchingCriteria)
+  {
+    $this->autoMatchingCriteria = $autoMatchingCriteria;
+  }
+  public function getAutoMatchingCriteria()
+  {
+    return $this->autoMatchingCriteria;
+  }
+  public function setInvitedPlayerIds($invitedPlayerIds)
+  {
+    $this->invitedPlayerIds = $invitedPlayerIds;
+  }
+  public function getInvitedPlayerIds()
+  {
+    return $this->invitedPlayerIds;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRequestId($requestId)
+  {
+    $this->requestId = $requestId;
+  }
+  public function getRequestId()
+  {
+    return $this->requestId;
+  }
+  public function setVariant($variant)
+  {
+    $this->variant = $variant;
+  }
+  public function getVariant()
+  {
+    return $this->variant;
+  }
+}
+
+class Google_Service_Games_TurnBasedMatchData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $data;
+  public $dataAvailable;
+  public $kind;
+
+
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setDataAvailable($dataAvailable)
+  {
+    $this->dataAvailable = $dataAvailable;
+  }
+  public function getDataAvailable()
+  {
+    return $this->dataAvailable;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Games_TurnBasedMatchDataRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $data;
+  public $kind;
+
+
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Games_TurnBasedMatchList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Games_TurnBasedMatch';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Games_TurnBasedMatchModification extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $modifiedTimestampMillis;
+  public $participantId;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setModifiedTimestampMillis($modifiedTimestampMillis)
+  {
+    $this->modifiedTimestampMillis = $modifiedTimestampMillis;
+  }
+  public function getModifiedTimestampMillis()
+  {
+    return $this->modifiedTimestampMillis;
+  }
+  public function setParticipantId($participantId)
+  {
+    $this->participantId = $participantId;
+  }
+  public function getParticipantId()
+  {
+    return $this->participantId;
+  }
+}
+
+class Google_Service_Games_TurnBasedMatchParticipant extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $autoMatched;
+  protected $autoMatchedPlayerType = 'Google_Service_Games_AnonymousPlayer';
+  protected $autoMatchedPlayerDataType = '';
+  public $id;
+  public $kind;
+  protected $playerType = 'Google_Service_Games_Player';
+  protected $playerDataType = '';
+  public $status;
+
+
+  public function setAutoMatched($autoMatched)
+  {
+    $this->autoMatched = $autoMatched;
+  }
+  public function getAutoMatched()
+  {
+    return $this->autoMatched;
+  }
+  public function setAutoMatchedPlayer(Google_Service_Games_AnonymousPlayer $autoMatchedPlayer)
+  {
+    $this->autoMatchedPlayer = $autoMatchedPlayer;
+  }
+  public function getAutoMatchedPlayer()
+  {
+    return $this->autoMatchedPlayer;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPlayer(Google_Service_Games_Player $player)
+  {
+    $this->player = $player;
+  }
+  public function getPlayer()
+  {
+    return $this->player;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_Games_TurnBasedMatchRematch extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $previousMatchType = 'Google_Service_Games_TurnBasedMatch';
+  protected $previousMatchDataType = '';
+  protected $rematchType = 'Google_Service_Games_TurnBasedMatch';
+  protected $rematchDataType = '';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPreviousMatch(Google_Service_Games_TurnBasedMatch $previousMatch)
+  {
+    $this->previousMatch = $previousMatch;
+  }
+  public function getPreviousMatch()
+  {
+    return $this->previousMatch;
+  }
+  public function setRematch(Google_Service_Games_TurnBasedMatch $rematch)
+  {
+    $this->rematch = $rematch;
+  }
+  public function getRematch()
+  {
+    return $this->rematch;
+  }
+}
+
+class Google_Service_Games_TurnBasedMatchResults extends Google_Collection
+{
+  protected $collection_key = 'results';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $dataType = 'Google_Service_Games_TurnBasedMatchDataRequest';
+  protected $dataDataType = '';
+  public $kind;
+  public $matchVersion;
+  protected $resultsType = 'Google_Service_Games_ParticipantResult';
+  protected $resultsDataType = 'array';
+
+
+  public function setData(Google_Service_Games_TurnBasedMatchDataRequest $data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMatchVersion($matchVersion)
+  {
+    $this->matchVersion = $matchVersion;
+  }
+  public function getMatchVersion()
+  {
+    return $this->matchVersion;
+  }
+  public function setResults($results)
+  {
+    $this->results = $results;
+  }
+  public function getResults()
+  {
+    return $this->results;
+  }
+}
+
+class Google_Service_Games_TurnBasedMatchSync extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Games_TurnBasedMatch';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $moreAvailable;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMoreAvailable($moreAvailable)
+  {
+    $this->moreAvailable = $moreAvailable;
+  }
+  public function getMoreAvailable()
+  {
+    return $this->moreAvailable;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Games_TurnBasedMatchTurn extends Google_Collection
+{
+  protected $collection_key = 'results';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $dataType = 'Google_Service_Games_TurnBasedMatchDataRequest';
+  protected $dataDataType = '';
+  public $kind;
+  public $matchVersion;
+  public $pendingParticipantId;
+  protected $resultsType = 'Google_Service_Games_ParticipantResult';
+  protected $resultsDataType = 'array';
+
+
+  public function setData(Google_Service_Games_TurnBasedMatchDataRequest $data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMatchVersion($matchVersion)
+  {
+    $this->matchVersion = $matchVersion;
+  }
+  public function getMatchVersion()
+  {
+    return $this->matchVersion;
+  }
+  public function setPendingParticipantId($pendingParticipantId)
+  {
+    $this->pendingParticipantId = $pendingParticipantId;
+  }
+  public function getPendingParticipantId()
+  {
+    return $this->pendingParticipantId;
+  }
+  public function setResults($results)
+  {
+    $this->results = $results;
+  }
+  public function getResults()
+  {
+    return $this->results;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/GamesConfiguration.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/GamesConfiguration.php
@@ -1,0 +1,1068 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for GamesConfiguration (v1configuration).
+ *
+ * <p>
+ * The Publishing API for Google Play Game Services.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/games/services" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_GamesConfiguration extends Google_Service
+{
+  /** View and manage your Google Play Developer account. */
+  const ANDROIDPUBLISHER =
+      "https://www.googleapis.com/auth/androidpublisher";
+
+  public $achievementConfigurations;
+  public $imageConfigurations;
+  public $leaderboardConfigurations;
+  
+
+  /**
+   * Constructs the internal representation of the GamesConfiguration service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'games/v1configuration/';
+    $this->version = 'v1configuration';
+    $this->serviceName = 'gamesConfiguration';
+
+    $this->achievementConfigurations = new Google_Service_GamesConfiguration_AchievementConfigurations_Resource(
+        $this,
+        $this->serviceName,
+        'achievementConfigurations',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'achievements/{achievementId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'achievementId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'achievements/{achievementId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'achievementId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'applications/{applicationId}/achievements',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'applicationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'applications/{applicationId}/achievements',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'applicationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'achievements/{achievementId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'achievementId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'achievements/{achievementId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'achievementId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->imageConfigurations = new Google_Service_GamesConfiguration_ImageConfigurations_Resource(
+        $this,
+        $this->serviceName,
+        'imageConfigurations',
+        array(
+          'methods' => array(
+            'upload' => array(
+              'path' => 'images/{resourceId}/imageType/{imageType}',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'resourceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'imageType' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->leaderboardConfigurations = new Google_Service_GamesConfiguration_LeaderboardConfigurations_Resource(
+        $this,
+        $this->serviceName,
+        'leaderboardConfigurations',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'leaderboards/{leaderboardId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'leaderboardId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'leaderboards/{leaderboardId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'leaderboardId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'applications/{applicationId}/leaderboards',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'applicationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'applications/{applicationId}/leaderboards',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'applicationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'leaderboards/{leaderboardId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'leaderboardId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'leaderboards/{leaderboardId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'leaderboardId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "achievementConfigurations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesConfigurationService = new Google_Service_GamesConfiguration(...);
+ *   $achievementConfigurations = $gamesConfigurationService->achievementConfigurations;
+ *  </code>
+ */
+class Google_Service_GamesConfiguration_AchievementConfigurations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete the achievement configuration with the given ID.
+   * (achievementConfigurations.delete)
+   *
+   * @param string $achievementId The ID of the achievement used by this method.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($achievementId, $optParams = array())
+  {
+    $params = array('achievementId' => $achievementId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves the metadata of the achievement configuration with the given ID.
+   * (achievementConfigurations.get)
+   *
+   * @param string $achievementId The ID of the achievement used by this method.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_GamesConfiguration_AchievementConfiguration
+   */
+  public function get($achievementId, $optParams = array())
+  {
+    $params = array('achievementId' => $achievementId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_GamesConfiguration_AchievementConfiguration");
+  }
+
+  /**
+   * Insert a new achievement configuration in this application.
+   * (achievementConfigurations.insert)
+   *
+   * @param string $applicationId The application ID from the Google Play
+   * developer console.
+   * @param Google_AchievementConfiguration $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_GamesConfiguration_AchievementConfiguration
+   */
+  public function insert($applicationId, Google_Service_GamesConfiguration_AchievementConfiguration $postBody, $optParams = array())
+  {
+    $params = array('applicationId' => $applicationId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_GamesConfiguration_AchievementConfiguration");
+  }
+
+  /**
+   * Returns a list of the achievement configurations in this application.
+   * (achievementConfigurations.listAchievementConfigurations)
+   *
+   * @param string $applicationId The application ID from the Google Play
+   * developer console.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param int maxResults The maximum number of resource configurations to
+   * return in the response, used for paging. For any response, the actual number
+   * of resources returned may be less than the specified maxResults.
+   * @return Google_Service_GamesConfiguration_AchievementConfigurationListResponse
+   */
+  public function listAchievementConfigurations($applicationId, $optParams = array())
+  {
+    $params = array('applicationId' => $applicationId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_GamesConfiguration_AchievementConfigurationListResponse");
+  }
+
+  /**
+   * Update the metadata of the achievement configuration with the given ID. This
+   * method supports patch semantics. (achievementConfigurations.patch)
+   *
+   * @param string $achievementId The ID of the achievement used by this method.
+   * @param Google_AchievementConfiguration $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_GamesConfiguration_AchievementConfiguration
+   */
+  public function patch($achievementId, Google_Service_GamesConfiguration_AchievementConfiguration $postBody, $optParams = array())
+  {
+    $params = array('achievementId' => $achievementId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_GamesConfiguration_AchievementConfiguration");
+  }
+
+  /**
+   * Update the metadata of the achievement configuration with the given ID.
+   * (achievementConfigurations.update)
+   *
+   * @param string $achievementId The ID of the achievement used by this method.
+   * @param Google_AchievementConfiguration $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_GamesConfiguration_AchievementConfiguration
+   */
+  public function update($achievementId, Google_Service_GamesConfiguration_AchievementConfiguration $postBody, $optParams = array())
+  {
+    $params = array('achievementId' => $achievementId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_GamesConfiguration_AchievementConfiguration");
+  }
+}
+
+/**
+ * The "imageConfigurations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesConfigurationService = new Google_Service_GamesConfiguration(...);
+ *   $imageConfigurations = $gamesConfigurationService->imageConfigurations;
+ *  </code>
+ */
+class Google_Service_GamesConfiguration_ImageConfigurations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Uploads an image for a resource with the given ID and image type.
+   * (imageConfigurations.upload)
+   *
+   * @param string $resourceId The ID of the resource used by this method.
+   * @param string $imageType Selects which image in a resource for this method.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_GamesConfiguration_ImageConfiguration
+   */
+  public function upload($resourceId, $imageType, $optParams = array())
+  {
+    $params = array('resourceId' => $resourceId, 'imageType' => $imageType);
+    $params = array_merge($params, $optParams);
+    return $this->call('upload', array($params), "Google_Service_GamesConfiguration_ImageConfiguration");
+  }
+}
+
+/**
+ * The "leaderboardConfigurations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesConfigurationService = new Google_Service_GamesConfiguration(...);
+ *   $leaderboardConfigurations = $gamesConfigurationService->leaderboardConfigurations;
+ *  </code>
+ */
+class Google_Service_GamesConfiguration_LeaderboardConfigurations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete the leaderboard configuration with the given ID.
+   * (leaderboardConfigurations.delete)
+   *
+   * @param string $leaderboardId The ID of the leaderboard.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($leaderboardId, $optParams = array())
+  {
+    $params = array('leaderboardId' => $leaderboardId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves the metadata of the leaderboard configuration with the given ID.
+   * (leaderboardConfigurations.get)
+   *
+   * @param string $leaderboardId The ID of the leaderboard.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_GamesConfiguration_LeaderboardConfiguration
+   */
+  public function get($leaderboardId, $optParams = array())
+  {
+    $params = array('leaderboardId' => $leaderboardId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_GamesConfiguration_LeaderboardConfiguration");
+  }
+
+  /**
+   * Insert a new leaderboard configuration in this application.
+   * (leaderboardConfigurations.insert)
+   *
+   * @param string $applicationId The application ID from the Google Play
+   * developer console.
+   * @param Google_LeaderboardConfiguration $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_GamesConfiguration_LeaderboardConfiguration
+   */
+  public function insert($applicationId, Google_Service_GamesConfiguration_LeaderboardConfiguration $postBody, $optParams = array())
+  {
+    $params = array('applicationId' => $applicationId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_GamesConfiguration_LeaderboardConfiguration");
+  }
+
+  /**
+   * Returns a list of the leaderboard configurations in this application.
+   * (leaderboardConfigurations.listLeaderboardConfigurations)
+   *
+   * @param string $applicationId The application ID from the Google Play
+   * developer console.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param int maxResults The maximum number of resource configurations to
+   * return in the response, used for paging. For any response, the actual number
+   * of resources returned may be less than the specified maxResults.
+   * @return Google_Service_GamesConfiguration_LeaderboardConfigurationListResponse
+   */
+  public function listLeaderboardConfigurations($applicationId, $optParams = array())
+  {
+    $params = array('applicationId' => $applicationId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_GamesConfiguration_LeaderboardConfigurationListResponse");
+  }
+
+  /**
+   * Update the metadata of the leaderboard configuration with the given ID. This
+   * method supports patch semantics. (leaderboardConfigurations.patch)
+   *
+   * @param string $leaderboardId The ID of the leaderboard.
+   * @param Google_LeaderboardConfiguration $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_GamesConfiguration_LeaderboardConfiguration
+   */
+  public function patch($leaderboardId, Google_Service_GamesConfiguration_LeaderboardConfiguration $postBody, $optParams = array())
+  {
+    $params = array('leaderboardId' => $leaderboardId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_GamesConfiguration_LeaderboardConfiguration");
+  }
+
+  /**
+   * Update the metadata of the leaderboard configuration with the given ID.
+   * (leaderboardConfigurations.update)
+   *
+   * @param string $leaderboardId The ID of the leaderboard.
+   * @param Google_LeaderboardConfiguration $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_GamesConfiguration_LeaderboardConfiguration
+   */
+  public function update($leaderboardId, Google_Service_GamesConfiguration_LeaderboardConfiguration $postBody, $optParams = array())
+  {
+    $params = array('leaderboardId' => $leaderboardId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_GamesConfiguration_LeaderboardConfiguration");
+  }
+}
+
+
+
+
+class Google_Service_GamesConfiguration_AchievementConfiguration extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $achievementType;
+  protected $draftType = 'Google_Service_GamesConfiguration_AchievementConfigurationDetail';
+  protected $draftDataType = '';
+  public $id;
+  public $initialState;
+  public $kind;
+  protected $publishedType = 'Google_Service_GamesConfiguration_AchievementConfigurationDetail';
+  protected $publishedDataType = '';
+  public $stepsToUnlock;
+  public $token;
+
+
+  public function setAchievementType($achievementType)
+  {
+    $this->achievementType = $achievementType;
+  }
+  public function getAchievementType()
+  {
+    return $this->achievementType;
+  }
+  public function setDraft(Google_Service_GamesConfiguration_AchievementConfigurationDetail $draft)
+  {
+    $this->draft = $draft;
+  }
+  public function getDraft()
+  {
+    return $this->draft;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInitialState($initialState)
+  {
+    $this->initialState = $initialState;
+  }
+  public function getInitialState()
+  {
+    return $this->initialState;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPublished(Google_Service_GamesConfiguration_AchievementConfigurationDetail $published)
+  {
+    $this->published = $published;
+  }
+  public function getPublished()
+  {
+    return $this->published;
+  }
+  public function setStepsToUnlock($stepsToUnlock)
+  {
+    $this->stepsToUnlock = $stepsToUnlock;
+  }
+  public function getStepsToUnlock()
+  {
+    return $this->stepsToUnlock;
+  }
+  public function setToken($token)
+  {
+    $this->token = $token;
+  }
+  public function getToken()
+  {
+    return $this->token;
+  }
+}
+
+class Google_Service_GamesConfiguration_AchievementConfigurationDetail extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $descriptionType = 'Google_Service_GamesConfiguration_LocalizedStringBundle';
+  protected $descriptionDataType = '';
+  public $iconUrl;
+  public $kind;
+  protected $nameType = 'Google_Service_GamesConfiguration_LocalizedStringBundle';
+  protected $nameDataType = '';
+  public $pointValue;
+  public $sortRank;
+
+
+  public function setDescription(Google_Service_GamesConfiguration_LocalizedStringBundle $description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setIconUrl($iconUrl)
+  {
+    $this->iconUrl = $iconUrl;
+  }
+  public function getIconUrl()
+  {
+    return $this->iconUrl;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName(Google_Service_GamesConfiguration_LocalizedStringBundle $name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPointValue($pointValue)
+  {
+    $this->pointValue = $pointValue;
+  }
+  public function getPointValue()
+  {
+    return $this->pointValue;
+  }
+  public function setSortRank($sortRank)
+  {
+    $this->sortRank = $sortRank;
+  }
+  public function getSortRank()
+  {
+    return $this->sortRank;
+  }
+}
+
+class Google_Service_GamesConfiguration_AchievementConfigurationListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_GamesConfiguration_AchievementConfiguration';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_GamesConfiguration_GamesNumberAffixConfiguration extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $fewType = 'Google_Service_GamesConfiguration_LocalizedStringBundle';
+  protected $fewDataType = '';
+  protected $manyType = 'Google_Service_GamesConfiguration_LocalizedStringBundle';
+  protected $manyDataType = '';
+  protected $oneType = 'Google_Service_GamesConfiguration_LocalizedStringBundle';
+  protected $oneDataType = '';
+  protected $otherType = 'Google_Service_GamesConfiguration_LocalizedStringBundle';
+  protected $otherDataType = '';
+  protected $twoType = 'Google_Service_GamesConfiguration_LocalizedStringBundle';
+  protected $twoDataType = '';
+  protected $zeroType = 'Google_Service_GamesConfiguration_LocalizedStringBundle';
+  protected $zeroDataType = '';
+
+
+  public function setFew(Google_Service_GamesConfiguration_LocalizedStringBundle $few)
+  {
+    $this->few = $few;
+  }
+  public function getFew()
+  {
+    return $this->few;
+  }
+  public function setMany(Google_Service_GamesConfiguration_LocalizedStringBundle $many)
+  {
+    $this->many = $many;
+  }
+  public function getMany()
+  {
+    return $this->many;
+  }
+  public function setOne(Google_Service_GamesConfiguration_LocalizedStringBundle $one)
+  {
+    $this->one = $one;
+  }
+  public function getOne()
+  {
+    return $this->one;
+  }
+  public function setOther(Google_Service_GamesConfiguration_LocalizedStringBundle $other)
+  {
+    $this->other = $other;
+  }
+  public function getOther()
+  {
+    return $this->other;
+  }
+  public function setTwo(Google_Service_GamesConfiguration_LocalizedStringBundle $two)
+  {
+    $this->two = $two;
+  }
+  public function getTwo()
+  {
+    return $this->two;
+  }
+  public function setZero(Google_Service_GamesConfiguration_LocalizedStringBundle $zero)
+  {
+    $this->zero = $zero;
+  }
+  public function getZero()
+  {
+    return $this->zero;
+  }
+}
+
+class Google_Service_GamesConfiguration_GamesNumberFormatConfiguration extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $currencyCode;
+  public $numDecimalPlaces;
+  public $numberFormatType;
+  protected $suffixType = 'Google_Service_GamesConfiguration_GamesNumberAffixConfiguration';
+  protected $suffixDataType = '';
+
+
+  public function setCurrencyCode($currencyCode)
+  {
+    $this->currencyCode = $currencyCode;
+  }
+  public function getCurrencyCode()
+  {
+    return $this->currencyCode;
+  }
+  public function setNumDecimalPlaces($numDecimalPlaces)
+  {
+    $this->numDecimalPlaces = $numDecimalPlaces;
+  }
+  public function getNumDecimalPlaces()
+  {
+    return $this->numDecimalPlaces;
+  }
+  public function setNumberFormatType($numberFormatType)
+  {
+    $this->numberFormatType = $numberFormatType;
+  }
+  public function getNumberFormatType()
+  {
+    return $this->numberFormatType;
+  }
+  public function setSuffix(Google_Service_GamesConfiguration_GamesNumberAffixConfiguration $suffix)
+  {
+    $this->suffix = $suffix;
+  }
+  public function getSuffix()
+  {
+    return $this->suffix;
+  }
+}
+
+class Google_Service_GamesConfiguration_ImageConfiguration extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $imageType;
+  public $kind;
+  public $resourceId;
+  public $url;
+
+
+  public function setImageType($imageType)
+  {
+    $this->imageType = $imageType;
+  }
+  public function getImageType()
+  {
+    return $this->imageType;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setResourceId($resourceId)
+  {
+    $this->resourceId = $resourceId;
+  }
+  public function getResourceId()
+  {
+    return $this->resourceId;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_GamesConfiguration_LeaderboardConfiguration extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $draftType = 'Google_Service_GamesConfiguration_LeaderboardConfigurationDetail';
+  protected $draftDataType = '';
+  public $id;
+  public $kind;
+  protected $publishedType = 'Google_Service_GamesConfiguration_LeaderboardConfigurationDetail';
+  protected $publishedDataType = '';
+  public $scoreMax;
+  public $scoreMin;
+  public $scoreOrder;
+  public $token;
+
+
+  public function setDraft(Google_Service_GamesConfiguration_LeaderboardConfigurationDetail $draft)
+  {
+    $this->draft = $draft;
+  }
+  public function getDraft()
+  {
+    return $this->draft;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPublished(Google_Service_GamesConfiguration_LeaderboardConfigurationDetail $published)
+  {
+    $this->published = $published;
+  }
+  public function getPublished()
+  {
+    return $this->published;
+  }
+  public function setScoreMax($scoreMax)
+  {
+    $this->scoreMax = $scoreMax;
+  }
+  public function getScoreMax()
+  {
+    return $this->scoreMax;
+  }
+  public function setScoreMin($scoreMin)
+  {
+    $this->scoreMin = $scoreMin;
+  }
+  public function getScoreMin()
+  {
+    return $this->scoreMin;
+  }
+  public function setScoreOrder($scoreOrder)
+  {
+    $this->scoreOrder = $scoreOrder;
+  }
+  public function getScoreOrder()
+  {
+    return $this->scoreOrder;
+  }
+  public function setToken($token)
+  {
+    $this->token = $token;
+  }
+  public function getToken()
+  {
+    return $this->token;
+  }
+}
+
+class Google_Service_GamesConfiguration_LeaderboardConfigurationDetail extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $iconUrl;
+  public $kind;
+  protected $nameType = 'Google_Service_GamesConfiguration_LocalizedStringBundle';
+  protected $nameDataType = '';
+  protected $scoreFormatType = 'Google_Service_GamesConfiguration_GamesNumberFormatConfiguration';
+  protected $scoreFormatDataType = '';
+  public $sortRank;
+
+
+  public function setIconUrl($iconUrl)
+  {
+    $this->iconUrl = $iconUrl;
+  }
+  public function getIconUrl()
+  {
+    return $this->iconUrl;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName(Google_Service_GamesConfiguration_LocalizedStringBundle $name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setScoreFormat(Google_Service_GamesConfiguration_GamesNumberFormatConfiguration $scoreFormat)
+  {
+    $this->scoreFormat = $scoreFormat;
+  }
+  public function getScoreFormat()
+  {
+    return $this->scoreFormat;
+  }
+  public function setSortRank($sortRank)
+  {
+    $this->sortRank = $sortRank;
+  }
+  public function getSortRank()
+  {
+    return $this->sortRank;
+  }
+}
+
+class Google_Service_GamesConfiguration_LeaderboardConfigurationListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_GamesConfiguration_LeaderboardConfiguration';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_GamesConfiguration_LocalizedString extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $locale;
+  public $value;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocale($locale)
+  {
+    $this->locale = $locale;
+  }
+  public function getLocale()
+  {
+    return $this->locale;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_GamesConfiguration_LocalizedStringBundle extends Google_Collection
+{
+  protected $collection_key = 'translations';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $translationsType = 'Google_Service_GamesConfiguration_LocalizedString';
+  protected $translationsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setTranslations($translations)
+  {
+    $this->translations = $translations;
+  }
+  public function getTranslations()
+  {
+    return $this->translations;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/GamesManagement.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/GamesManagement.php
@@ -1,0 +1,1404 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for GamesManagement (v1management).
+ *
+ * <p>
+ * The Management API for Google Play Game Services.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/games/services" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_GamesManagement extends Google_Service
+{
+  /** Share your Google+ profile information and view and manage your game activity. */
+  const GAMES =
+      "https://www.googleapis.com/auth/games";
+  /** Know your basic profile info and list of people in your circles.. */
+  const PLUS_LOGIN =
+      "https://www.googleapis.com/auth/plus.login";
+
+  public $achievements;
+  public $applications;
+  public $events;
+  public $players;
+  public $quests;
+  public $rooms;
+  public $scores;
+  public $turnBasedMatches;
+  
+
+  /**
+   * Constructs the internal representation of the GamesManagement service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'games/v1management/';
+    $this->version = 'v1management';
+    $this->serviceName = 'gamesManagement';
+
+    $this->achievements = new Google_Service_GamesManagement_Achievements_Resource(
+        $this,
+        $this->serviceName,
+        'achievements',
+        array(
+          'methods' => array(
+            'reset' => array(
+              'path' => 'achievements/{achievementId}/reset',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'achievementId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'resetAll' => array(
+              'path' => 'achievements/reset',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'resetAllForAllPlayers' => array(
+              'path' => 'achievements/resetAllForAllPlayers',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'resetForAllPlayers' => array(
+              'path' => 'achievements/{achievementId}/resetForAllPlayers',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'achievementId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'resetMultipleForAllPlayers' => array(
+              'path' => 'achievements/resetMultipleForAllPlayers',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->applications = new Google_Service_GamesManagement_Applications_Resource(
+        $this,
+        $this->serviceName,
+        'applications',
+        array(
+          'methods' => array(
+            'listHidden' => array(
+              'path' => 'applications/{applicationId}/players/hidden',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'applicationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->events = new Google_Service_GamesManagement_Events_Resource(
+        $this,
+        $this->serviceName,
+        'events',
+        array(
+          'methods' => array(
+            'reset' => array(
+              'path' => 'events/{eventId}/reset',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'eventId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'resetAll' => array(
+              'path' => 'events/reset',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'resetAllForAllPlayers' => array(
+              'path' => 'events/resetAllForAllPlayers',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'resetForAllPlayers' => array(
+              'path' => 'events/{eventId}/resetForAllPlayers',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'eventId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'resetMultipleForAllPlayers' => array(
+              'path' => 'events/resetMultipleForAllPlayers',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->players = new Google_Service_GamesManagement_Players_Resource(
+        $this,
+        $this->serviceName,
+        'players',
+        array(
+          'methods' => array(
+            'hide' => array(
+              'path' => 'applications/{applicationId}/players/hidden/{playerId}',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'applicationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'playerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'unhide' => array(
+              'path' => 'applications/{applicationId}/players/hidden/{playerId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'applicationId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'playerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->quests = new Google_Service_GamesManagement_Quests_Resource(
+        $this,
+        $this->serviceName,
+        'quests',
+        array(
+          'methods' => array(
+            'reset' => array(
+              'path' => 'quests/{questId}/reset',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'questId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'resetAll' => array(
+              'path' => 'quests/reset',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'resetAllForAllPlayers' => array(
+              'path' => 'quests/resetAllForAllPlayers',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'resetForAllPlayers' => array(
+              'path' => 'quests/{questId}/resetForAllPlayers',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'questId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'resetMultipleForAllPlayers' => array(
+              'path' => 'quests/resetMultipleForAllPlayers',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->rooms = new Google_Service_GamesManagement_Rooms_Resource(
+        $this,
+        $this->serviceName,
+        'rooms',
+        array(
+          'methods' => array(
+            'reset' => array(
+              'path' => 'rooms/reset',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'resetForAllPlayers' => array(
+              'path' => 'rooms/resetForAllPlayers',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->scores = new Google_Service_GamesManagement_Scores_Resource(
+        $this,
+        $this->serviceName,
+        'scores',
+        array(
+          'methods' => array(
+            'reset' => array(
+              'path' => 'leaderboards/{leaderboardId}/scores/reset',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'leaderboardId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'resetAll' => array(
+              'path' => 'scores/reset',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'resetAllForAllPlayers' => array(
+              'path' => 'scores/resetAllForAllPlayers',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'resetForAllPlayers' => array(
+              'path' => 'leaderboards/{leaderboardId}/scores/resetForAllPlayers',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'leaderboardId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'resetMultipleForAllPlayers' => array(
+              'path' => 'scores/resetMultipleForAllPlayers',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->turnBasedMatches = new Google_Service_GamesManagement_TurnBasedMatches_Resource(
+        $this,
+        $this->serviceName,
+        'turnBasedMatches',
+        array(
+          'methods' => array(
+            'reset' => array(
+              'path' => 'turnbasedmatches/reset',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'resetForAllPlayers' => array(
+              'path' => 'turnbasedmatches/resetForAllPlayers',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "achievements" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesManagementService = new Google_Service_GamesManagement(...);
+ *   $achievements = $gamesManagementService->achievements;
+ *  </code>
+ */
+class Google_Service_GamesManagement_Achievements_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Resets the achievement with the given ID for the currently authenticated
+   * player. This method is only accessible to whitelisted tester accounts for
+   * your application. (achievements.reset)
+   *
+   * @param string $achievementId The ID of the achievement used by this method.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_GamesManagement_AchievementResetResponse
+   */
+  public function reset($achievementId, $optParams = array())
+  {
+    $params = array('achievementId' => $achievementId);
+    $params = array_merge($params, $optParams);
+    return $this->call('reset', array($params), "Google_Service_GamesManagement_AchievementResetResponse");
+  }
+
+  /**
+   * Resets all achievements for the currently authenticated player for your
+   * application. This method is only accessible to whitelisted tester accounts
+   * for your application. (achievements.resetAll)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_GamesManagement_AchievementResetAllResponse
+   */
+  public function resetAll($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('resetAll', array($params), "Google_Service_GamesManagement_AchievementResetAllResponse");
+  }
+
+  /**
+   * Resets all draft achievements for all players. This method is only available
+   * to user accounts for your developer console.
+   * (achievements.resetAllForAllPlayers)
+   *
+   * @param array $optParams Optional parameters.
+   */
+  public function resetAllForAllPlayers($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('resetAllForAllPlayers', array($params));
+  }
+
+  /**
+   * Resets the achievement with the given ID for all players. This method is only
+   * available to user accounts for your developer console. Only draft
+   * achievements can be reset. (achievements.resetForAllPlayers)
+   *
+   * @param string $achievementId The ID of the achievement used by this method.
+   * @param array $optParams Optional parameters.
+   */
+  public function resetForAllPlayers($achievementId, $optParams = array())
+  {
+    $params = array('achievementId' => $achievementId);
+    $params = array_merge($params, $optParams);
+    return $this->call('resetForAllPlayers', array($params));
+  }
+
+  /**
+   * Resets achievements with the given IDs for all players. This method is only
+   * available to user accounts for your developer console. Only draft
+   * achievements may be reset. (achievements.resetMultipleForAllPlayers)
+   *
+   * @param Google_AchievementResetMultipleForAllRequest $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function resetMultipleForAllPlayers(Google_Service_GamesManagement_AchievementResetMultipleForAllRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('resetMultipleForAllPlayers', array($params));
+  }
+}
+
+/**
+ * The "applications" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesManagementService = new Google_Service_GamesManagement(...);
+ *   $applications = $gamesManagementService->applications;
+ *  </code>
+ */
+class Google_Service_GamesManagement_Applications_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get the list of players hidden from the given application. This method is
+   * only available to user accounts for your developer console.
+   * (applications.listHidden)
+   *
+   * @param string $applicationId The application ID from the Google Play
+   * developer console.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param int maxResults The maximum number of player resources to return in
+   * the response, used for paging. For any response, the actual number of player
+   * resources returned may be less than the specified maxResults.
+   * @return Google_Service_GamesManagement_HiddenPlayerList
+   */
+  public function listHidden($applicationId, $optParams = array())
+  {
+    $params = array('applicationId' => $applicationId);
+    $params = array_merge($params, $optParams);
+    return $this->call('listHidden', array($params), "Google_Service_GamesManagement_HiddenPlayerList");
+  }
+}
+
+/**
+ * The "events" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesManagementService = new Google_Service_GamesManagement(...);
+ *   $events = $gamesManagementService->events;
+ *  </code>
+ */
+class Google_Service_GamesManagement_Events_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Resets all player progress on the event with the given ID for the currently
+   * authenticated player. This method is only accessible to whitelisted tester
+   * accounts for your application. All quests for this player that use the event
+   * will also be reset. (events.reset)
+   *
+   * @param string $eventId The ID of the event.
+   * @param array $optParams Optional parameters.
+   */
+  public function reset($eventId, $optParams = array())
+  {
+    $params = array('eventId' => $eventId);
+    $params = array_merge($params, $optParams);
+    return $this->call('reset', array($params));
+  }
+
+  /**
+   * Resets all player progress on all events for the currently authenticated
+   * player. This method is only accessible to whitelisted tester accounts for
+   * your application. All quests for this player will also be reset.
+   * (events.resetAll)
+   *
+   * @param array $optParams Optional parameters.
+   */
+  public function resetAll($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('resetAll', array($params));
+  }
+
+  /**
+   * Resets all draft events for all players. This method is only available to
+   * user accounts for your developer console. All quests that use any of these
+   * events will also be reset. (events.resetAllForAllPlayers)
+   *
+   * @param array $optParams Optional parameters.
+   */
+  public function resetAllForAllPlayers($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('resetAllForAllPlayers', array($params));
+  }
+
+  /**
+   * Resets the event with the given ID for all players. This method is only
+   * available to user accounts for your developer console. Only draft events can
+   * be reset. All quests that use the event will also be reset.
+   * (events.resetForAllPlayers)
+   *
+   * @param string $eventId The ID of the event.
+   * @param array $optParams Optional parameters.
+   */
+  public function resetForAllPlayers($eventId, $optParams = array())
+  {
+    $params = array('eventId' => $eventId);
+    $params = array_merge($params, $optParams);
+    return $this->call('resetForAllPlayers', array($params));
+  }
+
+  /**
+   * Resets events with the given IDs for all players. This method is only
+   * available to user accounts for your developer console. Only draft events may
+   * be reset. All quests that use any of the events will also be reset.
+   * (events.resetMultipleForAllPlayers)
+   *
+   * @param Google_EventsResetMultipleForAllRequest $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function resetMultipleForAllPlayers(Google_Service_GamesManagement_EventsResetMultipleForAllRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('resetMultipleForAllPlayers', array($params));
+  }
+}
+
+/**
+ * The "players" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesManagementService = new Google_Service_GamesManagement(...);
+ *   $players = $gamesManagementService->players;
+ *  </code>
+ */
+class Google_Service_GamesManagement_Players_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Hide the given player's leaderboard scores from the given application. This
+   * method is only available to user accounts for your developer console.
+   * (players.hide)
+   *
+   * @param string $applicationId The application ID from the Google Play
+   * developer console.
+   * @param string $playerId A player ID. A value of me may be used in place of
+   * the authenticated player's ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function hide($applicationId, $playerId, $optParams = array())
+  {
+    $params = array('applicationId' => $applicationId, 'playerId' => $playerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('hide', array($params));
+  }
+
+  /**
+   * Unhide the given player's leaderboard scores from the given application. This
+   * method is only available to user accounts for your developer console.
+   * (players.unhide)
+   *
+   * @param string $applicationId The application ID from the Google Play
+   * developer console.
+   * @param string $playerId A player ID. A value of me may be used in place of
+   * the authenticated player's ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function unhide($applicationId, $playerId, $optParams = array())
+  {
+    $params = array('applicationId' => $applicationId, 'playerId' => $playerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('unhide', array($params));
+  }
+}
+
+/**
+ * The "quests" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesManagementService = new Google_Service_GamesManagement(...);
+ *   $quests = $gamesManagementService->quests;
+ *  </code>
+ */
+class Google_Service_GamesManagement_Quests_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Resets all player progress on the quest with the given ID for the currently
+   * authenticated player. This method is only accessible to whitelisted tester
+   * accounts for your application. (quests.reset)
+   *
+   * @param string $questId The ID of the quest.
+   * @param array $optParams Optional parameters.
+   */
+  public function reset($questId, $optParams = array())
+  {
+    $params = array('questId' => $questId);
+    $params = array_merge($params, $optParams);
+    return $this->call('reset', array($params));
+  }
+
+  /**
+   * Resets all player progress on all quests for the currently authenticated
+   * player. This method is only accessible to whitelisted tester accounts for
+   * your application. (quests.resetAll)
+   *
+   * @param array $optParams Optional parameters.
+   */
+  public function resetAll($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('resetAll', array($params));
+  }
+
+  /**
+   * Resets all draft quests for all players. This method is only available to
+   * user accounts for your developer console. (quests.resetAllForAllPlayers)
+   *
+   * @param array $optParams Optional parameters.
+   */
+  public function resetAllForAllPlayers($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('resetAllForAllPlayers', array($params));
+  }
+
+  /**
+   * Resets all player progress on the quest with the given ID for all players.
+   * This method is only available to user accounts for your developer console.
+   * Only draft quests can be reset. (quests.resetForAllPlayers)
+   *
+   * @param string $questId The ID of the quest.
+   * @param array $optParams Optional parameters.
+   */
+  public function resetForAllPlayers($questId, $optParams = array())
+  {
+    $params = array('questId' => $questId);
+    $params = array_merge($params, $optParams);
+    return $this->call('resetForAllPlayers', array($params));
+  }
+
+  /**
+   * Resets quests with the given IDs for all players. This method is only
+   * available to user accounts for your developer console. Only draft quests may
+   * be reset. (quests.resetMultipleForAllPlayers)
+   *
+   * @param Google_QuestsResetMultipleForAllRequest $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function resetMultipleForAllPlayers(Google_Service_GamesManagement_QuestsResetMultipleForAllRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('resetMultipleForAllPlayers', array($params));
+  }
+}
+
+/**
+ * The "rooms" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesManagementService = new Google_Service_GamesManagement(...);
+ *   $rooms = $gamesManagementService->rooms;
+ *  </code>
+ */
+class Google_Service_GamesManagement_Rooms_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Reset all rooms for the currently authenticated player for your application.
+   * This method is only accessible to whitelisted tester accounts for your
+   * application. (rooms.reset)
+   *
+   * @param array $optParams Optional parameters.
+   */
+  public function reset($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('reset', array($params));
+  }
+
+  /**
+   * Deletes rooms where the only room participants are from whitelisted tester
+   * accounts for your application. This method is only available to user accounts
+   * for your developer console. (rooms.resetForAllPlayers)
+   *
+   * @param array $optParams Optional parameters.
+   */
+  public function resetForAllPlayers($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('resetForAllPlayers', array($params));
+  }
+}
+
+/**
+ * The "scores" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesManagementService = new Google_Service_GamesManagement(...);
+ *   $scores = $gamesManagementService->scores;
+ *  </code>
+ */
+class Google_Service_GamesManagement_Scores_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Resets scores for the leaderboard with the given ID for the currently
+   * authenticated player. This method is only accessible to whitelisted tester
+   * accounts for your application. (scores.reset)
+   *
+   * @param string $leaderboardId The ID of the leaderboard.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_GamesManagement_PlayerScoreResetResponse
+   */
+  public function reset($leaderboardId, $optParams = array())
+  {
+    $params = array('leaderboardId' => $leaderboardId);
+    $params = array_merge($params, $optParams);
+    return $this->call('reset', array($params), "Google_Service_GamesManagement_PlayerScoreResetResponse");
+  }
+
+  /**
+   * Resets all scores for all leaderboards for the currently authenticated
+   * players. This method is only accessible to whitelisted tester accounts for
+   * your application. (scores.resetAll)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_GamesManagement_PlayerScoreResetAllResponse
+   */
+  public function resetAll($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('resetAll', array($params), "Google_Service_GamesManagement_PlayerScoreResetAllResponse");
+  }
+
+  /**
+   * Resets scores for all draft leaderboards for all players. This method is only
+   * available to user accounts for your developer console.
+   * (scores.resetAllForAllPlayers)
+   *
+   * @param array $optParams Optional parameters.
+   */
+  public function resetAllForAllPlayers($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('resetAllForAllPlayers', array($params));
+  }
+
+  /**
+   * Resets scores for the leaderboard with the given ID for all players. This
+   * method is only available to user accounts for your developer console. Only
+   * draft leaderboards can be reset. (scores.resetForAllPlayers)
+   *
+   * @param string $leaderboardId The ID of the leaderboard.
+   * @param array $optParams Optional parameters.
+   */
+  public function resetForAllPlayers($leaderboardId, $optParams = array())
+  {
+    $params = array('leaderboardId' => $leaderboardId);
+    $params = array_merge($params, $optParams);
+    return $this->call('resetForAllPlayers', array($params));
+  }
+
+  /**
+   * Resets scores for the leaderboards with the given IDs for all players. This
+   * method is only available to user accounts for your developer console. Only
+   * draft leaderboards may be reset. (scores.resetMultipleForAllPlayers)
+   *
+   * @param Google_ScoresResetMultipleForAllRequest $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function resetMultipleForAllPlayers(Google_Service_GamesManagement_ScoresResetMultipleForAllRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('resetMultipleForAllPlayers', array($params));
+  }
+}
+
+/**
+ * The "turnBasedMatches" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gamesManagementService = new Google_Service_GamesManagement(...);
+ *   $turnBasedMatches = $gamesManagementService->turnBasedMatches;
+ *  </code>
+ */
+class Google_Service_GamesManagement_TurnBasedMatches_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Reset all turn-based match data for a user. This method is only accessible to
+   * whitelisted tester accounts for your application. (turnBasedMatches.reset)
+   *
+   * @param array $optParams Optional parameters.
+   */
+  public function reset($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('reset', array($params));
+  }
+
+  /**
+   * Deletes turn-based matches where the only match participants are from
+   * whitelisted tester accounts for your application. This method is only
+   * available to user accounts for your developer console.
+   * (turnBasedMatches.resetForAllPlayers)
+   *
+   * @param array $optParams Optional parameters.
+   */
+  public function resetForAllPlayers($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('resetForAllPlayers', array($params));
+  }
+}
+
+
+
+
+class Google_Service_GamesManagement_AchievementResetAllResponse extends Google_Collection
+{
+  protected $collection_key = 'results';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $resultsType = 'Google_Service_GamesManagement_AchievementResetResponse';
+  protected $resultsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setResults($results)
+  {
+    $this->results = $results;
+  }
+  public function getResults()
+  {
+    return $this->results;
+  }
+}
+
+class Google_Service_GamesManagement_AchievementResetMultipleForAllRequest extends Google_Collection
+{
+  protected $collection_key = 'achievement_ids';
+  protected $internal_gapi_mappings = array(
+        "achievementIds" => "achievement_ids",
+  );
+  public $achievementIds;
+  public $kind;
+
+
+  public function setAchievementIds($achievementIds)
+  {
+    $this->achievementIds = $achievementIds;
+  }
+  public function getAchievementIds()
+  {
+    return $this->achievementIds;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_GamesManagement_AchievementResetResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $currentState;
+  public $definitionId;
+  public $kind;
+  public $updateOccurred;
+
+
+  public function setCurrentState($currentState)
+  {
+    $this->currentState = $currentState;
+  }
+  public function getCurrentState()
+  {
+    return $this->currentState;
+  }
+  public function setDefinitionId($definitionId)
+  {
+    $this->definitionId = $definitionId;
+  }
+  public function getDefinitionId()
+  {
+    return $this->definitionId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUpdateOccurred($updateOccurred)
+  {
+    $this->updateOccurred = $updateOccurred;
+  }
+  public function getUpdateOccurred()
+  {
+    return $this->updateOccurred;
+  }
+}
+
+class Google_Service_GamesManagement_EventsResetMultipleForAllRequest extends Google_Collection
+{
+  protected $collection_key = 'event_ids';
+  protected $internal_gapi_mappings = array(
+        "eventIds" => "event_ids",
+  );
+  public $eventIds;
+  public $kind;
+
+
+  public function setEventIds($eventIds)
+  {
+    $this->eventIds = $eventIds;
+  }
+  public function getEventIds()
+  {
+    return $this->eventIds;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_GamesManagement_GamesPlayedResource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $autoMatched;
+  public $timeMillis;
+
+
+  public function setAutoMatched($autoMatched)
+  {
+    $this->autoMatched = $autoMatched;
+  }
+  public function getAutoMatched()
+  {
+    return $this->autoMatched;
+  }
+  public function setTimeMillis($timeMillis)
+  {
+    $this->timeMillis = $timeMillis;
+  }
+  public function getTimeMillis()
+  {
+    return $this->timeMillis;
+  }
+}
+
+class Google_Service_GamesManagement_GamesPlayerExperienceInfoResource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $currentExperiencePoints;
+  protected $currentLevelType = 'Google_Service_GamesManagement_GamesPlayerLevelResource';
+  protected $currentLevelDataType = '';
+  public $lastLevelUpTimestampMillis;
+  protected $nextLevelType = 'Google_Service_GamesManagement_GamesPlayerLevelResource';
+  protected $nextLevelDataType = '';
+
+
+  public function setCurrentExperiencePoints($currentExperiencePoints)
+  {
+    $this->currentExperiencePoints = $currentExperiencePoints;
+  }
+  public function getCurrentExperiencePoints()
+  {
+    return $this->currentExperiencePoints;
+  }
+  public function setCurrentLevel(Google_Service_GamesManagement_GamesPlayerLevelResource $currentLevel)
+  {
+    $this->currentLevel = $currentLevel;
+  }
+  public function getCurrentLevel()
+  {
+    return $this->currentLevel;
+  }
+  public function setLastLevelUpTimestampMillis($lastLevelUpTimestampMillis)
+  {
+    $this->lastLevelUpTimestampMillis = $lastLevelUpTimestampMillis;
+  }
+  public function getLastLevelUpTimestampMillis()
+  {
+    return $this->lastLevelUpTimestampMillis;
+  }
+  public function setNextLevel(Google_Service_GamesManagement_GamesPlayerLevelResource $nextLevel)
+  {
+    $this->nextLevel = $nextLevel;
+  }
+  public function getNextLevel()
+  {
+    return $this->nextLevel;
+  }
+}
+
+class Google_Service_GamesManagement_GamesPlayerLevelResource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $level;
+  public $maxExperiencePoints;
+  public $minExperiencePoints;
+
+
+  public function setLevel($level)
+  {
+    $this->level = $level;
+  }
+  public function getLevel()
+  {
+    return $this->level;
+  }
+  public function setMaxExperiencePoints($maxExperiencePoints)
+  {
+    $this->maxExperiencePoints = $maxExperiencePoints;
+  }
+  public function getMaxExperiencePoints()
+  {
+    return $this->maxExperiencePoints;
+  }
+  public function setMinExperiencePoints($minExperiencePoints)
+  {
+    $this->minExperiencePoints = $minExperiencePoints;
+  }
+  public function getMinExperiencePoints()
+  {
+    return $this->minExperiencePoints;
+  }
+}
+
+class Google_Service_GamesManagement_HiddenPlayer extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $hiddenTimeMillis;
+  public $kind;
+  protected $playerType = 'Google_Service_GamesManagement_Player';
+  protected $playerDataType = '';
+
+
+  public function setHiddenTimeMillis($hiddenTimeMillis)
+  {
+    $this->hiddenTimeMillis = $hiddenTimeMillis;
+  }
+  public function getHiddenTimeMillis()
+  {
+    return $this->hiddenTimeMillis;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPlayer(Google_Service_GamesManagement_Player $player)
+  {
+    $this->player = $player;
+  }
+  public function getPlayer()
+  {
+    return $this->player;
+  }
+}
+
+class Google_Service_GamesManagement_HiddenPlayerList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_GamesManagement_HiddenPlayer';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_GamesManagement_Player extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $avatarImageUrl;
+  public $bannerUrlLandscape;
+  public $bannerUrlPortrait;
+  public $displayName;
+  protected $experienceInfoType = 'Google_Service_GamesManagement_GamesPlayerExperienceInfoResource';
+  protected $experienceInfoDataType = '';
+  public $kind;
+  protected $lastPlayedWithType = 'Google_Service_GamesManagement_GamesPlayedResource';
+  protected $lastPlayedWithDataType = '';
+  protected $nameType = 'Google_Service_GamesManagement_PlayerName';
+  protected $nameDataType = '';
+  public $playerId;
+  public $title;
+
+
+  public function setAvatarImageUrl($avatarImageUrl)
+  {
+    $this->avatarImageUrl = $avatarImageUrl;
+  }
+  public function getAvatarImageUrl()
+  {
+    return $this->avatarImageUrl;
+  }
+  public function setBannerUrlLandscape($bannerUrlLandscape)
+  {
+    $this->bannerUrlLandscape = $bannerUrlLandscape;
+  }
+  public function getBannerUrlLandscape()
+  {
+    return $this->bannerUrlLandscape;
+  }
+  public function setBannerUrlPortrait($bannerUrlPortrait)
+  {
+    $this->bannerUrlPortrait = $bannerUrlPortrait;
+  }
+  public function getBannerUrlPortrait()
+  {
+    return $this->bannerUrlPortrait;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setExperienceInfo(Google_Service_GamesManagement_GamesPlayerExperienceInfoResource $experienceInfo)
+  {
+    $this->experienceInfo = $experienceInfo;
+  }
+  public function getExperienceInfo()
+  {
+    return $this->experienceInfo;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastPlayedWith(Google_Service_GamesManagement_GamesPlayedResource $lastPlayedWith)
+  {
+    $this->lastPlayedWith = $lastPlayedWith;
+  }
+  public function getLastPlayedWith()
+  {
+    return $this->lastPlayedWith;
+  }
+  public function setName(Google_Service_GamesManagement_PlayerName $name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPlayerId($playerId)
+  {
+    $this->playerId = $playerId;
+  }
+  public function getPlayerId()
+  {
+    return $this->playerId;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_GamesManagement_PlayerName extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $familyName;
+  public $givenName;
+
+
+  public function setFamilyName($familyName)
+  {
+    $this->familyName = $familyName;
+  }
+  public function getFamilyName()
+  {
+    return $this->familyName;
+  }
+  public function setGivenName($givenName)
+  {
+    $this->givenName = $givenName;
+  }
+  public function getGivenName()
+  {
+    return $this->givenName;
+  }
+}
+
+class Google_Service_GamesManagement_PlayerScoreResetAllResponse extends Google_Collection
+{
+  protected $collection_key = 'results';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $resultsType = 'Google_Service_GamesManagement_PlayerScoreResetResponse';
+  protected $resultsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setResults($results)
+  {
+    $this->results = $results;
+  }
+  public function getResults()
+  {
+    return $this->results;
+  }
+}
+
+class Google_Service_GamesManagement_PlayerScoreResetResponse extends Google_Collection
+{
+  protected $collection_key = 'resetScoreTimeSpans';
+  protected $internal_gapi_mappings = array(
+  );
+  public $definitionId;
+  public $kind;
+  public $resetScoreTimeSpans;
+
+
+  public function setDefinitionId($definitionId)
+  {
+    $this->definitionId = $definitionId;
+  }
+  public function getDefinitionId()
+  {
+    return $this->definitionId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setResetScoreTimeSpans($resetScoreTimeSpans)
+  {
+    $this->resetScoreTimeSpans = $resetScoreTimeSpans;
+  }
+  public function getResetScoreTimeSpans()
+  {
+    return $this->resetScoreTimeSpans;
+  }
+}
+
+class Google_Service_GamesManagement_QuestsResetMultipleForAllRequest extends Google_Collection
+{
+  protected $collection_key = 'quest_ids';
+  protected $internal_gapi_mappings = array(
+        "questIds" => "quest_ids",
+  );
+  public $kind;
+  public $questIds;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setQuestIds($questIds)
+  {
+    $this->questIds = $questIds;
+  }
+  public function getQuestIds()
+  {
+    return $this->questIds;
+  }
+}
+
+class Google_Service_GamesManagement_ScoresResetMultipleForAllRequest extends Google_Collection
+{
+  protected $collection_key = 'leaderboard_ids';
+  protected $internal_gapi_mappings = array(
+        "leaderboardIds" => "leaderboard_ids",
+  );
+  public $kind;
+  public $leaderboardIds;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLeaderboardIds($leaderboardIds)
+  {
+    $this->leaderboardIds = $leaderboardIds;
+  }
+  public function getLeaderboardIds()
+  {
+    return $this->leaderboardIds;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Genomics.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Genomics.php
@@ -1,0 +1,3990 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Genomics (v1).
+ *
+ * <p>
+ * An API to store, process, explore, and share DNA sequence reads, reference-
+ * based alignments, and variant calls.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Genomics extends Google_Service
+{
+  /** View and manage your data in Google BigQuery. */
+  const BIGQUERY =
+      "https://www.googleapis.com/auth/bigquery";
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+  /** Manage your data in Google Cloud Storage. */
+  const DEVSTORAGE_READ_WRITE =
+      "https://www.googleapis.com/auth/devstorage.read_write";
+  /** View and manage Genomics data. */
+  const GENOMICS =
+      "https://www.googleapis.com/auth/genomics";
+  /** View Genomics data. */
+  const GENOMICS_READONLY =
+      "https://www.googleapis.com/auth/genomics.readonly";
+
+  public $callsets;
+  public $datasets;
+  public $operations;
+  public $readgroupsets;
+  public $readgroupsets_coveragebuckets;
+  public $reads;
+  public $references;
+  public $references_bases;
+  public $referencesets;
+  public $variants;
+  public $variantsets;
+
+
+  /**
+   * Constructs the internal representation of the Genomics service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://genomics.googleapis.com/';
+    $this->servicePath = '';
+    $this->version = 'v1';
+    $this->serviceName = 'genomics';
+
+    $this->callsets = new Google_Service_Genomics_Callsets_Resource(
+        $this,
+        $this->serviceName,
+        'callsets',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'v1/callsets',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'delete' => array(
+              'path' => 'v1/callsets/{callSetId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'callSetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v1/callsets/{callSetId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'callSetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'v1/callsets/{callSetId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'callSetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'updateMask' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'search' => array(
+              'path' => 'v1/callsets/search',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->datasets = new Google_Service_Genomics_Datasets_Resource(
+        $this,
+        $this->serviceName,
+        'datasets',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'v1/datasets',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'delete' => array(
+              'path' => 'v1/datasets/{datasetId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v1/datasets/{datasetId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getIamPolicy' => array(
+              'path' => 'v1/{+resource}:getIamPolicy',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'resource' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1/datasets',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'v1/datasets/{datasetId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'updateMask' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'setIamPolicy' => array(
+              'path' => 'v1/{+resource}:setIamPolicy',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'resource' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'testIamPermissions' => array(
+              'path' => 'v1/{+resource}:testIamPermissions',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'resource' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'undelete' => array(
+              'path' => 'v1/datasets/{datasetId}:undelete',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'datasetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->operations = new Google_Service_Genomics_Operations_Resource(
+        $this,
+        $this->serviceName,
+        'operations',
+        array(
+          'methods' => array(
+            'cancel' => array(
+              'path' => 'v1/{+name}:cancel',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'name' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'v1/{+name}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'name' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v1/{+name}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'name' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1/{+name}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'name' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->readgroupsets = new Google_Service_Genomics_Readgroupsets_Resource(
+        $this,
+        $this->serviceName,
+        'readgroupsets',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'v1/readgroupsets/{readGroupSetId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'readGroupSetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'export' => array(
+              'path' => 'v1/readgroupsets/{readGroupSetId}:export',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'readGroupSetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v1/readgroupsets/{readGroupSetId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'readGroupSetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'import' => array(
+              'path' => 'v1/readgroupsets:import',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'patch' => array(
+              'path' => 'v1/readgroupsets/{readGroupSetId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'readGroupSetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'updateMask' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'search' => array(
+              'path' => 'v1/readgroupsets/search',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->readgroupsets_coveragebuckets = new Google_Service_Genomics_ReadgroupsetsCoveragebuckets_Resource(
+        $this,
+        $this->serviceName,
+        'coveragebuckets',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'v1/readgroupsets/{readGroupSetId}/coveragebuckets',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'readGroupSetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'end' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'start' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'targetBucketWidth' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'referenceName' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->reads = new Google_Service_Genomics_Reads_Resource(
+        $this,
+        $this->serviceName,
+        'reads',
+        array(
+          'methods' => array(
+            'search' => array(
+              'path' => 'v1/reads/search',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->references = new Google_Service_Genomics_References_Resource(
+        $this,
+        $this->serviceName,
+        'references',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'v1/references/{referenceId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'referenceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'search' => array(
+              'path' => 'v1/references/search',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->references_bases = new Google_Service_Genomics_ReferencesBases_Resource(
+        $this,
+        $this->serviceName,
+        'bases',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'v1/references/{referenceId}/bases',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'referenceId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'start' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'end' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->referencesets = new Google_Service_Genomics_Referencesets_Resource(
+        $this,
+        $this->serviceName,
+        'referencesets',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'v1/referencesets/{referenceSetId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'referenceSetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'search' => array(
+              'path' => 'v1/referencesets/search',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->variants = new Google_Service_Genomics_Variants_Resource(
+        $this,
+        $this->serviceName,
+        'variants',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'v1/variants',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'delete' => array(
+              'path' => 'v1/variants/{variantId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'variantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v1/variants/{variantId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'variantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'import' => array(
+              'path' => 'v1/variants:import',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'patch' => array(
+              'path' => 'v1/variants/{variantId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'variantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'updateMask' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'search' => array(
+              'path' => 'v1/variants/search',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->variantsets = new Google_Service_Genomics_Variantsets_Resource(
+        $this,
+        $this->serviceName,
+        'variantsets',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'v1/variantsets',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'delete' => array(
+              'path' => 'v1/variantsets/{variantSetId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'variantSetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'export' => array(
+              'path' => 'v1/variantsets/{variantSetId}:export',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'variantSetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v1/variantsets/{variantSetId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'variantSetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'v1/variantsets/{variantSetId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'variantSetId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'updateMask' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'search' => array(
+              'path' => 'v1/variantsets/search',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "callsets" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $genomicsService = new Google_Service_Genomics(...);
+ *   $callsets = $genomicsService->callsets;
+ *  </code>
+ */
+class Google_Service_Genomics_Callsets_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a new call set. (callsets.create)
+   *
+   * @param Google_CallSet $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_CallSet
+   */
+  public function create(Google_Service_Genomics_CallSet $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Genomics_CallSet");
+  }
+
+  /**
+   * Deletes a call set. (callsets.delete)
+   *
+   * @param string $callSetId The ID of the call set to be deleted.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Empty
+   */
+  public function delete($callSetId, $optParams = array())
+  {
+    $params = array('callSetId' => $callSetId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Genomics_Empty");
+  }
+
+  /**
+   * Gets a call set by ID. (callsets.get)
+   *
+   * @param string $callSetId The ID of the call set.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_CallSet
+   */
+  public function get($callSetId, $optParams = array())
+  {
+    $params = array('callSetId' => $callSetId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Genomics_CallSet");
+  }
+
+  /**
+   * Updates a call set. This method supports patch semantics. (callsets.patch)
+   *
+   * @param string $callSetId The ID of the call set to be updated.
+   * @param Google_CallSet $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string updateMask An optional mask specifying which fields to
+   * update. At this time, the only mutable field is name. The only acceptable
+   * value is "name". If unspecified, all mutable fields will be updated.
+   * @return Google_Service_Genomics_CallSet
+   */
+  public function patch($callSetId, Google_Service_Genomics_CallSet $postBody, $optParams = array())
+  {
+    $params = array('callSetId' => $callSetId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Genomics_CallSet");
+  }
+
+  /**
+   * Gets a list of call sets matching the criteria. Implements [GlobalAllianceApi
+   * .searchCallSets](https://github.com/ga4gh/schemas/blob/v0.5.1/src/main/resour
+   * ces/avro/variantmethods.avdl#L178). (callsets.search)
+   *
+   * @param Google_SearchCallSetsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_SearchCallSetsResponse
+   */
+  public function search(Google_Service_Genomics_SearchCallSetsRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('search', array($params), "Google_Service_Genomics_SearchCallSetsResponse");
+  }
+}
+
+/**
+ * The "datasets" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $genomicsService = new Google_Service_Genomics(...);
+ *   $datasets = $genomicsService->datasets;
+ *  </code>
+ */
+class Google_Service_Genomics_Datasets_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a new dataset. (datasets.create)
+   *
+   * @param Google_Dataset $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Dataset
+   */
+  public function create(Google_Service_Genomics_Dataset $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Genomics_Dataset");
+  }
+
+  /**
+   * Deletes a dataset. (datasets.delete)
+   *
+   * @param string $datasetId The ID of the dataset to be deleted.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Empty
+   */
+  public function delete($datasetId, $optParams = array())
+  {
+    $params = array('datasetId' => $datasetId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Genomics_Empty");
+  }
+
+  /**
+   * Gets a dataset by ID. (datasets.get)
+   *
+   * @param string $datasetId The ID of the dataset.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Dataset
+   */
+  public function get($datasetId, $optParams = array())
+  {
+    $params = array('datasetId' => $datasetId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Genomics_Dataset");
+  }
+
+  /**
+   * Gets the access control policy for the dataset. Is empty if the policy or the
+   * resource does not exist. See Getting a Policy for more information.
+   * (datasets.getIamPolicy)
+   *
+   * @param string $resource REQUIRED: The resource for which policy is being
+   * specified. Format is `datasets/`.
+   * @param Google_GetIamPolicyRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Policy
+   */
+  public function getIamPolicy($resource, Google_Service_Genomics_GetIamPolicyRequest $postBody, $optParams = array())
+  {
+    $params = array('resource' => $resource, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('getIamPolicy', array($params), "Google_Service_Genomics_Policy");
+  }
+
+  /**
+   * Lists datasets within a project. (datasets.listDatasets)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string projectId Required. The project to list datasets for.
+   * @opt_param int pageSize The maximum number of results returned by this
+   * request. If unspecified, defaults to 50. The maximum value is 1024.
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large result sets. To get the next page of results, set this
+   * parameter to the value of `nextPageToken` from the previous response.
+   * @return Google_Service_Genomics_ListDatasetsResponse
+   */
+  public function listDatasets($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Genomics_ListDatasetsResponse");
+  }
+
+  /**
+   * Updates a dataset. This method supports patch semantics. (datasets.patch)
+   *
+   * @param string $datasetId The ID of the dataset to be updated.
+   * @param Google_Dataset $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string updateMask An optional mask specifying which fields to
+   * update. At this time, the only mutable field is name. The only acceptable
+   * value is "name". If unspecified, all mutable fields will be updated.
+   * @return Google_Service_Genomics_Dataset
+   */
+  public function patch($datasetId, Google_Service_Genomics_Dataset $postBody, $optParams = array())
+  {
+    $params = array('datasetId' => $datasetId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Genomics_Dataset");
+  }
+
+  /**
+   * Sets the access control policy on the specified dataset. Replaces any
+   * existing policy. See Setting a Policy for more information.
+   * (datasets.setIamPolicy)
+   *
+   * @param string $resource REQUIRED: The resource for which policy is being
+   * specified. Format is `datasets/`.
+   * @param Google_SetIamPolicyRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Policy
+   */
+  public function setIamPolicy($resource, Google_Service_Genomics_SetIamPolicyRequest $postBody, $optParams = array())
+  {
+    $params = array('resource' => $resource, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setIamPolicy', array($params), "Google_Service_Genomics_Policy");
+  }
+
+  /**
+   * Returns permissions that a caller has on the specified resource. See Testing
+   * Permissions for more information. (datasets.testIamPermissions)
+   *
+   * @param string $resource REQUIRED: The resource for which policy is being
+   * specified. Format is `datasets/`.
+   * @param Google_TestIamPermissionsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_TestIamPermissionsResponse
+   */
+  public function testIamPermissions($resource, Google_Service_Genomics_TestIamPermissionsRequest $postBody, $optParams = array())
+  {
+    $params = array('resource' => $resource, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('testIamPermissions', array($params), "Google_Service_Genomics_TestIamPermissionsResponse");
+  }
+
+  /**
+   * Undeletes a dataset by restoring a dataset which was deleted via this API.
+   * This operation is only possible for a week after the deletion occurred.
+   * (datasets.undelete)
+   *
+   * @param string $datasetId The ID of the dataset to be undeleted.
+   * @param Google_UndeleteDatasetRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Dataset
+   */
+  public function undelete($datasetId, Google_Service_Genomics_UndeleteDatasetRequest $postBody, $optParams = array())
+  {
+    $params = array('datasetId' => $datasetId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('undelete', array($params), "Google_Service_Genomics_Dataset");
+  }
+}
+
+/**
+ * The "operations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $genomicsService = new Google_Service_Genomics(...);
+ *   $operations = $genomicsService->operations;
+ *  </code>
+ */
+class Google_Service_Genomics_Operations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Starts asynchronous cancellation on a long-running operation. The server
+   * makes a best effort to cancel the operation, but success is not guaranteed.
+   * Clients may use Operations.GetOperation or Operations.ListOperations to check
+   * whether the cancellation succeeded or the operation completed despite
+   * cancellation. (operations.cancel)
+   *
+   * @param string $name The name of the operation resource to be cancelled.
+   * @param Google_CancelOperationRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Empty
+   */
+  public function cancel($name, Google_Service_Genomics_CancelOperationRequest $postBody, $optParams = array())
+  {
+    $params = array('name' => $name, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('cancel', array($params), "Google_Service_Genomics_Empty");
+  }
+
+  /**
+   * This method is not implemented. To cancel an operation, please use
+   * Operations.CancelOperation. (operations.delete)
+   *
+   * @param string $name The name of the operation resource to be deleted.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Empty
+   */
+  public function delete($name, $optParams = array())
+  {
+    $params = array('name' => $name);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Genomics_Empty");
+  }
+
+  /**
+   * Gets the latest state of a long-running operation. Clients can use this
+   * method to poll the operation result at intervals as recommended by the API
+   * service. (operations.get)
+   *
+   * @param string $name The name of the operation resource.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Operation
+   */
+  public function get($name, $optParams = array())
+  {
+    $params = array('name' => $name);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Genomics_Operation");
+  }
+
+  /**
+   * Lists operations that match the specified filter in the request.
+   * (operations.listOperations)
+   *
+   * @param string $name The name of the operation collection.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter A string for filtering Operations. The following
+   * filter fields are supported: * projectId: Required. Corresponds to
+   * OperationMetadata.projectId. * createTime: The time this job was created, in
+   * seconds from the [epoch](http://en.wikipedia.org/wiki/Unix_time). Can use
+   * `>=` and/or `= 1432140000` * `projectId = my-project AND createTime >=
+   * 1432140000 AND createTime <= 1432150000 AND status = RUNNING`
+   * @opt_param string pageToken The standard list page token.
+   * @opt_param int pageSize The maximum number of results to return. If
+   * unspecified, defaults to 256. The maximum value is 2048.
+   * @return Google_Service_Genomics_ListOperationsResponse
+   */
+  public function listOperations($name, $optParams = array())
+  {
+    $params = array('name' => $name);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Genomics_ListOperationsResponse");
+  }
+}
+
+/**
+ * The "readgroupsets" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $genomicsService = new Google_Service_Genomics(...);
+ *   $readgroupsets = $genomicsService->readgroupsets;
+ *  </code>
+ */
+class Google_Service_Genomics_Readgroupsets_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a read group set. (readgroupsets.delete)
+   *
+   * @param string $readGroupSetId The ID of the read group set to be deleted. The
+   * caller must have WRITE permissions to the dataset associated with this read
+   * group set.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Empty
+   */
+  public function delete($readGroupSetId, $optParams = array())
+  {
+    $params = array('readGroupSetId' => $readGroupSetId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Genomics_Empty");
+  }
+
+  /**
+   * Exports a read group set to a BAM file in Google Cloud Storage. Note that
+   * currently there may be some differences between exported BAM files and the
+   * original BAM file at the time of import. See
+   * [ImportReadGroupSets](google.genomics.v1.ReadServiceV1.ImportReadGroupSets)
+   * for caveats. (readgroupsets.export)
+   *
+   * @param string $readGroupSetId Required. The ID of the read group set to
+   * export.
+   * @param Google_ExportReadGroupSetRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Operation
+   */
+  public function export($readGroupSetId, Google_Service_Genomics_ExportReadGroupSetRequest $postBody, $optParams = array())
+  {
+    $params = array('readGroupSetId' => $readGroupSetId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('export', array($params), "Google_Service_Genomics_Operation");
+  }
+
+  /**
+   * Gets a read group set by ID. (readgroupsets.get)
+   *
+   * @param string $readGroupSetId The ID of the read group set.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_ReadGroupSet
+   */
+  public function get($readGroupSetId, $optParams = array())
+  {
+    $params = array('readGroupSetId' => $readGroupSetId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Genomics_ReadGroupSet");
+  }
+
+  /**
+   * Creates read group sets by asynchronously importing the provided information.
+   * The caller must have WRITE permissions to the dataset. ## Notes on
+   * [BAM](https://samtools.github.io/hts-specs/SAMv1.pdf) import - Tags will be
+   * converted to strings - tag types are not preserved - Comments (`@CO`) in the
+   * input file header will not be preserved - Original header order of references
+   * (`@SQ`) will not be preserved - Any reverse stranded unmapped reads will be
+   * reverse complemented, and their qualities (and "BQ" tag, if any) will be
+   * reversed - Unmapped reads will be stripped of positional information
+   * (reference name and position) (readgroupsets.import)
+   *
+   * @param Google_ImportReadGroupSetsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Operation
+   */
+  public function import(Google_Service_Genomics_ImportReadGroupSetsRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('import', array($params), "Google_Service_Genomics_Operation");
+  }
+
+  /**
+   * Updates a read group set. This method supports patch semantics.
+   * (readgroupsets.patch)
+   *
+   * @param string $readGroupSetId The ID of the read group set to be updated. The
+   * caller must have WRITE permissions to the dataset associated with this read
+   * group set.
+   * @param Google_ReadGroupSet $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string updateMask An optional mask specifying which fields to
+   * update. At this time, mutable fields are referenceSetId and name. Acceptable
+   * values are "referenceSetId" and "name". If unspecified, all mutable fields
+   * will be updated.
+   * @return Google_Service_Genomics_ReadGroupSet
+   */
+  public function patch($readGroupSetId, Google_Service_Genomics_ReadGroupSet $postBody, $optParams = array())
+  {
+    $params = array('readGroupSetId' => $readGroupSetId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Genomics_ReadGroupSet");
+  }
+
+  /**
+   * Searches for read group sets matching the criteria. Implements [GlobalAllianc
+   * eApi.searchReadGroupSets](https://github.com/ga4gh/schemas/blob/v0.5.1/src/ma
+   * in/resources/avro/readmethods.avdl#L135). (readgroupsets.search)
+   *
+   * @param Google_SearchReadGroupSetsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_SearchReadGroupSetsResponse
+   */
+  public function search(Google_Service_Genomics_SearchReadGroupSetsRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('search', array($params), "Google_Service_Genomics_SearchReadGroupSetsResponse");
+  }
+}
+
+/**
+ * The "coveragebuckets" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $genomicsService = new Google_Service_Genomics(...);
+ *   $coveragebuckets = $genomicsService->coveragebuckets;
+ *  </code>
+ */
+class Google_Service_Genomics_ReadgroupsetsCoveragebuckets_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Lists fixed width coverage buckets for a read group set, each of which
+   * correspond to a range of a reference sequence. Each bucket summarizes
+   * coverage information across its corresponding genomic range. Coverage is
+   * defined as the number of reads which are aligned to a given base in the
+   * reference sequence. Coverage buckets are available at several precomputed
+   * bucket widths, enabling retrieval of various coverage 'zoom levels'. The
+   * caller must have READ permissions for the target read group set.
+   * (coveragebuckets.listReadgroupsetsCoveragebuckets)
+   *
+   * @param string $readGroupSetId Required. The ID of the read group set over
+   * which coverage is requested.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string end The end position of the range on the reference, 0-based
+   * exclusive. If specified, `referenceName` must also be specified. If unset or
+   * 0, defaults to the length of the reference.
+   * @opt_param int pageSize The maximum number of results to return in a single
+   * page. If unspecified, defaults to 1024. The maximum value is 2048.
+   * @opt_param string start The start position of the range on the reference,
+   * 0-based inclusive. If specified, `referenceName` must also be specified.
+   * Defaults to 0.
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large result sets. To get the next page of results, set this
+   * parameter to the value of `nextPageToken` from the previous response.
+   * @opt_param string targetBucketWidth The desired width of each reported
+   * coverage bucket in base pairs. This will be rounded down to the nearest
+   * precomputed bucket width; the value of which is returned as `bucketWidth` in
+   * the response. Defaults to infinity (each bucket spans an entire reference
+   * sequence) or the length of the target range, if specified. The smallest
+   * precomputed `bucketWidth` is currently 2048 base pairs; this is subject to
+   * change.
+   * @opt_param string referenceName The name of the reference to query, within
+   * the reference set associated with this query. Optional.
+   * @return Google_Service_Genomics_ListCoverageBucketsResponse
+   */
+  public function listReadgroupsetsCoveragebuckets($readGroupSetId, $optParams = array())
+  {
+    $params = array('readGroupSetId' => $readGroupSetId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Genomics_ListCoverageBucketsResponse");
+  }
+}
+
+/**
+ * The "reads" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $genomicsService = new Google_Service_Genomics(...);
+ *   $reads = $genomicsService->reads;
+ *  </code>
+ */
+class Google_Service_Genomics_Reads_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets a list of reads for one or more read group sets. Reads search operates
+   * over a genomic coordinate space of reference sequence & position defined over
+   * the reference sequences to which the requested read group sets are aligned.
+   * If a target positional range is specified, search returns all reads whose
+   * alignment to the reference genome overlap the range. A query which specifies
+   * only read group set IDs yields all reads in those read group sets, including
+   * unmapped reads. All reads returned (including reads on subsequent pages) are
+   * ordered by genomic coordinate (reference sequence & position). Reads with
+   * equivalent genomic coordinates are returned in a deterministic order.
+   * Implements [GlobalAllianceApi.searchReads](https://github.com/ga4gh/schemas/b
+   * lob/v0.5.1/src/main/resources/avro/readmethods.avdl#L85). (reads.search)
+   *
+   * @param Google_SearchReadsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_SearchReadsResponse
+   */
+  public function search(Google_Service_Genomics_SearchReadsRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('search', array($params), "Google_Service_Genomics_SearchReadsResponse");
+  }
+}
+
+/**
+ * The "references" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $genomicsService = new Google_Service_Genomics(...);
+ *   $references = $genomicsService->references;
+ *  </code>
+ */
+class Google_Service_Genomics_References_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets a reference. Implements [GlobalAllianceApi.getReference](https://github.
+   * com/ga4gh/schemas/blob/v0.5.1/src/main/resources/avro/referencemethods.avdl#L
+   * 158). (references.get)
+   *
+   * @param string $referenceId The ID of the reference.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Reference
+   */
+  public function get($referenceId, $optParams = array())
+  {
+    $params = array('referenceId' => $referenceId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Genomics_Reference");
+  }
+
+  /**
+   * Searches for references which match the given criteria. Implements [GlobalAll
+   * ianceApi.searchReferences](https://github.com/ga4gh/schemas/blob/v0.5.1/src/m
+   * ain/resources/avro/referencemethods.avdl#L146). (references.search)
+   *
+   * @param Google_SearchReferencesRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_SearchReferencesResponse
+   */
+  public function search(Google_Service_Genomics_SearchReferencesRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('search', array($params), "Google_Service_Genomics_SearchReferencesResponse");
+  }
+}
+
+/**
+ * The "bases" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $genomicsService = new Google_Service_Genomics(...);
+ *   $bases = $genomicsService->bases;
+ *  </code>
+ */
+class Google_Service_Genomics_ReferencesBases_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Lists the bases in a reference, optionally restricted to a range. Implements
+   * [GlobalAllianceApi.getReferenceBases](https://github.com/ga4gh/schemas/blob/v
+   * 0.5.1/src/main/resources/avro/referencemethods.avdl#L221).
+   * (bases.listReferencesBases)
+   *
+   * @param string $referenceId The ID of the reference.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string start The start position (0-based) of this query. Defaults
+   * to 0.
+   * @opt_param string end The end position (0-based, exclusive) of this query.
+   * Defaults to the length of this reference.
+   * @opt_param int pageSize Specifies the maximum number of bases to return in a
+   * single page.
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large result sets. To get the next page of results, set this
+   * parameter to the value of `nextPageToken` from the previous response.
+   * @return Google_Service_Genomics_ListBasesResponse
+   */
+  public function listReferencesBases($referenceId, $optParams = array())
+  {
+    $params = array('referenceId' => $referenceId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Genomics_ListBasesResponse");
+  }
+}
+
+/**
+ * The "referencesets" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $genomicsService = new Google_Service_Genomics(...);
+ *   $referencesets = $genomicsService->referencesets;
+ *  </code>
+ */
+class Google_Service_Genomics_Referencesets_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets a reference set. Implements [GlobalAllianceApi.getReferenceSet](https://
+   * github.com/ga4gh/schemas/blob/v0.5.1/src/main/resources/avro/referencemethods
+   * .avdl#L83). (referencesets.get)
+   *
+   * @param string $referenceSetId The ID of the reference set.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_ReferenceSet
+   */
+  public function get($referenceSetId, $optParams = array())
+  {
+    $params = array('referenceSetId' => $referenceSetId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Genomics_ReferenceSet");
+  }
+
+  /**
+   * Searches for reference sets which match the given criteria. Implements [Globa
+   * lAllianceApi.searchReferenceSets](http://ga4gh.org/documentation/api/v0.5.1/g
+   * a4gh_api.html#/schema/org.ga4gh.searchReferenceSets). (referencesets.search)
+   *
+   * @param Google_SearchReferenceSetsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_SearchReferenceSetsResponse
+   */
+  public function search(Google_Service_Genomics_SearchReferenceSetsRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('search', array($params), "Google_Service_Genomics_SearchReferenceSetsResponse");
+  }
+}
+
+/**
+ * The "variants" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $genomicsService = new Google_Service_Genomics(...);
+ *   $variants = $genomicsService->variants;
+ *  </code>
+ */
+class Google_Service_Genomics_Variants_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a new variant. (variants.create)
+   *
+   * @param Google_Variant $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Variant
+   */
+  public function create(Google_Service_Genomics_Variant $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Genomics_Variant");
+  }
+
+  /**
+   * Deletes a variant. (variants.delete)
+   *
+   * @param string $variantId The ID of the variant to be deleted.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Empty
+   */
+  public function delete($variantId, $optParams = array())
+  {
+    $params = array('variantId' => $variantId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Genomics_Empty");
+  }
+
+  /**
+   * Gets a variant by ID. (variants.get)
+   *
+   * @param string $variantId The ID of the variant.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Variant
+   */
+  public function get($variantId, $optParams = array())
+  {
+    $params = array('variantId' => $variantId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Genomics_Variant");
+  }
+
+  /**
+   * Creates variant data by asynchronously importing the provided information.
+   * The variants for import will be merged with any existing variant that matches
+   * its reference sequence, start, end, reference bases, and alternative bases.
+   * If no such variant exists, a new one will be created. When variants are
+   * merged, the call information from the new variant is added to the existing
+   * variant, and other fields (such as key/value pairs) are discarded. In
+   * particular, this means for merged VCF variants that have conflicting INFO
+   * fields, some data will be arbitrarily discarded. As a special case, for
+   * single-sample VCF files, QUAL and FILTER fields will be moved to the call
+   * level; these are sometimes interpreted in a call-specific context. Imported
+   * VCF headers are appended to the metadata already in a variant set.
+   * (variants.import)
+   *
+   * @param Google_ImportVariantsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Operation
+   */
+  public function import(Google_Service_Genomics_ImportVariantsRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('import', array($params), "Google_Service_Genomics_Operation");
+  }
+
+  /**
+   * Updates a variant. This method supports patch semantics. Returns the modified
+   * variant without its calls. (variants.patch)
+   *
+   * @param string $variantId The ID of the variant to be updated.
+   * @param Google_Variant $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string updateMask An optional mask specifying which fields to
+   * update. At this time, mutable fields are names and info. Acceptable values
+   * are "names" and "info". If unspecified, all mutable fields will be updated.
+   * @return Google_Service_Genomics_Variant
+   */
+  public function patch($variantId, Google_Service_Genomics_Variant $postBody, $optParams = array())
+  {
+    $params = array('variantId' => $variantId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Genomics_Variant");
+  }
+
+  /**
+   * Gets a list of variants matching the criteria. Implements [GlobalAllianceApi.
+   * searchVariants](https://github.com/ga4gh/schemas/blob/v0.5.1/src/main/resourc
+   * es/avro/variantmethods.avdl#L126). (variants.search)
+   *
+   * @param Google_SearchVariantsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_SearchVariantsResponse
+   */
+  public function search(Google_Service_Genomics_SearchVariantsRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('search', array($params), "Google_Service_Genomics_SearchVariantsResponse");
+  }
+}
+
+/**
+ * The "variantsets" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $genomicsService = new Google_Service_Genomics(...);
+ *   $variantsets = $genomicsService->variantsets;
+ *  </code>
+ */
+class Google_Service_Genomics_Variantsets_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a new variant set. The provided variant set must have a valid
+   * `datasetId` set - all other fields are optional. Note that the `id` field
+   * will be ignored, as this is assigned by the server. (variantsets.create)
+   *
+   * @param Google_VariantSet $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_VariantSet
+   */
+  public function create(Google_Service_Genomics_VariantSet $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Genomics_VariantSet");
+  }
+
+  /**
+   * Deletes the contents of a variant set. The variant set object is not deleted.
+   * (variantsets.delete)
+   *
+   * @param string $variantSetId The ID of the variant set to be deleted.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Empty
+   */
+  public function delete($variantSetId, $optParams = array())
+  {
+    $params = array('variantSetId' => $variantSetId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Genomics_Empty");
+  }
+
+  /**
+   * Exports variant set data to an external destination. (variantsets.export)
+   *
+   * @param string $variantSetId Required. The ID of the variant set that contains
+   * variant data which should be exported. The caller must have READ access to
+   * this variant set.
+   * @param Google_ExportVariantSetRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_Operation
+   */
+  public function export($variantSetId, Google_Service_Genomics_ExportVariantSetRequest $postBody, $optParams = array())
+  {
+    $params = array('variantSetId' => $variantSetId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('export', array($params), "Google_Service_Genomics_Operation");
+  }
+
+  /**
+   * Gets a variant set by ID. (variantsets.get)
+   *
+   * @param string $variantSetId Required. The ID of the variant set.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_VariantSet
+   */
+  public function get($variantSetId, $optParams = array())
+  {
+    $params = array('variantSetId' => $variantSetId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Genomics_VariantSet");
+  }
+
+  /**
+   * Updates a variant set. This method supports patch semantics.
+   * (variantsets.patch)
+   *
+   * @param string $variantSetId The ID of the variant to be updated (must already
+   * exist).
+   * @param Google_VariantSet $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string updateMask An optional mask specifying which fields to
+   * update. At this time, the only mutable field is metadata. The only acceptable
+   * value is "metadata". If unspecified, all mutable fields will be updated.
+   * @return Google_Service_Genomics_VariantSet
+   */
+  public function patch($variantSetId, Google_Service_Genomics_VariantSet $postBody, $optParams = array())
+  {
+    $params = array('variantSetId' => $variantSetId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Genomics_VariantSet");
+  }
+
+  /**
+   * Returns a list of all variant sets matching search criteria. Implements [Glob
+   * alAllianceApi.searchVariantSets](https://github.com/ga4gh/schemas/blob/v0.5.1
+   * /src/main/resources/avro/variantmethods.avdl#L49). (variantsets.search)
+   *
+   * @param Google_SearchVariantSetsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Genomics_SearchVariantSetsResponse
+   */
+  public function search(Google_Service_Genomics_SearchVariantSetsRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('search', array($params), "Google_Service_Genomics_SearchVariantSetsResponse");
+  }
+}
+
+
+
+
+class Google_Service_Genomics_Binding extends Google_Collection
+{
+  protected $collection_key = 'members';
+  protected $internal_gapi_mappings = array(
+  );
+  public $members;
+  public $role;
+
+
+  public function setMembers($members)
+  {
+    $this->members = $members;
+  }
+  public function getMembers()
+  {
+    return $this->members;
+  }
+  public function setRole($role)
+  {
+    $this->role = $role;
+  }
+  public function getRole()
+  {
+    return $this->role;
+  }
+}
+
+class Google_Service_Genomics_CallSet extends Google_Collection
+{
+  protected $collection_key = 'variantSetIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $created;
+  public $id;
+  public $info;
+  public $name;
+  public $sampleId;
+  public $variantSetIds;
+
+
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInfo($info)
+  {
+    $this->info = $info;
+  }
+  public function getInfo()
+  {
+    return $this->info;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSampleId($sampleId)
+  {
+    $this->sampleId = $sampleId;
+  }
+  public function getSampleId()
+  {
+    return $this->sampleId;
+  }
+  public function setVariantSetIds($variantSetIds)
+  {
+    $this->variantSetIds = $variantSetIds;
+  }
+  public function getVariantSetIds()
+  {
+    return $this->variantSetIds;
+  }
+}
+
+class Google_Service_Genomics_CallSetInfo extends Google_Model
+{
+}
+
+class Google_Service_Genomics_CancelOperationRequest extends Google_Model
+{
+}
+
+class Google_Service_Genomics_CigarUnit extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $operation;
+  public $operationLength;
+  public $referenceSequence;
+
+
+  public function setOperation($operation)
+  {
+    $this->operation = $operation;
+  }
+  public function getOperation()
+  {
+    return $this->operation;
+  }
+  public function setOperationLength($operationLength)
+  {
+    $this->operationLength = $operationLength;
+  }
+  public function getOperationLength()
+  {
+    return $this->operationLength;
+  }
+  public function setReferenceSequence($referenceSequence)
+  {
+    $this->referenceSequence = $referenceSequence;
+  }
+  public function getReferenceSequence()
+  {
+    return $this->referenceSequence;
+  }
+}
+
+class Google_Service_Genomics_CoverageBucket extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $meanCoverage;
+  protected $rangeType = 'Google_Service_Genomics_Range';
+  protected $rangeDataType = '';
+
+
+  public function setMeanCoverage($meanCoverage)
+  {
+    $this->meanCoverage = $meanCoverage;
+  }
+  public function getMeanCoverage()
+  {
+    return $this->meanCoverage;
+  }
+  public function setRange(Google_Service_Genomics_Range $range)
+  {
+    $this->range = $range;
+  }
+  public function getRange()
+  {
+    return $this->range;
+  }
+}
+
+class Google_Service_Genomics_Dataset extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $createTime;
+  public $id;
+  public $name;
+  public $projectId;
+
+
+  public function setCreateTime($createTime)
+  {
+    $this->createTime = $createTime;
+  }
+  public function getCreateTime()
+  {
+    return $this->createTime;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+}
+
+class Google_Service_Genomics_Empty extends Google_Model
+{
+}
+
+class Google_Service_Genomics_Experiment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $instrumentModel;
+  public $libraryId;
+  public $platformUnit;
+  public $sequencingCenter;
+
+
+  public function setInstrumentModel($instrumentModel)
+  {
+    $this->instrumentModel = $instrumentModel;
+  }
+  public function getInstrumentModel()
+  {
+    return $this->instrumentModel;
+  }
+  public function setLibraryId($libraryId)
+  {
+    $this->libraryId = $libraryId;
+  }
+  public function getLibraryId()
+  {
+    return $this->libraryId;
+  }
+  public function setPlatformUnit($platformUnit)
+  {
+    $this->platformUnit = $platformUnit;
+  }
+  public function getPlatformUnit()
+  {
+    return $this->platformUnit;
+  }
+  public function setSequencingCenter($sequencingCenter)
+  {
+    $this->sequencingCenter = $sequencingCenter;
+  }
+  public function getSequencingCenter()
+  {
+    return $this->sequencingCenter;
+  }
+}
+
+class Google_Service_Genomics_ExportReadGroupSetRequest extends Google_Collection
+{
+  protected $collection_key = 'referenceNames';
+  protected $internal_gapi_mappings = array(
+  );
+  public $exportUri;
+  public $projectId;
+  public $referenceNames;
+
+
+  public function setExportUri($exportUri)
+  {
+    $this->exportUri = $exportUri;
+  }
+  public function getExportUri()
+  {
+    return $this->exportUri;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setReferenceNames($referenceNames)
+  {
+    $this->referenceNames = $referenceNames;
+  }
+  public function getReferenceNames()
+  {
+    return $this->referenceNames;
+  }
+}
+
+class Google_Service_Genomics_ExportVariantSetRequest extends Google_Collection
+{
+  protected $collection_key = 'callSetIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $bigqueryDataset;
+  public $bigqueryTable;
+  public $callSetIds;
+  public $format;
+  public $projectId;
+
+
+  public function setBigqueryDataset($bigqueryDataset)
+  {
+    $this->bigqueryDataset = $bigqueryDataset;
+  }
+  public function getBigqueryDataset()
+  {
+    return $this->bigqueryDataset;
+  }
+  public function setBigqueryTable($bigqueryTable)
+  {
+    $this->bigqueryTable = $bigqueryTable;
+  }
+  public function getBigqueryTable()
+  {
+    return $this->bigqueryTable;
+  }
+  public function setCallSetIds($callSetIds)
+  {
+    $this->callSetIds = $callSetIds;
+  }
+  public function getCallSetIds()
+  {
+    return $this->callSetIds;
+  }
+  public function setFormat($format)
+  {
+    $this->format = $format;
+  }
+  public function getFormat()
+  {
+    return $this->format;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+}
+
+class Google_Service_Genomics_GetIamPolicyRequest extends Google_Model
+{
+}
+
+class Google_Service_Genomics_ImportReadGroupSetsRequest extends Google_Collection
+{
+  protected $collection_key = 'sourceUris';
+  protected $internal_gapi_mappings = array(
+  );
+  public $datasetId;
+  public $partitionStrategy;
+  public $referenceSetId;
+  public $sourceUris;
+
+
+  public function setDatasetId($datasetId)
+  {
+    $this->datasetId = $datasetId;
+  }
+  public function getDatasetId()
+  {
+    return $this->datasetId;
+  }
+  public function setPartitionStrategy($partitionStrategy)
+  {
+    $this->partitionStrategy = $partitionStrategy;
+  }
+  public function getPartitionStrategy()
+  {
+    return $this->partitionStrategy;
+  }
+  public function setReferenceSetId($referenceSetId)
+  {
+    $this->referenceSetId = $referenceSetId;
+  }
+  public function getReferenceSetId()
+  {
+    return $this->referenceSetId;
+  }
+  public function setSourceUris($sourceUris)
+  {
+    $this->sourceUris = $sourceUris;
+  }
+  public function getSourceUris()
+  {
+    return $this->sourceUris;
+  }
+}
+
+class Google_Service_Genomics_ImportReadGroupSetsResponse extends Google_Collection
+{
+  protected $collection_key = 'readGroupSetIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $readGroupSetIds;
+
+
+  public function setReadGroupSetIds($readGroupSetIds)
+  {
+    $this->readGroupSetIds = $readGroupSetIds;
+  }
+  public function getReadGroupSetIds()
+  {
+    return $this->readGroupSetIds;
+  }
+}
+
+class Google_Service_Genomics_ImportVariantsRequest extends Google_Collection
+{
+  protected $collection_key = 'sourceUris';
+  protected $internal_gapi_mappings = array(
+  );
+  public $format;
+  public $normalizeReferenceNames;
+  public $sourceUris;
+  public $variantSetId;
+
+
+  public function setFormat($format)
+  {
+    $this->format = $format;
+  }
+  public function getFormat()
+  {
+    return $this->format;
+  }
+  public function setNormalizeReferenceNames($normalizeReferenceNames)
+  {
+    $this->normalizeReferenceNames = $normalizeReferenceNames;
+  }
+  public function getNormalizeReferenceNames()
+  {
+    return $this->normalizeReferenceNames;
+  }
+  public function setSourceUris($sourceUris)
+  {
+    $this->sourceUris = $sourceUris;
+  }
+  public function getSourceUris()
+  {
+    return $this->sourceUris;
+  }
+  public function setVariantSetId($variantSetId)
+  {
+    $this->variantSetId = $variantSetId;
+  }
+  public function getVariantSetId()
+  {
+    return $this->variantSetId;
+  }
+}
+
+class Google_Service_Genomics_ImportVariantsResponse extends Google_Collection
+{
+  protected $collection_key = 'callSetIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $callSetIds;
+
+
+  public function setCallSetIds($callSetIds)
+  {
+    $this->callSetIds = $callSetIds;
+  }
+  public function getCallSetIds()
+  {
+    return $this->callSetIds;
+  }
+}
+
+class Google_Service_Genomics_LinearAlignment extends Google_Collection
+{
+  protected $collection_key = 'cigar';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $cigarType = 'Google_Service_Genomics_CigarUnit';
+  protected $cigarDataType = 'array';
+  public $mappingQuality;
+  protected $positionType = 'Google_Service_Genomics_Position';
+  protected $positionDataType = '';
+
+
+  public function setCigar($cigar)
+  {
+    $this->cigar = $cigar;
+  }
+  public function getCigar()
+  {
+    return $this->cigar;
+  }
+  public function setMappingQuality($mappingQuality)
+  {
+    $this->mappingQuality = $mappingQuality;
+  }
+  public function getMappingQuality()
+  {
+    return $this->mappingQuality;
+  }
+  public function setPosition(Google_Service_Genomics_Position $position)
+  {
+    $this->position = $position;
+  }
+  public function getPosition()
+  {
+    return $this->position;
+  }
+}
+
+class Google_Service_Genomics_ListBasesResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  public $offset;
+  public $sequence;
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setOffset($offset)
+  {
+    $this->offset = $offset;
+  }
+  public function getOffset()
+  {
+    return $this->offset;
+  }
+  public function setSequence($sequence)
+  {
+    $this->sequence = $sequence;
+  }
+  public function getSequence()
+  {
+    return $this->sequence;
+  }
+}
+
+class Google_Service_Genomics_ListCoverageBucketsResponse extends Google_Collection
+{
+  protected $collection_key = 'coverageBuckets';
+  protected $internal_gapi_mappings = array(
+  );
+  public $bucketWidth;
+  protected $coverageBucketsType = 'Google_Service_Genomics_CoverageBucket';
+  protected $coverageBucketsDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setBucketWidth($bucketWidth)
+  {
+    $this->bucketWidth = $bucketWidth;
+  }
+  public function getBucketWidth()
+  {
+    return $this->bucketWidth;
+  }
+  public function setCoverageBuckets($coverageBuckets)
+  {
+    $this->coverageBuckets = $coverageBuckets;
+  }
+  public function getCoverageBuckets()
+  {
+    return $this->coverageBuckets;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Genomics_ListDatasetsResponse extends Google_Collection
+{
+  protected $collection_key = 'datasets';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $datasetsType = 'Google_Service_Genomics_Dataset';
+  protected $datasetsDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setDatasets($datasets)
+  {
+    $this->datasets = $datasets;
+  }
+  public function getDatasets()
+  {
+    return $this->datasets;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Genomics_ListOperationsResponse extends Google_Collection
+{
+  protected $collection_key = 'operations';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $operationsType = 'Google_Service_Genomics_Operation';
+  protected $operationsDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setOperations($operations)
+  {
+    $this->operations = $operations;
+  }
+  public function getOperations()
+  {
+    return $this->operations;
+  }
+}
+
+class Google_Service_Genomics_Operation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $done;
+  protected $errorType = 'Google_Service_Genomics_Status';
+  protected $errorDataType = '';
+  public $metadata;
+  public $name;
+  public $response;
+
+
+  public function setDone($done)
+  {
+    $this->done = $done;
+  }
+  public function getDone()
+  {
+    return $this->done;
+  }
+  public function setError(Google_Service_Genomics_Status $error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setMetadata($metadata)
+  {
+    $this->metadata = $metadata;
+  }
+  public function getMetadata()
+  {
+    return $this->metadata;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setResponse($response)
+  {
+    $this->response = $response;
+  }
+  public function getResponse()
+  {
+    return $this->response;
+  }
+}
+
+class Google_Service_Genomics_OperationEvent extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+}
+
+class Google_Service_Genomics_OperationMetadata extends Google_Collection
+{
+  protected $collection_key = 'events';
+  protected $internal_gapi_mappings = array(
+  );
+  public $createTime;
+  protected $eventsType = 'Google_Service_Genomics_OperationEvent';
+  protected $eventsDataType = 'array';
+  public $projectId;
+  public $request;
+
+
+  public function setCreateTime($createTime)
+  {
+    $this->createTime = $createTime;
+  }
+  public function getCreateTime()
+  {
+    return $this->createTime;
+  }
+  public function setEvents($events)
+  {
+    $this->events = $events;
+  }
+  public function getEvents()
+  {
+    return $this->events;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setRequest($request)
+  {
+    $this->request = $request;
+  }
+  public function getRequest()
+  {
+    return $this->request;
+  }
+}
+
+class Google_Service_Genomics_OperationMetadataRequest extends Google_Model
+{
+}
+
+class Google_Service_Genomics_OperationResponse extends Google_Model
+{
+}
+
+class Google_Service_Genomics_Policy extends Google_Collection
+{
+  protected $collection_key = 'bindings';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $bindingsType = 'Google_Service_Genomics_Binding';
+  protected $bindingsDataType = 'array';
+  public $etag;
+  public $version;
+
+
+  public function setBindings($bindings)
+  {
+    $this->bindings = $bindings;
+  }
+  public function getBindings()
+  {
+    return $this->bindings;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Genomics_Position extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $position;
+  public $referenceName;
+  public $reverseStrand;
+
+
+  public function setPosition($position)
+  {
+    $this->position = $position;
+  }
+  public function getPosition()
+  {
+    return $this->position;
+  }
+  public function setReferenceName($referenceName)
+  {
+    $this->referenceName = $referenceName;
+  }
+  public function getReferenceName()
+  {
+    return $this->referenceName;
+  }
+  public function setReverseStrand($reverseStrand)
+  {
+    $this->reverseStrand = $reverseStrand;
+  }
+  public function getReverseStrand()
+  {
+    return $this->reverseStrand;
+  }
+}
+
+class Google_Service_Genomics_Program extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $commandLine;
+  public $id;
+  public $name;
+  public $prevProgramId;
+  public $version;
+
+
+  public function setCommandLine($commandLine)
+  {
+    $this->commandLine = $commandLine;
+  }
+  public function getCommandLine()
+  {
+    return $this->commandLine;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPrevProgramId($prevProgramId)
+  {
+    $this->prevProgramId = $prevProgramId;
+  }
+  public function getPrevProgramId()
+  {
+    return $this->prevProgramId;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Genomics_Range extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $end;
+  public $referenceName;
+  public $start;
+
+
+  public function setEnd($end)
+  {
+    $this->end = $end;
+  }
+  public function getEnd()
+  {
+    return $this->end;
+  }
+  public function setReferenceName($referenceName)
+  {
+    $this->referenceName = $referenceName;
+  }
+  public function getReferenceName()
+  {
+    return $this->referenceName;
+  }
+  public function setStart($start)
+  {
+    $this->start = $start;
+  }
+  public function getStart()
+  {
+    return $this->start;
+  }
+}
+
+class Google_Service_Genomics_Read extends Google_Collection
+{
+  protected $collection_key = 'alignedQuality';
+  protected $internal_gapi_mappings = array(
+  );
+  public $alignedQuality;
+  public $alignedSequence;
+  protected $alignmentType = 'Google_Service_Genomics_LinearAlignment';
+  protected $alignmentDataType = '';
+  public $duplicateFragment;
+  public $failedVendorQualityChecks;
+  public $fragmentLength;
+  public $fragmentName;
+  public $id;
+  public $info;
+  protected $nextMatePositionType = 'Google_Service_Genomics_Position';
+  protected $nextMatePositionDataType = '';
+  public $numberReads;
+  public $properPlacement;
+  public $readGroupId;
+  public $readGroupSetId;
+  public $readNumber;
+  public $secondaryAlignment;
+  public $supplementaryAlignment;
+
+
+  public function setAlignedQuality($alignedQuality)
+  {
+    $this->alignedQuality = $alignedQuality;
+  }
+  public function getAlignedQuality()
+  {
+    return $this->alignedQuality;
+  }
+  public function setAlignedSequence($alignedSequence)
+  {
+    $this->alignedSequence = $alignedSequence;
+  }
+  public function getAlignedSequence()
+  {
+    return $this->alignedSequence;
+  }
+  public function setAlignment(Google_Service_Genomics_LinearAlignment $alignment)
+  {
+    $this->alignment = $alignment;
+  }
+  public function getAlignment()
+  {
+    return $this->alignment;
+  }
+  public function setDuplicateFragment($duplicateFragment)
+  {
+    $this->duplicateFragment = $duplicateFragment;
+  }
+  public function getDuplicateFragment()
+  {
+    return $this->duplicateFragment;
+  }
+  public function setFailedVendorQualityChecks($failedVendorQualityChecks)
+  {
+    $this->failedVendorQualityChecks = $failedVendorQualityChecks;
+  }
+  public function getFailedVendorQualityChecks()
+  {
+    return $this->failedVendorQualityChecks;
+  }
+  public function setFragmentLength($fragmentLength)
+  {
+    $this->fragmentLength = $fragmentLength;
+  }
+  public function getFragmentLength()
+  {
+    return $this->fragmentLength;
+  }
+  public function setFragmentName($fragmentName)
+  {
+    $this->fragmentName = $fragmentName;
+  }
+  public function getFragmentName()
+  {
+    return $this->fragmentName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInfo($info)
+  {
+    $this->info = $info;
+  }
+  public function getInfo()
+  {
+    return $this->info;
+  }
+  public function setNextMatePosition(Google_Service_Genomics_Position $nextMatePosition)
+  {
+    $this->nextMatePosition = $nextMatePosition;
+  }
+  public function getNextMatePosition()
+  {
+    return $this->nextMatePosition;
+  }
+  public function setNumberReads($numberReads)
+  {
+    $this->numberReads = $numberReads;
+  }
+  public function getNumberReads()
+  {
+    return $this->numberReads;
+  }
+  public function setProperPlacement($properPlacement)
+  {
+    $this->properPlacement = $properPlacement;
+  }
+  public function getProperPlacement()
+  {
+    return $this->properPlacement;
+  }
+  public function setReadGroupId($readGroupId)
+  {
+    $this->readGroupId = $readGroupId;
+  }
+  public function getReadGroupId()
+  {
+    return $this->readGroupId;
+  }
+  public function setReadGroupSetId($readGroupSetId)
+  {
+    $this->readGroupSetId = $readGroupSetId;
+  }
+  public function getReadGroupSetId()
+  {
+    return $this->readGroupSetId;
+  }
+  public function setReadNumber($readNumber)
+  {
+    $this->readNumber = $readNumber;
+  }
+  public function getReadNumber()
+  {
+    return $this->readNumber;
+  }
+  public function setSecondaryAlignment($secondaryAlignment)
+  {
+    $this->secondaryAlignment = $secondaryAlignment;
+  }
+  public function getSecondaryAlignment()
+  {
+    return $this->secondaryAlignment;
+  }
+  public function setSupplementaryAlignment($supplementaryAlignment)
+  {
+    $this->supplementaryAlignment = $supplementaryAlignment;
+  }
+  public function getSupplementaryAlignment()
+  {
+    return $this->supplementaryAlignment;
+  }
+}
+
+class Google_Service_Genomics_ReadGroup extends Google_Collection
+{
+  protected $collection_key = 'programs';
+  protected $internal_gapi_mappings = array(
+  );
+  public $datasetId;
+  public $description;
+  protected $experimentType = 'Google_Service_Genomics_Experiment';
+  protected $experimentDataType = '';
+  public $id;
+  public $info;
+  public $name;
+  public $predictedInsertSize;
+  protected $programsType = 'Google_Service_Genomics_Program';
+  protected $programsDataType = 'array';
+  public $referenceSetId;
+  public $sampleId;
+
+
+  public function setDatasetId($datasetId)
+  {
+    $this->datasetId = $datasetId;
+  }
+  public function getDatasetId()
+  {
+    return $this->datasetId;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setExperiment(Google_Service_Genomics_Experiment $experiment)
+  {
+    $this->experiment = $experiment;
+  }
+  public function getExperiment()
+  {
+    return $this->experiment;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInfo($info)
+  {
+    $this->info = $info;
+  }
+  public function getInfo()
+  {
+    return $this->info;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPredictedInsertSize($predictedInsertSize)
+  {
+    $this->predictedInsertSize = $predictedInsertSize;
+  }
+  public function getPredictedInsertSize()
+  {
+    return $this->predictedInsertSize;
+  }
+  public function setPrograms($programs)
+  {
+    $this->programs = $programs;
+  }
+  public function getPrograms()
+  {
+    return $this->programs;
+  }
+  public function setReferenceSetId($referenceSetId)
+  {
+    $this->referenceSetId = $referenceSetId;
+  }
+  public function getReferenceSetId()
+  {
+    return $this->referenceSetId;
+  }
+  public function setSampleId($sampleId)
+  {
+    $this->sampleId = $sampleId;
+  }
+  public function getSampleId()
+  {
+    return $this->sampleId;
+  }
+}
+
+class Google_Service_Genomics_ReadGroupInfo extends Google_Model
+{
+}
+
+class Google_Service_Genomics_ReadGroupSet extends Google_Collection
+{
+  protected $collection_key = 'readGroups';
+  protected $internal_gapi_mappings = array(
+  );
+  public $datasetId;
+  public $filename;
+  public $id;
+  public $info;
+  public $name;
+  protected $readGroupsType = 'Google_Service_Genomics_ReadGroup';
+  protected $readGroupsDataType = 'array';
+  public $referenceSetId;
+
+
+  public function setDatasetId($datasetId)
+  {
+    $this->datasetId = $datasetId;
+  }
+  public function getDatasetId()
+  {
+    return $this->datasetId;
+  }
+  public function setFilename($filename)
+  {
+    $this->filename = $filename;
+  }
+  public function getFilename()
+  {
+    return $this->filename;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInfo($info)
+  {
+    $this->info = $info;
+  }
+  public function getInfo()
+  {
+    return $this->info;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setReadGroups($readGroups)
+  {
+    $this->readGroups = $readGroups;
+  }
+  public function getReadGroups()
+  {
+    return $this->readGroups;
+  }
+  public function setReferenceSetId($referenceSetId)
+  {
+    $this->referenceSetId = $referenceSetId;
+  }
+  public function getReferenceSetId()
+  {
+    return $this->referenceSetId;
+  }
+}
+
+class Google_Service_Genomics_ReadGroupSetInfo extends Google_Model
+{
+}
+
+class Google_Service_Genomics_ReadInfo extends Google_Model
+{
+}
+
+class Google_Service_Genomics_Reference extends Google_Collection
+{
+  protected $collection_key = 'sourceAccessions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $length;
+  public $md5checksum;
+  public $name;
+  public $ncbiTaxonId;
+  public $sourceAccessions;
+  public $sourceUri;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLength($length)
+  {
+    $this->length = $length;
+  }
+  public function getLength()
+  {
+    return $this->length;
+  }
+  public function setMd5checksum($md5checksum)
+  {
+    $this->md5checksum = $md5checksum;
+  }
+  public function getMd5checksum()
+  {
+    return $this->md5checksum;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNcbiTaxonId($ncbiTaxonId)
+  {
+    $this->ncbiTaxonId = $ncbiTaxonId;
+  }
+  public function getNcbiTaxonId()
+  {
+    return $this->ncbiTaxonId;
+  }
+  public function setSourceAccessions($sourceAccessions)
+  {
+    $this->sourceAccessions = $sourceAccessions;
+  }
+  public function getSourceAccessions()
+  {
+    return $this->sourceAccessions;
+  }
+  public function setSourceUri($sourceUri)
+  {
+    $this->sourceUri = $sourceUri;
+  }
+  public function getSourceUri()
+  {
+    return $this->sourceUri;
+  }
+}
+
+class Google_Service_Genomics_ReferenceBound extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $referenceName;
+  public $upperBound;
+
+
+  public function setReferenceName($referenceName)
+  {
+    $this->referenceName = $referenceName;
+  }
+  public function getReferenceName()
+  {
+    return $this->referenceName;
+  }
+  public function setUpperBound($upperBound)
+  {
+    $this->upperBound = $upperBound;
+  }
+  public function getUpperBound()
+  {
+    return $this->upperBound;
+  }
+}
+
+class Google_Service_Genomics_ReferenceSet extends Google_Collection
+{
+  protected $collection_key = 'sourceAccessions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $assemblyId;
+  public $description;
+  public $id;
+  public $md5checksum;
+  public $ncbiTaxonId;
+  public $referenceIds;
+  public $sourceAccessions;
+  public $sourceUri;
+
+
+  public function setAssemblyId($assemblyId)
+  {
+    $this->assemblyId = $assemblyId;
+  }
+  public function getAssemblyId()
+  {
+    return $this->assemblyId;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setMd5checksum($md5checksum)
+  {
+    $this->md5checksum = $md5checksum;
+  }
+  public function getMd5checksum()
+  {
+    return $this->md5checksum;
+  }
+  public function setNcbiTaxonId($ncbiTaxonId)
+  {
+    $this->ncbiTaxonId = $ncbiTaxonId;
+  }
+  public function getNcbiTaxonId()
+  {
+    return $this->ncbiTaxonId;
+  }
+  public function setReferenceIds($referenceIds)
+  {
+    $this->referenceIds = $referenceIds;
+  }
+  public function getReferenceIds()
+  {
+    return $this->referenceIds;
+  }
+  public function setSourceAccessions($sourceAccessions)
+  {
+    $this->sourceAccessions = $sourceAccessions;
+  }
+  public function getSourceAccessions()
+  {
+    return $this->sourceAccessions;
+  }
+  public function setSourceUri($sourceUri)
+  {
+    $this->sourceUri = $sourceUri;
+  }
+  public function getSourceUri()
+  {
+    return $this->sourceUri;
+  }
+}
+
+class Google_Service_Genomics_SearchCallSetsRequest extends Google_Collection
+{
+  protected $collection_key = 'variantSetIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $pageSize;
+  public $pageToken;
+  public $variantSetIds;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPageSize($pageSize)
+  {
+    $this->pageSize = $pageSize;
+  }
+  public function getPageSize()
+  {
+    return $this->pageSize;
+  }
+  public function setPageToken($pageToken)
+  {
+    $this->pageToken = $pageToken;
+  }
+  public function getPageToken()
+  {
+    return $this->pageToken;
+  }
+  public function setVariantSetIds($variantSetIds)
+  {
+    $this->variantSetIds = $variantSetIds;
+  }
+  public function getVariantSetIds()
+  {
+    return $this->variantSetIds;
+  }
+}
+
+class Google_Service_Genomics_SearchCallSetsResponse extends Google_Collection
+{
+  protected $collection_key = 'callSets';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $callSetsType = 'Google_Service_Genomics_CallSet';
+  protected $callSetsDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setCallSets($callSets)
+  {
+    $this->callSets = $callSets;
+  }
+  public function getCallSets()
+  {
+    return $this->callSets;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Genomics_SearchReadGroupSetsRequest extends Google_Collection
+{
+  protected $collection_key = 'datasetIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $datasetIds;
+  public $name;
+  public $pageSize;
+  public $pageToken;
+
+
+  public function setDatasetIds($datasetIds)
+  {
+    $this->datasetIds = $datasetIds;
+  }
+  public function getDatasetIds()
+  {
+    return $this->datasetIds;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPageSize($pageSize)
+  {
+    $this->pageSize = $pageSize;
+  }
+  public function getPageSize()
+  {
+    return $this->pageSize;
+  }
+  public function setPageToken($pageToken)
+  {
+    $this->pageToken = $pageToken;
+  }
+  public function getPageToken()
+  {
+    return $this->pageToken;
+  }
+}
+
+class Google_Service_Genomics_SearchReadGroupSetsResponse extends Google_Collection
+{
+  protected $collection_key = 'readGroupSets';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $readGroupSetsType = 'Google_Service_Genomics_ReadGroupSet';
+  protected $readGroupSetsDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setReadGroupSets($readGroupSets)
+  {
+    $this->readGroupSets = $readGroupSets;
+  }
+  public function getReadGroupSets()
+  {
+    return $this->readGroupSets;
+  }
+}
+
+class Google_Service_Genomics_SearchReadsRequest extends Google_Collection
+{
+  protected $collection_key = 'readGroupSetIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $end;
+  public $pageSize;
+  public $pageToken;
+  public $readGroupIds;
+  public $readGroupSetIds;
+  public $referenceName;
+  public $start;
+
+
+  public function setEnd($end)
+  {
+    $this->end = $end;
+  }
+  public function getEnd()
+  {
+    return $this->end;
+  }
+  public function setPageSize($pageSize)
+  {
+    $this->pageSize = $pageSize;
+  }
+  public function getPageSize()
+  {
+    return $this->pageSize;
+  }
+  public function setPageToken($pageToken)
+  {
+    $this->pageToken = $pageToken;
+  }
+  public function getPageToken()
+  {
+    return $this->pageToken;
+  }
+  public function setReadGroupIds($readGroupIds)
+  {
+    $this->readGroupIds = $readGroupIds;
+  }
+  public function getReadGroupIds()
+  {
+    return $this->readGroupIds;
+  }
+  public function setReadGroupSetIds($readGroupSetIds)
+  {
+    $this->readGroupSetIds = $readGroupSetIds;
+  }
+  public function getReadGroupSetIds()
+  {
+    return $this->readGroupSetIds;
+  }
+  public function setReferenceName($referenceName)
+  {
+    $this->referenceName = $referenceName;
+  }
+  public function getReferenceName()
+  {
+    return $this->referenceName;
+  }
+  public function setStart($start)
+  {
+    $this->start = $start;
+  }
+  public function getStart()
+  {
+    return $this->start;
+  }
+}
+
+class Google_Service_Genomics_SearchReadsResponse extends Google_Collection
+{
+  protected $collection_key = 'alignments';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $alignmentsType = 'Google_Service_Genomics_Read';
+  protected $alignmentsDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setAlignments($alignments)
+  {
+    $this->alignments = $alignments;
+  }
+  public function getAlignments()
+  {
+    return $this->alignments;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Genomics_SearchReferenceSetsRequest extends Google_Collection
+{
+  protected $collection_key = 'md5checksums';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accessions;
+  public $assemblyId;
+  public $md5checksums;
+  public $pageSize;
+  public $pageToken;
+
+
+  public function setAccessions($accessions)
+  {
+    $this->accessions = $accessions;
+  }
+  public function getAccessions()
+  {
+    return $this->accessions;
+  }
+  public function setAssemblyId($assemblyId)
+  {
+    $this->assemblyId = $assemblyId;
+  }
+  public function getAssemblyId()
+  {
+    return $this->assemblyId;
+  }
+  public function setMd5checksums($md5checksums)
+  {
+    $this->md5checksums = $md5checksums;
+  }
+  public function getMd5checksums()
+  {
+    return $this->md5checksums;
+  }
+  public function setPageSize($pageSize)
+  {
+    $this->pageSize = $pageSize;
+  }
+  public function getPageSize()
+  {
+    return $this->pageSize;
+  }
+  public function setPageToken($pageToken)
+  {
+    $this->pageToken = $pageToken;
+  }
+  public function getPageToken()
+  {
+    return $this->pageToken;
+  }
+}
+
+class Google_Service_Genomics_SearchReferenceSetsResponse extends Google_Collection
+{
+  protected $collection_key = 'referenceSets';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $referenceSetsType = 'Google_Service_Genomics_ReferenceSet';
+  protected $referenceSetsDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setReferenceSets($referenceSets)
+  {
+    $this->referenceSets = $referenceSets;
+  }
+  public function getReferenceSets()
+  {
+    return $this->referenceSets;
+  }
+}
+
+class Google_Service_Genomics_SearchReferencesRequest extends Google_Collection
+{
+  protected $collection_key = 'md5checksums';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accessions;
+  public $md5checksums;
+  public $pageSize;
+  public $pageToken;
+  public $referenceSetId;
+
+
+  public function setAccessions($accessions)
+  {
+    $this->accessions = $accessions;
+  }
+  public function getAccessions()
+  {
+    return $this->accessions;
+  }
+  public function setMd5checksums($md5checksums)
+  {
+    $this->md5checksums = $md5checksums;
+  }
+  public function getMd5checksums()
+  {
+    return $this->md5checksums;
+  }
+  public function setPageSize($pageSize)
+  {
+    $this->pageSize = $pageSize;
+  }
+  public function getPageSize()
+  {
+    return $this->pageSize;
+  }
+  public function setPageToken($pageToken)
+  {
+    $this->pageToken = $pageToken;
+  }
+  public function getPageToken()
+  {
+    return $this->pageToken;
+  }
+  public function setReferenceSetId($referenceSetId)
+  {
+    $this->referenceSetId = $referenceSetId;
+  }
+  public function getReferenceSetId()
+  {
+    return $this->referenceSetId;
+  }
+}
+
+class Google_Service_Genomics_SearchReferencesResponse extends Google_Collection
+{
+  protected $collection_key = 'references';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $referencesType = 'Google_Service_Genomics_Reference';
+  protected $referencesDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setReferences($references)
+  {
+    $this->references = $references;
+  }
+  public function getReferences()
+  {
+    return $this->references;
+  }
+}
+
+class Google_Service_Genomics_SearchVariantSetsRequest extends Google_Collection
+{
+  protected $collection_key = 'datasetIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $datasetIds;
+  public $pageSize;
+  public $pageToken;
+
+
+  public function setDatasetIds($datasetIds)
+  {
+    $this->datasetIds = $datasetIds;
+  }
+  public function getDatasetIds()
+  {
+    return $this->datasetIds;
+  }
+  public function setPageSize($pageSize)
+  {
+    $this->pageSize = $pageSize;
+  }
+  public function getPageSize()
+  {
+    return $this->pageSize;
+  }
+  public function setPageToken($pageToken)
+  {
+    $this->pageToken = $pageToken;
+  }
+  public function getPageToken()
+  {
+    return $this->pageToken;
+  }
+}
+
+class Google_Service_Genomics_SearchVariantSetsResponse extends Google_Collection
+{
+  protected $collection_key = 'variantSets';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $variantSetsType = 'Google_Service_Genomics_VariantSet';
+  protected $variantSetsDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setVariantSets($variantSets)
+  {
+    $this->variantSets = $variantSets;
+  }
+  public function getVariantSets()
+  {
+    return $this->variantSets;
+  }
+}
+
+class Google_Service_Genomics_SearchVariantsRequest extends Google_Collection
+{
+  protected $collection_key = 'variantSetIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $callSetIds;
+  public $end;
+  public $maxCalls;
+  public $pageSize;
+  public $pageToken;
+  public $referenceName;
+  public $start;
+  public $variantName;
+  public $variantSetIds;
+
+
+  public function setCallSetIds($callSetIds)
+  {
+    $this->callSetIds = $callSetIds;
+  }
+  public function getCallSetIds()
+  {
+    return $this->callSetIds;
+  }
+  public function setEnd($end)
+  {
+    $this->end = $end;
+  }
+  public function getEnd()
+  {
+    return $this->end;
+  }
+  public function setMaxCalls($maxCalls)
+  {
+    $this->maxCalls = $maxCalls;
+  }
+  public function getMaxCalls()
+  {
+    return $this->maxCalls;
+  }
+  public function setPageSize($pageSize)
+  {
+    $this->pageSize = $pageSize;
+  }
+  public function getPageSize()
+  {
+    return $this->pageSize;
+  }
+  public function setPageToken($pageToken)
+  {
+    $this->pageToken = $pageToken;
+  }
+  public function getPageToken()
+  {
+    return $this->pageToken;
+  }
+  public function setReferenceName($referenceName)
+  {
+    $this->referenceName = $referenceName;
+  }
+  public function getReferenceName()
+  {
+    return $this->referenceName;
+  }
+  public function setStart($start)
+  {
+    $this->start = $start;
+  }
+  public function getStart()
+  {
+    return $this->start;
+  }
+  public function setVariantName($variantName)
+  {
+    $this->variantName = $variantName;
+  }
+  public function getVariantName()
+  {
+    return $this->variantName;
+  }
+  public function setVariantSetIds($variantSetIds)
+  {
+    $this->variantSetIds = $variantSetIds;
+  }
+  public function getVariantSetIds()
+  {
+    return $this->variantSetIds;
+  }
+}
+
+class Google_Service_Genomics_SearchVariantsResponse extends Google_Collection
+{
+  protected $collection_key = 'variants';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $variantsType = 'Google_Service_Genomics_Variant';
+  protected $variantsDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setVariants($variants)
+  {
+    $this->variants = $variants;
+  }
+  public function getVariants()
+  {
+    return $this->variants;
+  }
+}
+
+class Google_Service_Genomics_SetIamPolicyRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $policyType = 'Google_Service_Genomics_Policy';
+  protected $policyDataType = '';
+
+
+  public function setPolicy(Google_Service_Genomics_Policy $policy)
+  {
+    $this->policy = $policy;
+  }
+  public function getPolicy()
+  {
+    return $this->policy;
+  }
+}
+
+class Google_Service_Genomics_Status extends Google_Collection
+{
+  protected $collection_key = 'details';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $details;
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setDetails($details)
+  {
+    $this->details = $details;
+  }
+  public function getDetails()
+  {
+    return $this->details;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Genomics_StatusDetails extends Google_Model
+{
+}
+
+class Google_Service_Genomics_TestIamPermissionsRequest extends Google_Collection
+{
+  protected $collection_key = 'permissions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $permissions;
+
+
+  public function setPermissions($permissions)
+  {
+    $this->permissions = $permissions;
+  }
+  public function getPermissions()
+  {
+    return $this->permissions;
+  }
+}
+
+class Google_Service_Genomics_TestIamPermissionsResponse extends Google_Collection
+{
+  protected $collection_key = 'permissions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $permissions;
+
+
+  public function setPermissions($permissions)
+  {
+    $this->permissions = $permissions;
+  }
+  public function getPermissions()
+  {
+    return $this->permissions;
+  }
+}
+
+class Google_Service_Genomics_UndeleteDatasetRequest extends Google_Model
+{
+}
+
+class Google_Service_Genomics_Variant extends Google_Collection
+{
+  protected $collection_key = 'names';
+  protected $internal_gapi_mappings = array(
+  );
+  public $alternateBases;
+  protected $callsType = 'Google_Service_Genomics_VariantCall';
+  protected $callsDataType = 'array';
+  public $created;
+  public $end;
+  public $filter;
+  public $id;
+  public $info;
+  public $names;
+  public $quality;
+  public $referenceBases;
+  public $referenceName;
+  public $start;
+  public $variantSetId;
+
+
+  public function setAlternateBases($alternateBases)
+  {
+    $this->alternateBases = $alternateBases;
+  }
+  public function getAlternateBases()
+  {
+    return $this->alternateBases;
+  }
+  public function setCalls($calls)
+  {
+    $this->calls = $calls;
+  }
+  public function getCalls()
+  {
+    return $this->calls;
+  }
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setEnd($end)
+  {
+    $this->end = $end;
+  }
+  public function getEnd()
+  {
+    return $this->end;
+  }
+  public function setFilter($filter)
+  {
+    $this->filter = $filter;
+  }
+  public function getFilter()
+  {
+    return $this->filter;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInfo($info)
+  {
+    $this->info = $info;
+  }
+  public function getInfo()
+  {
+    return $this->info;
+  }
+  public function setNames($names)
+  {
+    $this->names = $names;
+  }
+  public function getNames()
+  {
+    return $this->names;
+  }
+  public function setQuality($quality)
+  {
+    $this->quality = $quality;
+  }
+  public function getQuality()
+  {
+    return $this->quality;
+  }
+  public function setReferenceBases($referenceBases)
+  {
+    $this->referenceBases = $referenceBases;
+  }
+  public function getReferenceBases()
+  {
+    return $this->referenceBases;
+  }
+  public function setReferenceName($referenceName)
+  {
+    $this->referenceName = $referenceName;
+  }
+  public function getReferenceName()
+  {
+    return $this->referenceName;
+  }
+  public function setStart($start)
+  {
+    $this->start = $start;
+  }
+  public function getStart()
+  {
+    return $this->start;
+  }
+  public function setVariantSetId($variantSetId)
+  {
+    $this->variantSetId = $variantSetId;
+  }
+  public function getVariantSetId()
+  {
+    return $this->variantSetId;
+  }
+}
+
+class Google_Service_Genomics_VariantCall extends Google_Collection
+{
+  protected $collection_key = 'genotypeLikelihood';
+  protected $internal_gapi_mappings = array(
+  );
+  public $callSetId;
+  public $callSetName;
+  public $genotype;
+  public $genotypeLikelihood;
+  public $info;
+  public $phaseset;
+
+
+  public function setCallSetId($callSetId)
+  {
+    $this->callSetId = $callSetId;
+  }
+  public function getCallSetId()
+  {
+    return $this->callSetId;
+  }
+  public function setCallSetName($callSetName)
+  {
+    $this->callSetName = $callSetName;
+  }
+  public function getCallSetName()
+  {
+    return $this->callSetName;
+  }
+  public function setGenotype($genotype)
+  {
+    $this->genotype = $genotype;
+  }
+  public function getGenotype()
+  {
+    return $this->genotype;
+  }
+  public function setGenotypeLikelihood($genotypeLikelihood)
+  {
+    $this->genotypeLikelihood = $genotypeLikelihood;
+  }
+  public function getGenotypeLikelihood()
+  {
+    return $this->genotypeLikelihood;
+  }
+  public function setInfo($info)
+  {
+    $this->info = $info;
+  }
+  public function getInfo()
+  {
+    return $this->info;
+  }
+  public function setPhaseset($phaseset)
+  {
+    $this->phaseset = $phaseset;
+  }
+  public function getPhaseset()
+  {
+    return $this->phaseset;
+  }
+}
+
+class Google_Service_Genomics_VariantCallInfo extends Google_Model
+{
+}
+
+class Google_Service_Genomics_VariantInfo extends Google_Model
+{
+}
+
+class Google_Service_Genomics_VariantSet extends Google_Collection
+{
+  protected $collection_key = 'referenceBounds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $datasetId;
+  public $id;
+  protected $metadataType = 'Google_Service_Genomics_VariantSetMetadata';
+  protected $metadataDataType = 'array';
+  protected $referenceBoundsType = 'Google_Service_Genomics_ReferenceBound';
+  protected $referenceBoundsDataType = 'array';
+
+
+  public function setDatasetId($datasetId)
+  {
+    $this->datasetId = $datasetId;
+  }
+  public function getDatasetId()
+  {
+    return $this->datasetId;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setMetadata($metadata)
+  {
+    $this->metadata = $metadata;
+  }
+  public function getMetadata()
+  {
+    return $this->metadata;
+  }
+  public function setReferenceBounds($referenceBounds)
+  {
+    $this->referenceBounds = $referenceBounds;
+  }
+  public function getReferenceBounds()
+  {
+    return $this->referenceBounds;
+  }
+}
+
+class Google_Service_Genomics_VariantSetMetadata extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $id;
+  public $info;
+  public $key;
+  public $number;
+  public $type;
+  public $value;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInfo($info)
+  {
+    $this->info = $info;
+  }
+  public function getInfo()
+  {
+    return $this->info;
+  }
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setNumber($number)
+  {
+    $this->number = $number;
+  }
+  public function getNumber()
+  {
+    return $this->number;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Genomics_VariantSetMetadataInfo extends Google_Model
+{
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Gmail.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Gmail.php
@@ -1,0 +1,2215 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Gmail (v1).
+ *
+ * <p>
+ * The Gmail REST API.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/gmail/api/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Gmail extends Google_Service
+{
+  /** View and manage your mail. */
+  const MAIL_GOOGLE_COM =
+      "https://mail.google.com/";
+  /** Manage drafts and send emails. */
+  const GMAIL_COMPOSE =
+      "https://www.googleapis.com/auth/gmail.compose";
+  /** Insert mail into your mailbox. */
+  const GMAIL_INSERT =
+      "https://www.googleapis.com/auth/gmail.insert";
+  /** Manage mailbox labels. */
+  const GMAIL_LABELS =
+      "https://www.googleapis.com/auth/gmail.labels";
+  /** View and modify but not delete your email. */
+  const GMAIL_MODIFY =
+      "https://www.googleapis.com/auth/gmail.modify";
+  /** View your emails messages and settings. */
+  const GMAIL_READONLY =
+      "https://www.googleapis.com/auth/gmail.readonly";
+  /** Send email on your behalf. */
+  const GMAIL_SEND =
+      "https://www.googleapis.com/auth/gmail.send";
+
+  public $users;
+  public $users_drafts;
+  public $users_history;
+  public $users_labels;
+  public $users_messages;
+  public $users_messages_attachments;
+  public $users_threads;
+  
+
+  /**
+   * Constructs the internal representation of the Gmail service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'gmail/v1/users/';
+    $this->version = 'v1';
+    $this->serviceName = 'gmail';
+
+    $this->users = new Google_Service_Gmail_Users_Resource(
+        $this,
+        $this->serviceName,
+        'users',
+        array(
+          'methods' => array(
+            'getProfile' => array(
+              'path' => '{userId}/profile',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'stop' => array(
+              'path' => '{userId}/stop',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'watch' => array(
+              'path' => '{userId}/watch',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->users_drafts = new Google_Service_Gmail_UsersDrafts_Resource(
+        $this,
+        $this->serviceName,
+        'drafts',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => '{userId}/drafts',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{userId}/drafts/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{userId}/drafts/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'format' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{userId}/drafts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'send' => array(
+              'path' => '{userId}/drafts/send',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{userId}/drafts/{id}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->users_history = new Google_Service_Gmail_UsersHistory_Resource(
+        $this,
+        $this->serviceName,
+        'history',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => '{userId}/history',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'labelId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'startHistoryId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->users_labels = new Google_Service_Gmail_UsersLabels_Resource(
+        $this,
+        $this->serviceName,
+        'labels',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => '{userId}/labels',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{userId}/labels/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{userId}/labels/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{userId}/labels',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{userId}/labels/{id}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{userId}/labels/{id}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->users_messages = new Google_Service_Gmail_UsersMessages_Resource(
+        $this,
+        $this->serviceName,
+        'messages',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{userId}/messages/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{userId}/messages/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'metadataHeaders' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'format' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'import' => array(
+              'path' => '{userId}/messages/import',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deleted' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'processForCalendar' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'internalDateSource' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'neverMarkSpam' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{userId}/messages',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deleted' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'internalDateSource' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{userId}/messages',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'q' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'includeSpamTrash' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'labelIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),'modify' => array(
+              'path' => '{userId}/messages/{id}/modify',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'send' => array(
+              'path' => '{userId}/messages/send',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'trash' => array(
+              'path' => '{userId}/messages/{id}/trash',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'untrash' => array(
+              'path' => '{userId}/messages/{id}/untrash',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->users_messages_attachments = new Google_Service_Gmail_UsersMessagesAttachments_Resource(
+        $this,
+        $this->serviceName,
+        'attachments',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{userId}/messages/{messageId}/attachments/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'messageId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->users_threads = new Google_Service_Gmail_UsersThreads_Resource(
+        $this,
+        $this->serviceName,
+        'threads',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{userId}/threads/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{userId}/threads/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'metadataHeaders' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'format' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{userId}/threads',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'q' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'includeSpamTrash' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'labelIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),'modify' => array(
+              'path' => '{userId}/threads/{id}/modify',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'trash' => array(
+              'path' => '{userId}/threads/{id}/trash',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'untrash' => array(
+              'path' => '{userId}/threads/{id}/untrash',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "users" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gmailService = new Google_Service_Gmail(...);
+ *   $users = $gmailService->users;
+ *  </code>
+ */
+class Google_Service_Gmail_Users_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the current user's Gmail profile. (users.getProfile)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Gmail_Profile
+   */
+  public function getProfile($userId, $optParams = array())
+  {
+    $params = array('userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('getProfile', array($params), "Google_Service_Gmail_Profile");
+  }
+
+  /**
+   * Stop receiving push notifications for the given user mailbox. (users.stop)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param array $optParams Optional parameters.
+   */
+  public function stop($userId, $optParams = array())
+  {
+    $params = array('userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('stop', array($params));
+  }
+
+  /**
+   * Set up or update a push notification watch on the given user mailbox.
+   * (users.watch)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param Google_WatchRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Gmail_WatchResponse
+   */
+  public function watch($userId, Google_Service_Gmail_WatchRequest $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('watch', array($params), "Google_Service_Gmail_WatchResponse");
+  }
+}
+
+/**
+ * The "drafts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gmailService = new Google_Service_Gmail(...);
+ *   $drafts = $gmailService->drafts;
+ *  </code>
+ */
+class Google_Service_Gmail_UsersDrafts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a new draft with the DRAFT label. (drafts.create)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param Google_Draft $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Gmail_Draft
+   */
+  public function create($userId, Google_Service_Gmail_Draft $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Gmail_Draft");
+  }
+
+  /**
+   * Immediately and permanently deletes the specified draft. Does not simply
+   * trash it. (drafts.delete)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param string $id The ID of the draft to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($userId, $id, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets the specified draft. (drafts.get)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param string $id The ID of the draft to retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string format The format to return the draft in.
+   * @return Google_Service_Gmail_Draft
+   */
+  public function get($userId, $id, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Gmail_Draft");
+  }
+
+  /**
+   * Lists the drafts in the user's mailbox. (drafts.listUsersDrafts)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Page token to retrieve a specific page of results
+   * in the list.
+   * @opt_param string maxResults Maximum number of drafts to return.
+   * @return Google_Service_Gmail_ListDraftsResponse
+   */
+  public function listUsersDrafts($userId, $optParams = array())
+  {
+    $params = array('userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Gmail_ListDraftsResponse");
+  }
+
+  /**
+   * Sends the specified, existing draft to the recipients in the To, Cc, and Bcc
+   * headers. (drafts.send)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param Google_Draft $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Gmail_Message
+   */
+  public function send($userId, Google_Service_Gmail_Draft $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('send', array($params), "Google_Service_Gmail_Message");
+  }
+
+  /**
+   * Replaces a draft's content. (drafts.update)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param string $id The ID of the draft to update.
+   * @param Google_Draft $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Gmail_Draft
+   */
+  public function update($userId, $id, Google_Service_Gmail_Draft $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Gmail_Draft");
+  }
+}
+/**
+ * The "history" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gmailService = new Google_Service_Gmail(...);
+ *   $history = $gmailService->history;
+ *  </code>
+ */
+class Google_Service_Gmail_UsersHistory_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Lists the history of all changes to the given mailbox. History results are
+   * returned in chronological order (increasing historyId).
+   * (history.listUsersHistory)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Page token to retrieve a specific page of results
+   * in the list.
+   * @opt_param string maxResults The maximum number of history records to return.
+   * @opt_param string labelId Only return messages with a label matching the ID.
+   * @opt_param string startHistoryId Required. Returns history records after the
+   * specified startHistoryId. The supplied startHistoryId should be obtained from
+   * the historyId of a message, thread, or previous list response. History IDs
+   * increase chronologically but are not contiguous with random gaps in between
+   * valid IDs. Supplying an invalid or out of date startHistoryId typically
+   * returns an HTTP 404 error code. A historyId is typically valid for at least a
+   * week, but in some rare circumstances may be valid for only a few hours. If
+   * you receive an HTTP 404 error response, your application should perform a
+   * full sync. If you receive no nextPageToken in the response, there are no
+   * updates to retrieve and you can store the returned historyId for a future
+   * request.
+   * @return Google_Service_Gmail_ListHistoryResponse
+   */
+  public function listUsersHistory($userId, $optParams = array())
+  {
+    $params = array('userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Gmail_ListHistoryResponse");
+  }
+}
+/**
+ * The "labels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gmailService = new Google_Service_Gmail(...);
+ *   $labels = $gmailService->labels;
+ *  </code>
+ */
+class Google_Service_Gmail_UsersLabels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a new label. (labels.create)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param Google_Label $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Gmail_Label
+   */
+  public function create($userId, Google_Service_Gmail_Label $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Gmail_Label");
+  }
+
+  /**
+   * Immediately and permanently deletes the specified label and removes it from
+   * any messages and threads that it is applied to. (labels.delete)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param string $id The ID of the label to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($userId, $id, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets the specified label. (labels.get)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param string $id The ID of the label to retrieve.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Gmail_Label
+   */
+  public function get($userId, $id, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Gmail_Label");
+  }
+
+  /**
+   * Lists all labels in the user's mailbox. (labels.listUsersLabels)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Gmail_ListLabelsResponse
+   */
+  public function listUsersLabels($userId, $optParams = array())
+  {
+    $params = array('userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Gmail_ListLabelsResponse");
+  }
+
+  /**
+   * Updates the specified label. This method supports patch semantics.
+   * (labels.patch)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param string $id The ID of the label to update.
+   * @param Google_Label $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Gmail_Label
+   */
+  public function patch($userId, $id, Google_Service_Gmail_Label $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Gmail_Label");
+  }
+
+  /**
+   * Updates the specified label. (labels.update)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param string $id The ID of the label to update.
+   * @param Google_Label $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Gmail_Label
+   */
+  public function update($userId, $id, Google_Service_Gmail_Label $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Gmail_Label");
+  }
+}
+/**
+ * The "messages" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gmailService = new Google_Service_Gmail(...);
+ *   $messages = $gmailService->messages;
+ *  </code>
+ */
+class Google_Service_Gmail_UsersMessages_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Immediately and permanently deletes the specified message. This operation
+   * cannot be undone. Prefer messages.trash instead. (messages.delete)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param string $id The ID of the message to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($userId, $id, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets the specified message. (messages.get)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param string $id The ID of the message to retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string metadataHeaders When given and format is METADATA, only
+   * include headers specified.
+   * @opt_param string format The format to return the message in.
+   * @return Google_Service_Gmail_Message
+   */
+  public function get($userId, $id, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Gmail_Message");
+  }
+
+  /**
+   * Imports a message into only this user's mailbox, with standard email delivery
+   * scanning and classification similar to receiving via SMTP. Does not send a
+   * message. (messages.import)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param Google_Message $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool deleted Mark the email as permanently deleted (not TRASH) and
+   * only visible in Google Apps Vault to a Vault administrator. Only used for
+   * Google Apps for Work accounts.
+   * @opt_param bool processForCalendar Process calendar invites in the email and
+   * add any extracted meetings to the Google Calendar for this user.
+   * @opt_param string internalDateSource Source for Gmail's internal date of the
+   * message.
+   * @opt_param bool neverMarkSpam Ignore the Gmail spam classifier decision and
+   * never mark this email as SPAM in the mailbox.
+   * @return Google_Service_Gmail_Message
+   */
+  public function import($userId, Google_Service_Gmail_Message $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('import', array($params), "Google_Service_Gmail_Message");
+  }
+
+  /**
+   * Directly inserts a message into only this user's mailbox similar to IMAP
+   * APPEND, bypassing most scanning and classification. Does not send a message.
+   * (messages.insert)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param Google_Message $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool deleted Mark the email as permanently deleted (not TRASH) and
+   * only visible in Google Apps Vault to a Vault administrator. Only used for
+   * Google Apps for Work accounts.
+   * @opt_param string internalDateSource Source for Gmail's internal date of the
+   * message.
+   * @return Google_Service_Gmail_Message
+   */
+  public function insert($userId, Google_Service_Gmail_Message $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Gmail_Message");
+  }
+
+  /**
+   * Lists the messages in the user's mailbox. (messages.listUsersMessages)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string maxResults Maximum number of messages to return.
+   * @opt_param string q Only return messages matching the specified query.
+   * Supports the same query format as the Gmail search box. For example,
+   * "from:someuser@example.com rfc822msgid: is:unread".
+   * @opt_param string pageToken Page token to retrieve a specific page of results
+   * in the list.
+   * @opt_param bool includeSpamTrash Include messages from SPAM and TRASH in the
+   * results.
+   * @opt_param string labelIds Only return messages with labels that match all of
+   * the specified label IDs.
+   * @return Google_Service_Gmail_ListMessagesResponse
+   */
+  public function listUsersMessages($userId, $optParams = array())
+  {
+    $params = array('userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Gmail_ListMessagesResponse");
+  }
+
+  /**
+   * Modifies the labels on the specified message. (messages.modify)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param string $id The ID of the message to modify.
+   * @param Google_ModifyMessageRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Gmail_Message
+   */
+  public function modify($userId, $id, Google_Service_Gmail_ModifyMessageRequest $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('modify', array($params), "Google_Service_Gmail_Message");
+  }
+
+  /**
+   * Sends the specified message to the recipients in the To, Cc, and Bcc headers.
+   * (messages.send)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param Google_Message $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Gmail_Message
+   */
+  public function send($userId, Google_Service_Gmail_Message $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('send', array($params), "Google_Service_Gmail_Message");
+  }
+
+  /**
+   * Moves the specified message to the trash. (messages.trash)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param string $id The ID of the message to Trash.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Gmail_Message
+   */
+  public function trash($userId, $id, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('trash', array($params), "Google_Service_Gmail_Message");
+  }
+
+  /**
+   * Removes the specified message from the trash. (messages.untrash)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param string $id The ID of the message to remove from Trash.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Gmail_Message
+   */
+  public function untrash($userId, $id, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('untrash', array($params), "Google_Service_Gmail_Message");
+  }
+}
+
+/**
+ * The "attachments" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gmailService = new Google_Service_Gmail(...);
+ *   $attachments = $gmailService->attachments;
+ *  </code>
+ */
+class Google_Service_Gmail_UsersMessagesAttachments_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the specified message attachment. (attachments.get)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param string $messageId The ID of the message containing the attachment.
+   * @param string $id The ID of the attachment.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Gmail_MessagePartBody
+   */
+  public function get($userId, $messageId, $id, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'messageId' => $messageId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Gmail_MessagePartBody");
+  }
+}
+/**
+ * The "threads" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $gmailService = new Google_Service_Gmail(...);
+ *   $threads = $gmailService->threads;
+ *  </code>
+ */
+class Google_Service_Gmail_UsersThreads_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Immediately and permanently deletes the specified thread. This operation
+   * cannot be undone. Prefer threads.trash instead. (threads.delete)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param string $id ID of the Thread to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($userId, $id, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets the specified thread. (threads.get)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param string $id The ID of the thread to retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string metadataHeaders When given and format is METADATA, only
+   * include headers specified.
+   * @opt_param string format The format to return the messages in.
+   * @return Google_Service_Gmail_Thread
+   */
+  public function get($userId, $id, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Gmail_Thread");
+  }
+
+  /**
+   * Lists the threads in the user's mailbox. (threads.listUsersThreads)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string maxResults Maximum number of threads to return.
+   * @opt_param string q Only return threads matching the specified query.
+   * Supports the same query format as the Gmail search box. For example,
+   * "from:someuser@example.com rfc822msgid: is:unread".
+   * @opt_param string pageToken Page token to retrieve a specific page of results
+   * in the list.
+   * @opt_param bool includeSpamTrash Include threads from SPAM and TRASH in the
+   * results.
+   * @opt_param string labelIds Only return threads with labels that match all of
+   * the specified label IDs.
+   * @return Google_Service_Gmail_ListThreadsResponse
+   */
+  public function listUsersThreads($userId, $optParams = array())
+  {
+    $params = array('userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Gmail_ListThreadsResponse");
+  }
+
+  /**
+   * Modifies the labels applied to the thread. This applies to all messages in
+   * the thread. (threads.modify)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param string $id The ID of the thread to modify.
+   * @param Google_ModifyThreadRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Gmail_Thread
+   */
+  public function modify($userId, $id, Google_Service_Gmail_ModifyThreadRequest $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('modify', array($params), "Google_Service_Gmail_Thread");
+  }
+
+  /**
+   * Moves the specified thread to the trash. (threads.trash)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param string $id The ID of the thread to Trash.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Gmail_Thread
+   */
+  public function trash($userId, $id, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('trash', array($params), "Google_Service_Gmail_Thread");
+  }
+
+  /**
+   * Removes the specified thread from the trash. (threads.untrash)
+   *
+   * @param string $userId The user's email address. The special value me can be
+   * used to indicate the authenticated user.
+   * @param string $id The ID of the thread to remove from Trash.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Gmail_Thread
+   */
+  public function untrash($userId, $id, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('untrash', array($params), "Google_Service_Gmail_Thread");
+  }
+}
+
+
+
+
+class Google_Service_Gmail_Draft extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $messageType = 'Google_Service_Gmail_Message';
+  protected $messageDataType = '';
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setMessage(Google_Service_Gmail_Message $message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Gmail_History extends Google_Collection
+{
+  protected $collection_key = 'messagesDeleted';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $labelsAddedType = 'Google_Service_Gmail_HistoryLabelAdded';
+  protected $labelsAddedDataType = 'array';
+  protected $labelsRemovedType = 'Google_Service_Gmail_HistoryLabelRemoved';
+  protected $labelsRemovedDataType = 'array';
+  protected $messagesType = 'Google_Service_Gmail_Message';
+  protected $messagesDataType = 'array';
+  protected $messagesAddedType = 'Google_Service_Gmail_HistoryMessageAdded';
+  protected $messagesAddedDataType = 'array';
+  protected $messagesDeletedType = 'Google_Service_Gmail_HistoryMessageDeleted';
+  protected $messagesDeletedDataType = 'array';
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLabelsAdded($labelsAdded)
+  {
+    $this->labelsAdded = $labelsAdded;
+  }
+  public function getLabelsAdded()
+  {
+    return $this->labelsAdded;
+  }
+  public function setLabelsRemoved($labelsRemoved)
+  {
+    $this->labelsRemoved = $labelsRemoved;
+  }
+  public function getLabelsRemoved()
+  {
+    return $this->labelsRemoved;
+  }
+  public function setMessages($messages)
+  {
+    $this->messages = $messages;
+  }
+  public function getMessages()
+  {
+    return $this->messages;
+  }
+  public function setMessagesAdded($messagesAdded)
+  {
+    $this->messagesAdded = $messagesAdded;
+  }
+  public function getMessagesAdded()
+  {
+    return $this->messagesAdded;
+  }
+  public function setMessagesDeleted($messagesDeleted)
+  {
+    $this->messagesDeleted = $messagesDeleted;
+  }
+  public function getMessagesDeleted()
+  {
+    return $this->messagesDeleted;
+  }
+}
+
+class Google_Service_Gmail_HistoryLabelAdded extends Google_Collection
+{
+  protected $collection_key = 'labelIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $labelIds;
+  protected $messageType = 'Google_Service_Gmail_Message';
+  protected $messageDataType = '';
+
+
+  public function setLabelIds($labelIds)
+  {
+    $this->labelIds = $labelIds;
+  }
+  public function getLabelIds()
+  {
+    return $this->labelIds;
+  }
+  public function setMessage(Google_Service_Gmail_Message $message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Gmail_HistoryLabelRemoved extends Google_Collection
+{
+  protected $collection_key = 'labelIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $labelIds;
+  protected $messageType = 'Google_Service_Gmail_Message';
+  protected $messageDataType = '';
+
+
+  public function setLabelIds($labelIds)
+  {
+    $this->labelIds = $labelIds;
+  }
+  public function getLabelIds()
+  {
+    return $this->labelIds;
+  }
+  public function setMessage(Google_Service_Gmail_Message $message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Gmail_HistoryMessageAdded extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $messageType = 'Google_Service_Gmail_Message';
+  protected $messageDataType = '';
+
+
+  public function setMessage(Google_Service_Gmail_Message $message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Gmail_HistoryMessageDeleted extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $messageType = 'Google_Service_Gmail_Message';
+  protected $messageDataType = '';
+
+
+  public function setMessage(Google_Service_Gmail_Message $message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Gmail_Label extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $labelListVisibility;
+  public $messageListVisibility;
+  public $messagesTotal;
+  public $messagesUnread;
+  public $name;
+  public $threadsTotal;
+  public $threadsUnread;
+  public $type;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLabelListVisibility($labelListVisibility)
+  {
+    $this->labelListVisibility = $labelListVisibility;
+  }
+  public function getLabelListVisibility()
+  {
+    return $this->labelListVisibility;
+  }
+  public function setMessageListVisibility($messageListVisibility)
+  {
+    $this->messageListVisibility = $messageListVisibility;
+  }
+  public function getMessageListVisibility()
+  {
+    return $this->messageListVisibility;
+  }
+  public function setMessagesTotal($messagesTotal)
+  {
+    $this->messagesTotal = $messagesTotal;
+  }
+  public function getMessagesTotal()
+  {
+    return $this->messagesTotal;
+  }
+  public function setMessagesUnread($messagesUnread)
+  {
+    $this->messagesUnread = $messagesUnread;
+  }
+  public function getMessagesUnread()
+  {
+    return $this->messagesUnread;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setThreadsTotal($threadsTotal)
+  {
+    $this->threadsTotal = $threadsTotal;
+  }
+  public function getThreadsTotal()
+  {
+    return $this->threadsTotal;
+  }
+  public function setThreadsUnread($threadsUnread)
+  {
+    $this->threadsUnread = $threadsUnread;
+  }
+  public function getThreadsUnread()
+  {
+    return $this->threadsUnread;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Gmail_ListDraftsResponse extends Google_Collection
+{
+  protected $collection_key = 'drafts';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $draftsType = 'Google_Service_Gmail_Draft';
+  protected $draftsDataType = 'array';
+  public $nextPageToken;
+  public $resultSizeEstimate;
+
+
+  public function setDrafts($drafts)
+  {
+    $this->drafts = $drafts;
+  }
+  public function getDrafts()
+  {
+    return $this->drafts;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setResultSizeEstimate($resultSizeEstimate)
+  {
+    $this->resultSizeEstimate = $resultSizeEstimate;
+  }
+  public function getResultSizeEstimate()
+  {
+    return $this->resultSizeEstimate;
+  }
+}
+
+class Google_Service_Gmail_ListHistoryResponse extends Google_Collection
+{
+  protected $collection_key = 'history';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $historyType = 'Google_Service_Gmail_History';
+  protected $historyDataType = 'array';
+  public $historyId;
+  public $nextPageToken;
+
+
+  public function setHistory($history)
+  {
+    $this->history = $history;
+  }
+  public function getHistory()
+  {
+    return $this->history;
+  }
+  public function setHistoryId($historyId)
+  {
+    $this->historyId = $historyId;
+  }
+  public function getHistoryId()
+  {
+    return $this->historyId;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Gmail_ListLabelsResponse extends Google_Collection
+{
+  protected $collection_key = 'labels';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $labelsType = 'Google_Service_Gmail_Label';
+  protected $labelsDataType = 'array';
+
+
+  public function setLabels($labels)
+  {
+    $this->labels = $labels;
+  }
+  public function getLabels()
+  {
+    return $this->labels;
+  }
+}
+
+class Google_Service_Gmail_ListMessagesResponse extends Google_Collection
+{
+  protected $collection_key = 'messages';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $messagesType = 'Google_Service_Gmail_Message';
+  protected $messagesDataType = 'array';
+  public $nextPageToken;
+  public $resultSizeEstimate;
+
+
+  public function setMessages($messages)
+  {
+    $this->messages = $messages;
+  }
+  public function getMessages()
+  {
+    return $this->messages;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setResultSizeEstimate($resultSizeEstimate)
+  {
+    $this->resultSizeEstimate = $resultSizeEstimate;
+  }
+  public function getResultSizeEstimate()
+  {
+    return $this->resultSizeEstimate;
+  }
+}
+
+class Google_Service_Gmail_ListThreadsResponse extends Google_Collection
+{
+  protected $collection_key = 'threads';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  public $resultSizeEstimate;
+  protected $threadsType = 'Google_Service_Gmail_Thread';
+  protected $threadsDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setResultSizeEstimate($resultSizeEstimate)
+  {
+    $this->resultSizeEstimate = $resultSizeEstimate;
+  }
+  public function getResultSizeEstimate()
+  {
+    return $this->resultSizeEstimate;
+  }
+  public function setThreads($threads)
+  {
+    $this->threads = $threads;
+  }
+  public function getThreads()
+  {
+    return $this->threads;
+  }
+}
+
+class Google_Service_Gmail_Message extends Google_Collection
+{
+  protected $collection_key = 'labelIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $historyId;
+  public $id;
+  public $internalDate;
+  public $labelIds;
+  protected $payloadType = 'Google_Service_Gmail_MessagePart';
+  protected $payloadDataType = '';
+  public $raw;
+  public $sizeEstimate;
+  public $snippet;
+  public $threadId;
+
+
+  public function setHistoryId($historyId)
+  {
+    $this->historyId = $historyId;
+  }
+  public function getHistoryId()
+  {
+    return $this->historyId;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInternalDate($internalDate)
+  {
+    $this->internalDate = $internalDate;
+  }
+  public function getInternalDate()
+  {
+    return $this->internalDate;
+  }
+  public function setLabelIds($labelIds)
+  {
+    $this->labelIds = $labelIds;
+  }
+  public function getLabelIds()
+  {
+    return $this->labelIds;
+  }
+  public function setPayload(Google_Service_Gmail_MessagePart $payload)
+  {
+    $this->payload = $payload;
+  }
+  public function getPayload()
+  {
+    return $this->payload;
+  }
+  public function setRaw($raw)
+  {
+    $this->raw = $raw;
+  }
+  public function getRaw()
+  {
+    return $this->raw;
+  }
+  public function setSizeEstimate($sizeEstimate)
+  {
+    $this->sizeEstimate = $sizeEstimate;
+  }
+  public function getSizeEstimate()
+  {
+    return $this->sizeEstimate;
+  }
+  public function setSnippet($snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+  public function setThreadId($threadId)
+  {
+    $this->threadId = $threadId;
+  }
+  public function getThreadId()
+  {
+    return $this->threadId;
+  }
+}
+
+class Google_Service_Gmail_MessagePart extends Google_Collection
+{
+  protected $collection_key = 'parts';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $bodyType = 'Google_Service_Gmail_MessagePartBody';
+  protected $bodyDataType = '';
+  public $filename;
+  protected $headersType = 'Google_Service_Gmail_MessagePartHeader';
+  protected $headersDataType = 'array';
+  public $mimeType;
+  public $partId;
+  protected $partsType = 'Google_Service_Gmail_MessagePart';
+  protected $partsDataType = 'array';
+
+
+  public function setBody(Google_Service_Gmail_MessagePartBody $body)
+  {
+    $this->body = $body;
+  }
+  public function getBody()
+  {
+    return $this->body;
+  }
+  public function setFilename($filename)
+  {
+    $this->filename = $filename;
+  }
+  public function getFilename()
+  {
+    return $this->filename;
+  }
+  public function setHeaders($headers)
+  {
+    $this->headers = $headers;
+  }
+  public function getHeaders()
+  {
+    return $this->headers;
+  }
+  public function setMimeType($mimeType)
+  {
+    $this->mimeType = $mimeType;
+  }
+  public function getMimeType()
+  {
+    return $this->mimeType;
+  }
+  public function setPartId($partId)
+  {
+    $this->partId = $partId;
+  }
+  public function getPartId()
+  {
+    return $this->partId;
+  }
+  public function setParts($parts)
+  {
+    $this->parts = $parts;
+  }
+  public function getParts()
+  {
+    return $this->parts;
+  }
+}
+
+class Google_Service_Gmail_MessagePartBody extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $attachmentId;
+  public $data;
+  public $size;
+
+
+  public function setAttachmentId($attachmentId)
+  {
+    $this->attachmentId = $attachmentId;
+  }
+  public function getAttachmentId()
+  {
+    return $this->attachmentId;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setSize($size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+}
+
+class Google_Service_Gmail_MessagePartHeader extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $value;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Gmail_ModifyMessageRequest extends Google_Collection
+{
+  protected $collection_key = 'removeLabelIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $addLabelIds;
+  public $removeLabelIds;
+
+
+  public function setAddLabelIds($addLabelIds)
+  {
+    $this->addLabelIds = $addLabelIds;
+  }
+  public function getAddLabelIds()
+  {
+    return $this->addLabelIds;
+  }
+  public function setRemoveLabelIds($removeLabelIds)
+  {
+    $this->removeLabelIds = $removeLabelIds;
+  }
+  public function getRemoveLabelIds()
+  {
+    return $this->removeLabelIds;
+  }
+}
+
+class Google_Service_Gmail_ModifyThreadRequest extends Google_Collection
+{
+  protected $collection_key = 'removeLabelIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $addLabelIds;
+  public $removeLabelIds;
+
+
+  public function setAddLabelIds($addLabelIds)
+  {
+    $this->addLabelIds = $addLabelIds;
+  }
+  public function getAddLabelIds()
+  {
+    return $this->addLabelIds;
+  }
+  public function setRemoveLabelIds($removeLabelIds)
+  {
+    $this->removeLabelIds = $removeLabelIds;
+  }
+  public function getRemoveLabelIds()
+  {
+    return $this->removeLabelIds;
+  }
+}
+
+class Google_Service_Gmail_Profile extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $emailAddress;
+  public $historyId;
+  public $messagesTotal;
+  public $threadsTotal;
+
+
+  public function setEmailAddress($emailAddress)
+  {
+    $this->emailAddress = $emailAddress;
+  }
+  public function getEmailAddress()
+  {
+    return $this->emailAddress;
+  }
+  public function setHistoryId($historyId)
+  {
+    $this->historyId = $historyId;
+  }
+  public function getHistoryId()
+  {
+    return $this->historyId;
+  }
+  public function setMessagesTotal($messagesTotal)
+  {
+    $this->messagesTotal = $messagesTotal;
+  }
+  public function getMessagesTotal()
+  {
+    return $this->messagesTotal;
+  }
+  public function setThreadsTotal($threadsTotal)
+  {
+    $this->threadsTotal = $threadsTotal;
+  }
+  public function getThreadsTotal()
+  {
+    return $this->threadsTotal;
+  }
+}
+
+class Google_Service_Gmail_Thread extends Google_Collection
+{
+  protected $collection_key = 'messages';
+  protected $internal_gapi_mappings = array(
+  );
+  public $historyId;
+  public $id;
+  protected $messagesType = 'Google_Service_Gmail_Message';
+  protected $messagesDataType = 'array';
+  public $snippet;
+
+
+  public function setHistoryId($historyId)
+  {
+    $this->historyId = $historyId;
+  }
+  public function getHistoryId()
+  {
+    return $this->historyId;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setMessages($messages)
+  {
+    $this->messages = $messages;
+  }
+  public function getMessages()
+  {
+    return $this->messages;
+  }
+  public function setSnippet($snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+}
+
+class Google_Service_Gmail_WatchRequest extends Google_Collection
+{
+  protected $collection_key = 'labelIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $labelFilterAction;
+  public $labelIds;
+  public $topicName;
+
+
+  public function setLabelFilterAction($labelFilterAction)
+  {
+    $this->labelFilterAction = $labelFilterAction;
+  }
+  public function getLabelFilterAction()
+  {
+    return $this->labelFilterAction;
+  }
+  public function setLabelIds($labelIds)
+  {
+    $this->labelIds = $labelIds;
+  }
+  public function getLabelIds()
+  {
+    return $this->labelIds;
+  }
+  public function setTopicName($topicName)
+  {
+    $this->topicName = $topicName;
+  }
+  public function getTopicName()
+  {
+    return $this->topicName;
+  }
+}
+
+class Google_Service_Gmail_WatchResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $expiration;
+  public $historyId;
+
+
+  public function setExpiration($expiration)
+  {
+    $this->expiration = $expiration;
+  }
+  public function getExpiration()
+  {
+    return $this->expiration;
+  }
+  public function setHistoryId($historyId)
+  {
+    $this->historyId = $historyId;
+  }
+  public function getHistoryId()
+  {
+    return $this->historyId;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/GroupsMigration.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/GroupsMigration.php
@@ -1,0 +1,130 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for GroupsMigration (v1).
+ *
+ * <p>
+ * Groups Migration Api.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/google-apps/groups-migration/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_GroupsMigration extends Google_Service
+{
+  /** Manage messages in groups on your domain. */
+  const APPS_GROUPS_MIGRATION =
+      "https://www.googleapis.com/auth/apps.groups.migration";
+
+  public $archive;
+  
+
+  /**
+   * Constructs the internal representation of the GroupsMigration service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'groups/v1/groups/';
+    $this->version = 'v1';
+    $this->serviceName = 'groupsmigration';
+
+    $this->archive = new Google_Service_GroupsMigration_Archive_Resource(
+        $this,
+        $this->serviceName,
+        'archive',
+        array(
+          'methods' => array(
+            'insert' => array(
+              'path' => '{groupId}/archive',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'groupId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "archive" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $groupsmigrationService = new Google_Service_GroupsMigration(...);
+ *   $archive = $groupsmigrationService->archive;
+ *  </code>
+ */
+class Google_Service_GroupsMigration_Archive_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Inserts a new mail into the archive of the Google group. (archive.insert)
+   *
+   * @param string $groupId The group ID
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_GroupsMigration_Groups
+   */
+  public function insert($groupId, $optParams = array())
+  {
+    $params = array('groupId' => $groupId);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_GroupsMigration_Groups");
+  }
+}
+
+
+
+
+class Google_Service_GroupsMigration_Groups extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $responseCode;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setResponseCode($responseCode)
+  {
+    $this->responseCode = $responseCode;
+  }
+  public function getResponseCode()
+  {
+    return $this->responseCode;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Groupssettings.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Groupssettings.php
@@ -1,0 +1,415 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Groupssettings (v1).
+ *
+ * <p>
+ * Lets you manage permission levels and related settings of a group.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/google-apps/groups-settings/get_started" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Groupssettings extends Google_Service
+{
+  /** View and manage the settings of a Google Apps Group. */
+  const APPS_GROUPS_SETTINGS =
+      "https://www.googleapis.com/auth/apps.groups.settings";
+
+  public $groups;
+  
+
+  /**
+   * Constructs the internal representation of the Groupssettings service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'groups/v1/groups/';
+    $this->version = 'v1';
+    $this->serviceName = 'groupssettings';
+
+    $this->groups = new Google_Service_Groupssettings_Groups_Resource(
+        $this,
+        $this->serviceName,
+        'groups',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{groupUniqueId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'groupUniqueId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{groupUniqueId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'groupUniqueId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{groupUniqueId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'groupUniqueId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "groups" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $groupssettingsService = new Google_Service_Groupssettings(...);
+ *   $groups = $groupssettingsService->groups;
+ *  </code>
+ */
+class Google_Service_Groupssettings_Groups_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets one resource by id. (groups.get)
+   *
+   * @param string $groupUniqueId The resource ID
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Groupssettings_Groups
+   */
+  public function get($groupUniqueId, $optParams = array())
+  {
+    $params = array('groupUniqueId' => $groupUniqueId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Groupssettings_Groups");
+  }
+
+  /**
+   * Updates an existing resource. This method supports patch semantics.
+   * (groups.patch)
+   *
+   * @param string $groupUniqueId The resource ID
+   * @param Google_Groups $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Groupssettings_Groups
+   */
+  public function patch($groupUniqueId, Google_Service_Groupssettings_Groups $postBody, $optParams = array())
+  {
+    $params = array('groupUniqueId' => $groupUniqueId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Groupssettings_Groups");
+  }
+
+  /**
+   * Updates an existing resource. (groups.update)
+   *
+   * @param string $groupUniqueId The resource ID
+   * @param Google_Groups $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Groupssettings_Groups
+   */
+  public function update($groupUniqueId, Google_Service_Groupssettings_Groups $postBody, $optParams = array())
+  {
+    $params = array('groupUniqueId' => $groupUniqueId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Groupssettings_Groups");
+  }
+}
+
+
+
+
+class Google_Service_Groupssettings_Groups extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $allowExternalMembers;
+  public $allowGoogleCommunication;
+  public $allowWebPosting;
+  public $archiveOnly;
+  public $customReplyTo;
+  public $defaultMessageDenyNotificationText;
+  public $description;
+  public $email;
+  public $includeInGlobalAddressList;
+  public $isArchived;
+  public $kind;
+  public $maxMessageBytes;
+  public $membersCanPostAsTheGroup;
+  public $messageDisplayFont;
+  public $messageModerationLevel;
+  public $name;
+  public $primaryLanguage;
+  public $replyTo;
+  public $sendMessageDenyNotification;
+  public $showInGroupDirectory;
+  public $spamModerationLevel;
+  public $whoCanContactOwner;
+  public $whoCanInvite;
+  public $whoCanJoin;
+  public $whoCanLeaveGroup;
+  public $whoCanPostMessage;
+  public $whoCanViewGroup;
+  public $whoCanViewMembership;
+
+
+  public function setAllowExternalMembers($allowExternalMembers)
+  {
+    $this->allowExternalMembers = $allowExternalMembers;
+  }
+  public function getAllowExternalMembers()
+  {
+    return $this->allowExternalMembers;
+  }
+  public function setAllowGoogleCommunication($allowGoogleCommunication)
+  {
+    $this->allowGoogleCommunication = $allowGoogleCommunication;
+  }
+  public function getAllowGoogleCommunication()
+  {
+    return $this->allowGoogleCommunication;
+  }
+  public function setAllowWebPosting($allowWebPosting)
+  {
+    $this->allowWebPosting = $allowWebPosting;
+  }
+  public function getAllowWebPosting()
+  {
+    return $this->allowWebPosting;
+  }
+  public function setArchiveOnly($archiveOnly)
+  {
+    $this->archiveOnly = $archiveOnly;
+  }
+  public function getArchiveOnly()
+  {
+    return $this->archiveOnly;
+  }
+  public function setCustomReplyTo($customReplyTo)
+  {
+    $this->customReplyTo = $customReplyTo;
+  }
+  public function getCustomReplyTo()
+  {
+    return $this->customReplyTo;
+  }
+  public function setDefaultMessageDenyNotificationText($defaultMessageDenyNotificationText)
+  {
+    $this->defaultMessageDenyNotificationText = $defaultMessageDenyNotificationText;
+  }
+  public function getDefaultMessageDenyNotificationText()
+  {
+    return $this->defaultMessageDenyNotificationText;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setIncludeInGlobalAddressList($includeInGlobalAddressList)
+  {
+    $this->includeInGlobalAddressList = $includeInGlobalAddressList;
+  }
+  public function getIncludeInGlobalAddressList()
+  {
+    return $this->includeInGlobalAddressList;
+  }
+  public function setIsArchived($isArchived)
+  {
+    $this->isArchived = $isArchived;
+  }
+  public function getIsArchived()
+  {
+    return $this->isArchived;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMaxMessageBytes($maxMessageBytes)
+  {
+    $this->maxMessageBytes = $maxMessageBytes;
+  }
+  public function getMaxMessageBytes()
+  {
+    return $this->maxMessageBytes;
+  }
+  public function setMembersCanPostAsTheGroup($membersCanPostAsTheGroup)
+  {
+    $this->membersCanPostAsTheGroup = $membersCanPostAsTheGroup;
+  }
+  public function getMembersCanPostAsTheGroup()
+  {
+    return $this->membersCanPostAsTheGroup;
+  }
+  public function setMessageDisplayFont($messageDisplayFont)
+  {
+    $this->messageDisplayFont = $messageDisplayFont;
+  }
+  public function getMessageDisplayFont()
+  {
+    return $this->messageDisplayFont;
+  }
+  public function setMessageModerationLevel($messageModerationLevel)
+  {
+    $this->messageModerationLevel = $messageModerationLevel;
+  }
+  public function getMessageModerationLevel()
+  {
+    return $this->messageModerationLevel;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPrimaryLanguage($primaryLanguage)
+  {
+    $this->primaryLanguage = $primaryLanguage;
+  }
+  public function getPrimaryLanguage()
+  {
+    return $this->primaryLanguage;
+  }
+  public function setReplyTo($replyTo)
+  {
+    $this->replyTo = $replyTo;
+  }
+  public function getReplyTo()
+  {
+    return $this->replyTo;
+  }
+  public function setSendMessageDenyNotification($sendMessageDenyNotification)
+  {
+    $this->sendMessageDenyNotification = $sendMessageDenyNotification;
+  }
+  public function getSendMessageDenyNotification()
+  {
+    return $this->sendMessageDenyNotification;
+  }
+  public function setShowInGroupDirectory($showInGroupDirectory)
+  {
+    $this->showInGroupDirectory = $showInGroupDirectory;
+  }
+  public function getShowInGroupDirectory()
+  {
+    return $this->showInGroupDirectory;
+  }
+  public function setSpamModerationLevel($spamModerationLevel)
+  {
+    $this->spamModerationLevel = $spamModerationLevel;
+  }
+  public function getSpamModerationLevel()
+  {
+    return $this->spamModerationLevel;
+  }
+  public function setWhoCanContactOwner($whoCanContactOwner)
+  {
+    $this->whoCanContactOwner = $whoCanContactOwner;
+  }
+  public function getWhoCanContactOwner()
+  {
+    return $this->whoCanContactOwner;
+  }
+  public function setWhoCanInvite($whoCanInvite)
+  {
+    $this->whoCanInvite = $whoCanInvite;
+  }
+  public function getWhoCanInvite()
+  {
+    return $this->whoCanInvite;
+  }
+  public function setWhoCanJoin($whoCanJoin)
+  {
+    $this->whoCanJoin = $whoCanJoin;
+  }
+  public function getWhoCanJoin()
+  {
+    return $this->whoCanJoin;
+  }
+  public function setWhoCanLeaveGroup($whoCanLeaveGroup)
+  {
+    $this->whoCanLeaveGroup = $whoCanLeaveGroup;
+  }
+  public function getWhoCanLeaveGroup()
+  {
+    return $this->whoCanLeaveGroup;
+  }
+  public function setWhoCanPostMessage($whoCanPostMessage)
+  {
+    $this->whoCanPostMessage = $whoCanPostMessage;
+  }
+  public function getWhoCanPostMessage()
+  {
+    return $this->whoCanPostMessage;
+  }
+  public function setWhoCanViewGroup($whoCanViewGroup)
+  {
+    $this->whoCanViewGroup = $whoCanViewGroup;
+  }
+  public function getWhoCanViewGroup()
+  {
+    return $this->whoCanViewGroup;
+  }
+  public function setWhoCanViewMembership($whoCanViewMembership)
+  {
+    $this->whoCanViewMembership = $whoCanViewMembership;
+  }
+  public function getWhoCanViewMembership()
+  {
+    return $this->whoCanViewMembership;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/IdentityToolkit.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/IdentityToolkit.php
@@ -1,0 +1,1818 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for IdentityToolkit (v3).
+ *
+ * <p>
+ * Help the third party sites to implement federated login.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/identity-toolkit/v3/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_IdentityToolkit extends Google_Service
+{
+
+
+  public $relyingparty;
+  
+
+  /**
+   * Constructs the internal representation of the IdentityToolkit service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'identitytoolkit/v3/relyingparty/';
+    $this->version = 'v3';
+    $this->serviceName = 'identitytoolkit';
+
+    $this->relyingparty = new Google_Service_IdentityToolkit_Relyingparty_Resource(
+        $this,
+        $this->serviceName,
+        'relyingparty',
+        array(
+          'methods' => array(
+            'createAuthUri' => array(
+              'path' => 'createAuthUri',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'deleteAccount' => array(
+              'path' => 'deleteAccount',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'downloadAccount' => array(
+              'path' => 'downloadAccount',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'getAccountInfo' => array(
+              'path' => 'getAccountInfo',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'getOobConfirmationCode' => array(
+              'path' => 'getOobConfirmationCode',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'getPublicKeys' => array(
+              'path' => 'publicKeys',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),'getRecaptchaParam' => array(
+              'path' => 'getRecaptchaParam',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),'resetPassword' => array(
+              'path' => 'resetPassword',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'setAccountInfo' => array(
+              'path' => 'setAccountInfo',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'uploadAccount' => array(
+              'path' => 'uploadAccount',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'verifyAssertion' => array(
+              'path' => 'verifyAssertion',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'verifyPassword' => array(
+              'path' => 'verifyPassword',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "relyingparty" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $identitytoolkitService = new Google_Service_IdentityToolkit(...);
+ *   $relyingparty = $identitytoolkitService->relyingparty;
+ *  </code>
+ */
+class Google_Service_IdentityToolkit_Relyingparty_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates the URI used by the IdP to authenticate the user.
+   * (relyingparty.createAuthUri)
+   *
+   * @param Google_IdentitytoolkitRelyingpartyCreateAuthUriRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_IdentityToolkit_CreateAuthUriResponse
+   */
+  public function createAuthUri(Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyCreateAuthUriRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('createAuthUri', array($params), "Google_Service_IdentityToolkit_CreateAuthUriResponse");
+  }
+
+  /**
+   * Delete user account. (relyingparty.deleteAccount)
+   *
+   * @param Google_IdentitytoolkitRelyingpartyDeleteAccountRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_IdentityToolkit_DeleteAccountResponse
+   */
+  public function deleteAccount(Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyDeleteAccountRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('deleteAccount', array($params), "Google_Service_IdentityToolkit_DeleteAccountResponse");
+  }
+
+  /**
+   * Batch download user accounts. (relyingparty.downloadAccount)
+   *
+   * @param Google_IdentitytoolkitRelyingpartyDownloadAccountRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_IdentityToolkit_DownloadAccountResponse
+   */
+  public function downloadAccount(Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyDownloadAccountRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('downloadAccount', array($params), "Google_Service_IdentityToolkit_DownloadAccountResponse");
+  }
+
+  /**
+   * Returns the account info. (relyingparty.getAccountInfo)
+   *
+   * @param Google_IdentitytoolkitRelyingpartyGetAccountInfoRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_IdentityToolkit_GetAccountInfoResponse
+   */
+  public function getAccountInfo(Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyGetAccountInfoRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('getAccountInfo', array($params), "Google_Service_IdentityToolkit_GetAccountInfoResponse");
+  }
+
+  /**
+   * Get a code for user action confirmation.
+   * (relyingparty.getOobConfirmationCode)
+   *
+   * @param Google_Relyingparty $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_IdentityToolkit_GetOobConfirmationCodeResponse
+   */
+  public function getOobConfirmationCode(Google_Service_IdentityToolkit_Relyingparty $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('getOobConfirmationCode', array($params), "Google_Service_IdentityToolkit_GetOobConfirmationCodeResponse");
+  }
+
+  /**
+   * Get token signing public key. (relyingparty.getPublicKeys)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyGetPublicKeysResponse
+   */
+  public function getPublicKeys($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('getPublicKeys', array($params), "Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyGetPublicKeysResponse");
+  }
+
+  /**
+   * Get recaptcha secure param. (relyingparty.getRecaptchaParam)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_IdentityToolkit_GetRecaptchaParamResponse
+   */
+  public function getRecaptchaParam($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('getRecaptchaParam', array($params), "Google_Service_IdentityToolkit_GetRecaptchaParamResponse");
+  }
+
+  /**
+   * Reset password for a user. (relyingparty.resetPassword)
+   *
+   * @param Google_IdentitytoolkitRelyingpartyResetPasswordRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_IdentityToolkit_ResetPasswordResponse
+   */
+  public function resetPassword(Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyResetPasswordRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('resetPassword', array($params), "Google_Service_IdentityToolkit_ResetPasswordResponse");
+  }
+
+  /**
+   * Set account info for a user. (relyingparty.setAccountInfo)
+   *
+   * @param Google_IdentitytoolkitRelyingpartySetAccountInfoRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_IdentityToolkit_SetAccountInfoResponse
+   */
+  public function setAccountInfo(Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartySetAccountInfoRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setAccountInfo', array($params), "Google_Service_IdentityToolkit_SetAccountInfoResponse");
+  }
+
+  /**
+   * Batch upload existing user accounts. (relyingparty.uploadAccount)
+   *
+   * @param Google_IdentitytoolkitRelyingpartyUploadAccountRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_IdentityToolkit_UploadAccountResponse
+   */
+  public function uploadAccount(Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyUploadAccountRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('uploadAccount', array($params), "Google_Service_IdentityToolkit_UploadAccountResponse");
+  }
+
+  /**
+   * Verifies the assertion returned by the IdP. (relyingparty.verifyAssertion)
+   *
+   * @param Google_IdentitytoolkitRelyingpartyVerifyAssertionRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_IdentityToolkit_VerifyAssertionResponse
+   */
+  public function verifyAssertion(Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyVerifyAssertionRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('verifyAssertion', array($params), "Google_Service_IdentityToolkit_VerifyAssertionResponse");
+  }
+
+  /**
+   * Verifies the user entered password. (relyingparty.verifyPassword)
+   *
+   * @param Google_IdentitytoolkitRelyingpartyVerifyPasswordRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_IdentityToolkit_VerifyPasswordResponse
+   */
+  public function verifyPassword(Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyVerifyPasswordRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('verifyPassword', array($params), "Google_Service_IdentityToolkit_VerifyPasswordResponse");
+  }
+}
+
+
+
+
+class Google_Service_IdentityToolkit_CreateAuthUriResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $authUri;
+  public $captchaRequired;
+  public $forExistingProvider;
+  public $kind;
+  public $providerId;
+  public $registered;
+
+
+  public function setAuthUri($authUri)
+  {
+    $this->authUri = $authUri;
+  }
+  public function getAuthUri()
+  {
+    return $this->authUri;
+  }
+  public function setCaptchaRequired($captchaRequired)
+  {
+    $this->captchaRequired = $captchaRequired;
+  }
+  public function getCaptchaRequired()
+  {
+    return $this->captchaRequired;
+  }
+  public function setForExistingProvider($forExistingProvider)
+  {
+    $this->forExistingProvider = $forExistingProvider;
+  }
+  public function getForExistingProvider()
+  {
+    return $this->forExistingProvider;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProviderId($providerId)
+  {
+    $this->providerId = $providerId;
+  }
+  public function getProviderId()
+  {
+    return $this->providerId;
+  }
+  public function setRegistered($registered)
+  {
+    $this->registered = $registered;
+  }
+  public function getRegistered()
+  {
+    return $this->registered;
+  }
+}
+
+class Google_Service_IdentityToolkit_DeleteAccountResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_IdentityToolkit_DownloadAccountResponse extends Google_Collection
+{
+  protected $collection_key = 'users';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $usersType = 'Google_Service_IdentityToolkit_UserInfo';
+  protected $usersDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setUsers($users)
+  {
+    $this->users = $users;
+  }
+  public function getUsers()
+  {
+    return $this->users;
+  }
+}
+
+class Google_Service_IdentityToolkit_GetAccountInfoResponse extends Google_Collection
+{
+  protected $collection_key = 'users';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $usersType = 'Google_Service_IdentityToolkit_UserInfo';
+  protected $usersDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUsers($users)
+  {
+    $this->users = $users;
+  }
+  public function getUsers()
+  {
+    return $this->users;
+  }
+}
+
+class Google_Service_IdentityToolkit_GetOobConfirmationCodeResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $oobCode;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setOobCode($oobCode)
+  {
+    $this->oobCode = $oobCode;
+  }
+  public function getOobCode()
+  {
+    return $this->oobCode;
+  }
+}
+
+class Google_Service_IdentityToolkit_GetRecaptchaParamResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $recaptchaSiteKey;
+  public $recaptchaStoken;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRecaptchaSiteKey($recaptchaSiteKey)
+  {
+    $this->recaptchaSiteKey = $recaptchaSiteKey;
+  }
+  public function getRecaptchaSiteKey()
+  {
+    return $this->recaptchaSiteKey;
+  }
+  public function setRecaptchaStoken($recaptchaStoken)
+  {
+    $this->recaptchaStoken = $recaptchaStoken;
+  }
+  public function getRecaptchaStoken()
+  {
+    return $this->recaptchaStoken;
+  }
+}
+
+class Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyCreateAuthUriRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $appId;
+  public $clientId;
+  public $context;
+  public $continueUri;
+  public $identifier;
+  public $oauthConsumerKey;
+  public $oauthScope;
+  public $openidRealm;
+  public $otaApp;
+  public $providerId;
+
+
+  public function setAppId($appId)
+  {
+    $this->appId = $appId;
+  }
+  public function getAppId()
+  {
+    return $this->appId;
+  }
+  public function setClientId($clientId)
+  {
+    $this->clientId = $clientId;
+  }
+  public function getClientId()
+  {
+    return $this->clientId;
+  }
+  public function setContext($context)
+  {
+    $this->context = $context;
+  }
+  public function getContext()
+  {
+    return $this->context;
+  }
+  public function setContinueUri($continueUri)
+  {
+    $this->continueUri = $continueUri;
+  }
+  public function getContinueUri()
+  {
+    return $this->continueUri;
+  }
+  public function setIdentifier($identifier)
+  {
+    $this->identifier = $identifier;
+  }
+  public function getIdentifier()
+  {
+    return $this->identifier;
+  }
+  public function setOauthConsumerKey($oauthConsumerKey)
+  {
+    $this->oauthConsumerKey = $oauthConsumerKey;
+  }
+  public function getOauthConsumerKey()
+  {
+    return $this->oauthConsumerKey;
+  }
+  public function setOauthScope($oauthScope)
+  {
+    $this->oauthScope = $oauthScope;
+  }
+  public function getOauthScope()
+  {
+    return $this->oauthScope;
+  }
+  public function setOpenidRealm($openidRealm)
+  {
+    $this->openidRealm = $openidRealm;
+  }
+  public function getOpenidRealm()
+  {
+    return $this->openidRealm;
+  }
+  public function setOtaApp($otaApp)
+  {
+    $this->otaApp = $otaApp;
+  }
+  public function getOtaApp()
+  {
+    return $this->otaApp;
+  }
+  public function setProviderId($providerId)
+  {
+    $this->providerId = $providerId;
+  }
+  public function getProviderId()
+  {
+    return $this->providerId;
+  }
+}
+
+class Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyDeleteAccountRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $localId;
+
+
+  public function setLocalId($localId)
+  {
+    $this->localId = $localId;
+  }
+  public function getLocalId()
+  {
+    return $this->localId;
+  }
+}
+
+class Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyDownloadAccountRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $maxResults;
+  public $nextPageToken;
+
+
+  public function setMaxResults($maxResults)
+  {
+    $this->maxResults = $maxResults;
+  }
+  public function getMaxResults()
+  {
+    return $this->maxResults;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyGetAccountInfoRequest extends Google_Collection
+{
+  protected $collection_key = 'localId';
+  protected $internal_gapi_mappings = array(
+  );
+  public $email;
+  public $idToken;
+  public $localId;
+
+
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setIdToken($idToken)
+  {
+    $this->idToken = $idToken;
+  }
+  public function getIdToken()
+  {
+    return $this->idToken;
+  }
+  public function setLocalId($localId)
+  {
+    $this->localId = $localId;
+  }
+  public function getLocalId()
+  {
+    return $this->localId;
+  }
+}
+
+class Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyGetPublicKeysResponse extends Google_Model
+{
+}
+
+class Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyResetPasswordRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $email;
+  public $newPassword;
+  public $oldPassword;
+  public $oobCode;
+
+
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setNewPassword($newPassword)
+  {
+    $this->newPassword = $newPassword;
+  }
+  public function getNewPassword()
+  {
+    return $this->newPassword;
+  }
+  public function setOldPassword($oldPassword)
+  {
+    $this->oldPassword = $oldPassword;
+  }
+  public function getOldPassword()
+  {
+    return $this->oldPassword;
+  }
+  public function setOobCode($oobCode)
+  {
+    $this->oobCode = $oobCode;
+  }
+  public function getOobCode()
+  {
+    return $this->oobCode;
+  }
+}
+
+class Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartySetAccountInfoRequest extends Google_Collection
+{
+  protected $collection_key = 'provider';
+  protected $internal_gapi_mappings = array(
+  );
+  public $captchaChallenge;
+  public $captchaResponse;
+  public $disableUser;
+  public $displayName;
+  public $email;
+  public $emailVerified;
+  public $idToken;
+  public $localId;
+  public $oobCode;
+  public $password;
+  public $provider;
+  public $upgradeToFederatedLogin;
+  public $validSince;
+
+
+  public function setCaptchaChallenge($captchaChallenge)
+  {
+    $this->captchaChallenge = $captchaChallenge;
+  }
+  public function getCaptchaChallenge()
+  {
+    return $this->captchaChallenge;
+  }
+  public function setCaptchaResponse($captchaResponse)
+  {
+    $this->captchaResponse = $captchaResponse;
+  }
+  public function getCaptchaResponse()
+  {
+    return $this->captchaResponse;
+  }
+  public function setDisableUser($disableUser)
+  {
+    $this->disableUser = $disableUser;
+  }
+  public function getDisableUser()
+  {
+    return $this->disableUser;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setEmailVerified($emailVerified)
+  {
+    $this->emailVerified = $emailVerified;
+  }
+  public function getEmailVerified()
+  {
+    return $this->emailVerified;
+  }
+  public function setIdToken($idToken)
+  {
+    $this->idToken = $idToken;
+  }
+  public function getIdToken()
+  {
+    return $this->idToken;
+  }
+  public function setLocalId($localId)
+  {
+    $this->localId = $localId;
+  }
+  public function getLocalId()
+  {
+    return $this->localId;
+  }
+  public function setOobCode($oobCode)
+  {
+    $this->oobCode = $oobCode;
+  }
+  public function getOobCode()
+  {
+    return $this->oobCode;
+  }
+  public function setPassword($password)
+  {
+    $this->password = $password;
+  }
+  public function getPassword()
+  {
+    return $this->password;
+  }
+  public function setProvider($provider)
+  {
+    $this->provider = $provider;
+  }
+  public function getProvider()
+  {
+    return $this->provider;
+  }
+  public function setUpgradeToFederatedLogin($upgradeToFederatedLogin)
+  {
+    $this->upgradeToFederatedLogin = $upgradeToFederatedLogin;
+  }
+  public function getUpgradeToFederatedLogin()
+  {
+    return $this->upgradeToFederatedLogin;
+  }
+  public function setValidSince($validSince)
+  {
+    $this->validSince = $validSince;
+  }
+  public function getValidSince()
+  {
+    return $this->validSince;
+  }
+}
+
+class Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyUploadAccountRequest extends Google_Collection
+{
+  protected $collection_key = 'users';
+  protected $internal_gapi_mappings = array(
+  );
+  public $hashAlgorithm;
+  public $memoryCost;
+  public $rounds;
+  public $saltSeparator;
+  public $signerKey;
+  protected $usersType = 'Google_Service_IdentityToolkit_UserInfo';
+  protected $usersDataType = 'array';
+
+
+  public function setHashAlgorithm($hashAlgorithm)
+  {
+    $this->hashAlgorithm = $hashAlgorithm;
+  }
+  public function getHashAlgorithm()
+  {
+    return $this->hashAlgorithm;
+  }
+  public function setMemoryCost($memoryCost)
+  {
+    $this->memoryCost = $memoryCost;
+  }
+  public function getMemoryCost()
+  {
+    return $this->memoryCost;
+  }
+  public function setRounds($rounds)
+  {
+    $this->rounds = $rounds;
+  }
+  public function getRounds()
+  {
+    return $this->rounds;
+  }
+  public function setSaltSeparator($saltSeparator)
+  {
+    $this->saltSeparator = $saltSeparator;
+  }
+  public function getSaltSeparator()
+  {
+    return $this->saltSeparator;
+  }
+  public function setSignerKey($signerKey)
+  {
+    $this->signerKey = $signerKey;
+  }
+  public function getSignerKey()
+  {
+    return $this->signerKey;
+  }
+  public function setUsers($users)
+  {
+    $this->users = $users;
+  }
+  public function getUsers()
+  {
+    return $this->users;
+  }
+}
+
+class Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyVerifyAssertionRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $pendingIdToken;
+  public $postBody;
+  public $requestUri;
+  public $returnRefreshToken;
+
+
+  public function setPendingIdToken($pendingIdToken)
+  {
+    $this->pendingIdToken = $pendingIdToken;
+  }
+  public function getPendingIdToken()
+  {
+    return $this->pendingIdToken;
+  }
+  public function setPostBody($postBody)
+  {
+    $this->postBody = $postBody;
+  }
+  public function getPostBody()
+  {
+    return $this->postBody;
+  }
+  public function setRequestUri($requestUri)
+  {
+    $this->requestUri = $requestUri;
+  }
+  public function getRequestUri()
+  {
+    return $this->requestUri;
+  }
+  public function setReturnRefreshToken($returnRefreshToken)
+  {
+    $this->returnRefreshToken = $returnRefreshToken;
+  }
+  public function getReturnRefreshToken()
+  {
+    return $this->returnRefreshToken;
+  }
+}
+
+class Google_Service_IdentityToolkit_IdentitytoolkitRelyingpartyVerifyPasswordRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $captchaChallenge;
+  public $captchaResponse;
+  public $email;
+  public $password;
+  public $pendingIdToken;
+
+
+  public function setCaptchaChallenge($captchaChallenge)
+  {
+    $this->captchaChallenge = $captchaChallenge;
+  }
+  public function getCaptchaChallenge()
+  {
+    return $this->captchaChallenge;
+  }
+  public function setCaptchaResponse($captchaResponse)
+  {
+    $this->captchaResponse = $captchaResponse;
+  }
+  public function getCaptchaResponse()
+  {
+    return $this->captchaResponse;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setPassword($password)
+  {
+    $this->password = $password;
+  }
+  public function getPassword()
+  {
+    return $this->password;
+  }
+  public function setPendingIdToken($pendingIdToken)
+  {
+    $this->pendingIdToken = $pendingIdToken;
+  }
+  public function getPendingIdToken()
+  {
+    return $this->pendingIdToken;
+  }
+}
+
+class Google_Service_IdentityToolkit_Relyingparty extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $captchaResp;
+  public $challenge;
+  public $email;
+  public $idToken;
+  public $kind;
+  public $newEmail;
+  public $requestType;
+  public $userIp;
+
+
+  public function setCaptchaResp($captchaResp)
+  {
+    $this->captchaResp = $captchaResp;
+  }
+  public function getCaptchaResp()
+  {
+    return $this->captchaResp;
+  }
+  public function setChallenge($challenge)
+  {
+    $this->challenge = $challenge;
+  }
+  public function getChallenge()
+  {
+    return $this->challenge;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setIdToken($idToken)
+  {
+    $this->idToken = $idToken;
+  }
+  public function getIdToken()
+  {
+    return $this->idToken;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNewEmail($newEmail)
+  {
+    $this->newEmail = $newEmail;
+  }
+  public function getNewEmail()
+  {
+    return $this->newEmail;
+  }
+  public function setRequestType($requestType)
+  {
+    $this->requestType = $requestType;
+  }
+  public function getRequestType()
+  {
+    return $this->requestType;
+  }
+  public function setUserIp($userIp)
+  {
+    $this->userIp = $userIp;
+  }
+  public function getUserIp()
+  {
+    return $this->userIp;
+  }
+}
+
+class Google_Service_IdentityToolkit_ResetPasswordResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $email;
+  public $kind;
+
+
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_IdentityToolkit_SetAccountInfoResponse extends Google_Collection
+{
+  protected $collection_key = 'providerUserInfo';
+  protected $internal_gapi_mappings = array(
+  );
+  public $displayName;
+  public $email;
+  public $idToken;
+  public $kind;
+  public $newEmail;
+  protected $providerUserInfoType = 'Google_Service_IdentityToolkit_SetAccountInfoResponseProviderUserInfo';
+  protected $providerUserInfoDataType = 'array';
+
+
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setIdToken($idToken)
+  {
+    $this->idToken = $idToken;
+  }
+  public function getIdToken()
+  {
+    return $this->idToken;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNewEmail($newEmail)
+  {
+    $this->newEmail = $newEmail;
+  }
+  public function getNewEmail()
+  {
+    return $this->newEmail;
+  }
+  public function setProviderUserInfo($providerUserInfo)
+  {
+    $this->providerUserInfo = $providerUserInfo;
+  }
+  public function getProviderUserInfo()
+  {
+    return $this->providerUserInfo;
+  }
+}
+
+class Google_Service_IdentityToolkit_SetAccountInfoResponseProviderUserInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $displayName;
+  public $photoUrl;
+  public $providerId;
+
+
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setPhotoUrl($photoUrl)
+  {
+    $this->photoUrl = $photoUrl;
+  }
+  public function getPhotoUrl()
+  {
+    return $this->photoUrl;
+  }
+  public function setProviderId($providerId)
+  {
+    $this->providerId = $providerId;
+  }
+  public function getProviderId()
+  {
+    return $this->providerId;
+  }
+}
+
+class Google_Service_IdentityToolkit_UploadAccountResponse extends Google_Collection
+{
+  protected $collection_key = 'error';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorType = 'Google_Service_IdentityToolkit_UploadAccountResponseError';
+  protected $errorDataType = 'array';
+  public $kind;
+
+
+  public function setError($error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_IdentityToolkit_UploadAccountResponseError extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $index;
+  public $message;
+
+
+  public function setIndex($index)
+  {
+    $this->index = $index;
+  }
+  public function getIndex()
+  {
+    return $this->index;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_IdentityToolkit_UserInfo extends Google_Collection
+{
+  protected $collection_key = 'providerUserInfo';
+  protected $internal_gapi_mappings = array(
+  );
+  public $disabled;
+  public $displayName;
+  public $email;
+  public $emailVerified;
+  public $localId;
+  public $passwordHash;
+  public $passwordUpdatedAt;
+  public $photoUrl;
+  protected $providerUserInfoType = 'Google_Service_IdentityToolkit_UserInfoProviderUserInfo';
+  protected $providerUserInfoDataType = 'array';
+  public $salt;
+  public $validSince;
+  public $version;
+
+
+  public function setDisabled($disabled)
+  {
+    $this->disabled = $disabled;
+  }
+  public function getDisabled()
+  {
+    return $this->disabled;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setEmailVerified($emailVerified)
+  {
+    $this->emailVerified = $emailVerified;
+  }
+  public function getEmailVerified()
+  {
+    return $this->emailVerified;
+  }
+  public function setLocalId($localId)
+  {
+    $this->localId = $localId;
+  }
+  public function getLocalId()
+  {
+    return $this->localId;
+  }
+  public function setPasswordHash($passwordHash)
+  {
+    $this->passwordHash = $passwordHash;
+  }
+  public function getPasswordHash()
+  {
+    return $this->passwordHash;
+  }
+  public function setPasswordUpdatedAt($passwordUpdatedAt)
+  {
+    $this->passwordUpdatedAt = $passwordUpdatedAt;
+  }
+  public function getPasswordUpdatedAt()
+  {
+    return $this->passwordUpdatedAt;
+  }
+  public function setPhotoUrl($photoUrl)
+  {
+    $this->photoUrl = $photoUrl;
+  }
+  public function getPhotoUrl()
+  {
+    return $this->photoUrl;
+  }
+  public function setProviderUserInfo($providerUserInfo)
+  {
+    $this->providerUserInfo = $providerUserInfo;
+  }
+  public function getProviderUserInfo()
+  {
+    return $this->providerUserInfo;
+  }
+  public function setSalt($salt)
+  {
+    $this->salt = $salt;
+  }
+  public function getSalt()
+  {
+    return $this->salt;
+  }
+  public function setValidSince($validSince)
+  {
+    $this->validSince = $validSince;
+  }
+  public function getValidSince()
+  {
+    return $this->validSince;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_IdentityToolkit_UserInfoProviderUserInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $displayName;
+  public $federatedId;
+  public $photoUrl;
+  public $providerId;
+
+
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setFederatedId($federatedId)
+  {
+    $this->federatedId = $federatedId;
+  }
+  public function getFederatedId()
+  {
+    return $this->federatedId;
+  }
+  public function setPhotoUrl($photoUrl)
+  {
+    $this->photoUrl = $photoUrl;
+  }
+  public function getPhotoUrl()
+  {
+    return $this->photoUrl;
+  }
+  public function setProviderId($providerId)
+  {
+    $this->providerId = $providerId;
+  }
+  public function getProviderId()
+  {
+    return $this->providerId;
+  }
+}
+
+class Google_Service_IdentityToolkit_VerifyAssertionResponse extends Google_Collection
+{
+  protected $collection_key = 'verifiedProvider';
+  protected $internal_gapi_mappings = array(
+  );
+  public $action;
+  public $appInstallationUrl;
+  public $appScheme;
+  public $context;
+  public $dateOfBirth;
+  public $displayName;
+  public $email;
+  public $emailRecycled;
+  public $emailVerified;
+  public $federatedId;
+  public $firstName;
+  public $fullName;
+  public $idToken;
+  public $inputEmail;
+  public $kind;
+  public $language;
+  public $lastName;
+  public $localId;
+  public $needConfirmation;
+  public $needEmail;
+  public $nickName;
+  public $oauthAccessToken;
+  public $oauthAuthorizationCode;
+  public $oauthExpireIn;
+  public $oauthRequestToken;
+  public $oauthScope;
+  public $originalEmail;
+  public $photoUrl;
+  public $providerId;
+  public $timeZone;
+  public $verifiedProvider;
+
+
+  public function setAction($action)
+  {
+    $this->action = $action;
+  }
+  public function getAction()
+  {
+    return $this->action;
+  }
+  public function setAppInstallationUrl($appInstallationUrl)
+  {
+    $this->appInstallationUrl = $appInstallationUrl;
+  }
+  public function getAppInstallationUrl()
+  {
+    return $this->appInstallationUrl;
+  }
+  public function setAppScheme($appScheme)
+  {
+    $this->appScheme = $appScheme;
+  }
+  public function getAppScheme()
+  {
+    return $this->appScheme;
+  }
+  public function setContext($context)
+  {
+    $this->context = $context;
+  }
+  public function getContext()
+  {
+    return $this->context;
+  }
+  public function setDateOfBirth($dateOfBirth)
+  {
+    $this->dateOfBirth = $dateOfBirth;
+  }
+  public function getDateOfBirth()
+  {
+    return $this->dateOfBirth;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setEmailRecycled($emailRecycled)
+  {
+    $this->emailRecycled = $emailRecycled;
+  }
+  public function getEmailRecycled()
+  {
+    return $this->emailRecycled;
+  }
+  public function setEmailVerified($emailVerified)
+  {
+    $this->emailVerified = $emailVerified;
+  }
+  public function getEmailVerified()
+  {
+    return $this->emailVerified;
+  }
+  public function setFederatedId($federatedId)
+  {
+    $this->federatedId = $federatedId;
+  }
+  public function getFederatedId()
+  {
+    return $this->federatedId;
+  }
+  public function setFirstName($firstName)
+  {
+    $this->firstName = $firstName;
+  }
+  public function getFirstName()
+  {
+    return $this->firstName;
+  }
+  public function setFullName($fullName)
+  {
+    $this->fullName = $fullName;
+  }
+  public function getFullName()
+  {
+    return $this->fullName;
+  }
+  public function setIdToken($idToken)
+  {
+    $this->idToken = $idToken;
+  }
+  public function getIdToken()
+  {
+    return $this->idToken;
+  }
+  public function setInputEmail($inputEmail)
+  {
+    $this->inputEmail = $inputEmail;
+  }
+  public function getInputEmail()
+  {
+    return $this->inputEmail;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLanguage($language)
+  {
+    $this->language = $language;
+  }
+  public function getLanguage()
+  {
+    return $this->language;
+  }
+  public function setLastName($lastName)
+  {
+    $this->lastName = $lastName;
+  }
+  public function getLastName()
+  {
+    return $this->lastName;
+  }
+  public function setLocalId($localId)
+  {
+    $this->localId = $localId;
+  }
+  public function getLocalId()
+  {
+    return $this->localId;
+  }
+  public function setNeedConfirmation($needConfirmation)
+  {
+    $this->needConfirmation = $needConfirmation;
+  }
+  public function getNeedConfirmation()
+  {
+    return $this->needConfirmation;
+  }
+  public function setNeedEmail($needEmail)
+  {
+    $this->needEmail = $needEmail;
+  }
+  public function getNeedEmail()
+  {
+    return $this->needEmail;
+  }
+  public function setNickName($nickName)
+  {
+    $this->nickName = $nickName;
+  }
+  public function getNickName()
+  {
+    return $this->nickName;
+  }
+  public function setOauthAccessToken($oauthAccessToken)
+  {
+    $this->oauthAccessToken = $oauthAccessToken;
+  }
+  public function getOauthAccessToken()
+  {
+    return $this->oauthAccessToken;
+  }
+  public function setOauthAuthorizationCode($oauthAuthorizationCode)
+  {
+    $this->oauthAuthorizationCode = $oauthAuthorizationCode;
+  }
+  public function getOauthAuthorizationCode()
+  {
+    return $this->oauthAuthorizationCode;
+  }
+  public function setOauthExpireIn($oauthExpireIn)
+  {
+    $this->oauthExpireIn = $oauthExpireIn;
+  }
+  public function getOauthExpireIn()
+  {
+    return $this->oauthExpireIn;
+  }
+  public function setOauthRequestToken($oauthRequestToken)
+  {
+    $this->oauthRequestToken = $oauthRequestToken;
+  }
+  public function getOauthRequestToken()
+  {
+    return $this->oauthRequestToken;
+  }
+  public function setOauthScope($oauthScope)
+  {
+    $this->oauthScope = $oauthScope;
+  }
+  public function getOauthScope()
+  {
+    return $this->oauthScope;
+  }
+  public function setOriginalEmail($originalEmail)
+  {
+    $this->originalEmail = $originalEmail;
+  }
+  public function getOriginalEmail()
+  {
+    return $this->originalEmail;
+  }
+  public function setPhotoUrl($photoUrl)
+  {
+    $this->photoUrl = $photoUrl;
+  }
+  public function getPhotoUrl()
+  {
+    return $this->photoUrl;
+  }
+  public function setProviderId($providerId)
+  {
+    $this->providerId = $providerId;
+  }
+  public function getProviderId()
+  {
+    return $this->providerId;
+  }
+  public function setTimeZone($timeZone)
+  {
+    $this->timeZone = $timeZone;
+  }
+  public function getTimeZone()
+  {
+    return $this->timeZone;
+  }
+  public function setVerifiedProvider($verifiedProvider)
+  {
+    $this->verifiedProvider = $verifiedProvider;
+  }
+  public function getVerifiedProvider()
+  {
+    return $this->verifiedProvider;
+  }
+}
+
+class Google_Service_IdentityToolkit_VerifyPasswordResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $displayName;
+  public $email;
+  public $idToken;
+  public $kind;
+  public $localId;
+  public $oauthAccessToken;
+  public $oauthAuthorizationCode;
+  public $oauthExpireIn;
+  public $photoUrl;
+  public $registered;
+
+
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setIdToken($idToken)
+  {
+    $this->idToken = $idToken;
+  }
+  public function getIdToken()
+  {
+    return $this->idToken;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocalId($localId)
+  {
+    $this->localId = $localId;
+  }
+  public function getLocalId()
+  {
+    return $this->localId;
+  }
+  public function setOauthAccessToken($oauthAccessToken)
+  {
+    $this->oauthAccessToken = $oauthAccessToken;
+  }
+  public function getOauthAccessToken()
+  {
+    return $this->oauthAccessToken;
+  }
+  public function setOauthAuthorizationCode($oauthAuthorizationCode)
+  {
+    $this->oauthAuthorizationCode = $oauthAuthorizationCode;
+  }
+  public function getOauthAuthorizationCode()
+  {
+    return $this->oauthAuthorizationCode;
+  }
+  public function setOauthExpireIn($oauthExpireIn)
+  {
+    $this->oauthExpireIn = $oauthExpireIn;
+  }
+  public function getOauthExpireIn()
+  {
+    return $this->oauthExpireIn;
+  }
+  public function setPhotoUrl($photoUrl)
+  {
+    $this->photoUrl = $photoUrl;
+  }
+  public function getPhotoUrl()
+  {
+    return $this->photoUrl;
+  }
+  public function setRegistered($registered)
+  {
+    $this->registered = $registered;
+  }
+  public function getRegistered()
+  {
+    return $this->registered;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Licensing.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Licensing.php
@@ -1,0 +1,479 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Licensing (v1).
+ *
+ * <p>
+ * Licensing API to view and manage license for your domain.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/google-apps/licensing/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Licensing extends Google_Service
+{
+  /** View and manage Google Apps licenses for your domain. */
+  const APPS_LICENSING =
+      "https://www.googleapis.com/auth/apps.licensing";
+
+  public $licenseAssignments;
+  
+
+  /**
+   * Constructs the internal representation of the Licensing service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'apps/licensing/v1/product/';
+    $this->version = 'v1';
+    $this->serviceName = 'licensing';
+
+    $this->licenseAssignments = new Google_Service_Licensing_LicenseAssignments_Resource(
+        $this,
+        $this->serviceName,
+        'licenseAssignments',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{productId}/sku/{skuId}/user/{userId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'productId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'skuId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{productId}/sku/{skuId}/user/{userId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'productId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'skuId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{productId}/sku/{skuId}/user',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'productId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'skuId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'listForProduct' => array(
+              'path' => '{productId}/users',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'productId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customerId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'listForProductAndSku' => array(
+              'path' => '{productId}/sku/{skuId}/users',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'productId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'skuId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customerId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{productId}/sku/{skuId}/user/{userId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'productId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'skuId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{productId}/sku/{skuId}/user/{userId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'productId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'skuId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "licenseAssignments" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $licensingService = new Google_Service_Licensing(...);
+ *   $licenseAssignments = $licensingService->licenseAssignments;
+ *  </code>
+ */
+class Google_Service_Licensing_LicenseAssignments_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Revoke License. (licenseAssignments.delete)
+   *
+   * @param string $productId Name for product
+   * @param string $skuId Name for sku
+   * @param string $userId email id or unique Id of the user
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($productId, $skuId, $userId, $optParams = array())
+  {
+    $params = array('productId' => $productId, 'skuId' => $skuId, 'userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Get license assignment of a particular product and sku for a user
+   * (licenseAssignments.get)
+   *
+   * @param string $productId Name for product
+   * @param string $skuId Name for sku
+   * @param string $userId email id or unique Id of the user
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Licensing_LicenseAssignment
+   */
+  public function get($productId, $skuId, $userId, $optParams = array())
+  {
+    $params = array('productId' => $productId, 'skuId' => $skuId, 'userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Licensing_LicenseAssignment");
+  }
+
+  /**
+   * Assign License. (licenseAssignments.insert)
+   *
+   * @param string $productId Name for product
+   * @param string $skuId Name for sku
+   * @param Google_LicenseAssignmentInsert $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Licensing_LicenseAssignment
+   */
+  public function insert($productId, $skuId, Google_Service_Licensing_LicenseAssignmentInsert $postBody, $optParams = array())
+  {
+    $params = array('productId' => $productId, 'skuId' => $skuId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Licensing_LicenseAssignment");
+  }
+
+  /**
+   * List license assignments for given product of the customer.
+   * (licenseAssignments.listForProduct)
+   *
+   * @param string $productId Name for product
+   * @param string $customerId CustomerId represents the customer for whom
+   * licenseassignments are queried
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Token to fetch the next page.Optional. By default
+   * server will return first page
+   * @opt_param string maxResults Maximum number of campaigns to return at one
+   * time. Must be positive. Optional. Default value is 100.
+   * @return Google_Service_Licensing_LicenseAssignmentList
+   */
+  public function listForProduct($productId, $customerId, $optParams = array())
+  {
+    $params = array('productId' => $productId, 'customerId' => $customerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('listForProduct', array($params), "Google_Service_Licensing_LicenseAssignmentList");
+  }
+
+  /**
+   * List license assignments for given product and sku of the customer.
+   * (licenseAssignments.listForProductAndSku)
+   *
+   * @param string $productId Name for product
+   * @param string $skuId Name for sku
+   * @param string $customerId CustomerId represents the customer for whom
+   * licenseassignments are queried
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Token to fetch the next page.Optional. By default
+   * server will return first page
+   * @opt_param string maxResults Maximum number of campaigns to return at one
+   * time. Must be positive. Optional. Default value is 100.
+   * @return Google_Service_Licensing_LicenseAssignmentList
+   */
+  public function listForProductAndSku($productId, $skuId, $customerId, $optParams = array())
+  {
+    $params = array('productId' => $productId, 'skuId' => $skuId, 'customerId' => $customerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('listForProductAndSku', array($params), "Google_Service_Licensing_LicenseAssignmentList");
+  }
+
+  /**
+   * Assign License. This method supports patch semantics.
+   * (licenseAssignments.patch)
+   *
+   * @param string $productId Name for product
+   * @param string $skuId Name for sku for which license would be revoked
+   * @param string $userId email id or unique Id of the user
+   * @param Google_LicenseAssignment $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Licensing_LicenseAssignment
+   */
+  public function patch($productId, $skuId, $userId, Google_Service_Licensing_LicenseAssignment $postBody, $optParams = array())
+  {
+    $params = array('productId' => $productId, 'skuId' => $skuId, 'userId' => $userId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Licensing_LicenseAssignment");
+  }
+
+  /**
+   * Assign License. (licenseAssignments.update)
+   *
+   * @param string $productId Name for product
+   * @param string $skuId Name for sku for which license would be revoked
+   * @param string $userId email id or unique Id of the user
+   * @param Google_LicenseAssignment $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Licensing_LicenseAssignment
+   */
+  public function update($productId, $skuId, $userId, Google_Service_Licensing_LicenseAssignment $postBody, $optParams = array())
+  {
+    $params = array('productId' => $productId, 'skuId' => $skuId, 'userId' => $userId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Licensing_LicenseAssignment");
+  }
+}
+
+
+
+
+class Google_Service_Licensing_LicenseAssignment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etags;
+  public $kind;
+  public $productId;
+  public $selfLink;
+  public $skuId;
+  public $userId;
+
+
+  public function setEtags($etags)
+  {
+    $this->etags = $etags;
+  }
+  public function getEtags()
+  {
+    return $this->etags;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProductId($productId)
+  {
+    $this->productId = $productId;
+  }
+  public function getProductId()
+  {
+    return $this->productId;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setSkuId($skuId)
+  {
+    $this->skuId = $skuId;
+  }
+  public function getSkuId()
+  {
+    return $this->skuId;
+  }
+  public function setUserId($userId)
+  {
+    $this->userId = $userId;
+  }
+  public function getUserId()
+  {
+    return $this->userId;
+  }
+}
+
+class Google_Service_Licensing_LicenseAssignmentInsert extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $userId;
+
+
+  public function setUserId($userId)
+  {
+    $this->userId = $userId;
+  }
+  public function getUserId()
+  {
+    return $this->userId;
+  }
+}
+
+class Google_Service_Licensing_LicenseAssignmentList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Licensing_LicenseAssignment';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Logging.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Logging.php
@@ -1,0 +1,453 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Logging (v2beta1).
+ *
+ * <p>
+ * Google Cloud Logging API lets you create logs, ingest log entries, and manage
+ * log sinks.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://cloud.google.com/logging/docs/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Logging extends Google_Service
+{
+
+
+
+  
+
+  /**
+   * Constructs the internal representation of the Logging service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://logging.googleapis.com/';
+    $this->servicePath = '';
+    $this->version = 'v2beta1';
+    $this->serviceName = 'logging';
+
+  }
+}
+
+
+
+
+
+class Google_Service_Logging_LogLine extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $logMessage;
+  public $severity;
+  protected $sourceLocationType = 'Google_Service_Logging_SourceLocation';
+  protected $sourceLocationDataType = '';
+  public $time;
+
+
+  public function setLogMessage($logMessage)
+  {
+    $this->logMessage = $logMessage;
+  }
+  public function getLogMessage()
+  {
+    return $this->logMessage;
+  }
+  public function setSeverity($severity)
+  {
+    $this->severity = $severity;
+  }
+  public function getSeverity()
+  {
+    return $this->severity;
+  }
+  public function setSourceLocation(Google_Service_Logging_SourceLocation $sourceLocation)
+  {
+    $this->sourceLocation = $sourceLocation;
+  }
+  public function getSourceLocation()
+  {
+    return $this->sourceLocation;
+  }
+  public function setTime($time)
+  {
+    $this->time = $time;
+  }
+  public function getTime()
+  {
+    return $this->time;
+  }
+}
+
+class Google_Service_Logging_RequestLog extends Google_Collection
+{
+  protected $collection_key = 'sourceReference';
+  protected $internal_gapi_mappings = array(
+  );
+  public $appEngineRelease;
+  public $appId;
+  public $cost;
+  public $endTime;
+  public $finished;
+  public $host;
+  public $httpVersion;
+  public $instanceId;
+  public $instanceIndex;
+  public $ip;
+  public $latency;
+  protected $lineType = 'Google_Service_Logging_LogLine';
+  protected $lineDataType = 'array';
+  public $megaCycles;
+  public $method;
+  public $moduleId;
+  public $nickname;
+  public $pendingTime;
+  public $referrer;
+  public $requestId;
+  public $resource;
+  public $responseSize;
+  protected $sourceReferenceType = 'Google_Service_Logging_SourceReference';
+  protected $sourceReferenceDataType = 'array';
+  public $startTime;
+  public $status;
+  public $taskName;
+  public $taskQueueName;
+  public $traceId;
+  public $urlMapEntry;
+  public $userAgent;
+  public $versionId;
+  public $wasLoadingRequest;
+
+
+  public function setAppEngineRelease($appEngineRelease)
+  {
+    $this->appEngineRelease = $appEngineRelease;
+  }
+  public function getAppEngineRelease()
+  {
+    return $this->appEngineRelease;
+  }
+  public function setAppId($appId)
+  {
+    $this->appId = $appId;
+  }
+  public function getAppId()
+  {
+    return $this->appId;
+  }
+  public function setCost($cost)
+  {
+    $this->cost = $cost;
+  }
+  public function getCost()
+  {
+    return $this->cost;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setFinished($finished)
+  {
+    $this->finished = $finished;
+  }
+  public function getFinished()
+  {
+    return $this->finished;
+  }
+  public function setHost($host)
+  {
+    $this->host = $host;
+  }
+  public function getHost()
+  {
+    return $this->host;
+  }
+  public function setHttpVersion($httpVersion)
+  {
+    $this->httpVersion = $httpVersion;
+  }
+  public function getHttpVersion()
+  {
+    return $this->httpVersion;
+  }
+  public function setInstanceId($instanceId)
+  {
+    $this->instanceId = $instanceId;
+  }
+  public function getInstanceId()
+  {
+    return $this->instanceId;
+  }
+  public function setInstanceIndex($instanceIndex)
+  {
+    $this->instanceIndex = $instanceIndex;
+  }
+  public function getInstanceIndex()
+  {
+    return $this->instanceIndex;
+  }
+  public function setIp($ip)
+  {
+    $this->ip = $ip;
+  }
+  public function getIp()
+  {
+    return $this->ip;
+  }
+  public function setLatency($latency)
+  {
+    $this->latency = $latency;
+  }
+  public function getLatency()
+  {
+    return $this->latency;
+  }
+  public function setLine($line)
+  {
+    $this->line = $line;
+  }
+  public function getLine()
+  {
+    return $this->line;
+  }
+  public function setMegaCycles($megaCycles)
+  {
+    $this->megaCycles = $megaCycles;
+  }
+  public function getMegaCycles()
+  {
+    return $this->megaCycles;
+  }
+  public function setMethod($method)
+  {
+    $this->method = $method;
+  }
+  public function getMethod()
+  {
+    return $this->method;
+  }
+  public function setModuleId($moduleId)
+  {
+    $this->moduleId = $moduleId;
+  }
+  public function getModuleId()
+  {
+    return $this->moduleId;
+  }
+  public function setNickname($nickname)
+  {
+    $this->nickname = $nickname;
+  }
+  public function getNickname()
+  {
+    return $this->nickname;
+  }
+  public function setPendingTime($pendingTime)
+  {
+    $this->pendingTime = $pendingTime;
+  }
+  public function getPendingTime()
+  {
+    return $this->pendingTime;
+  }
+  public function setReferrer($referrer)
+  {
+    $this->referrer = $referrer;
+  }
+  public function getReferrer()
+  {
+    return $this->referrer;
+  }
+  public function setRequestId($requestId)
+  {
+    $this->requestId = $requestId;
+  }
+  public function getRequestId()
+  {
+    return $this->requestId;
+  }
+  public function setResource($resource)
+  {
+    $this->resource = $resource;
+  }
+  public function getResource()
+  {
+    return $this->resource;
+  }
+  public function setResponseSize($responseSize)
+  {
+    $this->responseSize = $responseSize;
+  }
+  public function getResponseSize()
+  {
+    return $this->responseSize;
+  }
+  public function setSourceReference($sourceReference)
+  {
+    $this->sourceReference = $sourceReference;
+  }
+  public function getSourceReference()
+  {
+    return $this->sourceReference;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setTaskName($taskName)
+  {
+    $this->taskName = $taskName;
+  }
+  public function getTaskName()
+  {
+    return $this->taskName;
+  }
+  public function setTaskQueueName($taskQueueName)
+  {
+    $this->taskQueueName = $taskQueueName;
+  }
+  public function getTaskQueueName()
+  {
+    return $this->taskQueueName;
+  }
+  public function setTraceId($traceId)
+  {
+    $this->traceId = $traceId;
+  }
+  public function getTraceId()
+  {
+    return $this->traceId;
+  }
+  public function setUrlMapEntry($urlMapEntry)
+  {
+    $this->urlMapEntry = $urlMapEntry;
+  }
+  public function getUrlMapEntry()
+  {
+    return $this->urlMapEntry;
+  }
+  public function setUserAgent($userAgent)
+  {
+    $this->userAgent = $userAgent;
+  }
+  public function getUserAgent()
+  {
+    return $this->userAgent;
+  }
+  public function setVersionId($versionId)
+  {
+    $this->versionId = $versionId;
+  }
+  public function getVersionId()
+  {
+    return $this->versionId;
+  }
+  public function setWasLoadingRequest($wasLoadingRequest)
+  {
+    $this->wasLoadingRequest = $wasLoadingRequest;
+  }
+  public function getWasLoadingRequest()
+  {
+    return $this->wasLoadingRequest;
+  }
+}
+
+class Google_Service_Logging_SourceLocation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $file;
+  public $functionName;
+  public $line;
+
+
+  public function setFile($file)
+  {
+    $this->file = $file;
+  }
+  public function getFile()
+  {
+    return $this->file;
+  }
+  public function setFunctionName($functionName)
+  {
+    $this->functionName = $functionName;
+  }
+  public function getFunctionName()
+  {
+    return $this->functionName;
+  }
+  public function setLine($line)
+  {
+    $this->line = $line;
+  }
+  public function getLine()
+  {
+    return $this->line;
+  }
+}
+
+class Google_Service_Logging_SourceReference extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $repository;
+  public $revisionId;
+
+
+  public function setRepository($repository)
+  {
+    $this->repository = $repository;
+  }
+  public function getRepository()
+  {
+    return $this->repository;
+  }
+  public function setRevisionId($revisionId)
+  {
+    $this->revisionId = $revisionId;
+  }
+  public function getRevisionId()
+  {
+    return $this->revisionId;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Manager.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Manager.php
@@ -1,0 +1,1861 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Manager (v1beta2).
+ *
+ * <p>
+ * The Deployment Manager API allows users to declaratively configure, deploy
+ * and run complex solutions on the Google Cloud Platform.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/deployment-manager/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Manager extends Google_Service
+{
+  /** View and manage your applications deployed on Google App Engine. */
+  const APPENGINE_ADMIN =
+      "https://www.googleapis.com/auth/appengine.admin";
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+  /** View your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM_READ_ONLY =
+      "https://www.googleapis.com/auth/cloud-platform.read-only";
+  /** View and manage your Google Compute Engine resources. */
+  const COMPUTE =
+      "https://www.googleapis.com/auth/compute";
+  /** Manage your data in Google Cloud Storage. */
+  const DEVSTORAGE_READ_WRITE =
+      "https://www.googleapis.com/auth/devstorage.read_write";
+  /** View and manage your Google Cloud Platform management resources and deployment status information. */
+  const NDEV_CLOUDMAN =
+      "https://www.googleapis.com/auth/ndev.cloudman";
+  /** View your Google Cloud Platform management resources and deployment status information. */
+  const NDEV_CLOUDMAN_READONLY =
+      "https://www.googleapis.com/auth/ndev.cloudman.readonly";
+
+  public $deployments;
+  public $templates;
+  
+
+  /**
+   * Constructs the internal representation of the Manager service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'manager/v1beta2/projects/';
+    $this->version = 'v1beta2';
+    $this->serviceName = 'manager';
+
+    $this->deployments = new Google_Service_Manager_Deployments_Resource(
+        $this,
+        $this->serviceName,
+        'deployments',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{projectId}/regions/{region}/deployments/{deploymentName}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deploymentName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{projectId}/regions/{region}/deployments/{deploymentName}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deploymentName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{projectId}/regions/{region}/deployments',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{projectId}/regions/{region}/deployments',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'region' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->templates = new Google_Service_Manager_Templates_Resource(
+        $this,
+        $this->serviceName,
+        'templates',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{projectId}/templates/{templateName}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'templateName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{projectId}/templates/{templateName}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'templateName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{projectId}/templates',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{projectId}/templates',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "deployments" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $managerService = new Google_Service_Manager(...);
+ *   $deployments = $managerService->deployments;
+ *  </code>
+ */
+class Google_Service_Manager_Deployments_Resource extends Google_Service_Resource
+{
+
+  /**
+   * (deployments.delete)
+   *
+   * @param string $projectId
+   * @param string $region
+   * @param string $deploymentName
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($projectId, $region, $deploymentName, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'region' => $region, 'deploymentName' => $deploymentName);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * (deployments.get)
+   *
+   * @param string $projectId
+   * @param string $region
+   * @param string $deploymentName
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Manager_Deployment
+   */
+  public function get($projectId, $region, $deploymentName, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'region' => $region, 'deploymentName' => $deploymentName);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Manager_Deployment");
+  }
+
+  /**
+   * (deployments.insert)
+   *
+   * @param string $projectId
+   * @param string $region
+   * @param Google_Deployment $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Manager_Deployment
+   */
+  public function insert($projectId, $region, Google_Service_Manager_Deployment $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'region' => $region, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Manager_Deployment");
+  }
+
+  /**
+   * (deployments.listDeployments)
+   *
+   * @param string $projectId
+   * @param string $region
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Specifies a nextPageToken returned by a previous
+   * list request. This token can be used to request the next page of results from
+   * a previous list request.
+   * @opt_param int maxResults Maximum count of results to be returned. Acceptable
+   * values are 0 to 100, inclusive. (Default: 50)
+   * @return Google_Service_Manager_DeploymentsListResponse
+   */
+  public function listDeployments($projectId, $region, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'region' => $region);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Manager_DeploymentsListResponse");
+  }
+}
+
+/**
+ * The "templates" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $managerService = new Google_Service_Manager(...);
+ *   $templates = $managerService->templates;
+ *  </code>
+ */
+class Google_Service_Manager_Templates_Resource extends Google_Service_Resource
+{
+
+  /**
+   * (templates.delete)
+   *
+   * @param string $projectId
+   * @param string $templateName
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($projectId, $templateName, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'templateName' => $templateName);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * (templates.get)
+   *
+   * @param string $projectId
+   * @param string $templateName
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Manager_Template
+   */
+  public function get($projectId, $templateName, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'templateName' => $templateName);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Manager_Template");
+  }
+
+  /**
+   * (templates.insert)
+   *
+   * @param string $projectId
+   * @param Google_Template $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Manager_Template
+   */
+  public function insert($projectId, Google_Service_Manager_Template $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Manager_Template");
+  }
+
+  /**
+   * (templates.listTemplates)
+   *
+   * @param string $projectId
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Specifies a nextPageToken returned by a previous
+   * list request. This token can be used to request the next page of results from
+   * a previous list request.
+   * @opt_param int maxResults Maximum count of results to be returned. Acceptable
+   * values are 0 to 100, inclusive. (Default: 50)
+   * @return Google_Service_Manager_TemplatesListResponse
+   */
+  public function listTemplates($projectId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Manager_TemplatesListResponse");
+  }
+}
+
+
+
+
+class Google_Service_Manager_AccessConfig extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $natIp;
+  public $type;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNatIp($natIp)
+  {
+    $this->natIp = $natIp;
+  }
+  public function getNatIp()
+  {
+    return $this->natIp;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Manager_Action extends Google_Collection
+{
+  protected $collection_key = 'commands';
+  protected $internal_gapi_mappings = array(
+  );
+  public $commands;
+  public $timeoutMs;
+
+
+  public function setCommands($commands)
+  {
+    $this->commands = $commands;
+  }
+  public function getCommands()
+  {
+    return $this->commands;
+  }
+  public function setTimeoutMs($timeoutMs)
+  {
+    $this->timeoutMs = $timeoutMs;
+  }
+  public function getTimeoutMs()
+  {
+    return $this->timeoutMs;
+  }
+}
+
+class Google_Service_Manager_AllowedRule extends Google_Collection
+{
+  protected $collection_key = 'ports';
+  protected $internal_gapi_mappings = array(
+        "iPProtocol" => "IPProtocol",
+  );
+  public $iPProtocol;
+  public $ports;
+
+
+  public function setIPProtocol($iPProtocol)
+  {
+    $this->iPProtocol = $iPProtocol;
+  }
+  public function getIPProtocol()
+  {
+    return $this->iPProtocol;
+  }
+  public function setPorts($ports)
+  {
+    $this->ports = $ports;
+  }
+  public function getPorts()
+  {
+    return $this->ports;
+  }
+}
+
+class Google_Service_Manager_AutoscalingModule extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $coolDownPeriodSec;
+  public $description;
+  public $maxNumReplicas;
+  public $minNumReplicas;
+  public $signalType;
+  public $targetModule;
+  public $targetUtilization;
+
+
+  public function setCoolDownPeriodSec($coolDownPeriodSec)
+  {
+    $this->coolDownPeriodSec = $coolDownPeriodSec;
+  }
+  public function getCoolDownPeriodSec()
+  {
+    return $this->coolDownPeriodSec;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setMaxNumReplicas($maxNumReplicas)
+  {
+    $this->maxNumReplicas = $maxNumReplicas;
+  }
+  public function getMaxNumReplicas()
+  {
+    return $this->maxNumReplicas;
+  }
+  public function setMinNumReplicas($minNumReplicas)
+  {
+    $this->minNumReplicas = $minNumReplicas;
+  }
+  public function getMinNumReplicas()
+  {
+    return $this->minNumReplicas;
+  }
+  public function setSignalType($signalType)
+  {
+    $this->signalType = $signalType;
+  }
+  public function getSignalType()
+  {
+    return $this->signalType;
+  }
+  public function setTargetModule($targetModule)
+  {
+    $this->targetModule = $targetModule;
+  }
+  public function getTargetModule()
+  {
+    return $this->targetModule;
+  }
+  public function setTargetUtilization($targetUtilization)
+  {
+    $this->targetUtilization = $targetUtilization;
+  }
+  public function getTargetUtilization()
+  {
+    return $this->targetUtilization;
+  }
+}
+
+class Google_Service_Manager_AutoscalingModuleStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $autoscalingConfigUrl;
+
+
+  public function setAutoscalingConfigUrl($autoscalingConfigUrl)
+  {
+    $this->autoscalingConfigUrl = $autoscalingConfigUrl;
+  }
+  public function getAutoscalingConfigUrl()
+  {
+    return $this->autoscalingConfigUrl;
+  }
+}
+
+class Google_Service_Manager_DeployState extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $details;
+  public $status;
+
+
+  public function setDetails($details)
+  {
+    $this->details = $details;
+  }
+  public function getDetails()
+  {
+    return $this->details;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_Manager_Deployment extends Google_Collection
+{
+  protected $collection_key = 'overrides';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationDate;
+  public $description;
+  protected $modulesType = 'Google_Service_Manager_ModuleStatus';
+  protected $modulesDataType = 'map';
+  public $name;
+  protected $overridesType = 'Google_Service_Manager_ParamOverride';
+  protected $overridesDataType = 'array';
+  protected $stateType = 'Google_Service_Manager_DeployState';
+  protected $stateDataType = '';
+  public $templateName;
+
+
+  public function setCreationDate($creationDate)
+  {
+    $this->creationDate = $creationDate;
+  }
+  public function getCreationDate()
+  {
+    return $this->creationDate;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setModules($modules)
+  {
+    $this->modules = $modules;
+  }
+  public function getModules()
+  {
+    return $this->modules;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOverrides($overrides)
+  {
+    $this->overrides = $overrides;
+  }
+  public function getOverrides()
+  {
+    return $this->overrides;
+  }
+  public function setState(Google_Service_Manager_DeployState $state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+  public function setTemplateName($templateName)
+  {
+    $this->templateName = $templateName;
+  }
+  public function getTemplateName()
+  {
+    return $this->templateName;
+  }
+}
+
+class Google_Service_Manager_DeploymentModules extends Google_Model
+{
+}
+
+class Google_Service_Manager_DeploymentsListResponse extends Google_Collection
+{
+  protected $collection_key = 'resources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $resourcesType = 'Google_Service_Manager_Deployment';
+  protected $resourcesDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setResources($resources)
+  {
+    $this->resources = $resources;
+  }
+  public function getResources()
+  {
+    return $this->resources;
+  }
+}
+
+class Google_Service_Manager_DiskAttachment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $deviceName;
+  public $index;
+
+
+  public function setDeviceName($deviceName)
+  {
+    $this->deviceName = $deviceName;
+  }
+  public function getDeviceName()
+  {
+    return $this->deviceName;
+  }
+  public function setIndex($index)
+  {
+    $this->index = $index;
+  }
+  public function getIndex()
+  {
+    return $this->index;
+  }
+}
+
+class Google_Service_Manager_EnvVariable extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $hidden;
+  public $value;
+
+
+  public function setHidden($hidden)
+  {
+    $this->hidden = $hidden;
+  }
+  public function getHidden()
+  {
+    return $this->hidden;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Manager_ExistingDisk extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $attachmentType = 'Google_Service_Manager_DiskAttachment';
+  protected $attachmentDataType = '';
+  public $source;
+
+
+  public function setAttachment(Google_Service_Manager_DiskAttachment $attachment)
+  {
+    $this->attachment = $attachment;
+  }
+  public function getAttachment()
+  {
+    return $this->attachment;
+  }
+  public function setSource($source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+}
+
+class Google_Service_Manager_FirewallModule extends Google_Collection
+{
+  protected $collection_key = 'targetTags';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $allowedType = 'Google_Service_Manager_AllowedRule';
+  protected $allowedDataType = 'array';
+  public $description;
+  public $network;
+  public $sourceRanges;
+  public $sourceTags;
+  public $targetTags;
+
+
+  public function setAllowed($allowed)
+  {
+    $this->allowed = $allowed;
+  }
+  public function getAllowed()
+  {
+    return $this->allowed;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setNetwork($network)
+  {
+    $this->network = $network;
+  }
+  public function getNetwork()
+  {
+    return $this->network;
+  }
+  public function setSourceRanges($sourceRanges)
+  {
+    $this->sourceRanges = $sourceRanges;
+  }
+  public function getSourceRanges()
+  {
+    return $this->sourceRanges;
+  }
+  public function setSourceTags($sourceTags)
+  {
+    $this->sourceTags = $sourceTags;
+  }
+  public function getSourceTags()
+  {
+    return $this->sourceTags;
+  }
+  public function setTargetTags($targetTags)
+  {
+    $this->targetTags = $targetTags;
+  }
+  public function getTargetTags()
+  {
+    return $this->targetTags;
+  }
+}
+
+class Google_Service_Manager_FirewallModuleStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $firewallUrl;
+
+
+  public function setFirewallUrl($firewallUrl)
+  {
+    $this->firewallUrl = $firewallUrl;
+  }
+  public function getFirewallUrl()
+  {
+    return $this->firewallUrl;
+  }
+}
+
+class Google_Service_Manager_HealthCheckModule extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $checkIntervalSec;
+  public $description;
+  public $healthyThreshold;
+  public $host;
+  public $path;
+  public $port;
+  public $timeoutSec;
+  public $unhealthyThreshold;
+
+
+  public function setCheckIntervalSec($checkIntervalSec)
+  {
+    $this->checkIntervalSec = $checkIntervalSec;
+  }
+  public function getCheckIntervalSec()
+  {
+    return $this->checkIntervalSec;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setHealthyThreshold($healthyThreshold)
+  {
+    $this->healthyThreshold = $healthyThreshold;
+  }
+  public function getHealthyThreshold()
+  {
+    return $this->healthyThreshold;
+  }
+  public function setHost($host)
+  {
+    $this->host = $host;
+  }
+  public function getHost()
+  {
+    return $this->host;
+  }
+  public function setPath($path)
+  {
+    $this->path = $path;
+  }
+  public function getPath()
+  {
+    return $this->path;
+  }
+  public function setPort($port)
+  {
+    $this->port = $port;
+  }
+  public function getPort()
+  {
+    return $this->port;
+  }
+  public function setTimeoutSec($timeoutSec)
+  {
+    $this->timeoutSec = $timeoutSec;
+  }
+  public function getTimeoutSec()
+  {
+    return $this->timeoutSec;
+  }
+  public function setUnhealthyThreshold($unhealthyThreshold)
+  {
+    $this->unhealthyThreshold = $unhealthyThreshold;
+  }
+  public function getUnhealthyThreshold()
+  {
+    return $this->unhealthyThreshold;
+  }
+}
+
+class Google_Service_Manager_HealthCheckModuleStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $healthCheckUrl;
+
+
+  public function setHealthCheckUrl($healthCheckUrl)
+  {
+    $this->healthCheckUrl = $healthCheckUrl;
+  }
+  public function getHealthCheckUrl()
+  {
+    return $this->healthCheckUrl;
+  }
+}
+
+class Google_Service_Manager_LbModule extends Google_Collection
+{
+  protected $collection_key = 'targetModules';
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $healthChecks;
+  public $ipAddress;
+  public $ipProtocol;
+  public $portRange;
+  public $sessionAffinity;
+  public $targetModules;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setHealthChecks($healthChecks)
+  {
+    $this->healthChecks = $healthChecks;
+  }
+  public function getHealthChecks()
+  {
+    return $this->healthChecks;
+  }
+  public function setIpAddress($ipAddress)
+  {
+    $this->ipAddress = $ipAddress;
+  }
+  public function getIpAddress()
+  {
+    return $this->ipAddress;
+  }
+  public function setIpProtocol($ipProtocol)
+  {
+    $this->ipProtocol = $ipProtocol;
+  }
+  public function getIpProtocol()
+  {
+    return $this->ipProtocol;
+  }
+  public function setPortRange($portRange)
+  {
+    $this->portRange = $portRange;
+  }
+  public function getPortRange()
+  {
+    return $this->portRange;
+  }
+  public function setSessionAffinity($sessionAffinity)
+  {
+    $this->sessionAffinity = $sessionAffinity;
+  }
+  public function getSessionAffinity()
+  {
+    return $this->sessionAffinity;
+  }
+  public function setTargetModules($targetModules)
+  {
+    $this->targetModules = $targetModules;
+  }
+  public function getTargetModules()
+  {
+    return $this->targetModules;
+  }
+}
+
+class Google_Service_Manager_LbModuleStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $forwardingRuleUrl;
+  public $targetPoolUrl;
+
+
+  public function setForwardingRuleUrl($forwardingRuleUrl)
+  {
+    $this->forwardingRuleUrl = $forwardingRuleUrl;
+  }
+  public function getForwardingRuleUrl()
+  {
+    return $this->forwardingRuleUrl;
+  }
+  public function setTargetPoolUrl($targetPoolUrl)
+  {
+    $this->targetPoolUrl = $targetPoolUrl;
+  }
+  public function getTargetPoolUrl()
+  {
+    return $this->targetPoolUrl;
+  }
+}
+
+class Google_Service_Manager_Metadata extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $fingerPrint;
+  protected $itemsType = 'Google_Service_Manager_MetadataItem';
+  protected $itemsDataType = 'array';
+
+
+  public function setFingerPrint($fingerPrint)
+  {
+    $this->fingerPrint = $fingerPrint;
+  }
+  public function getFingerPrint()
+  {
+    return $this->fingerPrint;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+}
+
+class Google_Service_Manager_MetadataItem extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Manager_Module extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $autoscalingModuleType = 'Google_Service_Manager_AutoscalingModule';
+  protected $autoscalingModuleDataType = '';
+  protected $firewallModuleType = 'Google_Service_Manager_FirewallModule';
+  protected $firewallModuleDataType = '';
+  protected $healthCheckModuleType = 'Google_Service_Manager_HealthCheckModule';
+  protected $healthCheckModuleDataType = '';
+  protected $lbModuleType = 'Google_Service_Manager_LbModule';
+  protected $lbModuleDataType = '';
+  protected $networkModuleType = 'Google_Service_Manager_NetworkModule';
+  protected $networkModuleDataType = '';
+  protected $replicaPoolModuleType = 'Google_Service_Manager_ReplicaPoolModule';
+  protected $replicaPoolModuleDataType = '';
+  public $type;
+
+
+  public function setAutoscalingModule(Google_Service_Manager_AutoscalingModule $autoscalingModule)
+  {
+    $this->autoscalingModule = $autoscalingModule;
+  }
+  public function getAutoscalingModule()
+  {
+    return $this->autoscalingModule;
+  }
+  public function setFirewallModule(Google_Service_Manager_FirewallModule $firewallModule)
+  {
+    $this->firewallModule = $firewallModule;
+  }
+  public function getFirewallModule()
+  {
+    return $this->firewallModule;
+  }
+  public function setHealthCheckModule(Google_Service_Manager_HealthCheckModule $healthCheckModule)
+  {
+    $this->healthCheckModule = $healthCheckModule;
+  }
+  public function getHealthCheckModule()
+  {
+    return $this->healthCheckModule;
+  }
+  public function setLbModule(Google_Service_Manager_LbModule $lbModule)
+  {
+    $this->lbModule = $lbModule;
+  }
+  public function getLbModule()
+  {
+    return $this->lbModule;
+  }
+  public function setNetworkModule(Google_Service_Manager_NetworkModule $networkModule)
+  {
+    $this->networkModule = $networkModule;
+  }
+  public function getNetworkModule()
+  {
+    return $this->networkModule;
+  }
+  public function setReplicaPoolModule(Google_Service_Manager_ReplicaPoolModule $replicaPoolModule)
+  {
+    $this->replicaPoolModule = $replicaPoolModule;
+  }
+  public function getReplicaPoolModule()
+  {
+    return $this->replicaPoolModule;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Manager_ModuleStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $autoscalingModuleStatusType = 'Google_Service_Manager_AutoscalingModuleStatus';
+  protected $autoscalingModuleStatusDataType = '';
+  protected $firewallModuleStatusType = 'Google_Service_Manager_FirewallModuleStatus';
+  protected $firewallModuleStatusDataType = '';
+  protected $healthCheckModuleStatusType = 'Google_Service_Manager_HealthCheckModuleStatus';
+  protected $healthCheckModuleStatusDataType = '';
+  protected $lbModuleStatusType = 'Google_Service_Manager_LbModuleStatus';
+  protected $lbModuleStatusDataType = '';
+  protected $networkModuleStatusType = 'Google_Service_Manager_NetworkModuleStatus';
+  protected $networkModuleStatusDataType = '';
+  protected $replicaPoolModuleStatusType = 'Google_Service_Manager_ReplicaPoolModuleStatus';
+  protected $replicaPoolModuleStatusDataType = '';
+  protected $stateType = 'Google_Service_Manager_DeployState';
+  protected $stateDataType = '';
+  public $type;
+
+
+  public function setAutoscalingModuleStatus(Google_Service_Manager_AutoscalingModuleStatus $autoscalingModuleStatus)
+  {
+    $this->autoscalingModuleStatus = $autoscalingModuleStatus;
+  }
+  public function getAutoscalingModuleStatus()
+  {
+    return $this->autoscalingModuleStatus;
+  }
+  public function setFirewallModuleStatus(Google_Service_Manager_FirewallModuleStatus $firewallModuleStatus)
+  {
+    $this->firewallModuleStatus = $firewallModuleStatus;
+  }
+  public function getFirewallModuleStatus()
+  {
+    return $this->firewallModuleStatus;
+  }
+  public function setHealthCheckModuleStatus(Google_Service_Manager_HealthCheckModuleStatus $healthCheckModuleStatus)
+  {
+    $this->healthCheckModuleStatus = $healthCheckModuleStatus;
+  }
+  public function getHealthCheckModuleStatus()
+  {
+    return $this->healthCheckModuleStatus;
+  }
+  public function setLbModuleStatus(Google_Service_Manager_LbModuleStatus $lbModuleStatus)
+  {
+    $this->lbModuleStatus = $lbModuleStatus;
+  }
+  public function getLbModuleStatus()
+  {
+    return $this->lbModuleStatus;
+  }
+  public function setNetworkModuleStatus(Google_Service_Manager_NetworkModuleStatus $networkModuleStatus)
+  {
+    $this->networkModuleStatus = $networkModuleStatus;
+  }
+  public function getNetworkModuleStatus()
+  {
+    return $this->networkModuleStatus;
+  }
+  public function setReplicaPoolModuleStatus(Google_Service_Manager_ReplicaPoolModuleStatus $replicaPoolModuleStatus)
+  {
+    $this->replicaPoolModuleStatus = $replicaPoolModuleStatus;
+  }
+  public function getReplicaPoolModuleStatus()
+  {
+    return $this->replicaPoolModuleStatus;
+  }
+  public function setState(Google_Service_Manager_DeployState $state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Manager_NetworkInterface extends Google_Collection
+{
+  protected $collection_key = 'accessConfigs';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accessConfigsType = 'Google_Service_Manager_AccessConfig';
+  protected $accessConfigsDataType = 'array';
+  public $name;
+  public $network;
+  public $networkIp;
+
+
+  public function setAccessConfigs($accessConfigs)
+  {
+    $this->accessConfigs = $accessConfigs;
+  }
+  public function getAccessConfigs()
+  {
+    return $this->accessConfigs;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNetwork($network)
+  {
+    $this->network = $network;
+  }
+  public function getNetwork()
+  {
+    return $this->network;
+  }
+  public function setNetworkIp($networkIp)
+  {
+    $this->networkIp = $networkIp;
+  }
+  public function getNetworkIp()
+  {
+    return $this->networkIp;
+  }
+}
+
+class Google_Service_Manager_NetworkModule extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "iPv4Range" => "IPv4Range",
+  );
+  public $iPv4Range;
+  public $description;
+  public $gatewayIPv4;
+
+
+  public function setIPv4Range($iPv4Range)
+  {
+    $this->iPv4Range = $iPv4Range;
+  }
+  public function getIPv4Range()
+  {
+    return $this->iPv4Range;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setGatewayIPv4($gatewayIPv4)
+  {
+    $this->gatewayIPv4 = $gatewayIPv4;
+  }
+  public function getGatewayIPv4()
+  {
+    return $this->gatewayIPv4;
+  }
+}
+
+class Google_Service_Manager_NetworkModuleStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $networkUrl;
+
+
+  public function setNetworkUrl($networkUrl)
+  {
+    $this->networkUrl = $networkUrl;
+  }
+  public function getNetworkUrl()
+  {
+    return $this->networkUrl;
+  }
+}
+
+class Google_Service_Manager_NewDisk extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $attachmentType = 'Google_Service_Manager_DiskAttachment';
+  protected $attachmentDataType = '';
+  public $autoDelete;
+  public $boot;
+  protected $initializeParamsType = 'Google_Service_Manager_NewDiskInitializeParams';
+  protected $initializeParamsDataType = '';
+
+
+  public function setAttachment(Google_Service_Manager_DiskAttachment $attachment)
+  {
+    $this->attachment = $attachment;
+  }
+  public function getAttachment()
+  {
+    return $this->attachment;
+  }
+  public function setAutoDelete($autoDelete)
+  {
+    $this->autoDelete = $autoDelete;
+  }
+  public function getAutoDelete()
+  {
+    return $this->autoDelete;
+  }
+  public function setBoot($boot)
+  {
+    $this->boot = $boot;
+  }
+  public function getBoot()
+  {
+    return $this->boot;
+  }
+  public function setInitializeParams(Google_Service_Manager_NewDiskInitializeParams $initializeParams)
+  {
+    $this->initializeParams = $initializeParams;
+  }
+  public function getInitializeParams()
+  {
+    return $this->initializeParams;
+  }
+}
+
+class Google_Service_Manager_NewDiskInitializeParams extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $diskSizeGb;
+  public $diskType;
+  public $sourceImage;
+
+
+  public function setDiskSizeGb($diskSizeGb)
+  {
+    $this->diskSizeGb = $diskSizeGb;
+  }
+  public function getDiskSizeGb()
+  {
+    return $this->diskSizeGb;
+  }
+  public function setDiskType($diskType)
+  {
+    $this->diskType = $diskType;
+  }
+  public function getDiskType()
+  {
+    return $this->diskType;
+  }
+  public function setSourceImage($sourceImage)
+  {
+    $this->sourceImage = $sourceImage;
+  }
+  public function getSourceImage()
+  {
+    return $this->sourceImage;
+  }
+}
+
+class Google_Service_Manager_ParamOverride extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $path;
+  public $value;
+
+
+  public function setPath($path)
+  {
+    $this->path = $path;
+  }
+  public function getPath()
+  {
+    return $this->path;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Manager_ReplicaPoolModule extends Google_Collection
+{
+  protected $collection_key = 'healthChecks';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $envVariablesType = 'Google_Service_Manager_EnvVariable';
+  protected $envVariablesDataType = 'map';
+  public $healthChecks;
+  public $numReplicas;
+  protected $replicaPoolParamsType = 'Google_Service_Manager_ReplicaPoolParams';
+  protected $replicaPoolParamsDataType = '';
+  public $resourceView;
+
+
+  public function setEnvVariables($envVariables)
+  {
+    $this->envVariables = $envVariables;
+  }
+  public function getEnvVariables()
+  {
+    return $this->envVariables;
+  }
+  public function setHealthChecks($healthChecks)
+  {
+    $this->healthChecks = $healthChecks;
+  }
+  public function getHealthChecks()
+  {
+    return $this->healthChecks;
+  }
+  public function setNumReplicas($numReplicas)
+  {
+    $this->numReplicas = $numReplicas;
+  }
+  public function getNumReplicas()
+  {
+    return $this->numReplicas;
+  }
+  public function setReplicaPoolParams(Google_Service_Manager_ReplicaPoolParams $replicaPoolParams)
+  {
+    $this->replicaPoolParams = $replicaPoolParams;
+  }
+  public function getReplicaPoolParams()
+  {
+    return $this->replicaPoolParams;
+  }
+  public function setResourceView($resourceView)
+  {
+    $this->resourceView = $resourceView;
+  }
+  public function getResourceView()
+  {
+    return $this->resourceView;
+  }
+}
+
+class Google_Service_Manager_ReplicaPoolModuleEnvVariables extends Google_Model
+{
+}
+
+class Google_Service_Manager_ReplicaPoolModuleStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $replicaPoolUrl;
+  public $resourceViewUrl;
+
+
+  public function setReplicaPoolUrl($replicaPoolUrl)
+  {
+    $this->replicaPoolUrl = $replicaPoolUrl;
+  }
+  public function getReplicaPoolUrl()
+  {
+    return $this->replicaPoolUrl;
+  }
+  public function setResourceViewUrl($resourceViewUrl)
+  {
+    $this->resourceViewUrl = $resourceViewUrl;
+  }
+  public function getResourceViewUrl()
+  {
+    return $this->resourceViewUrl;
+  }
+}
+
+class Google_Service_Manager_ReplicaPoolParams extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $v1beta1Type = 'Google_Service_Manager_ReplicaPoolParamsV1Beta1';
+  protected $v1beta1DataType = '';
+
+
+  public function setV1beta1(Google_Service_Manager_ReplicaPoolParamsV1Beta1 $v1beta1)
+  {
+    $this->v1beta1 = $v1beta1;
+  }
+  public function getV1beta1()
+  {
+    return $this->v1beta1;
+  }
+}
+
+class Google_Service_Manager_ReplicaPoolParamsV1Beta1 extends Google_Collection
+{
+  protected $collection_key = 'serviceAccounts';
+  protected $internal_gapi_mappings = array(
+  );
+  public $autoRestart;
+  public $baseInstanceName;
+  public $canIpForward;
+  public $description;
+  protected $disksToAttachType = 'Google_Service_Manager_ExistingDisk';
+  protected $disksToAttachDataType = 'array';
+  protected $disksToCreateType = 'Google_Service_Manager_NewDisk';
+  protected $disksToCreateDataType = 'array';
+  public $initAction;
+  public $machineType;
+  protected $metadataType = 'Google_Service_Manager_Metadata';
+  protected $metadataDataType = '';
+  protected $networkInterfacesType = 'Google_Service_Manager_NetworkInterface';
+  protected $networkInterfacesDataType = 'array';
+  public $onHostMaintenance;
+  protected $serviceAccountsType = 'Google_Service_Manager_ServiceAccount';
+  protected $serviceAccountsDataType = 'array';
+  protected $tagsType = 'Google_Service_Manager_Tag';
+  protected $tagsDataType = '';
+  public $zone;
+
+
+  public function setAutoRestart($autoRestart)
+  {
+    $this->autoRestart = $autoRestart;
+  }
+  public function getAutoRestart()
+  {
+    return $this->autoRestart;
+  }
+  public function setBaseInstanceName($baseInstanceName)
+  {
+    $this->baseInstanceName = $baseInstanceName;
+  }
+  public function getBaseInstanceName()
+  {
+    return $this->baseInstanceName;
+  }
+  public function setCanIpForward($canIpForward)
+  {
+    $this->canIpForward = $canIpForward;
+  }
+  public function getCanIpForward()
+  {
+    return $this->canIpForward;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDisksToAttach($disksToAttach)
+  {
+    $this->disksToAttach = $disksToAttach;
+  }
+  public function getDisksToAttach()
+  {
+    return $this->disksToAttach;
+  }
+  public function setDisksToCreate($disksToCreate)
+  {
+    $this->disksToCreate = $disksToCreate;
+  }
+  public function getDisksToCreate()
+  {
+    return $this->disksToCreate;
+  }
+  public function setInitAction($initAction)
+  {
+    $this->initAction = $initAction;
+  }
+  public function getInitAction()
+  {
+    return $this->initAction;
+  }
+  public function setMachineType($machineType)
+  {
+    $this->machineType = $machineType;
+  }
+  public function getMachineType()
+  {
+    return $this->machineType;
+  }
+  public function setMetadata(Google_Service_Manager_Metadata $metadata)
+  {
+    $this->metadata = $metadata;
+  }
+  public function getMetadata()
+  {
+    return $this->metadata;
+  }
+  public function setNetworkInterfaces($networkInterfaces)
+  {
+    $this->networkInterfaces = $networkInterfaces;
+  }
+  public function getNetworkInterfaces()
+  {
+    return $this->networkInterfaces;
+  }
+  public function setOnHostMaintenance($onHostMaintenance)
+  {
+    $this->onHostMaintenance = $onHostMaintenance;
+  }
+  public function getOnHostMaintenance()
+  {
+    return $this->onHostMaintenance;
+  }
+  public function setServiceAccounts($serviceAccounts)
+  {
+    $this->serviceAccounts = $serviceAccounts;
+  }
+  public function getServiceAccounts()
+  {
+    return $this->serviceAccounts;
+  }
+  public function setTags(Google_Service_Manager_Tag $tags)
+  {
+    $this->tags = $tags;
+  }
+  public function getTags()
+  {
+    return $this->tags;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_Manager_ServiceAccount extends Google_Collection
+{
+  protected $collection_key = 'scopes';
+  protected $internal_gapi_mappings = array(
+  );
+  public $email;
+  public $scopes;
+
+
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setScopes($scopes)
+  {
+    $this->scopes = $scopes;
+  }
+  public function getScopes()
+  {
+    return $this->scopes;
+  }
+}
+
+class Google_Service_Manager_Tag extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $fingerPrint;
+  public $items;
+
+
+  public function setFingerPrint($fingerPrint)
+  {
+    $this->fingerPrint = $fingerPrint;
+  }
+  public function getFingerPrint()
+  {
+    return $this->fingerPrint;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+}
+
+class Google_Service_Manager_Template extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $actionsType = 'Google_Service_Manager_Action';
+  protected $actionsDataType = 'map';
+  public $description;
+  protected $modulesType = 'Google_Service_Manager_Module';
+  protected $modulesDataType = 'map';
+  public $name;
+
+
+  public function setActions($actions)
+  {
+    $this->actions = $actions;
+  }
+  public function getActions()
+  {
+    return $this->actions;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setModules($modules)
+  {
+    $this->modules = $modules;
+  }
+  public function getModules()
+  {
+    return $this->modules;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Manager_TemplateActions extends Google_Model
+{
+}
+
+class Google_Service_Manager_TemplateModules extends Google_Model
+{
+}
+
+class Google_Service_Manager_TemplatesListResponse extends Google_Collection
+{
+  protected $collection_key = 'resources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $resourcesType = 'Google_Service_Manager_Template';
+  protected $resourcesDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setResources($resources)
+  {
+    $this->resources = $resources;
+  }
+  public function getResources()
+  {
+    return $this->resources;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/MapsEngine.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/MapsEngine.php
@@ -1,0 +1,6421 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for MapsEngine (v1).
+ *
+ * <p>
+ * The Google Maps Engine API allows developers to store and query geospatial
+ * vector and raster data.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/maps-engine/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_MapsEngine extends Google_Service
+{
+  /** View and manage your Google My Maps data. */
+  const MAPSENGINE =
+      "https://www.googleapis.com/auth/mapsengine";
+  /** View your Google My Maps data. */
+  const MAPSENGINE_READONLY =
+      "https://www.googleapis.com/auth/mapsengine.readonly";
+
+  public $assets;
+  public $assets_parents;
+  public $assets_permissions;
+  public $layers;
+  public $layers_parents;
+  public $layers_permissions;
+  public $maps;
+  public $maps_permissions;
+  public $projects;
+  public $projects_icons;
+  public $rasterCollections;
+  public $rasterCollections_parents;
+  public $rasterCollections_permissions;
+  public $rasterCollections_rasters;
+  public $rasters;
+  public $rasters_files;
+  public $rasters_parents;
+  public $rasters_permissions;
+  public $tables;
+  public $tables_features;
+  public $tables_files;
+  public $tables_parents;
+  public $tables_permissions;
+  
+
+  /**
+   * Constructs the internal representation of the MapsEngine service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'mapsengine/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'mapsengine';
+
+    $this->assets = new Google_Service_MapsEngine_Assets_Resource(
+        $this,
+        $this->serviceName,
+        'assets',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'assets/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'assets',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'modifiedAfter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'createdAfter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'tags' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projectId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'search' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'creatorEmail' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'bbox' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'modifiedBefore' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'createdBefore' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'role' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'type' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->assets_parents = new Google_Service_MapsEngine_AssetsParents_Resource(
+        $this,
+        $this->serviceName,
+        'parents',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'assets/{id}/parents',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->assets_permissions = new Google_Service_MapsEngine_AssetsPermissions_Resource(
+        $this,
+        $this->serviceName,
+        'permissions',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'assets/{id}/permissions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->layers = new Google_Service_MapsEngine_Layers_Resource(
+        $this,
+        $this->serviceName,
+        'layers',
+        array(
+          'methods' => array(
+            'cancelProcessing' => array(
+              'path' => 'layers/{id}/cancelProcessing',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'create' => array(
+              'path' => 'layers',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'process' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'layers/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'layers/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'version' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'getPublished' => array(
+              'path' => 'layers/{id}/published',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'layers',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'modifiedAfter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'createdAfter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'processingStatus' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projectId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'tags' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'search' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'creatorEmail' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'bbox' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'modifiedBefore' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'createdBefore' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'role' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'listPublished' => array(
+              'path' => 'layers/published',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'projectId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'layers/{id}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'process' => array(
+              'path' => 'layers/{id}/process',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'publish' => array(
+              'path' => 'layers/{id}/publish',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'force' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'unpublish' => array(
+              'path' => 'layers/{id}/unpublish',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->layers_parents = new Google_Service_MapsEngine_LayersParents_Resource(
+        $this,
+        $this->serviceName,
+        'parents',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'layers/{id}/parents',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->layers_permissions = new Google_Service_MapsEngine_LayersPermissions_Resource(
+        $this,
+        $this->serviceName,
+        'permissions',
+        array(
+          'methods' => array(
+            'batchDelete' => array(
+              'path' => 'layers/{id}/permissions/batchDelete',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'batchUpdate' => array(
+              'path' => 'layers/{id}/permissions/batchUpdate',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'layers/{id}/permissions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->maps = new Google_Service_MapsEngine_Maps_Resource(
+        $this,
+        $this->serviceName,
+        'maps',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'maps',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'delete' => array(
+              'path' => 'maps/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'maps/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'version' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'getPublished' => array(
+              'path' => 'maps/{id}/published',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'maps',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'modifiedAfter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'createdAfter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'processingStatus' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projectId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'tags' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'search' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'creatorEmail' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'bbox' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'modifiedBefore' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'createdBefore' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'role' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'listPublished' => array(
+              'path' => 'maps/published',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'projectId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'maps/{id}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'publish' => array(
+              'path' => 'maps/{id}/publish',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'force' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'unpublish' => array(
+              'path' => 'maps/{id}/unpublish',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->maps_permissions = new Google_Service_MapsEngine_MapsPermissions_Resource(
+        $this,
+        $this->serviceName,
+        'permissions',
+        array(
+          'methods' => array(
+            'batchDelete' => array(
+              'path' => 'maps/{id}/permissions/batchDelete',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'batchUpdate' => array(
+              'path' => 'maps/{id}/permissions/batchUpdate',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'maps/{id}/permissions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->projects = new Google_Service_MapsEngine_Projects_Resource(
+        $this,
+        $this->serviceName,
+        'projects',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'projects',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->projects_icons = new Google_Service_MapsEngine_ProjectsIcons_Resource(
+        $this,
+        $this->serviceName,
+        'icons',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'projects/{projectId}/icons',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'projects/{projectId}/icons/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'projects/{projectId}/icons',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->rasterCollections = new Google_Service_MapsEngine_RasterCollections_Resource(
+        $this,
+        $this->serviceName,
+        'rasterCollections',
+        array(
+          'methods' => array(
+            'cancelProcessing' => array(
+              'path' => 'rasterCollections/{id}/cancelProcessing',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'create' => array(
+              'path' => 'rasterCollections',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'delete' => array(
+              'path' => 'rasterCollections/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'rasterCollections/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'rasterCollections',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'modifiedAfter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'createdAfter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'processingStatus' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projectId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'tags' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'search' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'creatorEmail' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'bbox' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'modifiedBefore' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'createdBefore' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'role' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'rasterCollections/{id}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'process' => array(
+              'path' => 'rasterCollections/{id}/process',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->rasterCollections_parents = new Google_Service_MapsEngine_RasterCollectionsParents_Resource(
+        $this,
+        $this->serviceName,
+        'parents',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'rasterCollections/{id}/parents',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->rasterCollections_permissions = new Google_Service_MapsEngine_RasterCollectionsPermissions_Resource(
+        $this,
+        $this->serviceName,
+        'permissions',
+        array(
+          'methods' => array(
+            'batchDelete' => array(
+              'path' => 'rasterCollections/{id}/permissions/batchDelete',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'batchUpdate' => array(
+              'path' => 'rasterCollections/{id}/permissions/batchUpdate',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'rasterCollections/{id}/permissions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->rasterCollections_rasters = new Google_Service_MapsEngine_RasterCollectionsRasters_Resource(
+        $this,
+        $this->serviceName,
+        'rasters',
+        array(
+          'methods' => array(
+            'batchDelete' => array(
+              'path' => 'rasterCollections/{id}/rasters/batchDelete',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'batchInsert' => array(
+              'path' => 'rasterCollections/{id}/rasters/batchInsert',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'rasterCollections/{id}/rasters',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'modifiedAfter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'createdAfter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'tags' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'search' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'creatorEmail' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'bbox' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'modifiedBefore' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'createdBefore' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'role' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->rasters = new Google_Service_MapsEngine_Rasters_Resource(
+        $this,
+        $this->serviceName,
+        'rasters',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'rasters/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'rasters/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'rasters',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'modifiedAfter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'createdAfter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'processingStatus' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'tags' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'search' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'creatorEmail' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'bbox' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'modifiedBefore' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'createdBefore' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'role' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'rasters/{id}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'process' => array(
+              'path' => 'rasters/{id}/process',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'upload' => array(
+              'path' => 'rasters/upload',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->rasters_files = new Google_Service_MapsEngine_RastersFiles_Resource(
+        $this,
+        $this->serviceName,
+        'files',
+        array(
+          'methods' => array(
+            'insert' => array(
+              'path' => 'rasters/{id}/files',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filename' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->rasters_parents = new Google_Service_MapsEngine_RastersParents_Resource(
+        $this,
+        $this->serviceName,
+        'parents',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'rasters/{id}/parents',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->rasters_permissions = new Google_Service_MapsEngine_RastersPermissions_Resource(
+        $this,
+        $this->serviceName,
+        'permissions',
+        array(
+          'methods' => array(
+            'batchDelete' => array(
+              'path' => 'rasters/{id}/permissions/batchDelete',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'batchUpdate' => array(
+              'path' => 'rasters/{id}/permissions/batchUpdate',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'rasters/{id}/permissions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->tables = new Google_Service_MapsEngine_Tables_Resource(
+        $this,
+        $this->serviceName,
+        'tables',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'tables',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'delete' => array(
+              'path' => 'tables/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'tables/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'version' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'tables',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'modifiedAfter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'createdAfter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'processingStatus' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projectId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'tags' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'search' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'creatorEmail' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'bbox' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'modifiedBefore' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'createdBefore' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'role' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'tables/{id}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'process' => array(
+              'path' => 'tables/{id}/process',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'upload' => array(
+              'path' => 'tables/upload',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->tables_features = new Google_Service_MapsEngine_TablesFeatures_Resource(
+        $this,
+        $this->serviceName,
+        'features',
+        array(
+          'methods' => array(
+            'batchDelete' => array(
+              'path' => 'tables/{id}/features/batchDelete',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'batchInsert' => array(
+              'path' => 'tables/{id}/features/batchInsert',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'batchPatch' => array(
+              'path' => 'tables/{id}/features/batchPatch',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'tables/{tableId}/features/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'tableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'version' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'select' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'tables/{id}/features',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'intersects' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'version' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'limit' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'include' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'where' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'select' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->tables_files = new Google_Service_MapsEngine_TablesFiles_Resource(
+        $this,
+        $this->serviceName,
+        'files',
+        array(
+          'methods' => array(
+            'insert' => array(
+              'path' => 'tables/{id}/files',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filename' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->tables_parents = new Google_Service_MapsEngine_TablesParents_Resource(
+        $this,
+        $this->serviceName,
+        'parents',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'tables/{id}/parents',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->tables_permissions = new Google_Service_MapsEngine_TablesPermissions_Resource(
+        $this,
+        $this->serviceName,
+        'permissions',
+        array(
+          'methods' => array(
+            'batchDelete' => array(
+              'path' => 'tables/{id}/permissions/batchDelete',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'batchUpdate' => array(
+              'path' => 'tables/{id}/permissions/batchUpdate',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'tables/{id}/permissions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "assets" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $assets = $mapsengineService->assets;
+ *  </code>
+ */
+class Google_Service_MapsEngine_Assets_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Return metadata for a particular asset. (assets.get)
+   *
+   * @param string $id The ID of the asset.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_Asset
+   */
+  public function get($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_MapsEngine_Asset");
+  }
+
+  /**
+   * Return all assets readable by the current user. (assets.listAssets)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string modifiedAfter An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been modified at or after
+   * this time.
+   * @opt_param string createdAfter An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been created at or after
+   * this time.
+   * @opt_param string tags A comma separated list of tags. Returned assets will
+   * contain all the tags from the list.
+   * @opt_param string projectId The ID of a Maps Engine project, used to filter
+   * the response. To list all available projects with their IDs, send a Projects:
+   * list request. You can also find your project ID as the value of the
+   * DashboardPlace:cid URL parameter when signed in to mapsengine.google.com.
+   * @opt_param string search An unstructured search string used to filter the set
+   * of results based on asset metadata.
+   * @opt_param string maxResults The maximum number of items to include in a
+   * single response page. The maximum supported value is 100.
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of nextPageToken from the previous response.
+   * @opt_param string creatorEmail An email address representing a user. Returned
+   * assets that have been created by the user associated with the provided email
+   * address.
+   * @opt_param string bbox A bounding box, expressed as "west,south,east,north".
+   * If set, only assets which intersect this bounding box will be returned.
+   * @opt_param string modifiedBefore An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been modified at or before
+   * this time.
+   * @opt_param string createdBefore An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been created at or before
+   * this time.
+   * @opt_param string role The role parameter indicates that the response should
+   * only contain assets where the current user has the specified level of access.
+   * @opt_param string type A comma separated list of asset types. Returned assets
+   * will have one of the types from the provided list. Supported values are
+   * 'map', 'layer', 'rasterCollection' and 'table'.
+   * @return Google_Service_MapsEngine_AssetsListResponse
+   */
+  public function listAssets($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_AssetsListResponse");
+  }
+}
+
+/**
+ * The "parents" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $parents = $mapsengineService->parents;
+ *  </code>
+ */
+class Google_Service_MapsEngine_AssetsParents_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Return all parent ids of the specified asset. (parents.listAssetsParents)
+   *
+   * @param string $id The ID of the asset whose parents will be listed.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of nextPageToken from the previous response.
+   * @opt_param string maxResults The maximum number of items to include in a
+   * single response page. The maximum supported value is 50.
+   * @return Google_Service_MapsEngine_ParentsListResponse
+   */
+  public function listAssetsParents($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_ParentsListResponse");
+  }
+}
+/**
+ * The "permissions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $permissions = $mapsengineService->permissions;
+ *  </code>
+ */
+class Google_Service_MapsEngine_AssetsPermissions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Return all of the permissions for the specified asset.
+   * (permissions.listAssetsPermissions)
+   *
+   * @param string $id The ID of the asset whose permissions will be listed.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PermissionsListResponse
+   */
+  public function listAssetsPermissions($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_PermissionsListResponse");
+  }
+}
+
+/**
+ * The "layers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $layers = $mapsengineService->layers;
+ *  </code>
+ */
+class Google_Service_MapsEngine_Layers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Cancel processing on a layer asset. (layers.cancelProcessing)
+   *
+   * @param string $id The ID of the layer.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_ProcessResponse
+   */
+  public function cancelProcessing($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('cancelProcessing', array($params), "Google_Service_MapsEngine_ProcessResponse");
+  }
+
+  /**
+   * Create a layer asset. (layers.create)
+   *
+   * @param Google_Layer $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool process Whether to queue the created layer for processing.
+   * @return Google_Service_MapsEngine_Layer
+   */
+  public function create(Google_Service_MapsEngine_Layer $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_MapsEngine_Layer");
+  }
+
+  /**
+   * Delete a layer. (layers.delete)
+   *
+   * @param string $id The ID of the layer. Only the layer creator or project
+   * owner are permitted to delete. If the layer is published, or included in a
+   * map, the request will fail. Unpublish the layer, and remove it from all maps
+   * prior to deleting.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Return metadata for a particular layer. (layers.get)
+   *
+   * @param string $id The ID of the layer.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string version Deprecated: The version parameter indicates which
+   * version of the layer should be returned. When version is set to published,
+   * the published version of the layer will be returned. Please use the
+   * layers.getPublished endpoint instead.
+   * @return Google_Service_MapsEngine_Layer
+   */
+  public function get($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_MapsEngine_Layer");
+  }
+
+  /**
+   * Return the published metadata for a particular layer. (layers.getPublished)
+   *
+   * @param string $id The ID of the layer.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PublishedLayer
+   */
+  public function getPublished($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('getPublished', array($params), "Google_Service_MapsEngine_PublishedLayer");
+  }
+
+  /**
+   * Return all layers readable by the current user. (layers.listLayers)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string modifiedAfter An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been modified at or after
+   * this time.
+   * @opt_param string createdAfter An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been created at or after
+   * this time.
+   * @opt_param string processingStatus
+   * @opt_param string projectId The ID of a Maps Engine project, used to filter
+   * the response. To list all available projects with their IDs, send a Projects:
+   * list request. You can also find your project ID as the value of the
+   * DashboardPlace:cid URL parameter when signed in to mapsengine.google.com.
+   * @opt_param string tags A comma separated list of tags. Returned assets will
+   * contain all the tags from the list.
+   * @opt_param string search An unstructured search string used to filter the set
+   * of results based on asset metadata.
+   * @opt_param string maxResults The maximum number of items to include in a
+   * single response page. The maximum supported value is 100.
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of nextPageToken from the previous response.
+   * @opt_param string creatorEmail An email address representing a user. Returned
+   * assets that have been created by the user associated with the provided email
+   * address.
+   * @opt_param string bbox A bounding box, expressed as "west,south,east,north".
+   * If set, only assets which intersect this bounding box will be returned.
+   * @opt_param string modifiedBefore An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been modified at or before
+   * this time.
+   * @opt_param string createdBefore An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been created at or before
+   * this time.
+   * @opt_param string role The role parameter indicates that the response should
+   * only contain assets where the current user has the specified level of access.
+   * @return Google_Service_MapsEngine_LayersListResponse
+   */
+  public function listLayers($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_LayersListResponse");
+  }
+
+  /**
+   * Return all published layers readable by the current user.
+   * (layers.listPublished)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of nextPageToken from the previous response.
+   * @opt_param string maxResults The maximum number of items to include in a
+   * single response page. The maximum supported value is 100.
+   * @opt_param string projectId The ID of a Maps Engine project, used to filter
+   * the response. To list all available projects with their IDs, send a Projects:
+   * list request. You can also find your project ID as the value of the
+   * DashboardPlace:cid URL parameter when signed in to mapsengine.google.com.
+   * @return Google_Service_MapsEngine_PublishedLayersListResponse
+   */
+  public function listPublished($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('listPublished', array($params), "Google_Service_MapsEngine_PublishedLayersListResponse");
+  }
+
+  /**
+   * Mutate a layer asset. (layers.patch)
+   *
+   * @param string $id The ID of the layer.
+   * @param Google_Layer $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function patch($id, Google_Service_MapsEngine_Layer $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params));
+  }
+
+  /**
+   * Process a layer asset. (layers.process)
+   *
+   * @param string $id The ID of the layer.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_ProcessResponse
+   */
+  public function process($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('process', array($params), "Google_Service_MapsEngine_ProcessResponse");
+  }
+
+  /**
+   * Publish a layer asset. (layers.publish)
+   *
+   * @param string $id The ID of the layer.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool force If set to true, the API will allow publication of the
+   * layer even if it's out of date. If not true, you'll need to reprocess any
+   * out-of-date layer before publishing.
+   * @return Google_Service_MapsEngine_PublishResponse
+   */
+  public function publish($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('publish', array($params), "Google_Service_MapsEngine_PublishResponse");
+  }
+
+  /**
+   * Unpublish a layer asset. (layers.unpublish)
+   *
+   * @param string $id The ID of the layer.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PublishResponse
+   */
+  public function unpublish($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('unpublish', array($params), "Google_Service_MapsEngine_PublishResponse");
+  }
+}
+
+/**
+ * The "parents" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $parents = $mapsengineService->parents;
+ *  </code>
+ */
+class Google_Service_MapsEngine_LayersParents_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Return all parent ids of the specified layer. (parents.listLayersParents)
+   *
+   * @param string $id The ID of the layer whose parents will be listed.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of nextPageToken from the previous response.
+   * @opt_param string maxResults The maximum number of items to include in a
+   * single response page. The maximum supported value is 50.
+   * @return Google_Service_MapsEngine_ParentsListResponse
+   */
+  public function listLayersParents($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_ParentsListResponse");
+  }
+}
+/**
+ * The "permissions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $permissions = $mapsengineService->permissions;
+ *  </code>
+ */
+class Google_Service_MapsEngine_LayersPermissions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Remove permission entries from an already existing asset.
+   * (permissions.batchDelete)
+   *
+   * @param string $id The ID of the asset from which permissions will be removed.
+   * @param Google_PermissionsBatchDeleteRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PermissionsBatchDeleteResponse
+   */
+  public function batchDelete($id, Google_Service_MapsEngine_PermissionsBatchDeleteRequest $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('batchDelete', array($params), "Google_Service_MapsEngine_PermissionsBatchDeleteResponse");
+  }
+
+  /**
+   * Add or update permission entries to an already existing asset.
+   *
+   * An asset can hold up to 20 different permission entries. Each batchInsert
+   * request is atomic. (permissions.batchUpdate)
+   *
+   * @param string $id The ID of the asset to which permissions will be added.
+   * @param Google_PermissionsBatchUpdateRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PermissionsBatchUpdateResponse
+   */
+  public function batchUpdate($id, Google_Service_MapsEngine_PermissionsBatchUpdateRequest $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('batchUpdate', array($params), "Google_Service_MapsEngine_PermissionsBatchUpdateResponse");
+  }
+
+  /**
+   * Return all of the permissions for the specified asset.
+   * (permissions.listLayersPermissions)
+   *
+   * @param string $id The ID of the asset whose permissions will be listed.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PermissionsListResponse
+   */
+  public function listLayersPermissions($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_PermissionsListResponse");
+  }
+}
+
+/**
+ * The "maps" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $maps = $mapsengineService->maps;
+ *  </code>
+ */
+class Google_Service_MapsEngine_Maps_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Create a map asset. (maps.create)
+   *
+   * @param Google_Map $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_Map
+   */
+  public function create(Google_Service_MapsEngine_Map $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_MapsEngine_Map");
+  }
+
+  /**
+   * Delete a map. (maps.delete)
+   *
+   * @param string $id The ID of the map. Only the map creator or project owner
+   * are permitted to delete. If the map is published the request will fail.
+   * Unpublish the map prior to deleting.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Return metadata for a particular map. (maps.get)
+   *
+   * @param string $id The ID of the map.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string version Deprecated: The version parameter indicates which
+   * version of the map should be returned. When version is set to published, the
+   * published version of the map will be returned. Please use the
+   * maps.getPublished endpoint instead.
+   * @return Google_Service_MapsEngine_Map
+   */
+  public function get($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_MapsEngine_Map");
+  }
+
+  /**
+   * Return the published metadata for a particular map. (maps.getPublished)
+   *
+   * @param string $id The ID of the map.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PublishedMap
+   */
+  public function getPublished($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('getPublished', array($params), "Google_Service_MapsEngine_PublishedMap");
+  }
+
+  /**
+   * Return all maps readable by the current user. (maps.listMaps)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string modifiedAfter An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been modified at or after
+   * this time.
+   * @opt_param string createdAfter An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been created at or after
+   * this time.
+   * @opt_param string processingStatus
+   * @opt_param string projectId The ID of a Maps Engine project, used to filter
+   * the response. To list all available projects with their IDs, send a Projects:
+   * list request. You can also find your project ID as the value of the
+   * DashboardPlace:cid URL parameter when signed in to mapsengine.google.com.
+   * @opt_param string tags A comma separated list of tags. Returned assets will
+   * contain all the tags from the list.
+   * @opt_param string search An unstructured search string used to filter the set
+   * of results based on asset metadata.
+   * @opt_param string maxResults The maximum number of items to include in a
+   * single response page. The maximum supported value is 100.
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of nextPageToken from the previous response.
+   * @opt_param string creatorEmail An email address representing a user. Returned
+   * assets that have been created by the user associated with the provided email
+   * address.
+   * @opt_param string bbox A bounding box, expressed as "west,south,east,north".
+   * If set, only assets which intersect this bounding box will be returned.
+   * @opt_param string modifiedBefore An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been modified at or before
+   * this time.
+   * @opt_param string createdBefore An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been created at or before
+   * this time.
+   * @opt_param string role The role parameter indicates that the response should
+   * only contain assets where the current user has the specified level of access.
+   * @return Google_Service_MapsEngine_MapsListResponse
+   */
+  public function listMaps($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_MapsListResponse");
+  }
+
+  /**
+   * Return all published maps readable by the current user. (maps.listPublished)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of nextPageToken from the previous response.
+   * @opt_param string maxResults The maximum number of items to include in a
+   * single response page. The maximum supported value is 100.
+   * @opt_param string projectId The ID of a Maps Engine project, used to filter
+   * the response. To list all available projects with their IDs, send a Projects:
+   * list request. You can also find your project ID as the value of the
+   * DashboardPlace:cid URL parameter when signed in to mapsengine.google.com.
+   * @return Google_Service_MapsEngine_PublishedMapsListResponse
+   */
+  public function listPublished($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('listPublished', array($params), "Google_Service_MapsEngine_PublishedMapsListResponse");
+  }
+
+  /**
+   * Mutate a map asset. (maps.patch)
+   *
+   * @param string $id The ID of the map.
+   * @param Google_Map $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function patch($id, Google_Service_MapsEngine_Map $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params));
+  }
+
+  /**
+   * Publish a map asset. (maps.publish)
+   *
+   * @param string $id The ID of the map.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool force If set to true, the API will allow publication of the
+   * map even if it's out of date. If false, the map must have a processingStatus
+   * of complete before publishing.
+   * @return Google_Service_MapsEngine_PublishResponse
+   */
+  public function publish($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('publish', array($params), "Google_Service_MapsEngine_PublishResponse");
+  }
+
+  /**
+   * Unpublish a map asset. (maps.unpublish)
+   *
+   * @param string $id The ID of the map.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PublishResponse
+   */
+  public function unpublish($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('unpublish', array($params), "Google_Service_MapsEngine_PublishResponse");
+  }
+}
+
+/**
+ * The "permissions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $permissions = $mapsengineService->permissions;
+ *  </code>
+ */
+class Google_Service_MapsEngine_MapsPermissions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Remove permission entries from an already existing asset.
+   * (permissions.batchDelete)
+   *
+   * @param string $id The ID of the asset from which permissions will be removed.
+   * @param Google_PermissionsBatchDeleteRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PermissionsBatchDeleteResponse
+   */
+  public function batchDelete($id, Google_Service_MapsEngine_PermissionsBatchDeleteRequest $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('batchDelete', array($params), "Google_Service_MapsEngine_PermissionsBatchDeleteResponse");
+  }
+
+  /**
+   * Add or update permission entries to an already existing asset.
+   *
+   * An asset can hold up to 20 different permission entries. Each batchInsert
+   * request is atomic. (permissions.batchUpdate)
+   *
+   * @param string $id The ID of the asset to which permissions will be added.
+   * @param Google_PermissionsBatchUpdateRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PermissionsBatchUpdateResponse
+   */
+  public function batchUpdate($id, Google_Service_MapsEngine_PermissionsBatchUpdateRequest $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('batchUpdate', array($params), "Google_Service_MapsEngine_PermissionsBatchUpdateResponse");
+  }
+
+  /**
+   * Return all of the permissions for the specified asset.
+   * (permissions.listMapsPermissions)
+   *
+   * @param string $id The ID of the asset whose permissions will be listed.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PermissionsListResponse
+   */
+  public function listMapsPermissions($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_PermissionsListResponse");
+  }
+}
+
+/**
+ * The "projects" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $projects = $mapsengineService->projects;
+ *  </code>
+ */
+class Google_Service_MapsEngine_Projects_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Return all projects readable by the current user. (projects.listProjects)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_ProjectsListResponse
+   */
+  public function listProjects($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_ProjectsListResponse");
+  }
+}
+
+/**
+ * The "icons" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $icons = $mapsengineService->icons;
+ *  </code>
+ */
+class Google_Service_MapsEngine_ProjectsIcons_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Create an icon. (icons.create)
+   *
+   * @param string $projectId The ID of the project.
+   * @param Google_Icon $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_Icon
+   */
+  public function create($projectId, Google_Service_MapsEngine_Icon $postBody, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_MapsEngine_Icon");
+  }
+
+  /**
+   * Return an icon or its associated metadata (icons.get)
+   *
+   * @param string $projectId The ID of the project.
+   * @param string $id The ID of the icon.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_Icon
+   */
+  public function get($projectId, $id, $optParams = array())
+  {
+    $params = array('projectId' => $projectId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_MapsEngine_Icon");
+  }
+
+  /**
+   * Return all icons in the current project (icons.listProjectsIcons)
+   *
+   * @param string $projectId The ID of the project.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of nextPageToken from the previous response.
+   * @opt_param string maxResults The maximum number of items to include in a
+   * single response page. The maximum supported value is 50.
+   * @return Google_Service_MapsEngine_IconsListResponse
+   */
+  public function listProjectsIcons($projectId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_IconsListResponse");
+  }
+}
+
+/**
+ * The "rasterCollections" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $rasterCollections = $mapsengineService->rasterCollections;
+ *  </code>
+ */
+class Google_Service_MapsEngine_RasterCollections_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Cancel processing on a raster collection asset.
+   * (rasterCollections.cancelProcessing)
+   *
+   * @param string $id The ID of the raster collection.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_ProcessResponse
+   */
+  public function cancelProcessing($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('cancelProcessing', array($params), "Google_Service_MapsEngine_ProcessResponse");
+  }
+
+  /**
+   * Create a raster collection asset. (rasterCollections.create)
+   *
+   * @param Google_RasterCollection $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_RasterCollection
+   */
+  public function create(Google_Service_MapsEngine_RasterCollection $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_MapsEngine_RasterCollection");
+  }
+
+  /**
+   * Delete a raster collection. (rasterCollections.delete)
+   *
+   * @param string $id The ID of the raster collection. Only the raster collection
+   * creator or project owner are permitted to delete. If the rastor collection is
+   * included in a layer, the request will fail. Remove the raster collection from
+   * all layers prior to deleting.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Return metadata for a particular raster collection. (rasterCollections.get)
+   *
+   * @param string $id The ID of the raster collection.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_RasterCollection
+   */
+  public function get($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_MapsEngine_RasterCollection");
+  }
+
+  /**
+   * Return all raster collections readable by the current user.
+   * (rasterCollections.listRasterCollections)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string modifiedAfter An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been modified at or after
+   * this time.
+   * @opt_param string createdAfter An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been created at or after
+   * this time.
+   * @opt_param string processingStatus
+   * @opt_param string projectId The ID of a Maps Engine project, used to filter
+   * the response. To list all available projects with their IDs, send a Projects:
+   * list request. You can also find your project ID as the value of the
+   * DashboardPlace:cid URL parameter when signed in to mapsengine.google.com.
+   * @opt_param string tags A comma separated list of tags. Returned assets will
+   * contain all the tags from the list.
+   * @opt_param string search An unstructured search string used to filter the set
+   * of results based on asset metadata.
+   * @opt_param string maxResults The maximum number of items to include in a
+   * single response page. The maximum supported value is 100.
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of nextPageToken from the previous response.
+   * @opt_param string creatorEmail An email address representing a user. Returned
+   * assets that have been created by the user associated with the provided email
+   * address.
+   * @opt_param string bbox A bounding box, expressed as "west,south,east,north".
+   * If set, only assets which intersect this bounding box will be returned.
+   * @opt_param string modifiedBefore An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been modified at or before
+   * this time.
+   * @opt_param string createdBefore An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been created at or before
+   * this time.
+   * @opt_param string role The role parameter indicates that the response should
+   * only contain assets where the current user has the specified level of access.
+   * @return Google_Service_MapsEngine_RasterCollectionsListResponse
+   */
+  public function listRasterCollections($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_RasterCollectionsListResponse");
+  }
+
+  /**
+   * Mutate a raster collection asset. (rasterCollections.patch)
+   *
+   * @param string $id The ID of the raster collection.
+   * @param Google_RasterCollection $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function patch($id, Google_Service_MapsEngine_RasterCollection $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params));
+  }
+
+  /**
+   * Process a raster collection asset. (rasterCollections.process)
+   *
+   * @param string $id The ID of the raster collection.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_ProcessResponse
+   */
+  public function process($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('process', array($params), "Google_Service_MapsEngine_ProcessResponse");
+  }
+}
+
+/**
+ * The "parents" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $parents = $mapsengineService->parents;
+ *  </code>
+ */
+class Google_Service_MapsEngine_RasterCollectionsParents_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Return all parent ids of the specified raster collection.
+   * (parents.listRasterCollectionsParents)
+   *
+   * @param string $id The ID of the raster collection whose parents will be
+   * listed.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of nextPageToken from the previous response.
+   * @opt_param string maxResults The maximum number of items to include in a
+   * single response page. The maximum supported value is 50.
+   * @return Google_Service_MapsEngine_ParentsListResponse
+   */
+  public function listRasterCollectionsParents($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_ParentsListResponse");
+  }
+}
+/**
+ * The "permissions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $permissions = $mapsengineService->permissions;
+ *  </code>
+ */
+class Google_Service_MapsEngine_RasterCollectionsPermissions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Remove permission entries from an already existing asset.
+   * (permissions.batchDelete)
+   *
+   * @param string $id The ID of the asset from which permissions will be removed.
+   * @param Google_PermissionsBatchDeleteRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PermissionsBatchDeleteResponse
+   */
+  public function batchDelete($id, Google_Service_MapsEngine_PermissionsBatchDeleteRequest $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('batchDelete', array($params), "Google_Service_MapsEngine_PermissionsBatchDeleteResponse");
+  }
+
+  /**
+   * Add or update permission entries to an already existing asset.
+   *
+   * An asset can hold up to 20 different permission entries. Each batchInsert
+   * request is atomic. (permissions.batchUpdate)
+   *
+   * @param string $id The ID of the asset to which permissions will be added.
+   * @param Google_PermissionsBatchUpdateRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PermissionsBatchUpdateResponse
+   */
+  public function batchUpdate($id, Google_Service_MapsEngine_PermissionsBatchUpdateRequest $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('batchUpdate', array($params), "Google_Service_MapsEngine_PermissionsBatchUpdateResponse");
+  }
+
+  /**
+   * Return all of the permissions for the specified asset.
+   * (permissions.listRasterCollectionsPermissions)
+   *
+   * @param string $id The ID of the asset whose permissions will be listed.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PermissionsListResponse
+   */
+  public function listRasterCollectionsPermissions($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_PermissionsListResponse");
+  }
+}
+/**
+ * The "rasters" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $rasters = $mapsengineService->rasters;
+ *  </code>
+ */
+class Google_Service_MapsEngine_RasterCollectionsRasters_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Remove rasters from an existing raster collection.
+   *
+   * Up to 50 rasters can be included in a single batchDelete request. Each
+   * batchDelete request is atomic. (rasters.batchDelete)
+   *
+   * @param string $id The ID of the raster collection to which these rasters
+   * belong.
+   * @param Google_RasterCollectionsRasterBatchDeleteRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_RasterCollectionsRastersBatchDeleteResponse
+   */
+  public function batchDelete($id, Google_Service_MapsEngine_RasterCollectionsRasterBatchDeleteRequest $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('batchDelete', array($params), "Google_Service_MapsEngine_RasterCollectionsRastersBatchDeleteResponse");
+  }
+
+  /**
+   * Add rasters to an existing raster collection. Rasters must be successfully
+   * processed in order to be added to a raster collection.
+   *
+   * Up to 50 rasters can be included in a single batchInsert request. Each
+   * batchInsert request is atomic. (rasters.batchInsert)
+   *
+   * @param string $id The ID of the raster collection to which these rasters
+   * belong.
+   * @param Google_RasterCollectionsRastersBatchInsertRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_RasterCollectionsRastersBatchInsertResponse
+   */
+  public function batchInsert($id, Google_Service_MapsEngine_RasterCollectionsRastersBatchInsertRequest $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('batchInsert', array($params), "Google_Service_MapsEngine_RasterCollectionsRastersBatchInsertResponse");
+  }
+
+  /**
+   * Return all rasters within a raster collection.
+   * (rasters.listRasterCollectionsRasters)
+   *
+   * @param string $id The ID of the raster collection to which these rasters
+   * belong.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string modifiedAfter An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been modified at or after
+   * this time.
+   * @opt_param string createdAfter An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been created at or after
+   * this time.
+   * @opt_param string tags A comma separated list of tags. Returned assets will
+   * contain all the tags from the list.
+   * @opt_param string search An unstructured search string used to filter the set
+   * of results based on asset metadata.
+   * @opt_param string maxResults The maximum number of items to include in a
+   * single response page. The maximum supported value is 100.
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of nextPageToken from the previous response.
+   * @opt_param string creatorEmail An email address representing a user. Returned
+   * assets that have been created by the user associated with the provided email
+   * address.
+   * @opt_param string bbox A bounding box, expressed as "west,south,east,north".
+   * If set, only assets which intersect this bounding box will be returned.
+   * @opt_param string modifiedBefore An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been modified at or before
+   * this time.
+   * @opt_param string createdBefore An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been created at or before
+   * this time.
+   * @opt_param string role The role parameter indicates that the response should
+   * only contain assets where the current user has the specified level of access.
+   * @return Google_Service_MapsEngine_RasterCollectionsRastersListResponse
+   */
+  public function listRasterCollectionsRasters($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_RasterCollectionsRastersListResponse");
+  }
+}
+
+/**
+ * The "rasters" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $rasters = $mapsengineService->rasters;
+ *  </code>
+ */
+class Google_Service_MapsEngine_Rasters_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete a raster. (rasters.delete)
+   *
+   * @param string $id The ID of the raster. Only the raster creator or project
+   * owner are permitted to delete. If the raster is included in a layer or
+   * mosaic, the request will fail. Remove it from all parents prior to deleting.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Return metadata for a single raster. (rasters.get)
+   *
+   * @param string $id The ID of the raster.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_Raster
+   */
+  public function get($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_MapsEngine_Raster");
+  }
+
+  /**
+   * Return all rasters readable by the current user. (rasters.listRasters)
+   *
+   * @param string $projectId The ID of a Maps Engine project, used to filter the
+   * response. To list all available projects with their IDs, send a Projects:
+   * list request. You can also find your project ID as the value of the
+   * DashboardPlace:cid URL parameter when signed in to mapsengine.google.com.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string modifiedAfter An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been modified at or after
+   * this time.
+   * @opt_param string createdAfter An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been created at or after
+   * this time.
+   * @opt_param string processingStatus
+   * @opt_param string tags A comma separated list of tags. Returned assets will
+   * contain all the tags from the list.
+   * @opt_param string search An unstructured search string used to filter the set
+   * of results based on asset metadata.
+   * @opt_param string maxResults The maximum number of items to include in a
+   * single response page. The maximum supported value is 100.
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of nextPageToken from the previous response.
+   * @opt_param string creatorEmail An email address representing a user. Returned
+   * assets that have been created by the user associated with the provided email
+   * address.
+   * @opt_param string bbox A bounding box, expressed as "west,south,east,north".
+   * If set, only assets which intersect this bounding box will be returned.
+   * @opt_param string modifiedBefore An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been modified at or before
+   * this time.
+   * @opt_param string createdBefore An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been created at or before
+   * this time.
+   * @opt_param string role The role parameter indicates that the response should
+   * only contain assets where the current user has the specified level of access.
+   * @return Google_Service_MapsEngine_RastersListResponse
+   */
+  public function listRasters($projectId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_RastersListResponse");
+  }
+
+  /**
+   * Mutate a raster asset. (rasters.patch)
+   *
+   * @param string $id The ID of the raster.
+   * @param Google_Raster $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function patch($id, Google_Service_MapsEngine_Raster $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params));
+  }
+
+  /**
+   * Process a raster asset. (rasters.process)
+   *
+   * @param string $id The ID of the raster.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_ProcessResponse
+   */
+  public function process($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('process', array($params), "Google_Service_MapsEngine_ProcessResponse");
+  }
+
+  /**
+   * Create a skeleton raster asset for upload. (rasters.upload)
+   *
+   * @param Google_Raster $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_Raster
+   */
+  public function upload(Google_Service_MapsEngine_Raster $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('upload', array($params), "Google_Service_MapsEngine_Raster");
+  }
+}
+
+/**
+ * The "files" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $files = $mapsengineService->files;
+ *  </code>
+ */
+class Google_Service_MapsEngine_RastersFiles_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Upload a file to a raster asset. (files.insert)
+   *
+   * @param string $id The ID of the raster asset.
+   * @param string $filename The file name of this uploaded file.
+   * @param array $optParams Optional parameters.
+   */
+  public function insert($id, $filename, $optParams = array())
+  {
+    $params = array('id' => $id, 'filename' => $filename);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params));
+  }
+}
+/**
+ * The "parents" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $parents = $mapsengineService->parents;
+ *  </code>
+ */
+class Google_Service_MapsEngine_RastersParents_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Return all parent ids of the specified rasters. (parents.listRastersParents)
+   *
+   * @param string $id The ID of the rasters whose parents will be listed.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of nextPageToken from the previous response.
+   * @opt_param string maxResults The maximum number of items to include in a
+   * single response page. The maximum supported value is 50.
+   * @return Google_Service_MapsEngine_ParentsListResponse
+   */
+  public function listRastersParents($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_ParentsListResponse");
+  }
+}
+/**
+ * The "permissions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $permissions = $mapsengineService->permissions;
+ *  </code>
+ */
+class Google_Service_MapsEngine_RastersPermissions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Remove permission entries from an already existing asset.
+   * (permissions.batchDelete)
+   *
+   * @param string $id The ID of the asset from which permissions will be removed.
+   * @param Google_PermissionsBatchDeleteRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PermissionsBatchDeleteResponse
+   */
+  public function batchDelete($id, Google_Service_MapsEngine_PermissionsBatchDeleteRequest $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('batchDelete', array($params), "Google_Service_MapsEngine_PermissionsBatchDeleteResponse");
+  }
+
+  /**
+   * Add or update permission entries to an already existing asset.
+   *
+   * An asset can hold up to 20 different permission entries. Each batchInsert
+   * request is atomic. (permissions.batchUpdate)
+   *
+   * @param string $id The ID of the asset to which permissions will be added.
+   * @param Google_PermissionsBatchUpdateRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PermissionsBatchUpdateResponse
+   */
+  public function batchUpdate($id, Google_Service_MapsEngine_PermissionsBatchUpdateRequest $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('batchUpdate', array($params), "Google_Service_MapsEngine_PermissionsBatchUpdateResponse");
+  }
+
+  /**
+   * Return all of the permissions for the specified asset.
+   * (permissions.listRastersPermissions)
+   *
+   * @param string $id The ID of the asset whose permissions will be listed.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PermissionsListResponse
+   */
+  public function listRastersPermissions($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_PermissionsListResponse");
+  }
+}
+
+/**
+ * The "tables" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $tables = $mapsengineService->tables;
+ *  </code>
+ */
+class Google_Service_MapsEngine_Tables_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Create a table asset. (tables.create)
+   *
+   * @param Google_Table $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_Table
+   */
+  public function create(Google_Service_MapsEngine_Table $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_MapsEngine_Table");
+  }
+
+  /**
+   * Delete a table. (tables.delete)
+   *
+   * @param string $id The ID of the table. Only the table creator or project
+   * owner are permitted to delete. If the table is included in a layer, the
+   * request will fail. Remove it from all layers prior to deleting.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Return metadata for a particular table, including the schema. (tables.get)
+   *
+   * @param string $id The ID of the table.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string version
+   * @return Google_Service_MapsEngine_Table
+   */
+  public function get($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_MapsEngine_Table");
+  }
+
+  /**
+   * Return all tables readable by the current user. (tables.listTables)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string modifiedAfter An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been modified at or after
+   * this time.
+   * @opt_param string createdAfter An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been created at or after
+   * this time.
+   * @opt_param string processingStatus
+   * @opt_param string projectId The ID of a Maps Engine project, used to filter
+   * the response. To list all available projects with their IDs, send a Projects:
+   * list request. You can also find your project ID as the value of the
+   * DashboardPlace:cid URL parameter when signed in to mapsengine.google.com.
+   * @opt_param string tags A comma separated list of tags. Returned assets will
+   * contain all the tags from the list.
+   * @opt_param string search An unstructured search string used to filter the set
+   * of results based on asset metadata.
+   * @opt_param string maxResults The maximum number of items to include in a
+   * single response page. The maximum supported value is 100.
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of nextPageToken from the previous response.
+   * @opt_param string creatorEmail An email address representing a user. Returned
+   * assets that have been created by the user associated with the provided email
+   * address.
+   * @opt_param string bbox A bounding box, expressed as "west,south,east,north".
+   * If set, only assets which intersect this bounding box will be returned.
+   * @opt_param string modifiedBefore An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been modified at or before
+   * this time.
+   * @opt_param string createdBefore An RFC 3339 formatted date-time value (e.g.
+   * 1970-01-01T00:00:00Z). Returned assets will have been created at or before
+   * this time.
+   * @opt_param string role The role parameter indicates that the response should
+   * only contain assets where the current user has the specified level of access.
+   * @return Google_Service_MapsEngine_TablesListResponse
+   */
+  public function listTables($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_TablesListResponse");
+  }
+
+  /**
+   * Mutate a table asset. (tables.patch)
+   *
+   * @param string $id The ID of the table.
+   * @param Google_Table $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function patch($id, Google_Service_MapsEngine_Table $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params));
+  }
+
+  /**
+   * Process a table asset. (tables.process)
+   *
+   * @param string $id The ID of the table.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_ProcessResponse
+   */
+  public function process($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('process', array($params), "Google_Service_MapsEngine_ProcessResponse");
+  }
+
+  /**
+   * Create a placeholder table asset to which table files can be uploaded. Once
+   * the placeholder has been created, files are uploaded to the
+   * https://www.googleapis.com/upload/mapsengine/v1/tables/table_id/files
+   * endpoint. See Table Upload in the Developer's Guide or Table.files: insert in
+   * the reference documentation for more information. (tables.upload)
+   *
+   * @param Google_Table $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_Table
+   */
+  public function upload(Google_Service_MapsEngine_Table $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('upload', array($params), "Google_Service_MapsEngine_Table");
+  }
+}
+
+/**
+ * The "features" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $features = $mapsengineService->features;
+ *  </code>
+ */
+class Google_Service_MapsEngine_TablesFeatures_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete all features matching the given IDs. (features.batchDelete)
+   *
+   * @param string $id The ID of the table that contains the features to be
+   * deleted.
+   * @param Google_FeaturesBatchDeleteRequest $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function batchDelete($id, Google_Service_MapsEngine_FeaturesBatchDeleteRequest $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('batchDelete', array($params));
+  }
+
+  /**
+   * Append features to an existing table.
+   *
+   * A single batchInsert request can create:
+   *
+   * - Up to 50 features. - A combined total of 10 000 vertices. Feature limits
+   * are documented in the Supported data formats and limits article of the Google
+   * Maps Engine help center. Note that free and paid accounts have different
+   * limits.
+   *
+   * For more information about inserting features, read Creating features in the
+   * Google Maps Engine developer's guide. (features.batchInsert)
+   *
+   * @param string $id The ID of the table to append the features to.
+   * @param Google_FeaturesBatchInsertRequest $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function batchInsert($id, Google_Service_MapsEngine_FeaturesBatchInsertRequest $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('batchInsert', array($params));
+  }
+
+  /**
+   * Update the supplied features.
+   *
+   * A single batchPatch request can update:
+   *
+   * - Up to 50 features. - A combined total of 10 000 vertices. Feature limits
+   * are documented in the Supported data formats and limits article of the Google
+   * Maps Engine help center. Note that free and paid accounts have different
+   * limits.
+   *
+   * Feature updates use HTTP PATCH semantics:
+   *
+   * - A supplied value replaces an existing value (if any) in that field. -
+   * Omitted fields remain unchanged. - Complex values in geometries and
+   * properties must be replaced as atomic units. For example, providing just the
+   * coordinates of a geometry is not allowed; the complete geometry, including
+   * type, must be supplied. - Setting a property's value to null deletes that
+   * property. For more information about updating features, read Updating
+   * features in the Google Maps Engine developer's guide. (features.batchPatch)
+   *
+   * @param string $id The ID of the table containing the features to be patched.
+   * @param Google_FeaturesBatchPatchRequest $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function batchPatch($id, Google_Service_MapsEngine_FeaturesBatchPatchRequest $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('batchPatch', array($params));
+  }
+
+  /**
+   * Return a single feature, given its ID. (features.get)
+   *
+   * @param string $tableId The ID of the table.
+   * @param string $id The ID of the feature to get.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string version The table version to access. See Accessing Public
+   * Data for information.
+   * @opt_param string select A SQL-like projection clause used to specify
+   * returned properties. If this parameter is not included, all properties are
+   * returned.
+   * @return Google_Service_MapsEngine_Feature
+   */
+  public function get($tableId, $id, $optParams = array())
+  {
+    $params = array('tableId' => $tableId, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_MapsEngine_Feature");
+  }
+
+  /**
+   * Return all features readable by the current user.
+   * (features.listTablesFeatures)
+   *
+   * @param string $id The ID of the table to which these features belong.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderBy An SQL-like order by clause used to sort results.
+   * If this parameter is not included, the order of features is undefined.
+   * @opt_param string intersects A geometry literal that specifies the spatial
+   * restriction of the query.
+   * @opt_param string maxResults The maximum number of items to include in the
+   * response, used for paging. The maximum supported value is 1000.
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of nextPageToken from the previous response.
+   * @opt_param string version The table version to access. See Accessing Public
+   * Data for information.
+   * @opt_param string limit The total number of features to return from the
+   * query, irrespective of the number of pages.
+   * @opt_param string include A comma separated list of optional data to include.
+   * Optional data available: schema.
+   * @opt_param string where An SQL-like predicate used to filter results.
+   * @opt_param string select A SQL-like projection clause used to specify
+   * returned properties. If this parameter is not included, all properties are
+   * returned.
+   * @return Google_Service_MapsEngine_FeaturesListResponse
+   */
+  public function listTablesFeatures($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_FeaturesListResponse");
+  }
+}
+/**
+ * The "files" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $files = $mapsengineService->files;
+ *  </code>
+ */
+class Google_Service_MapsEngine_TablesFiles_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Upload a file to a placeholder table asset. See Table Upload in the
+   * Developer's Guide for more information. Supported file types are listed in
+   * the Supported data formats and limits article of the Google Maps Engine help
+   * center. (files.insert)
+   *
+   * @param string $id The ID of the table asset.
+   * @param string $filename The file name of this uploaded file.
+   * @param array $optParams Optional parameters.
+   */
+  public function insert($id, $filename, $optParams = array())
+  {
+    $params = array('id' => $id, 'filename' => $filename);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params));
+  }
+}
+/**
+ * The "parents" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $parents = $mapsengineService->parents;
+ *  </code>
+ */
+class Google_Service_MapsEngine_TablesParents_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Return all parent ids of the specified table. (parents.listTablesParents)
+   *
+   * @param string $id The ID of the table whose parents will be listed.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of nextPageToken from the previous response.
+   * @opt_param string maxResults The maximum number of items to include in a
+   * single response page. The maximum supported value is 50.
+   * @return Google_Service_MapsEngine_ParentsListResponse
+   */
+  public function listTablesParents($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_ParentsListResponse");
+  }
+}
+/**
+ * The "permissions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mapsengineService = new Google_Service_MapsEngine(...);
+ *   $permissions = $mapsengineService->permissions;
+ *  </code>
+ */
+class Google_Service_MapsEngine_TablesPermissions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Remove permission entries from an already existing asset.
+   * (permissions.batchDelete)
+   *
+   * @param string $id The ID of the asset from which permissions will be removed.
+   * @param Google_PermissionsBatchDeleteRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PermissionsBatchDeleteResponse
+   */
+  public function batchDelete($id, Google_Service_MapsEngine_PermissionsBatchDeleteRequest $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('batchDelete', array($params), "Google_Service_MapsEngine_PermissionsBatchDeleteResponse");
+  }
+
+  /**
+   * Add or update permission entries to an already existing asset.
+   *
+   * An asset can hold up to 20 different permission entries. Each batchInsert
+   * request is atomic. (permissions.batchUpdate)
+   *
+   * @param string $id The ID of the asset to which permissions will be added.
+   * @param Google_PermissionsBatchUpdateRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PermissionsBatchUpdateResponse
+   */
+  public function batchUpdate($id, Google_Service_MapsEngine_PermissionsBatchUpdateRequest $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('batchUpdate', array($params), "Google_Service_MapsEngine_PermissionsBatchUpdateResponse");
+  }
+
+  /**
+   * Return all of the permissions for the specified asset.
+   * (permissions.listTablesPermissions)
+   *
+   * @param string $id The ID of the asset whose permissions will be listed.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_MapsEngine_PermissionsListResponse
+   */
+  public function listTablesPermissions($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_MapsEngine_PermissionsListResponse");
+  }
+}
+
+
+
+
+class Google_Service_MapsEngine_AcquisitionTime extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $end;
+  public $precision;
+  public $start;
+
+
+  public function setEnd($end)
+  {
+    $this->end = $end;
+  }
+  public function getEnd()
+  {
+    return $this->end;
+  }
+  public function setPrecision($precision)
+  {
+    $this->precision = $precision;
+  }
+  public function getPrecision()
+  {
+    return $this->precision;
+  }
+  public function setStart($start)
+  {
+    $this->start = $start;
+  }
+  public function getStart()
+  {
+    return $this->start;
+  }
+}
+
+class Google_Service_MapsEngine_Asset extends Google_Collection
+{
+  protected $collection_key = 'tags';
+  protected $internal_gapi_mappings = array(
+  );
+  public $bbox;
+  public $creationTime;
+  public $creatorEmail;
+  public $description;
+  public $etag;
+  public $id;
+  public $lastModifiedTime;
+  public $lastModifierEmail;
+  public $name;
+  public $projectId;
+  public $resource;
+  public $tags;
+  public $type;
+  public $writersCanEditPermissions;
+
+
+  public function setBbox($bbox)
+  {
+    $this->bbox = $bbox;
+  }
+  public function getBbox()
+  {
+    return $this->bbox;
+  }
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setCreatorEmail($creatorEmail)
+  {
+    $this->creatorEmail = $creatorEmail;
+  }
+  public function getCreatorEmail()
+  {
+    return $this->creatorEmail;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLastModifiedTime($lastModifiedTime)
+  {
+    $this->lastModifiedTime = $lastModifiedTime;
+  }
+  public function getLastModifiedTime()
+  {
+    return $this->lastModifiedTime;
+  }
+  public function setLastModifierEmail($lastModifierEmail)
+  {
+    $this->lastModifierEmail = $lastModifierEmail;
+  }
+  public function getLastModifierEmail()
+  {
+    return $this->lastModifierEmail;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setResource($resource)
+  {
+    $this->resource = $resource;
+  }
+  public function getResource()
+  {
+    return $this->resource;
+  }
+  public function setTags($tags)
+  {
+    $this->tags = $tags;
+  }
+  public function getTags()
+  {
+    return $this->tags;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setWritersCanEditPermissions($writersCanEditPermissions)
+  {
+    $this->writersCanEditPermissions = $writersCanEditPermissions;
+  }
+  public function getWritersCanEditPermissions()
+  {
+    return $this->writersCanEditPermissions;
+  }
+}
+
+class Google_Service_MapsEngine_AssetsListResponse extends Google_Collection
+{
+  protected $collection_key = 'assets';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $assetsType = 'Google_Service_MapsEngine_Asset';
+  protected $assetsDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setAssets($assets)
+  {
+    $this->assets = $assets;
+  }
+  public function getAssets()
+  {
+    return $this->assets;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_MapsEngine_Border extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $color;
+  public $opacity;
+  public $width;
+
+
+  public function setColor($color)
+  {
+    $this->color = $color;
+  }
+  public function getColor()
+  {
+    return $this->color;
+  }
+  public function setOpacity($opacity)
+  {
+    $this->opacity = $opacity;
+  }
+  public function getOpacity()
+  {
+    return $this->opacity;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_MapsEngine_Color extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $color;
+  public $opacity;
+
+
+  public function setColor($color)
+  {
+    $this->color = $color;
+  }
+  public function getColor()
+  {
+    return $this->color;
+  }
+  public function setOpacity($opacity)
+  {
+    $this->opacity = $opacity;
+  }
+  public function getOpacity()
+  {
+    return $this->opacity;
+  }
+}
+
+class Google_Service_MapsEngine_Datasource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+}
+
+class Google_Service_MapsEngine_DisplayRule extends Google_Collection
+{
+  protected $collection_key = 'filters';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $filtersType = 'Google_Service_MapsEngine_Filter';
+  protected $filtersDataType = 'array';
+  protected $lineOptionsType = 'Google_Service_MapsEngine_LineStyle';
+  protected $lineOptionsDataType = '';
+  public $name;
+  protected $pointOptionsType = 'Google_Service_MapsEngine_PointStyle';
+  protected $pointOptionsDataType = '';
+  protected $polygonOptionsType = 'Google_Service_MapsEngine_PolygonStyle';
+  protected $polygonOptionsDataType = '';
+  protected $zoomLevelsType = 'Google_Service_MapsEngine_ZoomLevels';
+  protected $zoomLevelsDataType = '';
+
+
+  public function setFilters($filters)
+  {
+    $this->filters = $filters;
+  }
+  public function getFilters()
+  {
+    return $this->filters;
+  }
+  public function setLineOptions(Google_Service_MapsEngine_LineStyle $lineOptions)
+  {
+    $this->lineOptions = $lineOptions;
+  }
+  public function getLineOptions()
+  {
+    return $this->lineOptions;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPointOptions(Google_Service_MapsEngine_PointStyle $pointOptions)
+  {
+    $this->pointOptions = $pointOptions;
+  }
+  public function getPointOptions()
+  {
+    return $this->pointOptions;
+  }
+  public function setPolygonOptions(Google_Service_MapsEngine_PolygonStyle $polygonOptions)
+  {
+    $this->polygonOptions = $polygonOptions;
+  }
+  public function getPolygonOptions()
+  {
+    return $this->polygonOptions;
+  }
+  public function setZoomLevels(Google_Service_MapsEngine_ZoomLevels $zoomLevels)
+  {
+    $this->zoomLevels = $zoomLevels;
+  }
+  public function getZoomLevels()
+  {
+    return $this->zoomLevels;
+  }
+}
+
+class Google_Service_MapsEngine_Feature extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $geometryType = 'Google_Service_MapsEngine_GeoJsonGeometry';
+  protected $geometryDataType = '';
+  public $properties;
+  public $type;
+
+
+  public function setGeometry(Google_Service_MapsEngine_GeoJsonGeometry $geometry)
+  {
+    $this->geometry = $geometry;
+  }
+  public function getGeometry()
+  {
+    return $this->geometry;
+  }
+  public function setProperties($properties)
+  {
+    $this->properties = $properties;
+  }
+  public function getProperties()
+  {
+    return $this->properties;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_MapsEngine_FeatureInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $content;
+
+
+  public function setContent($content)
+  {
+    $this->content = $content;
+  }
+  public function getContent()
+  {
+    return $this->content;
+  }
+}
+
+class Google_Service_MapsEngine_FeaturesBatchDeleteRequest extends Google_Collection
+{
+  protected $collection_key = 'primaryKeys';
+  protected $internal_gapi_mappings = array(
+        "gxIds" => "gx_ids",
+  );
+  public $gxIds;
+  public $primaryKeys;
+
+
+  public function setGxIds($gxIds)
+  {
+    $this->gxIds = $gxIds;
+  }
+  public function getGxIds()
+  {
+    return $this->gxIds;
+  }
+  public function setPrimaryKeys($primaryKeys)
+  {
+    $this->primaryKeys = $primaryKeys;
+  }
+  public function getPrimaryKeys()
+  {
+    return $this->primaryKeys;
+  }
+}
+
+class Google_Service_MapsEngine_FeaturesBatchInsertRequest extends Google_Collection
+{
+  protected $collection_key = 'features';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $featuresType = 'Google_Service_MapsEngine_Feature';
+  protected $featuresDataType = 'array';
+  public $normalizeGeometries;
+
+
+  public function setFeatures($features)
+  {
+    $this->features = $features;
+  }
+  public function getFeatures()
+  {
+    return $this->features;
+  }
+  public function setNormalizeGeometries($normalizeGeometries)
+  {
+    $this->normalizeGeometries = $normalizeGeometries;
+  }
+  public function getNormalizeGeometries()
+  {
+    return $this->normalizeGeometries;
+  }
+}
+
+class Google_Service_MapsEngine_FeaturesBatchPatchRequest extends Google_Collection
+{
+  protected $collection_key = 'features';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $featuresType = 'Google_Service_MapsEngine_Feature';
+  protected $featuresDataType = 'array';
+  public $normalizeGeometries;
+
+
+  public function setFeatures($features)
+  {
+    $this->features = $features;
+  }
+  public function getFeatures()
+  {
+    return $this->features;
+  }
+  public function setNormalizeGeometries($normalizeGeometries)
+  {
+    $this->normalizeGeometries = $normalizeGeometries;
+  }
+  public function getNormalizeGeometries()
+  {
+    return $this->normalizeGeometries;
+  }
+}
+
+class Google_Service_MapsEngine_FeaturesListResponse extends Google_Collection
+{
+  protected $collection_key = 'features';
+  protected $internal_gapi_mappings = array(
+  );
+  public $allowedQueriesPerSecond;
+  protected $featuresType = 'Google_Service_MapsEngine_Feature';
+  protected $featuresDataType = 'array';
+  public $nextPageToken;
+  protected $schemaType = 'Google_Service_MapsEngine_Schema';
+  protected $schemaDataType = '';
+  public $type;
+
+
+  public function setAllowedQueriesPerSecond($allowedQueriesPerSecond)
+  {
+    $this->allowedQueriesPerSecond = $allowedQueriesPerSecond;
+  }
+  public function getAllowedQueriesPerSecond()
+  {
+    return $this->allowedQueriesPerSecond;
+  }
+  public function setFeatures($features)
+  {
+    $this->features = $features;
+  }
+  public function getFeatures()
+  {
+    return $this->features;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSchema(Google_Service_MapsEngine_Schema $schema)
+  {
+    $this->schema = $schema;
+  }
+  public function getSchema()
+  {
+    return $this->schema;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_MapsEngine_Filter extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $column;
+  public $operator;
+  public $value;
+
+
+  public function setColumn($column)
+  {
+    $this->column = $column;
+  }
+  public function getColumn()
+  {
+    return $this->column;
+  }
+  public function setOperator($operator)
+  {
+    $this->operator = $operator;
+  }
+  public function getOperator()
+  {
+    return $this->operator;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_MapsEngine_GeoJsonGeometry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $type;
+
+
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_MapsEngine_GeoJsonGeometryCollection extends Google_Service_MapsEngine_GeoJsonGeometry
+{
+  protected $collection_key = 'geometries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $geometriesType = 'Google_Service_MapsEngine_GeoJsonGeometry';
+  protected $geometriesDataType = 'array';
+  protected function gapiInit()
+  {
+    $this->type = 'GeometryCollection';
+  }
+
+  public function setGeometries($geometries)
+  {
+    $this->geometries = $geometries;
+  }
+  public function getGeometries()
+  {
+    return $this->geometries;
+  }
+}
+
+class Google_Service_MapsEngine_GeoJsonLineString extends Google_Service_MapsEngine_GeoJsonGeometry
+{
+  protected $collection_key = 'coordinates';
+  protected $internal_gapi_mappings = array(
+  );
+  public $coordinates;
+  protected function gapiInit()
+  {
+    $this->type = 'LineString';
+  }
+
+  public function setCoordinates($coordinates)
+  {
+    $this->coordinates = $coordinates;
+  }
+  public function getCoordinates()
+  {
+    return $this->coordinates;
+  }
+}
+
+class Google_Service_MapsEngine_GeoJsonMultiLineString extends Google_Service_MapsEngine_GeoJsonGeometry
+{
+  protected $collection_key = 'coordinates';
+  protected $internal_gapi_mappings = array(
+  );
+  public $coordinates;
+  protected function gapiInit()
+  {
+    $this->type = 'MultiLineString';
+  }
+
+  public function setCoordinates($coordinates)
+  {
+    $this->coordinates = $coordinates;
+  }
+  public function getCoordinates()
+  {
+    return $this->coordinates;
+  }
+}
+
+class Google_Service_MapsEngine_GeoJsonMultiPoint extends Google_Service_MapsEngine_GeoJsonGeometry
+{
+  protected $collection_key = 'coordinates';
+  protected $internal_gapi_mappings = array(
+  );
+  public $coordinates;
+  protected function gapiInit()
+  {
+    $this->type = 'MultiPoint';
+  }
+
+  public function setCoordinates($coordinates)
+  {
+    $this->coordinates = $coordinates;
+  }
+  public function getCoordinates()
+  {
+    return $this->coordinates;
+  }
+}
+
+class Google_Service_MapsEngine_GeoJsonMultiPolygon extends Google_Service_MapsEngine_GeoJsonGeometry
+{
+  protected $collection_key = 'coordinates';
+  protected $internal_gapi_mappings = array(
+  );
+  public $coordinates;
+  protected function gapiInit()
+  {
+    $this->type = 'MultiPolygon';
+  }
+
+  public function setCoordinates($coordinates)
+  {
+    $this->coordinates = $coordinates;
+  }
+  public function getCoordinates()
+  {
+    return $this->coordinates;
+  }
+}
+
+class Google_Service_MapsEngine_GeoJsonPoint extends Google_Service_MapsEngine_GeoJsonGeometry
+{
+  protected $collection_key = 'coordinates';
+  protected $internal_gapi_mappings = array(
+  );
+  public $coordinates;
+  protected function gapiInit()
+  {
+    $this->type = 'Point';
+  }
+
+  public function setCoordinates($coordinates)
+  {
+    $this->coordinates = $coordinates;
+  }
+  public function getCoordinates()
+  {
+    return $this->coordinates;
+  }
+}
+
+class Google_Service_MapsEngine_GeoJsonPolygon extends Google_Service_MapsEngine_GeoJsonGeometry
+{
+  protected $collection_key = 'coordinates';
+  protected $internal_gapi_mappings = array(
+  );
+  public $coordinates;
+  protected function gapiInit()
+  {
+    $this->type = 'Polygon';
+  }
+
+  public function setCoordinates($coordinates)
+  {
+    $this->coordinates = $coordinates;
+  }
+  public function getCoordinates()
+  {
+    return $this->coordinates;
+  }
+}
+
+class Google_Service_MapsEngine_GeoJsonProperties extends Google_Model
+{
+}
+
+class Google_Service_MapsEngine_Icon extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $id;
+  public $name;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_MapsEngine_IconStyle extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $name;
+  protected $scaledShapeType = 'Google_Service_MapsEngine_ScaledShape';
+  protected $scaledShapeDataType = '';
+  protected $scalingFunctionType = 'Google_Service_MapsEngine_ScalingFunction';
+  protected $scalingFunctionDataType = '';
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setScaledShape(Google_Service_MapsEngine_ScaledShape $scaledShape)
+  {
+    $this->scaledShape = $scaledShape;
+  }
+  public function getScaledShape()
+  {
+    return $this->scaledShape;
+  }
+  public function setScalingFunction(Google_Service_MapsEngine_ScalingFunction $scalingFunction)
+  {
+    $this->scalingFunction = $scalingFunction;
+  }
+  public function getScalingFunction()
+  {
+    return $this->scalingFunction;
+  }
+}
+
+class Google_Service_MapsEngine_IconsListResponse extends Google_Collection
+{
+  protected $collection_key = 'icons';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $iconsType = 'Google_Service_MapsEngine_Icon';
+  protected $iconsDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setIcons($icons)
+  {
+    $this->icons = $icons;
+  }
+  public function getIcons()
+  {
+    return $this->icons;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_MapsEngine_LabelStyle extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $color;
+  public $column;
+  public $fontStyle;
+  public $fontWeight;
+  public $opacity;
+  protected $outlineType = 'Google_Service_MapsEngine_Color';
+  protected $outlineDataType = '';
+  public $size;
+
+
+  public function setColor($color)
+  {
+    $this->color = $color;
+  }
+  public function getColor()
+  {
+    return $this->color;
+  }
+  public function setColumn($column)
+  {
+    $this->column = $column;
+  }
+  public function getColumn()
+  {
+    return $this->column;
+  }
+  public function setFontStyle($fontStyle)
+  {
+    $this->fontStyle = $fontStyle;
+  }
+  public function getFontStyle()
+  {
+    return $this->fontStyle;
+  }
+  public function setFontWeight($fontWeight)
+  {
+    $this->fontWeight = $fontWeight;
+  }
+  public function getFontWeight()
+  {
+    return $this->fontWeight;
+  }
+  public function setOpacity($opacity)
+  {
+    $this->opacity = $opacity;
+  }
+  public function getOpacity()
+  {
+    return $this->opacity;
+  }
+  public function setOutline(Google_Service_MapsEngine_Color $outline)
+  {
+    $this->outline = $outline;
+  }
+  public function getOutline()
+  {
+    return $this->outline;
+  }
+  public function setSize($size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+}
+
+class Google_Service_MapsEngine_Layer extends Google_Collection
+{
+  protected $collection_key = 'tags';
+  protected $internal_gapi_mappings = array(
+  );
+  public $bbox;
+  public $creationTime;
+  public $creatorEmail;
+  public $datasourceType;
+  protected $datasourcesType = 'Google_Service_MapsEngine_Datasource';
+  protected $datasourcesDataType = 'array';
+  public $description;
+  public $draftAccessList;
+  public $etag;
+  public $id;
+  public $lastModifiedTime;
+  public $lastModifierEmail;
+  public $layerType;
+  public $name;
+  public $processingStatus;
+  public $projectId;
+  public $publishedAccessList;
+  public $publishingStatus;
+  protected $styleType = 'Google_Service_MapsEngine_VectorStyle';
+  protected $styleDataType = '';
+  public $tags;
+  public $writersCanEditPermissions;
+
+
+  public function setBbox($bbox)
+  {
+    $this->bbox = $bbox;
+  }
+  public function getBbox()
+  {
+    return $this->bbox;
+  }
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setCreatorEmail($creatorEmail)
+  {
+    $this->creatorEmail = $creatorEmail;
+  }
+  public function getCreatorEmail()
+  {
+    return $this->creatorEmail;
+  }
+  public function setDatasourceType($datasourceType)
+  {
+    $this->datasourceType = $datasourceType;
+  }
+  public function getDatasourceType()
+  {
+    return $this->datasourceType;
+  }
+  public function setDatasources(Google_Service_MapsEngine_Datasource $datasources)
+  {
+    $this->datasources = $datasources;
+  }
+  public function getDatasources()
+  {
+    return $this->datasources;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDraftAccessList($draftAccessList)
+  {
+    $this->draftAccessList = $draftAccessList;
+  }
+  public function getDraftAccessList()
+  {
+    return $this->draftAccessList;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLastModifiedTime($lastModifiedTime)
+  {
+    $this->lastModifiedTime = $lastModifiedTime;
+  }
+  public function getLastModifiedTime()
+  {
+    return $this->lastModifiedTime;
+  }
+  public function setLastModifierEmail($lastModifierEmail)
+  {
+    $this->lastModifierEmail = $lastModifierEmail;
+  }
+  public function getLastModifierEmail()
+  {
+    return $this->lastModifierEmail;
+  }
+  public function setLayerType($layerType)
+  {
+    $this->layerType = $layerType;
+  }
+  public function getLayerType()
+  {
+    return $this->layerType;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProcessingStatus($processingStatus)
+  {
+    $this->processingStatus = $processingStatus;
+  }
+  public function getProcessingStatus()
+  {
+    return $this->processingStatus;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setPublishedAccessList($publishedAccessList)
+  {
+    $this->publishedAccessList = $publishedAccessList;
+  }
+  public function getPublishedAccessList()
+  {
+    return $this->publishedAccessList;
+  }
+  public function setPublishingStatus($publishingStatus)
+  {
+    $this->publishingStatus = $publishingStatus;
+  }
+  public function getPublishingStatus()
+  {
+    return $this->publishingStatus;
+  }
+  public function setStyle(Google_Service_MapsEngine_VectorStyle $style)
+  {
+    $this->style = $style;
+  }
+  public function getStyle()
+  {
+    return $this->style;
+  }
+  public function setTags($tags)
+  {
+    $this->tags = $tags;
+  }
+  public function getTags()
+  {
+    return $this->tags;
+  }
+  public function setWritersCanEditPermissions($writersCanEditPermissions)
+  {
+    $this->writersCanEditPermissions = $writersCanEditPermissions;
+  }
+  public function getWritersCanEditPermissions()
+  {
+    return $this->writersCanEditPermissions;
+  }
+}
+
+class Google_Service_MapsEngine_LayersListResponse extends Google_Collection
+{
+  protected $collection_key = 'layers';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $layersType = 'Google_Service_MapsEngine_Layer';
+  protected $layersDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setLayers($layers)
+  {
+    $this->layers = $layers;
+  }
+  public function getLayers()
+  {
+    return $this->layers;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_MapsEngine_LineStyle extends Google_Collection
+{
+  protected $collection_key = 'dash';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $borderType = 'Google_Service_MapsEngine_Border';
+  protected $borderDataType = '';
+  public $dash;
+  protected $labelType = 'Google_Service_MapsEngine_LabelStyle';
+  protected $labelDataType = '';
+  protected $strokeType = 'Google_Service_MapsEngine_LineStyleStroke';
+  protected $strokeDataType = '';
+
+
+  public function setBorder(Google_Service_MapsEngine_Border $border)
+  {
+    $this->border = $border;
+  }
+  public function getBorder()
+  {
+    return $this->border;
+  }
+  public function setDash($dash)
+  {
+    $this->dash = $dash;
+  }
+  public function getDash()
+  {
+    return $this->dash;
+  }
+  public function setLabel(Google_Service_MapsEngine_LabelStyle $label)
+  {
+    $this->label = $label;
+  }
+  public function getLabel()
+  {
+    return $this->label;
+  }
+  public function setStroke(Google_Service_MapsEngine_LineStyleStroke $stroke)
+  {
+    $this->stroke = $stroke;
+  }
+  public function getStroke()
+  {
+    return $this->stroke;
+  }
+}
+
+class Google_Service_MapsEngine_LineStyleStroke extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $color;
+  public $opacity;
+  public $width;
+
+
+  public function setColor($color)
+  {
+    $this->color = $color;
+  }
+  public function getColor()
+  {
+    return $this->color;
+  }
+  public function setOpacity($opacity)
+  {
+    $this->opacity = $opacity;
+  }
+  public function getOpacity()
+  {
+    return $this->opacity;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_MapsEngine_Map extends Google_Collection
+{
+  protected $collection_key = 'versions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $bbox;
+  protected $contentsType = 'Google_Service_MapsEngine_MapItem';
+  protected $contentsDataType = '';
+  public $creationTime;
+  public $creatorEmail;
+  public $defaultViewport;
+  public $description;
+  public $draftAccessList;
+  public $etag;
+  public $id;
+  public $lastModifiedTime;
+  public $lastModifierEmail;
+  public $name;
+  public $processingStatus;
+  public $projectId;
+  public $publishedAccessList;
+  public $publishingStatus;
+  public $tags;
+  public $versions;
+  public $writersCanEditPermissions;
+
+
+  public function setBbox($bbox)
+  {
+    $this->bbox = $bbox;
+  }
+  public function getBbox()
+  {
+    return $this->bbox;
+  }
+  public function setContents(Google_Service_MapsEngine_MapItem $contents)
+  {
+    $this->contents = $contents;
+  }
+  public function getContents()
+  {
+    return $this->contents;
+  }
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setCreatorEmail($creatorEmail)
+  {
+    $this->creatorEmail = $creatorEmail;
+  }
+  public function getCreatorEmail()
+  {
+    return $this->creatorEmail;
+  }
+  public function setDefaultViewport($defaultViewport)
+  {
+    $this->defaultViewport = $defaultViewport;
+  }
+  public function getDefaultViewport()
+  {
+    return $this->defaultViewport;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDraftAccessList($draftAccessList)
+  {
+    $this->draftAccessList = $draftAccessList;
+  }
+  public function getDraftAccessList()
+  {
+    return $this->draftAccessList;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLastModifiedTime($lastModifiedTime)
+  {
+    $this->lastModifiedTime = $lastModifiedTime;
+  }
+  public function getLastModifiedTime()
+  {
+    return $this->lastModifiedTime;
+  }
+  public function setLastModifierEmail($lastModifierEmail)
+  {
+    $this->lastModifierEmail = $lastModifierEmail;
+  }
+  public function getLastModifierEmail()
+  {
+    return $this->lastModifierEmail;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProcessingStatus($processingStatus)
+  {
+    $this->processingStatus = $processingStatus;
+  }
+  public function getProcessingStatus()
+  {
+    return $this->processingStatus;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setPublishedAccessList($publishedAccessList)
+  {
+    $this->publishedAccessList = $publishedAccessList;
+  }
+  public function getPublishedAccessList()
+  {
+    return $this->publishedAccessList;
+  }
+  public function setPublishingStatus($publishingStatus)
+  {
+    $this->publishingStatus = $publishingStatus;
+  }
+  public function getPublishingStatus()
+  {
+    return $this->publishingStatus;
+  }
+  public function setTags($tags)
+  {
+    $this->tags = $tags;
+  }
+  public function getTags()
+  {
+    return $this->tags;
+  }
+  public function setVersions($versions)
+  {
+    $this->versions = $versions;
+  }
+  public function getVersions()
+  {
+    return $this->versions;
+  }
+  public function setWritersCanEditPermissions($writersCanEditPermissions)
+  {
+    $this->writersCanEditPermissions = $writersCanEditPermissions;
+  }
+  public function getWritersCanEditPermissions()
+  {
+    return $this->writersCanEditPermissions;
+  }
+}
+
+class Google_Service_MapsEngine_MapFolder extends Google_Service_MapsEngine_MapItem
+{
+  protected $collection_key = 'defaultViewport';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $contentsType = 'Google_Service_MapsEngine_MapItem';
+  protected $contentsDataType = 'array';
+  public $defaultViewport;
+  public $expandable;
+  public $key;
+  public $name;
+  public $visibility;
+  protected function gapiInit()
+  {
+    $this->type = 'folder';
+  }
+
+  public function setContents($contents)
+  {
+    $this->contents = $contents;
+  }
+  public function getContents()
+  {
+    return $this->contents;
+  }
+  public function setDefaultViewport($defaultViewport)
+  {
+    $this->defaultViewport = $defaultViewport;
+  }
+  public function getDefaultViewport()
+  {
+    return $this->defaultViewport;
+  }
+  public function setExpandable($expandable)
+  {
+    $this->expandable = $expandable;
+  }
+  public function getExpandable()
+  {
+    return $this->expandable;
+  }
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setVisibility($visibility)
+  {
+    $this->visibility = $visibility;
+  }
+  public function getVisibility()
+  {
+    return $this->visibility;
+  }
+}
+
+class Google_Service_MapsEngine_MapItem extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $type;
+
+
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_MapsEngine_MapKmlLink extends Google_Service_MapsEngine_MapItem
+{
+  protected $collection_key = 'defaultViewport';
+  protected $internal_gapi_mappings = array(
+  );
+  public $defaultViewport;
+  public $kmlUrl;
+  public $name;
+  public $visibility;
+  protected function gapiInit()
+  {
+    $this->type = 'kmlLink';
+  }
+
+  public function setDefaultViewport($defaultViewport)
+  {
+    $this->defaultViewport = $defaultViewport;
+  }
+  public function getDefaultViewport()
+  {
+    return $this->defaultViewport;
+  }
+  public function setKmlUrl($kmlUrl)
+  {
+    $this->kmlUrl = $kmlUrl;
+  }
+  public function getKmlUrl()
+  {
+    return $this->kmlUrl;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setVisibility($visibility)
+  {
+    $this->visibility = $visibility;
+  }
+  public function getVisibility()
+  {
+    return $this->visibility;
+  }
+}
+
+class Google_Service_MapsEngine_MapLayer extends Google_Service_MapsEngine_MapItem
+{
+  protected $collection_key = 'defaultViewport';
+  protected $internal_gapi_mappings = array(
+  );
+  public $defaultViewport;
+  public $id;
+  public $key;
+  public $name;
+  public $visibility;
+  protected function gapiInit()
+  {
+    $this->type = 'layer';
+  }
+
+  public function setDefaultViewport($defaultViewport)
+  {
+    $this->defaultViewport = $defaultViewport;
+  }
+  public function getDefaultViewport()
+  {
+    return $this->defaultViewport;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setVisibility($visibility)
+  {
+    $this->visibility = $visibility;
+  }
+  public function getVisibility()
+  {
+    return $this->visibility;
+  }
+}
+
+class Google_Service_MapsEngine_MapsListResponse extends Google_Collection
+{
+  protected $collection_key = 'maps';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $mapsType = 'Google_Service_MapsEngine_Map';
+  protected $mapsDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setMaps($maps)
+  {
+    $this->maps = $maps;
+  }
+  public function getMaps()
+  {
+    return $this->maps;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_MapsEngine_MapsengineFile extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $filename;
+  public $size;
+  public $uploadStatus;
+
+
+  public function setFilename($filename)
+  {
+    $this->filename = $filename;
+  }
+  public function getFilename()
+  {
+    return $this->filename;
+  }
+  public function setSize($size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+  public function setUploadStatus($uploadStatus)
+  {
+    $this->uploadStatus = $uploadStatus;
+  }
+  public function getUploadStatus()
+  {
+    return $this->uploadStatus;
+  }
+}
+
+class Google_Service_MapsEngine_Parent extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+}
+
+class Google_Service_MapsEngine_ParentsListResponse extends Google_Collection
+{
+  protected $collection_key = 'parents';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $parentsType = 'Google_Service_MapsEngine_Parent';
+  protected $parentsDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setParents($parents)
+  {
+    $this->parents = $parents;
+  }
+  public function getParents()
+  {
+    return $this->parents;
+  }
+}
+
+class Google_Service_MapsEngine_Permission extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $discoverable;
+  public $id;
+  public $role;
+  public $type;
+
+
+  public function setDiscoverable($discoverable)
+  {
+    $this->discoverable = $discoverable;
+  }
+  public function getDiscoverable()
+  {
+    return $this->discoverable;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setRole($role)
+  {
+    $this->role = $role;
+  }
+  public function getRole()
+  {
+    return $this->role;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_MapsEngine_PermissionsBatchDeleteRequest extends Google_Collection
+{
+  protected $collection_key = 'ids';
+  protected $internal_gapi_mappings = array(
+  );
+  public $ids;
+
+
+  public function setIds($ids)
+  {
+    $this->ids = $ids;
+  }
+  public function getIds()
+  {
+    return $this->ids;
+  }
+}
+
+class Google_Service_MapsEngine_PermissionsBatchDeleteResponse extends Google_Model
+{
+}
+
+class Google_Service_MapsEngine_PermissionsBatchUpdateRequest extends Google_Collection
+{
+  protected $collection_key = 'permissions';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $permissionsType = 'Google_Service_MapsEngine_Permission';
+  protected $permissionsDataType = 'array';
+
+
+  public function setPermissions($permissions)
+  {
+    $this->permissions = $permissions;
+  }
+  public function getPermissions()
+  {
+    return $this->permissions;
+  }
+}
+
+class Google_Service_MapsEngine_PermissionsBatchUpdateResponse extends Google_Model
+{
+}
+
+class Google_Service_MapsEngine_PermissionsListResponse extends Google_Collection
+{
+  protected $collection_key = 'permissions';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $permissionsType = 'Google_Service_MapsEngine_Permission';
+  protected $permissionsDataType = 'array';
+
+
+  public function setPermissions($permissions)
+  {
+    $this->permissions = $permissions;
+  }
+  public function getPermissions()
+  {
+    return $this->permissions;
+  }
+}
+
+class Google_Service_MapsEngine_PointStyle extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $iconType = 'Google_Service_MapsEngine_IconStyle';
+  protected $iconDataType = '';
+  protected $labelType = 'Google_Service_MapsEngine_LabelStyle';
+  protected $labelDataType = '';
+
+
+  public function setIcon(Google_Service_MapsEngine_IconStyle $icon)
+  {
+    $this->icon = $icon;
+  }
+  public function getIcon()
+  {
+    return $this->icon;
+  }
+  public function setLabel(Google_Service_MapsEngine_LabelStyle $label)
+  {
+    $this->label = $label;
+  }
+  public function getLabel()
+  {
+    return $this->label;
+  }
+}
+
+class Google_Service_MapsEngine_PolygonStyle extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $fillType = 'Google_Service_MapsEngine_Color';
+  protected $fillDataType = '';
+  protected $labelType = 'Google_Service_MapsEngine_LabelStyle';
+  protected $labelDataType = '';
+  protected $strokeType = 'Google_Service_MapsEngine_Border';
+  protected $strokeDataType = '';
+
+
+  public function setFill(Google_Service_MapsEngine_Color $fill)
+  {
+    $this->fill = $fill;
+  }
+  public function getFill()
+  {
+    return $this->fill;
+  }
+  public function setLabel(Google_Service_MapsEngine_LabelStyle $label)
+  {
+    $this->label = $label;
+  }
+  public function getLabel()
+  {
+    return $this->label;
+  }
+  public function setStroke(Google_Service_MapsEngine_Border $stroke)
+  {
+    $this->stroke = $stroke;
+  }
+  public function getStroke()
+  {
+    return $this->stroke;
+  }
+}
+
+class Google_Service_MapsEngine_ProcessResponse extends Google_Model
+{
+}
+
+class Google_Service_MapsEngine_Project extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $name;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_MapsEngine_ProjectsListResponse extends Google_Collection
+{
+  protected $collection_key = 'projects';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $projectsType = 'Google_Service_MapsEngine_Project';
+  protected $projectsDataType = 'array';
+
+
+  public function setProjects($projects)
+  {
+    $this->projects = $projects;
+  }
+  public function getProjects()
+  {
+    return $this->projects;
+  }
+}
+
+class Google_Service_MapsEngine_PublishResponse extends Google_Model
+{
+}
+
+class Google_Service_MapsEngine_PublishedLayer extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $id;
+  public $layerType;
+  public $name;
+  public $projectId;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLayerType($layerType)
+  {
+    $this->layerType = $layerType;
+  }
+  public function getLayerType()
+  {
+    return $this->layerType;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+}
+
+class Google_Service_MapsEngine_PublishedLayersListResponse extends Google_Collection
+{
+  protected $collection_key = 'layers';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $layersType = 'Google_Service_MapsEngine_PublishedLayer';
+  protected $layersDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setLayers($layers)
+  {
+    $this->layers = $layers;
+  }
+  public function getLayers()
+  {
+    return $this->layers;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_MapsEngine_PublishedMap extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $contentsType = 'Google_Service_MapsEngine_MapItem';
+  protected $contentsDataType = '';
+  public $defaultViewport;
+  public $description;
+  public $id;
+  public $name;
+  public $projectId;
+
+
+  public function setContents(Google_Service_MapsEngine_MapItem $contents)
+  {
+    $this->contents = $contents;
+  }
+  public function getContents()
+  {
+    return $this->contents;
+  }
+  public function setDefaultViewport($defaultViewport)
+  {
+    $this->defaultViewport = $defaultViewport;
+  }
+  public function getDefaultViewport()
+  {
+    return $this->defaultViewport;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+}
+
+class Google_Service_MapsEngine_PublishedMapsListResponse extends Google_Collection
+{
+  protected $collection_key = 'maps';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $mapsType = 'Google_Service_MapsEngine_PublishedMap';
+  protected $mapsDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setMaps($maps)
+  {
+    $this->maps = $maps;
+  }
+  public function getMaps()
+  {
+    return $this->maps;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_MapsEngine_Raster extends Google_Collection
+{
+  protected $collection_key = 'files';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $acquisitionTimeType = 'Google_Service_MapsEngine_AcquisitionTime';
+  protected $acquisitionTimeDataType = '';
+  public $attribution;
+  public $bbox;
+  public $creationTime;
+  public $creatorEmail;
+  public $description;
+  public $draftAccessList;
+  public $etag;
+  protected $filesType = 'Google_Service_MapsEngine_MapsengineFile';
+  protected $filesDataType = 'array';
+  public $id;
+  public $lastModifiedTime;
+  public $lastModifierEmail;
+  public $maskType;
+  public $name;
+  public $processingStatus;
+  public $projectId;
+  public $rasterType;
+  public $tags;
+  public $writersCanEditPermissions;
+
+
+  public function setAcquisitionTime(Google_Service_MapsEngine_AcquisitionTime $acquisitionTime)
+  {
+    $this->acquisitionTime = $acquisitionTime;
+  }
+  public function getAcquisitionTime()
+  {
+    return $this->acquisitionTime;
+  }
+  public function setAttribution($attribution)
+  {
+    $this->attribution = $attribution;
+  }
+  public function getAttribution()
+  {
+    return $this->attribution;
+  }
+  public function setBbox($bbox)
+  {
+    $this->bbox = $bbox;
+  }
+  public function getBbox()
+  {
+    return $this->bbox;
+  }
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setCreatorEmail($creatorEmail)
+  {
+    $this->creatorEmail = $creatorEmail;
+  }
+  public function getCreatorEmail()
+  {
+    return $this->creatorEmail;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDraftAccessList($draftAccessList)
+  {
+    $this->draftAccessList = $draftAccessList;
+  }
+  public function getDraftAccessList()
+  {
+    return $this->draftAccessList;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setFiles($files)
+  {
+    $this->files = $files;
+  }
+  public function getFiles()
+  {
+    return $this->files;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLastModifiedTime($lastModifiedTime)
+  {
+    $this->lastModifiedTime = $lastModifiedTime;
+  }
+  public function getLastModifiedTime()
+  {
+    return $this->lastModifiedTime;
+  }
+  public function setLastModifierEmail($lastModifierEmail)
+  {
+    $this->lastModifierEmail = $lastModifierEmail;
+  }
+  public function getLastModifierEmail()
+  {
+    return $this->lastModifierEmail;
+  }
+  public function setMaskType($maskType)
+  {
+    $this->maskType = $maskType;
+  }
+  public function getMaskType()
+  {
+    return $this->maskType;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProcessingStatus($processingStatus)
+  {
+    $this->processingStatus = $processingStatus;
+  }
+  public function getProcessingStatus()
+  {
+    return $this->processingStatus;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setRasterType($rasterType)
+  {
+    $this->rasterType = $rasterType;
+  }
+  public function getRasterType()
+  {
+    return $this->rasterType;
+  }
+  public function setTags($tags)
+  {
+    $this->tags = $tags;
+  }
+  public function getTags()
+  {
+    return $this->tags;
+  }
+  public function setWritersCanEditPermissions($writersCanEditPermissions)
+  {
+    $this->writersCanEditPermissions = $writersCanEditPermissions;
+  }
+  public function getWritersCanEditPermissions()
+  {
+    return $this->writersCanEditPermissions;
+  }
+}
+
+class Google_Service_MapsEngine_RasterCollection extends Google_Collection
+{
+  protected $collection_key = 'bbox';
+  protected $internal_gapi_mappings = array(
+  );
+  public $attribution;
+  public $bbox;
+  public $creationTime;
+  public $creatorEmail;
+  public $description;
+  public $draftAccessList;
+  public $etag;
+  public $id;
+  public $lastModifiedTime;
+  public $lastModifierEmail;
+  public $mosaic;
+  public $name;
+  public $processingStatus;
+  public $projectId;
+  public $rasterType;
+  public $tags;
+  public $writersCanEditPermissions;
+
+
+  public function setAttribution($attribution)
+  {
+    $this->attribution = $attribution;
+  }
+  public function getAttribution()
+  {
+    return $this->attribution;
+  }
+  public function setBbox($bbox)
+  {
+    $this->bbox = $bbox;
+  }
+  public function getBbox()
+  {
+    return $this->bbox;
+  }
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setCreatorEmail($creatorEmail)
+  {
+    $this->creatorEmail = $creatorEmail;
+  }
+  public function getCreatorEmail()
+  {
+    return $this->creatorEmail;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDraftAccessList($draftAccessList)
+  {
+    $this->draftAccessList = $draftAccessList;
+  }
+  public function getDraftAccessList()
+  {
+    return $this->draftAccessList;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLastModifiedTime($lastModifiedTime)
+  {
+    $this->lastModifiedTime = $lastModifiedTime;
+  }
+  public function getLastModifiedTime()
+  {
+    return $this->lastModifiedTime;
+  }
+  public function setLastModifierEmail($lastModifierEmail)
+  {
+    $this->lastModifierEmail = $lastModifierEmail;
+  }
+  public function getLastModifierEmail()
+  {
+    return $this->lastModifierEmail;
+  }
+  public function setMosaic($mosaic)
+  {
+    $this->mosaic = $mosaic;
+  }
+  public function getMosaic()
+  {
+    return $this->mosaic;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProcessingStatus($processingStatus)
+  {
+    $this->processingStatus = $processingStatus;
+  }
+  public function getProcessingStatus()
+  {
+    return $this->processingStatus;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setRasterType($rasterType)
+  {
+    $this->rasterType = $rasterType;
+  }
+  public function getRasterType()
+  {
+    return $this->rasterType;
+  }
+  public function setTags($tags)
+  {
+    $this->tags = $tags;
+  }
+  public function getTags()
+  {
+    return $this->tags;
+  }
+  public function setWritersCanEditPermissions($writersCanEditPermissions)
+  {
+    $this->writersCanEditPermissions = $writersCanEditPermissions;
+  }
+  public function getWritersCanEditPermissions()
+  {
+    return $this->writersCanEditPermissions;
+  }
+}
+
+class Google_Service_MapsEngine_RasterCollectionsListResponse extends Google_Collection
+{
+  protected $collection_key = 'rasterCollections';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $rasterCollectionsType = 'Google_Service_MapsEngine_RasterCollection';
+  protected $rasterCollectionsDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setRasterCollections($rasterCollections)
+  {
+    $this->rasterCollections = $rasterCollections;
+  }
+  public function getRasterCollections()
+  {
+    return $this->rasterCollections;
+  }
+}
+
+class Google_Service_MapsEngine_RasterCollectionsRaster extends Google_Collection
+{
+  protected $collection_key = 'tags';
+  protected $internal_gapi_mappings = array(
+  );
+  public $bbox;
+  public $creationTime;
+  public $description;
+  public $id;
+  public $lastModifiedTime;
+  public $name;
+  public $projectId;
+  public $rasterType;
+  public $tags;
+
+
+  public function setBbox($bbox)
+  {
+    $this->bbox = $bbox;
+  }
+  public function getBbox()
+  {
+    return $this->bbox;
+  }
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLastModifiedTime($lastModifiedTime)
+  {
+    $this->lastModifiedTime = $lastModifiedTime;
+  }
+  public function getLastModifiedTime()
+  {
+    return $this->lastModifiedTime;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setRasterType($rasterType)
+  {
+    $this->rasterType = $rasterType;
+  }
+  public function getRasterType()
+  {
+    return $this->rasterType;
+  }
+  public function setTags($tags)
+  {
+    $this->tags = $tags;
+  }
+  public function getTags()
+  {
+    return $this->tags;
+  }
+}
+
+class Google_Service_MapsEngine_RasterCollectionsRasterBatchDeleteRequest extends Google_Collection
+{
+  protected $collection_key = 'ids';
+  protected $internal_gapi_mappings = array(
+  );
+  public $ids;
+
+
+  public function setIds($ids)
+  {
+    $this->ids = $ids;
+  }
+  public function getIds()
+  {
+    return $this->ids;
+  }
+}
+
+class Google_Service_MapsEngine_RasterCollectionsRastersBatchDeleteResponse extends Google_Model
+{
+}
+
+class Google_Service_MapsEngine_RasterCollectionsRastersBatchInsertRequest extends Google_Collection
+{
+  protected $collection_key = 'ids';
+  protected $internal_gapi_mappings = array(
+  );
+  public $ids;
+
+
+  public function setIds($ids)
+  {
+    $this->ids = $ids;
+  }
+  public function getIds()
+  {
+    return $this->ids;
+  }
+}
+
+class Google_Service_MapsEngine_RasterCollectionsRastersBatchInsertResponse extends Google_Model
+{
+}
+
+class Google_Service_MapsEngine_RasterCollectionsRastersListResponse extends Google_Collection
+{
+  protected $collection_key = 'rasters';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $rastersType = 'Google_Service_MapsEngine_RasterCollectionsRaster';
+  protected $rastersDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setRasters($rasters)
+  {
+    $this->rasters = $rasters;
+  }
+  public function getRasters()
+  {
+    return $this->rasters;
+  }
+}
+
+class Google_Service_MapsEngine_RastersListResponse extends Google_Collection
+{
+  protected $collection_key = 'rasters';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $rastersType = 'Google_Service_MapsEngine_Raster';
+  protected $rastersDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setRasters($rasters)
+  {
+    $this->rasters = $rasters;
+  }
+  public function getRasters()
+  {
+    return $this->rasters;
+  }
+}
+
+class Google_Service_MapsEngine_ScaledShape extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $borderType = 'Google_Service_MapsEngine_Border';
+  protected $borderDataType = '';
+  protected $fillType = 'Google_Service_MapsEngine_Color';
+  protected $fillDataType = '';
+  public $shape;
+
+
+  public function setBorder(Google_Service_MapsEngine_Border $border)
+  {
+    $this->border = $border;
+  }
+  public function getBorder()
+  {
+    return $this->border;
+  }
+  public function setFill(Google_Service_MapsEngine_Color $fill)
+  {
+    $this->fill = $fill;
+  }
+  public function getFill()
+  {
+    return $this->fill;
+  }
+  public function setShape($shape)
+  {
+    $this->shape = $shape;
+  }
+  public function getShape()
+  {
+    return $this->shape;
+  }
+}
+
+class Google_Service_MapsEngine_ScalingFunction extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $column;
+  public $scalingType;
+  protected $sizeRangeType = 'Google_Service_MapsEngine_SizeRange';
+  protected $sizeRangeDataType = '';
+  protected $valueRangeType = 'Google_Service_MapsEngine_ValueRange';
+  protected $valueRangeDataType = '';
+
+
+  public function setColumn($column)
+  {
+    $this->column = $column;
+  }
+  public function getColumn()
+  {
+    return $this->column;
+  }
+  public function setScalingType($scalingType)
+  {
+    $this->scalingType = $scalingType;
+  }
+  public function getScalingType()
+  {
+    return $this->scalingType;
+  }
+  public function setSizeRange(Google_Service_MapsEngine_SizeRange $sizeRange)
+  {
+    $this->sizeRange = $sizeRange;
+  }
+  public function getSizeRange()
+  {
+    return $this->sizeRange;
+  }
+  public function setValueRange(Google_Service_MapsEngine_ValueRange $valueRange)
+  {
+    $this->valueRange = $valueRange;
+  }
+  public function getValueRange()
+  {
+    return $this->valueRange;
+  }
+}
+
+class Google_Service_MapsEngine_Schema extends Google_Collection
+{
+  protected $collection_key = 'columns';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $columnsType = 'Google_Service_MapsEngine_TableColumn';
+  protected $columnsDataType = 'array';
+  public $primaryGeometry;
+  public $primaryKey;
+
+
+  public function setColumns($columns)
+  {
+    $this->columns = $columns;
+  }
+  public function getColumns()
+  {
+    return $this->columns;
+  }
+  public function setPrimaryGeometry($primaryGeometry)
+  {
+    $this->primaryGeometry = $primaryGeometry;
+  }
+  public function getPrimaryGeometry()
+  {
+    return $this->primaryGeometry;
+  }
+  public function setPrimaryKey($primaryKey)
+  {
+    $this->primaryKey = $primaryKey;
+  }
+  public function getPrimaryKey()
+  {
+    return $this->primaryKey;
+  }
+}
+
+class Google_Service_MapsEngine_SizeRange extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $max;
+  public $min;
+
+
+  public function setMax($max)
+  {
+    $this->max = $max;
+  }
+  public function getMax()
+  {
+    return $this->max;
+  }
+  public function setMin($min)
+  {
+    $this->min = $min;
+  }
+  public function getMin()
+  {
+    return $this->min;
+  }
+}
+
+class Google_Service_MapsEngine_Table extends Google_Collection
+{
+  protected $collection_key = 'tags';
+  protected $internal_gapi_mappings = array(
+  );
+  public $bbox;
+  public $creationTime;
+  public $creatorEmail;
+  public $description;
+  public $draftAccessList;
+  public $etag;
+  protected $filesType = 'Google_Service_MapsEngine_MapsengineFile';
+  protected $filesDataType = 'array';
+  public $id;
+  public $lastModifiedTime;
+  public $lastModifierEmail;
+  public $name;
+  public $processingStatus;
+  public $projectId;
+  public $publishedAccessList;
+  protected $schemaType = 'Google_Service_MapsEngine_Schema';
+  protected $schemaDataType = '';
+  public $sourceEncoding;
+  public $tags;
+  public $writersCanEditPermissions;
+
+
+  public function setBbox($bbox)
+  {
+    $this->bbox = $bbox;
+  }
+  public function getBbox()
+  {
+    return $this->bbox;
+  }
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setCreatorEmail($creatorEmail)
+  {
+    $this->creatorEmail = $creatorEmail;
+  }
+  public function getCreatorEmail()
+  {
+    return $this->creatorEmail;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDraftAccessList($draftAccessList)
+  {
+    $this->draftAccessList = $draftAccessList;
+  }
+  public function getDraftAccessList()
+  {
+    return $this->draftAccessList;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setFiles($files)
+  {
+    $this->files = $files;
+  }
+  public function getFiles()
+  {
+    return $this->files;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLastModifiedTime($lastModifiedTime)
+  {
+    $this->lastModifiedTime = $lastModifiedTime;
+  }
+  public function getLastModifiedTime()
+  {
+    return $this->lastModifiedTime;
+  }
+  public function setLastModifierEmail($lastModifierEmail)
+  {
+    $this->lastModifierEmail = $lastModifierEmail;
+  }
+  public function getLastModifierEmail()
+  {
+    return $this->lastModifierEmail;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProcessingStatus($processingStatus)
+  {
+    $this->processingStatus = $processingStatus;
+  }
+  public function getProcessingStatus()
+  {
+    return $this->processingStatus;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setPublishedAccessList($publishedAccessList)
+  {
+    $this->publishedAccessList = $publishedAccessList;
+  }
+  public function getPublishedAccessList()
+  {
+    return $this->publishedAccessList;
+  }
+  public function setSchema(Google_Service_MapsEngine_Schema $schema)
+  {
+    $this->schema = $schema;
+  }
+  public function getSchema()
+  {
+    return $this->schema;
+  }
+  public function setSourceEncoding($sourceEncoding)
+  {
+    $this->sourceEncoding = $sourceEncoding;
+  }
+  public function getSourceEncoding()
+  {
+    return $this->sourceEncoding;
+  }
+  public function setTags($tags)
+  {
+    $this->tags = $tags;
+  }
+  public function getTags()
+  {
+    return $this->tags;
+  }
+  public function setWritersCanEditPermissions($writersCanEditPermissions)
+  {
+    $this->writersCanEditPermissions = $writersCanEditPermissions;
+  }
+  public function getWritersCanEditPermissions()
+  {
+    return $this->writersCanEditPermissions;
+  }
+}
+
+class Google_Service_MapsEngine_TableColumn extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $type;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_MapsEngine_TablesListResponse extends Google_Collection
+{
+  protected $collection_key = 'tables';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $tablesType = 'Google_Service_MapsEngine_Table';
+  protected $tablesDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTables($tables)
+  {
+    $this->tables = $tables;
+  }
+  public function getTables()
+  {
+    return $this->tables;
+  }
+}
+
+class Google_Service_MapsEngine_ValueRange extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $max;
+  public $min;
+
+
+  public function setMax($max)
+  {
+    $this->max = $max;
+  }
+  public function getMax()
+  {
+    return $this->max;
+  }
+  public function setMin($min)
+  {
+    $this->min = $min;
+  }
+  public function getMin()
+  {
+    return $this->min;
+  }
+}
+
+class Google_Service_MapsEngine_VectorStyle extends Google_Collection
+{
+  protected $collection_key = 'displayRules';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $displayRulesType = 'Google_Service_MapsEngine_DisplayRule';
+  protected $displayRulesDataType = 'array';
+  protected $featureInfoType = 'Google_Service_MapsEngine_FeatureInfo';
+  protected $featureInfoDataType = '';
+  public $type;
+
+
+  public function setDisplayRules($displayRules)
+  {
+    $this->displayRules = $displayRules;
+  }
+  public function getDisplayRules()
+  {
+    return $this->displayRules;
+  }
+  public function setFeatureInfo(Google_Service_MapsEngine_FeatureInfo $featureInfo)
+  {
+    $this->featureInfo = $featureInfo;
+  }
+  public function getFeatureInfo()
+  {
+    return $this->featureInfo;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_MapsEngine_ZoomLevels extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $max;
+  public $min;
+
+
+  public function setMax($max)
+  {
+    $this->max = $max;
+  }
+  public function getMax()
+  {
+    return $this->max;
+  }
+  public function setMin($min)
+  {
+    $this->min = $min;
+  }
+  public function getMin()
+  {
+    return $this->min;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Mirror.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Mirror.php
@@ -1,0 +1,1932 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Mirror (v1).
+ *
+ * <p>
+ * API for interacting with Glass users via the timeline.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/glass" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Mirror extends Google_Service
+{
+  /** View your location. */
+  const GLASS_LOCATION =
+      "https://www.googleapis.com/auth/glass.location";
+  /** View and manage your Glass timeline. */
+  const GLASS_TIMELINE =
+      "https://www.googleapis.com/auth/glass.timeline";
+
+  public $accounts;
+  public $contacts;
+  public $locations;
+  public $settings;
+  public $subscriptions;
+  public $timeline;
+  public $timeline_attachments;
+  
+
+  /**
+   * Constructs the internal representation of the Mirror service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'mirror/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'mirror';
+
+    $this->accounts = new Google_Service_Mirror_Accounts_Resource(
+        $this,
+        $this->serviceName,
+        'accounts',
+        array(
+          'methods' => array(
+            'insert' => array(
+              'path' => 'accounts/{userToken}/{accountType}/{accountName}',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userToken' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'accountType' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'accountName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->contacts = new Google_Service_Mirror_Contacts_Resource(
+        $this,
+        $this->serviceName,
+        'contacts',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'contacts/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'contacts/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'contacts',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'list' => array(
+              'path' => 'contacts',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),'patch' => array(
+              'path' => 'contacts/{id}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'contacts/{id}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->locations = new Google_Service_Mirror_Locations_Resource(
+        $this,
+        $this->serviceName,
+        'locations',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'locations/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'locations',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->settings = new Google_Service_Mirror_Settings_Resource(
+        $this,
+        $this->serviceName,
+        'settings',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'settings/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->subscriptions = new Google_Service_Mirror_Subscriptions_Resource(
+        $this,
+        $this->serviceName,
+        'subscriptions',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'subscriptions/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'subscriptions',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'list' => array(
+              'path' => 'subscriptions',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),'update' => array(
+              'path' => 'subscriptions/{id}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->timeline = new Google_Service_Mirror_Timeline_Resource(
+        $this,
+        $this->serviceName,
+        'timeline',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'timeline/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'timeline/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'timeline',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'list' => array(
+              'path' => 'timeline',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'includeDeleted' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sourceItemId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pinnedOnly' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'bundleId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'timeline/{id}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'timeline/{id}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->timeline_attachments = new Google_Service_Mirror_TimelineAttachments_Resource(
+        $this,
+        $this->serviceName,
+        'attachments',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'timeline/{itemId}/attachments/{attachmentId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'itemId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'attachmentId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'timeline/{itemId}/attachments/{attachmentId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'itemId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'attachmentId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'timeline/{itemId}/attachments',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'itemId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'timeline/{itemId}/attachments',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'itemId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "accounts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mirrorService = new Google_Service_Mirror(...);
+ *   $accounts = $mirrorService->accounts;
+ *  </code>
+ */
+class Google_Service_Mirror_Accounts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Inserts a new account for a user (accounts.insert)
+   *
+   * @param string $userToken The ID for the user.
+   * @param string $accountType Account type to be passed to Android Account
+   * Manager.
+   * @param string $accountName The name of the account to be passed to the
+   * Android Account Manager.
+   * @param Google_Account $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_Account
+   */
+  public function insert($userToken, $accountType, $accountName, Google_Service_Mirror_Account $postBody, $optParams = array())
+  {
+    $params = array('userToken' => $userToken, 'accountType' => $accountType, 'accountName' => $accountName, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Mirror_Account");
+  }
+}
+
+/**
+ * The "contacts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mirrorService = new Google_Service_Mirror(...);
+ *   $contacts = $mirrorService->contacts;
+ *  </code>
+ */
+class Google_Service_Mirror_Contacts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a contact. (contacts.delete)
+   *
+   * @param string $id The ID of the contact.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets a single contact by ID. (contacts.get)
+   *
+   * @param string $id The ID of the contact.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_Contact
+   */
+  public function get($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Mirror_Contact");
+  }
+
+  /**
+   * Inserts a new contact. (contacts.insert)
+   *
+   * @param Google_Contact $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_Contact
+   */
+  public function insert(Google_Service_Mirror_Contact $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Mirror_Contact");
+  }
+
+  /**
+   * Retrieves a list of contacts for the authenticated user.
+   * (contacts.listContacts)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_ContactsListResponse
+   */
+  public function listContacts($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Mirror_ContactsListResponse");
+  }
+
+  /**
+   * Updates a contact in place. This method supports patch semantics.
+   * (contacts.patch)
+   *
+   * @param string $id The ID of the contact.
+   * @param Google_Contact $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_Contact
+   */
+  public function patch($id, Google_Service_Mirror_Contact $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Mirror_Contact");
+  }
+
+  /**
+   * Updates a contact in place. (contacts.update)
+   *
+   * @param string $id The ID of the contact.
+   * @param Google_Contact $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_Contact
+   */
+  public function update($id, Google_Service_Mirror_Contact $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Mirror_Contact");
+  }
+}
+
+/**
+ * The "locations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mirrorService = new Google_Service_Mirror(...);
+ *   $locations = $mirrorService->locations;
+ *  </code>
+ */
+class Google_Service_Mirror_Locations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets a single location by ID. (locations.get)
+   *
+   * @param string $id The ID of the location or latest for the last known
+   * location.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_Location
+   */
+  public function get($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Mirror_Location");
+  }
+
+  /**
+   * Retrieves a list of locations for the user. (locations.listLocations)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_LocationsListResponse
+   */
+  public function listLocations($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Mirror_LocationsListResponse");
+  }
+}
+
+/**
+ * The "settings" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mirrorService = new Google_Service_Mirror(...);
+ *   $settings = $mirrorService->settings;
+ *  </code>
+ */
+class Google_Service_Mirror_Settings_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets a single setting by ID. (settings.get)
+   *
+   * @param string $id The ID of the setting. The following IDs are valid: -
+   * locale - The key to the user’s language/locale (BCP 47 identifier) that
+   * Glassware should use to render localized content.  - timezone - The key to
+   * the user’s current time zone region as defined in the tz database. Example:
+   * America/Los_Angeles.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_Setting
+   */
+  public function get($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Mirror_Setting");
+  }
+}
+
+/**
+ * The "subscriptions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mirrorService = new Google_Service_Mirror(...);
+ *   $subscriptions = $mirrorService->subscriptions;
+ *  </code>
+ */
+class Google_Service_Mirror_Subscriptions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a subscription. (subscriptions.delete)
+   *
+   * @param string $id The ID of the subscription.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Creates a new subscription. (subscriptions.insert)
+   *
+   * @param Google_Subscription $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_Subscription
+   */
+  public function insert(Google_Service_Mirror_Subscription $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Mirror_Subscription");
+  }
+
+  /**
+   * Retrieves a list of subscriptions for the authenticated user and service.
+   * (subscriptions.listSubscriptions)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_SubscriptionsListResponse
+   */
+  public function listSubscriptions($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Mirror_SubscriptionsListResponse");
+  }
+
+  /**
+   * Updates an existing subscription in place. (subscriptions.update)
+   *
+   * @param string $id The ID of the subscription.
+   * @param Google_Subscription $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_Subscription
+   */
+  public function update($id, Google_Service_Mirror_Subscription $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Mirror_Subscription");
+  }
+}
+
+/**
+ * The "timeline" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mirrorService = new Google_Service_Mirror(...);
+ *   $timeline = $mirrorService->timeline;
+ *  </code>
+ */
+class Google_Service_Mirror_Timeline_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a timeline item. (timeline.delete)
+   *
+   * @param string $id The ID of the timeline item.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets a single timeline item by ID. (timeline.get)
+   *
+   * @param string $id The ID of the timeline item.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_TimelineItem
+   */
+  public function get($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Mirror_TimelineItem");
+  }
+
+  /**
+   * Inserts a new item into the timeline. (timeline.insert)
+   *
+   * @param Google_TimelineItem $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_TimelineItem
+   */
+  public function insert(Google_Service_Mirror_TimelineItem $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Mirror_TimelineItem");
+  }
+
+  /**
+   * Retrieves a list of timeline items for the authenticated user.
+   * (timeline.listTimeline)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderBy Controls the order in which timeline items are
+   * returned.
+   * @opt_param bool includeDeleted If true, tombstone records for deleted items
+   * will be returned.
+   * @opt_param string maxResults The maximum number of items to include in the
+   * response, used for paging.
+   * @opt_param string pageToken Token for the page of results to return.
+   * @opt_param string sourceItemId If provided, only items with the given
+   * sourceItemId will be returned.
+   * @opt_param bool pinnedOnly If true, only pinned items will be returned.
+   * @opt_param string bundleId If provided, only items with the given bundleId
+   * will be returned.
+   * @return Google_Service_Mirror_TimelineListResponse
+   */
+  public function listTimeline($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Mirror_TimelineListResponse");
+  }
+
+  /**
+   * Updates a timeline item in place. This method supports patch semantics.
+   * (timeline.patch)
+   *
+   * @param string $id The ID of the timeline item.
+   * @param Google_TimelineItem $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_TimelineItem
+   */
+  public function patch($id, Google_Service_Mirror_TimelineItem $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Mirror_TimelineItem");
+  }
+
+  /**
+   * Updates a timeline item in place. (timeline.update)
+   *
+   * @param string $id The ID of the timeline item.
+   * @param Google_TimelineItem $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_TimelineItem
+   */
+  public function update($id, Google_Service_Mirror_TimelineItem $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Mirror_TimelineItem");
+  }
+}
+
+/**
+ * The "attachments" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $mirrorService = new Google_Service_Mirror(...);
+ *   $attachments = $mirrorService->attachments;
+ *  </code>
+ */
+class Google_Service_Mirror_TimelineAttachments_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes an attachment from a timeline item. (attachments.delete)
+   *
+   * @param string $itemId The ID of the timeline item the attachment belongs to.
+   * @param string $attachmentId The ID of the attachment.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($itemId, $attachmentId, $optParams = array())
+  {
+    $params = array('itemId' => $itemId, 'attachmentId' => $attachmentId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves an attachment on a timeline item by item ID and attachment ID.
+   * (attachments.get)
+   *
+   * @param string $itemId The ID of the timeline item the attachment belongs to.
+   * @param string $attachmentId The ID of the attachment.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_Attachment
+   */
+  public function get($itemId, $attachmentId, $optParams = array())
+  {
+    $params = array('itemId' => $itemId, 'attachmentId' => $attachmentId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Mirror_Attachment");
+  }
+
+  /**
+   * Adds a new attachment to a timeline item. (attachments.insert)
+   *
+   * @param string $itemId The ID of the timeline item the attachment belongs to.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_Attachment
+   */
+  public function insert($itemId, $optParams = array())
+  {
+    $params = array('itemId' => $itemId);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Mirror_Attachment");
+  }
+
+  /**
+   * Returns a list of attachments for a timeline item.
+   * (attachments.listTimelineAttachments)
+   *
+   * @param string $itemId The ID of the timeline item whose attachments should be
+   * listed.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Mirror_AttachmentsListResponse
+   */
+  public function listTimelineAttachments($itemId, $optParams = array())
+  {
+    $params = array('itemId' => $itemId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Mirror_AttachmentsListResponse");
+  }
+}
+
+
+
+
+class Google_Service_Mirror_Account extends Google_Collection
+{
+  protected $collection_key = 'userData';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $authTokensType = 'Google_Service_Mirror_AuthToken';
+  protected $authTokensDataType = 'array';
+  public $features;
+  public $password;
+  protected $userDataType = 'Google_Service_Mirror_UserData';
+  protected $userDataDataType = 'array';
+
+
+  public function setAuthTokens($authTokens)
+  {
+    $this->authTokens = $authTokens;
+  }
+  public function getAuthTokens()
+  {
+    return $this->authTokens;
+  }
+  public function setFeatures($features)
+  {
+    $this->features = $features;
+  }
+  public function getFeatures()
+  {
+    return $this->features;
+  }
+  public function setPassword($password)
+  {
+    $this->password = $password;
+  }
+  public function getPassword()
+  {
+    return $this->password;
+  }
+  public function setUserData($userData)
+  {
+    $this->userData = $userData;
+  }
+  public function getUserData()
+  {
+    return $this->userData;
+  }
+}
+
+class Google_Service_Mirror_Attachment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $contentType;
+  public $contentUrl;
+  public $id;
+  public $isProcessingContent;
+
+
+  public function setContentType($contentType)
+  {
+    $this->contentType = $contentType;
+  }
+  public function getContentType()
+  {
+    return $this->contentType;
+  }
+  public function setContentUrl($contentUrl)
+  {
+    $this->contentUrl = $contentUrl;
+  }
+  public function getContentUrl()
+  {
+    return $this->contentUrl;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIsProcessingContent($isProcessingContent)
+  {
+    $this->isProcessingContent = $isProcessingContent;
+  }
+  public function getIsProcessingContent()
+  {
+    return $this->isProcessingContent;
+  }
+}
+
+class Google_Service_Mirror_AttachmentsListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Mirror_Attachment';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Mirror_AuthToken extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $authToken;
+  public $type;
+
+
+  public function setAuthToken($authToken)
+  {
+    $this->authToken = $authToken;
+  }
+  public function getAuthToken()
+  {
+    return $this->authToken;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Mirror_Command extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $type;
+
+
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Mirror_Contact extends Google_Collection
+{
+  protected $collection_key = 'sharingFeatures';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $acceptCommandsType = 'Google_Service_Mirror_Command';
+  protected $acceptCommandsDataType = 'array';
+  public $acceptTypes;
+  public $displayName;
+  public $id;
+  public $imageUrls;
+  public $kind;
+  public $phoneNumber;
+  public $priority;
+  public $sharingFeatures;
+  public $source;
+  public $speakableName;
+  public $type;
+
+
+  public function setAcceptCommands($acceptCommands)
+  {
+    $this->acceptCommands = $acceptCommands;
+  }
+  public function getAcceptCommands()
+  {
+    return $this->acceptCommands;
+  }
+  public function setAcceptTypes($acceptTypes)
+  {
+    $this->acceptTypes = $acceptTypes;
+  }
+  public function getAcceptTypes()
+  {
+    return $this->acceptTypes;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImageUrls($imageUrls)
+  {
+    $this->imageUrls = $imageUrls;
+  }
+  public function getImageUrls()
+  {
+    return $this->imageUrls;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPhoneNumber($phoneNumber)
+  {
+    $this->phoneNumber = $phoneNumber;
+  }
+  public function getPhoneNumber()
+  {
+    return $this->phoneNumber;
+  }
+  public function setPriority($priority)
+  {
+    $this->priority = $priority;
+  }
+  public function getPriority()
+  {
+    return $this->priority;
+  }
+  public function setSharingFeatures($sharingFeatures)
+  {
+    $this->sharingFeatures = $sharingFeatures;
+  }
+  public function getSharingFeatures()
+  {
+    return $this->sharingFeatures;
+  }
+  public function setSource($source)
+  {
+    $this->source = $source;
+  }
+  public function getSource()
+  {
+    return $this->source;
+  }
+  public function setSpeakableName($speakableName)
+  {
+    $this->speakableName = $speakableName;
+  }
+  public function getSpeakableName()
+  {
+    return $this->speakableName;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Mirror_ContactsListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Mirror_Contact';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Mirror_Location extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accuracy;
+  public $address;
+  public $displayName;
+  public $id;
+  public $kind;
+  public $latitude;
+  public $longitude;
+  public $timestamp;
+
+
+  public function setAccuracy($accuracy)
+  {
+    $this->accuracy = $accuracy;
+  }
+  public function getAccuracy()
+  {
+    return $this->accuracy;
+  }
+  public function setAddress($address)
+  {
+    $this->address = $address;
+  }
+  public function getAddress()
+  {
+    return $this->address;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLatitude($latitude)
+  {
+    $this->latitude = $latitude;
+  }
+  public function getLatitude()
+  {
+    return $this->latitude;
+  }
+  public function setLongitude($longitude)
+  {
+    $this->longitude = $longitude;
+  }
+  public function getLongitude()
+  {
+    return $this->longitude;
+  }
+  public function setTimestamp($timestamp)
+  {
+    $this->timestamp = $timestamp;
+  }
+  public function getTimestamp()
+  {
+    return $this->timestamp;
+  }
+}
+
+class Google_Service_Mirror_LocationsListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Mirror_Location';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Mirror_MenuItem extends Google_Collection
+{
+  protected $collection_key = 'values';
+  protected $internal_gapi_mappings = array(
+        "contextualCommand" => "contextual_command",
+  );
+  public $action;
+  public $contextualCommand;
+  public $id;
+  public $payload;
+  public $removeWhenSelected;
+  protected $valuesType = 'Google_Service_Mirror_MenuValue';
+  protected $valuesDataType = 'array';
+
+
+  public function setAction($action)
+  {
+    $this->action = $action;
+  }
+  public function getAction()
+  {
+    return $this->action;
+  }
+  public function setContextualCommand($contextualCommand)
+  {
+    $this->contextualCommand = $contextualCommand;
+  }
+  public function getContextualCommand()
+  {
+    return $this->contextualCommand;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setPayload($payload)
+  {
+    $this->payload = $payload;
+  }
+  public function getPayload()
+  {
+    return $this->payload;
+  }
+  public function setRemoveWhenSelected($removeWhenSelected)
+  {
+    $this->removeWhenSelected = $removeWhenSelected;
+  }
+  public function getRemoveWhenSelected()
+  {
+    return $this->removeWhenSelected;
+  }
+  public function setValues($values)
+  {
+    $this->values = $values;
+  }
+  public function getValues()
+  {
+    return $this->values;
+  }
+}
+
+class Google_Service_Mirror_MenuValue extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $displayName;
+  public $iconUrl;
+  public $state;
+
+
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setIconUrl($iconUrl)
+  {
+    $this->iconUrl = $iconUrl;
+  }
+  public function getIconUrl()
+  {
+    return $this->iconUrl;
+  }
+  public function setState($state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+}
+
+class Google_Service_Mirror_Notification extends Google_Collection
+{
+  protected $collection_key = 'userActions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $collection;
+  public $itemId;
+  public $operation;
+  protected $userActionsType = 'Google_Service_Mirror_UserAction';
+  protected $userActionsDataType = 'array';
+  public $userToken;
+  public $verifyToken;
+
+
+  public function setCollection($collection)
+  {
+    $this->collection = $collection;
+  }
+  public function getCollection()
+  {
+    return $this->collection;
+  }
+  public function setItemId($itemId)
+  {
+    $this->itemId = $itemId;
+  }
+  public function getItemId()
+  {
+    return $this->itemId;
+  }
+  public function setOperation($operation)
+  {
+    $this->operation = $operation;
+  }
+  public function getOperation()
+  {
+    return $this->operation;
+  }
+  public function setUserActions($userActions)
+  {
+    $this->userActions = $userActions;
+  }
+  public function getUserActions()
+  {
+    return $this->userActions;
+  }
+  public function setUserToken($userToken)
+  {
+    $this->userToken = $userToken;
+  }
+  public function getUserToken()
+  {
+    return $this->userToken;
+  }
+  public function setVerifyToken($verifyToken)
+  {
+    $this->verifyToken = $verifyToken;
+  }
+  public function getVerifyToken()
+  {
+    return $this->verifyToken;
+  }
+}
+
+class Google_Service_Mirror_NotificationConfig extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $deliveryTime;
+  public $level;
+
+
+  public function setDeliveryTime($deliveryTime)
+  {
+    $this->deliveryTime = $deliveryTime;
+  }
+  public function getDeliveryTime()
+  {
+    return $this->deliveryTime;
+  }
+  public function setLevel($level)
+  {
+    $this->level = $level;
+  }
+  public function getLevel()
+  {
+    return $this->level;
+  }
+}
+
+class Google_Service_Mirror_Setting extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $value;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Mirror_Subscription extends Google_Collection
+{
+  protected $collection_key = 'operation';
+  protected $internal_gapi_mappings = array(
+  );
+  public $callbackUrl;
+  public $collection;
+  public $id;
+  public $kind;
+  protected $notificationType = 'Google_Service_Mirror_Notification';
+  protected $notificationDataType = '';
+  public $operation;
+  public $updated;
+  public $userToken;
+  public $verifyToken;
+
+
+  public function setCallbackUrl($callbackUrl)
+  {
+    $this->callbackUrl = $callbackUrl;
+  }
+  public function getCallbackUrl()
+  {
+    return $this->callbackUrl;
+  }
+  public function setCollection($collection)
+  {
+    $this->collection = $collection;
+  }
+  public function getCollection()
+  {
+    return $this->collection;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNotification(Google_Service_Mirror_Notification $notification)
+  {
+    $this->notification = $notification;
+  }
+  public function getNotification()
+  {
+    return $this->notification;
+  }
+  public function setOperation($operation)
+  {
+    $this->operation = $operation;
+  }
+  public function getOperation()
+  {
+    return $this->operation;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setUserToken($userToken)
+  {
+    $this->userToken = $userToken;
+  }
+  public function getUserToken()
+  {
+    return $this->userToken;
+  }
+  public function setVerifyToken($verifyToken)
+  {
+    $this->verifyToken = $verifyToken;
+  }
+  public function getVerifyToken()
+  {
+    return $this->verifyToken;
+  }
+}
+
+class Google_Service_Mirror_SubscriptionsListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Mirror_Subscription';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Mirror_TimelineItem extends Google_Collection
+{
+  protected $collection_key = 'recipients';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $attachmentsType = 'Google_Service_Mirror_Attachment';
+  protected $attachmentsDataType = 'array';
+  public $bundleId;
+  public $canonicalUrl;
+  public $created;
+  protected $creatorType = 'Google_Service_Mirror_Contact';
+  protected $creatorDataType = '';
+  public $displayTime;
+  public $etag;
+  public $html;
+  public $id;
+  public $inReplyTo;
+  public $isBundleCover;
+  public $isDeleted;
+  public $isPinned;
+  public $kind;
+  protected $locationType = 'Google_Service_Mirror_Location';
+  protected $locationDataType = '';
+  protected $menuItemsType = 'Google_Service_Mirror_MenuItem';
+  protected $menuItemsDataType = 'array';
+  protected $notificationType = 'Google_Service_Mirror_NotificationConfig';
+  protected $notificationDataType = '';
+  public $pinScore;
+  protected $recipientsType = 'Google_Service_Mirror_Contact';
+  protected $recipientsDataType = 'array';
+  public $selfLink;
+  public $sourceItemId;
+  public $speakableText;
+  public $speakableType;
+  public $text;
+  public $title;
+  public $updated;
+
+
+  public function setAttachments($attachments)
+  {
+    $this->attachments = $attachments;
+  }
+  public function getAttachments()
+  {
+    return $this->attachments;
+  }
+  public function setBundleId($bundleId)
+  {
+    $this->bundleId = $bundleId;
+  }
+  public function getBundleId()
+  {
+    return $this->bundleId;
+  }
+  public function setCanonicalUrl($canonicalUrl)
+  {
+    $this->canonicalUrl = $canonicalUrl;
+  }
+  public function getCanonicalUrl()
+  {
+    return $this->canonicalUrl;
+  }
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setCreator(Google_Service_Mirror_Contact $creator)
+  {
+    $this->creator = $creator;
+  }
+  public function getCreator()
+  {
+    return $this->creator;
+  }
+  public function setDisplayTime($displayTime)
+  {
+    $this->displayTime = $displayTime;
+  }
+  public function getDisplayTime()
+  {
+    return $this->displayTime;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setHtml($html)
+  {
+    $this->html = $html;
+  }
+  public function getHtml()
+  {
+    return $this->html;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInReplyTo($inReplyTo)
+  {
+    $this->inReplyTo = $inReplyTo;
+  }
+  public function getInReplyTo()
+  {
+    return $this->inReplyTo;
+  }
+  public function setIsBundleCover($isBundleCover)
+  {
+    $this->isBundleCover = $isBundleCover;
+  }
+  public function getIsBundleCover()
+  {
+    return $this->isBundleCover;
+  }
+  public function setIsDeleted($isDeleted)
+  {
+    $this->isDeleted = $isDeleted;
+  }
+  public function getIsDeleted()
+  {
+    return $this->isDeleted;
+  }
+  public function setIsPinned($isPinned)
+  {
+    $this->isPinned = $isPinned;
+  }
+  public function getIsPinned()
+  {
+    return $this->isPinned;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocation(Google_Service_Mirror_Location $location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setMenuItems($menuItems)
+  {
+    $this->menuItems = $menuItems;
+  }
+  public function getMenuItems()
+  {
+    return $this->menuItems;
+  }
+  public function setNotification(Google_Service_Mirror_NotificationConfig $notification)
+  {
+    $this->notification = $notification;
+  }
+  public function getNotification()
+  {
+    return $this->notification;
+  }
+  public function setPinScore($pinScore)
+  {
+    $this->pinScore = $pinScore;
+  }
+  public function getPinScore()
+  {
+    return $this->pinScore;
+  }
+  public function setRecipients($recipients)
+  {
+    $this->recipients = $recipients;
+  }
+  public function getRecipients()
+  {
+    return $this->recipients;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setSourceItemId($sourceItemId)
+  {
+    $this->sourceItemId = $sourceItemId;
+  }
+  public function getSourceItemId()
+  {
+    return $this->sourceItemId;
+  }
+  public function setSpeakableText($speakableText)
+  {
+    $this->speakableText = $speakableText;
+  }
+  public function getSpeakableText()
+  {
+    return $this->speakableText;
+  }
+  public function setSpeakableType($speakableType)
+  {
+    $this->speakableType = $speakableType;
+  }
+  public function getSpeakableType()
+  {
+    return $this->speakableType;
+  }
+  public function setText($text)
+  {
+    $this->text = $text;
+  }
+  public function getText()
+  {
+    return $this->text;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+}
+
+class Google_Service_Mirror_TimelineListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Mirror_TimelineItem';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Mirror_UserAction extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $payload;
+  public $type;
+
+
+  public function setPayload($payload)
+  {
+    $this->payload = $payload;
+  }
+  public function getPayload()
+  {
+    return $this->payload;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Mirror_UserData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Oauth2.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Oauth2.php
@@ -1,0 +1,503 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Oauth2 (v2).
+ *
+ * <p>
+ * Lets you access OAuth2 protocol related APIs.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/accounts/docs/OAuth2" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Oauth2 extends Google_Service
+{
+  /** Know your basic profile info and list of people in your circles.. */
+  const PLUS_LOGIN =
+      "https://www.googleapis.com/auth/plus.login";
+  /** Know who you are on Google. */
+  const PLUS_ME =
+      "https://www.googleapis.com/auth/plus.me";
+  /** View your email address. */
+  const USERINFO_EMAIL =
+      "https://www.googleapis.com/auth/userinfo.email";
+  /** View your basic profile info. */
+  const USERINFO_PROFILE =
+      "https://www.googleapis.com/auth/userinfo.profile";
+
+  public $userinfo;
+  public $userinfo_v2_me;
+  private $base_methods;
+
+  /**
+   * Constructs the internal representation of the Oauth2 service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = '';
+    $this->version = 'v2';
+    $this->serviceName = 'oauth2';
+
+    $this->userinfo = new Google_Service_Oauth2_Userinfo_Resource(
+        $this,
+        $this->serviceName,
+        'userinfo',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'oauth2/v2/userinfo',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->userinfo_v2_me = new Google_Service_Oauth2_UserinfoV2Me_Resource(
+        $this,
+        $this->serviceName,
+        'me',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'userinfo/v2/me',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->base_methods = new Google_Service_Resource(
+        $this,
+        $this->serviceName,
+        '',
+        array(
+          'methods' => array(
+            'getCertForOpenIdConnect' => array(
+              'path' => 'oauth2/v2/certs',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),'tokeninfo' => array(
+              'path' => 'oauth2/v2/tokeninfo',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'access_token' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'id_token' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'token_handle' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+  /**
+   * (getCertForOpenIdConnect)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Oauth2_Jwk
+   */
+  public function getCertForOpenIdConnect($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->base_methods->call('getCertForOpenIdConnect', array($params), "Google_Service_Oauth2_Jwk");
+  }
+  /**
+   * (tokeninfo)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string access_token
+   * @opt_param string id_token
+   * @opt_param string token_handle
+   * @return Google_Service_Oauth2_Tokeninfo
+   */
+  public function tokeninfo($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->base_methods->call('tokeninfo', array($params), "Google_Service_Oauth2_Tokeninfo");
+  }
+}
+
+
+/**
+ * The "userinfo" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $oauth2Service = new Google_Service_Oauth2(...);
+ *   $userinfo = $oauth2Service->userinfo;
+ *  </code>
+ */
+class Google_Service_Oauth2_Userinfo_Resource extends Google_Service_Resource
+{
+
+  /**
+   * (userinfo.get)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Oauth2_Userinfoplus
+   */
+  public function get($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Oauth2_Userinfoplus");
+  }
+}
+
+/**
+ * The "v2" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $oauth2Service = new Google_Service_Oauth2(...);
+ *   $v2 = $oauth2Service->v2;
+ *  </code>
+ */
+class Google_Service_Oauth2_UserinfoV2_Resource extends Google_Service_Resource
+{
+}
+
+/**
+ * The "me" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $oauth2Service = new Google_Service_Oauth2(...);
+ *   $me = $oauth2Service->me;
+ *  </code>
+ */
+class Google_Service_Oauth2_UserinfoV2Me_Resource extends Google_Service_Resource
+{
+
+  /**
+   * (me.get)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Oauth2_Userinfoplus
+   */
+  public function get($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Oauth2_Userinfoplus");
+  }
+}
+
+
+
+
+class Google_Service_Oauth2_Jwk extends Google_Collection
+{
+  protected $collection_key = 'keys';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $keysType = 'Google_Service_Oauth2_JwkKeys';
+  protected $keysDataType = 'array';
+
+
+  public function setKeys($keys)
+  {
+    $this->keys = $keys;
+  }
+  public function getKeys()
+  {
+    return $this->keys;
+  }
+}
+
+class Google_Service_Oauth2_JwkKeys extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $alg;
+  public $e;
+  public $kid;
+  public $kty;
+  public $n;
+  public $use;
+
+
+  public function setAlg($alg)
+  {
+    $this->alg = $alg;
+  }
+  public function getAlg()
+  {
+    return $this->alg;
+  }
+  public function setE($e)
+  {
+    $this->e = $e;
+  }
+  public function getE()
+  {
+    return $this->e;
+  }
+  public function setKid($kid)
+  {
+    $this->kid = $kid;
+  }
+  public function getKid()
+  {
+    return $this->kid;
+  }
+  public function setKty($kty)
+  {
+    $this->kty = $kty;
+  }
+  public function getKty()
+  {
+    return $this->kty;
+  }
+  public function setN($n)
+  {
+    $this->n = $n;
+  }
+  public function getN()
+  {
+    return $this->n;
+  }
+  public function setUse($use)
+  {
+    $this->use = $use;
+  }
+  public function getUse()
+  {
+    return $this->use;
+  }
+}
+
+class Google_Service_Oauth2_Tokeninfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "accessType" => "access_type",
+        "expiresIn" => "expires_in",
+        "issuedTo" => "issued_to",
+        "tokenHandle" => "token_handle",
+        "userId" => "user_id",
+        "verifiedEmail" => "verified_email",
+  );
+  public $accessType;
+  public $audience;
+  public $email;
+  public $expiresIn;
+  public $issuedTo;
+  public $scope;
+  public $tokenHandle;
+  public $userId;
+  public $verifiedEmail;
+
+
+  public function setAccessType($accessType)
+  {
+    $this->accessType = $accessType;
+  }
+  public function getAccessType()
+  {
+    return $this->accessType;
+  }
+  public function setAudience($audience)
+  {
+    $this->audience = $audience;
+  }
+  public function getAudience()
+  {
+    return $this->audience;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setExpiresIn($expiresIn)
+  {
+    $this->expiresIn = $expiresIn;
+  }
+  public function getExpiresIn()
+  {
+    return $this->expiresIn;
+  }
+  public function setIssuedTo($issuedTo)
+  {
+    $this->issuedTo = $issuedTo;
+  }
+  public function getIssuedTo()
+  {
+    return $this->issuedTo;
+  }
+  public function setScope($scope)
+  {
+    $this->scope = $scope;
+  }
+  public function getScope()
+  {
+    return $this->scope;
+  }
+  public function setTokenHandle($tokenHandle)
+  {
+    $this->tokenHandle = $tokenHandle;
+  }
+  public function getTokenHandle()
+  {
+    return $this->tokenHandle;
+  }
+  public function setUserId($userId)
+  {
+    $this->userId = $userId;
+  }
+  public function getUserId()
+  {
+    return $this->userId;
+  }
+  public function setVerifiedEmail($verifiedEmail)
+  {
+    $this->verifiedEmail = $verifiedEmail;
+  }
+  public function getVerifiedEmail()
+  {
+    return $this->verifiedEmail;
+  }
+}
+
+class Google_Service_Oauth2_Userinfoplus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "familyName" => "family_name",
+        "givenName" => "given_name",
+        "verifiedEmail" => "verified_email",
+  );
+  public $email;
+  public $familyName;
+  public $gender;
+  public $givenName;
+  public $hd;
+  public $id;
+  public $link;
+  public $locale;
+  public $name;
+  public $picture;
+  public $verifiedEmail;
+
+
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setFamilyName($familyName)
+  {
+    $this->familyName = $familyName;
+  }
+  public function getFamilyName()
+  {
+    return $this->familyName;
+  }
+  public function setGender($gender)
+  {
+    $this->gender = $gender;
+  }
+  public function getGender()
+  {
+    return $this->gender;
+  }
+  public function setGivenName($givenName)
+  {
+    $this->givenName = $givenName;
+  }
+  public function getGivenName()
+  {
+    return $this->givenName;
+  }
+  public function setHd($hd)
+  {
+    $this->hd = $hd;
+  }
+  public function getHd()
+  {
+    return $this->hd;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLink($link)
+  {
+    $this->link = $link;
+  }
+  public function getLink()
+  {
+    return $this->link;
+  }
+  public function setLocale($locale)
+  {
+    $this->locale = $locale;
+  }
+  public function getLocale()
+  {
+    return $this->locale;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPicture($picture)
+  {
+    $this->picture = $picture;
+  }
+  public function getPicture()
+  {
+    return $this->picture;
+  }
+  public function setVerifiedEmail($verifiedEmail)
+  {
+    $this->verifiedEmail = $verifiedEmail;
+  }
+  public function getVerifiedEmail()
+  {
+    return $this->verifiedEmail;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Pagespeedonline.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Pagespeedonline.php
@@ -1,0 +1,838 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Pagespeedonline (v2).
+ *
+ * <p>
+ * Lets you analyze the performance of a web page and get tailored suggestions
+ * to make that page faster.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/speed/docs/insights/v2/getting-started" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Pagespeedonline extends Google_Service
+{
+
+
+  public $pagespeedapi;
+  
+
+  /**
+   * Constructs the internal representation of the Pagespeedonline service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'pagespeedonline/v2/';
+    $this->version = 'v2';
+    $this->serviceName = 'pagespeedonline';
+
+    $this->pagespeedapi = new Google_Service_Pagespeedonline_Pagespeedapi_Resource(
+        $this,
+        $this->serviceName,
+        'pagespeedapi',
+        array(
+          'methods' => array(
+            'runpagespeed' => array(
+              'path' => 'runPagespeed',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'url' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'screenshot' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'rule' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'strategy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'filter_third_party_resources' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "pagespeedapi" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $pagespeedonlineService = new Google_Service_Pagespeedonline(...);
+ *   $pagespeedapi = $pagespeedonlineService->pagespeedapi;
+ *  </code>
+ */
+class Google_Service_Pagespeedonline_Pagespeedapi_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Runs PageSpeed analysis on the page at the specified URL, and returns
+   * PageSpeed scores, a list of suggestions to make that page faster, and other
+   * information. (pagespeedapi.runpagespeed)
+   *
+   * @param string $url The URL to fetch and analyze
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool screenshot Indicates if binary data containing a screenshot
+   * should be included
+   * @opt_param string locale The locale used to localize formatted results
+   * @opt_param string rule A PageSpeed rule to run; if none are given, all rules
+   * are run
+   * @opt_param string strategy The analysis strategy to use
+   * @opt_param bool filter_third_party_resources Indicates if third party
+   * resources should be filtered out before PageSpeed analysis.
+   * @return Google_Service_Pagespeedonline_Result
+   */
+  public function runpagespeed($url, $optParams = array())
+  {
+    $params = array('url' => $url);
+    $params = array_merge($params, $optParams);
+    return $this->call('runpagespeed', array($params), "Google_Service_Pagespeedonline_Result");
+  }
+}
+
+
+
+
+class Google_Service_Pagespeedonline_PagespeedApiFormatStringV2 extends Google_Collection
+{
+  protected $collection_key = 'args';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $argsType = 'Google_Service_Pagespeedonline_PagespeedApiFormatStringV2Args';
+  protected $argsDataType = 'array';
+  public $format;
+
+
+  public function setArgs($args)
+  {
+    $this->args = $args;
+  }
+  public function getArgs()
+  {
+    return $this->args;
+  }
+  public function setFormat($format)
+  {
+    $this->format = $format;
+  }
+  public function getFormat()
+  {
+    return $this->format;
+  }
+}
+
+class Google_Service_Pagespeedonline_PagespeedApiFormatStringV2Args extends Google_Collection
+{
+  protected $collection_key = 'secondary_rects';
+  protected $internal_gapi_mappings = array(
+        "secondaryRects" => "secondary_rects",
+  );
+  public $key;
+  protected $rectsType = 'Google_Service_Pagespeedonline_PagespeedApiFormatStringV2ArgsRects';
+  protected $rectsDataType = 'array';
+  protected $secondaryRectsType = 'Google_Service_Pagespeedonline_PagespeedApiFormatStringV2ArgsSecondaryRects';
+  protected $secondaryRectsDataType = 'array';
+  public $type;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setRects($rects)
+  {
+    $this->rects = $rects;
+  }
+  public function getRects()
+  {
+    return $this->rects;
+  }
+  public function setSecondaryRects($secondaryRects)
+  {
+    $this->secondaryRects = $secondaryRects;
+  }
+  public function getSecondaryRects()
+  {
+    return $this->secondaryRects;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Pagespeedonline_PagespeedApiFormatStringV2ArgsRects extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $left;
+  public $top;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setLeft($left)
+  {
+    $this->left = $left;
+  }
+  public function getLeft()
+  {
+    return $this->left;
+  }
+  public function setTop($top)
+  {
+    $this->top = $top;
+  }
+  public function getTop()
+  {
+    return $this->top;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_Pagespeedonline_PagespeedApiFormatStringV2ArgsSecondaryRects extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $left;
+  public $top;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setLeft($left)
+  {
+    $this->left = $left;
+  }
+  public function getLeft()
+  {
+    return $this->left;
+  }
+  public function setTop($top)
+  {
+    $this->top = $top;
+  }
+  public function getTop()
+  {
+    return $this->top;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_Pagespeedonline_PagespeedApiImageV2 extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "mimeType" => "mime_type",
+        "pageRect" => "page_rect",
+  );
+  public $data;
+  public $height;
+  public $key;
+  public $mimeType;
+  protected $pageRectType = 'Google_Service_Pagespeedonline_PagespeedApiImageV2PageRect';
+  protected $pageRectDataType = '';
+  public $width;
+
+
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setMimeType($mimeType)
+  {
+    $this->mimeType = $mimeType;
+  }
+  public function getMimeType()
+  {
+    return $this->mimeType;
+  }
+  public function setPageRect(Google_Service_Pagespeedonline_PagespeedApiImageV2PageRect $pageRect)
+  {
+    $this->pageRect = $pageRect;
+  }
+  public function getPageRect()
+  {
+    return $this->pageRect;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_Pagespeedonline_PagespeedApiImageV2PageRect extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $left;
+  public $top;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setLeft($left)
+  {
+    $this->left = $left;
+  }
+  public function getLeft()
+  {
+    return $this->left;
+  }
+  public function setTop($top)
+  {
+    $this->top = $top;
+  }
+  public function getTop()
+  {
+    return $this->top;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_Pagespeedonline_Result extends Google_Collection
+{
+  protected $collection_key = 'invalidRules';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $formattedResultsType = 'Google_Service_Pagespeedonline_ResultFormattedResults';
+  protected $formattedResultsDataType = '';
+  public $id;
+  public $invalidRules;
+  public $kind;
+  protected $pageStatsType = 'Google_Service_Pagespeedonline_ResultPageStats';
+  protected $pageStatsDataType = '';
+  public $responseCode;
+  protected $ruleGroupsType = 'Google_Service_Pagespeedonline_ResultRuleGroupsElement';
+  protected $ruleGroupsDataType = 'map';
+  protected $screenshotType = 'Google_Service_Pagespeedonline_PagespeedApiImageV2';
+  protected $screenshotDataType = '';
+  public $title;
+  protected $versionType = 'Google_Service_Pagespeedonline_ResultVersion';
+  protected $versionDataType = '';
+
+
+  public function setFormattedResults(Google_Service_Pagespeedonline_ResultFormattedResults $formattedResults)
+  {
+    $this->formattedResults = $formattedResults;
+  }
+  public function getFormattedResults()
+  {
+    return $this->formattedResults;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInvalidRules($invalidRules)
+  {
+    $this->invalidRules = $invalidRules;
+  }
+  public function getInvalidRules()
+  {
+    return $this->invalidRules;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPageStats(Google_Service_Pagespeedonline_ResultPageStats $pageStats)
+  {
+    $this->pageStats = $pageStats;
+  }
+  public function getPageStats()
+  {
+    return $this->pageStats;
+  }
+  public function setResponseCode($responseCode)
+  {
+    $this->responseCode = $responseCode;
+  }
+  public function getResponseCode()
+  {
+    return $this->responseCode;
+  }
+  public function setRuleGroups($ruleGroups)
+  {
+    $this->ruleGroups = $ruleGroups;
+  }
+  public function getRuleGroups()
+  {
+    return $this->ruleGroups;
+  }
+  public function setScreenshot(Google_Service_Pagespeedonline_PagespeedApiImageV2 $screenshot)
+  {
+    $this->screenshot = $screenshot;
+  }
+  public function getScreenshot()
+  {
+    return $this->screenshot;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setVersion(Google_Service_Pagespeedonline_ResultVersion $version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Pagespeedonline_ResultFormattedResults extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $locale;
+  protected $ruleResultsType = 'Google_Service_Pagespeedonline_ResultFormattedResultsRuleResultsElement';
+  protected $ruleResultsDataType = 'map';
+
+
+  public function setLocale($locale)
+  {
+    $this->locale = $locale;
+  }
+  public function getLocale()
+  {
+    return $this->locale;
+  }
+  public function setRuleResults($ruleResults)
+  {
+    $this->ruleResults = $ruleResults;
+  }
+  public function getRuleResults()
+  {
+    return $this->ruleResults;
+  }
+}
+
+class Google_Service_Pagespeedonline_ResultFormattedResultsRuleResults extends Google_Model
+{
+}
+
+class Google_Service_Pagespeedonline_ResultFormattedResultsRuleResultsElement extends Google_Collection
+{
+  protected $collection_key = 'urlBlocks';
+  protected $internal_gapi_mappings = array(
+  );
+  public $groups;
+  public $localizedRuleName;
+  public $ruleImpact;
+  protected $summaryType = 'Google_Service_Pagespeedonline_PagespeedApiFormatStringV2';
+  protected $summaryDataType = '';
+  protected $urlBlocksType = 'Google_Service_Pagespeedonline_ResultFormattedResultsRuleResultsElementUrlBlocks';
+  protected $urlBlocksDataType = 'array';
+
+
+  public function setGroups($groups)
+  {
+    $this->groups = $groups;
+  }
+  public function getGroups()
+  {
+    return $this->groups;
+  }
+  public function setLocalizedRuleName($localizedRuleName)
+  {
+    $this->localizedRuleName = $localizedRuleName;
+  }
+  public function getLocalizedRuleName()
+  {
+    return $this->localizedRuleName;
+  }
+  public function setRuleImpact($ruleImpact)
+  {
+    $this->ruleImpact = $ruleImpact;
+  }
+  public function getRuleImpact()
+  {
+    return $this->ruleImpact;
+  }
+  public function setSummary(Google_Service_Pagespeedonline_PagespeedApiFormatStringV2 $summary)
+  {
+    $this->summary = $summary;
+  }
+  public function getSummary()
+  {
+    return $this->summary;
+  }
+  public function setUrlBlocks($urlBlocks)
+  {
+    $this->urlBlocks = $urlBlocks;
+  }
+  public function getUrlBlocks()
+  {
+    return $this->urlBlocks;
+  }
+}
+
+class Google_Service_Pagespeedonline_ResultFormattedResultsRuleResultsElementUrlBlocks extends Google_Collection
+{
+  protected $collection_key = 'urls';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $headerType = 'Google_Service_Pagespeedonline_PagespeedApiFormatStringV2';
+  protected $headerDataType = '';
+  protected $urlsType = 'Google_Service_Pagespeedonline_ResultFormattedResultsRuleResultsElementUrlBlocksUrls';
+  protected $urlsDataType = 'array';
+
+
+  public function setHeader(Google_Service_Pagespeedonline_PagespeedApiFormatStringV2 $header)
+  {
+    $this->header = $header;
+  }
+  public function getHeader()
+  {
+    return $this->header;
+  }
+  public function setUrls($urls)
+  {
+    $this->urls = $urls;
+  }
+  public function getUrls()
+  {
+    return $this->urls;
+  }
+}
+
+class Google_Service_Pagespeedonline_ResultFormattedResultsRuleResultsElementUrlBlocksUrls extends Google_Collection
+{
+  protected $collection_key = 'details';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $detailsType = 'Google_Service_Pagespeedonline_PagespeedApiFormatStringV2';
+  protected $detailsDataType = 'array';
+  protected $resultType = 'Google_Service_Pagespeedonline_PagespeedApiFormatStringV2';
+  protected $resultDataType = '';
+
+
+  public function setDetails($details)
+  {
+    $this->details = $details;
+  }
+  public function getDetails()
+  {
+    return $this->details;
+  }
+  public function setResult(Google_Service_Pagespeedonline_PagespeedApiFormatStringV2 $result)
+  {
+    $this->result = $result;
+  }
+  public function getResult()
+  {
+    return $this->result;
+  }
+}
+
+class Google_Service_Pagespeedonline_ResultPageStats extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $cssResponseBytes;
+  public $flashResponseBytes;
+  public $htmlResponseBytes;
+  public $imageResponseBytes;
+  public $javascriptResponseBytes;
+  public $numberCssResources;
+  public $numberHosts;
+  public $numberJsResources;
+  public $numberResources;
+  public $numberStaticResources;
+  public $otherResponseBytes;
+  public $textResponseBytes;
+  public $totalRequestBytes;
+
+
+  public function setCssResponseBytes($cssResponseBytes)
+  {
+    $this->cssResponseBytes = $cssResponseBytes;
+  }
+  public function getCssResponseBytes()
+  {
+    return $this->cssResponseBytes;
+  }
+  public function setFlashResponseBytes($flashResponseBytes)
+  {
+    $this->flashResponseBytes = $flashResponseBytes;
+  }
+  public function getFlashResponseBytes()
+  {
+    return $this->flashResponseBytes;
+  }
+  public function setHtmlResponseBytes($htmlResponseBytes)
+  {
+    $this->htmlResponseBytes = $htmlResponseBytes;
+  }
+  public function getHtmlResponseBytes()
+  {
+    return $this->htmlResponseBytes;
+  }
+  public function setImageResponseBytes($imageResponseBytes)
+  {
+    $this->imageResponseBytes = $imageResponseBytes;
+  }
+  public function getImageResponseBytes()
+  {
+    return $this->imageResponseBytes;
+  }
+  public function setJavascriptResponseBytes($javascriptResponseBytes)
+  {
+    $this->javascriptResponseBytes = $javascriptResponseBytes;
+  }
+  public function getJavascriptResponseBytes()
+  {
+    return $this->javascriptResponseBytes;
+  }
+  public function setNumberCssResources($numberCssResources)
+  {
+    $this->numberCssResources = $numberCssResources;
+  }
+  public function getNumberCssResources()
+  {
+    return $this->numberCssResources;
+  }
+  public function setNumberHosts($numberHosts)
+  {
+    $this->numberHosts = $numberHosts;
+  }
+  public function getNumberHosts()
+  {
+    return $this->numberHosts;
+  }
+  public function setNumberJsResources($numberJsResources)
+  {
+    $this->numberJsResources = $numberJsResources;
+  }
+  public function getNumberJsResources()
+  {
+    return $this->numberJsResources;
+  }
+  public function setNumberResources($numberResources)
+  {
+    $this->numberResources = $numberResources;
+  }
+  public function getNumberResources()
+  {
+    return $this->numberResources;
+  }
+  public function setNumberStaticResources($numberStaticResources)
+  {
+    $this->numberStaticResources = $numberStaticResources;
+  }
+  public function getNumberStaticResources()
+  {
+    return $this->numberStaticResources;
+  }
+  public function setOtherResponseBytes($otherResponseBytes)
+  {
+    $this->otherResponseBytes = $otherResponseBytes;
+  }
+  public function getOtherResponseBytes()
+  {
+    return $this->otherResponseBytes;
+  }
+  public function setTextResponseBytes($textResponseBytes)
+  {
+    $this->textResponseBytes = $textResponseBytes;
+  }
+  public function getTextResponseBytes()
+  {
+    return $this->textResponseBytes;
+  }
+  public function setTotalRequestBytes($totalRequestBytes)
+  {
+    $this->totalRequestBytes = $totalRequestBytes;
+  }
+  public function getTotalRequestBytes()
+  {
+    return $this->totalRequestBytes;
+  }
+}
+
+class Google_Service_Pagespeedonline_ResultRuleGroups extends Google_Model
+{
+}
+
+class Google_Service_Pagespeedonline_ResultRuleGroupsElement extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $score;
+
+
+  public function setScore($score)
+  {
+    $this->score = $score;
+  }
+  public function getScore()
+  {
+    return $this->score;
+  }
+}
+
+class Google_Service_Pagespeedonline_ResultVersion extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $major;
+  public $minor;
+
+
+  public function setMajor($major)
+  {
+    $this->major = $major;
+  }
+  public function getMajor()
+  {
+    return $this->major;
+  }
+  public function setMinor($minor)
+  {
+    $this->minor = $minor;
+  }
+  public function getMinor()
+  {
+    return $this->minor;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Partners.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Partners.php
@@ -1,0 +1,1610 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Partners (v2).
+ *
+ * <p>
+ * Lets advertisers search certified companies and create contact leads with
+ * them, and also audits the usage of clients.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/partners/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Partners extends Google_Service
+{
+
+
+  public $clientMessages;
+  public $companies;
+  public $companies_leads;
+  public $userEvents;
+  public $userStates;
+  
+
+  /**
+   * Constructs the internal representation of the Partners service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://partners.googleapis.com/';
+    $this->servicePath = '';
+    $this->version = 'v2';
+    $this->serviceName = 'partners';
+
+    $this->clientMessages = new Google_Service_Partners_ClientMessages_Resource(
+        $this,
+        $this->serviceName,
+        'clientMessages',
+        array(
+          'methods' => array(
+            'log' => array(
+              'path' => 'v2/clientMessages:log',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->companies = new Google_Service_Partners_Companies_Resource(
+        $this,
+        $this->serviceName,
+        'companies',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'v2/companies/{companyId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'companyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'requestMetadata.userOverrides.userId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'requestMetadata.userOverrides.ipAddress' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'requestMetadata.partnersSessionId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'requestMetadata.trafficSource.trafficSubId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'requestMetadata.locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'address' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'requestMetadata.experimentIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'currencyCode' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'requestMetadata.trafficSource.trafficSourceId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v2/companies',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'requestMetadata.partnersSessionId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxMonthlyBudget.currencyCode' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxMonthlyBudget.nanos' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'languageCodes' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'minMonthlyBudget.nanos' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'requestMetadata.trafficSource.trafficSubId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'industries' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'minMonthlyBudget.currencyCode' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'minMonthlyBudget.units' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'requestMetadata.locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'requestMetadata.trafficSource.trafficSourceId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'companyName' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'address' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'services' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'requestMetadata.experimentIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'gpsMotivations' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'requestMetadata.userOverrides.ipAddress' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'websiteUrl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'requestMetadata.userOverrides.userId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'view' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxMonthlyBudget.units' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->companies_leads = new Google_Service_Partners_CompaniesLeads_Resource(
+        $this,
+        $this->serviceName,
+        'leads',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'v2/companies/{companyId}/leads',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'companyId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->userEvents = new Google_Service_Partners_UserEvents_Resource(
+        $this,
+        $this->serviceName,
+        'userEvents',
+        array(
+          'methods' => array(
+            'log' => array(
+              'path' => 'v2/userEvents:log',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->userStates = new Google_Service_Partners_UserStates_Resource(
+        $this,
+        $this->serviceName,
+        'userStates',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'v2/userStates',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'requestMetadata.userOverrides.userId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'requestMetadata.userOverrides.ipAddress' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'requestMetadata.partnersSessionId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'requestMetadata.trafficSource.trafficSubId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'requestMetadata.locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'requestMetadata.experimentIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'requestMetadata.trafficSource.trafficSourceId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "clientMessages" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $partnersService = new Google_Service_Partners(...);
+ *   $clientMessages = $partnersService->clientMessages;
+ *  </code>
+ */
+class Google_Service_Partners_ClientMessages_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Logs a generic message from the client, such as `Failed to render component`,
+   * `Profile page is running slow`, `More than 500 users have accessed this
+   * result.`, etc. (clientMessages.log)
+   *
+   * @param Google_LogMessageRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Partners_LogMessageResponse
+   */
+  public function log(Google_Service_Partners_LogMessageRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('log', array($params), "Google_Service_Partners_LogMessageResponse");
+  }
+}
+
+/**
+ * The "companies" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $partnersService = new Google_Service_Partners(...);
+ *   $companies = $partnersService->companies;
+ *  </code>
+ */
+class Google_Service_Partners_Companies_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets a company. (companies.get)
+   *
+   * @param string $companyId The ID of the company to retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderBy How to order addresses within the returned company.
+   * Currently, only `address` and `address desc` is supported which will sorted
+   * by closest to farthest in distance from given address and farthest to closest
+   * distance from given address respectively.
+   * @opt_param string requestMetadata.userOverrides.userId Logged-in user ID to
+   * impersonate instead of the user's ID.
+   * @opt_param string requestMetadata.userOverrides.ipAddress IP address to use
+   * instead of the user's geo-located IP address.
+   * @opt_param string requestMetadata.partnersSessionId Google Partners session
+   * ID.
+   * @opt_param string requestMetadata.trafficSource.trafficSubId Second level
+   * identifier to indicate where the traffic comes from. An identifier has
+   * multiple letters created by a team which redirected the traffic to us.
+   * @opt_param string requestMetadata.locale Locale to use for the current
+   * request.
+   * @opt_param string address The address to use for sorting the company's
+   * addresses by proximity. If not given, the geo-located address of the request
+   * is used. Used when order_by is set.
+   * @opt_param string requestMetadata.experimentIds Experiment IDs the current
+   * request belongs to.
+   * @opt_param string currencyCode If the company's budget is in a different
+   * currency code than this one, then the converted budget is converted to this
+   * currency code.
+   * @opt_param string requestMetadata.trafficSource.trafficSourceId Identifier to
+   * indicate where the traffic comes from. An identifier has multiple letters
+   * created by a team which redirected the traffic to us.
+   * @opt_param string view The view of `Company` resource to be returned. This
+   * must not be `COMPANY_VIEW_UNSPECIFIED`.
+   * @return Google_Service_Partners_GetCompanyResponse
+   */
+  public function get($companyId, $optParams = array())
+  {
+    $params = array('companyId' => $companyId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Partners_GetCompanyResponse");
+  }
+
+  /**
+   * Lists companies. (companies.listCompanies)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderBy How to order addresses within the returned
+   * companies. Currently, only `address` and `address desc` is supported which
+   * will sorted by closest to farthest in distance from given address and
+   * farthest to closest distance from given address respectively.
+   * @opt_param int pageSize Requested page size. Server may return fewer
+   * companies than requested. If unspecified, server picks an appropriate
+   * default.
+   * @opt_param string requestMetadata.partnersSessionId Google Partners session
+   * ID.
+   * @opt_param string maxMonthlyBudget.currencyCode The 3-letter currency code
+   * defined in ISO 4217.
+   * @opt_param int maxMonthlyBudget.nanos Number of nano (10^-9) units of the
+   * amount. The value must be between -999,999,999 and +999,999,999 inclusive. If
+   * `units` is positive, `nanos` must be positive or zero. If `units` is zero,
+   * `nanos` can be positive, zero, or negative. If `units` is negative, `nanos`
+   * must be negative or zero. For example $-1.75 is represented as `units`=-1 and
+   * `nanos`=-750,000,000.
+   * @opt_param string languageCodes List of language codes that company can
+   * support. Only primary language subtags are accepted as defined by BCP 47
+   * (IETF BCP 47, "Tags for Identifying Languages").
+   * @opt_param int minMonthlyBudget.nanos Number of nano (10^-9) units of the
+   * amount. The value must be between -999,999,999 and +999,999,999 inclusive. If
+   * `units` is positive, `nanos` must be positive or zero. If `units` is zero,
+   * `nanos` can be positive, zero, or negative. If `units` is negative, `nanos`
+   * must be negative or zero. For example $-1.75 is represented as `units`=-1 and
+   * `nanos`=-750,000,000.
+   * @opt_param string requestMetadata.trafficSource.trafficSubId Second level
+   * identifier to indicate where the traffic comes from. An identifier has
+   * multiple letters created by a team which redirected the traffic to us.
+   * @opt_param string industries List of industries the company can help with.
+   * @opt_param string minMonthlyBudget.currencyCode The 3-letter currency code
+   * defined in ISO 4217.
+   * @opt_param string minMonthlyBudget.units The whole units of the amount. For
+   * example if `currencyCode` is `"USD"`, then 1 unit is one US dollar.
+   * @opt_param string pageToken A token identifying a page of results that the
+   * server returns. Typically, this is the value of
+   * `ListCompaniesResponse.next_page_token` returned from the previous call to
+   * ListCompanies.
+   * @opt_param string requestMetadata.locale Locale to use for the current
+   * request.
+   * @opt_param string requestMetadata.trafficSource.trafficSourceId Identifier to
+   * indicate where the traffic comes from. An identifier has multiple letters
+   * created by a team which redirected the traffic to us.
+   * @opt_param string companyName Company name to search for.
+   * @opt_param string address The address to use when searching for companies. If
+   * not given, the geo-located address of the request is used.
+   * @opt_param string services List of services the company can help with.
+   * @opt_param string requestMetadata.experimentIds Experiment IDs the current
+   * request belongs to.
+   * @opt_param string gpsMotivations List of reasons for using Google Partner
+   * Search to get companies.
+   * @opt_param string requestMetadata.userOverrides.ipAddress IP address to use
+   * instead of the user's geo-located IP address.
+   * @opt_param string websiteUrl Website URL that will help to find a better
+   * matched company. .
+   * @opt_param string requestMetadata.userOverrides.userId Logged-in user ID to
+   * impersonate instead of the user's ID.
+   * @opt_param string view The view of the `Company` resource to be returned.
+   * This must not be `COMPANY_VIEW_UNSPECIFIED`.
+   * @opt_param string maxMonthlyBudget.units The whole units of the amount. For
+   * example if `currencyCode` is `"USD"`, then 1 unit is one US dollar.
+   * @return Google_Service_Partners_ListCompaniesResponse
+   */
+  public function listCompanies($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Partners_ListCompaniesResponse");
+  }
+}
+
+/**
+ * The "leads" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $partnersService = new Google_Service_Partners(...);
+ *   $leads = $partnersService->leads;
+ *  </code>
+ */
+class Google_Service_Partners_CompaniesLeads_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates an advertiser lead for the given company ID. (leads.create)
+   *
+   * @param string $companyId The ID of the company to contact.
+   * @param Google_CreateLeadRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Partners_CreateLeadResponse
+   */
+  public function create($companyId, Google_Service_Partners_CreateLeadRequest $postBody, $optParams = array())
+  {
+    $params = array('companyId' => $companyId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Partners_CreateLeadResponse");
+  }
+}
+
+/**
+ * The "userEvents" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $partnersService = new Google_Service_Partners(...);
+ *   $userEvents = $partnersService->userEvents;
+ *  </code>
+ */
+class Google_Service_Partners_UserEvents_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Logs a user event. (userEvents.log)
+   *
+   * @param Google_LogUserEventRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Partners_LogUserEventResponse
+   */
+  public function log(Google_Service_Partners_LogUserEventRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('log', array($params), "Google_Service_Partners_LogUserEventResponse");
+  }
+}
+
+/**
+ * The "userStates" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $partnersService = new Google_Service_Partners(...);
+ *   $userStates = $partnersService->userStates;
+ *  </code>
+ */
+class Google_Service_Partners_UserStates_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Lists states for current user. (userStates.listUserStates)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string requestMetadata.userOverrides.userId Logged-in user ID to
+   * impersonate instead of the user's ID.
+   * @opt_param string requestMetadata.userOverrides.ipAddress IP address to use
+   * instead of the user's geo-located IP address.
+   * @opt_param string requestMetadata.partnersSessionId Google Partners session
+   * ID.
+   * @opt_param string requestMetadata.trafficSource.trafficSubId Second level
+   * identifier to indicate where the traffic comes from. An identifier has
+   * multiple letters created by a team which redirected the traffic to us.
+   * @opt_param string requestMetadata.locale Locale to use for the current
+   * request.
+   * @opt_param string requestMetadata.experimentIds Experiment IDs the current
+   * request belongs to.
+   * @opt_param string requestMetadata.trafficSource.trafficSourceId Identifier to
+   * indicate where the traffic comes from. An identifier has multiple letters
+   * created by a team which redirected the traffic to us.
+   * @return Google_Service_Partners_ListUserStatesResponse
+   */
+  public function listUserStates($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Partners_ListUserStatesResponse");
+  }
+}
+
+
+
+
+class Google_Service_Partners_CertificationExamStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $numberUsersPass;
+  public $type;
+
+
+  public function setNumberUsersPass($numberUsersPass)
+  {
+    $this->numberUsersPass = $numberUsersPass;
+  }
+  public function getNumberUsersPass()
+  {
+    return $this->numberUsersPass;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Partners_CertificationStatus extends Google_Collection
+{
+  protected $collection_key = 'examStatuses';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $examStatusesType = 'Google_Service_Partners_CertificationExamStatus';
+  protected $examStatusesDataType = 'array';
+  public $isCertified;
+  public $type;
+
+
+  public function setExamStatuses($examStatuses)
+  {
+    $this->examStatuses = $examStatuses;
+  }
+  public function getExamStatuses()
+  {
+    return $this->examStatuses;
+  }
+  public function setIsCertified($isCertified)
+  {
+    $this->isCertified = $isCertified;
+  }
+  public function getIsCertified()
+  {
+    return $this->isCertified;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Partners_Company extends Google_Collection
+{
+  protected $collection_key = 'services';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $certificationStatusesType = 'Google_Service_Partners_CertificationStatus';
+  protected $certificationStatusesDataType = 'array';
+  protected $convertedMinMonthlyBudgetType = 'Google_Service_Partners_Money';
+  protected $convertedMinMonthlyBudgetDataType = '';
+  public $id;
+  public $industries;
+  protected $localizedInfosType = 'Google_Service_Partners_LocalizedCompanyInfo';
+  protected $localizedInfosDataType = 'array';
+  protected $locationsType = 'Google_Service_Partners_Location';
+  protected $locationsDataType = 'array';
+  public $name;
+  protected $originalMinMonthlyBudgetType = 'Google_Service_Partners_Money';
+  protected $originalMinMonthlyBudgetDataType = '';
+  protected $publicProfileType = 'Google_Service_Partners_PublicProfile';
+  protected $publicProfileDataType = '';
+  protected $ranksType = 'Google_Service_Partners_Rank';
+  protected $ranksDataType = 'array';
+  public $services;
+  public $websiteUrl;
+
+
+  public function setCertificationStatuses($certificationStatuses)
+  {
+    $this->certificationStatuses = $certificationStatuses;
+  }
+  public function getCertificationStatuses()
+  {
+    return $this->certificationStatuses;
+  }
+  public function setConvertedMinMonthlyBudget(Google_Service_Partners_Money $convertedMinMonthlyBudget)
+  {
+    $this->convertedMinMonthlyBudget = $convertedMinMonthlyBudget;
+  }
+  public function getConvertedMinMonthlyBudget()
+  {
+    return $this->convertedMinMonthlyBudget;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIndustries($industries)
+  {
+    $this->industries = $industries;
+  }
+  public function getIndustries()
+  {
+    return $this->industries;
+  }
+  public function setLocalizedInfos($localizedInfos)
+  {
+    $this->localizedInfos = $localizedInfos;
+  }
+  public function getLocalizedInfos()
+  {
+    return $this->localizedInfos;
+  }
+  public function setLocations($locations)
+  {
+    $this->locations = $locations;
+  }
+  public function getLocations()
+  {
+    return $this->locations;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOriginalMinMonthlyBudget(Google_Service_Partners_Money $originalMinMonthlyBudget)
+  {
+    $this->originalMinMonthlyBudget = $originalMinMonthlyBudget;
+  }
+  public function getOriginalMinMonthlyBudget()
+  {
+    return $this->originalMinMonthlyBudget;
+  }
+  public function setPublicProfile(Google_Service_Partners_PublicProfile $publicProfile)
+  {
+    $this->publicProfile = $publicProfile;
+  }
+  public function getPublicProfile()
+  {
+    return $this->publicProfile;
+  }
+  public function setRanks($ranks)
+  {
+    $this->ranks = $ranks;
+  }
+  public function getRanks()
+  {
+    return $this->ranks;
+  }
+  public function setServices($services)
+  {
+    $this->services = $services;
+  }
+  public function getServices()
+  {
+    return $this->services;
+  }
+  public function setWebsiteUrl($websiteUrl)
+  {
+    $this->websiteUrl = $websiteUrl;
+  }
+  public function getWebsiteUrl()
+  {
+    return $this->websiteUrl;
+  }
+}
+
+class Google_Service_Partners_CreateLeadRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $leadType = 'Google_Service_Partners_Lead';
+  protected $leadDataType = '';
+  protected $recaptchaChallengeType = 'Google_Service_Partners_RecaptchaChallenge';
+  protected $recaptchaChallengeDataType = '';
+  protected $requestMetadataType = 'Google_Service_Partners_RequestMetadata';
+  protected $requestMetadataDataType = '';
+
+
+  public function setLead(Google_Service_Partners_Lead $lead)
+  {
+    $this->lead = $lead;
+  }
+  public function getLead()
+  {
+    return $this->lead;
+  }
+  public function setRecaptchaChallenge(Google_Service_Partners_RecaptchaChallenge $recaptchaChallenge)
+  {
+    $this->recaptchaChallenge = $recaptchaChallenge;
+  }
+  public function getRecaptchaChallenge()
+  {
+    return $this->recaptchaChallenge;
+  }
+  public function setRequestMetadata(Google_Service_Partners_RequestMetadata $requestMetadata)
+  {
+    $this->requestMetadata = $requestMetadata;
+  }
+  public function getRequestMetadata()
+  {
+    return $this->requestMetadata;
+  }
+}
+
+class Google_Service_Partners_CreateLeadResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $leadType = 'Google_Service_Partners_Lead';
+  protected $leadDataType = '';
+  public $recaptchaStatus;
+  protected $responseMetadataType = 'Google_Service_Partners_ResponseMetadata';
+  protected $responseMetadataDataType = '';
+
+
+  public function setLead(Google_Service_Partners_Lead $lead)
+  {
+    $this->lead = $lead;
+  }
+  public function getLead()
+  {
+    return $this->lead;
+  }
+  public function setRecaptchaStatus($recaptchaStatus)
+  {
+    $this->recaptchaStatus = $recaptchaStatus;
+  }
+  public function getRecaptchaStatus()
+  {
+    return $this->recaptchaStatus;
+  }
+  public function setResponseMetadata(Google_Service_Partners_ResponseMetadata $responseMetadata)
+  {
+    $this->responseMetadata = $responseMetadata;
+  }
+  public function getResponseMetadata()
+  {
+    return $this->responseMetadata;
+  }
+}
+
+class Google_Service_Partners_DebugInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $serverInfo;
+  public $serverTraceInfo;
+  public $serviceUrl;
+
+
+  public function setServerInfo($serverInfo)
+  {
+    $this->serverInfo = $serverInfo;
+  }
+  public function getServerInfo()
+  {
+    return $this->serverInfo;
+  }
+  public function setServerTraceInfo($serverTraceInfo)
+  {
+    $this->serverTraceInfo = $serverTraceInfo;
+  }
+  public function getServerTraceInfo()
+  {
+    return $this->serverTraceInfo;
+  }
+  public function setServiceUrl($serviceUrl)
+  {
+    $this->serviceUrl = $serviceUrl;
+  }
+  public function getServiceUrl()
+  {
+    return $this->serviceUrl;
+  }
+}
+
+class Google_Service_Partners_EventData extends Google_Collection
+{
+  protected $collection_key = 'values';
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $values;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValues($values)
+  {
+    $this->values = $values;
+  }
+  public function getValues()
+  {
+    return $this->values;
+  }
+}
+
+class Google_Service_Partners_GetCompanyResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $companyType = 'Google_Service_Partners_Company';
+  protected $companyDataType = '';
+  protected $responseMetadataType = 'Google_Service_Partners_ResponseMetadata';
+  protected $responseMetadataDataType = '';
+
+
+  public function setCompany(Google_Service_Partners_Company $company)
+  {
+    $this->company = $company;
+  }
+  public function getCompany()
+  {
+    return $this->company;
+  }
+  public function setResponseMetadata(Google_Service_Partners_ResponseMetadata $responseMetadata)
+  {
+    $this->responseMetadata = $responseMetadata;
+  }
+  public function getResponseMetadata()
+  {
+    return $this->responseMetadata;
+  }
+}
+
+class Google_Service_Partners_LatLng extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $latitude;
+  public $longitude;
+
+
+  public function setLatitude($latitude)
+  {
+    $this->latitude = $latitude;
+  }
+  public function getLatitude()
+  {
+    return $this->latitude;
+  }
+  public function setLongitude($longitude)
+  {
+    $this->longitude = $longitude;
+  }
+  public function getLongitude()
+  {
+    return $this->longitude;
+  }
+}
+
+class Google_Service_Partners_Lead extends Google_Collection
+{
+  protected $collection_key = 'gpsMotivations';
+  protected $internal_gapi_mappings = array(
+  );
+  public $comments;
+  public $email;
+  public $familyName;
+  public $givenName;
+  public $gpsMotivations;
+  public $id;
+  protected $minMonthlyBudgetType = 'Google_Service_Partners_Money';
+  protected $minMonthlyBudgetDataType = '';
+  public $phoneNumber;
+  public $type;
+  public $websiteUrl;
+
+
+  public function setComments($comments)
+  {
+    $this->comments = $comments;
+  }
+  public function getComments()
+  {
+    return $this->comments;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setFamilyName($familyName)
+  {
+    $this->familyName = $familyName;
+  }
+  public function getFamilyName()
+  {
+    return $this->familyName;
+  }
+  public function setGivenName($givenName)
+  {
+    $this->givenName = $givenName;
+  }
+  public function getGivenName()
+  {
+    return $this->givenName;
+  }
+  public function setGpsMotivations($gpsMotivations)
+  {
+    $this->gpsMotivations = $gpsMotivations;
+  }
+  public function getGpsMotivations()
+  {
+    return $this->gpsMotivations;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setMinMonthlyBudget(Google_Service_Partners_Money $minMonthlyBudget)
+  {
+    $this->minMonthlyBudget = $minMonthlyBudget;
+  }
+  public function getMinMonthlyBudget()
+  {
+    return $this->minMonthlyBudget;
+  }
+  public function setPhoneNumber($phoneNumber)
+  {
+    $this->phoneNumber = $phoneNumber;
+  }
+  public function getPhoneNumber()
+  {
+    return $this->phoneNumber;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setWebsiteUrl($websiteUrl)
+  {
+    $this->websiteUrl = $websiteUrl;
+  }
+  public function getWebsiteUrl()
+  {
+    return $this->websiteUrl;
+  }
+}
+
+class Google_Service_Partners_ListCompaniesResponse extends Google_Collection
+{
+  protected $collection_key = 'companies';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $companiesType = 'Google_Service_Partners_Company';
+  protected $companiesDataType = 'array';
+  public $nextPageToken;
+  protected $responseMetadataType = 'Google_Service_Partners_ResponseMetadata';
+  protected $responseMetadataDataType = '';
+
+
+  public function setCompanies($companies)
+  {
+    $this->companies = $companies;
+  }
+  public function getCompanies()
+  {
+    return $this->companies;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setResponseMetadata(Google_Service_Partners_ResponseMetadata $responseMetadata)
+  {
+    $this->responseMetadata = $responseMetadata;
+  }
+  public function getResponseMetadata()
+  {
+    return $this->responseMetadata;
+  }
+}
+
+class Google_Service_Partners_ListUserStatesResponse extends Google_Collection
+{
+  protected $collection_key = 'userStates';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $responseMetadataType = 'Google_Service_Partners_ResponseMetadata';
+  protected $responseMetadataDataType = '';
+  public $userStates;
+
+
+  public function setResponseMetadata(Google_Service_Partners_ResponseMetadata $responseMetadata)
+  {
+    $this->responseMetadata = $responseMetadata;
+  }
+  public function getResponseMetadata()
+  {
+    return $this->responseMetadata;
+  }
+  public function setUserStates($userStates)
+  {
+    $this->userStates = $userStates;
+  }
+  public function getUserStates()
+  {
+    return $this->userStates;
+  }
+}
+
+class Google_Service_Partners_LocalizedCompanyInfo extends Google_Collection
+{
+  protected $collection_key = 'countryCodes';
+  protected $internal_gapi_mappings = array(
+  );
+  public $countryCodes;
+  public $displayName;
+  public $languageCode;
+  public $overview;
+
+
+  public function setCountryCodes($countryCodes)
+  {
+    $this->countryCodes = $countryCodes;
+  }
+  public function getCountryCodes()
+  {
+    return $this->countryCodes;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setLanguageCode($languageCode)
+  {
+    $this->languageCode = $languageCode;
+  }
+  public function getLanguageCode()
+  {
+    return $this->languageCode;
+  }
+  public function setOverview($overview)
+  {
+    $this->overview = $overview;
+  }
+  public function getOverview()
+  {
+    return $this->overview;
+  }
+}
+
+class Google_Service_Partners_Location extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $address;
+  protected $latLngType = 'Google_Service_Partners_LatLng';
+  protected $latLngDataType = '';
+
+
+  public function setAddress($address)
+  {
+    $this->address = $address;
+  }
+  public function getAddress()
+  {
+    return $this->address;
+  }
+  public function setLatLng(Google_Service_Partners_LatLng $latLng)
+  {
+    $this->latLng = $latLng;
+  }
+  public function getLatLng()
+  {
+    return $this->latLng;
+  }
+}
+
+class Google_Service_Partners_LogMessageRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $clientInfo;
+  public $details;
+  public $level;
+  protected $requestMetadataType = 'Google_Service_Partners_RequestMetadata';
+  protected $requestMetadataDataType = '';
+
+
+  public function setClientInfo($clientInfo)
+  {
+    $this->clientInfo = $clientInfo;
+  }
+  public function getClientInfo()
+  {
+    return $this->clientInfo;
+  }
+  public function setDetails($details)
+  {
+    $this->details = $details;
+  }
+  public function getDetails()
+  {
+    return $this->details;
+  }
+  public function setLevel($level)
+  {
+    $this->level = $level;
+  }
+  public function getLevel()
+  {
+    return $this->level;
+  }
+  public function setRequestMetadata(Google_Service_Partners_RequestMetadata $requestMetadata)
+  {
+    $this->requestMetadata = $requestMetadata;
+  }
+  public function getRequestMetadata()
+  {
+    return $this->requestMetadata;
+  }
+}
+
+class Google_Service_Partners_LogMessageRequestClientInfo extends Google_Model
+{
+}
+
+class Google_Service_Partners_LogMessageResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $responseMetadataType = 'Google_Service_Partners_ResponseMetadata';
+  protected $responseMetadataDataType = '';
+
+
+  public function setResponseMetadata(Google_Service_Partners_ResponseMetadata $responseMetadata)
+  {
+    $this->responseMetadata = $responseMetadata;
+  }
+  public function getResponseMetadata()
+  {
+    return $this->responseMetadata;
+  }
+}
+
+class Google_Service_Partners_LogUserEventRequest extends Google_Collection
+{
+  protected $collection_key = 'eventDatas';
+  protected $internal_gapi_mappings = array(
+  );
+  public $eventAction;
+  public $eventCategory;
+  protected $eventDatasType = 'Google_Service_Partners_EventData';
+  protected $eventDatasDataType = 'array';
+  public $eventScope;
+  protected $leadType = 'Google_Service_Partners_Lead';
+  protected $leadDataType = '';
+  protected $requestMetadataType = 'Google_Service_Partners_RequestMetadata';
+  protected $requestMetadataDataType = '';
+  public $url;
+
+
+  public function setEventAction($eventAction)
+  {
+    $this->eventAction = $eventAction;
+  }
+  public function getEventAction()
+  {
+    return $this->eventAction;
+  }
+  public function setEventCategory($eventCategory)
+  {
+    $this->eventCategory = $eventCategory;
+  }
+  public function getEventCategory()
+  {
+    return $this->eventCategory;
+  }
+  public function setEventDatas($eventDatas)
+  {
+    $this->eventDatas = $eventDatas;
+  }
+  public function getEventDatas()
+  {
+    return $this->eventDatas;
+  }
+  public function setEventScope($eventScope)
+  {
+    $this->eventScope = $eventScope;
+  }
+  public function getEventScope()
+  {
+    return $this->eventScope;
+  }
+  public function setLead(Google_Service_Partners_Lead $lead)
+  {
+    $this->lead = $lead;
+  }
+  public function getLead()
+  {
+    return $this->lead;
+  }
+  public function setRequestMetadata(Google_Service_Partners_RequestMetadata $requestMetadata)
+  {
+    $this->requestMetadata = $requestMetadata;
+  }
+  public function getRequestMetadata()
+  {
+    return $this->requestMetadata;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Partners_LogUserEventResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $responseMetadataType = 'Google_Service_Partners_ResponseMetadata';
+  protected $responseMetadataDataType = '';
+
+
+  public function setResponseMetadata(Google_Service_Partners_ResponseMetadata $responseMetadata)
+  {
+    $this->responseMetadata = $responseMetadata;
+  }
+  public function getResponseMetadata()
+  {
+    return $this->responseMetadata;
+  }
+}
+
+class Google_Service_Partners_Money extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $currencyCode;
+  public $nanos;
+  public $units;
+
+
+  public function setCurrencyCode($currencyCode)
+  {
+    $this->currencyCode = $currencyCode;
+  }
+  public function getCurrencyCode()
+  {
+    return $this->currencyCode;
+  }
+  public function setNanos($nanos)
+  {
+    $this->nanos = $nanos;
+  }
+  public function getNanos()
+  {
+    return $this->nanos;
+  }
+  public function setUnits($units)
+  {
+    $this->units = $units;
+  }
+  public function getUnits()
+  {
+    return $this->units;
+  }
+}
+
+class Google_Service_Partners_PublicProfile extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $displayImageUrl;
+  public $displayName;
+  public $id;
+  public $url;
+
+
+  public function setDisplayImageUrl($displayImageUrl)
+  {
+    $this->displayImageUrl = $displayImageUrl;
+  }
+  public function getDisplayImageUrl()
+  {
+    return $this->displayImageUrl;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Partners_Rank extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $type;
+  public $value;
+
+
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Partners_RecaptchaChallenge extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $response;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setResponse($response)
+  {
+    $this->response = $response;
+  }
+  public function getResponse()
+  {
+    return $this->response;
+  }
+}
+
+class Google_Service_Partners_RequestMetadata extends Google_Collection
+{
+  protected $collection_key = 'experimentIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $experimentIds;
+  public $locale;
+  public $partnersSessionId;
+  protected $trafficSourceType = 'Google_Service_Partners_TrafficSource';
+  protected $trafficSourceDataType = '';
+  protected $userOverridesType = 'Google_Service_Partners_UserOverrides';
+  protected $userOverridesDataType = '';
+
+
+  public function setExperimentIds($experimentIds)
+  {
+    $this->experimentIds = $experimentIds;
+  }
+  public function getExperimentIds()
+  {
+    return $this->experimentIds;
+  }
+  public function setLocale($locale)
+  {
+    $this->locale = $locale;
+  }
+  public function getLocale()
+  {
+    return $this->locale;
+  }
+  public function setPartnersSessionId($partnersSessionId)
+  {
+    $this->partnersSessionId = $partnersSessionId;
+  }
+  public function getPartnersSessionId()
+  {
+    return $this->partnersSessionId;
+  }
+  public function setTrafficSource(Google_Service_Partners_TrafficSource $trafficSource)
+  {
+    $this->trafficSource = $trafficSource;
+  }
+  public function getTrafficSource()
+  {
+    return $this->trafficSource;
+  }
+  public function setUserOverrides(Google_Service_Partners_UserOverrides $userOverrides)
+  {
+    $this->userOverrides = $userOverrides;
+  }
+  public function getUserOverrides()
+  {
+    return $this->userOverrides;
+  }
+}
+
+class Google_Service_Partners_ResponseMetadata extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $debugInfoType = 'Google_Service_Partners_DebugInfo';
+  protected $debugInfoDataType = '';
+
+
+  public function setDebugInfo(Google_Service_Partners_DebugInfo $debugInfo)
+  {
+    $this->debugInfo = $debugInfo;
+  }
+  public function getDebugInfo()
+  {
+    return $this->debugInfo;
+  }
+}
+
+class Google_Service_Partners_TrafficSource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $trafficSourceId;
+  public $trafficSubId;
+
+
+  public function setTrafficSourceId($trafficSourceId)
+  {
+    $this->trafficSourceId = $trafficSourceId;
+  }
+  public function getTrafficSourceId()
+  {
+    return $this->trafficSourceId;
+  }
+  public function setTrafficSubId($trafficSubId)
+  {
+    $this->trafficSubId = $trafficSubId;
+  }
+  public function getTrafficSubId()
+  {
+    return $this->trafficSubId;
+  }
+}
+
+class Google_Service_Partners_UserOverrides extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $ipAddress;
+  public $userId;
+
+
+  public function setIpAddress($ipAddress)
+  {
+    $this->ipAddress = $ipAddress;
+  }
+  public function getIpAddress()
+  {
+    return $this->ipAddress;
+  }
+  public function setUserId($userId)
+  {
+    $this->userId = $userId;
+  }
+  public function getUserId()
+  {
+    return $this->userId;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Playmoviespartner.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Playmoviespartner.php
@@ -1,0 +1,1676 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Playmoviespartner (v1).
+ *
+ * <p>
+ * Lets Google Play Movies Partners get the delivery status of their titles.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/playmoviespartner/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Playmoviespartner extends Google_Service
+{
+  /** View the digital assets you publish on Google Play Movies and TV. */
+  const PLAYMOVIES_PARTNER_READONLY =
+      "https://www.googleapis.com/auth/playmovies_partner.readonly";
+
+  public $accounts_avails;
+  public $accounts_experienceLocales;
+  public $accounts_orders;
+  public $accounts_storeInfos;
+  public $accounts_storeInfos_country;
+  
+
+  /**
+   * Constructs the internal representation of the Playmoviespartner service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://playmoviespartner.googleapis.com/';
+    $this->servicePath = '';
+    $this->version = 'v1';
+    $this->serviceName = 'playmoviespartner';
+
+    $this->accounts_avails = new Google_Service_Playmoviespartner_AccountsAvails_Resource(
+        $this,
+        $this->serviceName,
+        'avails',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'v1/accounts/{accountId}/avails',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pphNames' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'videoIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'title' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'altId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'territories' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'studioNames' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_experienceLocales = new Google_Service_Playmoviespartner_AccountsExperienceLocales_Resource(
+        $this,
+        $this->serviceName,
+        'experienceLocales',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'v1/accounts/{accountId}/experienceLocales/{elId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'elId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1/accounts/{accountId}/experienceLocales',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pphNames' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'status' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'titleLevelEidr' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'studioNames' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'editLevelEidr' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'customId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'altCutId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_orders = new Google_Service_Playmoviespartner_AccountsOrders_Resource(
+        $this,
+        $this->serviceName,
+        'orders',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'v1/accounts/{accountId}/orders/{orderId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1/accounts/{accountId}/orders',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pphNames' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'status' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'name' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'studioNames' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'customId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_storeInfos = new Google_Service_Playmoviespartner_AccountsStoreInfos_Resource(
+        $this,
+        $this->serviceName,
+        'storeInfos',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'v1/accounts/{accountId}/storeInfos',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pphNames' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'name' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'countries' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'videoId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'studioNames' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'videoIds' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_storeInfos_country = new Google_Service_Playmoviespartner_AccountsStoreInfosCountry_Resource(
+        $this,
+        $this->serviceName,
+        'country',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'v1/accounts/{accountId}/storeInfos/{videoId}/country/{country}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'videoId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'country' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "accounts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $playmoviespartnerService = new Google_Service_Playmoviespartner(...);
+ *   $accounts = $playmoviespartnerService->accounts;
+ *  </code>
+ */
+class Google_Service_Playmoviespartner_Accounts_Resource extends Google_Service_Resource
+{
+}
+
+/**
+ * The "avails" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $playmoviespartnerService = new Google_Service_Playmoviespartner(...);
+ *   $avails = $playmoviespartnerService->avails;
+ *  </code>
+ */
+class Google_Service_Playmoviespartner_AccountsAvails_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List Avails owned or managed by the partner. See _Authentication and
+   * Authorization rules_ and _List methods rules_ for more information about this
+   * method. (avails.listAccountsAvails)
+   *
+   * @param string $accountId REQUIRED. See _General rules_ for more information
+   * about this field.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pphNames See _List methods rules_ for info about this
+   * field.
+   * @opt_param string videoIds Filter Avails that match any of the given
+   * `video_id`s.
+   * @opt_param int pageSize See _List methods rules_ for info about this field.
+   * @opt_param string title Filter Avails that match a case-insensitive substring
+   * of the default Title name.
+   * @opt_param string altId Filter Avails that match a case-insensitive, partner-
+   * specific custom id.
+   * @opt_param string territories Filter Avails that match (case-insensitive) any
+   * of the given country codes, using the "ISO 3166-1 alpha-2" format (examples:
+   * "US", "us", "Us").
+   * @opt_param string studioNames See _List methods rules_ for info about this
+   * field.
+   * @opt_param string pageToken See _List methods rules_ for info about this
+   * field.
+   * @return Google_Service_Playmoviespartner_ListAvailsResponse
+   */
+  public function listAccountsAvails($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Playmoviespartner_ListAvailsResponse");
+  }
+}
+/**
+ * The "experienceLocales" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $playmoviespartnerService = new Google_Service_Playmoviespartner(...);
+ *   $experienceLocales = $playmoviespartnerService->experienceLocales;
+ *  </code>
+ */
+class Google_Service_Playmoviespartner_AccountsExperienceLocales_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get an ExperienceLocale given its id. See _Authentication and Authorization
+   * rules_ and _Get methods rules_ for more information about this method.
+   * (experienceLocales.get)
+   *
+   * @param string $accountId REQUIRED. See _General rules_ for more information
+   * about this field.
+   * @param string $elId REQUIRED. ExperienceLocale ID, as defined by Google.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Playmoviespartner_ExperienceLocale
+   */
+  public function get($accountId, $elId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'elId' => $elId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Playmoviespartner_ExperienceLocale");
+  }
+
+  /**
+   * List ExperienceLocales owned or managed by the partner. See _Authentication
+   * and Authorization rules_ and _List methods rules_ for more information about
+   * this method. (experienceLocales.listAccountsExperienceLocales)
+   *
+   * @param string $accountId REQUIRED. See _General rules_ for more information
+   * about this field.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pphNames See _List methods rules_ for info about this
+   * field.
+   * @opt_param string status Filter ExperienceLocales that match one of the given
+   * status.
+   * @opt_param string titleLevelEidr Filter ExperienceLocales that match a given
+   * title-level EIDR.
+   * @opt_param int pageSize See _List methods rules_ for info about this field.
+   * @opt_param string studioNames See _List methods rules_ for info about this
+   * field.
+   * @opt_param string pageToken See _List methods rules_ for info about this
+   * field.
+   * @opt_param string editLevelEidr Filter ExperienceLocales that match a given
+   * edit-level EIDR.
+   * @opt_param string customId Filter ExperienceLocales that match a case-
+   * insensitive, partner-specific custom id.
+   * @opt_param string altCutId Filter ExperienceLocales that match a case-
+   * insensitive, partner-specific Alternative Cut ID.
+   * @return Google_Service_Playmoviespartner_ListExperienceLocalesResponse
+   */
+  public function listAccountsExperienceLocales($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Playmoviespartner_ListExperienceLocalesResponse");
+  }
+}
+/**
+ * The "orders" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $playmoviespartnerService = new Google_Service_Playmoviespartner(...);
+ *   $orders = $playmoviespartnerService->orders;
+ *  </code>
+ */
+class Google_Service_Playmoviespartner_AccountsOrders_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get an Order given its id. See _Authentication and Authorization rules_ and
+   * _Get methods rules_ for more information about this method. (orders.get)
+   *
+   * @param string $accountId REQUIRED. See _General rules_ for more information
+   * about this field.
+   * @param string $orderId REQUIRED. Order ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Playmoviespartner_Order
+   */
+  public function get($accountId, $orderId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'orderId' => $orderId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Playmoviespartner_Order");
+  }
+
+  /**
+   * List Orders owned or managed by the partner. See _Authentication and
+   * Authorization rules_ and _List methods rules_ for more information about this
+   * method. (orders.listAccountsOrders)
+   *
+   * @param string $accountId REQUIRED. See _General rules_ for more information
+   * about this field.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pphNames See _List methods rules_ for info about this
+   * field.
+   * @opt_param string status Filter Orders that match one of the given status.
+   * @opt_param string name Filter Orders that match a title name (case-
+   * insensitive, sub-string match).
+   * @opt_param int pageSize See _List methods rules_ for info about this field.
+   * @opt_param string studioNames See _List methods rules_ for info about this
+   * field.
+   * @opt_param string pageToken See _List methods rules_ for info about this
+   * field.
+   * @opt_param string customId Filter Orders that match a case-insensitive,
+   * partner-specific custom id.
+   * @return Google_Service_Playmoviespartner_ListOrdersResponse
+   */
+  public function listAccountsOrders($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Playmoviespartner_ListOrdersResponse");
+  }
+}
+/**
+ * The "storeInfos" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $playmoviespartnerService = new Google_Service_Playmoviespartner(...);
+ *   $storeInfos = $playmoviespartnerService->storeInfos;
+ *  </code>
+ */
+class Google_Service_Playmoviespartner_AccountsStoreInfos_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List StoreInfos owned or managed by the partner. See _Authentication and
+   * Authorization rules_ and _List methods rules_ for more information about this
+   * method. (storeInfos.listAccountsStoreInfos)
+   *
+   * @param string $accountId REQUIRED. See _General rules_ for more information
+   * about this field.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pphNames See _List methods rules_ for info about this
+   * field.
+   * @opt_param string name Filter StoreInfos that match a case-insensitive
+   * substring of the default name.
+   * @opt_param int pageSize See _List methods rules_ for info about this field.
+   * @opt_param string countries Filter StoreInfos that match (case-insensitive)
+   * any of the given country codes, using the "ISO 3166-1 alpha-2" format
+   * (examples: "US", "us", "Us").
+   * @opt_param string videoId Filter StoreInfos that match a given `video_id`.
+   * NOTE: this field is deprecated and will be removed on V2; `video_ids` should
+   * be used instead.
+   * @opt_param string studioNames See _List methods rules_ for info about this
+   * field.
+   * @opt_param string pageToken See _List methods rules_ for info about this
+   * field.
+   * @opt_param string videoIds Filter StoreInfos that match any of the given
+   * `video_id`s.
+   * @return Google_Service_Playmoviespartner_ListStoreInfosResponse
+   */
+  public function listAccountsStoreInfos($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Playmoviespartner_ListStoreInfosResponse");
+  }
+}
+
+/**
+ * The "country" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $playmoviespartnerService = new Google_Service_Playmoviespartner(...);
+ *   $country = $playmoviespartnerService->country;
+ *  </code>
+ */
+class Google_Service_Playmoviespartner_AccountsStoreInfosCountry_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get a StoreInfo given its video id and country. See _Authentication and
+   * Authorization rules_ and _Get methods rules_ for more information about this
+   * method. (country.get)
+   *
+   * @param string $accountId REQUIRED. See _General rules_ for more information
+   * about this field.
+   * @param string $videoId REQUIRED. Video ID.
+   * @param string $country REQUIRED. Edit country.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Playmoviespartner_StoreInfo
+   */
+  public function get($accountId, $videoId, $country, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'videoId' => $videoId, 'country' => $country);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Playmoviespartner_StoreInfo");
+  }
+}
+
+
+
+
+class Google_Service_Playmoviespartner_Avail extends Google_Collection
+{
+  protected $collection_key = 'pphNames';
+  protected $internal_gapi_mappings = array(
+  );
+  public $altId;
+  public $captionExemption;
+  public $captionIncluded;
+  public $contentId;
+  public $displayName;
+  public $encodeId;
+  public $end;
+  public $episodeAltId;
+  public $episodeNumber;
+  public $episodeTitleInternalAlias;
+  public $formatProfile;
+  public $licenseType;
+  public $pphNames;
+  public $priceType;
+  public $priceValue;
+  public $productId;
+  public $ratingReason;
+  public $ratingSystem;
+  public $ratingValue;
+  public $releaseDate;
+  public $seasonAltId;
+  public $seasonNumber;
+  public $seasonTitleInternalAlias;
+  public $seriesAltId;
+  public $seriesTitleInternalAlias;
+  public $start;
+  public $storeLanguage;
+  public $suppressionLiftDate;
+  public $territory;
+  public $titleInternalAlias;
+  public $videoId;
+  public $workType;
+
+
+  public function setAltId($altId)
+  {
+    $this->altId = $altId;
+  }
+  public function getAltId()
+  {
+    return $this->altId;
+  }
+  public function setCaptionExemption($captionExemption)
+  {
+    $this->captionExemption = $captionExemption;
+  }
+  public function getCaptionExemption()
+  {
+    return $this->captionExemption;
+  }
+  public function setCaptionIncluded($captionIncluded)
+  {
+    $this->captionIncluded = $captionIncluded;
+  }
+  public function getCaptionIncluded()
+  {
+    return $this->captionIncluded;
+  }
+  public function setContentId($contentId)
+  {
+    $this->contentId = $contentId;
+  }
+  public function getContentId()
+  {
+    return $this->contentId;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setEncodeId($encodeId)
+  {
+    $this->encodeId = $encodeId;
+  }
+  public function getEncodeId()
+  {
+    return $this->encodeId;
+  }
+  public function setEnd($end)
+  {
+    $this->end = $end;
+  }
+  public function getEnd()
+  {
+    return $this->end;
+  }
+  public function setEpisodeAltId($episodeAltId)
+  {
+    $this->episodeAltId = $episodeAltId;
+  }
+  public function getEpisodeAltId()
+  {
+    return $this->episodeAltId;
+  }
+  public function setEpisodeNumber($episodeNumber)
+  {
+    $this->episodeNumber = $episodeNumber;
+  }
+  public function getEpisodeNumber()
+  {
+    return $this->episodeNumber;
+  }
+  public function setEpisodeTitleInternalAlias($episodeTitleInternalAlias)
+  {
+    $this->episodeTitleInternalAlias = $episodeTitleInternalAlias;
+  }
+  public function getEpisodeTitleInternalAlias()
+  {
+    return $this->episodeTitleInternalAlias;
+  }
+  public function setFormatProfile($formatProfile)
+  {
+    $this->formatProfile = $formatProfile;
+  }
+  public function getFormatProfile()
+  {
+    return $this->formatProfile;
+  }
+  public function setLicenseType($licenseType)
+  {
+    $this->licenseType = $licenseType;
+  }
+  public function getLicenseType()
+  {
+    return $this->licenseType;
+  }
+  public function setPphNames($pphNames)
+  {
+    $this->pphNames = $pphNames;
+  }
+  public function getPphNames()
+  {
+    return $this->pphNames;
+  }
+  public function setPriceType($priceType)
+  {
+    $this->priceType = $priceType;
+  }
+  public function getPriceType()
+  {
+    return $this->priceType;
+  }
+  public function setPriceValue($priceValue)
+  {
+    $this->priceValue = $priceValue;
+  }
+  public function getPriceValue()
+  {
+    return $this->priceValue;
+  }
+  public function setProductId($productId)
+  {
+    $this->productId = $productId;
+  }
+  public function getProductId()
+  {
+    return $this->productId;
+  }
+  public function setRatingReason($ratingReason)
+  {
+    $this->ratingReason = $ratingReason;
+  }
+  public function getRatingReason()
+  {
+    return $this->ratingReason;
+  }
+  public function setRatingSystem($ratingSystem)
+  {
+    $this->ratingSystem = $ratingSystem;
+  }
+  public function getRatingSystem()
+  {
+    return $this->ratingSystem;
+  }
+  public function setRatingValue($ratingValue)
+  {
+    $this->ratingValue = $ratingValue;
+  }
+  public function getRatingValue()
+  {
+    return $this->ratingValue;
+  }
+  public function setReleaseDate($releaseDate)
+  {
+    $this->releaseDate = $releaseDate;
+  }
+  public function getReleaseDate()
+  {
+    return $this->releaseDate;
+  }
+  public function setSeasonAltId($seasonAltId)
+  {
+    $this->seasonAltId = $seasonAltId;
+  }
+  public function getSeasonAltId()
+  {
+    return $this->seasonAltId;
+  }
+  public function setSeasonNumber($seasonNumber)
+  {
+    $this->seasonNumber = $seasonNumber;
+  }
+  public function getSeasonNumber()
+  {
+    return $this->seasonNumber;
+  }
+  public function setSeasonTitleInternalAlias($seasonTitleInternalAlias)
+  {
+    $this->seasonTitleInternalAlias = $seasonTitleInternalAlias;
+  }
+  public function getSeasonTitleInternalAlias()
+  {
+    return $this->seasonTitleInternalAlias;
+  }
+  public function setSeriesAltId($seriesAltId)
+  {
+    $this->seriesAltId = $seriesAltId;
+  }
+  public function getSeriesAltId()
+  {
+    return $this->seriesAltId;
+  }
+  public function setSeriesTitleInternalAlias($seriesTitleInternalAlias)
+  {
+    $this->seriesTitleInternalAlias = $seriesTitleInternalAlias;
+  }
+  public function getSeriesTitleInternalAlias()
+  {
+    return $this->seriesTitleInternalAlias;
+  }
+  public function setStart($start)
+  {
+    $this->start = $start;
+  }
+  public function getStart()
+  {
+    return $this->start;
+  }
+  public function setStoreLanguage($storeLanguage)
+  {
+    $this->storeLanguage = $storeLanguage;
+  }
+  public function getStoreLanguage()
+  {
+    return $this->storeLanguage;
+  }
+  public function setSuppressionLiftDate($suppressionLiftDate)
+  {
+    $this->suppressionLiftDate = $suppressionLiftDate;
+  }
+  public function getSuppressionLiftDate()
+  {
+    return $this->suppressionLiftDate;
+  }
+  public function setTerritory($territory)
+  {
+    $this->territory = $territory;
+  }
+  public function getTerritory()
+  {
+    return $this->territory;
+  }
+  public function setTitleInternalAlias($titleInternalAlias)
+  {
+    $this->titleInternalAlias = $titleInternalAlias;
+  }
+  public function getTitleInternalAlias()
+  {
+    return $this->titleInternalAlias;
+  }
+  public function setVideoId($videoId)
+  {
+    $this->videoId = $videoId;
+  }
+  public function getVideoId()
+  {
+    return $this->videoId;
+  }
+  public function setWorkType($workType)
+  {
+    $this->workType = $workType;
+  }
+  public function getWorkType()
+  {
+    return $this->workType;
+  }
+}
+
+class Google_Service_Playmoviespartner_ExperienceLocale extends Google_Collection
+{
+  protected $collection_key = 'pphNames';
+  protected $internal_gapi_mappings = array(
+  );
+  public $altCutId;
+  public $approvedTime;
+  public $channelId;
+  public $country;
+  public $createdTime;
+  public $customIds;
+  public $earliestAvailStartTime;
+  public $editLevelEidr;
+  public $elId;
+  public $inventoryId;
+  public $language;
+  public $name;
+  public $normalizedPriority;
+  public $playableSequenceId;
+  public $pphNames;
+  public $presentationId;
+  public $priority;
+  public $status;
+  public $studioName;
+  public $titleLevelEidr;
+  public $trailerId;
+  public $type;
+  public $videoId;
+
+
+  public function setAltCutId($altCutId)
+  {
+    $this->altCutId = $altCutId;
+  }
+  public function getAltCutId()
+  {
+    return $this->altCutId;
+  }
+  public function setApprovedTime($approvedTime)
+  {
+    $this->approvedTime = $approvedTime;
+  }
+  public function getApprovedTime()
+  {
+    return $this->approvedTime;
+  }
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setCountry($country)
+  {
+    $this->country = $country;
+  }
+  public function getCountry()
+  {
+    return $this->country;
+  }
+  public function setCreatedTime($createdTime)
+  {
+    $this->createdTime = $createdTime;
+  }
+  public function getCreatedTime()
+  {
+    return $this->createdTime;
+  }
+  public function setCustomIds($customIds)
+  {
+    $this->customIds = $customIds;
+  }
+  public function getCustomIds()
+  {
+    return $this->customIds;
+  }
+  public function setEarliestAvailStartTime($earliestAvailStartTime)
+  {
+    $this->earliestAvailStartTime = $earliestAvailStartTime;
+  }
+  public function getEarliestAvailStartTime()
+  {
+    return $this->earliestAvailStartTime;
+  }
+  public function setEditLevelEidr($editLevelEidr)
+  {
+    $this->editLevelEidr = $editLevelEidr;
+  }
+  public function getEditLevelEidr()
+  {
+    return $this->editLevelEidr;
+  }
+  public function setElId($elId)
+  {
+    $this->elId = $elId;
+  }
+  public function getElId()
+  {
+    return $this->elId;
+  }
+  public function setInventoryId($inventoryId)
+  {
+    $this->inventoryId = $inventoryId;
+  }
+  public function getInventoryId()
+  {
+    return $this->inventoryId;
+  }
+  public function setLanguage($language)
+  {
+    $this->language = $language;
+  }
+  public function getLanguage()
+  {
+    return $this->language;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNormalizedPriority($normalizedPriority)
+  {
+    $this->normalizedPriority = $normalizedPriority;
+  }
+  public function getNormalizedPriority()
+  {
+    return $this->normalizedPriority;
+  }
+  public function setPlayableSequenceId($playableSequenceId)
+  {
+    $this->playableSequenceId = $playableSequenceId;
+  }
+  public function getPlayableSequenceId()
+  {
+    return $this->playableSequenceId;
+  }
+  public function setPphNames($pphNames)
+  {
+    $this->pphNames = $pphNames;
+  }
+  public function getPphNames()
+  {
+    return $this->pphNames;
+  }
+  public function setPresentationId($presentationId)
+  {
+    $this->presentationId = $presentationId;
+  }
+  public function getPresentationId()
+  {
+    return $this->presentationId;
+  }
+  public function setPriority($priority)
+  {
+    $this->priority = $priority;
+  }
+  public function getPriority()
+  {
+    return $this->priority;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setStudioName($studioName)
+  {
+    $this->studioName = $studioName;
+  }
+  public function getStudioName()
+  {
+    return $this->studioName;
+  }
+  public function setTitleLevelEidr($titleLevelEidr)
+  {
+    $this->titleLevelEidr = $titleLevelEidr;
+  }
+  public function getTitleLevelEidr()
+  {
+    return $this->titleLevelEidr;
+  }
+  public function setTrailerId($trailerId)
+  {
+    $this->trailerId = $trailerId;
+  }
+  public function getTrailerId()
+  {
+    return $this->trailerId;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVideoId($videoId)
+  {
+    $this->videoId = $videoId;
+  }
+  public function getVideoId()
+  {
+    return $this->videoId;
+  }
+}
+
+class Google_Service_Playmoviespartner_ListAvailsResponse extends Google_Collection
+{
+  protected $collection_key = 'avails';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $availsType = 'Google_Service_Playmoviespartner_Avail';
+  protected $availsDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setAvails($avails)
+  {
+    $this->avails = $avails;
+  }
+  public function getAvails()
+  {
+    return $this->avails;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Playmoviespartner_ListExperienceLocalesResponse extends Google_Collection
+{
+  protected $collection_key = 'experienceLocales';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $experienceLocalesType = 'Google_Service_Playmoviespartner_ExperienceLocale';
+  protected $experienceLocalesDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setExperienceLocales($experienceLocales)
+  {
+    $this->experienceLocales = $experienceLocales;
+  }
+  public function getExperienceLocales()
+  {
+    return $this->experienceLocales;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Playmoviespartner_ListOrdersResponse extends Google_Collection
+{
+  protected $collection_key = 'orders';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $ordersType = 'Google_Service_Playmoviespartner_Order';
+  protected $ordersDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setOrders($orders)
+  {
+    $this->orders = $orders;
+  }
+  public function getOrders()
+  {
+    return $this->orders;
+  }
+}
+
+class Google_Service_Playmoviespartner_ListStoreInfosResponse extends Google_Collection
+{
+  protected $collection_key = 'storeInfos';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $storeInfosType = 'Google_Service_Playmoviespartner_StoreInfo';
+  protected $storeInfosDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setStoreInfos($storeInfos)
+  {
+    $this->storeInfos = $storeInfos;
+  }
+  public function getStoreInfos()
+  {
+    return $this->storeInfos;
+  }
+}
+
+class Google_Service_Playmoviespartner_Order extends Google_Collection
+{
+  protected $collection_key = 'countries';
+  protected $internal_gapi_mappings = array(
+  );
+  public $approvedTime;
+  public $channelId;
+  public $channelName;
+  public $countries;
+  public $customId;
+  public $earliestAvailStartTime;
+  public $episodeName;
+  public $legacyPriority;
+  public $name;
+  public $normalizedPriority;
+  public $orderId;
+  public $orderedTime;
+  public $pphName;
+  public $priority;
+  public $receivedTime;
+  public $rejectionNote;
+  public $seasonName;
+  public $showName;
+  public $status;
+  public $statusDetail;
+  public $studioName;
+  public $type;
+  public $videoId;
+
+
+  public function setApprovedTime($approvedTime)
+  {
+    $this->approvedTime = $approvedTime;
+  }
+  public function getApprovedTime()
+  {
+    return $this->approvedTime;
+  }
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setChannelName($channelName)
+  {
+    $this->channelName = $channelName;
+  }
+  public function getChannelName()
+  {
+    return $this->channelName;
+  }
+  public function setCountries($countries)
+  {
+    $this->countries = $countries;
+  }
+  public function getCountries()
+  {
+    return $this->countries;
+  }
+  public function setCustomId($customId)
+  {
+    $this->customId = $customId;
+  }
+  public function getCustomId()
+  {
+    return $this->customId;
+  }
+  public function setEarliestAvailStartTime($earliestAvailStartTime)
+  {
+    $this->earliestAvailStartTime = $earliestAvailStartTime;
+  }
+  public function getEarliestAvailStartTime()
+  {
+    return $this->earliestAvailStartTime;
+  }
+  public function setEpisodeName($episodeName)
+  {
+    $this->episodeName = $episodeName;
+  }
+  public function getEpisodeName()
+  {
+    return $this->episodeName;
+  }
+  public function setLegacyPriority($legacyPriority)
+  {
+    $this->legacyPriority = $legacyPriority;
+  }
+  public function getLegacyPriority()
+  {
+    return $this->legacyPriority;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNormalizedPriority($normalizedPriority)
+  {
+    $this->normalizedPriority = $normalizedPriority;
+  }
+  public function getNormalizedPriority()
+  {
+    return $this->normalizedPriority;
+  }
+  public function setOrderId($orderId)
+  {
+    $this->orderId = $orderId;
+  }
+  public function getOrderId()
+  {
+    return $this->orderId;
+  }
+  public function setOrderedTime($orderedTime)
+  {
+    $this->orderedTime = $orderedTime;
+  }
+  public function getOrderedTime()
+  {
+    return $this->orderedTime;
+  }
+  public function setPphName($pphName)
+  {
+    $this->pphName = $pphName;
+  }
+  public function getPphName()
+  {
+    return $this->pphName;
+  }
+  public function setPriority($priority)
+  {
+    $this->priority = $priority;
+  }
+  public function getPriority()
+  {
+    return $this->priority;
+  }
+  public function setReceivedTime($receivedTime)
+  {
+    $this->receivedTime = $receivedTime;
+  }
+  public function getReceivedTime()
+  {
+    return $this->receivedTime;
+  }
+  public function setRejectionNote($rejectionNote)
+  {
+    $this->rejectionNote = $rejectionNote;
+  }
+  public function getRejectionNote()
+  {
+    return $this->rejectionNote;
+  }
+  public function setSeasonName($seasonName)
+  {
+    $this->seasonName = $seasonName;
+  }
+  public function getSeasonName()
+  {
+    return $this->seasonName;
+  }
+  public function setShowName($showName)
+  {
+    $this->showName = $showName;
+  }
+  public function getShowName()
+  {
+    return $this->showName;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setStatusDetail($statusDetail)
+  {
+    $this->statusDetail = $statusDetail;
+  }
+  public function getStatusDetail()
+  {
+    return $this->statusDetail;
+  }
+  public function setStudioName($studioName)
+  {
+    $this->studioName = $studioName;
+  }
+  public function getStudioName()
+  {
+    return $this->studioName;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVideoId($videoId)
+  {
+    $this->videoId = $videoId;
+  }
+  public function getVideoId()
+  {
+    return $this->videoId;
+  }
+}
+
+class Google_Service_Playmoviespartner_StoreInfo extends Google_Collection
+{
+  protected $collection_key = 'subtitles';
+  protected $internal_gapi_mappings = array(
+  );
+  public $audioTracks;
+  public $country;
+  public $editLevelEidr;
+  public $episodeNumber;
+  public $hasAudio51;
+  public $hasEstOffer;
+  public $hasHdOffer;
+  public $hasInfoCards;
+  public $hasSdOffer;
+  public $hasVodOffer;
+  public $liveTime;
+  public $mid;
+  public $name;
+  public $pphNames;
+  public $seasonId;
+  public $seasonName;
+  public $seasonNumber;
+  public $showId;
+  public $showName;
+  public $studioName;
+  public $subtitles;
+  public $titleLevelEidr;
+  public $trailerId;
+  public $type;
+  public $videoId;
+
+
+  public function setAudioTracks($audioTracks)
+  {
+    $this->audioTracks = $audioTracks;
+  }
+  public function getAudioTracks()
+  {
+    return $this->audioTracks;
+  }
+  public function setCountry($country)
+  {
+    $this->country = $country;
+  }
+  public function getCountry()
+  {
+    return $this->country;
+  }
+  public function setEditLevelEidr($editLevelEidr)
+  {
+    $this->editLevelEidr = $editLevelEidr;
+  }
+  public function getEditLevelEidr()
+  {
+    return $this->editLevelEidr;
+  }
+  public function setEpisodeNumber($episodeNumber)
+  {
+    $this->episodeNumber = $episodeNumber;
+  }
+  public function getEpisodeNumber()
+  {
+    return $this->episodeNumber;
+  }
+  public function setHasAudio51($hasAudio51)
+  {
+    $this->hasAudio51 = $hasAudio51;
+  }
+  public function getHasAudio51()
+  {
+    return $this->hasAudio51;
+  }
+  public function setHasEstOffer($hasEstOffer)
+  {
+    $this->hasEstOffer = $hasEstOffer;
+  }
+  public function getHasEstOffer()
+  {
+    return $this->hasEstOffer;
+  }
+  public function setHasHdOffer($hasHdOffer)
+  {
+    $this->hasHdOffer = $hasHdOffer;
+  }
+  public function getHasHdOffer()
+  {
+    return $this->hasHdOffer;
+  }
+  public function setHasInfoCards($hasInfoCards)
+  {
+    $this->hasInfoCards = $hasInfoCards;
+  }
+  public function getHasInfoCards()
+  {
+    return $this->hasInfoCards;
+  }
+  public function setHasSdOffer($hasSdOffer)
+  {
+    $this->hasSdOffer = $hasSdOffer;
+  }
+  public function getHasSdOffer()
+  {
+    return $this->hasSdOffer;
+  }
+  public function setHasVodOffer($hasVodOffer)
+  {
+    $this->hasVodOffer = $hasVodOffer;
+  }
+  public function getHasVodOffer()
+  {
+    return $this->hasVodOffer;
+  }
+  public function setLiveTime($liveTime)
+  {
+    $this->liveTime = $liveTime;
+  }
+  public function getLiveTime()
+  {
+    return $this->liveTime;
+  }
+  public function setMid($mid)
+  {
+    $this->mid = $mid;
+  }
+  public function getMid()
+  {
+    return $this->mid;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPphNames($pphNames)
+  {
+    $this->pphNames = $pphNames;
+  }
+  public function getPphNames()
+  {
+    return $this->pphNames;
+  }
+  public function setSeasonId($seasonId)
+  {
+    $this->seasonId = $seasonId;
+  }
+  public function getSeasonId()
+  {
+    return $this->seasonId;
+  }
+  public function setSeasonName($seasonName)
+  {
+    $this->seasonName = $seasonName;
+  }
+  public function getSeasonName()
+  {
+    return $this->seasonName;
+  }
+  public function setSeasonNumber($seasonNumber)
+  {
+    $this->seasonNumber = $seasonNumber;
+  }
+  public function getSeasonNumber()
+  {
+    return $this->seasonNumber;
+  }
+  public function setShowId($showId)
+  {
+    $this->showId = $showId;
+  }
+  public function getShowId()
+  {
+    return $this->showId;
+  }
+  public function setShowName($showName)
+  {
+    $this->showName = $showName;
+  }
+  public function getShowName()
+  {
+    return $this->showName;
+  }
+  public function setStudioName($studioName)
+  {
+    $this->studioName = $studioName;
+  }
+  public function getStudioName()
+  {
+    return $this->studioName;
+  }
+  public function setSubtitles($subtitles)
+  {
+    $this->subtitles = $subtitles;
+  }
+  public function getSubtitles()
+  {
+    return $this->subtitles;
+  }
+  public function setTitleLevelEidr($titleLevelEidr)
+  {
+    $this->titleLevelEidr = $titleLevelEidr;
+  }
+  public function getTitleLevelEidr()
+  {
+    return $this->titleLevelEidr;
+  }
+  public function setTrailerId($trailerId)
+  {
+    $this->trailerId = $trailerId;
+  }
+  public function getTrailerId()
+  {
+    return $this->trailerId;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVideoId($videoId)
+  {
+    $this->videoId = $videoId;
+  }
+  public function getVideoId()
+  {
+    return $this->videoId;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Plus.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Plus.php
@@ -1,0 +1,3692 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Plus (v1).
+ *
+ * <p>
+ * The Google+ API enables developers to build on top of the Google+ platform.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/+/api/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Plus extends Google_Service
+{
+  /** Know your basic profile info and list of people in your circles.. */
+  const PLUS_LOGIN =
+      "https://www.googleapis.com/auth/plus.login";
+  /** Know who you are on Google. */
+  const PLUS_ME =
+      "https://www.googleapis.com/auth/plus.me";
+  /** View your email address. */
+  const USERINFO_EMAIL =
+      "https://www.googleapis.com/auth/userinfo.email";
+  /** View your basic profile info. */
+  const USERINFO_PROFILE =
+      "https://www.googleapis.com/auth/userinfo.profile";
+
+  public $activities;
+  public $comments;
+  public $moments;
+  public $people;
+  
+
+  /**
+   * Constructs the internal representation of the Plus service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'plus/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'plus';
+
+    $this->activities = new Google_Service_Plus_Activities_Resource(
+        $this,
+        $this->serviceName,
+        'activities',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'activities/{activityId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'activityId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'people/{userId}/activities/{collection}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collection' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'search' => array(
+              'path' => 'activities',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'query' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->comments = new Google_Service_Plus_Comments_Resource(
+        $this,
+        $this->serviceName,
+        'comments',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'comments/{commentId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'commentId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'activities/{activityId}/comments',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'activityId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->moments = new Google_Service_Plus_Moments_Resource(
+        $this,
+        $this->serviceName,
+        'moments',
+        array(
+          'methods' => array(
+            'insert' => array(
+              'path' => 'people/{userId}/moments/{collection}',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collection' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'debug' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'people/{userId}/moments/{collection}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collection' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'targetUrl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'type' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->people = new Google_Service_Plus_People_Resource(
+        $this,
+        $this->serviceName,
+        'people',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'people/{userId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'people/{userId}/people/{collection}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collection' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'listByActivity' => array(
+              'path' => 'activities/{activityId}/people/{collection}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'activityId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collection' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'search' => array(
+              'path' => 'people',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'query' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'language' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "activities" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $plusService = new Google_Service_Plus(...);
+ *   $activities = $plusService->activities;
+ *  </code>
+ */
+class Google_Service_Plus_Activities_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get an activity. (activities.get)
+   *
+   * @param string $activityId The ID of the activity to get.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Plus_Activity
+   */
+  public function get($activityId, $optParams = array())
+  {
+    $params = array('activityId' => $activityId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Plus_Activity");
+  }
+
+  /**
+   * List all of the activities in the specified collection for a particular user.
+   * (activities.listActivities)
+   *
+   * @param string $userId The ID of the user to get activities for. The special
+   * value "me" can be used to indicate the authenticated user.
+   * @param string $collection The collection of activities to list.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large result sets. To get the next page of results, set this
+   * parameter to the value of "nextPageToken" from the previous response.
+   * @opt_param string maxResults The maximum number of activities to include in
+   * the response, which is used for paging. For any response, the actual number
+   * returned might be less than the specified maxResults.
+   * @return Google_Service_Plus_ActivityFeed
+   */
+  public function listActivities($userId, $collection, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'collection' => $collection);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Plus_ActivityFeed");
+  }
+
+  /**
+   * Search public activities. (activities.search)
+   *
+   * @param string $query Full-text search query string.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderBy Specifies how to order search results.
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large result sets. To get the next page of results, set this
+   * parameter to the value of "nextPageToken" from the previous response. This
+   * token can be of any length.
+   * @opt_param string maxResults The maximum number of activities to include in
+   * the response, which is used for paging. For any response, the actual number
+   * returned might be less than the specified maxResults.
+   * @opt_param string language Specify the preferred language to search with. See
+   * search language codes for available values.
+   * @return Google_Service_Plus_ActivityFeed
+   */
+  public function search($query, $optParams = array())
+  {
+    $params = array('query' => $query);
+    $params = array_merge($params, $optParams);
+    return $this->call('search', array($params), "Google_Service_Plus_ActivityFeed");
+  }
+}
+
+/**
+ * The "comments" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $plusService = new Google_Service_Plus(...);
+ *   $comments = $plusService->comments;
+ *  </code>
+ */
+class Google_Service_Plus_Comments_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get a comment. (comments.get)
+   *
+   * @param string $commentId The ID of the comment to get.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Plus_Comment
+   */
+  public function get($commentId, $optParams = array())
+  {
+    $params = array('commentId' => $commentId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Plus_Comment");
+  }
+
+  /**
+   * List all of the comments for an activity. (comments.listComments)
+   *
+   * @param string $activityId The ID of the activity to get comments for.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large result sets. To get the next page of results, set this
+   * parameter to the value of "nextPageToken" from the previous response.
+   * @opt_param string sortOrder The order in which to sort the list of comments.
+   * @opt_param string maxResults The maximum number of comments to include in the
+   * response, which is used for paging. For any response, the actual number
+   * returned might be less than the specified maxResults.
+   * @return Google_Service_Plus_CommentFeed
+   */
+  public function listComments($activityId, $optParams = array())
+  {
+    $params = array('activityId' => $activityId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Plus_CommentFeed");
+  }
+}
+
+/**
+ * The "moments" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $plusService = new Google_Service_Plus(...);
+ *   $moments = $plusService->moments;
+ *  </code>
+ */
+class Google_Service_Plus_Moments_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Record a moment representing a user's action such as making a purchase or
+   * commenting on a blog. (moments.insert)
+   *
+   * @param string $userId The ID of the user to record actions for. The only
+   * valid values are "me" and the ID of the authenticated user.
+   * @param string $collection The collection to which to write moments.
+   * @param Google_Moment $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool debug Return the moment as written. Should be used only for
+   * debugging.
+   * @return Google_Service_Plus_Moment
+   */
+  public function insert($userId, $collection, Google_Service_Plus_Moment $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'collection' => $collection, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Plus_Moment");
+  }
+
+  /**
+   * List all of the moments for a particular user. (moments.listMoments)
+   *
+   * @param string $userId The ID of the user to get moments for. The special
+   * value "me" can be used to indicate the authenticated user.
+   * @param string $collection The collection of moments to list.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string maxResults The maximum number of moments to include in the
+   * response, which is used for paging. For any response, the actual number
+   * returned might be less than the specified maxResults.
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large result sets. To get the next page of results, set this
+   * parameter to the value of "nextPageToken" from the previous response.
+   * @opt_param string targetUrl Only moments containing this targetUrl will be
+   * returned.
+   * @opt_param string type Only moments of this type will be returned.
+   * @return Google_Service_Plus_MomentsFeed
+   */
+  public function listMoments($userId, $collection, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'collection' => $collection);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Plus_MomentsFeed");
+  }
+}
+
+/**
+ * The "people" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $plusService = new Google_Service_Plus(...);
+ *   $people = $plusService->people;
+ *  </code>
+ */
+class Google_Service_Plus_People_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get a person's profile. If your app uses scope
+   * https://www.googleapis.com/auth/plus.login, this method is guaranteed to
+   * return ageRange and language. (people.get)
+   *
+   * @param string $userId The ID of the person to get the profile for. The
+   * special value "me" can be used to indicate the authenticated user.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Plus_Person
+   */
+  public function get($userId, $optParams = array())
+  {
+    $params = array('userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Plus_Person");
+  }
+
+  /**
+   * List all of the people in the specified collection. (people.listPeople)
+   *
+   * @param string $userId Get the collection of people for the person identified.
+   * Use "me" to indicate the authenticated user.
+   * @param string $collection The collection of people to list.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderBy The order to return people in.
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large result sets. To get the next page of results, set this
+   * parameter to the value of "nextPageToken" from the previous response.
+   * @opt_param string maxResults The maximum number of people to include in the
+   * response, which is used for paging. For any response, the actual number
+   * returned might be less than the specified maxResults.
+   * @return Google_Service_Plus_PeopleFeed
+   */
+  public function listPeople($userId, $collection, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'collection' => $collection);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Plus_PeopleFeed");
+  }
+
+  /**
+   * List all of the people in the specified collection for a particular activity.
+   * (people.listByActivity)
+   *
+   * @param string $activityId The ID of the activity to get the list of people
+   * for.
+   * @param string $collection The collection of people to list.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large result sets. To get the next page of results, set this
+   * parameter to the value of "nextPageToken" from the previous response.
+   * @opt_param string maxResults The maximum number of people to include in the
+   * response, which is used for paging. For any response, the actual number
+   * returned might be less than the specified maxResults.
+   * @return Google_Service_Plus_PeopleFeed
+   */
+  public function listByActivity($activityId, $collection, $optParams = array())
+  {
+    $params = array('activityId' => $activityId, 'collection' => $collection);
+    $params = array_merge($params, $optParams);
+    return $this->call('listByActivity', array($params), "Google_Service_Plus_PeopleFeed");
+  }
+
+  /**
+   * Search all public profiles. (people.search)
+   *
+   * @param string $query Specify a query string for full text search of public
+   * text in all profiles.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large result sets. To get the next page of results, set this
+   * parameter to the value of "nextPageToken" from the previous response. This
+   * token can be of any length.
+   * @opt_param string maxResults The maximum number of people to include in the
+   * response, which is used for paging. For any response, the actual number
+   * returned might be less than the specified maxResults.
+   * @opt_param string language Specify the preferred language to search with. See
+   * search language codes for available values.
+   * @return Google_Service_Plus_PeopleFeed
+   */
+  public function search($query, $optParams = array())
+  {
+    $params = array('query' => $query);
+    $params = array_merge($params, $optParams);
+    return $this->call('search', array($params), "Google_Service_Plus_PeopleFeed");
+  }
+}
+
+
+
+
+class Google_Service_Plus_Acl extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  protected $itemsType = 'Google_Service_Plus_PlusAclentryResource';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Plus_Activity extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accessType = 'Google_Service_Plus_Acl';
+  protected $accessDataType = '';
+  protected $actorType = 'Google_Service_Plus_ActivityActor';
+  protected $actorDataType = '';
+  public $address;
+  public $annotation;
+  public $crosspostSource;
+  public $etag;
+  public $geocode;
+  public $id;
+  public $kind;
+  protected $locationType = 'Google_Service_Plus_Place';
+  protected $locationDataType = '';
+  protected $objectType = 'Google_Service_Plus_ActivityObject';
+  protected $objectDataType = '';
+  public $placeId;
+  public $placeName;
+  protected $providerType = 'Google_Service_Plus_ActivityProvider';
+  protected $providerDataType = '';
+  public $published;
+  public $radius;
+  public $title;
+  public $updated;
+  public $url;
+  public $verb;
+
+
+  public function setAccess(Google_Service_Plus_Acl $access)
+  {
+    $this->access = $access;
+  }
+  public function getAccess()
+  {
+    return $this->access;
+  }
+  public function setActor(Google_Service_Plus_ActivityActor $actor)
+  {
+    $this->actor = $actor;
+  }
+  public function getActor()
+  {
+    return $this->actor;
+  }
+  public function setAddress($address)
+  {
+    $this->address = $address;
+  }
+  public function getAddress()
+  {
+    return $this->address;
+  }
+  public function setAnnotation($annotation)
+  {
+    $this->annotation = $annotation;
+  }
+  public function getAnnotation()
+  {
+    return $this->annotation;
+  }
+  public function setCrosspostSource($crosspostSource)
+  {
+    $this->crosspostSource = $crosspostSource;
+  }
+  public function getCrosspostSource()
+  {
+    return $this->crosspostSource;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setGeocode($geocode)
+  {
+    $this->geocode = $geocode;
+  }
+  public function getGeocode()
+  {
+    return $this->geocode;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocation(Google_Service_Plus_Place $location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setObject(Google_Service_Plus_ActivityObject $object)
+  {
+    $this->object = $object;
+  }
+  public function getObject()
+  {
+    return $this->object;
+  }
+  public function setPlaceId($placeId)
+  {
+    $this->placeId = $placeId;
+  }
+  public function getPlaceId()
+  {
+    return $this->placeId;
+  }
+  public function setPlaceName($placeName)
+  {
+    $this->placeName = $placeName;
+  }
+  public function getPlaceName()
+  {
+    return $this->placeName;
+  }
+  public function setProvider(Google_Service_Plus_ActivityProvider $provider)
+  {
+    $this->provider = $provider;
+  }
+  public function getProvider()
+  {
+    return $this->provider;
+  }
+  public function setPublished($published)
+  {
+    $this->published = $published;
+  }
+  public function getPublished()
+  {
+    return $this->published;
+  }
+  public function setRadius($radius)
+  {
+    $this->radius = $radius;
+  }
+  public function getRadius()
+  {
+    return $this->radius;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setVerb($verb)
+  {
+    $this->verb = $verb;
+  }
+  public function getVerb()
+  {
+    return $this->verb;
+  }
+}
+
+class Google_Service_Plus_ActivityActor extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $clientSpecificActorInfoType = 'Google_Service_Plus_ActivityActorClientSpecificActorInfo';
+  protected $clientSpecificActorInfoDataType = '';
+  public $displayName;
+  public $id;
+  protected $imageType = 'Google_Service_Plus_ActivityActorImage';
+  protected $imageDataType = '';
+  protected $nameType = 'Google_Service_Plus_ActivityActorName';
+  protected $nameDataType = '';
+  public $url;
+  protected $verificationType = 'Google_Service_Plus_ActivityActorVerification';
+  protected $verificationDataType = '';
+
+
+  public function setClientSpecificActorInfo(Google_Service_Plus_ActivityActorClientSpecificActorInfo $clientSpecificActorInfo)
+  {
+    $this->clientSpecificActorInfo = $clientSpecificActorInfo;
+  }
+  public function getClientSpecificActorInfo()
+  {
+    return $this->clientSpecificActorInfo;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImage(Google_Service_Plus_ActivityActorImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setName(Google_Service_Plus_ActivityActorName $name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setVerification(Google_Service_Plus_ActivityActorVerification $verification)
+  {
+    $this->verification = $verification;
+  }
+  public function getVerification()
+  {
+    return $this->verification;
+  }
+}
+
+class Google_Service_Plus_ActivityActorClientSpecificActorInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $youtubeActorInfoType = 'Google_Service_Plus_ActivityActorClientSpecificActorInfoYoutubeActorInfo';
+  protected $youtubeActorInfoDataType = '';
+
+
+  public function setYoutubeActorInfo(Google_Service_Plus_ActivityActorClientSpecificActorInfoYoutubeActorInfo $youtubeActorInfo)
+  {
+    $this->youtubeActorInfo = $youtubeActorInfo;
+  }
+  public function getYoutubeActorInfo()
+  {
+    return $this->youtubeActorInfo;
+  }
+}
+
+class Google_Service_Plus_ActivityActorClientSpecificActorInfoYoutubeActorInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $channelId;
+
+
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+}
+
+class Google_Service_Plus_ActivityActorImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $url;
+
+
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Plus_ActivityActorName extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $familyName;
+  public $givenName;
+
+
+  public function setFamilyName($familyName)
+  {
+    $this->familyName = $familyName;
+  }
+  public function getFamilyName()
+  {
+    return $this->familyName;
+  }
+  public function setGivenName($givenName)
+  {
+    $this->givenName = $givenName;
+  }
+  public function getGivenName()
+  {
+    return $this->givenName;
+  }
+}
+
+class Google_Service_Plus_ActivityActorVerification extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $adHocVerified;
+
+
+  public function setAdHocVerified($adHocVerified)
+  {
+    $this->adHocVerified = $adHocVerified;
+  }
+  public function getAdHocVerified()
+  {
+    return $this->adHocVerified;
+  }
+}
+
+class Google_Service_Plus_ActivityFeed extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $id;
+  protected $itemsType = 'Google_Service_Plus_Activity';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextLink;
+  public $nextPageToken;
+  public $selfLink;
+  public $title;
+  public $updated;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+}
+
+class Google_Service_Plus_ActivityObject extends Google_Collection
+{
+  protected $collection_key = 'attachments';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $actorType = 'Google_Service_Plus_ActivityObjectActor';
+  protected $actorDataType = '';
+  protected $attachmentsType = 'Google_Service_Plus_ActivityObjectAttachments';
+  protected $attachmentsDataType = 'array';
+  public $content;
+  public $id;
+  public $objectType;
+  public $originalContent;
+  protected $plusonersType = 'Google_Service_Plus_ActivityObjectPlusoners';
+  protected $plusonersDataType = '';
+  protected $repliesType = 'Google_Service_Plus_ActivityObjectReplies';
+  protected $repliesDataType = '';
+  protected $resharersType = 'Google_Service_Plus_ActivityObjectResharers';
+  protected $resharersDataType = '';
+  public $url;
+
+
+  public function setActor(Google_Service_Plus_ActivityObjectActor $actor)
+  {
+    $this->actor = $actor;
+  }
+  public function getActor()
+  {
+    return $this->actor;
+  }
+  public function setAttachments($attachments)
+  {
+    $this->attachments = $attachments;
+  }
+  public function getAttachments()
+  {
+    return $this->attachments;
+  }
+  public function setContent($content)
+  {
+    $this->content = $content;
+  }
+  public function getContent()
+  {
+    return $this->content;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setObjectType($objectType)
+  {
+    $this->objectType = $objectType;
+  }
+  public function getObjectType()
+  {
+    return $this->objectType;
+  }
+  public function setOriginalContent($originalContent)
+  {
+    $this->originalContent = $originalContent;
+  }
+  public function getOriginalContent()
+  {
+    return $this->originalContent;
+  }
+  public function setPlusoners(Google_Service_Plus_ActivityObjectPlusoners $plusoners)
+  {
+    $this->plusoners = $plusoners;
+  }
+  public function getPlusoners()
+  {
+    return $this->plusoners;
+  }
+  public function setReplies(Google_Service_Plus_ActivityObjectReplies $replies)
+  {
+    $this->replies = $replies;
+  }
+  public function getReplies()
+  {
+    return $this->replies;
+  }
+  public function setResharers(Google_Service_Plus_ActivityObjectResharers $resharers)
+  {
+    $this->resharers = $resharers;
+  }
+  public function getResharers()
+  {
+    return $this->resharers;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Plus_ActivityObjectActor extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $clientSpecificActorInfoType = 'Google_Service_Plus_ActivityObjectActorClientSpecificActorInfo';
+  protected $clientSpecificActorInfoDataType = '';
+  public $displayName;
+  public $id;
+  protected $imageType = 'Google_Service_Plus_ActivityObjectActorImage';
+  protected $imageDataType = '';
+  public $url;
+  protected $verificationType = 'Google_Service_Plus_ActivityObjectActorVerification';
+  protected $verificationDataType = '';
+
+
+  public function setClientSpecificActorInfo(Google_Service_Plus_ActivityObjectActorClientSpecificActorInfo $clientSpecificActorInfo)
+  {
+    $this->clientSpecificActorInfo = $clientSpecificActorInfo;
+  }
+  public function getClientSpecificActorInfo()
+  {
+    return $this->clientSpecificActorInfo;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImage(Google_Service_Plus_ActivityObjectActorImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setVerification(Google_Service_Plus_ActivityObjectActorVerification $verification)
+  {
+    $this->verification = $verification;
+  }
+  public function getVerification()
+  {
+    return $this->verification;
+  }
+}
+
+class Google_Service_Plus_ActivityObjectActorClientSpecificActorInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $youtubeActorInfoType = 'Google_Service_Plus_ActivityObjectActorClientSpecificActorInfoYoutubeActorInfo';
+  protected $youtubeActorInfoDataType = '';
+
+
+  public function setYoutubeActorInfo(Google_Service_Plus_ActivityObjectActorClientSpecificActorInfoYoutubeActorInfo $youtubeActorInfo)
+  {
+    $this->youtubeActorInfo = $youtubeActorInfo;
+  }
+  public function getYoutubeActorInfo()
+  {
+    return $this->youtubeActorInfo;
+  }
+}
+
+class Google_Service_Plus_ActivityObjectActorClientSpecificActorInfoYoutubeActorInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $channelId;
+
+
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+}
+
+class Google_Service_Plus_ActivityObjectActorImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $url;
+
+
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Plus_ActivityObjectActorVerification extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $adHocVerified;
+
+
+  public function setAdHocVerified($adHocVerified)
+  {
+    $this->adHocVerified = $adHocVerified;
+  }
+  public function getAdHocVerified()
+  {
+    return $this->adHocVerified;
+  }
+}
+
+class Google_Service_Plus_ActivityObjectAttachments extends Google_Collection
+{
+  protected $collection_key = 'thumbnails';
+  protected $internal_gapi_mappings = array(
+  );
+  public $content;
+  public $displayName;
+  protected $embedType = 'Google_Service_Plus_ActivityObjectAttachmentsEmbed';
+  protected $embedDataType = '';
+  protected $fullImageType = 'Google_Service_Plus_ActivityObjectAttachmentsFullImage';
+  protected $fullImageDataType = '';
+  public $id;
+  protected $imageType = 'Google_Service_Plus_ActivityObjectAttachmentsImage';
+  protected $imageDataType = '';
+  public $objectType;
+  protected $thumbnailsType = 'Google_Service_Plus_ActivityObjectAttachmentsThumbnails';
+  protected $thumbnailsDataType = 'array';
+  public $url;
+
+
+  public function setContent($content)
+  {
+    $this->content = $content;
+  }
+  public function getContent()
+  {
+    return $this->content;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setEmbed(Google_Service_Plus_ActivityObjectAttachmentsEmbed $embed)
+  {
+    $this->embed = $embed;
+  }
+  public function getEmbed()
+  {
+    return $this->embed;
+  }
+  public function setFullImage(Google_Service_Plus_ActivityObjectAttachmentsFullImage $fullImage)
+  {
+    $this->fullImage = $fullImage;
+  }
+  public function getFullImage()
+  {
+    return $this->fullImage;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImage(Google_Service_Plus_ActivityObjectAttachmentsImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setObjectType($objectType)
+  {
+    $this->objectType = $objectType;
+  }
+  public function getObjectType()
+  {
+    return $this->objectType;
+  }
+  public function setThumbnails($thumbnails)
+  {
+    $this->thumbnails = $thumbnails;
+  }
+  public function getThumbnails()
+  {
+    return $this->thumbnails;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Plus_ActivityObjectAttachmentsEmbed extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $type;
+  public $url;
+
+
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Plus_ActivityObjectAttachmentsFullImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $type;
+  public $url;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_Plus_ActivityObjectAttachmentsImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $type;
+  public $url;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_Plus_ActivityObjectAttachmentsThumbnails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  protected $imageType = 'Google_Service_Plus_ActivityObjectAttachmentsThumbnailsImage';
+  protected $imageDataType = '';
+  public $url;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setImage(Google_Service_Plus_ActivityObjectAttachmentsThumbnailsImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Plus_ActivityObjectAttachmentsThumbnailsImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $type;
+  public $url;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_Plus_ActivityObjectPlusoners extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $selfLink;
+  public $totalItems;
+
+
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_Plus_ActivityObjectReplies extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $selfLink;
+  public $totalItems;
+
+
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_Plus_ActivityObjectResharers extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $selfLink;
+  public $totalItems;
+
+
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_Plus_ActivityProvider extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $title;
+
+
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_Plus_Comment extends Google_Collection
+{
+  protected $collection_key = 'inReplyTo';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $actorType = 'Google_Service_Plus_CommentActor';
+  protected $actorDataType = '';
+  public $etag;
+  public $id;
+  protected $inReplyToType = 'Google_Service_Plus_CommentInReplyTo';
+  protected $inReplyToDataType = 'array';
+  public $kind;
+  protected $objectType = 'Google_Service_Plus_CommentObject';
+  protected $objectDataType = '';
+  protected $plusonersType = 'Google_Service_Plus_CommentPlusoners';
+  protected $plusonersDataType = '';
+  public $published;
+  public $selfLink;
+  public $updated;
+  public $verb;
+
+
+  public function setActor(Google_Service_Plus_CommentActor $actor)
+  {
+    $this->actor = $actor;
+  }
+  public function getActor()
+  {
+    return $this->actor;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInReplyTo($inReplyTo)
+  {
+    $this->inReplyTo = $inReplyTo;
+  }
+  public function getInReplyTo()
+  {
+    return $this->inReplyTo;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setObject(Google_Service_Plus_CommentObject $object)
+  {
+    $this->object = $object;
+  }
+  public function getObject()
+  {
+    return $this->object;
+  }
+  public function setPlusoners(Google_Service_Plus_CommentPlusoners $plusoners)
+  {
+    $this->plusoners = $plusoners;
+  }
+  public function getPlusoners()
+  {
+    return $this->plusoners;
+  }
+  public function setPublished($published)
+  {
+    $this->published = $published;
+  }
+  public function getPublished()
+  {
+    return $this->published;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setVerb($verb)
+  {
+    $this->verb = $verb;
+  }
+  public function getVerb()
+  {
+    return $this->verb;
+  }
+}
+
+class Google_Service_Plus_CommentActor extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $clientSpecificActorInfoType = 'Google_Service_Plus_CommentActorClientSpecificActorInfo';
+  protected $clientSpecificActorInfoDataType = '';
+  public $displayName;
+  public $id;
+  protected $imageType = 'Google_Service_Plus_CommentActorImage';
+  protected $imageDataType = '';
+  public $url;
+  protected $verificationType = 'Google_Service_Plus_CommentActorVerification';
+  protected $verificationDataType = '';
+
+
+  public function setClientSpecificActorInfo(Google_Service_Plus_CommentActorClientSpecificActorInfo $clientSpecificActorInfo)
+  {
+    $this->clientSpecificActorInfo = $clientSpecificActorInfo;
+  }
+  public function getClientSpecificActorInfo()
+  {
+    return $this->clientSpecificActorInfo;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImage(Google_Service_Plus_CommentActorImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setVerification(Google_Service_Plus_CommentActorVerification $verification)
+  {
+    $this->verification = $verification;
+  }
+  public function getVerification()
+  {
+    return $this->verification;
+  }
+}
+
+class Google_Service_Plus_CommentActorClientSpecificActorInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $youtubeActorInfoType = 'Google_Service_Plus_CommentActorClientSpecificActorInfoYoutubeActorInfo';
+  protected $youtubeActorInfoDataType = '';
+
+
+  public function setYoutubeActorInfo(Google_Service_Plus_CommentActorClientSpecificActorInfoYoutubeActorInfo $youtubeActorInfo)
+  {
+    $this->youtubeActorInfo = $youtubeActorInfo;
+  }
+  public function getYoutubeActorInfo()
+  {
+    return $this->youtubeActorInfo;
+  }
+}
+
+class Google_Service_Plus_CommentActorClientSpecificActorInfoYoutubeActorInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $channelId;
+
+
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+}
+
+class Google_Service_Plus_CommentActorImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $url;
+
+
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Plus_CommentActorVerification extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $adHocVerified;
+
+
+  public function setAdHocVerified($adHocVerified)
+  {
+    $this->adHocVerified = $adHocVerified;
+  }
+  public function getAdHocVerified()
+  {
+    return $this->adHocVerified;
+  }
+}
+
+class Google_Service_Plus_CommentFeed extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $id;
+  protected $itemsType = 'Google_Service_Plus_Comment';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextLink;
+  public $nextPageToken;
+  public $title;
+  public $updated;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+}
+
+class Google_Service_Plus_CommentInReplyTo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $url;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Plus_CommentObject extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $content;
+  public $objectType;
+  public $originalContent;
+
+
+  public function setContent($content)
+  {
+    $this->content = $content;
+  }
+  public function getContent()
+  {
+    return $this->content;
+  }
+  public function setObjectType($objectType)
+  {
+    $this->objectType = $objectType;
+  }
+  public function getObjectType()
+  {
+    return $this->objectType;
+  }
+  public function setOriginalContent($originalContent)
+  {
+    $this->originalContent = $originalContent;
+  }
+  public function getOriginalContent()
+  {
+    return $this->originalContent;
+  }
+}
+
+class Google_Service_Plus_CommentPlusoners extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $totalItems;
+
+
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_Plus_ItemScope extends Google_Collection
+{
+  protected $collection_key = 'performers';
+  protected $internal_gapi_mappings = array(
+        "associatedMedia" => "associated_media",
+  );
+  protected $aboutType = 'Google_Service_Plus_ItemScope';
+  protected $aboutDataType = '';
+  public $additionalName;
+  protected $addressType = 'Google_Service_Plus_ItemScope';
+  protected $addressDataType = '';
+  public $addressCountry;
+  public $addressLocality;
+  public $addressRegion;
+  protected $associatedMediaType = 'Google_Service_Plus_ItemScope';
+  protected $associatedMediaDataType = 'array';
+  public $attendeeCount;
+  protected $attendeesType = 'Google_Service_Plus_ItemScope';
+  protected $attendeesDataType = 'array';
+  protected $audioType = 'Google_Service_Plus_ItemScope';
+  protected $audioDataType = '';
+  protected $authorType = 'Google_Service_Plus_ItemScope';
+  protected $authorDataType = 'array';
+  public $bestRating;
+  public $birthDate;
+  protected $byArtistType = 'Google_Service_Plus_ItemScope';
+  protected $byArtistDataType = '';
+  public $caption;
+  public $contentSize;
+  public $contentUrl;
+  protected $contributorType = 'Google_Service_Plus_ItemScope';
+  protected $contributorDataType = 'array';
+  public $dateCreated;
+  public $dateModified;
+  public $datePublished;
+  public $description;
+  public $duration;
+  public $embedUrl;
+  public $endDate;
+  public $familyName;
+  public $gender;
+  protected $geoType = 'Google_Service_Plus_ItemScope';
+  protected $geoDataType = '';
+  public $givenName;
+  public $height;
+  public $id;
+  public $image;
+  protected $inAlbumType = 'Google_Service_Plus_ItemScope';
+  protected $inAlbumDataType = '';
+  public $kind;
+  public $latitude;
+  protected $locationType = 'Google_Service_Plus_ItemScope';
+  protected $locationDataType = '';
+  public $longitude;
+  public $name;
+  protected $partOfTVSeriesType = 'Google_Service_Plus_ItemScope';
+  protected $partOfTVSeriesDataType = '';
+  protected $performersType = 'Google_Service_Plus_ItemScope';
+  protected $performersDataType = 'array';
+  public $playerType;
+  public $postOfficeBoxNumber;
+  public $postalCode;
+  public $ratingValue;
+  protected $reviewRatingType = 'Google_Service_Plus_ItemScope';
+  protected $reviewRatingDataType = '';
+  public $startDate;
+  public $streetAddress;
+  public $text;
+  protected $thumbnailType = 'Google_Service_Plus_ItemScope';
+  protected $thumbnailDataType = '';
+  public $thumbnailUrl;
+  public $tickerSymbol;
+  public $type;
+  public $url;
+  public $width;
+  public $worstRating;
+
+
+  public function setAbout(Google_Service_Plus_ItemScope $about)
+  {
+    $this->about = $about;
+  }
+  public function getAbout()
+  {
+    return $this->about;
+  }
+  public function setAdditionalName($additionalName)
+  {
+    $this->additionalName = $additionalName;
+  }
+  public function getAdditionalName()
+  {
+    return $this->additionalName;
+  }
+  public function setAddress(Google_Service_Plus_ItemScope $address)
+  {
+    $this->address = $address;
+  }
+  public function getAddress()
+  {
+    return $this->address;
+  }
+  public function setAddressCountry($addressCountry)
+  {
+    $this->addressCountry = $addressCountry;
+  }
+  public function getAddressCountry()
+  {
+    return $this->addressCountry;
+  }
+  public function setAddressLocality($addressLocality)
+  {
+    $this->addressLocality = $addressLocality;
+  }
+  public function getAddressLocality()
+  {
+    return $this->addressLocality;
+  }
+  public function setAddressRegion($addressRegion)
+  {
+    $this->addressRegion = $addressRegion;
+  }
+  public function getAddressRegion()
+  {
+    return $this->addressRegion;
+  }
+  public function setAssociatedMedia($associatedMedia)
+  {
+    $this->associatedMedia = $associatedMedia;
+  }
+  public function getAssociatedMedia()
+  {
+    return $this->associatedMedia;
+  }
+  public function setAttendeeCount($attendeeCount)
+  {
+    $this->attendeeCount = $attendeeCount;
+  }
+  public function getAttendeeCount()
+  {
+    return $this->attendeeCount;
+  }
+  public function setAttendees($attendees)
+  {
+    $this->attendees = $attendees;
+  }
+  public function getAttendees()
+  {
+    return $this->attendees;
+  }
+  public function setAudio(Google_Service_Plus_ItemScope $audio)
+  {
+    $this->audio = $audio;
+  }
+  public function getAudio()
+  {
+    return $this->audio;
+  }
+  public function setAuthor($author)
+  {
+    $this->author = $author;
+  }
+  public function getAuthor()
+  {
+    return $this->author;
+  }
+  public function setBestRating($bestRating)
+  {
+    $this->bestRating = $bestRating;
+  }
+  public function getBestRating()
+  {
+    return $this->bestRating;
+  }
+  public function setBirthDate($birthDate)
+  {
+    $this->birthDate = $birthDate;
+  }
+  public function getBirthDate()
+  {
+    return $this->birthDate;
+  }
+  public function setByArtist(Google_Service_Plus_ItemScope $byArtist)
+  {
+    $this->byArtist = $byArtist;
+  }
+  public function getByArtist()
+  {
+    return $this->byArtist;
+  }
+  public function setCaption($caption)
+  {
+    $this->caption = $caption;
+  }
+  public function getCaption()
+  {
+    return $this->caption;
+  }
+  public function setContentSize($contentSize)
+  {
+    $this->contentSize = $contentSize;
+  }
+  public function getContentSize()
+  {
+    return $this->contentSize;
+  }
+  public function setContentUrl($contentUrl)
+  {
+    $this->contentUrl = $contentUrl;
+  }
+  public function getContentUrl()
+  {
+    return $this->contentUrl;
+  }
+  public function setContributor($contributor)
+  {
+    $this->contributor = $contributor;
+  }
+  public function getContributor()
+  {
+    return $this->contributor;
+  }
+  public function setDateCreated($dateCreated)
+  {
+    $this->dateCreated = $dateCreated;
+  }
+  public function getDateCreated()
+  {
+    return $this->dateCreated;
+  }
+  public function setDateModified($dateModified)
+  {
+    $this->dateModified = $dateModified;
+  }
+  public function getDateModified()
+  {
+    return $this->dateModified;
+  }
+  public function setDatePublished($datePublished)
+  {
+    $this->datePublished = $datePublished;
+  }
+  public function getDatePublished()
+  {
+    return $this->datePublished;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDuration($duration)
+  {
+    $this->duration = $duration;
+  }
+  public function getDuration()
+  {
+    return $this->duration;
+  }
+  public function setEmbedUrl($embedUrl)
+  {
+    $this->embedUrl = $embedUrl;
+  }
+  public function getEmbedUrl()
+  {
+    return $this->embedUrl;
+  }
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setFamilyName($familyName)
+  {
+    $this->familyName = $familyName;
+  }
+  public function getFamilyName()
+  {
+    return $this->familyName;
+  }
+  public function setGender($gender)
+  {
+    $this->gender = $gender;
+  }
+  public function getGender()
+  {
+    return $this->gender;
+  }
+  public function setGeo(Google_Service_Plus_ItemScope $geo)
+  {
+    $this->geo = $geo;
+  }
+  public function getGeo()
+  {
+    return $this->geo;
+  }
+  public function setGivenName($givenName)
+  {
+    $this->givenName = $givenName;
+  }
+  public function getGivenName()
+  {
+    return $this->givenName;
+  }
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImage($image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setInAlbum(Google_Service_Plus_ItemScope $inAlbum)
+  {
+    $this->inAlbum = $inAlbum;
+  }
+  public function getInAlbum()
+  {
+    return $this->inAlbum;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLatitude($latitude)
+  {
+    $this->latitude = $latitude;
+  }
+  public function getLatitude()
+  {
+    return $this->latitude;
+  }
+  public function setLocation(Google_Service_Plus_ItemScope $location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setLongitude($longitude)
+  {
+    $this->longitude = $longitude;
+  }
+  public function getLongitude()
+  {
+    return $this->longitude;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPartOfTVSeries(Google_Service_Plus_ItemScope $partOfTVSeries)
+  {
+    $this->partOfTVSeries = $partOfTVSeries;
+  }
+  public function getPartOfTVSeries()
+  {
+    return $this->partOfTVSeries;
+  }
+  public function setPerformers($performers)
+  {
+    $this->performers = $performers;
+  }
+  public function getPerformers()
+  {
+    return $this->performers;
+  }
+  public function setPlayerType($playerType)
+  {
+    $this->playerType = $playerType;
+  }
+  public function getPlayerType()
+  {
+    return $this->playerType;
+  }
+  public function setPostOfficeBoxNumber($postOfficeBoxNumber)
+  {
+    $this->postOfficeBoxNumber = $postOfficeBoxNumber;
+  }
+  public function getPostOfficeBoxNumber()
+  {
+    return $this->postOfficeBoxNumber;
+  }
+  public function setPostalCode($postalCode)
+  {
+    $this->postalCode = $postalCode;
+  }
+  public function getPostalCode()
+  {
+    return $this->postalCode;
+  }
+  public function setRatingValue($ratingValue)
+  {
+    $this->ratingValue = $ratingValue;
+  }
+  public function getRatingValue()
+  {
+    return $this->ratingValue;
+  }
+  public function setReviewRating(Google_Service_Plus_ItemScope $reviewRating)
+  {
+    $this->reviewRating = $reviewRating;
+  }
+  public function getReviewRating()
+  {
+    return $this->reviewRating;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+  public function setStreetAddress($streetAddress)
+  {
+    $this->streetAddress = $streetAddress;
+  }
+  public function getStreetAddress()
+  {
+    return $this->streetAddress;
+  }
+  public function setText($text)
+  {
+    $this->text = $text;
+  }
+  public function getText()
+  {
+    return $this->text;
+  }
+  public function setThumbnail(Google_Service_Plus_ItemScope $thumbnail)
+  {
+    $this->thumbnail = $thumbnail;
+  }
+  public function getThumbnail()
+  {
+    return $this->thumbnail;
+  }
+  public function setThumbnailUrl($thumbnailUrl)
+  {
+    $this->thumbnailUrl = $thumbnailUrl;
+  }
+  public function getThumbnailUrl()
+  {
+    return $this->thumbnailUrl;
+  }
+  public function setTickerSymbol($tickerSymbol)
+  {
+    $this->tickerSymbol = $tickerSymbol;
+  }
+  public function getTickerSymbol()
+  {
+    return $this->tickerSymbol;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+  public function setWorstRating($worstRating)
+  {
+    $this->worstRating = $worstRating;
+  }
+  public function getWorstRating()
+  {
+    return $this->worstRating;
+  }
+}
+
+class Google_Service_Plus_Moment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  protected $objectType = 'Google_Service_Plus_ItemScope';
+  protected $objectDataType = '';
+  protected $resultType = 'Google_Service_Plus_ItemScope';
+  protected $resultDataType = '';
+  public $startDate;
+  protected $targetType = 'Google_Service_Plus_ItemScope';
+  protected $targetDataType = '';
+  public $type;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setObject(Google_Service_Plus_ItemScope $object)
+  {
+    $this->object = $object;
+  }
+  public function getObject()
+  {
+    return $this->object;
+  }
+  public function setResult(Google_Service_Plus_ItemScope $result)
+  {
+    $this->result = $result;
+  }
+  public function getResult()
+  {
+    return $this->result;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+  public function setTarget(Google_Service_Plus_ItemScope $target)
+  {
+    $this->target = $target;
+  }
+  public function getTarget()
+  {
+    return $this->target;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Plus_MomentsFeed extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Plus_Moment';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextLink;
+  public $nextPageToken;
+  public $selfLink;
+  public $title;
+  public $updated;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+}
+
+class Google_Service_Plus_PeopleFeed extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Plus_Person';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+  public $title;
+  public $totalItems;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_Plus_Person extends Google_Collection
+{
+  protected $collection_key = 'urls';
+  protected $internal_gapi_mappings = array(
+  );
+  public $aboutMe;
+  protected $ageRangeType = 'Google_Service_Plus_PersonAgeRange';
+  protected $ageRangeDataType = '';
+  public $birthday;
+  public $braggingRights;
+  public $circledByCount;
+  protected $coverType = 'Google_Service_Plus_PersonCover';
+  protected $coverDataType = '';
+  public $currentLocation;
+  public $displayName;
+  public $domain;
+  protected $emailsType = 'Google_Service_Plus_PersonEmails';
+  protected $emailsDataType = 'array';
+  public $etag;
+  public $gender;
+  public $id;
+  protected $imageType = 'Google_Service_Plus_PersonImage';
+  protected $imageDataType = '';
+  public $isPlusUser;
+  public $kind;
+  public $language;
+  protected $nameType = 'Google_Service_Plus_PersonName';
+  protected $nameDataType = '';
+  public $nickname;
+  public $objectType;
+  public $occupation;
+  protected $organizationsType = 'Google_Service_Plus_PersonOrganizations';
+  protected $organizationsDataType = 'array';
+  protected $placesLivedType = 'Google_Service_Plus_PersonPlacesLived';
+  protected $placesLivedDataType = 'array';
+  public $plusOneCount;
+  public $relationshipStatus;
+  public $skills;
+  public $tagline;
+  public $url;
+  protected $urlsType = 'Google_Service_Plus_PersonUrls';
+  protected $urlsDataType = 'array';
+  public $verified;
+
+
+  public function setAboutMe($aboutMe)
+  {
+    $this->aboutMe = $aboutMe;
+  }
+  public function getAboutMe()
+  {
+    return $this->aboutMe;
+  }
+  public function setAgeRange(Google_Service_Plus_PersonAgeRange $ageRange)
+  {
+    $this->ageRange = $ageRange;
+  }
+  public function getAgeRange()
+  {
+    return $this->ageRange;
+  }
+  public function setBirthday($birthday)
+  {
+    $this->birthday = $birthday;
+  }
+  public function getBirthday()
+  {
+    return $this->birthday;
+  }
+  public function setBraggingRights($braggingRights)
+  {
+    $this->braggingRights = $braggingRights;
+  }
+  public function getBraggingRights()
+  {
+    return $this->braggingRights;
+  }
+  public function setCircledByCount($circledByCount)
+  {
+    $this->circledByCount = $circledByCount;
+  }
+  public function getCircledByCount()
+  {
+    return $this->circledByCount;
+  }
+  public function setCover(Google_Service_Plus_PersonCover $cover)
+  {
+    $this->cover = $cover;
+  }
+  public function getCover()
+  {
+    return $this->cover;
+  }
+  public function setCurrentLocation($currentLocation)
+  {
+    $this->currentLocation = $currentLocation;
+  }
+  public function getCurrentLocation()
+  {
+    return $this->currentLocation;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setDomain($domain)
+  {
+    $this->domain = $domain;
+  }
+  public function getDomain()
+  {
+    return $this->domain;
+  }
+  public function setEmails($emails)
+  {
+    $this->emails = $emails;
+  }
+  public function getEmails()
+  {
+    return $this->emails;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setGender($gender)
+  {
+    $this->gender = $gender;
+  }
+  public function getGender()
+  {
+    return $this->gender;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImage(Google_Service_Plus_PersonImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setIsPlusUser($isPlusUser)
+  {
+    $this->isPlusUser = $isPlusUser;
+  }
+  public function getIsPlusUser()
+  {
+    return $this->isPlusUser;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLanguage($language)
+  {
+    $this->language = $language;
+  }
+  public function getLanguage()
+  {
+    return $this->language;
+  }
+  public function setName(Google_Service_Plus_PersonName $name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNickname($nickname)
+  {
+    $this->nickname = $nickname;
+  }
+  public function getNickname()
+  {
+    return $this->nickname;
+  }
+  public function setObjectType($objectType)
+  {
+    $this->objectType = $objectType;
+  }
+  public function getObjectType()
+  {
+    return $this->objectType;
+  }
+  public function setOccupation($occupation)
+  {
+    $this->occupation = $occupation;
+  }
+  public function getOccupation()
+  {
+    return $this->occupation;
+  }
+  public function setOrganizations($organizations)
+  {
+    $this->organizations = $organizations;
+  }
+  public function getOrganizations()
+  {
+    return $this->organizations;
+  }
+  public function setPlacesLived($placesLived)
+  {
+    $this->placesLived = $placesLived;
+  }
+  public function getPlacesLived()
+  {
+    return $this->placesLived;
+  }
+  public function setPlusOneCount($plusOneCount)
+  {
+    $this->plusOneCount = $plusOneCount;
+  }
+  public function getPlusOneCount()
+  {
+    return $this->plusOneCount;
+  }
+  public function setRelationshipStatus($relationshipStatus)
+  {
+    $this->relationshipStatus = $relationshipStatus;
+  }
+  public function getRelationshipStatus()
+  {
+    return $this->relationshipStatus;
+  }
+  public function setSkills($skills)
+  {
+    $this->skills = $skills;
+  }
+  public function getSkills()
+  {
+    return $this->skills;
+  }
+  public function setTagline($tagline)
+  {
+    $this->tagline = $tagline;
+  }
+  public function getTagline()
+  {
+    return $this->tagline;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setUrls($urls)
+  {
+    $this->urls = $urls;
+  }
+  public function getUrls()
+  {
+    return $this->urls;
+  }
+  public function setVerified($verified)
+  {
+    $this->verified = $verified;
+  }
+  public function getVerified()
+  {
+    return $this->verified;
+  }
+}
+
+class Google_Service_Plus_PersonAgeRange extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $max;
+  public $min;
+
+
+  public function setMax($max)
+  {
+    $this->max = $max;
+  }
+  public function getMax()
+  {
+    return $this->max;
+  }
+  public function setMin($min)
+  {
+    $this->min = $min;
+  }
+  public function getMin()
+  {
+    return $this->min;
+  }
+}
+
+class Google_Service_Plus_PersonCover extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $coverInfoType = 'Google_Service_Plus_PersonCoverCoverInfo';
+  protected $coverInfoDataType = '';
+  protected $coverPhotoType = 'Google_Service_Plus_PersonCoverCoverPhoto';
+  protected $coverPhotoDataType = '';
+  public $layout;
+
+
+  public function setCoverInfo(Google_Service_Plus_PersonCoverCoverInfo $coverInfo)
+  {
+    $this->coverInfo = $coverInfo;
+  }
+  public function getCoverInfo()
+  {
+    return $this->coverInfo;
+  }
+  public function setCoverPhoto(Google_Service_Plus_PersonCoverCoverPhoto $coverPhoto)
+  {
+    $this->coverPhoto = $coverPhoto;
+  }
+  public function getCoverPhoto()
+  {
+    return $this->coverPhoto;
+  }
+  public function setLayout($layout)
+  {
+    $this->layout = $layout;
+  }
+  public function getLayout()
+  {
+    return $this->layout;
+  }
+}
+
+class Google_Service_Plus_PersonCoverCoverInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $leftImageOffset;
+  public $topImageOffset;
+
+
+  public function setLeftImageOffset($leftImageOffset)
+  {
+    $this->leftImageOffset = $leftImageOffset;
+  }
+  public function getLeftImageOffset()
+  {
+    return $this->leftImageOffset;
+  }
+  public function setTopImageOffset($topImageOffset)
+  {
+    $this->topImageOffset = $topImageOffset;
+  }
+  public function getTopImageOffset()
+  {
+    return $this->topImageOffset;
+  }
+}
+
+class Google_Service_Plus_PersonCoverCoverPhoto extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $url;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_Plus_PersonEmails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $type;
+  public $value;
+
+
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Plus_PersonImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $isDefault;
+  public $url;
+
+
+  public function setIsDefault($isDefault)
+  {
+    $this->isDefault = $isDefault;
+  }
+  public function getIsDefault()
+  {
+    return $this->isDefault;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Plus_PersonName extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $familyName;
+  public $formatted;
+  public $givenName;
+  public $honorificPrefix;
+  public $honorificSuffix;
+  public $middleName;
+
+
+  public function setFamilyName($familyName)
+  {
+    $this->familyName = $familyName;
+  }
+  public function getFamilyName()
+  {
+    return $this->familyName;
+  }
+  public function setFormatted($formatted)
+  {
+    $this->formatted = $formatted;
+  }
+  public function getFormatted()
+  {
+    return $this->formatted;
+  }
+  public function setGivenName($givenName)
+  {
+    $this->givenName = $givenName;
+  }
+  public function getGivenName()
+  {
+    return $this->givenName;
+  }
+  public function setHonorificPrefix($honorificPrefix)
+  {
+    $this->honorificPrefix = $honorificPrefix;
+  }
+  public function getHonorificPrefix()
+  {
+    return $this->honorificPrefix;
+  }
+  public function setHonorificSuffix($honorificSuffix)
+  {
+    $this->honorificSuffix = $honorificSuffix;
+  }
+  public function getHonorificSuffix()
+  {
+    return $this->honorificSuffix;
+  }
+  public function setMiddleName($middleName)
+  {
+    $this->middleName = $middleName;
+  }
+  public function getMiddleName()
+  {
+    return $this->middleName;
+  }
+}
+
+class Google_Service_Plus_PersonOrganizations extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $department;
+  public $description;
+  public $endDate;
+  public $location;
+  public $name;
+  public $primary;
+  public $startDate;
+  public $title;
+  public $type;
+
+
+  public function setDepartment($department)
+  {
+    $this->department = $department;
+  }
+  public function getDepartment()
+  {
+    return $this->department;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPrimary($primary)
+  {
+    $this->primary = $primary;
+  }
+  public function getPrimary()
+  {
+    return $this->primary;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Plus_PersonPlacesLived extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $primary;
+  public $value;
+
+
+  public function setPrimary($primary)
+  {
+    $this->primary = $primary;
+  }
+  public function getPrimary()
+  {
+    return $this->primary;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Plus_PersonUrls extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $label;
+  public $type;
+  public $value;
+
+
+  public function setLabel($label)
+  {
+    $this->label = $label;
+  }
+  public function getLabel()
+  {
+    return $this->label;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Plus_Place extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $addressType = 'Google_Service_Plus_PlaceAddress';
+  protected $addressDataType = '';
+  public $displayName;
+  public $id;
+  public $kind;
+  protected $positionType = 'Google_Service_Plus_PlacePosition';
+  protected $positionDataType = '';
+
+
+  public function setAddress(Google_Service_Plus_PlaceAddress $address)
+  {
+    $this->address = $address;
+  }
+  public function getAddress()
+  {
+    return $this->address;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPosition(Google_Service_Plus_PlacePosition $position)
+  {
+    $this->position = $position;
+  }
+  public function getPosition()
+  {
+    return $this->position;
+  }
+}
+
+class Google_Service_Plus_PlaceAddress extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $formatted;
+
+
+  public function setFormatted($formatted)
+  {
+    $this->formatted = $formatted;
+  }
+  public function getFormatted()
+  {
+    return $this->formatted;
+  }
+}
+
+class Google_Service_Plus_PlacePosition extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $latitude;
+  public $longitude;
+
+
+  public function setLatitude($latitude)
+  {
+    $this->latitude = $latitude;
+  }
+  public function getLatitude()
+  {
+    return $this->latitude;
+  }
+  public function setLongitude($longitude)
+  {
+    $this->longitude = $longitude;
+  }
+  public function getLongitude()
+  {
+    return $this->longitude;
+  }
+}
+
+class Google_Service_Plus_PlusAclentryResource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $displayName;
+  public $id;
+  public $type;
+
+
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/PlusDomains.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/PlusDomains.php
@@ -1,0 +1,3929 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for PlusDomains (v1).
+ *
+ * <p>
+ * The Google+ API enables developers to build on top of the Google+ platform.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/+/domains/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_PlusDomains extends Google_Service
+{
+  /** View your circles and the people and pages in them. */
+  const PLUS_CIRCLES_READ =
+      "https://www.googleapis.com/auth/plus.circles.read";
+  /** Manage your circles and add people and pages. People and pages you add to your circles will be notified. Others may see this information publicly. People you add to circles can use Hangouts with you.. */
+  const PLUS_CIRCLES_WRITE =
+      "https://www.googleapis.com/auth/plus.circles.write";
+  /** Know your basic profile info and list of people in your circles.. */
+  const PLUS_LOGIN =
+      "https://www.googleapis.com/auth/plus.login";
+  /** Know who you are on Google. */
+  const PLUS_ME =
+      "https://www.googleapis.com/auth/plus.me";
+  /** Send your photos and videos to Google+. */
+  const PLUS_MEDIA_UPLOAD =
+      "https://www.googleapis.com/auth/plus.media.upload";
+  /** View your own Google+ profile and profiles visible to you. */
+  const PLUS_PROFILES_READ =
+      "https://www.googleapis.com/auth/plus.profiles.read";
+  /** View your Google+ posts, comments, and stream. */
+  const PLUS_STREAM_READ =
+      "https://www.googleapis.com/auth/plus.stream.read";
+  /** Manage your Google+ posts, comments, and stream. */
+  const PLUS_STREAM_WRITE =
+      "https://www.googleapis.com/auth/plus.stream.write";
+  /** View your email address. */
+  const USERINFO_EMAIL =
+      "https://www.googleapis.com/auth/userinfo.email";
+  /** View your basic profile info. */
+  const USERINFO_PROFILE =
+      "https://www.googleapis.com/auth/userinfo.profile";
+
+  public $activities;
+  public $audiences;
+  public $circles;
+  public $comments;
+  public $media;
+  public $people;
+  
+
+  /**
+   * Constructs the internal representation of the PlusDomains service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'plusDomains/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'plusDomains';
+
+    $this->activities = new Google_Service_PlusDomains_Activities_Resource(
+        $this,
+        $this->serviceName,
+        'activities',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'activities/{activityId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'activityId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'people/{userId}/activities',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'preview' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'people/{userId}/activities/{collection}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collection' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->audiences = new Google_Service_PlusDomains_Audiences_Resource(
+        $this,
+        $this->serviceName,
+        'audiences',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'people/{userId}/audiences',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->circles = new Google_Service_PlusDomains_Circles_Resource(
+        $this,
+        $this->serviceName,
+        'circles',
+        array(
+          'methods' => array(
+            'addPeople' => array(
+              'path' => 'circles/{circleId}/people',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'circleId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'email' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'circles/{circleId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'circleId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'people/{userId}/circles',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'people/{userId}/circles',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'circles/{circleId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'circleId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'remove' => array(
+              'path' => 'circles/{circleId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'circleId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'removePeople' => array(
+              'path' => 'circles/{circleId}/people',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'circleId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'userId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'email' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'circles/{circleId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'circleId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->comments = new Google_Service_PlusDomains_Comments_Resource(
+        $this,
+        $this->serviceName,
+        'comments',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'comments/{commentId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'commentId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'activities/{activityId}/comments',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'activityId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'activities/{activityId}/comments',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'activityId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sortOrder' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->media = new Google_Service_PlusDomains_Media_Resource(
+        $this,
+        $this->serviceName,
+        'media',
+        array(
+          'methods' => array(
+            'insert' => array(
+              'path' => 'people/{userId}/media/{collection}',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collection' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->people = new Google_Service_PlusDomains_People_Resource(
+        $this,
+        $this->serviceName,
+        'people',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'people/{userId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'people/{userId}/people/{collection}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collection' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'listByActivity' => array(
+              'path' => 'activities/{activityId}/people/{collection}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'activityId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'collection' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'listByCircle' => array(
+              'path' => 'circles/{circleId}/people',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'circleId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "activities" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $plusDomainsService = new Google_Service_PlusDomains(...);
+ *   $activities = $plusDomainsService->activities;
+ *  </code>
+ */
+class Google_Service_PlusDomains_Activities_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get an activity. (activities.get)
+   *
+   * @param string $activityId The ID of the activity to get.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_PlusDomains_Activity
+   */
+  public function get($activityId, $optParams = array())
+  {
+    $params = array('activityId' => $activityId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_PlusDomains_Activity");
+  }
+
+  /**
+   * Create a new activity for the authenticated user. (activities.insert)
+   *
+   * @param string $userId The ID of the user to create the activity on behalf of.
+   * Its value should be "me", to indicate the authenticated user.
+   * @param Google_Activity $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool preview If "true", extract the potential media attachments
+   * for a URL. The response will include all possible attachments for a URL,
+   * including video, photos, and articles based on the content of the page.
+   * @return Google_Service_PlusDomains_Activity
+   */
+  public function insert($userId, Google_Service_PlusDomains_Activity $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_PlusDomains_Activity");
+  }
+
+  /**
+   * List all of the activities in the specified collection for a particular user.
+   * (activities.listActivities)
+   *
+   * @param string $userId The ID of the user to get activities for. The special
+   * value "me" can be used to indicate the authenticated user.
+   * @param string $collection The collection of activities to list.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large result sets. To get the next page of results, set this
+   * parameter to the value of "nextPageToken" from the previous response.
+   * @opt_param string maxResults The maximum number of activities to include in
+   * the response, which is used for paging. For any response, the actual number
+   * returned might be less than the specified maxResults.
+   * @return Google_Service_PlusDomains_ActivityFeed
+   */
+  public function listActivities($userId, $collection, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'collection' => $collection);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_PlusDomains_ActivityFeed");
+  }
+}
+
+/**
+ * The "audiences" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $plusDomainsService = new Google_Service_PlusDomains(...);
+ *   $audiences = $plusDomainsService->audiences;
+ *  </code>
+ */
+class Google_Service_PlusDomains_Audiences_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List all of the audiences to which a user can share.
+   * (audiences.listAudiences)
+   *
+   * @param string $userId The ID of the user to get audiences for. The special
+   * value "me" can be used to indicate the authenticated user.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large result sets. To get the next page of results, set this
+   * parameter to the value of "nextPageToken" from the previous response.
+   * @opt_param string maxResults The maximum number of circles to include in the
+   * response, which is used for paging. For any response, the actual number
+   * returned might be less than the specified maxResults.
+   * @return Google_Service_PlusDomains_AudiencesFeed
+   */
+  public function listAudiences($userId, $optParams = array())
+  {
+    $params = array('userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_PlusDomains_AudiencesFeed");
+  }
+}
+
+/**
+ * The "circles" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $plusDomainsService = new Google_Service_PlusDomains(...);
+ *   $circles = $plusDomainsService->circles;
+ *  </code>
+ */
+class Google_Service_PlusDomains_Circles_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Add a person to a circle. Google+ limits certain circle operations, including
+   * the number of circle adds. Learn More. (circles.addPeople)
+   *
+   * @param string $circleId The ID of the circle to add the person to.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string userId IDs of the people to add to the circle. Optional,
+   * can be repeated.
+   * @opt_param string email Email of the people to add to the circle. Optional,
+   * can be repeated.
+   * @return Google_Service_PlusDomains_Circle
+   */
+  public function addPeople($circleId, $optParams = array())
+  {
+    $params = array('circleId' => $circleId);
+    $params = array_merge($params, $optParams);
+    return $this->call('addPeople', array($params), "Google_Service_PlusDomains_Circle");
+  }
+
+  /**
+   * Get a circle. (circles.get)
+   *
+   * @param string $circleId The ID of the circle to get.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_PlusDomains_Circle
+   */
+  public function get($circleId, $optParams = array())
+  {
+    $params = array('circleId' => $circleId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_PlusDomains_Circle");
+  }
+
+  /**
+   * Create a new circle for the authenticated user. (circles.insert)
+   *
+   * @param string $userId The ID of the user to create the circle on behalf of.
+   * The value "me" can be used to indicate the authenticated user.
+   * @param Google_Circle $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_PlusDomains_Circle
+   */
+  public function insert($userId, Google_Service_PlusDomains_Circle $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_PlusDomains_Circle");
+  }
+
+  /**
+   * List all of the circles for a user. (circles.listCircles)
+   *
+   * @param string $userId The ID of the user to get circles for. The special
+   * value "me" can be used to indicate the authenticated user.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large result sets. To get the next page of results, set this
+   * parameter to the value of "nextPageToken" from the previous response.
+   * @opt_param string maxResults The maximum number of circles to include in the
+   * response, which is used for paging. For any response, the actual number
+   * returned might be less than the specified maxResults.
+   * @return Google_Service_PlusDomains_CircleFeed
+   */
+  public function listCircles($userId, $optParams = array())
+  {
+    $params = array('userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_PlusDomains_CircleFeed");
+  }
+
+  /**
+   * Update a circle's description. This method supports patch semantics.
+   * (circles.patch)
+   *
+   * @param string $circleId The ID of the circle to update.
+   * @param Google_Circle $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_PlusDomains_Circle
+   */
+  public function patch($circleId, Google_Service_PlusDomains_Circle $postBody, $optParams = array())
+  {
+    $params = array('circleId' => $circleId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_PlusDomains_Circle");
+  }
+
+  /**
+   * Delete a circle. (circles.remove)
+   *
+   * @param string $circleId The ID of the circle to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function remove($circleId, $optParams = array())
+  {
+    $params = array('circleId' => $circleId);
+    $params = array_merge($params, $optParams);
+    return $this->call('remove', array($params));
+  }
+
+  /**
+   * Remove a person from a circle. (circles.removePeople)
+   *
+   * @param string $circleId The ID of the circle to remove the person from.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string userId IDs of the people to remove from the circle.
+   * Optional, can be repeated.
+   * @opt_param string email Email of the people to add to the circle. Optional,
+   * can be repeated.
+   */
+  public function removePeople($circleId, $optParams = array())
+  {
+    $params = array('circleId' => $circleId);
+    $params = array_merge($params, $optParams);
+    return $this->call('removePeople', array($params));
+  }
+
+  /**
+   * Update a circle's description. (circles.update)
+   *
+   * @param string $circleId The ID of the circle to update.
+   * @param Google_Circle $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_PlusDomains_Circle
+   */
+  public function update($circleId, Google_Service_PlusDomains_Circle $postBody, $optParams = array())
+  {
+    $params = array('circleId' => $circleId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_PlusDomains_Circle");
+  }
+}
+
+/**
+ * The "comments" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $plusDomainsService = new Google_Service_PlusDomains(...);
+ *   $comments = $plusDomainsService->comments;
+ *  </code>
+ */
+class Google_Service_PlusDomains_Comments_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get a comment. (comments.get)
+   *
+   * @param string $commentId The ID of the comment to get.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_PlusDomains_Comment
+   */
+  public function get($commentId, $optParams = array())
+  {
+    $params = array('commentId' => $commentId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_PlusDomains_Comment");
+  }
+
+  /**
+   * Create a new comment in reply to an activity. (comments.insert)
+   *
+   * @param string $activityId The ID of the activity to reply to.
+   * @param Google_Comment $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_PlusDomains_Comment
+   */
+  public function insert($activityId, Google_Service_PlusDomains_Comment $postBody, $optParams = array())
+  {
+    $params = array('activityId' => $activityId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_PlusDomains_Comment");
+  }
+
+  /**
+   * List all of the comments for an activity. (comments.listComments)
+   *
+   * @param string $activityId The ID of the activity to get comments for.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large result sets. To get the next page of results, set this
+   * parameter to the value of "nextPageToken" from the previous response.
+   * @opt_param string sortOrder The order in which to sort the list of comments.
+   * @opt_param string maxResults The maximum number of comments to include in the
+   * response, which is used for paging. For any response, the actual number
+   * returned might be less than the specified maxResults.
+   * @return Google_Service_PlusDomains_CommentFeed
+   */
+  public function listComments($activityId, $optParams = array())
+  {
+    $params = array('activityId' => $activityId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_PlusDomains_CommentFeed");
+  }
+}
+
+/**
+ * The "media" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $plusDomainsService = new Google_Service_PlusDomains(...);
+ *   $media = $plusDomainsService->media;
+ *  </code>
+ */
+class Google_Service_PlusDomains_Media_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Add a new media item to an album. The current upload size limitations are
+   * 36MB for a photo and 1GB for a video. Uploads do not count against quota if
+   * photos are less than 2048 pixels on their longest side or videos are less
+   * than 15 minutes in length. (media.insert)
+   *
+   * @param string $userId The ID of the user to create the activity on behalf of.
+   * @param string $collection
+   * @param Google_Media $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_PlusDomains_Media
+   */
+  public function insert($userId, $collection, Google_Service_PlusDomains_Media $postBody, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'collection' => $collection, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_PlusDomains_Media");
+  }
+}
+
+/**
+ * The "people" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $plusDomainsService = new Google_Service_PlusDomains(...);
+ *   $people = $plusDomainsService->people;
+ *  </code>
+ */
+class Google_Service_PlusDomains_People_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get a person's profile. (people.get)
+   *
+   * @param string $userId The ID of the person to get the profile for. The
+   * special value "me" can be used to indicate the authenticated user.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_PlusDomains_Person
+   */
+  public function get($userId, $optParams = array())
+  {
+    $params = array('userId' => $userId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_PlusDomains_Person");
+  }
+
+  /**
+   * List all of the people in the specified collection. (people.listPeople)
+   *
+   * @param string $userId Get the collection of people for the person identified.
+   * Use "me" to indicate the authenticated user.
+   * @param string $collection The collection of people to list.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderBy The order to return people in.
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large result sets. To get the next page of results, set this
+   * parameter to the value of "nextPageToken" from the previous response.
+   * @opt_param string maxResults The maximum number of people to include in the
+   * response, which is used for paging. For any response, the actual number
+   * returned might be less than the specified maxResults.
+   * @return Google_Service_PlusDomains_PeopleFeed
+   */
+  public function listPeople($userId, $collection, $optParams = array())
+  {
+    $params = array('userId' => $userId, 'collection' => $collection);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_PlusDomains_PeopleFeed");
+  }
+
+  /**
+   * List all of the people in the specified collection for a particular activity.
+   * (people.listByActivity)
+   *
+   * @param string $activityId The ID of the activity to get the list of people
+   * for.
+   * @param string $collection The collection of people to list.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large result sets. To get the next page of results, set this
+   * parameter to the value of "nextPageToken" from the previous response.
+   * @opt_param string maxResults The maximum number of people to include in the
+   * response, which is used for paging. For any response, the actual number
+   * returned might be less than the specified maxResults.
+   * @return Google_Service_PlusDomains_PeopleFeed
+   */
+  public function listByActivity($activityId, $collection, $optParams = array())
+  {
+    $params = array('activityId' => $activityId, 'collection' => $collection);
+    $params = array_merge($params, $optParams);
+    return $this->call('listByActivity', array($params), "Google_Service_PlusDomains_PeopleFeed");
+  }
+
+  /**
+   * List all of the people who are members of a circle. (people.listByCircle)
+   *
+   * @param string $circleId The ID of the circle to get the members of.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The continuation token, which is used to page
+   * through large result sets. To get the next page of results, set this
+   * parameter to the value of "nextPageToken" from the previous response.
+   * @opt_param string maxResults The maximum number of people to include in the
+   * response, which is used for paging. For any response, the actual number
+   * returned might be less than the specified maxResults.
+   * @return Google_Service_PlusDomains_PeopleFeed
+   */
+  public function listByCircle($circleId, $optParams = array())
+  {
+    $params = array('circleId' => $circleId);
+    $params = array_merge($params, $optParams);
+    return $this->call('listByCircle', array($params), "Google_Service_PlusDomains_PeopleFeed");
+  }
+}
+
+
+
+
+class Google_Service_PlusDomains_Acl extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $domainRestricted;
+  protected $itemsType = 'Google_Service_PlusDomains_PlusDomainsAclentryResource';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDomainRestricted($domainRestricted)
+  {
+    $this->domainRestricted = $domainRestricted;
+  }
+  public function getDomainRestricted()
+  {
+    return $this->domainRestricted;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_PlusDomains_Activity extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accessType = 'Google_Service_PlusDomains_Acl';
+  protected $accessDataType = '';
+  protected $actorType = 'Google_Service_PlusDomains_ActivityActor';
+  protected $actorDataType = '';
+  public $address;
+  public $annotation;
+  public $crosspostSource;
+  public $etag;
+  public $geocode;
+  public $id;
+  public $kind;
+  protected $locationType = 'Google_Service_PlusDomains_Place';
+  protected $locationDataType = '';
+  protected $objectType = 'Google_Service_PlusDomains_ActivityObject';
+  protected $objectDataType = '';
+  public $placeId;
+  public $placeName;
+  protected $providerType = 'Google_Service_PlusDomains_ActivityProvider';
+  protected $providerDataType = '';
+  public $published;
+  public $radius;
+  public $title;
+  public $updated;
+  public $url;
+  public $verb;
+
+
+  public function setAccess(Google_Service_PlusDomains_Acl $access)
+  {
+    $this->access = $access;
+  }
+  public function getAccess()
+  {
+    return $this->access;
+  }
+  public function setActor(Google_Service_PlusDomains_ActivityActor $actor)
+  {
+    $this->actor = $actor;
+  }
+  public function getActor()
+  {
+    return $this->actor;
+  }
+  public function setAddress($address)
+  {
+    $this->address = $address;
+  }
+  public function getAddress()
+  {
+    return $this->address;
+  }
+  public function setAnnotation($annotation)
+  {
+    $this->annotation = $annotation;
+  }
+  public function getAnnotation()
+  {
+    return $this->annotation;
+  }
+  public function setCrosspostSource($crosspostSource)
+  {
+    $this->crosspostSource = $crosspostSource;
+  }
+  public function getCrosspostSource()
+  {
+    return $this->crosspostSource;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setGeocode($geocode)
+  {
+    $this->geocode = $geocode;
+  }
+  public function getGeocode()
+  {
+    return $this->geocode;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocation(Google_Service_PlusDomains_Place $location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setObject(Google_Service_PlusDomains_ActivityObject $object)
+  {
+    $this->object = $object;
+  }
+  public function getObject()
+  {
+    return $this->object;
+  }
+  public function setPlaceId($placeId)
+  {
+    $this->placeId = $placeId;
+  }
+  public function getPlaceId()
+  {
+    return $this->placeId;
+  }
+  public function setPlaceName($placeName)
+  {
+    $this->placeName = $placeName;
+  }
+  public function getPlaceName()
+  {
+    return $this->placeName;
+  }
+  public function setProvider(Google_Service_PlusDomains_ActivityProvider $provider)
+  {
+    $this->provider = $provider;
+  }
+  public function getProvider()
+  {
+    return $this->provider;
+  }
+  public function setPublished($published)
+  {
+    $this->published = $published;
+  }
+  public function getPublished()
+  {
+    return $this->published;
+  }
+  public function setRadius($radius)
+  {
+    $this->radius = $radius;
+  }
+  public function getRadius()
+  {
+    return $this->radius;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setVerb($verb)
+  {
+    $this->verb = $verb;
+  }
+  public function getVerb()
+  {
+    return $this->verb;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityActor extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $clientSpecificActorInfoType = 'Google_Service_PlusDomains_ActivityActorClientSpecificActorInfo';
+  protected $clientSpecificActorInfoDataType = '';
+  public $displayName;
+  public $id;
+  protected $imageType = 'Google_Service_PlusDomains_ActivityActorImage';
+  protected $imageDataType = '';
+  protected $nameType = 'Google_Service_PlusDomains_ActivityActorName';
+  protected $nameDataType = '';
+  public $url;
+  protected $verificationType = 'Google_Service_PlusDomains_ActivityActorVerification';
+  protected $verificationDataType = '';
+
+
+  public function setClientSpecificActorInfo(Google_Service_PlusDomains_ActivityActorClientSpecificActorInfo $clientSpecificActorInfo)
+  {
+    $this->clientSpecificActorInfo = $clientSpecificActorInfo;
+  }
+  public function getClientSpecificActorInfo()
+  {
+    return $this->clientSpecificActorInfo;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImage(Google_Service_PlusDomains_ActivityActorImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setName(Google_Service_PlusDomains_ActivityActorName $name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setVerification(Google_Service_PlusDomains_ActivityActorVerification $verification)
+  {
+    $this->verification = $verification;
+  }
+  public function getVerification()
+  {
+    return $this->verification;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityActorClientSpecificActorInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $youtubeActorInfoType = 'Google_Service_PlusDomains_ActivityActorClientSpecificActorInfoYoutubeActorInfo';
+  protected $youtubeActorInfoDataType = '';
+
+
+  public function setYoutubeActorInfo(Google_Service_PlusDomains_ActivityActorClientSpecificActorInfoYoutubeActorInfo $youtubeActorInfo)
+  {
+    $this->youtubeActorInfo = $youtubeActorInfo;
+  }
+  public function getYoutubeActorInfo()
+  {
+    return $this->youtubeActorInfo;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityActorClientSpecificActorInfoYoutubeActorInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $channelId;
+
+
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityActorImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $url;
+
+
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityActorName extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $familyName;
+  public $givenName;
+
+
+  public function setFamilyName($familyName)
+  {
+    $this->familyName = $familyName;
+  }
+  public function getFamilyName()
+  {
+    return $this->familyName;
+  }
+  public function setGivenName($givenName)
+  {
+    $this->givenName = $givenName;
+  }
+  public function getGivenName()
+  {
+    return $this->givenName;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityActorVerification extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $adHocVerified;
+
+
+  public function setAdHocVerified($adHocVerified)
+  {
+    $this->adHocVerified = $adHocVerified;
+  }
+  public function getAdHocVerified()
+  {
+    return $this->adHocVerified;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityFeed extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $id;
+  protected $itemsType = 'Google_Service_PlusDomains_Activity';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextLink;
+  public $nextPageToken;
+  public $selfLink;
+  public $title;
+  public $updated;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityObject extends Google_Collection
+{
+  protected $collection_key = 'attachments';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $actorType = 'Google_Service_PlusDomains_ActivityObjectActor';
+  protected $actorDataType = '';
+  protected $attachmentsType = 'Google_Service_PlusDomains_ActivityObjectAttachments';
+  protected $attachmentsDataType = 'array';
+  public $content;
+  public $id;
+  public $objectType;
+  public $originalContent;
+  protected $plusonersType = 'Google_Service_PlusDomains_ActivityObjectPlusoners';
+  protected $plusonersDataType = '';
+  protected $repliesType = 'Google_Service_PlusDomains_ActivityObjectReplies';
+  protected $repliesDataType = '';
+  protected $resharersType = 'Google_Service_PlusDomains_ActivityObjectResharers';
+  protected $resharersDataType = '';
+  protected $statusForViewerType = 'Google_Service_PlusDomains_ActivityObjectStatusForViewer';
+  protected $statusForViewerDataType = '';
+  public $url;
+
+
+  public function setActor(Google_Service_PlusDomains_ActivityObjectActor $actor)
+  {
+    $this->actor = $actor;
+  }
+  public function getActor()
+  {
+    return $this->actor;
+  }
+  public function setAttachments($attachments)
+  {
+    $this->attachments = $attachments;
+  }
+  public function getAttachments()
+  {
+    return $this->attachments;
+  }
+  public function setContent($content)
+  {
+    $this->content = $content;
+  }
+  public function getContent()
+  {
+    return $this->content;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setObjectType($objectType)
+  {
+    $this->objectType = $objectType;
+  }
+  public function getObjectType()
+  {
+    return $this->objectType;
+  }
+  public function setOriginalContent($originalContent)
+  {
+    $this->originalContent = $originalContent;
+  }
+  public function getOriginalContent()
+  {
+    return $this->originalContent;
+  }
+  public function setPlusoners(Google_Service_PlusDomains_ActivityObjectPlusoners $plusoners)
+  {
+    $this->plusoners = $plusoners;
+  }
+  public function getPlusoners()
+  {
+    return $this->plusoners;
+  }
+  public function setReplies(Google_Service_PlusDomains_ActivityObjectReplies $replies)
+  {
+    $this->replies = $replies;
+  }
+  public function getReplies()
+  {
+    return $this->replies;
+  }
+  public function setResharers(Google_Service_PlusDomains_ActivityObjectResharers $resharers)
+  {
+    $this->resharers = $resharers;
+  }
+  public function getResharers()
+  {
+    return $this->resharers;
+  }
+  public function setStatusForViewer(Google_Service_PlusDomains_ActivityObjectStatusForViewer $statusForViewer)
+  {
+    $this->statusForViewer = $statusForViewer;
+  }
+  public function getStatusForViewer()
+  {
+    return $this->statusForViewer;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityObjectActor extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $clientSpecificActorInfoType = 'Google_Service_PlusDomains_ActivityObjectActorClientSpecificActorInfo';
+  protected $clientSpecificActorInfoDataType = '';
+  public $displayName;
+  public $id;
+  protected $imageType = 'Google_Service_PlusDomains_ActivityObjectActorImage';
+  protected $imageDataType = '';
+  public $url;
+  protected $verificationType = 'Google_Service_PlusDomains_ActivityObjectActorVerification';
+  protected $verificationDataType = '';
+
+
+  public function setClientSpecificActorInfo(Google_Service_PlusDomains_ActivityObjectActorClientSpecificActorInfo $clientSpecificActorInfo)
+  {
+    $this->clientSpecificActorInfo = $clientSpecificActorInfo;
+  }
+  public function getClientSpecificActorInfo()
+  {
+    return $this->clientSpecificActorInfo;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImage(Google_Service_PlusDomains_ActivityObjectActorImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setVerification(Google_Service_PlusDomains_ActivityObjectActorVerification $verification)
+  {
+    $this->verification = $verification;
+  }
+  public function getVerification()
+  {
+    return $this->verification;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityObjectActorClientSpecificActorInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $youtubeActorInfoType = 'Google_Service_PlusDomains_ActivityObjectActorClientSpecificActorInfoYoutubeActorInfo';
+  protected $youtubeActorInfoDataType = '';
+
+
+  public function setYoutubeActorInfo(Google_Service_PlusDomains_ActivityObjectActorClientSpecificActorInfoYoutubeActorInfo $youtubeActorInfo)
+  {
+    $this->youtubeActorInfo = $youtubeActorInfo;
+  }
+  public function getYoutubeActorInfo()
+  {
+    return $this->youtubeActorInfo;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityObjectActorClientSpecificActorInfoYoutubeActorInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $channelId;
+
+
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityObjectActorImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $url;
+
+
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityObjectActorVerification extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $adHocVerified;
+
+
+  public function setAdHocVerified($adHocVerified)
+  {
+    $this->adHocVerified = $adHocVerified;
+  }
+  public function getAdHocVerified()
+  {
+    return $this->adHocVerified;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityObjectAttachments extends Google_Collection
+{
+  protected $collection_key = 'thumbnails';
+  protected $internal_gapi_mappings = array(
+  );
+  public $content;
+  public $displayName;
+  protected $embedType = 'Google_Service_PlusDomains_ActivityObjectAttachmentsEmbed';
+  protected $embedDataType = '';
+  protected $fullImageType = 'Google_Service_PlusDomains_ActivityObjectAttachmentsFullImage';
+  protected $fullImageDataType = '';
+  public $id;
+  protected $imageType = 'Google_Service_PlusDomains_ActivityObjectAttachmentsImage';
+  protected $imageDataType = '';
+  public $objectType;
+  protected $previewThumbnailsType = 'Google_Service_PlusDomains_ActivityObjectAttachmentsPreviewThumbnails';
+  protected $previewThumbnailsDataType = 'array';
+  protected $thumbnailsType = 'Google_Service_PlusDomains_ActivityObjectAttachmentsThumbnails';
+  protected $thumbnailsDataType = 'array';
+  public $url;
+
+
+  public function setContent($content)
+  {
+    $this->content = $content;
+  }
+  public function getContent()
+  {
+    return $this->content;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setEmbed(Google_Service_PlusDomains_ActivityObjectAttachmentsEmbed $embed)
+  {
+    $this->embed = $embed;
+  }
+  public function getEmbed()
+  {
+    return $this->embed;
+  }
+  public function setFullImage(Google_Service_PlusDomains_ActivityObjectAttachmentsFullImage $fullImage)
+  {
+    $this->fullImage = $fullImage;
+  }
+  public function getFullImage()
+  {
+    return $this->fullImage;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImage(Google_Service_PlusDomains_ActivityObjectAttachmentsImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setObjectType($objectType)
+  {
+    $this->objectType = $objectType;
+  }
+  public function getObjectType()
+  {
+    return $this->objectType;
+  }
+  public function setPreviewThumbnails($previewThumbnails)
+  {
+    $this->previewThumbnails = $previewThumbnails;
+  }
+  public function getPreviewThumbnails()
+  {
+    return $this->previewThumbnails;
+  }
+  public function setThumbnails($thumbnails)
+  {
+    $this->thumbnails = $thumbnails;
+  }
+  public function getThumbnails()
+  {
+    return $this->thumbnails;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityObjectAttachmentsEmbed extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $type;
+  public $url;
+
+
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityObjectAttachmentsFullImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $type;
+  public $url;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityObjectAttachmentsImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $type;
+  public $url;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityObjectAttachmentsPreviewThumbnails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $url;
+
+
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityObjectAttachmentsThumbnails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  protected $imageType = 'Google_Service_PlusDomains_ActivityObjectAttachmentsThumbnailsImage';
+  protected $imageDataType = '';
+  public $url;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setImage(Google_Service_PlusDomains_ActivityObjectAttachmentsThumbnailsImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityObjectAttachmentsThumbnailsImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $type;
+  public $url;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityObjectPlusoners extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $selfLink;
+  public $totalItems;
+
+
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityObjectReplies extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $selfLink;
+  public $totalItems;
+
+
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityObjectResharers extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $selfLink;
+  public $totalItems;
+
+
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityObjectStatusForViewer extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $canComment;
+  public $canPlusone;
+  public $canUpdate;
+  public $isPlusOned;
+  public $resharingDisabled;
+
+
+  public function setCanComment($canComment)
+  {
+    $this->canComment = $canComment;
+  }
+  public function getCanComment()
+  {
+    return $this->canComment;
+  }
+  public function setCanPlusone($canPlusone)
+  {
+    $this->canPlusone = $canPlusone;
+  }
+  public function getCanPlusone()
+  {
+    return $this->canPlusone;
+  }
+  public function setCanUpdate($canUpdate)
+  {
+    $this->canUpdate = $canUpdate;
+  }
+  public function getCanUpdate()
+  {
+    return $this->canUpdate;
+  }
+  public function setIsPlusOned($isPlusOned)
+  {
+    $this->isPlusOned = $isPlusOned;
+  }
+  public function getIsPlusOned()
+  {
+    return $this->isPlusOned;
+  }
+  public function setResharingDisabled($resharingDisabled)
+  {
+    $this->resharingDisabled = $resharingDisabled;
+  }
+  public function getResharingDisabled()
+  {
+    return $this->resharingDisabled;
+  }
+}
+
+class Google_Service_PlusDomains_ActivityProvider extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $title;
+
+
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_PlusDomains_Audience extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemType = 'Google_Service_PlusDomains_PlusDomainsAclentryResource';
+  protected $itemDataType = '';
+  public $kind;
+  public $memberCount;
+  public $visibility;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItem(Google_Service_PlusDomains_PlusDomainsAclentryResource $item)
+  {
+    $this->item = $item;
+  }
+  public function getItem()
+  {
+    return $this->item;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMemberCount($memberCount)
+  {
+    $this->memberCount = $memberCount;
+  }
+  public function getMemberCount()
+  {
+    return $this->memberCount;
+  }
+  public function setVisibility($visibility)
+  {
+    $this->visibility = $visibility;
+  }
+  public function getVisibility()
+  {
+    return $this->visibility;
+  }
+}
+
+class Google_Service_PlusDomains_AudiencesFeed extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_PlusDomains_Audience';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $totalItems;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_PlusDomains_Circle extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $displayName;
+  public $etag;
+  public $id;
+  public $kind;
+  protected $peopleType = 'Google_Service_PlusDomains_CirclePeople';
+  protected $peopleDataType = '';
+  public $selfLink;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPeople(Google_Service_PlusDomains_CirclePeople $people)
+  {
+    $this->people = $people;
+  }
+  public function getPeople()
+  {
+    return $this->people;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_PlusDomains_CircleFeed extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_PlusDomains_Circle';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextLink;
+  public $nextPageToken;
+  public $selfLink;
+  public $title;
+  public $totalItems;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_PlusDomains_CirclePeople extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $totalItems;
+
+
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_PlusDomains_Comment extends Google_Collection
+{
+  protected $collection_key = 'inReplyTo';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $actorType = 'Google_Service_PlusDomains_CommentActor';
+  protected $actorDataType = '';
+  public $etag;
+  public $id;
+  protected $inReplyToType = 'Google_Service_PlusDomains_CommentInReplyTo';
+  protected $inReplyToDataType = 'array';
+  public $kind;
+  protected $objectType = 'Google_Service_PlusDomains_CommentObject';
+  protected $objectDataType = '';
+  protected $plusonersType = 'Google_Service_PlusDomains_CommentPlusoners';
+  protected $plusonersDataType = '';
+  public $published;
+  public $selfLink;
+  public $updated;
+  public $verb;
+
+
+  public function setActor(Google_Service_PlusDomains_CommentActor $actor)
+  {
+    $this->actor = $actor;
+  }
+  public function getActor()
+  {
+    return $this->actor;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInReplyTo($inReplyTo)
+  {
+    $this->inReplyTo = $inReplyTo;
+  }
+  public function getInReplyTo()
+  {
+    return $this->inReplyTo;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setObject(Google_Service_PlusDomains_CommentObject $object)
+  {
+    $this->object = $object;
+  }
+  public function getObject()
+  {
+    return $this->object;
+  }
+  public function setPlusoners(Google_Service_PlusDomains_CommentPlusoners $plusoners)
+  {
+    $this->plusoners = $plusoners;
+  }
+  public function getPlusoners()
+  {
+    return $this->plusoners;
+  }
+  public function setPublished($published)
+  {
+    $this->published = $published;
+  }
+  public function getPublished()
+  {
+    return $this->published;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setVerb($verb)
+  {
+    $this->verb = $verb;
+  }
+  public function getVerb()
+  {
+    return $this->verb;
+  }
+}
+
+class Google_Service_PlusDomains_CommentActor extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $clientSpecificActorInfoType = 'Google_Service_PlusDomains_CommentActorClientSpecificActorInfo';
+  protected $clientSpecificActorInfoDataType = '';
+  public $displayName;
+  public $id;
+  protected $imageType = 'Google_Service_PlusDomains_CommentActorImage';
+  protected $imageDataType = '';
+  public $url;
+  protected $verificationType = 'Google_Service_PlusDomains_CommentActorVerification';
+  protected $verificationDataType = '';
+
+
+  public function setClientSpecificActorInfo(Google_Service_PlusDomains_CommentActorClientSpecificActorInfo $clientSpecificActorInfo)
+  {
+    $this->clientSpecificActorInfo = $clientSpecificActorInfo;
+  }
+  public function getClientSpecificActorInfo()
+  {
+    return $this->clientSpecificActorInfo;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImage(Google_Service_PlusDomains_CommentActorImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setVerification(Google_Service_PlusDomains_CommentActorVerification $verification)
+  {
+    $this->verification = $verification;
+  }
+  public function getVerification()
+  {
+    return $this->verification;
+  }
+}
+
+class Google_Service_PlusDomains_CommentActorClientSpecificActorInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $youtubeActorInfoType = 'Google_Service_PlusDomains_CommentActorClientSpecificActorInfoYoutubeActorInfo';
+  protected $youtubeActorInfoDataType = '';
+
+
+  public function setYoutubeActorInfo(Google_Service_PlusDomains_CommentActorClientSpecificActorInfoYoutubeActorInfo $youtubeActorInfo)
+  {
+    $this->youtubeActorInfo = $youtubeActorInfo;
+  }
+  public function getYoutubeActorInfo()
+  {
+    return $this->youtubeActorInfo;
+  }
+}
+
+class Google_Service_PlusDomains_CommentActorClientSpecificActorInfoYoutubeActorInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $channelId;
+
+
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+}
+
+class Google_Service_PlusDomains_CommentActorImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $url;
+
+
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_PlusDomains_CommentActorVerification extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $adHocVerified;
+
+
+  public function setAdHocVerified($adHocVerified)
+  {
+    $this->adHocVerified = $adHocVerified;
+  }
+  public function getAdHocVerified()
+  {
+    return $this->adHocVerified;
+  }
+}
+
+class Google_Service_PlusDomains_CommentFeed extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $id;
+  protected $itemsType = 'Google_Service_PlusDomains_Comment';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextLink;
+  public $nextPageToken;
+  public $title;
+  public $updated;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextLink($nextLink)
+  {
+    $this->nextLink = $nextLink;
+  }
+  public function getNextLink()
+  {
+    return $this->nextLink;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+}
+
+class Google_Service_PlusDomains_CommentInReplyTo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $url;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_PlusDomains_CommentObject extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $content;
+  public $objectType;
+  public $originalContent;
+
+
+  public function setContent($content)
+  {
+    $this->content = $content;
+  }
+  public function getContent()
+  {
+    return $this->content;
+  }
+  public function setObjectType($objectType)
+  {
+    $this->objectType = $objectType;
+  }
+  public function getObjectType()
+  {
+    return $this->objectType;
+  }
+  public function setOriginalContent($originalContent)
+  {
+    $this->originalContent = $originalContent;
+  }
+  public function getOriginalContent()
+  {
+    return $this->originalContent;
+  }
+}
+
+class Google_Service_PlusDomains_CommentPlusoners extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $totalItems;
+
+
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_PlusDomains_Media extends Google_Collection
+{
+  protected $collection_key = 'streams';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $authorType = 'Google_Service_PlusDomains_MediaAuthor';
+  protected $authorDataType = '';
+  public $displayName;
+  public $etag;
+  protected $exifType = 'Google_Service_PlusDomains_MediaExif';
+  protected $exifDataType = '';
+  public $height;
+  public $id;
+  public $kind;
+  public $mediaCreatedTime;
+  public $mediaUrl;
+  public $published;
+  public $sizeBytes;
+  protected $streamsType = 'Google_Service_PlusDomains_Videostream';
+  protected $streamsDataType = 'array';
+  public $summary;
+  public $updated;
+  public $url;
+  public $videoDuration;
+  public $videoStatus;
+  public $width;
+
+
+  public function setAuthor(Google_Service_PlusDomains_MediaAuthor $author)
+  {
+    $this->author = $author;
+  }
+  public function getAuthor()
+  {
+    return $this->author;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setExif(Google_Service_PlusDomains_MediaExif $exif)
+  {
+    $this->exif = $exif;
+  }
+  public function getExif()
+  {
+    return $this->exif;
+  }
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMediaCreatedTime($mediaCreatedTime)
+  {
+    $this->mediaCreatedTime = $mediaCreatedTime;
+  }
+  public function getMediaCreatedTime()
+  {
+    return $this->mediaCreatedTime;
+  }
+  public function setMediaUrl($mediaUrl)
+  {
+    $this->mediaUrl = $mediaUrl;
+  }
+  public function getMediaUrl()
+  {
+    return $this->mediaUrl;
+  }
+  public function setPublished($published)
+  {
+    $this->published = $published;
+  }
+  public function getPublished()
+  {
+    return $this->published;
+  }
+  public function setSizeBytes($sizeBytes)
+  {
+    $this->sizeBytes = $sizeBytes;
+  }
+  public function getSizeBytes()
+  {
+    return $this->sizeBytes;
+  }
+  public function setStreams($streams)
+  {
+    $this->streams = $streams;
+  }
+  public function getStreams()
+  {
+    return $this->streams;
+  }
+  public function setSummary($summary)
+  {
+    $this->summary = $summary;
+  }
+  public function getSummary()
+  {
+    return $this->summary;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setVideoDuration($videoDuration)
+  {
+    $this->videoDuration = $videoDuration;
+  }
+  public function getVideoDuration()
+  {
+    return $this->videoDuration;
+  }
+  public function setVideoStatus($videoStatus)
+  {
+    $this->videoStatus = $videoStatus;
+  }
+  public function getVideoStatus()
+  {
+    return $this->videoStatus;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_PlusDomains_MediaAuthor extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $displayName;
+  public $id;
+  protected $imageType = 'Google_Service_PlusDomains_MediaAuthorImage';
+  protected $imageDataType = '';
+  public $url;
+
+
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImage(Google_Service_PlusDomains_MediaAuthorImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_PlusDomains_MediaAuthorImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $url;
+
+
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_PlusDomains_MediaExif extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $time;
+
+
+  public function setTime($time)
+  {
+    $this->time = $time;
+  }
+  public function getTime()
+  {
+    return $this->time;
+  }
+}
+
+class Google_Service_PlusDomains_PeopleFeed extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_PlusDomains_Person';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+  public $title;
+  public $totalItems;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}
+
+class Google_Service_PlusDomains_Person extends Google_Collection
+{
+  protected $collection_key = 'urls';
+  protected $internal_gapi_mappings = array(
+  );
+  public $aboutMe;
+  public $birthday;
+  public $braggingRights;
+  public $circledByCount;
+  protected $coverType = 'Google_Service_PlusDomains_PersonCover';
+  protected $coverDataType = '';
+  public $currentLocation;
+  public $displayName;
+  public $domain;
+  protected $emailsType = 'Google_Service_PlusDomains_PersonEmails';
+  protected $emailsDataType = 'array';
+  public $etag;
+  public $gender;
+  public $id;
+  protected $imageType = 'Google_Service_PlusDomains_PersonImage';
+  protected $imageDataType = '';
+  public $isPlusUser;
+  public $kind;
+  protected $nameType = 'Google_Service_PlusDomains_PersonName';
+  protected $nameDataType = '';
+  public $nickname;
+  public $objectType;
+  public $occupation;
+  protected $organizationsType = 'Google_Service_PlusDomains_PersonOrganizations';
+  protected $organizationsDataType = 'array';
+  protected $placesLivedType = 'Google_Service_PlusDomains_PersonPlacesLived';
+  protected $placesLivedDataType = 'array';
+  public $plusOneCount;
+  public $relationshipStatus;
+  public $skills;
+  public $tagline;
+  public $url;
+  protected $urlsType = 'Google_Service_PlusDomains_PersonUrls';
+  protected $urlsDataType = 'array';
+  public $verified;
+
+
+  public function setAboutMe($aboutMe)
+  {
+    $this->aboutMe = $aboutMe;
+  }
+  public function getAboutMe()
+  {
+    return $this->aboutMe;
+  }
+  public function setBirthday($birthday)
+  {
+    $this->birthday = $birthday;
+  }
+  public function getBirthday()
+  {
+    return $this->birthday;
+  }
+  public function setBraggingRights($braggingRights)
+  {
+    $this->braggingRights = $braggingRights;
+  }
+  public function getBraggingRights()
+  {
+    return $this->braggingRights;
+  }
+  public function setCircledByCount($circledByCount)
+  {
+    $this->circledByCount = $circledByCount;
+  }
+  public function getCircledByCount()
+  {
+    return $this->circledByCount;
+  }
+  public function setCover(Google_Service_PlusDomains_PersonCover $cover)
+  {
+    $this->cover = $cover;
+  }
+  public function getCover()
+  {
+    return $this->cover;
+  }
+  public function setCurrentLocation($currentLocation)
+  {
+    $this->currentLocation = $currentLocation;
+  }
+  public function getCurrentLocation()
+  {
+    return $this->currentLocation;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setDomain($domain)
+  {
+    $this->domain = $domain;
+  }
+  public function getDomain()
+  {
+    return $this->domain;
+  }
+  public function setEmails($emails)
+  {
+    $this->emails = $emails;
+  }
+  public function getEmails()
+  {
+    return $this->emails;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setGender($gender)
+  {
+    $this->gender = $gender;
+  }
+  public function getGender()
+  {
+    return $this->gender;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImage(Google_Service_PlusDomains_PersonImage $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setIsPlusUser($isPlusUser)
+  {
+    $this->isPlusUser = $isPlusUser;
+  }
+  public function getIsPlusUser()
+  {
+    return $this->isPlusUser;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName(Google_Service_PlusDomains_PersonName $name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNickname($nickname)
+  {
+    $this->nickname = $nickname;
+  }
+  public function getNickname()
+  {
+    return $this->nickname;
+  }
+  public function setObjectType($objectType)
+  {
+    $this->objectType = $objectType;
+  }
+  public function getObjectType()
+  {
+    return $this->objectType;
+  }
+  public function setOccupation($occupation)
+  {
+    $this->occupation = $occupation;
+  }
+  public function getOccupation()
+  {
+    return $this->occupation;
+  }
+  public function setOrganizations($organizations)
+  {
+    $this->organizations = $organizations;
+  }
+  public function getOrganizations()
+  {
+    return $this->organizations;
+  }
+  public function setPlacesLived($placesLived)
+  {
+    $this->placesLived = $placesLived;
+  }
+  public function getPlacesLived()
+  {
+    return $this->placesLived;
+  }
+  public function setPlusOneCount($plusOneCount)
+  {
+    $this->plusOneCount = $plusOneCount;
+  }
+  public function getPlusOneCount()
+  {
+    return $this->plusOneCount;
+  }
+  public function setRelationshipStatus($relationshipStatus)
+  {
+    $this->relationshipStatus = $relationshipStatus;
+  }
+  public function getRelationshipStatus()
+  {
+    return $this->relationshipStatus;
+  }
+  public function setSkills($skills)
+  {
+    $this->skills = $skills;
+  }
+  public function getSkills()
+  {
+    return $this->skills;
+  }
+  public function setTagline($tagline)
+  {
+    $this->tagline = $tagline;
+  }
+  public function getTagline()
+  {
+    return $this->tagline;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setUrls($urls)
+  {
+    $this->urls = $urls;
+  }
+  public function getUrls()
+  {
+    return $this->urls;
+  }
+  public function setVerified($verified)
+  {
+    $this->verified = $verified;
+  }
+  public function getVerified()
+  {
+    return $this->verified;
+  }
+}
+
+class Google_Service_PlusDomains_PersonCover extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $coverInfoType = 'Google_Service_PlusDomains_PersonCoverCoverInfo';
+  protected $coverInfoDataType = '';
+  protected $coverPhotoType = 'Google_Service_PlusDomains_PersonCoverCoverPhoto';
+  protected $coverPhotoDataType = '';
+  public $layout;
+
+
+  public function setCoverInfo(Google_Service_PlusDomains_PersonCoverCoverInfo $coverInfo)
+  {
+    $this->coverInfo = $coverInfo;
+  }
+  public function getCoverInfo()
+  {
+    return $this->coverInfo;
+  }
+  public function setCoverPhoto(Google_Service_PlusDomains_PersonCoverCoverPhoto $coverPhoto)
+  {
+    $this->coverPhoto = $coverPhoto;
+  }
+  public function getCoverPhoto()
+  {
+    return $this->coverPhoto;
+  }
+  public function setLayout($layout)
+  {
+    $this->layout = $layout;
+  }
+  public function getLayout()
+  {
+    return $this->layout;
+  }
+}
+
+class Google_Service_PlusDomains_PersonCoverCoverInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $leftImageOffset;
+  public $topImageOffset;
+
+
+  public function setLeftImageOffset($leftImageOffset)
+  {
+    $this->leftImageOffset = $leftImageOffset;
+  }
+  public function getLeftImageOffset()
+  {
+    return $this->leftImageOffset;
+  }
+  public function setTopImageOffset($topImageOffset)
+  {
+    $this->topImageOffset = $topImageOffset;
+  }
+  public function getTopImageOffset()
+  {
+    return $this->topImageOffset;
+  }
+}
+
+class Google_Service_PlusDomains_PersonCoverCoverPhoto extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $url;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_PlusDomains_PersonEmails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $type;
+  public $value;
+
+
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_PlusDomains_PersonImage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $isDefault;
+  public $url;
+
+
+  public function setIsDefault($isDefault)
+  {
+    $this->isDefault = $isDefault;
+  }
+  public function getIsDefault()
+  {
+    return $this->isDefault;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_PlusDomains_PersonName extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $familyName;
+  public $formatted;
+  public $givenName;
+  public $honorificPrefix;
+  public $honorificSuffix;
+  public $middleName;
+
+
+  public function setFamilyName($familyName)
+  {
+    $this->familyName = $familyName;
+  }
+  public function getFamilyName()
+  {
+    return $this->familyName;
+  }
+  public function setFormatted($formatted)
+  {
+    $this->formatted = $formatted;
+  }
+  public function getFormatted()
+  {
+    return $this->formatted;
+  }
+  public function setGivenName($givenName)
+  {
+    $this->givenName = $givenName;
+  }
+  public function getGivenName()
+  {
+    return $this->givenName;
+  }
+  public function setHonorificPrefix($honorificPrefix)
+  {
+    $this->honorificPrefix = $honorificPrefix;
+  }
+  public function getHonorificPrefix()
+  {
+    return $this->honorificPrefix;
+  }
+  public function setHonorificSuffix($honorificSuffix)
+  {
+    $this->honorificSuffix = $honorificSuffix;
+  }
+  public function getHonorificSuffix()
+  {
+    return $this->honorificSuffix;
+  }
+  public function setMiddleName($middleName)
+  {
+    $this->middleName = $middleName;
+  }
+  public function getMiddleName()
+  {
+    return $this->middleName;
+  }
+}
+
+class Google_Service_PlusDomains_PersonOrganizations extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $department;
+  public $description;
+  public $endDate;
+  public $location;
+  public $name;
+  public $primary;
+  public $startDate;
+  public $title;
+  public $type;
+
+
+  public function setDepartment($department)
+  {
+    $this->department = $department;
+  }
+  public function getDepartment()
+  {
+    return $this->department;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPrimary($primary)
+  {
+    $this->primary = $primary;
+  }
+  public function getPrimary()
+  {
+    return $this->primary;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_PlusDomains_PersonPlacesLived extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $primary;
+  public $value;
+
+
+  public function setPrimary($primary)
+  {
+    $this->primary = $primary;
+  }
+  public function getPrimary()
+  {
+    return $this->primary;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_PlusDomains_PersonUrls extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $label;
+  public $type;
+  public $value;
+
+
+  public function setLabel($label)
+  {
+    $this->label = $label;
+  }
+  public function getLabel()
+  {
+    return $this->label;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_PlusDomains_Place extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $addressType = 'Google_Service_PlusDomains_PlaceAddress';
+  protected $addressDataType = '';
+  public $displayName;
+  public $id;
+  public $kind;
+  protected $positionType = 'Google_Service_PlusDomains_PlacePosition';
+  protected $positionDataType = '';
+
+
+  public function setAddress(Google_Service_PlusDomains_PlaceAddress $address)
+  {
+    $this->address = $address;
+  }
+  public function getAddress()
+  {
+    return $this->address;
+  }
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPosition(Google_Service_PlusDomains_PlacePosition $position)
+  {
+    $this->position = $position;
+  }
+  public function getPosition()
+  {
+    return $this->position;
+  }
+}
+
+class Google_Service_PlusDomains_PlaceAddress extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $formatted;
+
+
+  public function setFormatted($formatted)
+  {
+    $this->formatted = $formatted;
+  }
+  public function getFormatted()
+  {
+    return $this->formatted;
+  }
+}
+
+class Google_Service_PlusDomains_PlacePosition extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $latitude;
+  public $longitude;
+
+
+  public function setLatitude($latitude)
+  {
+    $this->latitude = $latitude;
+  }
+  public function getLatitude()
+  {
+    return $this->latitude;
+  }
+  public function setLongitude($longitude)
+  {
+    $this->longitude = $longitude;
+  }
+  public function getLongitude()
+  {
+    return $this->longitude;
+  }
+}
+
+class Google_Service_PlusDomains_PlusDomainsAclentryResource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $displayName;
+  public $id;
+  public $type;
+
+
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_PlusDomains_Videostream extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $type;
+  public $url;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Prediction.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Prediction.php
@@ -1,0 +1,1228 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Prediction (v1.6).
+ *
+ * <p>
+ * Lets you access a cloud hosted machine learning service that makes it easy to
+ * build smart apps</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/prediction/docs/developer-guide" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Prediction extends Google_Service
+{
+  /** Manage your data and permissions in Google Cloud Storage. */
+  const DEVSTORAGE_FULL_CONTROL =
+      "https://www.googleapis.com/auth/devstorage.full_control";
+  /** View your data in Google Cloud Storage. */
+  const DEVSTORAGE_READ_ONLY =
+      "https://www.googleapis.com/auth/devstorage.read_only";
+  /** Manage your data in Google Cloud Storage. */
+  const DEVSTORAGE_READ_WRITE =
+      "https://www.googleapis.com/auth/devstorage.read_write";
+  /** Manage your data in the Google Prediction API. */
+  const PREDICTION =
+      "https://www.googleapis.com/auth/prediction";
+
+  public $hostedmodels;
+  public $trainedmodels;
+  
+
+  /**
+   * Constructs the internal representation of the Prediction service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'prediction/v1.6/projects/';
+    $this->version = 'v1.6';
+    $this->serviceName = 'prediction';
+
+    $this->hostedmodels = new Google_Service_Prediction_Hostedmodels_Resource(
+        $this,
+        $this->serviceName,
+        'hostedmodels',
+        array(
+          'methods' => array(
+            'predict' => array(
+              'path' => '{project}/hostedmodels/{hostedModelName}/predict',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'hostedModelName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->trainedmodels = new Google_Service_Prediction_Trainedmodels_Resource(
+        $this,
+        $this->serviceName,
+        'trainedmodels',
+        array(
+          'methods' => array(
+            'analyze' => array(
+              'path' => '{project}/trainedmodels/{id}/analyze',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/trainedmodels/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/trainedmodels/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/trainedmodels',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/trainedmodels/list',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'predict' => array(
+              'path' => '{project}/trainedmodels/{id}/predict',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{project}/trainedmodels/{id}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "hostedmodels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $predictionService = new Google_Service_Prediction(...);
+ *   $hostedmodels = $predictionService->hostedmodels;
+ *  </code>
+ */
+class Google_Service_Prediction_Hostedmodels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Submit input and request an output against a hosted model.
+   * (hostedmodels.predict)
+   *
+   * @param string $project The project associated with the model.
+   * @param string $hostedModelName The name of a hosted model.
+   * @param Google_Input $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Prediction_Output
+   */
+  public function predict($project, $hostedModelName, Google_Service_Prediction_Input $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'hostedModelName' => $hostedModelName, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('predict', array($params), "Google_Service_Prediction_Output");
+  }
+}
+
+/**
+ * The "trainedmodels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $predictionService = new Google_Service_Prediction(...);
+ *   $trainedmodels = $predictionService->trainedmodels;
+ *  </code>
+ */
+class Google_Service_Prediction_Trainedmodels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get analysis of the model and the data the model was trained on.
+   * (trainedmodels.analyze)
+   *
+   * @param string $project The project associated with the model.
+   * @param string $id The unique name for the predictive model.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Prediction_Analyze
+   */
+  public function analyze($project, $id, $optParams = array())
+  {
+    $params = array('project' => $project, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('analyze', array($params), "Google_Service_Prediction_Analyze");
+  }
+
+  /**
+   * Delete a trained model. (trainedmodels.delete)
+   *
+   * @param string $project The project associated with the model.
+   * @param string $id The unique name for the predictive model.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($project, $id, $optParams = array())
+  {
+    $params = array('project' => $project, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Check training status of your model. (trainedmodels.get)
+   *
+   * @param string $project The project associated with the model.
+   * @param string $id The unique name for the predictive model.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Prediction_Insert2
+   */
+  public function get($project, $id, $optParams = array())
+  {
+    $params = array('project' => $project, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Prediction_Insert2");
+  }
+
+  /**
+   * Train a Prediction API model. (trainedmodels.insert)
+   *
+   * @param string $project The project associated with the model.
+   * @param Google_Insert $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Prediction_Insert2
+   */
+  public function insert($project, Google_Service_Prediction_Insert $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Prediction_Insert2");
+  }
+
+  /**
+   * List available models. (trainedmodels.listTrainedmodels)
+   *
+   * @param string $project The project associated with the model.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Pagination token.
+   * @opt_param string maxResults Maximum number of results to return.
+   * @return Google_Service_Prediction_PredictionList
+   */
+  public function listTrainedmodels($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Prediction_PredictionList");
+  }
+
+  /**
+   * Submit model id and request a prediction. (trainedmodels.predict)
+   *
+   * @param string $project The project associated with the model.
+   * @param string $id The unique name for the predictive model.
+   * @param Google_Input $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Prediction_Output
+   */
+  public function predict($project, $id, Google_Service_Prediction_Input $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('predict', array($params), "Google_Service_Prediction_Output");
+  }
+
+  /**
+   * Add new data to a trained model. (trainedmodels.update)
+   *
+   * @param string $project The project associated with the model.
+   * @param string $id The unique name for the predictive model.
+   * @param Google_Update $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Prediction_Insert2
+   */
+  public function update($project, $id, Google_Service_Prediction_Update $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Prediction_Insert2");
+  }
+}
+
+
+
+
+class Google_Service_Prediction_Analyze extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $dataDescriptionType = 'Google_Service_Prediction_AnalyzeDataDescription';
+  protected $dataDescriptionDataType = '';
+  public $errors;
+  public $id;
+  public $kind;
+  protected $modelDescriptionType = 'Google_Service_Prediction_AnalyzeModelDescription';
+  protected $modelDescriptionDataType = '';
+  public $selfLink;
+
+
+  public function setDataDescription(Google_Service_Prediction_AnalyzeDataDescription $dataDescription)
+  {
+    $this->dataDescription = $dataDescription;
+  }
+  public function getDataDescription()
+  {
+    return $this->dataDescription;
+  }
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setModelDescription(Google_Service_Prediction_AnalyzeModelDescription $modelDescription)
+  {
+    $this->modelDescription = $modelDescription;
+  }
+  public function getModelDescription()
+  {
+    return $this->modelDescription;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Prediction_AnalyzeDataDescription extends Google_Collection
+{
+  protected $collection_key = 'features';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $featuresType = 'Google_Service_Prediction_AnalyzeDataDescriptionFeatures';
+  protected $featuresDataType = 'array';
+  protected $outputFeatureType = 'Google_Service_Prediction_AnalyzeDataDescriptionOutputFeature';
+  protected $outputFeatureDataType = '';
+
+
+  public function setFeatures($features)
+  {
+    $this->features = $features;
+  }
+  public function getFeatures()
+  {
+    return $this->features;
+  }
+  public function setOutputFeature(Google_Service_Prediction_AnalyzeDataDescriptionOutputFeature $outputFeature)
+  {
+    $this->outputFeature = $outputFeature;
+  }
+  public function getOutputFeature()
+  {
+    return $this->outputFeature;
+  }
+}
+
+class Google_Service_Prediction_AnalyzeDataDescriptionFeatures extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $categoricalType = 'Google_Service_Prediction_AnalyzeDataDescriptionFeaturesCategorical';
+  protected $categoricalDataType = '';
+  public $index;
+  protected $numericType = 'Google_Service_Prediction_AnalyzeDataDescriptionFeaturesNumeric';
+  protected $numericDataType = '';
+  protected $textType = 'Google_Service_Prediction_AnalyzeDataDescriptionFeaturesText';
+  protected $textDataType = '';
+
+
+  public function setCategorical(Google_Service_Prediction_AnalyzeDataDescriptionFeaturesCategorical $categorical)
+  {
+    $this->categorical = $categorical;
+  }
+  public function getCategorical()
+  {
+    return $this->categorical;
+  }
+  public function setIndex($index)
+  {
+    $this->index = $index;
+  }
+  public function getIndex()
+  {
+    return $this->index;
+  }
+  public function setNumeric(Google_Service_Prediction_AnalyzeDataDescriptionFeaturesNumeric $numeric)
+  {
+    $this->numeric = $numeric;
+  }
+  public function getNumeric()
+  {
+    return $this->numeric;
+  }
+  public function setText(Google_Service_Prediction_AnalyzeDataDescriptionFeaturesText $text)
+  {
+    $this->text = $text;
+  }
+  public function getText()
+  {
+    return $this->text;
+  }
+}
+
+class Google_Service_Prediction_AnalyzeDataDescriptionFeaturesCategorical extends Google_Collection
+{
+  protected $collection_key = 'values';
+  protected $internal_gapi_mappings = array(
+  );
+  public $count;
+  protected $valuesType = 'Google_Service_Prediction_AnalyzeDataDescriptionFeaturesCategoricalValues';
+  protected $valuesDataType = 'array';
+
+
+  public function setCount($count)
+  {
+    $this->count = $count;
+  }
+  public function getCount()
+  {
+    return $this->count;
+  }
+  public function setValues($values)
+  {
+    $this->values = $values;
+  }
+  public function getValues()
+  {
+    return $this->values;
+  }
+}
+
+class Google_Service_Prediction_AnalyzeDataDescriptionFeaturesCategoricalValues extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $count;
+  public $value;
+
+
+  public function setCount($count)
+  {
+    $this->count = $count;
+  }
+  public function getCount()
+  {
+    return $this->count;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Prediction_AnalyzeDataDescriptionFeaturesNumeric extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $count;
+  public $mean;
+  public $variance;
+
+
+  public function setCount($count)
+  {
+    $this->count = $count;
+  }
+  public function getCount()
+  {
+    return $this->count;
+  }
+  public function setMean($mean)
+  {
+    $this->mean = $mean;
+  }
+  public function getMean()
+  {
+    return $this->mean;
+  }
+  public function setVariance($variance)
+  {
+    $this->variance = $variance;
+  }
+  public function getVariance()
+  {
+    return $this->variance;
+  }
+}
+
+class Google_Service_Prediction_AnalyzeDataDescriptionFeaturesText extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $count;
+
+
+  public function setCount($count)
+  {
+    $this->count = $count;
+  }
+  public function getCount()
+  {
+    return $this->count;
+  }
+}
+
+class Google_Service_Prediction_AnalyzeDataDescriptionOutputFeature extends Google_Collection
+{
+  protected $collection_key = 'text';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $numericType = 'Google_Service_Prediction_AnalyzeDataDescriptionOutputFeatureNumeric';
+  protected $numericDataType = '';
+  protected $textType = 'Google_Service_Prediction_AnalyzeDataDescriptionOutputFeatureText';
+  protected $textDataType = 'array';
+
+
+  public function setNumeric(Google_Service_Prediction_AnalyzeDataDescriptionOutputFeatureNumeric $numeric)
+  {
+    $this->numeric = $numeric;
+  }
+  public function getNumeric()
+  {
+    return $this->numeric;
+  }
+  public function setText($text)
+  {
+    $this->text = $text;
+  }
+  public function getText()
+  {
+    return $this->text;
+  }
+}
+
+class Google_Service_Prediction_AnalyzeDataDescriptionOutputFeatureNumeric extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $count;
+  public $mean;
+  public $variance;
+
+
+  public function setCount($count)
+  {
+    $this->count = $count;
+  }
+  public function getCount()
+  {
+    return $this->count;
+  }
+  public function setMean($mean)
+  {
+    $this->mean = $mean;
+  }
+  public function getMean()
+  {
+    return $this->mean;
+  }
+  public function setVariance($variance)
+  {
+    $this->variance = $variance;
+  }
+  public function getVariance()
+  {
+    return $this->variance;
+  }
+}
+
+class Google_Service_Prediction_AnalyzeDataDescriptionOutputFeatureText extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $count;
+  public $value;
+
+
+  public function setCount($count)
+  {
+    $this->count = $count;
+  }
+  public function getCount()
+  {
+    return $this->count;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Prediction_AnalyzeErrors extends Google_Model
+{
+}
+
+class Google_Service_Prediction_AnalyzeModelDescription extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $confusionMatrix;
+  public $confusionMatrixRowTotals;
+  protected $modelinfoType = 'Google_Service_Prediction_Insert2';
+  protected $modelinfoDataType = '';
+
+
+  public function setConfusionMatrix($confusionMatrix)
+  {
+    $this->confusionMatrix = $confusionMatrix;
+  }
+  public function getConfusionMatrix()
+  {
+    return $this->confusionMatrix;
+  }
+  public function setConfusionMatrixRowTotals($confusionMatrixRowTotals)
+  {
+    $this->confusionMatrixRowTotals = $confusionMatrixRowTotals;
+  }
+  public function getConfusionMatrixRowTotals()
+  {
+    return $this->confusionMatrixRowTotals;
+  }
+  public function setModelinfo(Google_Service_Prediction_Insert2 $modelinfo)
+  {
+    $this->modelinfo = $modelinfo;
+  }
+  public function getModelinfo()
+  {
+    return $this->modelinfo;
+  }
+}
+
+class Google_Service_Prediction_AnalyzeModelDescriptionConfusionMatrix extends Google_Model
+{
+}
+
+class Google_Service_Prediction_AnalyzeModelDescriptionConfusionMatrixElement extends Google_Model
+{
+}
+
+class Google_Service_Prediction_AnalyzeModelDescriptionConfusionMatrixRowTotals extends Google_Model
+{
+}
+
+class Google_Service_Prediction_Input extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $inputType = 'Google_Service_Prediction_InputInput';
+  protected $inputDataType = '';
+
+
+  public function setInput(Google_Service_Prediction_InputInput $input)
+  {
+    $this->input = $input;
+  }
+  public function getInput()
+  {
+    return $this->input;
+  }
+}
+
+class Google_Service_Prediction_InputInput extends Google_Collection
+{
+  protected $collection_key = 'csvInstance';
+  protected $internal_gapi_mappings = array(
+  );
+  public $csvInstance;
+
+
+  public function setCsvInstance($csvInstance)
+  {
+    $this->csvInstance = $csvInstance;
+  }
+  public function getCsvInstance()
+  {
+    return $this->csvInstance;
+  }
+}
+
+class Google_Service_Prediction_Insert extends Google_Collection
+{
+  protected $collection_key = 'utility';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $modelType;
+  public $sourceModel;
+  public $storageDataLocation;
+  public $storagePMMLLocation;
+  public $storagePMMLModelLocation;
+  protected $trainingInstancesType = 'Google_Service_Prediction_InsertTrainingInstances';
+  protected $trainingInstancesDataType = 'array';
+  public $utility;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setModelType($modelType)
+  {
+    $this->modelType = $modelType;
+  }
+  public function getModelType()
+  {
+    return $this->modelType;
+  }
+  public function setSourceModel($sourceModel)
+  {
+    $this->sourceModel = $sourceModel;
+  }
+  public function getSourceModel()
+  {
+    return $this->sourceModel;
+  }
+  public function setStorageDataLocation($storageDataLocation)
+  {
+    $this->storageDataLocation = $storageDataLocation;
+  }
+  public function getStorageDataLocation()
+  {
+    return $this->storageDataLocation;
+  }
+  public function setStoragePMMLLocation($storagePMMLLocation)
+  {
+    $this->storagePMMLLocation = $storagePMMLLocation;
+  }
+  public function getStoragePMMLLocation()
+  {
+    return $this->storagePMMLLocation;
+  }
+  public function setStoragePMMLModelLocation($storagePMMLModelLocation)
+  {
+    $this->storagePMMLModelLocation = $storagePMMLModelLocation;
+  }
+  public function getStoragePMMLModelLocation()
+  {
+    return $this->storagePMMLModelLocation;
+  }
+  public function setTrainingInstances($trainingInstances)
+  {
+    $this->trainingInstances = $trainingInstances;
+  }
+  public function getTrainingInstances()
+  {
+    return $this->trainingInstances;
+  }
+  public function setUtility($utility)
+  {
+    $this->utility = $utility;
+  }
+  public function getUtility()
+  {
+    return $this->utility;
+  }
+}
+
+class Google_Service_Prediction_Insert2 extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $created;
+  public $id;
+  public $kind;
+  protected $modelInfoType = 'Google_Service_Prediction_Insert2ModelInfo';
+  protected $modelInfoDataType = '';
+  public $modelType;
+  public $selfLink;
+  public $storageDataLocation;
+  public $storagePMMLLocation;
+  public $storagePMMLModelLocation;
+  public $trainingComplete;
+  public $trainingStatus;
+
+
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setModelInfo(Google_Service_Prediction_Insert2ModelInfo $modelInfo)
+  {
+    $this->modelInfo = $modelInfo;
+  }
+  public function getModelInfo()
+  {
+    return $this->modelInfo;
+  }
+  public function setModelType($modelType)
+  {
+    $this->modelType = $modelType;
+  }
+  public function getModelType()
+  {
+    return $this->modelType;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStorageDataLocation($storageDataLocation)
+  {
+    $this->storageDataLocation = $storageDataLocation;
+  }
+  public function getStorageDataLocation()
+  {
+    return $this->storageDataLocation;
+  }
+  public function setStoragePMMLLocation($storagePMMLLocation)
+  {
+    $this->storagePMMLLocation = $storagePMMLLocation;
+  }
+  public function getStoragePMMLLocation()
+  {
+    return $this->storagePMMLLocation;
+  }
+  public function setStoragePMMLModelLocation($storagePMMLModelLocation)
+  {
+    $this->storagePMMLModelLocation = $storagePMMLModelLocation;
+  }
+  public function getStoragePMMLModelLocation()
+  {
+    return $this->storagePMMLModelLocation;
+  }
+  public function setTrainingComplete($trainingComplete)
+  {
+    $this->trainingComplete = $trainingComplete;
+  }
+  public function getTrainingComplete()
+  {
+    return $this->trainingComplete;
+  }
+  public function setTrainingStatus($trainingStatus)
+  {
+    $this->trainingStatus = $trainingStatus;
+  }
+  public function getTrainingStatus()
+  {
+    return $this->trainingStatus;
+  }
+}
+
+class Google_Service_Prediction_Insert2ModelInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $classWeightedAccuracy;
+  public $classificationAccuracy;
+  public $meanSquaredError;
+  public $modelType;
+  public $numberInstances;
+  public $numberLabels;
+
+
+  public function setClassWeightedAccuracy($classWeightedAccuracy)
+  {
+    $this->classWeightedAccuracy = $classWeightedAccuracy;
+  }
+  public function getClassWeightedAccuracy()
+  {
+    return $this->classWeightedAccuracy;
+  }
+  public function setClassificationAccuracy($classificationAccuracy)
+  {
+    $this->classificationAccuracy = $classificationAccuracy;
+  }
+  public function getClassificationAccuracy()
+  {
+    return $this->classificationAccuracy;
+  }
+  public function setMeanSquaredError($meanSquaredError)
+  {
+    $this->meanSquaredError = $meanSquaredError;
+  }
+  public function getMeanSquaredError()
+  {
+    return $this->meanSquaredError;
+  }
+  public function setModelType($modelType)
+  {
+    $this->modelType = $modelType;
+  }
+  public function getModelType()
+  {
+    return $this->modelType;
+  }
+  public function setNumberInstances($numberInstances)
+  {
+    $this->numberInstances = $numberInstances;
+  }
+  public function getNumberInstances()
+  {
+    return $this->numberInstances;
+  }
+  public function setNumberLabels($numberLabels)
+  {
+    $this->numberLabels = $numberLabels;
+  }
+  public function getNumberLabels()
+  {
+    return $this->numberLabels;
+  }
+}
+
+class Google_Service_Prediction_InsertTrainingInstances extends Google_Collection
+{
+  protected $collection_key = 'csvInstance';
+  protected $internal_gapi_mappings = array(
+  );
+  public $csvInstance;
+  public $output;
+
+
+  public function setCsvInstance($csvInstance)
+  {
+    $this->csvInstance = $csvInstance;
+  }
+  public function getCsvInstance()
+  {
+    return $this->csvInstance;
+  }
+  public function setOutput($output)
+  {
+    $this->output = $output;
+  }
+  public function getOutput()
+  {
+    return $this->output;
+  }
+}
+
+class Google_Service_Prediction_InsertUtility extends Google_Model
+{
+}
+
+class Google_Service_Prediction_Output extends Google_Collection
+{
+  protected $collection_key = 'outputMulti';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $outputLabel;
+  protected $outputMultiType = 'Google_Service_Prediction_OutputOutputMulti';
+  protected $outputMultiDataType = 'array';
+  public $outputValue;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setOutputLabel($outputLabel)
+  {
+    $this->outputLabel = $outputLabel;
+  }
+  public function getOutputLabel()
+  {
+    return $this->outputLabel;
+  }
+  public function setOutputMulti($outputMulti)
+  {
+    $this->outputMulti = $outputMulti;
+  }
+  public function getOutputMulti()
+  {
+    return $this->outputMulti;
+  }
+  public function setOutputValue($outputValue)
+  {
+    $this->outputValue = $outputValue;
+  }
+  public function getOutputValue()
+  {
+    return $this->outputValue;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Prediction_OutputOutputMulti extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $label;
+  public $score;
+
+
+  public function setLabel($label)
+  {
+    $this->label = $label;
+  }
+  public function getLabel()
+  {
+    return $this->label;
+  }
+  public function setScore($score)
+  {
+    $this->score = $score;
+  }
+  public function getScore()
+  {
+    return $this->score;
+  }
+}
+
+class Google_Service_Prediction_PredictionList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Prediction_Insert2';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Prediction_Update extends Google_Collection
+{
+  protected $collection_key = 'csvInstance';
+  protected $internal_gapi_mappings = array(
+  );
+  public $csvInstance;
+  public $output;
+
+
+  public function setCsvInstance($csvInstance)
+  {
+    $this->csvInstance = $csvInstance;
+  }
+  public function getCsvInstance()
+  {
+    return $this->csvInstance;
+  }
+  public function setOutput($output)
+  {
+    $this->output = $output;
+  }
+  public function getOutput()
+  {
+    return $this->output;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Proximitybeacon.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Proximitybeacon.php
@@ -1,0 +1,1208 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Proximitybeacon (v1beta1).
+ *
+ * <p>
+ * This API provides services to register, manage, index, and search beacons.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/beacons/proximity/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Proximitybeacon extends Google_Service
+{
+
+
+  public $beaconinfo;
+  public $beacons;
+  public $beacons_attachments;
+  public $beacons_diagnostics;
+  public $namespaces;
+  
+
+  /**
+   * Constructs the internal representation of the Proximitybeacon service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://proximitybeacon.googleapis.com/';
+    $this->servicePath = '';
+    $this->version = 'v1beta1';
+    $this->serviceName = 'proximitybeacon';
+
+    $this->beaconinfo = new Google_Service_Proximitybeacon_Beaconinfo_Resource(
+        $this,
+        $this->serviceName,
+        'beaconinfo',
+        array(
+          'methods' => array(
+            'getforobserved' => array(
+              'path' => 'v1beta1/beaconinfo:getforobserved',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->beacons = new Google_Service_Proximitybeacon_Beacons_Resource(
+        $this,
+        $this->serviceName,
+        'beacons',
+        array(
+          'methods' => array(
+            'activate' => array(
+              'path' => 'v1beta1/{+beaconName}:activate',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'beaconName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'deactivate' => array(
+              'path' => 'v1beta1/{+beaconName}:deactivate',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'beaconName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'decommission' => array(
+              'path' => 'v1beta1/{+beaconName}:decommission',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'beaconName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v1beta1/{+beaconName}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'beaconName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1beta1/beacons',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'q' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'register' => array(
+              'path' => 'v1beta1/beacons:register',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'update' => array(
+              'path' => 'v1beta1/{+beaconName}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'beaconName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->beacons_attachments = new Google_Service_Proximitybeacon_BeaconsAttachments_Resource(
+        $this,
+        $this->serviceName,
+        'attachments',
+        array(
+          'methods' => array(
+            'batchDelete' => array(
+              'path' => 'v1beta1/{+beaconName}/attachments:batchDelete',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'beaconName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'namespacedType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'create' => array(
+              'path' => 'v1beta1/{+beaconName}/attachments',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'beaconName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'v1beta1/{+attachmentName}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'attachmentName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1beta1/{+beaconName}/attachments',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'beaconName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'namespacedType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->beacons_diagnostics = new Google_Service_Proximitybeacon_BeaconsDiagnostics_Resource(
+        $this,
+        $this->serviceName,
+        'diagnostics',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'v1beta1/{+beaconName}/diagnostics',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'beaconName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'alertFilter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->namespaces = new Google_Service_Proximitybeacon_Namespaces_Resource(
+        $this,
+        $this->serviceName,
+        'namespaces',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'v1beta1/namespaces',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "beaconinfo" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $proximitybeaconService = new Google_Service_Proximitybeacon(...);
+ *   $beaconinfo = $proximitybeaconService->beaconinfo;
+ *  </code>
+ */
+class Google_Service_Proximitybeacon_Beaconinfo_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Given one or more beacon observations, returns any beacon information and
+   * attachments accessible to your application. (beaconinfo.getforobserved)
+   *
+   * @param Google_GetInfoForObservedBeaconsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Proximitybeacon_GetInfoForObservedBeaconsResponse
+   */
+  public function getforobserved(Google_Service_Proximitybeacon_GetInfoForObservedBeaconsRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('getforobserved', array($params), "Google_Service_Proximitybeacon_GetInfoForObservedBeaconsResponse");
+  }
+}
+
+/**
+ * The "beacons" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $proximitybeaconService = new Google_Service_Proximitybeacon(...);
+ *   $beacons = $proximitybeaconService->beacons;
+ *  </code>
+ */
+class Google_Service_Proximitybeacon_Beacons_Resource extends Google_Service_Resource
+{
+
+  /**
+   * (Re)activates a beacon. A beacon that is active will return information and
+   * attachment data when queried via `beaconinfo.getforobserved`. Calling this
+   * method on an already active beacon will do nothing (but will return a
+   * successful response code). (beacons.activate)
+   *
+   * @param string $beaconName The beacon to activate. Required.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Proximitybeacon_Empty
+   */
+  public function activate($beaconName, $optParams = array())
+  {
+    $params = array('beaconName' => $beaconName);
+    $params = array_merge($params, $optParams);
+    return $this->call('activate', array($params), "Google_Service_Proximitybeacon_Empty");
+  }
+
+  /**
+   * Deactivates a beacon. Once deactivated, the API will not return information
+   * nor attachment data for the beacon when queried via
+   * `beaconinfo.getforobserved`. Calling this method on an already inactive
+   * beacon will do nothing (but will return a successful response code).
+   * (beacons.deactivate)
+   *
+   * @param string $beaconName The beacon name of this beacon.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Proximitybeacon_Empty
+   */
+  public function deactivate($beaconName, $optParams = array())
+  {
+    $params = array('beaconName' => $beaconName);
+    $params = array_merge($params, $optParams);
+    return $this->call('deactivate', array($params), "Google_Service_Proximitybeacon_Empty");
+  }
+
+  /**
+   * Decommissions the specified beacon in the service. This beacon will no longer
+   * be returned from `beaconinfo.getforobserved`. This operation is permanent --
+   * you will not be able to re-register a beacon with this ID again.
+   * (beacons.decommission)
+   *
+   * @param string $beaconName Beacon that should be decommissioned. Required.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Proximitybeacon_Empty
+   */
+  public function decommission($beaconName, $optParams = array())
+  {
+    $params = array('beaconName' => $beaconName);
+    $params = array_merge($params, $optParams);
+    return $this->call('decommission', array($params), "Google_Service_Proximitybeacon_Empty");
+  }
+
+  /**
+   * Returns detailed information about the specified beacon. (beacons.get)
+   *
+   * @param string $beaconName Beacon that is requested.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Proximitybeacon_Beacon
+   */
+  public function get($beaconName, $optParams = array())
+  {
+    $params = array('beaconName' => $beaconName);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Proximitybeacon_Beacon");
+  }
+
+  /**
+   * Searches the beacon registry for beacons that match the given search
+   * criteria. Only those beacons that the client has permission to list will be
+   * returned. (beacons.listBeacons)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string q Filter query string that supports the following field
+   * filters: * `description:""` For example: `description:"Room 3"` Returns
+   * beacons whose description matches tokens in the string "Room 3" (not
+   * necessarily that exact string). The string must be double-quoted. * `status:`
+   * For example: `status:active` Returns beacons whose status matches the given
+   * value. Values must be one of the Beacon.Status enum values (case
+   * insensitive). Accepts multiple filters which will be combined with OR logic.
+   * * `stability:` For example: `stability:mobile` Returns beacons whose expected
+   * stability matches the given value. Values must be one of the Beacon.Stability
+   * enum values (case insensitive). Accepts multiple filters which will be
+   * combined with OR logic. * `place_id:""` For example:
+   * `place_id:"ChIJVSZzVR8FdkgRXGmmm6SslKw="` Returns beacons explicitly
+   * registered at the given place, expressed as a Place ID obtained from [Google
+   * Places API](/places/place-id). Does not match places inside the given place.
+   * Does not consider the beacon's actual location (which may be different from
+   * its registered place). Accepts multiple filters that will be combined with OR
+   * logic. The place ID must be double-quoted. * `registration_time[|=]` For
+   * example: `registration_time>=1433116800` Returns beacons whose registration
+   * time matches the given filter. Supports the operators: , =. Timestamp must be
+   * expressed as an integer number of seconds since midnight January 1, 1970 UTC.
+   * Accepts at most two filters that will be combined with AND logic, to support
+   * "between" semantics. If more than two are supplied, the latter ones are
+   * ignored. * `lat: lng: radius:` For example: `lat:51.1232343 lng:-1.093852
+   * radius:1000` Returns beacons whose registered location is within the given
+   * circle. When any of these fields are given, all are required. Latitude and
+   * longitude must be decimal degrees between -90.0 and 90.0 and between -180.0
+   * and 180.0 respectively. Radius must be an integer number of meters less than
+   * 1,000,000 (1000 km). * `property:"="` For example: `property:"battery-
+   * type=CR2032"` Returns beacons which have a property of the given name and
+   * value. Supports multiple filters which will be combined with OR logic. The
+   * entire name=value string must be double-quoted as one string. *
+   * `attachment_type:""` For example: `attachment_type:"my-namespace/my-type"`
+   * Returns beacons having at least one attachment of the given namespaced type.
+   * Supports "any within this namespace" via the partial wildcard syntax: "my-
+   * namespace". Supports multiple filters which will be combined with OR logic.
+   * The string must be double-quoted. Multiple filters on the same field are
+   * combined with OR logic (except registration_time which is combined with AND
+   * logic). Multiple filters on different fields are combined with AND logic.
+   * Filters should be separated by spaces. As with any HTTP query string
+   * parameter, the whole filter expression must be URL-encoded. Example REST
+   * request: `GET
+   * /v1beta1/beacons?q=status:active%20lat:51.123%20lng:-1.095%20radius:1000`
+   * @opt_param string pageToken A pagination token obtained from a previous
+   * request to list beacons.
+   * @opt_param int pageSize The maximum number of records to return for this
+   * request, up to a server-defined upper limit.
+   * @return Google_Service_Proximitybeacon_ListBeaconsResponse
+   */
+  public function listBeacons($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Proximitybeacon_ListBeaconsResponse");
+  }
+
+  /**
+   * Registers a previously unregistered beacon given its `advertisedId`. These
+   * IDs are unique within the system. An ID can be registered only once.
+   * (beacons.register)
+   *
+   * @param Google_Beacon $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Proximitybeacon_Beacon
+   */
+  public function register(Google_Service_Proximitybeacon_Beacon $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('register', array($params), "Google_Service_Proximitybeacon_Beacon");
+  }
+
+  /**
+   * Updates the information about the specified beacon. **Any field that you do
+   * not populate in the submitted beacon will be permanently erased**, so you
+   * should follow the "read, modify, write" pattern to avoid inadvertently
+   * destroying data. Changes to the beacon status via this method will be
+   * silently ignored. To update beacon status, use the separate methods on this
+   * API for (de)activation and decommissioning. (beacons.update)
+   *
+   * @param string $beaconName Resource name of this beacon. A beacon name has the
+   * format "beacons/N!beaconId" where the beaconId is the base16 ID broadcast by
+   * the beacon and N is a code for the beacon's type. Possible values are `3` for
+   * Eddystone, `1` for iBeacon, or `5` for AltBeacon. This field must be left
+   * empty when registering. After reading a beacon, clients can use the name for
+   * future operations.
+   * @param Google_Beacon $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Proximitybeacon_Beacon
+   */
+  public function update($beaconName, Google_Service_Proximitybeacon_Beacon $postBody, $optParams = array())
+  {
+    $params = array('beaconName' => $beaconName, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Proximitybeacon_Beacon");
+  }
+}
+
+/**
+ * The "attachments" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $proximitybeaconService = new Google_Service_Proximitybeacon(...);
+ *   $attachments = $proximitybeaconService->attachments;
+ *  </code>
+ */
+class Google_Service_Proximitybeacon_BeaconsAttachments_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes multiple attachments on a given beacon. This operation is permanent
+   * and cannot be undone. You can optionally specify `namespacedType` to choose
+   * which attachments should be deleted. If you do not specify `namespacedType`,
+   * all your attachments on the given beacon will be deleted. You also may
+   * explicitly specify `*` to delete all. (attachments.batchDelete)
+   *
+   * @param string $beaconName The beacon whose attachments are to be deleted.
+   * Required.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string namespacedType Specifies the namespace and type of
+   * attachments to delete in `namespace/type` format. Accepts `*` to specify "all
+   * types in all namespaces". Optional.
+   * @return Google_Service_Proximitybeacon_DeleteAttachmentsResponse
+   */
+  public function batchDelete($beaconName, $optParams = array())
+  {
+    $params = array('beaconName' => $beaconName);
+    $params = array_merge($params, $optParams);
+    return $this->call('batchDelete', array($params), "Google_Service_Proximitybeacon_DeleteAttachmentsResponse");
+  }
+
+  /**
+   * Associates the given data with the specified beacon. Attachment data must
+   * contain two parts: - A namespaced type.  - The actual attachment data itself.
+   * The namespaced type consists of two parts, the namespace and the type. The
+   * namespace must be one of the values returned by the `namespaces` endpoint,
+   * while the type can be a string of any characters except for the forward slash
+   * (`/`) up to 100 characters in length. Attachment data can be up to 1024 bytes
+   * long. (attachments.create)
+   *
+   * @param string $beaconName The beacon on which the attachment should be
+   * created. Required.
+   * @param Google_BeaconAttachment $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Proximitybeacon_BeaconAttachment
+   */
+  public function create($beaconName, Google_Service_Proximitybeacon_BeaconAttachment $postBody, $optParams = array())
+  {
+    $params = array('beaconName' => $beaconName, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Proximitybeacon_BeaconAttachment");
+  }
+
+  /**
+   * Deletes the specified attachment for the given beacon. Each attachment has a
+   * unique attachment name (`attachmentName`) which is returned when you fetch
+   * the attachment data via this API. You specify this with the delete request to
+   * control which attachment is removed. This operation cannot be undone.
+   * (attachments.delete)
+   *
+   * @param string $attachmentName The attachment name (`attachmentName`) of the
+   * attachment to remove. For example:
+   * `beacons/3!893737abc9/attachments/c5e937-af0-494-959-ec49d12738` Required.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Proximitybeacon_Empty
+   */
+  public function delete($attachmentName, $optParams = array())
+  {
+    $params = array('attachmentName' => $attachmentName);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Proximitybeacon_Empty");
+  }
+
+  /**
+   * Returns the attachments for the specified beacon that match the specified
+   * namespaced-type pattern. To control which namespaced types are returned, you
+   * add the `namespacedType` query parameter to the request. You must either use
+   * `*`, to return all attachments, or the namespace must be one of the ones
+   * returned from the `namespaces` endpoint. (attachments.listBeaconsAttachments)
+   *
+   * @param string $beaconName The beacon whose attachments are to be fetched.
+   * Required.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string namespacedType Specifies the namespace and type of
+   * attachment to include in response in namespace/type format. Accepts `*` to
+   * specify "all types in all namespaces".
+   * @return Google_Service_Proximitybeacon_ListBeaconAttachmentsResponse
+   */
+  public function listBeaconsAttachments($beaconName, $optParams = array())
+  {
+    $params = array('beaconName' => $beaconName);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Proximitybeacon_ListBeaconAttachmentsResponse");
+  }
+}
+/**
+ * The "diagnostics" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $proximitybeaconService = new Google_Service_Proximitybeacon(...);
+ *   $diagnostics = $proximitybeaconService->diagnostics;
+ *  </code>
+ */
+class Google_Service_Proximitybeacon_BeaconsDiagnostics_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List the diagnostics for a single beacon. You can also list diagnostics for
+   * all the beacons owned by your Google Developers Console project by using the
+   * beacon name `beacons/-`. (diagnostics.listBeaconsDiagnostics)
+   *
+   * @param string $beaconName Beacon that the diagnostics are for.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Requests results that occur after the
+   * `page_token`, obtained from the response to a previous request. Optional.
+   * @opt_param string alertFilter Requests only beacons that have the given
+   * alert. For example, to find beacons that have low batteries use
+   * `alert_filter=LOW_BATTERY`.
+   * @opt_param int pageSize Specifies the maximum number of results to return.
+   * Defaults to 10. Maximum 1000. Optional.
+   * @return Google_Service_Proximitybeacon_ListDiagnosticsResponse
+   */
+  public function listBeaconsDiagnostics($beaconName, $optParams = array())
+  {
+    $params = array('beaconName' => $beaconName);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Proximitybeacon_ListDiagnosticsResponse");
+  }
+}
+
+/**
+ * The "namespaces" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $proximitybeaconService = new Google_Service_Proximitybeacon(...);
+ *   $namespaces = $proximitybeaconService->namespaces;
+ *  </code>
+ */
+class Google_Service_Proximitybeacon_Namespaces_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Lists all attachment namespaces owned by your Google Developers Console
+   * project. Attachment data associated with a beacon must include a namespaced
+   * type, and the namespace must be owned by your project.
+   * (namespaces.listNamespaces)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Proximitybeacon_ListNamespacesResponse
+   */
+  public function listNamespaces($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Proximitybeacon_ListNamespacesResponse");
+  }
+}
+
+
+
+
+class Google_Service_Proximitybeacon_AdvertisedId extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $type;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Proximitybeacon_AttachmentInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $data;
+  public $namespacedType;
+
+
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setNamespacedType($namespacedType)
+  {
+    $this->namespacedType = $namespacedType;
+  }
+  public function getNamespacedType()
+  {
+    return $this->namespacedType;
+  }
+}
+
+class Google_Service_Proximitybeacon_Beacon extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $advertisedIdType = 'Google_Service_Proximitybeacon_AdvertisedId';
+  protected $advertisedIdDataType = '';
+  public $beaconName;
+  public $description;
+  public $expectedStability;
+  protected $indoorLevelType = 'Google_Service_Proximitybeacon_IndoorLevel';
+  protected $indoorLevelDataType = '';
+  protected $latLngType = 'Google_Service_Proximitybeacon_LatLng';
+  protected $latLngDataType = '';
+  public $placeId;
+  public $properties;
+  public $status;
+
+
+  public function setAdvertisedId(Google_Service_Proximitybeacon_AdvertisedId $advertisedId)
+  {
+    $this->advertisedId = $advertisedId;
+  }
+  public function getAdvertisedId()
+  {
+    return $this->advertisedId;
+  }
+  public function setBeaconName($beaconName)
+  {
+    $this->beaconName = $beaconName;
+  }
+  public function getBeaconName()
+  {
+    return $this->beaconName;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setExpectedStability($expectedStability)
+  {
+    $this->expectedStability = $expectedStability;
+  }
+  public function getExpectedStability()
+  {
+    return $this->expectedStability;
+  }
+  public function setIndoorLevel(Google_Service_Proximitybeacon_IndoorLevel $indoorLevel)
+  {
+    $this->indoorLevel = $indoorLevel;
+  }
+  public function getIndoorLevel()
+  {
+    return $this->indoorLevel;
+  }
+  public function setLatLng(Google_Service_Proximitybeacon_LatLng $latLng)
+  {
+    $this->latLng = $latLng;
+  }
+  public function getLatLng()
+  {
+    return $this->latLng;
+  }
+  public function setPlaceId($placeId)
+  {
+    $this->placeId = $placeId;
+  }
+  public function getPlaceId()
+  {
+    return $this->placeId;
+  }
+  public function setProperties($properties)
+  {
+    $this->properties = $properties;
+  }
+  public function getProperties()
+  {
+    return $this->properties;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_Proximitybeacon_BeaconAttachment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $attachmentName;
+  public $data;
+  public $namespacedType;
+
+
+  public function setAttachmentName($attachmentName)
+  {
+    $this->attachmentName = $attachmentName;
+  }
+  public function getAttachmentName()
+  {
+    return $this->attachmentName;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setNamespacedType($namespacedType)
+  {
+    $this->namespacedType = $namespacedType;
+  }
+  public function getNamespacedType()
+  {
+    return $this->namespacedType;
+  }
+}
+
+class Google_Service_Proximitybeacon_BeaconInfo extends Google_Collection
+{
+  protected $collection_key = 'attachments';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $advertisedIdType = 'Google_Service_Proximitybeacon_AdvertisedId';
+  protected $advertisedIdDataType = '';
+  protected $attachmentsType = 'Google_Service_Proximitybeacon_AttachmentInfo';
+  protected $attachmentsDataType = 'array';
+  public $beaconName;
+  public $description;
+
+
+  public function setAdvertisedId(Google_Service_Proximitybeacon_AdvertisedId $advertisedId)
+  {
+    $this->advertisedId = $advertisedId;
+  }
+  public function getAdvertisedId()
+  {
+    return $this->advertisedId;
+  }
+  public function setAttachments($attachments)
+  {
+    $this->attachments = $attachments;
+  }
+  public function getAttachments()
+  {
+    return $this->attachments;
+  }
+  public function setBeaconName($beaconName)
+  {
+    $this->beaconName = $beaconName;
+  }
+  public function getBeaconName()
+  {
+    return $this->beaconName;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+}
+
+class Google_Service_Proximitybeacon_BeaconProperties extends Google_Model
+{
+}
+
+class Google_Service_Proximitybeacon_Date extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $day;
+  public $month;
+  public $year;
+
+
+  public function setDay($day)
+  {
+    $this->day = $day;
+  }
+  public function getDay()
+  {
+    return $this->day;
+  }
+  public function setMonth($month)
+  {
+    $this->month = $month;
+  }
+  public function getMonth()
+  {
+    return $this->month;
+  }
+  public function setYear($year)
+  {
+    $this->year = $year;
+  }
+  public function getYear()
+  {
+    return $this->year;
+  }
+}
+
+class Google_Service_Proximitybeacon_DeleteAttachmentsResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $numDeleted;
+
+
+  public function setNumDeleted($numDeleted)
+  {
+    $this->numDeleted = $numDeleted;
+  }
+  public function getNumDeleted()
+  {
+    return $this->numDeleted;
+  }
+}
+
+class Google_Service_Proximitybeacon_Diagnostics extends Google_Collection
+{
+  protected $collection_key = 'alerts';
+  protected $internal_gapi_mappings = array(
+  );
+  public $alerts;
+  public $beaconName;
+  protected $estimatedLowBatteryDateType = 'Google_Service_Proximitybeacon_Date';
+  protected $estimatedLowBatteryDateDataType = '';
+
+
+  public function setAlerts($alerts)
+  {
+    $this->alerts = $alerts;
+  }
+  public function getAlerts()
+  {
+    return $this->alerts;
+  }
+  public function setBeaconName($beaconName)
+  {
+    $this->beaconName = $beaconName;
+  }
+  public function getBeaconName()
+  {
+    return $this->beaconName;
+  }
+  public function setEstimatedLowBatteryDate(Google_Service_Proximitybeacon_Date $estimatedLowBatteryDate)
+  {
+    $this->estimatedLowBatteryDate = $estimatedLowBatteryDate;
+  }
+  public function getEstimatedLowBatteryDate()
+  {
+    return $this->estimatedLowBatteryDate;
+  }
+}
+
+class Google_Service_Proximitybeacon_Empty extends Google_Model
+{
+}
+
+class Google_Service_Proximitybeacon_GetInfoForObservedBeaconsRequest extends Google_Collection
+{
+  protected $collection_key = 'observations';
+  protected $internal_gapi_mappings = array(
+  );
+  public $namespacedTypes;
+  protected $observationsType = 'Google_Service_Proximitybeacon_Observation';
+  protected $observationsDataType = 'array';
+
+
+  public function setNamespacedTypes($namespacedTypes)
+  {
+    $this->namespacedTypes = $namespacedTypes;
+  }
+  public function getNamespacedTypes()
+  {
+    return $this->namespacedTypes;
+  }
+  public function setObservations($observations)
+  {
+    $this->observations = $observations;
+  }
+  public function getObservations()
+  {
+    return $this->observations;
+  }
+}
+
+class Google_Service_Proximitybeacon_GetInfoForObservedBeaconsResponse extends Google_Collection
+{
+  protected $collection_key = 'beacons';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $beaconsType = 'Google_Service_Proximitybeacon_BeaconInfo';
+  protected $beaconsDataType = 'array';
+
+
+  public function setBeacons($beacons)
+  {
+    $this->beacons = $beacons;
+  }
+  public function getBeacons()
+  {
+    return $this->beacons;
+  }
+}
+
+class Google_Service_Proximitybeacon_IndoorLevel extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Proximitybeacon_LatLng extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $latitude;
+  public $longitude;
+
+
+  public function setLatitude($latitude)
+  {
+    $this->latitude = $latitude;
+  }
+  public function getLatitude()
+  {
+    return $this->latitude;
+  }
+  public function setLongitude($longitude)
+  {
+    $this->longitude = $longitude;
+  }
+  public function getLongitude()
+  {
+    return $this->longitude;
+  }
+}
+
+class Google_Service_Proximitybeacon_ListBeaconAttachmentsResponse extends Google_Collection
+{
+  protected $collection_key = 'attachments';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $attachmentsType = 'Google_Service_Proximitybeacon_BeaconAttachment';
+  protected $attachmentsDataType = 'array';
+
+
+  public function setAttachments($attachments)
+  {
+    $this->attachments = $attachments;
+  }
+  public function getAttachments()
+  {
+    return $this->attachments;
+  }
+}
+
+class Google_Service_Proximitybeacon_ListBeaconsResponse extends Google_Collection
+{
+  protected $collection_key = 'beacons';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $beaconsType = 'Google_Service_Proximitybeacon_Beacon';
+  protected $beaconsDataType = 'array';
+  public $nextPageToken;
+  public $totalCount;
+
+
+  public function setBeacons($beacons)
+  {
+    $this->beacons = $beacons;
+  }
+  public function getBeacons()
+  {
+    return $this->beacons;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTotalCount($totalCount)
+  {
+    $this->totalCount = $totalCount;
+  }
+  public function getTotalCount()
+  {
+    return $this->totalCount;
+  }
+}
+
+class Google_Service_Proximitybeacon_ListDiagnosticsResponse extends Google_Collection
+{
+  protected $collection_key = 'diagnostics';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $diagnosticsType = 'Google_Service_Proximitybeacon_Diagnostics';
+  protected $diagnosticsDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setDiagnostics($diagnostics)
+  {
+    $this->diagnostics = $diagnostics;
+  }
+  public function getDiagnostics()
+  {
+    return $this->diagnostics;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Proximitybeacon_ListNamespacesResponse extends Google_Collection
+{
+  protected $collection_key = 'namespaces';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $namespacesType = 'Google_Service_Proximitybeacon_ProximitybeaconNamespace';
+  protected $namespacesDataType = 'array';
+
+
+  public function setNamespaces($namespaces)
+  {
+    $this->namespaces = $namespaces;
+  }
+  public function getNamespaces()
+  {
+    return $this->namespaces;
+  }
+}
+
+class Google_Service_Proximitybeacon_Observation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $advertisedIdType = 'Google_Service_Proximitybeacon_AdvertisedId';
+  protected $advertisedIdDataType = '';
+  public $telemetry;
+  public $timestampMs;
+
+
+  public function setAdvertisedId(Google_Service_Proximitybeacon_AdvertisedId $advertisedId)
+  {
+    $this->advertisedId = $advertisedId;
+  }
+  public function getAdvertisedId()
+  {
+    return $this->advertisedId;
+  }
+  public function setTelemetry($telemetry)
+  {
+    $this->telemetry = $telemetry;
+  }
+  public function getTelemetry()
+  {
+    return $this->telemetry;
+  }
+  public function setTimestampMs($timestampMs)
+  {
+    $this->timestampMs = $timestampMs;
+  }
+  public function getTimestampMs()
+  {
+    return $this->timestampMs;
+  }
+}
+
+class Google_Service_Proximitybeacon_ProximitybeaconNamespace extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $namespaceName;
+  public $servingVisibility;
+
+
+  public function setNamespaceName($namespaceName)
+  {
+    $this->namespaceName = $namespaceName;
+  }
+  public function getNamespaceName()
+  {
+    return $this->namespaceName;
+  }
+  public function setServingVisibility($servingVisibility)
+  {
+    $this->servingVisibility = $servingVisibility;
+  }
+  public function getServingVisibility()
+  {
+    return $this->servingVisibility;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Pubsub.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Pubsub.php
@@ -1,0 +1,991 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Pubsub (v1beta1).
+ *
+ * <p>
+ * Provides reliable, many-to-many, asynchronous messaging between applications.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/pubsub/v1beta1" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Pubsub extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+  /** View and manage Pub/Sub topics and subscriptions. */
+  const PUBSUB =
+      "https://www.googleapis.com/auth/pubsub";
+
+  public $subscriptions;
+  public $topics;
+  
+
+  /**
+   * Constructs the internal representation of the Pubsub service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'pubsub/v1beta1/';
+    $this->version = 'v1beta1';
+    $this->serviceName = 'pubsub';
+
+    $this->subscriptions = new Google_Service_Pubsub_Subscriptions_Resource(
+        $this,
+        $this->serviceName,
+        'subscriptions',
+        array(
+          'methods' => array(
+            'acknowledge' => array(
+              'path' => 'subscriptions/acknowledge',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'create' => array(
+              'path' => 'subscriptions',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'delete' => array(
+              'path' => 'subscriptions/{+subscription}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'subscription' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'subscriptions/{+subscription}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'subscription' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'subscriptions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'query' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'modifyAckDeadline' => array(
+              'path' => 'subscriptions/modifyAckDeadline',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'modifyPushConfig' => array(
+              'path' => 'subscriptions/modifyPushConfig',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'pull' => array(
+              'path' => 'subscriptions/pull',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'pullBatch' => array(
+              'path' => 'subscriptions/pullBatch',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->topics = new Google_Service_Pubsub_Topics_Resource(
+        $this,
+        $this->serviceName,
+        'topics',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'topics',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'delete' => array(
+              'path' => 'topics/{+topic}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'topic' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'topics/{+topic}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'topic' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'topics',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'query' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'publish' => array(
+              'path' => 'topics/publish',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'publishBatch' => array(
+              'path' => 'topics/publishBatch',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "subscriptions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $pubsubService = new Google_Service_Pubsub(...);
+ *   $subscriptions = $pubsubService->subscriptions;
+ *  </code>
+ */
+class Google_Service_Pubsub_Subscriptions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Acknowledges a particular received message: the Pub/Sub system can remove the
+   * given message from the subscription. Acknowledging a message whose Ack
+   * deadline has expired may succeed, but the message could have been already
+   * redelivered. Acknowledging a message more than once will not result in an
+   * error. This is only used for messages received via pull.
+   * (subscriptions.acknowledge)
+   *
+   * @param Google_AcknowledgeRequest $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function acknowledge(Google_Service_Pubsub_AcknowledgeRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('acknowledge', array($params));
+  }
+
+  /**
+   * Creates a subscription on a given topic for a given subscriber. If the
+   * subscription already exists, returns ALREADY_EXISTS. If the corresponding
+   * topic doesn't exist, returns NOT_FOUND.
+   *
+   * If the name is not provided in the request, the server will assign a random
+   * name for this subscription on the same project as the topic.
+   * (subscriptions.create)
+   *
+   * @param Google_Subscription $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Pubsub_Subscription
+   */
+  public function create(Google_Service_Pubsub_Subscription $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Pubsub_Subscription");
+  }
+
+  /**
+   * Deletes an existing subscription. All pending messages in the subscription
+   * are immediately dropped. Calls to Pull after deletion will return NOT_FOUND.
+   * (subscriptions.delete)
+   *
+   * @param string $subscription The subscription to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($subscription, $optParams = array())
+  {
+    $params = array('subscription' => $subscription);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets the configuration details of a subscription. (subscriptions.get)
+   *
+   * @param string $subscription The name of the subscription to get.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Pubsub_Subscription
+   */
+  public function get($subscription, $optParams = array())
+  {
+    $params = array('subscription' => $subscription);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Pubsub_Subscription");
+  }
+
+  /**
+   * Lists matching subscriptions. (subscriptions.listSubscriptions)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The value obtained in the last
+   * ListSubscriptionsResponse for continuation.
+   * @opt_param int maxResults Maximum number of subscriptions to return.
+   * @opt_param string query A valid label query expression.
+   * @return Google_Service_Pubsub_ListSubscriptionsResponse
+   */
+  public function listSubscriptions($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Pubsub_ListSubscriptionsResponse");
+  }
+
+  /**
+   * Modifies the Ack deadline for a message received from a pull request.
+   * (subscriptions.modifyAckDeadline)
+   *
+   * @param Google_ModifyAckDeadlineRequest $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function modifyAckDeadline(Google_Service_Pubsub_ModifyAckDeadlineRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('modifyAckDeadline', array($params));
+  }
+
+  /**
+   * Modifies the PushConfig for a specified subscription. This method can be used
+   * to suspend the flow of messages to an endpoint by clearing the PushConfig
+   * field in the request. Messages will be accumulated for delivery even if no
+   * push configuration is defined or while the configuration is modified.
+   * (subscriptions.modifyPushConfig)
+   *
+   * @param Google_ModifyPushConfigRequest $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function modifyPushConfig(Google_Service_Pubsub_ModifyPushConfigRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('modifyPushConfig', array($params));
+  }
+
+  /**
+   * Pulls a single message from the server. If return_immediately is true, and no
+   * messages are available in the subscription, this method returns
+   * FAILED_PRECONDITION. The system is free to return an UNAVAILABLE error if no
+   * messages are available in a reasonable amount of time (to reduce system
+   * load). (subscriptions.pull)
+   *
+   * @param Google_PullRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Pubsub_PullResponse
+   */
+  public function pull(Google_Service_Pubsub_PullRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('pull', array($params), "Google_Service_Pubsub_PullResponse");
+  }
+
+  /**
+   * Pulls messages from the server. Returns an empty list if there are no
+   * messages available in the backlog. The system is free to return UNAVAILABLE
+   * if there are too many pull requests outstanding for the given subscription.
+   * (subscriptions.pullBatch)
+   *
+   * @param Google_PullBatchRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Pubsub_PullBatchResponse
+   */
+  public function pullBatch(Google_Service_Pubsub_PullBatchRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('pullBatch', array($params), "Google_Service_Pubsub_PullBatchResponse");
+  }
+}
+
+/**
+ * The "topics" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $pubsubService = new Google_Service_Pubsub(...);
+ *   $topics = $pubsubService->topics;
+ *  </code>
+ */
+class Google_Service_Pubsub_Topics_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates the given topic with the given name. (topics.create)
+   *
+   * @param Google_Topic $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Pubsub_Topic
+   */
+  public function create(Google_Service_Pubsub_Topic $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Pubsub_Topic");
+  }
+
+  /**
+   * Deletes the topic with the given name. Returns NOT_FOUND if the topic does
+   * not exist. After a topic is deleted, a new topic may be created with the same
+   * name. (topics.delete)
+   *
+   * @param string $topic Name of the topic to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($topic, $optParams = array())
+  {
+    $params = array('topic' => $topic);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets the configuration of a topic. Since the topic only has the name
+   * attribute, this method is only useful to check the existence of a topic. If
+   * other attributes are added in the future, they will be returned here.
+   * (topics.get)
+   *
+   * @param string $topic The name of the topic to get.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Pubsub_Topic
+   */
+  public function get($topic, $optParams = array())
+  {
+    $params = array('topic' => $topic);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Pubsub_Topic");
+  }
+
+  /**
+   * Lists matching topics. (topics.listTopics)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The value obtained in the last ListTopicsResponse
+   * for continuation.
+   * @opt_param int maxResults Maximum number of topics to return.
+   * @opt_param string query A valid label query expression.
+   * @return Google_Service_Pubsub_ListTopicsResponse
+   */
+  public function listTopics($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Pubsub_ListTopicsResponse");
+  }
+
+  /**
+   * Adds a message to the topic. Returns NOT_FOUND if the topic does not exist.
+   * (topics.publish)
+   *
+   * @param Google_PublishRequest $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function publish(Google_Service_Pubsub_PublishRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('publish', array($params));
+  }
+
+  /**
+   * Adds one or more messages to the topic. Returns NOT_FOUND if the topic does
+   * not exist. (topics.publishBatch)
+   *
+   * @param Google_PublishBatchRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Pubsub_PublishBatchResponse
+   */
+  public function publishBatch(Google_Service_Pubsub_PublishBatchRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('publishBatch', array($params), "Google_Service_Pubsub_PublishBatchResponse");
+  }
+}
+
+
+
+
+class Google_Service_Pubsub_AcknowledgeRequest extends Google_Collection
+{
+  protected $collection_key = 'ackId';
+  protected $internal_gapi_mappings = array(
+  );
+  public $ackId;
+  public $subscription;
+
+
+  public function setAckId($ackId)
+  {
+    $this->ackId = $ackId;
+  }
+  public function getAckId()
+  {
+    return $this->ackId;
+  }
+  public function setSubscription($subscription)
+  {
+    $this->subscription = $subscription;
+  }
+  public function getSubscription()
+  {
+    return $this->subscription;
+  }
+}
+
+class Google_Service_Pubsub_Label extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $numValue;
+  public $strValue;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setNumValue($numValue)
+  {
+    $this->numValue = $numValue;
+  }
+  public function getNumValue()
+  {
+    return $this->numValue;
+  }
+  public function setStrValue($strValue)
+  {
+    $this->strValue = $strValue;
+  }
+  public function getStrValue()
+  {
+    return $this->strValue;
+  }
+}
+
+class Google_Service_Pubsub_ListSubscriptionsResponse extends Google_Collection
+{
+  protected $collection_key = 'subscription';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $subscriptionType = 'Google_Service_Pubsub_Subscription';
+  protected $subscriptionDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSubscription($subscription)
+  {
+    $this->subscription = $subscription;
+  }
+  public function getSubscription()
+  {
+    return $this->subscription;
+  }
+}
+
+class Google_Service_Pubsub_ListTopicsResponse extends Google_Collection
+{
+  protected $collection_key = 'topic';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $topicType = 'Google_Service_Pubsub_Topic';
+  protected $topicDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTopic($topic)
+  {
+    $this->topic = $topic;
+  }
+  public function getTopic()
+  {
+    return $this->topic;
+  }
+}
+
+class Google_Service_Pubsub_ModifyAckDeadlineRequest extends Google_Collection
+{
+  protected $collection_key = 'ackIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $ackDeadlineSeconds;
+  public $ackId;
+  public $ackIds;
+  public $subscription;
+
+
+  public function setAckDeadlineSeconds($ackDeadlineSeconds)
+  {
+    $this->ackDeadlineSeconds = $ackDeadlineSeconds;
+  }
+  public function getAckDeadlineSeconds()
+  {
+    return $this->ackDeadlineSeconds;
+  }
+  public function setAckId($ackId)
+  {
+    $this->ackId = $ackId;
+  }
+  public function getAckId()
+  {
+    return $this->ackId;
+  }
+  public function setAckIds($ackIds)
+  {
+    $this->ackIds = $ackIds;
+  }
+  public function getAckIds()
+  {
+    return $this->ackIds;
+  }
+  public function setSubscription($subscription)
+  {
+    $this->subscription = $subscription;
+  }
+  public function getSubscription()
+  {
+    return $this->subscription;
+  }
+}
+
+class Google_Service_Pubsub_ModifyPushConfigRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $pushConfigType = 'Google_Service_Pubsub_PushConfig';
+  protected $pushConfigDataType = '';
+  public $subscription;
+
+
+  public function setPushConfig(Google_Service_Pubsub_PushConfig $pushConfig)
+  {
+    $this->pushConfig = $pushConfig;
+  }
+  public function getPushConfig()
+  {
+    return $this->pushConfig;
+  }
+  public function setSubscription($subscription)
+  {
+    $this->subscription = $subscription;
+  }
+  public function getSubscription()
+  {
+    return $this->subscription;
+  }
+}
+
+class Google_Service_Pubsub_PublishBatchRequest extends Google_Collection
+{
+  protected $collection_key = 'messages';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $messagesType = 'Google_Service_Pubsub_PubsubMessage';
+  protected $messagesDataType = 'array';
+  public $topic;
+
+
+  public function setMessages($messages)
+  {
+    $this->messages = $messages;
+  }
+  public function getMessages()
+  {
+    return $this->messages;
+  }
+  public function setTopic($topic)
+  {
+    $this->topic = $topic;
+  }
+  public function getTopic()
+  {
+    return $this->topic;
+  }
+}
+
+class Google_Service_Pubsub_PublishBatchResponse extends Google_Collection
+{
+  protected $collection_key = 'messageIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $messageIds;
+
+
+  public function setMessageIds($messageIds)
+  {
+    $this->messageIds = $messageIds;
+  }
+  public function getMessageIds()
+  {
+    return $this->messageIds;
+  }
+}
+
+class Google_Service_Pubsub_PublishRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $messageType = 'Google_Service_Pubsub_PubsubMessage';
+  protected $messageDataType = '';
+  public $topic;
+
+
+  public function setMessage(Google_Service_Pubsub_PubsubMessage $message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+  public function setTopic($topic)
+  {
+    $this->topic = $topic;
+  }
+  public function getTopic()
+  {
+    return $this->topic;
+  }
+}
+
+class Google_Service_Pubsub_PubsubEvent extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $deleted;
+  protected $messageType = 'Google_Service_Pubsub_PubsubMessage';
+  protected $messageDataType = '';
+  public $subscription;
+  public $truncated;
+
+
+  public function setDeleted($deleted)
+  {
+    $this->deleted = $deleted;
+  }
+  public function getDeleted()
+  {
+    return $this->deleted;
+  }
+  public function setMessage(Google_Service_Pubsub_PubsubMessage $message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+  public function setSubscription($subscription)
+  {
+    $this->subscription = $subscription;
+  }
+  public function getSubscription()
+  {
+    return $this->subscription;
+  }
+  public function setTruncated($truncated)
+  {
+    $this->truncated = $truncated;
+  }
+  public function getTruncated()
+  {
+    return $this->truncated;
+  }
+}
+
+class Google_Service_Pubsub_PubsubMessage extends Google_Collection
+{
+  protected $collection_key = 'label';
+  protected $internal_gapi_mappings = array(
+  );
+  public $data;
+  protected $labelType = 'Google_Service_Pubsub_Label';
+  protected $labelDataType = 'array';
+  public $messageId;
+
+
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setLabel($label)
+  {
+    $this->label = $label;
+  }
+  public function getLabel()
+  {
+    return $this->label;
+  }
+  public function setMessageId($messageId)
+  {
+    $this->messageId = $messageId;
+  }
+  public function getMessageId()
+  {
+    return $this->messageId;
+  }
+}
+
+class Google_Service_Pubsub_PullBatchRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $maxEvents;
+  public $returnImmediately;
+  public $subscription;
+
+
+  public function setMaxEvents($maxEvents)
+  {
+    $this->maxEvents = $maxEvents;
+  }
+  public function getMaxEvents()
+  {
+    return $this->maxEvents;
+  }
+  public function setReturnImmediately($returnImmediately)
+  {
+    $this->returnImmediately = $returnImmediately;
+  }
+  public function getReturnImmediately()
+  {
+    return $this->returnImmediately;
+  }
+  public function setSubscription($subscription)
+  {
+    $this->subscription = $subscription;
+  }
+  public function getSubscription()
+  {
+    return $this->subscription;
+  }
+}
+
+class Google_Service_Pubsub_PullBatchResponse extends Google_Collection
+{
+  protected $collection_key = 'pullResponses';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $pullResponsesType = 'Google_Service_Pubsub_PullResponse';
+  protected $pullResponsesDataType = 'array';
+
+
+  public function setPullResponses($pullResponses)
+  {
+    $this->pullResponses = $pullResponses;
+  }
+  public function getPullResponses()
+  {
+    return $this->pullResponses;
+  }
+}
+
+class Google_Service_Pubsub_PullRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $returnImmediately;
+  public $subscription;
+
+
+  public function setReturnImmediately($returnImmediately)
+  {
+    $this->returnImmediately = $returnImmediately;
+  }
+  public function getReturnImmediately()
+  {
+    return $this->returnImmediately;
+  }
+  public function setSubscription($subscription)
+  {
+    $this->subscription = $subscription;
+  }
+  public function getSubscription()
+  {
+    return $this->subscription;
+  }
+}
+
+class Google_Service_Pubsub_PullResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $ackId;
+  protected $pubsubEventType = 'Google_Service_Pubsub_PubsubEvent';
+  protected $pubsubEventDataType = '';
+
+
+  public function setAckId($ackId)
+  {
+    $this->ackId = $ackId;
+  }
+  public function getAckId()
+  {
+    return $this->ackId;
+  }
+  public function setPubsubEvent(Google_Service_Pubsub_PubsubEvent $pubsubEvent)
+  {
+    $this->pubsubEvent = $pubsubEvent;
+  }
+  public function getPubsubEvent()
+  {
+    return $this->pubsubEvent;
+  }
+}
+
+class Google_Service_Pubsub_PushConfig extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $pushEndpoint;
+
+
+  public function setPushEndpoint($pushEndpoint)
+  {
+    $this->pushEndpoint = $pushEndpoint;
+  }
+  public function getPushEndpoint()
+  {
+    return $this->pushEndpoint;
+  }
+}
+
+class Google_Service_Pubsub_Subscription extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $ackDeadlineSeconds;
+  public $name;
+  protected $pushConfigType = 'Google_Service_Pubsub_PushConfig';
+  protected $pushConfigDataType = '';
+  public $topic;
+
+
+  public function setAckDeadlineSeconds($ackDeadlineSeconds)
+  {
+    $this->ackDeadlineSeconds = $ackDeadlineSeconds;
+  }
+  public function getAckDeadlineSeconds()
+  {
+    return $this->ackDeadlineSeconds;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPushConfig(Google_Service_Pubsub_PushConfig $pushConfig)
+  {
+    $this->pushConfig = $pushConfig;
+  }
+  public function getPushConfig()
+  {
+    return $this->pushConfig;
+  }
+  public function setTopic($topic)
+  {
+    $this->topic = $topic;
+  }
+  public function getTopic()
+  {
+    return $this->topic;
+  }
+}
+
+class Google_Service_Pubsub_Topic extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/QPXExpress.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/QPXExpress.php
@@ -1,0 +1,1538 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for QPXExpress (v1).
+ *
+ * <p>
+ * Lets you find the least expensive flights between an origin and a
+ * destination.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="http://developers.google.com/qpx-express" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_QPXExpress extends Google_Service
+{
+
+
+  public $trips;
+  
+
+  /**
+   * Constructs the internal representation of the QPXExpress service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'qpxExpress/v1/trips/';
+    $this->version = 'v1';
+    $this->serviceName = 'qpxExpress';
+
+    $this->trips = new Google_Service_QPXExpress_Trips_Resource(
+        $this,
+        $this->serviceName,
+        'trips',
+        array(
+          'methods' => array(
+            'search' => array(
+              'path' => 'search',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "trips" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $qpxExpressService = new Google_Service_QPXExpress(...);
+ *   $trips = $qpxExpressService->trips;
+ *  </code>
+ */
+class Google_Service_QPXExpress_Trips_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns a list of flights. (trips.search)
+   *
+   * @param Google_TripsSearchRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_QPXExpress_TripsSearchResponse
+   */
+  public function search(Google_Service_QPXExpress_TripsSearchRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('search', array($params), "Google_Service_QPXExpress_TripsSearchResponse");
+  }
+}
+
+
+
+
+class Google_Service_QPXExpress_AircraftData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $kind;
+  public $name;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_QPXExpress_AirportData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $city;
+  public $code;
+  public $kind;
+  public $name;
+
+
+  public function setCity($city)
+  {
+    $this->city = $city;
+  }
+  public function getCity()
+  {
+    return $this->city;
+  }
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_QPXExpress_BagDescriptor extends Google_Collection
+{
+  protected $collection_key = 'description';
+  protected $internal_gapi_mappings = array(
+  );
+  public $commercialName;
+  public $count;
+  public $description;
+  public $kind;
+  public $subcode;
+
+
+  public function setCommercialName($commercialName)
+  {
+    $this->commercialName = $commercialName;
+  }
+  public function getCommercialName()
+  {
+    return $this->commercialName;
+  }
+  public function setCount($count)
+  {
+    $this->count = $count;
+  }
+  public function getCount()
+  {
+    return $this->count;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSubcode($subcode)
+  {
+    $this->subcode = $subcode;
+  }
+  public function getSubcode()
+  {
+    return $this->subcode;
+  }
+}
+
+class Google_Service_QPXExpress_CarrierData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $kind;
+  public $name;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_QPXExpress_CityData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $country;
+  public $kind;
+  public $name;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setCountry($country)
+  {
+    $this->country = $country;
+  }
+  public function getCountry()
+  {
+    return $this->country;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_QPXExpress_Data extends Google_Collection
+{
+  protected $collection_key = 'tax';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $aircraftType = 'Google_Service_QPXExpress_AircraftData';
+  protected $aircraftDataType = 'array';
+  protected $airportType = 'Google_Service_QPXExpress_AirportData';
+  protected $airportDataType = 'array';
+  protected $carrierType = 'Google_Service_QPXExpress_CarrierData';
+  protected $carrierDataType = 'array';
+  protected $cityType = 'Google_Service_QPXExpress_CityData';
+  protected $cityDataType = 'array';
+  public $kind;
+  protected $taxType = 'Google_Service_QPXExpress_TaxData';
+  protected $taxDataType = 'array';
+
+
+  public function setAircraft($aircraft)
+  {
+    $this->aircraft = $aircraft;
+  }
+  public function getAircraft()
+  {
+    return $this->aircraft;
+  }
+  public function setAirport($airport)
+  {
+    $this->airport = $airport;
+  }
+  public function getAirport()
+  {
+    return $this->airport;
+  }
+  public function setCarrier($carrier)
+  {
+    $this->carrier = $carrier;
+  }
+  public function getCarrier()
+  {
+    return $this->carrier;
+  }
+  public function setCity($city)
+  {
+    $this->city = $city;
+  }
+  public function getCity()
+  {
+    return $this->city;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setTax($tax)
+  {
+    $this->tax = $tax;
+  }
+  public function getTax()
+  {
+    return $this->tax;
+  }
+}
+
+class Google_Service_QPXExpress_FareInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $basisCode;
+  public $carrier;
+  public $destination;
+  public $id;
+  public $kind;
+  public $origin;
+  public $private;
+
+
+  public function setBasisCode($basisCode)
+  {
+    $this->basisCode = $basisCode;
+  }
+  public function getBasisCode()
+  {
+    return $this->basisCode;
+  }
+  public function setCarrier($carrier)
+  {
+    $this->carrier = $carrier;
+  }
+  public function getCarrier()
+  {
+    return $this->carrier;
+  }
+  public function setDestination($destination)
+  {
+    $this->destination = $destination;
+  }
+  public function getDestination()
+  {
+    return $this->destination;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setOrigin($origin)
+  {
+    $this->origin = $origin;
+  }
+  public function getOrigin()
+  {
+    return $this->origin;
+  }
+  public function setPrivate($private)
+  {
+    $this->private = $private;
+  }
+  public function getPrivate()
+  {
+    return $this->private;
+  }
+}
+
+class Google_Service_QPXExpress_FlightInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $carrier;
+  public $number;
+
+
+  public function setCarrier($carrier)
+  {
+    $this->carrier = $carrier;
+  }
+  public function getCarrier()
+  {
+    return $this->carrier;
+  }
+  public function setNumber($number)
+  {
+    $this->number = $number;
+  }
+  public function getNumber()
+  {
+    return $this->number;
+  }
+}
+
+class Google_Service_QPXExpress_FreeBaggageAllowance extends Google_Collection
+{
+  protected $collection_key = 'bagDescriptor';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $bagDescriptorType = 'Google_Service_QPXExpress_BagDescriptor';
+  protected $bagDescriptorDataType = 'array';
+  public $kilos;
+  public $kilosPerPiece;
+  public $kind;
+  public $pieces;
+  public $pounds;
+
+
+  public function setBagDescriptor($bagDescriptor)
+  {
+    $this->bagDescriptor = $bagDescriptor;
+  }
+  public function getBagDescriptor()
+  {
+    return $this->bagDescriptor;
+  }
+  public function setKilos($kilos)
+  {
+    $this->kilos = $kilos;
+  }
+  public function getKilos()
+  {
+    return $this->kilos;
+  }
+  public function setKilosPerPiece($kilosPerPiece)
+  {
+    $this->kilosPerPiece = $kilosPerPiece;
+  }
+  public function getKilosPerPiece()
+  {
+    return $this->kilosPerPiece;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPieces($pieces)
+  {
+    $this->pieces = $pieces;
+  }
+  public function getPieces()
+  {
+    return $this->pieces;
+  }
+  public function setPounds($pounds)
+  {
+    $this->pounds = $pounds;
+  }
+  public function getPounds()
+  {
+    return $this->pounds;
+  }
+}
+
+class Google_Service_QPXExpress_LegInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $aircraft;
+  public $arrivalTime;
+  public $changePlane;
+  public $connectionDuration;
+  public $departureTime;
+  public $destination;
+  public $destinationTerminal;
+  public $duration;
+  public $id;
+  public $kind;
+  public $meal;
+  public $mileage;
+  public $onTimePerformance;
+  public $operatingDisclosure;
+  public $origin;
+  public $originTerminal;
+  public $secure;
+
+
+  public function setAircraft($aircraft)
+  {
+    $this->aircraft = $aircraft;
+  }
+  public function getAircraft()
+  {
+    return $this->aircraft;
+  }
+  public function setArrivalTime($arrivalTime)
+  {
+    $this->arrivalTime = $arrivalTime;
+  }
+  public function getArrivalTime()
+  {
+    return $this->arrivalTime;
+  }
+  public function setChangePlane($changePlane)
+  {
+    $this->changePlane = $changePlane;
+  }
+  public function getChangePlane()
+  {
+    return $this->changePlane;
+  }
+  public function setConnectionDuration($connectionDuration)
+  {
+    $this->connectionDuration = $connectionDuration;
+  }
+  public function getConnectionDuration()
+  {
+    return $this->connectionDuration;
+  }
+  public function setDepartureTime($departureTime)
+  {
+    $this->departureTime = $departureTime;
+  }
+  public function getDepartureTime()
+  {
+    return $this->departureTime;
+  }
+  public function setDestination($destination)
+  {
+    $this->destination = $destination;
+  }
+  public function getDestination()
+  {
+    return $this->destination;
+  }
+  public function setDestinationTerminal($destinationTerminal)
+  {
+    $this->destinationTerminal = $destinationTerminal;
+  }
+  public function getDestinationTerminal()
+  {
+    return $this->destinationTerminal;
+  }
+  public function setDuration($duration)
+  {
+    $this->duration = $duration;
+  }
+  public function getDuration()
+  {
+    return $this->duration;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMeal($meal)
+  {
+    $this->meal = $meal;
+  }
+  public function getMeal()
+  {
+    return $this->meal;
+  }
+  public function setMileage($mileage)
+  {
+    $this->mileage = $mileage;
+  }
+  public function getMileage()
+  {
+    return $this->mileage;
+  }
+  public function setOnTimePerformance($onTimePerformance)
+  {
+    $this->onTimePerformance = $onTimePerformance;
+  }
+  public function getOnTimePerformance()
+  {
+    return $this->onTimePerformance;
+  }
+  public function setOperatingDisclosure($operatingDisclosure)
+  {
+    $this->operatingDisclosure = $operatingDisclosure;
+  }
+  public function getOperatingDisclosure()
+  {
+    return $this->operatingDisclosure;
+  }
+  public function setOrigin($origin)
+  {
+    $this->origin = $origin;
+  }
+  public function getOrigin()
+  {
+    return $this->origin;
+  }
+  public function setOriginTerminal($originTerminal)
+  {
+    $this->originTerminal = $originTerminal;
+  }
+  public function getOriginTerminal()
+  {
+    return $this->originTerminal;
+  }
+  public function setSecure($secure)
+  {
+    $this->secure = $secure;
+  }
+  public function getSecure()
+  {
+    return $this->secure;
+  }
+}
+
+class Google_Service_QPXExpress_PassengerCounts extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $adultCount;
+  public $childCount;
+  public $infantInLapCount;
+  public $infantInSeatCount;
+  public $kind;
+  public $seniorCount;
+
+
+  public function setAdultCount($adultCount)
+  {
+    $this->adultCount = $adultCount;
+  }
+  public function getAdultCount()
+  {
+    return $this->adultCount;
+  }
+  public function setChildCount($childCount)
+  {
+    $this->childCount = $childCount;
+  }
+  public function getChildCount()
+  {
+    return $this->childCount;
+  }
+  public function setInfantInLapCount($infantInLapCount)
+  {
+    $this->infantInLapCount = $infantInLapCount;
+  }
+  public function getInfantInLapCount()
+  {
+    return $this->infantInLapCount;
+  }
+  public function setInfantInSeatCount($infantInSeatCount)
+  {
+    $this->infantInSeatCount = $infantInSeatCount;
+  }
+  public function getInfantInSeatCount()
+  {
+    return $this->infantInSeatCount;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSeniorCount($seniorCount)
+  {
+    $this->seniorCount = $seniorCount;
+  }
+  public function getSeniorCount()
+  {
+    return $this->seniorCount;
+  }
+}
+
+class Google_Service_QPXExpress_PricingInfo extends Google_Collection
+{
+  protected $collection_key = 'tax';
+  protected $internal_gapi_mappings = array(
+  );
+  public $baseFareTotal;
+  protected $fareType = 'Google_Service_QPXExpress_FareInfo';
+  protected $fareDataType = 'array';
+  public $fareCalculation;
+  public $kind;
+  public $latestTicketingTime;
+  protected $passengersType = 'Google_Service_QPXExpress_PassengerCounts';
+  protected $passengersDataType = '';
+  public $ptc;
+  public $refundable;
+  public $saleFareTotal;
+  public $saleTaxTotal;
+  public $saleTotal;
+  protected $segmentPricingType = 'Google_Service_QPXExpress_SegmentPricing';
+  protected $segmentPricingDataType = 'array';
+  protected $taxType = 'Google_Service_QPXExpress_TaxInfo';
+  protected $taxDataType = 'array';
+
+
+  public function setBaseFareTotal($baseFareTotal)
+  {
+    $this->baseFareTotal = $baseFareTotal;
+  }
+  public function getBaseFareTotal()
+  {
+    return $this->baseFareTotal;
+  }
+  public function setFare($fare)
+  {
+    $this->fare = $fare;
+  }
+  public function getFare()
+  {
+    return $this->fare;
+  }
+  public function setFareCalculation($fareCalculation)
+  {
+    $this->fareCalculation = $fareCalculation;
+  }
+  public function getFareCalculation()
+  {
+    return $this->fareCalculation;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLatestTicketingTime($latestTicketingTime)
+  {
+    $this->latestTicketingTime = $latestTicketingTime;
+  }
+  public function getLatestTicketingTime()
+  {
+    return $this->latestTicketingTime;
+  }
+  public function setPassengers(Google_Service_QPXExpress_PassengerCounts $passengers)
+  {
+    $this->passengers = $passengers;
+  }
+  public function getPassengers()
+  {
+    return $this->passengers;
+  }
+  public function setPtc($ptc)
+  {
+    $this->ptc = $ptc;
+  }
+  public function getPtc()
+  {
+    return $this->ptc;
+  }
+  public function setRefundable($refundable)
+  {
+    $this->refundable = $refundable;
+  }
+  public function getRefundable()
+  {
+    return $this->refundable;
+  }
+  public function setSaleFareTotal($saleFareTotal)
+  {
+    $this->saleFareTotal = $saleFareTotal;
+  }
+  public function getSaleFareTotal()
+  {
+    return $this->saleFareTotal;
+  }
+  public function setSaleTaxTotal($saleTaxTotal)
+  {
+    $this->saleTaxTotal = $saleTaxTotal;
+  }
+  public function getSaleTaxTotal()
+  {
+    return $this->saleTaxTotal;
+  }
+  public function setSaleTotal($saleTotal)
+  {
+    $this->saleTotal = $saleTotal;
+  }
+  public function getSaleTotal()
+  {
+    return $this->saleTotal;
+  }
+  public function setSegmentPricing($segmentPricing)
+  {
+    $this->segmentPricing = $segmentPricing;
+  }
+  public function getSegmentPricing()
+  {
+    return $this->segmentPricing;
+  }
+  public function setTax($tax)
+  {
+    $this->tax = $tax;
+  }
+  public function getTax()
+  {
+    return $this->tax;
+  }
+}
+
+class Google_Service_QPXExpress_SegmentInfo extends Google_Collection
+{
+  protected $collection_key = 'leg';
+  protected $internal_gapi_mappings = array(
+  );
+  public $bookingCode;
+  public $bookingCodeCount;
+  public $cabin;
+  public $connectionDuration;
+  public $duration;
+  protected $flightType = 'Google_Service_QPXExpress_FlightInfo';
+  protected $flightDataType = '';
+  public $id;
+  public $kind;
+  protected $legType = 'Google_Service_QPXExpress_LegInfo';
+  protected $legDataType = 'array';
+  public $marriedSegmentGroup;
+  public $subjectToGovernmentApproval;
+
+
+  public function setBookingCode($bookingCode)
+  {
+    $this->bookingCode = $bookingCode;
+  }
+  public function getBookingCode()
+  {
+    return $this->bookingCode;
+  }
+  public function setBookingCodeCount($bookingCodeCount)
+  {
+    $this->bookingCodeCount = $bookingCodeCount;
+  }
+  public function getBookingCodeCount()
+  {
+    return $this->bookingCodeCount;
+  }
+  public function setCabin($cabin)
+  {
+    $this->cabin = $cabin;
+  }
+  public function getCabin()
+  {
+    return $this->cabin;
+  }
+  public function setConnectionDuration($connectionDuration)
+  {
+    $this->connectionDuration = $connectionDuration;
+  }
+  public function getConnectionDuration()
+  {
+    return $this->connectionDuration;
+  }
+  public function setDuration($duration)
+  {
+    $this->duration = $duration;
+  }
+  public function getDuration()
+  {
+    return $this->duration;
+  }
+  public function setFlight(Google_Service_QPXExpress_FlightInfo $flight)
+  {
+    $this->flight = $flight;
+  }
+  public function getFlight()
+  {
+    return $this->flight;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLeg($leg)
+  {
+    $this->leg = $leg;
+  }
+  public function getLeg()
+  {
+    return $this->leg;
+  }
+  public function setMarriedSegmentGroup($marriedSegmentGroup)
+  {
+    $this->marriedSegmentGroup = $marriedSegmentGroup;
+  }
+  public function getMarriedSegmentGroup()
+  {
+    return $this->marriedSegmentGroup;
+  }
+  public function setSubjectToGovernmentApproval($subjectToGovernmentApproval)
+  {
+    $this->subjectToGovernmentApproval = $subjectToGovernmentApproval;
+  }
+  public function getSubjectToGovernmentApproval()
+  {
+    return $this->subjectToGovernmentApproval;
+  }
+}
+
+class Google_Service_QPXExpress_SegmentPricing extends Google_Collection
+{
+  protected $collection_key = 'freeBaggageOption';
+  protected $internal_gapi_mappings = array(
+  );
+  public $fareId;
+  protected $freeBaggageOptionType = 'Google_Service_QPXExpress_FreeBaggageAllowance';
+  protected $freeBaggageOptionDataType = 'array';
+  public $kind;
+  public $segmentId;
+
+
+  public function setFareId($fareId)
+  {
+    $this->fareId = $fareId;
+  }
+  public function getFareId()
+  {
+    return $this->fareId;
+  }
+  public function setFreeBaggageOption($freeBaggageOption)
+  {
+    $this->freeBaggageOption = $freeBaggageOption;
+  }
+  public function getFreeBaggageOption()
+  {
+    return $this->freeBaggageOption;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSegmentId($segmentId)
+  {
+    $this->segmentId = $segmentId;
+  }
+  public function getSegmentId()
+  {
+    return $this->segmentId;
+  }
+}
+
+class Google_Service_QPXExpress_SliceInfo extends Google_Collection
+{
+  protected $collection_key = 'segment';
+  protected $internal_gapi_mappings = array(
+  );
+  public $duration;
+  public $kind;
+  protected $segmentType = 'Google_Service_QPXExpress_SegmentInfo';
+  protected $segmentDataType = 'array';
+
+
+  public function setDuration($duration)
+  {
+    $this->duration = $duration;
+  }
+  public function getDuration()
+  {
+    return $this->duration;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSegment($segment)
+  {
+    $this->segment = $segment;
+  }
+  public function getSegment()
+  {
+    return $this->segment;
+  }
+}
+
+class Google_Service_QPXExpress_SliceInput extends Google_Collection
+{
+  protected $collection_key = 'prohibitedCarrier';
+  protected $internal_gapi_mappings = array(
+  );
+  public $alliance;
+  public $date;
+  public $destination;
+  public $kind;
+  public $maxConnectionDuration;
+  public $maxStops;
+  public $origin;
+  public $permittedCarrier;
+  protected $permittedDepartureTimeType = 'Google_Service_QPXExpress_TimeOfDayRange';
+  protected $permittedDepartureTimeDataType = '';
+  public $preferredCabin;
+  public $prohibitedCarrier;
+
+
+  public function setAlliance($alliance)
+  {
+    $this->alliance = $alliance;
+  }
+  public function getAlliance()
+  {
+    return $this->alliance;
+  }
+  public function setDate($date)
+  {
+    $this->date = $date;
+  }
+  public function getDate()
+  {
+    return $this->date;
+  }
+  public function setDestination($destination)
+  {
+    $this->destination = $destination;
+  }
+  public function getDestination()
+  {
+    return $this->destination;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMaxConnectionDuration($maxConnectionDuration)
+  {
+    $this->maxConnectionDuration = $maxConnectionDuration;
+  }
+  public function getMaxConnectionDuration()
+  {
+    return $this->maxConnectionDuration;
+  }
+  public function setMaxStops($maxStops)
+  {
+    $this->maxStops = $maxStops;
+  }
+  public function getMaxStops()
+  {
+    return $this->maxStops;
+  }
+  public function setOrigin($origin)
+  {
+    $this->origin = $origin;
+  }
+  public function getOrigin()
+  {
+    return $this->origin;
+  }
+  public function setPermittedCarrier($permittedCarrier)
+  {
+    $this->permittedCarrier = $permittedCarrier;
+  }
+  public function getPermittedCarrier()
+  {
+    return $this->permittedCarrier;
+  }
+  public function setPermittedDepartureTime(Google_Service_QPXExpress_TimeOfDayRange $permittedDepartureTime)
+  {
+    $this->permittedDepartureTime = $permittedDepartureTime;
+  }
+  public function getPermittedDepartureTime()
+  {
+    return $this->permittedDepartureTime;
+  }
+  public function setPreferredCabin($preferredCabin)
+  {
+    $this->preferredCabin = $preferredCabin;
+  }
+  public function getPreferredCabin()
+  {
+    return $this->preferredCabin;
+  }
+  public function setProhibitedCarrier($prohibitedCarrier)
+  {
+    $this->prohibitedCarrier = $prohibitedCarrier;
+  }
+  public function getProhibitedCarrier()
+  {
+    return $this->prohibitedCarrier;
+  }
+}
+
+class Google_Service_QPXExpress_TaxData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $name;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_QPXExpress_TaxInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $chargeType;
+  public $code;
+  public $country;
+  public $id;
+  public $kind;
+  public $salePrice;
+
+
+  public function setChargeType($chargeType)
+  {
+    $this->chargeType = $chargeType;
+  }
+  public function getChargeType()
+  {
+    return $this->chargeType;
+  }
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setCountry($country)
+  {
+    $this->country = $country;
+  }
+  public function getCountry()
+  {
+    return $this->country;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSalePrice($salePrice)
+  {
+    $this->salePrice = $salePrice;
+  }
+  public function getSalePrice()
+  {
+    return $this->salePrice;
+  }
+}
+
+class Google_Service_QPXExpress_TimeOfDayRange extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $earliestTime;
+  public $kind;
+  public $latestTime;
+
+
+  public function setEarliestTime($earliestTime)
+  {
+    $this->earliestTime = $earliestTime;
+  }
+  public function getEarliestTime()
+  {
+    return $this->earliestTime;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLatestTime($latestTime)
+  {
+    $this->latestTime = $latestTime;
+  }
+  public function getLatestTime()
+  {
+    return $this->latestTime;
+  }
+}
+
+class Google_Service_QPXExpress_TripOption extends Google_Collection
+{
+  protected $collection_key = 'slice';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  protected $pricingType = 'Google_Service_QPXExpress_PricingInfo';
+  protected $pricingDataType = 'array';
+  public $saleTotal;
+  protected $sliceType = 'Google_Service_QPXExpress_SliceInfo';
+  protected $sliceDataType = 'array';
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPricing($pricing)
+  {
+    $this->pricing = $pricing;
+  }
+  public function getPricing()
+  {
+    return $this->pricing;
+  }
+  public function setSaleTotal($saleTotal)
+  {
+    $this->saleTotal = $saleTotal;
+  }
+  public function getSaleTotal()
+  {
+    return $this->saleTotal;
+  }
+  public function setSlice($slice)
+  {
+    $this->slice = $slice;
+  }
+  public function getSlice()
+  {
+    return $this->slice;
+  }
+}
+
+class Google_Service_QPXExpress_TripOptionsRequest extends Google_Collection
+{
+  protected $collection_key = 'slice';
+  protected $internal_gapi_mappings = array(
+  );
+  public $maxPrice;
+  protected $passengersType = 'Google_Service_QPXExpress_PassengerCounts';
+  protected $passengersDataType = '';
+  public $refundable;
+  public $saleCountry;
+  protected $sliceType = 'Google_Service_QPXExpress_SliceInput';
+  protected $sliceDataType = 'array';
+  public $solutions;
+
+
+  public function setMaxPrice($maxPrice)
+  {
+    $this->maxPrice = $maxPrice;
+  }
+  public function getMaxPrice()
+  {
+    return $this->maxPrice;
+  }
+  public function setPassengers(Google_Service_QPXExpress_PassengerCounts $passengers)
+  {
+    $this->passengers = $passengers;
+  }
+  public function getPassengers()
+  {
+    return $this->passengers;
+  }
+  public function setRefundable($refundable)
+  {
+    $this->refundable = $refundable;
+  }
+  public function getRefundable()
+  {
+    return $this->refundable;
+  }
+  public function setSaleCountry($saleCountry)
+  {
+    $this->saleCountry = $saleCountry;
+  }
+  public function getSaleCountry()
+  {
+    return $this->saleCountry;
+  }
+  public function setSlice($slice)
+  {
+    $this->slice = $slice;
+  }
+  public function getSlice()
+  {
+    return $this->slice;
+  }
+  public function setSolutions($solutions)
+  {
+    $this->solutions = $solutions;
+  }
+  public function getSolutions()
+  {
+    return $this->solutions;
+  }
+}
+
+class Google_Service_QPXExpress_TripOptionsResponse extends Google_Collection
+{
+  protected $collection_key = 'tripOption';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $dataType = 'Google_Service_QPXExpress_Data';
+  protected $dataDataType = '';
+  public $kind;
+  public $requestId;
+  protected $tripOptionType = 'Google_Service_QPXExpress_TripOption';
+  protected $tripOptionDataType = 'array';
+
+
+  public function setData(Google_Service_QPXExpress_Data $data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRequestId($requestId)
+  {
+    $this->requestId = $requestId;
+  }
+  public function getRequestId()
+  {
+    return $this->requestId;
+  }
+  public function setTripOption($tripOption)
+  {
+    $this->tripOption = $tripOption;
+  }
+  public function getTripOption()
+  {
+    return $this->tripOption;
+  }
+}
+
+class Google_Service_QPXExpress_TripsSearchRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $requestType = 'Google_Service_QPXExpress_TripOptionsRequest';
+  protected $requestDataType = '';
+
+
+  public function setRequest(Google_Service_QPXExpress_TripOptionsRequest $request)
+  {
+    $this->request = $request;
+  }
+  public function getRequest()
+  {
+    return $this->request;
+  }
+}
+
+class Google_Service_QPXExpress_TripsSearchResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $tripsType = 'Google_Service_QPXExpress_TripOptionsResponse';
+  protected $tripsDataType = '';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setTrips(Google_Service_QPXExpress_TripOptionsResponse $trips)
+  {
+    $this->trips = $trips;
+  }
+  public function getTrips()
+  {
+    return $this->trips;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Replicapool.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Replicapool.php
@@ -1,0 +1,1313 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Replicapool (v1beta2).
+ *
+ * <p>
+ * The Google Compute Engine Instance Group Manager API provides groups of
+ * homogenous Compute Engine Instances.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/compute/docs/instance-groups/manager/v1beta2" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Replicapool extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+  /** View your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM_READ_ONLY =
+      "https://www.googleapis.com/auth/cloud-platform.read-only";
+  /** View and manage your Google Compute Engine resources. */
+  const COMPUTE =
+      "https://www.googleapis.com/auth/compute";
+  /** View your Google Compute Engine resources. */
+  const COMPUTE_READONLY =
+      "https://www.googleapis.com/auth/compute.readonly";
+
+  public $instanceGroupManagers;
+  public $zoneOperations;
+  
+
+  /**
+   * Constructs the internal representation of the Replicapool service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'replicapool/v1beta2/projects/';
+    $this->version = 'v1beta2';
+    $this->serviceName = 'replicapool';
+
+    $this->instanceGroupManagers = new Google_Service_Replicapool_InstanceGroupManagers_Resource(
+        $this,
+        $this->serviceName,
+        'instanceGroupManagers',
+        array(
+          'methods' => array(
+            'abandonInstances' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/abandonInstances',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroupManager' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroupManager' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'deleteInstances' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/deleteInstances',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroupManager' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroupManager' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'size' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'recreateInstances' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/recreateInstances',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroupManager' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'resize' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/resize',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroupManager' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'size' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'setInstanceTemplate' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/setInstanceTemplate',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroupManager' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setTargetPools' => array(
+              'path' => '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/setTargetPools',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instanceGroupManager' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->zoneOperations = new Google_Service_Replicapool_ZoneOperations_Resource(
+        $this,
+        $this->serviceName,
+        'zoneOperations',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{project}/zones/{zone}/operations/{operation}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operation' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/zones/{zone}/operations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "instanceGroupManagers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $replicapoolService = new Google_Service_Replicapool(...);
+ *   $instanceGroupManagers = $replicapoolService->instanceGroupManagers;
+ *  </code>
+ */
+class Google_Service_Replicapool_InstanceGroupManagers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Removes the specified instances from the managed instance group, and from any
+   * target pools of which they were members, without deleting the instances.
+   * (instanceGroupManagers.abandonInstances)
+   *
+   * @param string $project The Google Developers Console project name.
+   * @param string $zone The name of the zone in which the instance group manager
+   * resides.
+   * @param string $instanceGroupManager The name of the instance group manager.
+   * @param Google_InstanceGroupManagersAbandonInstancesRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Replicapool_Operation
+   */
+  public function abandonInstances($project, $zone, $instanceGroupManager, Google_Service_Replicapool_InstanceGroupManagersAbandonInstancesRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroupManager' => $instanceGroupManager, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('abandonInstances', array($params), "Google_Service_Replicapool_Operation");
+  }
+
+  /**
+   * Deletes the instance group manager and all instances contained within. If
+   * you'd like to delete the manager without deleting the instances, you must
+   * first abandon the instances to remove them from the group.
+   * (instanceGroupManagers.delete)
+   *
+   * @param string $project The Google Developers Console project name.
+   * @param string $zone The name of the zone in which the instance group manager
+   * resides.
+   * @param string $instanceGroupManager Name of the Instance Group Manager
+   * resource to delete.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Replicapool_Operation
+   */
+  public function delete($project, $zone, $instanceGroupManager, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroupManager' => $instanceGroupManager);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Replicapool_Operation");
+  }
+
+  /**
+   * Deletes the specified instances. The instances are deleted, then removed from
+   * the instance group and any target pools of which they were a member. The
+   * targetSize of the instance group manager is reduced by the number of
+   * instances deleted. (instanceGroupManagers.deleteInstances)
+   *
+   * @param string $project The Google Developers Console project name.
+   * @param string $zone The name of the zone in which the instance group manager
+   * resides.
+   * @param string $instanceGroupManager The name of the instance group manager.
+   * @param Google_InstanceGroupManagersDeleteInstancesRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Replicapool_Operation
+   */
+  public function deleteInstances($project, $zone, $instanceGroupManager, Google_Service_Replicapool_InstanceGroupManagersDeleteInstancesRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroupManager' => $instanceGroupManager, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('deleteInstances', array($params), "Google_Service_Replicapool_Operation");
+  }
+
+  /**
+   * Returns the specified Instance Group Manager resource.
+   * (instanceGroupManagers.get)
+   *
+   * @param string $project The Google Developers Console project name.
+   * @param string $zone The name of the zone in which the instance group manager
+   * resides.
+   * @param string $instanceGroupManager Name of the instance resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Replicapool_InstanceGroupManager
+   */
+  public function get($project, $zone, $instanceGroupManager, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroupManager' => $instanceGroupManager);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Replicapool_InstanceGroupManager");
+  }
+
+  /**
+   * Creates an instance group manager, as well as the instance group and the
+   * specified number of instances. (instanceGroupManagers.insert)
+   *
+   * @param string $project The Google Developers Console project name.
+   * @param string $zone The name of the zone in which the instance group manager
+   * resides.
+   * @param int $size Number of instances that should exist.
+   * @param Google_InstanceGroupManager $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Replicapool_Operation
+   */
+  public function insert($project, $zone, $size, Google_Service_Replicapool_InstanceGroupManager $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'size' => $size, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Replicapool_Operation");
+  }
+
+  /**
+   * Retrieves the list of Instance Group Manager resources contained within the
+   * specified zone. (instanceGroupManagers.listInstanceGroupManagers)
+   *
+   * @param string $project The Google Developers Console project name.
+   * @param string $zone The name of the zone in which the instance group manager
+   * resides.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Optional. Filter expression for filtering listed
+   * resources.
+   * @opt_param string pageToken Optional. Tag returned by a previous list request
+   * truncated by maxResults. Used to continue a previous list request.
+   * @opt_param string maxResults Optional. Maximum count of results to be
+   * returned. Maximum value is 500 and default value is 500.
+   * @return Google_Service_Replicapool_InstanceGroupManagerList
+   */
+  public function listInstanceGroupManagers($project, $zone, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Replicapool_InstanceGroupManagerList");
+  }
+
+  /**
+   * Recreates the specified instances. The instances are deleted, then recreated
+   * using the instance group manager's current instance template.
+   * (instanceGroupManagers.recreateInstances)
+   *
+   * @param string $project The Google Developers Console project name.
+   * @param string $zone The name of the zone in which the instance group manager
+   * resides.
+   * @param string $instanceGroupManager The name of the instance group manager.
+   * @param Google_InstanceGroupManagersRecreateInstancesRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Replicapool_Operation
+   */
+  public function recreateInstances($project, $zone, $instanceGroupManager, Google_Service_Replicapool_InstanceGroupManagersRecreateInstancesRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroupManager' => $instanceGroupManager, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('recreateInstances', array($params), "Google_Service_Replicapool_Operation");
+  }
+
+  /**
+   * Resizes the managed instance group up or down. If resized up, new instances
+   * are created using the current instance template. If resized down, instances
+   * are removed in the order outlined in Resizing a managed instance group.
+   * (instanceGroupManagers.resize)
+   *
+   * @param string $project The Google Developers Console project name.
+   * @param string $zone The name of the zone in which the instance group manager
+   * resides.
+   * @param string $instanceGroupManager The name of the instance group manager.
+   * @param int $size Number of instances that should exist in this Instance Group
+   * Manager.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Replicapool_Operation
+   */
+  public function resize($project, $zone, $instanceGroupManager, $size, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroupManager' => $instanceGroupManager, 'size' => $size);
+    $params = array_merge($params, $optParams);
+    return $this->call('resize', array($params), "Google_Service_Replicapool_Operation");
+  }
+
+  /**
+   * Sets the instance template to use when creating new instances in this group.
+   * Existing instances are not affected.
+   * (instanceGroupManagers.setInstanceTemplate)
+   *
+   * @param string $project The Google Developers Console project name.
+   * @param string $zone The name of the zone in which the instance group manager
+   * resides.
+   * @param string $instanceGroupManager The name of the instance group manager.
+   * @param Google_InstanceGroupManagersSetInstanceTemplateRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Replicapool_Operation
+   */
+  public function setInstanceTemplate($project, $zone, $instanceGroupManager, Google_Service_Replicapool_InstanceGroupManagersSetInstanceTemplateRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroupManager' => $instanceGroupManager, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setInstanceTemplate', array($params), "Google_Service_Replicapool_Operation");
+  }
+
+  /**
+   * Modifies the target pools to which all new instances in this group are
+   * assigned. Existing instances in the group are not affected.
+   * (instanceGroupManagers.setTargetPools)
+   *
+   * @param string $project The Google Developers Console project name.
+   * @param string $zone The name of the zone in which the instance group manager
+   * resides.
+   * @param string $instanceGroupManager The name of the instance group manager.
+   * @param Google_InstanceGroupManagersSetTargetPoolsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Replicapool_Operation
+   */
+  public function setTargetPools($project, $zone, $instanceGroupManager, Google_Service_Replicapool_InstanceGroupManagersSetTargetPoolsRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'instanceGroupManager' => $instanceGroupManager, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setTargetPools', array($params), "Google_Service_Replicapool_Operation");
+  }
+}
+
+/**
+ * The "zoneOperations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $replicapoolService = new Google_Service_Replicapool(...);
+ *   $zoneOperations = $replicapoolService->zoneOperations;
+ *  </code>
+ */
+class Google_Service_Replicapool_ZoneOperations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the specified zone-specific operation resource.
+   * (zoneOperations.get)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param string $operation Name of the operation resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Replicapool_Operation
+   */
+  public function get($project, $zone, $operation, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'operation' => $operation);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Replicapool_Operation");
+  }
+
+  /**
+   * Retrieves the list of operation resources contained within the specified
+   * zone. (zoneOperations.listZoneOperations)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Optional. Filter expression for filtering listed
+   * resources.
+   * @opt_param string pageToken Optional. Tag returned by a previous list request
+   * truncated by maxResults. Used to continue a previous list request.
+   * @opt_param string maxResults Optional. Maximum count of results to be
+   * returned. Maximum value is 500 and default value is 500.
+   * @return Google_Service_Replicapool_OperationList
+   */
+  public function listZoneOperations($project, $zone, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Replicapool_OperationList");
+  }
+}
+
+
+
+
+class Google_Service_Replicapool_InstanceGroupManager extends Google_Collection
+{
+  protected $collection_key = 'targetPools';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $autoHealingPoliciesType = 'Google_Service_Replicapool_ReplicaPoolAutoHealingPolicy';
+  protected $autoHealingPoliciesDataType = 'array';
+  public $baseInstanceName;
+  public $creationTimestamp;
+  public $currentSize;
+  public $description;
+  public $fingerprint;
+  public $group;
+  public $id;
+  public $instanceTemplate;
+  public $kind;
+  public $name;
+  public $selfLink;
+  public $targetPools;
+  public $targetSize;
+
+
+  public function setAutoHealingPolicies($autoHealingPolicies)
+  {
+    $this->autoHealingPolicies = $autoHealingPolicies;
+  }
+  public function getAutoHealingPolicies()
+  {
+    return $this->autoHealingPolicies;
+  }
+  public function setBaseInstanceName($baseInstanceName)
+  {
+    $this->baseInstanceName = $baseInstanceName;
+  }
+  public function getBaseInstanceName()
+  {
+    return $this->baseInstanceName;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setCurrentSize($currentSize)
+  {
+    $this->currentSize = $currentSize;
+  }
+  public function getCurrentSize()
+  {
+    return $this->currentSize;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setGroup($group)
+  {
+    $this->group = $group;
+  }
+  public function getGroup()
+  {
+    return $this->group;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInstanceTemplate($instanceTemplate)
+  {
+    $this->instanceTemplate = $instanceTemplate;
+  }
+  public function getInstanceTemplate()
+  {
+    return $this->instanceTemplate;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTargetPools($targetPools)
+  {
+    $this->targetPools = $targetPools;
+  }
+  public function getTargetPools()
+  {
+    return $this->targetPools;
+  }
+  public function setTargetSize($targetSize)
+  {
+    $this->targetSize = $targetSize;
+  }
+  public function getTargetSize()
+  {
+    return $this->targetSize;
+  }
+}
+
+class Google_Service_Replicapool_InstanceGroupManagerList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Replicapool_InstanceGroupManager';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Replicapool_InstanceGroupManagersAbandonInstancesRequest extends Google_Collection
+{
+  protected $collection_key = 'instances';
+  protected $internal_gapi_mappings = array(
+  );
+  public $instances;
+
+
+  public function setInstances($instances)
+  {
+    $this->instances = $instances;
+  }
+  public function getInstances()
+  {
+    return $this->instances;
+  }
+}
+
+class Google_Service_Replicapool_InstanceGroupManagersDeleteInstancesRequest extends Google_Collection
+{
+  protected $collection_key = 'instances';
+  protected $internal_gapi_mappings = array(
+  );
+  public $instances;
+
+
+  public function setInstances($instances)
+  {
+    $this->instances = $instances;
+  }
+  public function getInstances()
+  {
+    return $this->instances;
+  }
+}
+
+class Google_Service_Replicapool_InstanceGroupManagersRecreateInstancesRequest extends Google_Collection
+{
+  protected $collection_key = 'instances';
+  protected $internal_gapi_mappings = array(
+  );
+  public $instances;
+
+
+  public function setInstances($instances)
+  {
+    $this->instances = $instances;
+  }
+  public function getInstances()
+  {
+    return $this->instances;
+  }
+}
+
+class Google_Service_Replicapool_InstanceGroupManagersSetInstanceTemplateRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $instanceTemplate;
+
+
+  public function setInstanceTemplate($instanceTemplate)
+  {
+    $this->instanceTemplate = $instanceTemplate;
+  }
+  public function getInstanceTemplate()
+  {
+    return $this->instanceTemplate;
+  }
+}
+
+class Google_Service_Replicapool_InstanceGroupManagersSetTargetPoolsRequest extends Google_Collection
+{
+  protected $collection_key = 'targetPools';
+  protected $internal_gapi_mappings = array(
+  );
+  public $fingerprint;
+  public $targetPools;
+
+
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setTargetPools($targetPools)
+  {
+    $this->targetPools = $targetPools;
+  }
+  public function getTargetPools()
+  {
+    return $this->targetPools;
+  }
+}
+
+class Google_Service_Replicapool_Operation extends Google_Collection
+{
+  protected $collection_key = 'warnings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $clientOperationId;
+  public $creationTimestamp;
+  public $endTime;
+  protected $errorType = 'Google_Service_Replicapool_OperationError';
+  protected $errorDataType = '';
+  public $httpErrorMessage;
+  public $httpErrorStatusCode;
+  public $id;
+  public $insertTime;
+  public $kind;
+  public $name;
+  public $operationType;
+  public $progress;
+  public $region;
+  public $selfLink;
+  public $startTime;
+  public $status;
+  public $statusMessage;
+  public $targetId;
+  public $targetLink;
+  public $user;
+  protected $warningsType = 'Google_Service_Replicapool_OperationWarnings';
+  protected $warningsDataType = 'array';
+  public $zone;
+
+
+  public function setClientOperationId($clientOperationId)
+  {
+    $this->clientOperationId = $clientOperationId;
+  }
+  public function getClientOperationId()
+  {
+    return $this->clientOperationId;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setError(Google_Service_Replicapool_OperationError $error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setHttpErrorMessage($httpErrorMessage)
+  {
+    $this->httpErrorMessage = $httpErrorMessage;
+  }
+  public function getHttpErrorMessage()
+  {
+    return $this->httpErrorMessage;
+  }
+  public function setHttpErrorStatusCode($httpErrorStatusCode)
+  {
+    $this->httpErrorStatusCode = $httpErrorStatusCode;
+  }
+  public function getHttpErrorStatusCode()
+  {
+    return $this->httpErrorStatusCode;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInsertTime($insertTime)
+  {
+    $this->insertTime = $insertTime;
+  }
+  public function getInsertTime()
+  {
+    return $this->insertTime;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOperationType($operationType)
+  {
+    $this->operationType = $operationType;
+  }
+  public function getOperationType()
+  {
+    return $this->operationType;
+  }
+  public function setProgress($progress)
+  {
+    $this->progress = $progress;
+  }
+  public function getProgress()
+  {
+    return $this->progress;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setStatusMessage($statusMessage)
+  {
+    $this->statusMessage = $statusMessage;
+  }
+  public function getStatusMessage()
+  {
+    return $this->statusMessage;
+  }
+  public function setTargetId($targetId)
+  {
+    $this->targetId = $targetId;
+  }
+  public function getTargetId()
+  {
+    return $this->targetId;
+  }
+  public function setTargetLink($targetLink)
+  {
+    $this->targetLink = $targetLink;
+  }
+  public function getTargetLink()
+  {
+    return $this->targetLink;
+  }
+  public function setUser($user)
+  {
+    $this->user = $user;
+  }
+  public function getUser()
+  {
+    return $this->user;
+  }
+  public function setWarnings($warnings)
+  {
+    $this->warnings = $warnings;
+  }
+  public function getWarnings()
+  {
+    return $this->warnings;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_Replicapool_OperationError extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorsType = 'Google_Service_Replicapool_OperationErrorErrors';
+  protected $errorsDataType = 'array';
+
+
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+}
+
+class Google_Service_Replicapool_OperationErrorErrors extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $location;
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Replicapool_OperationList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Replicapool_Operation';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Replicapool_OperationWarnings extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Replicapool_OperationWarningsData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Replicapool_OperationWarningsData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Replicapool_ReplicaPoolAutoHealingPolicy extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $actionType;
+  public $healthCheck;
+
+
+  public function setActionType($actionType)
+  {
+    $this->actionType = $actionType;
+  }
+  public function getActionType()
+  {
+    return $this->actionType;
+  }
+  public function setHealthCheck($healthCheck)
+  {
+    $this->healthCheck = $healthCheck;
+  }
+  public function getHealthCheck()
+  {
+    return $this->healthCheck;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Replicapoolupdater.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Replicapoolupdater.php
@@ -1,0 +1,1355 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Replicapoolupdater (v1beta1).
+ *
+ * <p>
+ * The Google Compute Engine Instance Group Updater API provides services for
+ * updating groups of Compute Engine Instances.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://cloud.google.com/compute/docs/instance-groups/manager/#applying_rolling_updates_using_the_updater_service" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Replicapoolupdater extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+  /** View your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM_READ_ONLY =
+      "https://www.googleapis.com/auth/cloud-platform.read-only";
+  /** View and manage replica pools. */
+  const REPLICAPOOL =
+      "https://www.googleapis.com/auth/replicapool";
+  /** View replica pools. */
+  const REPLICAPOOL_READONLY =
+      "https://www.googleapis.com/auth/replicapool.readonly";
+
+  public $rollingUpdates;
+  public $zoneOperations;
+  
+
+  /**
+   * Constructs the internal representation of the Replicapoolupdater service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'replicapoolupdater/v1beta1/projects/';
+    $this->version = 'v1beta1';
+    $this->serviceName = 'replicapoolupdater';
+
+    $this->rollingUpdates = new Google_Service_Replicapoolupdater_RollingUpdates_Resource(
+        $this,
+        $this->serviceName,
+        'rollingUpdates',
+        array(
+          'methods' => array(
+            'cancel' => array(
+              'path' => '{project}/zones/{zone}/rollingUpdates/{rollingUpdate}/cancel',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'rollingUpdate' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/zones/{zone}/rollingUpdates/{rollingUpdate}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'rollingUpdate' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/zones/{zone}/rollingUpdates',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/zones/{zone}/rollingUpdates',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'listInstanceUpdates' => array(
+              'path' => '{project}/zones/{zone}/rollingUpdates/{rollingUpdate}/instanceUpdates',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'rollingUpdate' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'pause' => array(
+              'path' => '{project}/zones/{zone}/rollingUpdates/{rollingUpdate}/pause',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'rollingUpdate' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'resume' => array(
+              'path' => '{project}/zones/{zone}/rollingUpdates/{rollingUpdate}/resume',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'rollingUpdate' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'rollback' => array(
+              'path' => '{project}/zones/{zone}/rollingUpdates/{rollingUpdate}/rollback',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'rollingUpdate' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->zoneOperations = new Google_Service_Replicapoolupdater_ZoneOperations_Resource(
+        $this,
+        $this->serviceName,
+        'zoneOperations',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{project}/zones/{zone}/operations/{operation}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operation' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/zones/{zone}/operations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "rollingUpdates" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $replicapoolupdaterService = new Google_Service_Replicapoolupdater(...);
+ *   $rollingUpdates = $replicapoolupdaterService->rollingUpdates;
+ *  </code>
+ */
+class Google_Service_Replicapoolupdater_RollingUpdates_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Cancels an update. The update must be PAUSED before it can be cancelled. This
+   * has no effect if the update is already CANCELLED. (rollingUpdates.cancel)
+   *
+   * @param string $project The Google Developers Console project name.
+   * @param string $zone The name of the zone in which the update's target
+   * resides.
+   * @param string $rollingUpdate The name of the update.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Replicapoolupdater_Operation
+   */
+  public function cancel($project, $zone, $rollingUpdate, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'rollingUpdate' => $rollingUpdate);
+    $params = array_merge($params, $optParams);
+    return $this->call('cancel', array($params), "Google_Service_Replicapoolupdater_Operation");
+  }
+
+  /**
+   * Returns information about an update. (rollingUpdates.get)
+   *
+   * @param string $project The Google Developers Console project name.
+   * @param string $zone The name of the zone in which the update's target
+   * resides.
+   * @param string $rollingUpdate The name of the update.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Replicapoolupdater_RollingUpdate
+   */
+  public function get($project, $zone, $rollingUpdate, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'rollingUpdate' => $rollingUpdate);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Replicapoolupdater_RollingUpdate");
+  }
+
+  /**
+   * Inserts and starts a new update. (rollingUpdates.insert)
+   *
+   * @param string $project The Google Developers Console project name.
+   * @param string $zone The name of the zone in which the update's target
+   * resides.
+   * @param Google_RollingUpdate $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Replicapoolupdater_Operation
+   */
+  public function insert($project, $zone, Google_Service_Replicapoolupdater_RollingUpdate $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Replicapoolupdater_Operation");
+  }
+
+  /**
+   * Lists recent updates for a given managed instance group, in reverse
+   * chronological order and paginated format. (rollingUpdates.listRollingUpdates)
+   *
+   * @param string $project The Google Developers Console project name.
+   * @param string $zone The name of the zone in which the update's target
+   * resides.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Optional. Filter expression for filtering listed
+   * resources.
+   * @opt_param string pageToken Optional. Tag returned by a previous list request
+   * truncated by maxResults. Used to continue a previous list request.
+   * @opt_param string maxResults Optional. Maximum count of results to be
+   * returned. Maximum value is 500 and default value is 500.
+   * @return Google_Service_Replicapoolupdater_RollingUpdateList
+   */
+  public function listRollingUpdates($project, $zone, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Replicapoolupdater_RollingUpdateList");
+  }
+
+  /**
+   * Lists the current status for each instance within a given update.
+   * (rollingUpdates.listInstanceUpdates)
+   *
+   * @param string $project The Google Developers Console project name.
+   * @param string $zone The name of the zone in which the update's target
+   * resides.
+   * @param string $rollingUpdate The name of the update.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string maxResults Optional. Maximum count of results to be
+   * returned. Maximum value is 500 and default value is 500.
+   * @opt_param string filter Optional. Filter expression for filtering listed
+   * resources.
+   * @opt_param string pageToken Optional. Tag returned by a previous list request
+   * truncated by maxResults. Used to continue a previous list request.
+   * @return Google_Service_Replicapoolupdater_InstanceUpdateList
+   */
+  public function listInstanceUpdates($project, $zone, $rollingUpdate, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'rollingUpdate' => $rollingUpdate);
+    $params = array_merge($params, $optParams);
+    return $this->call('listInstanceUpdates', array($params), "Google_Service_Replicapoolupdater_InstanceUpdateList");
+  }
+
+  /**
+   * Pauses the update in state from ROLLING_FORWARD or ROLLING_BACK. Has no
+   * effect if invoked when the state of the update is PAUSED.
+   * (rollingUpdates.pause)
+   *
+   * @param string $project The Google Developers Console project name.
+   * @param string $zone The name of the zone in which the update's target
+   * resides.
+   * @param string $rollingUpdate The name of the update.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Replicapoolupdater_Operation
+   */
+  public function pause($project, $zone, $rollingUpdate, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'rollingUpdate' => $rollingUpdate);
+    $params = array_merge($params, $optParams);
+    return $this->call('pause', array($params), "Google_Service_Replicapoolupdater_Operation");
+  }
+
+  /**
+   * Continues an update in PAUSED state. Has no effect if invoked when the state
+   * of the update is ROLLED_OUT. (rollingUpdates.resume)
+   *
+   * @param string $project The Google Developers Console project name.
+   * @param string $zone The name of the zone in which the update's target
+   * resides.
+   * @param string $rollingUpdate The name of the update.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Replicapoolupdater_Operation
+   */
+  public function resume($project, $zone, $rollingUpdate, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'rollingUpdate' => $rollingUpdate);
+    $params = array_merge($params, $optParams);
+    return $this->call('resume', array($params), "Google_Service_Replicapoolupdater_Operation");
+  }
+
+  /**
+   * Rolls back the update in state from ROLLING_FORWARD or PAUSED. Has no effect
+   * if invoked when the state of the update is ROLLED_BACK.
+   * (rollingUpdates.rollback)
+   *
+   * @param string $project The Google Developers Console project name.
+   * @param string $zone The name of the zone in which the update's target
+   * resides.
+   * @param string $rollingUpdate The name of the update.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Replicapoolupdater_Operation
+   */
+  public function rollback($project, $zone, $rollingUpdate, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'rollingUpdate' => $rollingUpdate);
+    $params = array_merge($params, $optParams);
+    return $this->call('rollback', array($params), "Google_Service_Replicapoolupdater_Operation");
+  }
+}
+
+/**
+ * The "zoneOperations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $replicapoolupdaterService = new Google_Service_Replicapoolupdater(...);
+ *   $zoneOperations = $replicapoolupdaterService->zoneOperations;
+ *  </code>
+ */
+class Google_Service_Replicapoolupdater_ZoneOperations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the specified zone-specific operation resource.
+   * (zoneOperations.get)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param string $operation Name of the operation resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Replicapoolupdater_Operation
+   */
+  public function get($project, $zone, $operation, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'operation' => $operation);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Replicapoolupdater_Operation");
+  }
+
+  /**
+   * Retrieves the list of Operation resources contained within the specified
+   * zone. (zoneOperations.listZoneOperations)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Optional. Filter expression for filtering listed
+   * resources.
+   * @opt_param string pageToken Optional. Tag returned by a previous list request
+   * truncated by maxResults. Used to continue a previous list request.
+   * @opt_param string maxResults Optional. Maximum count of results to be
+   * returned. Maximum value is 500 and default value is 500.
+   * @return Google_Service_Replicapoolupdater_OperationList
+   */
+  public function listZoneOperations($project, $zone, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Replicapoolupdater_OperationList");
+  }
+}
+
+
+
+
+class Google_Service_Replicapoolupdater_InstanceUpdate extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorType = 'Google_Service_Replicapoolupdater_InstanceUpdateError';
+  protected $errorDataType = '';
+  public $instance;
+  public $status;
+
+
+  public function setError(Google_Service_Replicapoolupdater_InstanceUpdateError $error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setInstance($instance)
+  {
+    $this->instance = $instance;
+  }
+  public function getInstance()
+  {
+    return $this->instance;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_Replicapoolupdater_InstanceUpdateError extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorsType = 'Google_Service_Replicapoolupdater_InstanceUpdateErrorErrors';
+  protected $errorsDataType = 'array';
+
+
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+}
+
+class Google_Service_Replicapoolupdater_InstanceUpdateErrorErrors extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $location;
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Replicapoolupdater_InstanceUpdateList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Replicapoolupdater_InstanceUpdate';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Replicapoolupdater_Operation extends Google_Collection
+{
+  protected $collection_key = 'warnings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $clientOperationId;
+  public $creationTimestamp;
+  public $endTime;
+  protected $errorType = 'Google_Service_Replicapoolupdater_OperationError';
+  protected $errorDataType = '';
+  public $httpErrorMessage;
+  public $httpErrorStatusCode;
+  public $id;
+  public $insertTime;
+  public $kind;
+  public $name;
+  public $operationType;
+  public $progress;
+  public $region;
+  public $selfLink;
+  public $startTime;
+  public $status;
+  public $statusMessage;
+  public $targetId;
+  public $targetLink;
+  public $user;
+  protected $warningsType = 'Google_Service_Replicapoolupdater_OperationWarnings';
+  protected $warningsDataType = 'array';
+  public $zone;
+
+
+  public function setClientOperationId($clientOperationId)
+  {
+    $this->clientOperationId = $clientOperationId;
+  }
+  public function getClientOperationId()
+  {
+    return $this->clientOperationId;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setError(Google_Service_Replicapoolupdater_OperationError $error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setHttpErrorMessage($httpErrorMessage)
+  {
+    $this->httpErrorMessage = $httpErrorMessage;
+  }
+  public function getHttpErrorMessage()
+  {
+    return $this->httpErrorMessage;
+  }
+  public function setHttpErrorStatusCode($httpErrorStatusCode)
+  {
+    $this->httpErrorStatusCode = $httpErrorStatusCode;
+  }
+  public function getHttpErrorStatusCode()
+  {
+    return $this->httpErrorStatusCode;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInsertTime($insertTime)
+  {
+    $this->insertTime = $insertTime;
+  }
+  public function getInsertTime()
+  {
+    return $this->insertTime;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOperationType($operationType)
+  {
+    $this->operationType = $operationType;
+  }
+  public function getOperationType()
+  {
+    return $this->operationType;
+  }
+  public function setProgress($progress)
+  {
+    $this->progress = $progress;
+  }
+  public function getProgress()
+  {
+    return $this->progress;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setStatusMessage($statusMessage)
+  {
+    $this->statusMessage = $statusMessage;
+  }
+  public function getStatusMessage()
+  {
+    return $this->statusMessage;
+  }
+  public function setTargetId($targetId)
+  {
+    $this->targetId = $targetId;
+  }
+  public function getTargetId()
+  {
+    return $this->targetId;
+  }
+  public function setTargetLink($targetLink)
+  {
+    $this->targetLink = $targetLink;
+  }
+  public function getTargetLink()
+  {
+    return $this->targetLink;
+  }
+  public function setUser($user)
+  {
+    $this->user = $user;
+  }
+  public function getUser()
+  {
+    return $this->user;
+  }
+  public function setWarnings($warnings)
+  {
+    $this->warnings = $warnings;
+  }
+  public function getWarnings()
+  {
+    return $this->warnings;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_Replicapoolupdater_OperationError extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorsType = 'Google_Service_Replicapoolupdater_OperationErrorErrors';
+  protected $errorsDataType = 'array';
+
+
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+}
+
+class Google_Service_Replicapoolupdater_OperationErrorErrors extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $location;
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Replicapoolupdater_OperationList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Replicapoolupdater_Operation';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Replicapoolupdater_OperationWarnings extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Replicapoolupdater_OperationWarningsData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Replicapoolupdater_OperationWarningsData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Replicapoolupdater_RollingUpdate extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $actionType;
+  public $creationTimestamp;
+  public $description;
+  protected $errorType = 'Google_Service_Replicapoolupdater_RollingUpdateError';
+  protected $errorDataType = '';
+  public $id;
+  public $instanceGroup;
+  public $instanceGroupManager;
+  public $instanceTemplate;
+  public $kind;
+  public $oldInstanceTemplate;
+  protected $policyType = 'Google_Service_Replicapoolupdater_RollingUpdatePolicy';
+  protected $policyDataType = '';
+  public $progress;
+  public $selfLink;
+  public $status;
+  public $statusMessage;
+  public $user;
+
+
+  public function setActionType($actionType)
+  {
+    $this->actionType = $actionType;
+  }
+  public function getActionType()
+  {
+    return $this->actionType;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setError(Google_Service_Replicapoolupdater_RollingUpdateError $error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInstanceGroup($instanceGroup)
+  {
+    $this->instanceGroup = $instanceGroup;
+  }
+  public function getInstanceGroup()
+  {
+    return $this->instanceGroup;
+  }
+  public function setInstanceGroupManager($instanceGroupManager)
+  {
+    $this->instanceGroupManager = $instanceGroupManager;
+  }
+  public function getInstanceGroupManager()
+  {
+    return $this->instanceGroupManager;
+  }
+  public function setInstanceTemplate($instanceTemplate)
+  {
+    $this->instanceTemplate = $instanceTemplate;
+  }
+  public function getInstanceTemplate()
+  {
+    return $this->instanceTemplate;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setOldInstanceTemplate($oldInstanceTemplate)
+  {
+    $this->oldInstanceTemplate = $oldInstanceTemplate;
+  }
+  public function getOldInstanceTemplate()
+  {
+    return $this->oldInstanceTemplate;
+  }
+  public function setPolicy(Google_Service_Replicapoolupdater_RollingUpdatePolicy $policy)
+  {
+    $this->policy = $policy;
+  }
+  public function getPolicy()
+  {
+    return $this->policy;
+  }
+  public function setProgress($progress)
+  {
+    $this->progress = $progress;
+  }
+  public function getProgress()
+  {
+    return $this->progress;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setStatusMessage($statusMessage)
+  {
+    $this->statusMessage = $statusMessage;
+  }
+  public function getStatusMessage()
+  {
+    return $this->statusMessage;
+  }
+  public function setUser($user)
+  {
+    $this->user = $user;
+  }
+  public function getUser()
+  {
+    return $this->user;
+  }
+}
+
+class Google_Service_Replicapoolupdater_RollingUpdateError extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorsType = 'Google_Service_Replicapoolupdater_RollingUpdateErrorErrors';
+  protected $errorsDataType = 'array';
+
+
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+}
+
+class Google_Service_Replicapoolupdater_RollingUpdateErrorErrors extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $location;
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Replicapoolupdater_RollingUpdateList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Replicapoolupdater_RollingUpdate';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Replicapoolupdater_RollingUpdatePolicy extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $autoPauseAfterInstances;
+  public $instanceStartupTimeoutSec;
+  public $maxNumConcurrentInstances;
+  public $maxNumFailedInstances;
+  public $minInstanceUpdateTimeSec;
+
+
+  public function setAutoPauseAfterInstances($autoPauseAfterInstances)
+  {
+    $this->autoPauseAfterInstances = $autoPauseAfterInstances;
+  }
+  public function getAutoPauseAfterInstances()
+  {
+    return $this->autoPauseAfterInstances;
+  }
+  public function setInstanceStartupTimeoutSec($instanceStartupTimeoutSec)
+  {
+    $this->instanceStartupTimeoutSec = $instanceStartupTimeoutSec;
+  }
+  public function getInstanceStartupTimeoutSec()
+  {
+    return $this->instanceStartupTimeoutSec;
+  }
+  public function setMaxNumConcurrentInstances($maxNumConcurrentInstances)
+  {
+    $this->maxNumConcurrentInstances = $maxNumConcurrentInstances;
+  }
+  public function getMaxNumConcurrentInstances()
+  {
+    return $this->maxNumConcurrentInstances;
+  }
+  public function setMaxNumFailedInstances($maxNumFailedInstances)
+  {
+    $this->maxNumFailedInstances = $maxNumFailedInstances;
+  }
+  public function getMaxNumFailedInstances()
+  {
+    return $this->maxNumFailedInstances;
+  }
+  public function setMinInstanceUpdateTimeSec($minInstanceUpdateTimeSec)
+  {
+    $this->minInstanceUpdateTimeSec = $minInstanceUpdateTimeSec;
+  }
+  public function getMinInstanceUpdateTimeSec()
+  {
+    return $this->minInstanceUpdateTimeSec;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Reports.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Reports.php
@@ -1,0 +1,1136 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Reports (reports_v1).
+ *
+ * <p>
+ * Allows the administrators of Google Apps customers to fetch reports about the
+ * usage, collaboration, security and risk for their users.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/admin-sdk/reports/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Reports extends Google_Service
+{
+  /** View audit reports of Google Apps for your domain. */
+  const ADMIN_REPORTS_AUDIT_READONLY =
+      "https://www.googleapis.com/auth/admin.reports.audit.readonly";
+  /** View usage reports of Google Apps for your domain. */
+  const ADMIN_REPORTS_USAGE_READONLY =
+      "https://www.googleapis.com/auth/admin.reports.usage.readonly";
+
+  public $activities;
+  public $channels;
+  public $customerUsageReports;
+  public $userUsageReport;
+  
+
+  /**
+   * Constructs the internal representation of the Reports service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'admin/reports/v1/';
+    $this->version = 'reports_v1';
+    $this->serviceName = 'admin';
+
+    $this->activities = new Google_Service_Reports_Activities_Resource(
+        $this,
+        $this->serviceName,
+        'activities',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'activity/users/{userKey}/applications/{applicationName}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'applicationName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'startTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'actorIpAddress' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'eventName' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'filters' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'endTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'customerId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'watch' => array(
+              'path' => 'activity/users/{userKey}/applications/{applicationName}/watch',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'applicationName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'startTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'actorIpAddress' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'eventName' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'filters' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'endTime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'customerId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->channels = new Google_Service_Reports_Channels_Resource(
+        $this,
+        $this->serviceName,
+        'channels',
+        array(
+          'methods' => array(
+            'stop' => array(
+              'path' => '/admin/reports_v1/channels/stop',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->customerUsageReports = new Google_Service_Reports_CustomerUsageReports_Resource(
+        $this,
+        $this->serviceName,
+        'customerUsageReports',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'usage/dates/{date}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'date' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'customerId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'parameters' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->userUsageReport = new Google_Service_Reports_UserUsageReport_Resource(
+        $this,
+        $this->serviceName,
+        'userUsageReport',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'usage/users/{userKey}/dates/{date}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'userKey' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'date' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'parameters' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'filters' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'customerId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "activities" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Reports(...);
+ *   $activities = $adminService->activities;
+ *  </code>
+ */
+class Google_Service_Reports_Activities_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a list of activities for a specific customer and application.
+   * (activities.listActivities)
+   *
+   * @param string $userKey Represents the profile id or the user email for which
+   * the data should be filtered. When 'all' is specified as the userKey, it
+   * returns usageReports for all users.
+   * @param string $applicationName Application name for which the events are to
+   * be retrieved.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string startTime Return events which occured at or after this
+   * time.
+   * @opt_param string actorIpAddress IP Address of host where the event was
+   * performed. Supports both IPv4 and IPv6 addresses.
+   * @opt_param int maxResults Number of activity records to be shown in each
+   * page.
+   * @opt_param string eventName Name of the event being queried.
+   * @opt_param string pageToken Token to specify next page.
+   * @opt_param string filters Event parameters in the form [parameter1
+   * name][operator][parameter1 value],[parameter2 name][operator][parameter2
+   * value],...
+   * @opt_param string endTime Return events which occured at or before this time.
+   * @opt_param string customerId Represents the customer for which the data is to
+   * be fetched.
+   * @return Google_Service_Reports_Activities
+   */
+  public function listActivities($userKey, $applicationName, $optParams = array())
+  {
+    $params = array('userKey' => $userKey, 'applicationName' => $applicationName);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Reports_Activities");
+  }
+
+  /**
+   * Push changes to activities (activities.watch)
+   *
+   * @param string $userKey Represents the profile id or the user email for which
+   * the data should be filtered. When 'all' is specified as the userKey, it
+   * returns usageReports for all users.
+   * @param string $applicationName Application name for which the events are to
+   * be retrieved.
+   * @param Google_Channel $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string startTime Return events which occured at or after this
+   * time.
+   * @opt_param string actorIpAddress IP Address of host where the event was
+   * performed. Supports both IPv4 and IPv6 addresses.
+   * @opt_param int maxResults Number of activity records to be shown in each
+   * page.
+   * @opt_param string eventName Name of the event being queried.
+   * @opt_param string pageToken Token to specify next page.
+   * @opt_param string filters Event parameters in the form [parameter1
+   * name][operator][parameter1 value],[parameter2 name][operator][parameter2
+   * value],...
+   * @opt_param string endTime Return events which occured at or before this time.
+   * @opt_param string customerId Represents the customer for which the data is to
+   * be fetched.
+   * @return Google_Service_Reports_Channel
+   */
+  public function watch($userKey, $applicationName, Google_Service_Reports_Channel $postBody, $optParams = array())
+  {
+    $params = array('userKey' => $userKey, 'applicationName' => $applicationName, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('watch', array($params), "Google_Service_Reports_Channel");
+  }
+}
+
+/**
+ * The "channels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Reports(...);
+ *   $channels = $adminService->channels;
+ *  </code>
+ */
+class Google_Service_Reports_Channels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Stop watching resources through this channel (channels.stop)
+   *
+   * @param Google_Channel $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function stop(Google_Service_Reports_Channel $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('stop', array($params));
+  }
+}
+
+/**
+ * The "customerUsageReports" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Reports(...);
+ *   $customerUsageReports = $adminService->customerUsageReports;
+ *  </code>
+ */
+class Google_Service_Reports_CustomerUsageReports_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a report which is a collection of properties / statistics for a
+   * specific customer. (customerUsageReports.get)
+   *
+   * @param string $date Represents the date in yyyy-mm-dd format for which the
+   * data is to be fetched.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Token to specify next page.
+   * @opt_param string customerId Represents the customer for which the data is to
+   * be fetched.
+   * @opt_param string parameters Represents the application name, parameter name
+   * pairs to fetch in csv as app_name1:param_name1, app_name2:param_name2.
+   * @return Google_Service_Reports_UsageReports
+   */
+  public function get($date, $optParams = array())
+  {
+    $params = array('date' => $date);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Reports_UsageReports");
+  }
+}
+
+/**
+ * The "userUsageReport" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $adminService = new Google_Service_Reports(...);
+ *   $userUsageReport = $adminService->userUsageReport;
+ *  </code>
+ */
+class Google_Service_Reports_UserUsageReport_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a report which is a collection of properties / statistics for a set
+   * of users. (userUsageReport.get)
+   *
+   * @param string $userKey Represents the profile id or the user email for which
+   * the data should be filtered.
+   * @param string $date Represents the date in yyyy-mm-dd format for which the
+   * data is to be fetched.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string parameters Represents the application name, parameter name
+   * pairs to fetch in csv as app_name1:param_name1, app_name2:param_name2.
+   * @opt_param string maxResults Maximum number of results to return. Maximum
+   * allowed is 1000
+   * @opt_param string pageToken Token to specify next page.
+   * @opt_param string filters Represents the set of filters including parameter
+   * operator value.
+   * @opt_param string customerId Represents the customer for which the data is to
+   * be fetched.
+   * @return Google_Service_Reports_UsageReports
+   */
+  public function get($userKey, $date, $optParams = array())
+  {
+    $params = array('userKey' => $userKey, 'date' => $date);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Reports_UsageReports");
+  }
+}
+
+
+
+
+class Google_Service_Reports_Activities extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Reports_Activity';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Reports_Activity extends Google_Collection
+{
+  protected $collection_key = 'events';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $actorType = 'Google_Service_Reports_ActivityActor';
+  protected $actorDataType = '';
+  public $etag;
+  protected $eventsType = 'Google_Service_Reports_ActivityEvents';
+  protected $eventsDataType = 'array';
+  protected $idType = 'Google_Service_Reports_ActivityId';
+  protected $idDataType = '';
+  public $ipAddress;
+  public $kind;
+  public $ownerDomain;
+
+
+  public function setActor(Google_Service_Reports_ActivityActor $actor)
+  {
+    $this->actor = $actor;
+  }
+  public function getActor()
+  {
+    return $this->actor;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEvents($events)
+  {
+    $this->events = $events;
+  }
+  public function getEvents()
+  {
+    return $this->events;
+  }
+  public function setId(Google_Service_Reports_ActivityId $id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIpAddress($ipAddress)
+  {
+    $this->ipAddress = $ipAddress;
+  }
+  public function getIpAddress()
+  {
+    return $this->ipAddress;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setOwnerDomain($ownerDomain)
+  {
+    $this->ownerDomain = $ownerDomain;
+  }
+  public function getOwnerDomain()
+  {
+    return $this->ownerDomain;
+  }
+}
+
+class Google_Service_Reports_ActivityActor extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $callerType;
+  public $email;
+  public $key;
+  public $profileId;
+
+
+  public function setCallerType($callerType)
+  {
+    $this->callerType = $callerType;
+  }
+  public function getCallerType()
+  {
+    return $this->callerType;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setProfileId($profileId)
+  {
+    $this->profileId = $profileId;
+  }
+  public function getProfileId()
+  {
+    return $this->profileId;
+  }
+}
+
+class Google_Service_Reports_ActivityEvents extends Google_Collection
+{
+  protected $collection_key = 'parameters';
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  protected $parametersType = 'Google_Service_Reports_ActivityEventsParameters';
+  protected $parametersDataType = 'array';
+  public $type;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setParameters($parameters)
+  {
+    $this->parameters = $parameters;
+  }
+  public function getParameters()
+  {
+    return $this->parameters;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Reports_ActivityEventsParameters extends Google_Collection
+{
+  protected $collection_key = 'multiValue';
+  protected $internal_gapi_mappings = array(
+  );
+  public $boolValue;
+  public $intValue;
+  public $multiIntValue;
+  public $multiValue;
+  public $name;
+  public $value;
+
+
+  public function setBoolValue($boolValue)
+  {
+    $this->boolValue = $boolValue;
+  }
+  public function getBoolValue()
+  {
+    return $this->boolValue;
+  }
+  public function setIntValue($intValue)
+  {
+    $this->intValue = $intValue;
+  }
+  public function getIntValue()
+  {
+    return $this->intValue;
+  }
+  public function setMultiIntValue($multiIntValue)
+  {
+    $this->multiIntValue = $multiIntValue;
+  }
+  public function getMultiIntValue()
+  {
+    return $this->multiIntValue;
+  }
+  public function setMultiValue($multiValue)
+  {
+    $this->multiValue = $multiValue;
+  }
+  public function getMultiValue()
+  {
+    return $this->multiValue;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Reports_ActivityId extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $applicationName;
+  public $customerId;
+  public $time;
+  public $uniqueQualifier;
+
+
+  public function setApplicationName($applicationName)
+  {
+    $this->applicationName = $applicationName;
+  }
+  public function getApplicationName()
+  {
+    return $this->applicationName;
+  }
+  public function setCustomerId($customerId)
+  {
+    $this->customerId = $customerId;
+  }
+  public function getCustomerId()
+  {
+    return $this->customerId;
+  }
+  public function setTime($time)
+  {
+    $this->time = $time;
+  }
+  public function getTime()
+  {
+    return $this->time;
+  }
+  public function setUniqueQualifier($uniqueQualifier)
+  {
+    $this->uniqueQualifier = $uniqueQualifier;
+  }
+  public function getUniqueQualifier()
+  {
+    return $this->uniqueQualifier;
+  }
+}
+
+class Google_Service_Reports_Channel extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $address;
+  public $expiration;
+  public $id;
+  public $kind;
+  public $params;
+  public $payload;
+  public $resourceId;
+  public $resourceUri;
+  public $token;
+  public $type;
+
+
+  public function setAddress($address)
+  {
+    $this->address = $address;
+  }
+  public function getAddress()
+  {
+    return $this->address;
+  }
+  public function setExpiration($expiration)
+  {
+    $this->expiration = $expiration;
+  }
+  public function getExpiration()
+  {
+    return $this->expiration;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setParams($params)
+  {
+    $this->params = $params;
+  }
+  public function getParams()
+  {
+    return $this->params;
+  }
+  public function setPayload($payload)
+  {
+    $this->payload = $payload;
+  }
+  public function getPayload()
+  {
+    return $this->payload;
+  }
+  public function setResourceId($resourceId)
+  {
+    $this->resourceId = $resourceId;
+  }
+  public function getResourceId()
+  {
+    return $this->resourceId;
+  }
+  public function setResourceUri($resourceUri)
+  {
+    $this->resourceUri = $resourceUri;
+  }
+  public function getResourceUri()
+  {
+    return $this->resourceUri;
+  }
+  public function setToken($token)
+  {
+    $this->token = $token;
+  }
+  public function getToken()
+  {
+    return $this->token;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Reports_ChannelParams extends Google_Model
+{
+}
+
+class Google_Service_Reports_UsageReport extends Google_Collection
+{
+  protected $collection_key = 'parameters';
+  protected $internal_gapi_mappings = array(
+  );
+  public $date;
+  protected $entityType = 'Google_Service_Reports_UsageReportEntity';
+  protected $entityDataType = '';
+  public $etag;
+  public $kind;
+  protected $parametersType = 'Google_Service_Reports_UsageReportParameters';
+  protected $parametersDataType = 'array';
+
+
+  public function setDate($date)
+  {
+    $this->date = $date;
+  }
+  public function getDate()
+  {
+    return $this->date;
+  }
+  public function setEntity(Google_Service_Reports_UsageReportEntity $entity)
+  {
+    $this->entity = $entity;
+  }
+  public function getEntity()
+  {
+    return $this->entity;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setParameters($parameters)
+  {
+    $this->parameters = $parameters;
+  }
+  public function getParameters()
+  {
+    return $this->parameters;
+  }
+}
+
+class Google_Service_Reports_UsageReportEntity extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $customerId;
+  public $profileId;
+  public $type;
+  public $userEmail;
+
+
+  public function setCustomerId($customerId)
+  {
+    $this->customerId = $customerId;
+  }
+  public function getCustomerId()
+  {
+    return $this->customerId;
+  }
+  public function setProfileId($profileId)
+  {
+    $this->profileId = $profileId;
+  }
+  public function getProfileId()
+  {
+    return $this->profileId;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUserEmail($userEmail)
+  {
+    $this->userEmail = $userEmail;
+  }
+  public function getUserEmail()
+  {
+    return $this->userEmail;
+  }
+}
+
+class Google_Service_Reports_UsageReportParameters extends Google_Collection
+{
+  protected $collection_key = 'msgValue';
+  protected $internal_gapi_mappings = array(
+  );
+  public $boolValue;
+  public $datetimeValue;
+  public $intValue;
+  public $msgValue;
+  public $name;
+  public $stringValue;
+
+
+  public function setBoolValue($boolValue)
+  {
+    $this->boolValue = $boolValue;
+  }
+  public function getBoolValue()
+  {
+    return $this->boolValue;
+  }
+  public function setDatetimeValue($datetimeValue)
+  {
+    $this->datetimeValue = $datetimeValue;
+  }
+  public function getDatetimeValue()
+  {
+    return $this->datetimeValue;
+  }
+  public function setIntValue($intValue)
+  {
+    $this->intValue = $intValue;
+  }
+  public function getIntValue()
+  {
+    return $this->intValue;
+  }
+  public function setMsgValue($msgValue)
+  {
+    $this->msgValue = $msgValue;
+  }
+  public function getMsgValue()
+  {
+    return $this->msgValue;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setStringValue($stringValue)
+  {
+    $this->stringValue = $stringValue;
+  }
+  public function getStringValue()
+  {
+    return $this->stringValue;
+  }
+}
+
+class Google_Service_Reports_UsageReportParametersMsgValue extends Google_Model
+{
+}
+
+class Google_Service_Reports_UsageReports extends Google_Collection
+{
+  protected $collection_key = 'warnings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $kind;
+  public $nextPageToken;
+  protected $usageReportsType = 'Google_Service_Reports_UsageReport';
+  protected $usageReportsDataType = 'array';
+  protected $warningsType = 'Google_Service_Reports_UsageReportsWarnings';
+  protected $warningsDataType = 'array';
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setUsageReports($usageReports)
+  {
+    $this->usageReports = $usageReports;
+  }
+  public function getUsageReports()
+  {
+    return $this->usageReports;
+  }
+  public function setWarnings($warnings)
+  {
+    $this->warnings = $warnings;
+  }
+  public function getWarnings()
+  {
+    return $this->warnings;
+  }
+}
+
+class Google_Service_Reports_UsageReportsWarnings extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Reports_UsageReportsWarningsData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Reports_UsageReportsWarningsData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Reseller.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Reseller.php
@@ -1,0 +1,1144 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Reseller (v1).
+ *
+ * <p>
+ * Lets you create and manage your customers and their subscriptions.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/google-apps/reseller/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Reseller extends Google_Service
+{
+  /** Manage users on your domain. */
+  const APPS_ORDER =
+      "https://www.googleapis.com/auth/apps.order";
+  /** Manage users on your domain. */
+  const APPS_ORDER_READONLY =
+      "https://www.googleapis.com/auth/apps.order.readonly";
+
+  public $customers;
+  public $subscriptions;
+  
+
+  /**
+   * Constructs the internal representation of the Reseller service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'apps/reseller/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'reseller';
+
+    $this->customers = new Google_Service_Reseller_Customers_Resource(
+        $this,
+        $this->serviceName,
+        'customers',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'customers/{customerId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'customers',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'customerAuthToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'customers/{customerId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'customers/{customerId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->subscriptions = new Google_Service_Reseller_Subscriptions_Resource(
+        $this,
+        $this->serviceName,
+        'subscriptions',
+        array(
+          'methods' => array(
+            'activate' => array(
+              'path' => 'customers/{customerId}/subscriptions/{subscriptionId}/activate',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'subscriptionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'changePlan' => array(
+              'path' => 'customers/{customerId}/subscriptions/{subscriptionId}/changePlan',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'subscriptionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'changeRenewalSettings' => array(
+              'path' => 'customers/{customerId}/subscriptions/{subscriptionId}/changeRenewalSettings',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'subscriptionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'changeSeats' => array(
+              'path' => 'customers/{customerId}/subscriptions/{subscriptionId}/changeSeats',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'subscriptionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'customers/{customerId}/subscriptions/{subscriptionId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'subscriptionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'deletionType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'customers/{customerId}/subscriptions/{subscriptionId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'subscriptionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'customers/{customerId}/subscriptions',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'customerAuthToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'subscriptions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'customerAuthToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'customerId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'customerNamePrefix' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'startPaidService' => array(
+              'path' => 'customers/{customerId}/subscriptions/{subscriptionId}/startPaidService',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'subscriptionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'suspend' => array(
+              'path' => 'customers/{customerId}/subscriptions/{subscriptionId}/suspend',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'customerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'subscriptionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "customers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $resellerService = new Google_Service_Reseller(...);
+ *   $customers = $resellerService->customers;
+ *  </code>
+ */
+class Google_Service_Reseller_Customers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets a customer resource if one exists and is owned by the reseller.
+   * (customers.get)
+   *
+   * @param string $customerId Id of the Customer
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Reseller_Customer
+   */
+  public function get($customerId, $optParams = array())
+  {
+    $params = array('customerId' => $customerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Reseller_Customer");
+  }
+
+  /**
+   * Creates a customer resource if one does not already exist. (customers.insert)
+   *
+   * @param Google_Customer $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string customerAuthToken An auth token needed for inserting a
+   * customer for which domain already exists. Can be generated at
+   * https://www.google.com/a/cpanel//TransferToken. Optional.
+   * @return Google_Service_Reseller_Customer
+   */
+  public function insert(Google_Service_Reseller_Customer $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Reseller_Customer");
+  }
+
+  /**
+   * Update a customer resource if one it exists and is owned by the reseller.
+   * This method supports patch semantics. (customers.patch)
+   *
+   * @param string $customerId Id of the Customer
+   * @param Google_Customer $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Reseller_Customer
+   */
+  public function patch($customerId, Google_Service_Reseller_Customer $postBody, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Reseller_Customer");
+  }
+
+  /**
+   * Update a customer resource if one it exists and is owned by the reseller.
+   * (customers.update)
+   *
+   * @param string $customerId Id of the Customer
+   * @param Google_Customer $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Reseller_Customer
+   */
+  public function update($customerId, Google_Service_Reseller_Customer $postBody, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Reseller_Customer");
+  }
+}
+
+/**
+ * The "subscriptions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $resellerService = new Google_Service_Reseller(...);
+ *   $subscriptions = $resellerService->subscriptions;
+ *  </code>
+ */
+class Google_Service_Reseller_Subscriptions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Activates a subscription previously suspended by the reseller
+   * (subscriptions.activate)
+   *
+   * @param string $customerId Id of the Customer
+   * @param string $subscriptionId Id of the subscription, which is unique for a
+   * customer
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Reseller_Subscription
+   */
+  public function activate($customerId, $subscriptionId, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'subscriptionId' => $subscriptionId);
+    $params = array_merge($params, $optParams);
+    return $this->call('activate', array($params), "Google_Service_Reseller_Subscription");
+  }
+
+  /**
+   * Changes the plan of a subscription (subscriptions.changePlan)
+   *
+   * @param string $customerId Id of the Customer
+   * @param string $subscriptionId Id of the subscription, which is unique for a
+   * customer
+   * @param Google_ChangePlanRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Reseller_Subscription
+   */
+  public function changePlan($customerId, $subscriptionId, Google_Service_Reseller_ChangePlanRequest $postBody, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'subscriptionId' => $subscriptionId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('changePlan', array($params), "Google_Service_Reseller_Subscription");
+  }
+
+  /**
+   * Changes the renewal settings of a subscription
+   * (subscriptions.changeRenewalSettings)
+   *
+   * @param string $customerId Id of the Customer
+   * @param string $subscriptionId Id of the subscription, which is unique for a
+   * customer
+   * @param Google_RenewalSettings $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Reseller_Subscription
+   */
+  public function changeRenewalSettings($customerId, $subscriptionId, Google_Service_Reseller_RenewalSettings $postBody, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'subscriptionId' => $subscriptionId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('changeRenewalSettings', array($params), "Google_Service_Reseller_Subscription");
+  }
+
+  /**
+   * Changes the seats configuration of a subscription (subscriptions.changeSeats)
+   *
+   * @param string $customerId Id of the Customer
+   * @param string $subscriptionId Id of the subscription, which is unique for a
+   * customer
+   * @param Google_Seats $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Reseller_Subscription
+   */
+  public function changeSeats($customerId, $subscriptionId, Google_Service_Reseller_Seats $postBody, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'subscriptionId' => $subscriptionId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('changeSeats', array($params), "Google_Service_Reseller_Subscription");
+  }
+
+  /**
+   * Cancels/Downgrades a subscription. (subscriptions.delete)
+   *
+   * @param string $customerId Id of the Customer
+   * @param string $subscriptionId Id of the subscription, which is unique for a
+   * customer
+   * @param string $deletionType Whether the subscription is to be fully cancelled
+   * or downgraded
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($customerId, $subscriptionId, $deletionType, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'subscriptionId' => $subscriptionId, 'deletionType' => $deletionType);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets a subscription of the customer. (subscriptions.get)
+   *
+   * @param string $customerId Id of the Customer
+   * @param string $subscriptionId Id of the subscription, which is unique for a
+   * customer
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Reseller_Subscription
+   */
+  public function get($customerId, $subscriptionId, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'subscriptionId' => $subscriptionId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Reseller_Subscription");
+  }
+
+  /**
+   * Creates/Transfers a subscription for the customer. (subscriptions.insert)
+   *
+   * @param string $customerId Id of the Customer
+   * @param Google_Subscription $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string customerAuthToken An auth token needed for transferring a
+   * subscription. Can be generated at https://www.google.com/a/cpanel/customer-
+   * domain/TransferToken. Optional.
+   * @return Google_Service_Reseller_Subscription
+   */
+  public function insert($customerId, Google_Service_Reseller_Subscription $postBody, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Reseller_Subscription");
+  }
+
+  /**
+   * Lists subscriptions of a reseller, optionally filtered by a customer name
+   * prefix. (subscriptions.listSubscriptions)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string customerAuthToken An auth token needed if the customer is
+   * not a resold customer of this reseller. Can be generated at
+   * https://www.google.com/a/cpanel/customer-domain/TransferToken.Optional.
+   * @opt_param string pageToken Token to specify next page in the list
+   * @opt_param string customerId Id of the Customer
+   * @opt_param string maxResults Maximum number of results to return
+   * @opt_param string customerNamePrefix Prefix of the customer's domain name by
+   * which the subscriptions should be filtered. Optional
+   * @return Google_Service_Reseller_Subscriptions
+   */
+  public function listSubscriptions($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Reseller_Subscriptions");
+  }
+
+  /**
+   * Starts paid service of a trial subscription (subscriptions.startPaidService)
+   *
+   * @param string $customerId Id of the Customer
+   * @param string $subscriptionId Id of the subscription, which is unique for a
+   * customer
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Reseller_Subscription
+   */
+  public function startPaidService($customerId, $subscriptionId, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'subscriptionId' => $subscriptionId);
+    $params = array_merge($params, $optParams);
+    return $this->call('startPaidService', array($params), "Google_Service_Reseller_Subscription");
+  }
+
+  /**
+   * Suspends an active subscription (subscriptions.suspend)
+   *
+   * @param string $customerId Id of the Customer
+   * @param string $subscriptionId Id of the subscription, which is unique for a
+   * customer
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Reseller_Subscription
+   */
+  public function suspend($customerId, $subscriptionId, $optParams = array())
+  {
+    $params = array('customerId' => $customerId, 'subscriptionId' => $subscriptionId);
+    $params = array_merge($params, $optParams);
+    return $this->call('suspend', array($params), "Google_Service_Reseller_Subscription");
+  }
+}
+
+
+
+
+class Google_Service_Reseller_Address extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $addressLine1;
+  public $addressLine2;
+  public $addressLine3;
+  public $contactName;
+  public $countryCode;
+  public $kind;
+  public $locality;
+  public $organizationName;
+  public $postalCode;
+  public $region;
+
+
+  public function setAddressLine1($addressLine1)
+  {
+    $this->addressLine1 = $addressLine1;
+  }
+  public function getAddressLine1()
+  {
+    return $this->addressLine1;
+  }
+  public function setAddressLine2($addressLine2)
+  {
+    $this->addressLine2 = $addressLine2;
+  }
+  public function getAddressLine2()
+  {
+    return $this->addressLine2;
+  }
+  public function setAddressLine3($addressLine3)
+  {
+    $this->addressLine3 = $addressLine3;
+  }
+  public function getAddressLine3()
+  {
+    return $this->addressLine3;
+  }
+  public function setContactName($contactName)
+  {
+    $this->contactName = $contactName;
+  }
+  public function getContactName()
+  {
+    return $this->contactName;
+  }
+  public function setCountryCode($countryCode)
+  {
+    $this->countryCode = $countryCode;
+  }
+  public function getCountryCode()
+  {
+    return $this->countryCode;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocality($locality)
+  {
+    $this->locality = $locality;
+  }
+  public function getLocality()
+  {
+    return $this->locality;
+  }
+  public function setOrganizationName($organizationName)
+  {
+    $this->organizationName = $organizationName;
+  }
+  public function getOrganizationName()
+  {
+    return $this->organizationName;
+  }
+  public function setPostalCode($postalCode)
+  {
+    $this->postalCode = $postalCode;
+  }
+  public function getPostalCode()
+  {
+    return $this->postalCode;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+}
+
+class Google_Service_Reseller_ChangePlanRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $planName;
+  public $purchaseOrderId;
+  protected $seatsType = 'Google_Service_Reseller_Seats';
+  protected $seatsDataType = '';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPlanName($planName)
+  {
+    $this->planName = $planName;
+  }
+  public function getPlanName()
+  {
+    return $this->planName;
+  }
+  public function setPurchaseOrderId($purchaseOrderId)
+  {
+    $this->purchaseOrderId = $purchaseOrderId;
+  }
+  public function getPurchaseOrderId()
+  {
+    return $this->purchaseOrderId;
+  }
+  public function setSeats(Google_Service_Reseller_Seats $seats)
+  {
+    $this->seats = $seats;
+  }
+  public function getSeats()
+  {
+    return $this->seats;
+  }
+}
+
+class Google_Service_Reseller_Customer extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $alternateEmail;
+  public $customerDomain;
+  public $customerDomainVerified;
+  public $customerId;
+  public $kind;
+  public $phoneNumber;
+  protected $postalAddressType = 'Google_Service_Reseller_Address';
+  protected $postalAddressDataType = '';
+  public $resourceUiUrl;
+
+
+  public function setAlternateEmail($alternateEmail)
+  {
+    $this->alternateEmail = $alternateEmail;
+  }
+  public function getAlternateEmail()
+  {
+    return $this->alternateEmail;
+  }
+  public function setCustomerDomain($customerDomain)
+  {
+    $this->customerDomain = $customerDomain;
+  }
+  public function getCustomerDomain()
+  {
+    return $this->customerDomain;
+  }
+  public function setCustomerDomainVerified($customerDomainVerified)
+  {
+    $this->customerDomainVerified = $customerDomainVerified;
+  }
+  public function getCustomerDomainVerified()
+  {
+    return $this->customerDomainVerified;
+  }
+  public function setCustomerId($customerId)
+  {
+    $this->customerId = $customerId;
+  }
+  public function getCustomerId()
+  {
+    return $this->customerId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPhoneNumber($phoneNumber)
+  {
+    $this->phoneNumber = $phoneNumber;
+  }
+  public function getPhoneNumber()
+  {
+    return $this->phoneNumber;
+  }
+  public function setPostalAddress(Google_Service_Reseller_Address $postalAddress)
+  {
+    $this->postalAddress = $postalAddress;
+  }
+  public function getPostalAddress()
+  {
+    return $this->postalAddress;
+  }
+  public function setResourceUiUrl($resourceUiUrl)
+  {
+    $this->resourceUiUrl = $resourceUiUrl;
+  }
+  public function getResourceUiUrl()
+  {
+    return $this->resourceUiUrl;
+  }
+}
+
+class Google_Service_Reseller_RenewalSettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $renewalType;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRenewalType($renewalType)
+  {
+    $this->renewalType = $renewalType;
+  }
+  public function getRenewalType()
+  {
+    return $this->renewalType;
+  }
+}
+
+class Google_Service_Reseller_Seats extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $licensedNumberOfSeats;
+  public $maximumNumberOfSeats;
+  public $numberOfSeats;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLicensedNumberOfSeats($licensedNumberOfSeats)
+  {
+    $this->licensedNumberOfSeats = $licensedNumberOfSeats;
+  }
+  public function getLicensedNumberOfSeats()
+  {
+    return $this->licensedNumberOfSeats;
+  }
+  public function setMaximumNumberOfSeats($maximumNumberOfSeats)
+  {
+    $this->maximumNumberOfSeats = $maximumNumberOfSeats;
+  }
+  public function getMaximumNumberOfSeats()
+  {
+    return $this->maximumNumberOfSeats;
+  }
+  public function setNumberOfSeats($numberOfSeats)
+  {
+    $this->numberOfSeats = $numberOfSeats;
+  }
+  public function getNumberOfSeats()
+  {
+    return $this->numberOfSeats;
+  }
+}
+
+class Google_Service_Reseller_Subscription extends Google_Collection
+{
+  protected $collection_key = 'suspensionReasons';
+  protected $internal_gapi_mappings = array(
+  );
+  public $billingMethod;
+  public $creationTime;
+  public $customerId;
+  public $kind;
+  protected $planType = 'Google_Service_Reseller_SubscriptionPlan';
+  protected $planDataType = '';
+  public $purchaseOrderId;
+  protected $renewalSettingsType = 'Google_Service_Reseller_RenewalSettings';
+  protected $renewalSettingsDataType = '';
+  public $resourceUiUrl;
+  protected $seatsType = 'Google_Service_Reseller_Seats';
+  protected $seatsDataType = '';
+  public $skuId;
+  public $status;
+  public $subscriptionId;
+  public $suspensionReasons;
+  protected $transferInfoType = 'Google_Service_Reseller_SubscriptionTransferInfo';
+  protected $transferInfoDataType = '';
+  protected $trialSettingsType = 'Google_Service_Reseller_SubscriptionTrialSettings';
+  protected $trialSettingsDataType = '';
+
+
+  public function setBillingMethod($billingMethod)
+  {
+    $this->billingMethod = $billingMethod;
+  }
+  public function getBillingMethod()
+  {
+    return $this->billingMethod;
+  }
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setCustomerId($customerId)
+  {
+    $this->customerId = $customerId;
+  }
+  public function getCustomerId()
+  {
+    return $this->customerId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPlan(Google_Service_Reseller_SubscriptionPlan $plan)
+  {
+    $this->plan = $plan;
+  }
+  public function getPlan()
+  {
+    return $this->plan;
+  }
+  public function setPurchaseOrderId($purchaseOrderId)
+  {
+    $this->purchaseOrderId = $purchaseOrderId;
+  }
+  public function getPurchaseOrderId()
+  {
+    return $this->purchaseOrderId;
+  }
+  public function setRenewalSettings(Google_Service_Reseller_RenewalSettings $renewalSettings)
+  {
+    $this->renewalSettings = $renewalSettings;
+  }
+  public function getRenewalSettings()
+  {
+    return $this->renewalSettings;
+  }
+  public function setResourceUiUrl($resourceUiUrl)
+  {
+    $this->resourceUiUrl = $resourceUiUrl;
+  }
+  public function getResourceUiUrl()
+  {
+    return $this->resourceUiUrl;
+  }
+  public function setSeats(Google_Service_Reseller_Seats $seats)
+  {
+    $this->seats = $seats;
+  }
+  public function getSeats()
+  {
+    return $this->seats;
+  }
+  public function setSkuId($skuId)
+  {
+    $this->skuId = $skuId;
+  }
+  public function getSkuId()
+  {
+    return $this->skuId;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setSubscriptionId($subscriptionId)
+  {
+    $this->subscriptionId = $subscriptionId;
+  }
+  public function getSubscriptionId()
+  {
+    return $this->subscriptionId;
+  }
+  public function setSuspensionReasons($suspensionReasons)
+  {
+    $this->suspensionReasons = $suspensionReasons;
+  }
+  public function getSuspensionReasons()
+  {
+    return $this->suspensionReasons;
+  }
+  public function setTransferInfo(Google_Service_Reseller_SubscriptionTransferInfo $transferInfo)
+  {
+    $this->transferInfo = $transferInfo;
+  }
+  public function getTransferInfo()
+  {
+    return $this->transferInfo;
+  }
+  public function setTrialSettings(Google_Service_Reseller_SubscriptionTrialSettings $trialSettings)
+  {
+    $this->trialSettings = $trialSettings;
+  }
+  public function getTrialSettings()
+  {
+    return $this->trialSettings;
+  }
+}
+
+class Google_Service_Reseller_SubscriptionPlan extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $commitmentIntervalType = 'Google_Service_Reseller_SubscriptionPlanCommitmentInterval';
+  protected $commitmentIntervalDataType = '';
+  public $isCommitmentPlan;
+  public $planName;
+
+
+  public function setCommitmentInterval(Google_Service_Reseller_SubscriptionPlanCommitmentInterval $commitmentInterval)
+  {
+    $this->commitmentInterval = $commitmentInterval;
+  }
+  public function getCommitmentInterval()
+  {
+    return $this->commitmentInterval;
+  }
+  public function setIsCommitmentPlan($isCommitmentPlan)
+  {
+    $this->isCommitmentPlan = $isCommitmentPlan;
+  }
+  public function getIsCommitmentPlan()
+  {
+    return $this->isCommitmentPlan;
+  }
+  public function setPlanName($planName)
+  {
+    $this->planName = $planName;
+  }
+  public function getPlanName()
+  {
+    return $this->planName;
+  }
+}
+
+class Google_Service_Reseller_SubscriptionPlanCommitmentInterval extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $endTime;
+  public $startTime;
+
+
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+}
+
+class Google_Service_Reseller_SubscriptionTransferInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $minimumTransferableSeats;
+  public $transferabilityExpirationTime;
+
+
+  public function setMinimumTransferableSeats($minimumTransferableSeats)
+  {
+    $this->minimumTransferableSeats = $minimumTransferableSeats;
+  }
+  public function getMinimumTransferableSeats()
+  {
+    return $this->minimumTransferableSeats;
+  }
+  public function setTransferabilityExpirationTime($transferabilityExpirationTime)
+  {
+    $this->transferabilityExpirationTime = $transferabilityExpirationTime;
+  }
+  public function getTransferabilityExpirationTime()
+  {
+    return $this->transferabilityExpirationTime;
+  }
+}
+
+class Google_Service_Reseller_SubscriptionTrialSettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $isInTrial;
+  public $trialEndTime;
+
+
+  public function setIsInTrial($isInTrial)
+  {
+    $this->isInTrial = $isInTrial;
+  }
+  public function getIsInTrial()
+  {
+    return $this->isInTrial;
+  }
+  public function setTrialEndTime($trialEndTime)
+  {
+    $this->trialEndTime = $trialEndTime;
+  }
+  public function getTrialEndTime()
+  {
+    return $this->trialEndTime;
+  }
+}
+
+class Google_Service_Reseller_Subscriptions extends Google_Collection
+{
+  protected $collection_key = 'subscriptions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $subscriptionsType = 'Google_Service_Reseller_Subscription';
+  protected $subscriptionsDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSubscriptions($subscriptions)
+  {
+    $this->subscriptions = $subscriptions;
+  }
+  public function getSubscriptions()
+  {
+    return $this->subscriptions;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Resource.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Resource.php
@@ -15,20 +15,14 @@
  * limitations under the License.
  */
 
-require_once 'Google/Client.php';
-require_once 'Google/Exception.php';
-require_once 'Google/Utils.php';
-require_once 'Google/Http/Request.php';
-require_once 'Google/Http/MediaFileUpload.php';
-require_once 'Google/Http/REST.php';
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
 
 /**
  * Implements the actual methods/resources of the discovered Google API using magic function
  * calling overloading (__call()), which on call will see if the method name (plus.activities.list)
  * is available in this service, and if so construct an apiHttpRequest representing it.
- *
- * @author Chris Chabot <chabotc@google.com>
- * @author Chirag Shah <chirags@google.com>
  *
  */
 class Google_Service_Resource
@@ -39,22 +33,25 @@ class Google_Service_Resource
       'fields' => array('type' => 'string', 'location' => 'query'),
       'trace' => array('type' => 'string', 'location' => 'query'),
       'userIp' => array('type' => 'string', 'location' => 'query'),
-      'userip' => array('type' => 'string', 'location' => 'query'),
       'quotaUser' => array('type' => 'string', 'location' => 'query'),
       'data' => array('type' => 'string', 'location' => 'body'),
       'mimeType' => array('type' => 'string', 'location' => 'header'),
       'uploadType' => array('type' => 'string', 'location' => 'query'),
       'mediaUpload' => array('type' => 'complex', 'location' => 'query'),
+      'prettyPrint' => array('type' => 'string', 'location' => 'query'),
   );
 
-  /** @var Google_Service $service */
-  private $service;
+  /** @var string $rootUrl */
+  private $rootUrl;
 
   /** @var Google_Client $client */
   private $client;
 
   /** @var string $serviceName */
   private $serviceName;
+
+  /** @var string $servicePath */
+  private $servicePath;
 
   /** @var string $resourceName */
   private $resourceName;
@@ -64,17 +61,18 @@ class Google_Service_Resource
 
   public function __construct($service, $serviceName, $resourceName, $resource)
   {
-    $this->service = $service;
+    $this->rootUrl = $service->rootUrl;
     $this->client = $service->getClient();
+    $this->servicePath = $service->servicePath;
     $this->serviceName = $serviceName;
     $this->resourceName = $resourceName;
-    $this->methods = isset($resource['methods']) ?
+    $this->methods = is_array($resource) && isset($resource['methods']) ?
         $resource['methods'] :
         array($resourceName => $resource);
   }
 
   /**
-   * TODO(ianbarber): This function needs simplifying.
+   * TODO: This function needs simplifying.
    * @param $name
    * @param $arguments
    * @param $expected_class - optional, the expected class name
@@ -84,6 +82,15 @@ class Google_Service_Resource
   public function call($name, $arguments, $expected_class = null)
   {
     if (! isset($this->methods[$name])) {
+      $this->client->getLogger()->error(
+          'Service method unknown',
+          array(
+              'service' => $this->serviceName,
+              'resource' => $this->resourceName,
+              'method' => $name
+          )
+      );
+
       throw new Google_Exception(
           "Unknown function: " .
           "{$this->serviceName}->{$this->resourceName}->{$name}()"
@@ -108,10 +115,13 @@ class Google_Service_Resource
             $this->convertToArrayAndStripNulls($parameters['postBody']);
       }
       $postBody = json_encode($parameters['postBody']);
+      if ($postBody === false && $parameters['postBody'] !== false) {
+        throw new Google_Exception("JSON encoding failed. Ensure all strings in the request are UTF-8 encoded.");
+      }
       unset($parameters['postBody']);
     }
 
-    // TODO(ianbarber): optParams here probably should have been
+    // TODO: optParams here probably should have been
     // handled already - this may well be redundant code.
     if (isset($parameters['optParams'])) {
       $optParams = $parameters['optParams'];
@@ -124,11 +134,20 @@ class Google_Service_Resource
     }
 
     $method['parameters'] = array_merge(
-        $method['parameters'],
-        $this->stackParameters
+        $this->stackParameters,
+        $method['parameters']
     );
     foreach ($parameters as $key => $val) {
       if ($key != 'postBody' && ! isset($method['parameters'][$key])) {
+        $this->client->getLogger()->error(
+            'Service parameter unknown',
+            array(
+                'service' => $this->serviceName,
+                'resource' => $this->resourceName,
+                'method' => $name,
+                'parameter' => $key
+            )
+        );
         throw new Google_Exception("($name) unknown parameter: '$key'");
       }
     }
@@ -138,6 +157,15 @@ class Google_Service_Resource
           $paramSpec['required'] &&
           ! isset($parameters[$paramName])
       ) {
+        $this->client->getLogger()->error(
+            'Service parameter missing',
+            array(
+                'service' => $this->serviceName,
+                'resource' => $this->resourceName,
+                'method' => $name,
+                'parameter' => $paramName
+            )
+        );
         throw new Google_Exception("($name) missing required param: '$paramName'");
       }
       if (isset($parameters[$paramName])) {
@@ -151,10 +179,18 @@ class Google_Service_Resource
       }
     }
 
-    $servicePath = $this->service->servicePath;
+    $this->client->getLogger()->info(
+        'Service Call',
+        array(
+            'service' => $this->serviceName,
+            'resource' => $this->resourceName,
+            'method' => $name,
+            'arguments' => $parameters,
+        )
+    );
 
     $url = Google_Http_REST::createRequestUri(
-        $servicePath,
+        $this->servicePath,
         $method['path'],
         $parameters
     );
@@ -164,7 +200,12 @@ class Google_Service_Resource
         null,
         $postBody
     );
-    $httpRequest->setBaseComponent($this->client->getBasePath());
+
+    if ($this->rootUrl) {
+      $httpRequest->setBaseComponent($this->rootUrl);
+    } else {
+      $httpRequest->setBaseComponent($this->client->getBasePath());
+    }
 
     if ($postBody) {
       $contentTypeHeader = array();
@@ -185,6 +226,10 @@ class Google_Service_Resource
           isset($parameters['mimeType']) ? $parameters['mimeType']['value'] : 'application/octet-stream',
           $parameters['data']['value']
       );
+    }
+
+    if (isset($parameters['alt']) && $parameters['alt']['value'] == 'media') {
+      $httpRequest->enableExpectedRaw();
     }
 
     if ($this->client->shouldDefer()) {

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Resourceviews.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Resourceviews.php
@@ -1,0 +1,1345 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Resourceviews (v1beta2).
+ *
+ * <p>
+ * The Resource View API allows users to create and manage logical sets of
+ * Google Compute Engine instances.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/compute/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Resourceviews extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+  /** View your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM_READ_ONLY =
+      "https://www.googleapis.com/auth/cloud-platform.read-only";
+  /** View and manage your Google Compute Engine resources. */
+  const COMPUTE =
+      "https://www.googleapis.com/auth/compute";
+  /** View your Google Compute Engine resources. */
+  const COMPUTE_READONLY =
+      "https://www.googleapis.com/auth/compute.readonly";
+  /** View and manage your Google Cloud Platform management resources and deployment status information. */
+  const NDEV_CLOUDMAN =
+      "https://www.googleapis.com/auth/ndev.cloudman";
+  /** View your Google Cloud Platform management resources and deployment status information. */
+  const NDEV_CLOUDMAN_READONLY =
+      "https://www.googleapis.com/auth/ndev.cloudman.readonly";
+
+  public $zoneOperations;
+  public $zoneViews;
+  
+
+  /**
+   * Constructs the internal representation of the Resourceviews service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'resourceviews/v1beta2/projects/';
+    $this->version = 'v1beta2';
+    $this->serviceName = 'resourceviews';
+
+    $this->zoneOperations = new Google_Service_Resourceviews_ZoneOperations_Resource(
+        $this,
+        $this->serviceName,
+        'zoneOperations',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{project}/zones/{zone}/operations/{operation}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operation' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/zones/{zone}/operations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->zoneViews = new Google_Service_Resourceviews_ZoneViews_Resource(
+        $this,
+        $this->serviceName,
+        'zoneViews',
+        array(
+          'methods' => array(
+            'addResources' => array(
+              'path' => '{project}/zones/{zone}/resourceViews/{resourceView}/addResources',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'resourceView' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{project}/zones/{zone}/resourceViews/{resourceView}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'resourceView' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/zones/{zone}/resourceViews/{resourceView}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'resourceView' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getService' => array(
+              'path' => '{project}/zones/{zone}/resourceViews/{resourceView}/getService',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'resourceView' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'resourceName' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/zones/{zone}/resourceViews',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/zones/{zone}/resourceViews',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'listResources' => array(
+              'path' => '{project}/zones/{zone}/resourceViews/{resourceView}/resources',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'resourceView' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'listState' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'format' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'serviceName' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'removeResources' => array(
+              'path' => '{project}/zones/{zone}/resourceViews/{resourceView}/removeResources',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'resourceView' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setService' => array(
+              'path' => '{project}/zones/{zone}/resourceViews/{resourceView}/setService',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'zone' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'resourceView' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "zoneOperations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $resourceviewsService = new Google_Service_Resourceviews(...);
+ *   $zoneOperations = $resourceviewsService->zoneOperations;
+ *  </code>
+ */
+class Google_Service_Resourceviews_ZoneOperations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the specified zone-specific operation resource.
+   * (zoneOperations.get)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param string $operation Name of the operation resource to return.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Resourceviews_Operation
+   */
+  public function get($project, $zone, $operation, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'operation' => $operation);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Resourceviews_Operation");
+  }
+
+  /**
+   * Retrieves the list of operation resources contained within the specified
+   * zone. (zoneOperations.listZoneOperations)
+   *
+   * @param string $project Name of the project scoping this request.
+   * @param string $zone Name of the zone scoping this request.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter Optional. Filter expression for filtering listed
+   * resources.
+   * @opt_param string pageToken Optional. Tag returned by a previous list request
+   * truncated by maxResults. Used to continue a previous list request.
+   * @opt_param string maxResults Optional. Maximum count of results to be
+   * returned. Maximum value is 500 and default value is 500.
+   * @return Google_Service_Resourceviews_OperationList
+   */
+  public function listZoneOperations($project, $zone, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Resourceviews_OperationList");
+  }
+}
+
+/**
+ * The "zoneViews" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $resourceviewsService = new Google_Service_Resourceviews(...);
+ *   $zoneViews = $resourceviewsService->zoneViews;
+ *  </code>
+ */
+class Google_Service_Resourceviews_ZoneViews_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Add resources to the view. (zoneViews.addResources)
+   *
+   * @param string $project The project name of the resource view.
+   * @param string $zone The zone name of the resource view.
+   * @param string $resourceView The name of the resource view.
+   * @param Google_ZoneViewsAddResourcesRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Resourceviews_Operation
+   */
+  public function addResources($project, $zone, $resourceView, Google_Service_Resourceviews_ZoneViewsAddResourcesRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'resourceView' => $resourceView, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('addResources', array($params), "Google_Service_Resourceviews_Operation");
+  }
+
+  /**
+   * Delete a resource view. (zoneViews.delete)
+   *
+   * @param string $project The project name of the resource view.
+   * @param string $zone The zone name of the resource view.
+   * @param string $resourceView The name of the resource view.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Resourceviews_Operation
+   */
+  public function delete($project, $zone, $resourceView, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'resourceView' => $resourceView);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Resourceviews_Operation");
+  }
+
+  /**
+   * Get the information of a zonal resource view. (zoneViews.get)
+   *
+   * @param string $project The project name of the resource view.
+   * @param string $zone The zone name of the resource view.
+   * @param string $resourceView The name of the resource view.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Resourceviews_ResourceView
+   */
+  public function get($project, $zone, $resourceView, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'resourceView' => $resourceView);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Resourceviews_ResourceView");
+  }
+
+  /**
+   * Get the service information of a resource view or a resource.
+   * (zoneViews.getService)
+   *
+   * @param string $project The project name of the resource view.
+   * @param string $zone The zone name of the resource view.
+   * @param string $resourceView The name of the resource view.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string resourceName The name of the resource if user wants to get
+   * the service information of the resource.
+   * @return Google_Service_Resourceviews_ZoneViewsGetServiceResponse
+   */
+  public function getService($project, $zone, $resourceView, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'resourceView' => $resourceView);
+    $params = array_merge($params, $optParams);
+    return $this->call('getService', array($params), "Google_Service_Resourceviews_ZoneViewsGetServiceResponse");
+  }
+
+  /**
+   * Create a resource view. (zoneViews.insert)
+   *
+   * @param string $project The project name of the resource view.
+   * @param string $zone The zone name of the resource view.
+   * @param Google_ResourceView $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Resourceviews_Operation
+   */
+  public function insert($project, $zone, Google_Service_Resourceviews_ResourceView $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Resourceviews_Operation");
+  }
+
+  /**
+   * List resource views. (zoneViews.listZoneViews)
+   *
+   * @param string $project The project name of the resource view.
+   * @param string $zone The zone name of the resource view.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Specifies a nextPageToken returned by a previous
+   * list request. This token can be used to request the next page of results from
+   * a previous list request.
+   * @opt_param int maxResults Maximum count of results to be returned. Acceptable
+   * values are 0 to 5000, inclusive. (Default: 5000)
+   * @return Google_Service_Resourceviews_ZoneViewsList
+   */
+  public function listZoneViews($project, $zone, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Resourceviews_ZoneViewsList");
+  }
+
+  /**
+   * List the resources of the resource view. (zoneViews.listResources)
+   *
+   * @param string $project The project name of the resource view.
+   * @param string $zone The zone name of the resource view.
+   * @param string $resourceView The name of the resource view.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string listState The state of the instance to list. By default, it
+   * lists all instances.
+   * @opt_param string format The requested format of the return value. It can be
+   * URL or URL_PORT. A JSON object will be included in the response based on the
+   * format. The default format is NONE, which results in no JSON in the response.
+   * @opt_param int maxResults Maximum count of results to be returned. Acceptable
+   * values are 0 to 5000, inclusive. (Default: 5000)
+   * @opt_param string pageToken Specifies a nextPageToken returned by a previous
+   * list request. This token can be used to request the next page of results from
+   * a previous list request.
+   * @opt_param string serviceName The service name to return in the response. It
+   * is optional and if it is not set, all the service end points will be
+   * returned.
+   * @return Google_Service_Resourceviews_ZoneViewsListResourcesResponse
+   */
+  public function listResources($project, $zone, $resourceView, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'resourceView' => $resourceView);
+    $params = array_merge($params, $optParams);
+    return $this->call('listResources', array($params), "Google_Service_Resourceviews_ZoneViewsListResourcesResponse");
+  }
+
+  /**
+   * Remove resources from the view. (zoneViews.removeResources)
+   *
+   * @param string $project The project name of the resource view.
+   * @param string $zone The zone name of the resource view.
+   * @param string $resourceView The name of the resource view.
+   * @param Google_ZoneViewsRemoveResourcesRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Resourceviews_Operation
+   */
+  public function removeResources($project, $zone, $resourceView, Google_Service_Resourceviews_ZoneViewsRemoveResourcesRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'resourceView' => $resourceView, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('removeResources', array($params), "Google_Service_Resourceviews_Operation");
+  }
+
+  /**
+   * Update the service information of a resource view or a resource.
+   * (zoneViews.setService)
+   *
+   * @param string $project The project name of the resource view.
+   * @param string $zone The zone name of the resource view.
+   * @param string $resourceView The name of the resource view.
+   * @param Google_ZoneViewsSetServiceRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Resourceviews_Operation
+   */
+  public function setService($project, $zone, $resourceView, Google_Service_Resourceviews_ZoneViewsSetServiceRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'zone' => $zone, 'resourceView' => $resourceView, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('setService', array($params), "Google_Service_Resourceviews_Operation");
+  }
+}
+
+
+
+
+class Google_Service_Resourceviews_Label extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Resourceviews_ListResourceResponseItem extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $endpoints;
+  public $resource;
+
+
+  public function setEndpoints($endpoints)
+  {
+    $this->endpoints = $endpoints;
+  }
+  public function getEndpoints()
+  {
+    return $this->endpoints;
+  }
+  public function setResource($resource)
+  {
+    $this->resource = $resource;
+  }
+  public function getResource()
+  {
+    return $this->resource;
+  }
+}
+
+class Google_Service_Resourceviews_ListResourceResponseItemEndpoints extends Google_Model
+{
+}
+
+class Google_Service_Resourceviews_Operation extends Google_Collection
+{
+  protected $collection_key = 'warnings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $clientOperationId;
+  public $creationTimestamp;
+  public $endTime;
+  protected $errorType = 'Google_Service_Resourceviews_OperationError';
+  protected $errorDataType = '';
+  public $httpErrorMessage;
+  public $httpErrorStatusCode;
+  public $id;
+  public $insertTime;
+  public $kind;
+  public $name;
+  public $operationType;
+  public $progress;
+  public $region;
+  public $selfLink;
+  public $startTime;
+  public $status;
+  public $statusMessage;
+  public $targetId;
+  public $targetLink;
+  public $user;
+  protected $warningsType = 'Google_Service_Resourceviews_OperationWarnings';
+  protected $warningsDataType = 'array';
+  public $zone;
+
+
+  public function setClientOperationId($clientOperationId)
+  {
+    $this->clientOperationId = $clientOperationId;
+  }
+  public function getClientOperationId()
+  {
+    return $this->clientOperationId;
+  }
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setError(Google_Service_Resourceviews_OperationError $error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setHttpErrorMessage($httpErrorMessage)
+  {
+    $this->httpErrorMessage = $httpErrorMessage;
+  }
+  public function getHttpErrorMessage()
+  {
+    return $this->httpErrorMessage;
+  }
+  public function setHttpErrorStatusCode($httpErrorStatusCode)
+  {
+    $this->httpErrorStatusCode = $httpErrorStatusCode;
+  }
+  public function getHttpErrorStatusCode()
+  {
+    return $this->httpErrorStatusCode;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInsertTime($insertTime)
+  {
+    $this->insertTime = $insertTime;
+  }
+  public function getInsertTime()
+  {
+    return $this->insertTime;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOperationType($operationType)
+  {
+    $this->operationType = $operationType;
+  }
+  public function getOperationType()
+  {
+    return $this->operationType;
+  }
+  public function setProgress($progress)
+  {
+    $this->progress = $progress;
+  }
+  public function getProgress()
+  {
+    return $this->progress;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setStatusMessage($statusMessage)
+  {
+    $this->statusMessage = $statusMessage;
+  }
+  public function getStatusMessage()
+  {
+    return $this->statusMessage;
+  }
+  public function setTargetId($targetId)
+  {
+    $this->targetId = $targetId;
+  }
+  public function getTargetId()
+  {
+    return $this->targetId;
+  }
+  public function setTargetLink($targetLink)
+  {
+    $this->targetLink = $targetLink;
+  }
+  public function getTargetLink()
+  {
+    return $this->targetLink;
+  }
+  public function setUser($user)
+  {
+    $this->user = $user;
+  }
+  public function getUser()
+  {
+    return $this->user;
+  }
+  public function setWarnings($warnings)
+  {
+    $this->warnings = $warnings;
+  }
+  public function getWarnings()
+  {
+    return $this->warnings;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_Resourceviews_OperationError extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorsType = 'Google_Service_Resourceviews_OperationErrorErrors';
+  protected $errorsDataType = 'array';
+
+
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+}
+
+class Google_Service_Resourceviews_OperationErrorErrors extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $location;
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Resourceviews_OperationList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  protected $itemsType = 'Google_Service_Resourceviews_Operation';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Resourceviews_OperationWarnings extends Google_Collection
+{
+  protected $collection_key = 'data';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $dataType = 'Google_Service_Resourceviews_OperationWarningsData';
+  protected $dataDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+  public function getData()
+  {
+    return $this->data;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Resourceviews_OperationWarningsData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_Resourceviews_ResourceView extends Google_Collection
+{
+  protected $collection_key = 'resources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTimestamp;
+  public $description;
+  protected $endpointsType = 'Google_Service_Resourceviews_ServiceEndpoint';
+  protected $endpointsDataType = 'array';
+  public $fingerprint;
+  public $id;
+  public $kind;
+  protected $labelsType = 'Google_Service_Resourceviews_Label';
+  protected $labelsDataType = 'array';
+  public $name;
+  public $network;
+  public $resources;
+  public $selfLink;
+  public $size;
+
+
+  public function setCreationTimestamp($creationTimestamp)
+  {
+    $this->creationTimestamp = $creationTimestamp;
+  }
+  public function getCreationTimestamp()
+  {
+    return $this->creationTimestamp;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setEndpoints($endpoints)
+  {
+    $this->endpoints = $endpoints;
+  }
+  public function getEndpoints()
+  {
+    return $this->endpoints;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLabels($labels)
+  {
+    $this->labels = $labels;
+  }
+  public function getLabels()
+  {
+    return $this->labels;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNetwork($network)
+  {
+    $this->network = $network;
+  }
+  public function getNetwork()
+  {
+    return $this->network;
+  }
+  public function setResources($resources)
+  {
+    $this->resources = $resources;
+  }
+  public function getResources()
+  {
+    return $this->resources;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setSize($size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+}
+
+class Google_Service_Resourceviews_ServiceEndpoint extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $port;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPort($port)
+  {
+    $this->port = $port;
+  }
+  public function getPort()
+  {
+    return $this->port;
+  }
+}
+
+class Google_Service_Resourceviews_ZoneViewsAddResourcesRequest extends Google_Collection
+{
+  protected $collection_key = 'resources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $resources;
+
+
+  public function setResources($resources)
+  {
+    $this->resources = $resources;
+  }
+  public function getResources()
+  {
+    return $this->resources;
+  }
+}
+
+class Google_Service_Resourceviews_ZoneViewsGetServiceResponse extends Google_Collection
+{
+  protected $collection_key = 'endpoints';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $endpointsType = 'Google_Service_Resourceviews_ServiceEndpoint';
+  protected $endpointsDataType = 'array';
+  public $fingerprint;
+
+
+  public function setEndpoints($endpoints)
+  {
+    $this->endpoints = $endpoints;
+  }
+  public function getEndpoints()
+  {
+    return $this->endpoints;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+}
+
+class Google_Service_Resourceviews_ZoneViewsList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Resourceviews_ResourceView';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $selfLink;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Resourceviews_ZoneViewsListResourcesResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Resourceviews_ListResourceResponseItem';
+  protected $itemsDataType = 'array';
+  public $network;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setNetwork($network)
+  {
+    $this->network = $network;
+  }
+  public function getNetwork()
+  {
+    return $this->network;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Resourceviews_ZoneViewsRemoveResourcesRequest extends Google_Collection
+{
+  protected $collection_key = 'resources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $resources;
+
+
+  public function setResources($resources)
+  {
+    $this->resources = $resources;
+  }
+  public function getResources()
+  {
+    return $this->resources;
+  }
+}
+
+class Google_Service_Resourceviews_ZoneViewsSetServiceRequest extends Google_Collection
+{
+  protected $collection_key = 'endpoints';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $endpointsType = 'Google_Service_Resourceviews_ServiceEndpoint';
+  protected $endpointsDataType = 'array';
+  public $fingerprint;
+  public $resourceName;
+
+
+  public function setEndpoints($endpoints)
+  {
+    $this->endpoints = $endpoints;
+  }
+  public function getEndpoints()
+  {
+    return $this->endpoints;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setResourceName($resourceName)
+  {
+    $this->resourceName = $resourceName;
+  }
+  public function getResourceName()
+  {
+    return $this->resourceName;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/SQLAdmin.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/SQLAdmin.php
@@ -1,0 +1,3716 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for SQLAdmin (v1beta4).
+ *
+ * <p>
+ * API for Cloud SQL database instance management.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://cloud.google.com/sql/docs/reference/latest" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_SQLAdmin extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+  /** Manage your Google SQL Service instances. */
+  const SQLSERVICE_ADMIN =
+      "https://www.googleapis.com/auth/sqlservice.admin";
+
+  public $backupRuns;
+  public $databases;
+  public $flags;
+  public $instances;
+  public $operations;
+  public $sslCerts;
+  public $tiers;
+  public $users;
+  
+
+  /**
+   * Constructs the internal representation of the SQLAdmin service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'sql/v1beta4/';
+    $this->version = 'v1beta4';
+    $this->serviceName = 'sqladmin';
+
+    $this->backupRuns = new Google_Service_SQLAdmin_BackupRuns_Resource(
+        $this,
+        $this->serviceName,
+        'backupRuns',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'projects/{project}/instances/{instance}/backupRuns/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'projects/{project}/instances/{instance}/backupRuns/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'projects/{project}/instances/{instance}/backupRuns',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->databases = new Google_Service_SQLAdmin_Databases_Resource(
+        $this,
+        $this->serviceName,
+        'databases',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'projects/{project}/instances/{instance}/databases/{database}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'database' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'projects/{project}/instances/{instance}/databases/{database}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'database' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'projects/{project}/instances/{instance}/databases',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'projects/{project}/instances/{instance}/databases',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'projects/{project}/instances/{instance}/databases/{database}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'database' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'projects/{project}/instances/{instance}/databases/{database}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'database' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->flags = new Google_Service_SQLAdmin_Flags_Resource(
+        $this,
+        $this->serviceName,
+        'flags',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'flags',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->instances = new Google_Service_SQLAdmin_Instances_Resource(
+        $this,
+        $this->serviceName,
+        'instances',
+        array(
+          'methods' => array(
+            'clone' => array(
+              'path' => 'projects/{project}/instances/{instance}/clone',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'projects/{project}/instances/{instance}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'export' => array(
+              'path' => 'projects/{project}/instances/{instance}/export',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'failover' => array(
+              'path' => 'projects/{project}/instances/{instance}/failover',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'projects/{project}/instances/{instance}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'import' => array(
+              'path' => 'projects/{project}/instances/{instance}/import',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'projects/{project}/instances',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'projects/{project}/instances',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'projects/{project}/instances/{instance}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'promoteReplica' => array(
+              'path' => 'projects/{project}/instances/{instance}/promoteReplica',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'resetSslConfig' => array(
+              'path' => 'projects/{project}/instances/{instance}/resetSslConfig',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'restart' => array(
+              'path' => 'projects/{project}/instances/{instance}/restart',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'restoreBackup' => array(
+              'path' => 'projects/{project}/instances/{instance}/restoreBackup',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'startReplica' => array(
+              'path' => 'projects/{project}/instances/{instance}/startReplica',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'stopReplica' => array(
+              'path' => 'projects/{project}/instances/{instance}/stopReplica',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'projects/{project}/instances/{instance}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->operations = new Google_Service_SQLAdmin_Operations_Resource(
+        $this,
+        $this->serviceName,
+        'operations',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'projects/{project}/operations/{operation}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'operation' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'projects/{project}/operations',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->sslCerts = new Google_Service_SQLAdmin_SslCerts_Resource(
+        $this,
+        $this->serviceName,
+        'sslCerts',
+        array(
+          'methods' => array(
+            'createEphemeral' => array(
+              'path' => 'projects/{project}/instances/{instance}/createEphemeral',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'projects/{project}/instances/{instance}/sslCerts/{sha1Fingerprint}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sha1Fingerprint' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'projects/{project}/instances/{instance}/sslCerts/{sha1Fingerprint}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sha1Fingerprint' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'projects/{project}/instances/{instance}/sslCerts',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'projects/{project}/instances/{instance}/sslCerts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->tiers = new Google_Service_SQLAdmin_Tiers_Resource(
+        $this,
+        $this->serviceName,
+        'tiers',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'projects/{project}/tiers',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->users = new Google_Service_SQLAdmin_Users_Resource(
+        $this,
+        $this->serviceName,
+        'users',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'projects/{project}/instances/{instance}/users',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'host' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'name' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'projects/{project}/instances/{instance}/users',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'projects/{project}/instances/{instance}/users',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'projects/{project}/instances/{instance}/users',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'instance' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'host' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'name' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "backupRuns" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $sqladminService = new Google_Service_SQLAdmin(...);
+ *   $backupRuns = $sqladminService->backupRuns;
+ *  </code>
+ */
+class Google_Service_SQLAdmin_BackupRuns_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the backup taken by a backup run. (backupRuns.delete)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param string $id The ID of the Backup Run to delete. To find a Backup Run
+   * ID, use the list method.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function delete($project, $instance, $id, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Retrieves a resource containing information about a backup run.
+   * (backupRuns.get)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param string $id The ID of this Backup Run.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_BackupRun
+   */
+  public function get($project, $instance, $id, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_SQLAdmin_BackupRun");
+  }
+
+  /**
+   * Lists all backup runs associated with a given instance and configuration in
+   * the reverse chronological order of the enqueued time.
+   * (backupRuns.listBackupRuns)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int maxResults Maximum number of backup runs per response.
+   * @opt_param string pageToken A previously-returned page token representing
+   * part of the larger set of results to view.
+   * @return Google_Service_SQLAdmin_BackupRunsListResponse
+   */
+  public function listBackupRuns($project, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_SQLAdmin_BackupRunsListResponse");
+  }
+}
+
+/**
+ * The "databases" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $sqladminService = new Google_Service_SQLAdmin(...);
+ *   $databases = $sqladminService->databases;
+ *  </code>
+ */
+class Google_Service_SQLAdmin_Databases_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a resource containing information about a database inside a Cloud SQL
+   * instance. (databases.delete)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Database instance ID. This does not include the
+   * project ID.
+   * @param string $database Name of the database to be deleted in the instance.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function delete($project, $instance, $database, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'database' => $database);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Retrieves a resource containing information about a database inside a Cloud
+   * SQL instance. (databases.get)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Database instance ID. This does not include the
+   * project ID.
+   * @param string $database Name of the database in the instance.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Database
+   */
+  public function get($project, $instance, $database, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'database' => $database);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_SQLAdmin_Database");
+  }
+
+  /**
+   * Inserts a resource containing information about a database inside a Cloud SQL
+   * instance. (databases.insert)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Database instance ID. This does not include the
+   * project ID.
+   * @param Google_Database $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function insert($project, $instance, Google_Service_SQLAdmin_Database $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Lists databases in the specified Cloud SQL instance.
+   * (databases.listDatabases)
+   *
+   * @param string $project Project ID of the project for which to list Cloud SQL
+   * instances.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_DatabasesListResponse
+   */
+  public function listDatabases($project, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_SQLAdmin_DatabasesListResponse");
+  }
+
+  /**
+   * Updates a resource containing information about a database inside a Cloud SQL
+   * instance. This method supports patch semantics. (databases.patch)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Database instance ID. This does not include the
+   * project ID.
+   * @param string $database Name of the database to be updated in the instance.
+   * @param Google_Database $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function patch($project, $instance, $database, Google_Service_SQLAdmin_Database $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'database' => $database, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Updates a resource containing information about a database inside a Cloud SQL
+   * instance. (databases.update)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Database instance ID. This does not include the
+   * project ID.
+   * @param string $database Name of the database to be updated in the instance.
+   * @param Google_Database $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function update($project, $instance, $database, Google_Service_SQLAdmin_Database $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'database' => $database, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+}
+
+/**
+ * The "flags" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $sqladminService = new Google_Service_SQLAdmin(...);
+ *   $flags = $sqladminService->flags;
+ *  </code>
+ */
+class Google_Service_SQLAdmin_Flags_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List all available database flags for Google Cloud SQL instances.
+   * (flags.listFlags)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_FlagsListResponse
+   */
+  public function listFlags($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_SQLAdmin_FlagsListResponse");
+  }
+}
+
+/**
+ * The "instances" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $sqladminService = new Google_Service_SQLAdmin(...);
+ *   $instances = $sqladminService->instances;
+ *  </code>
+ */
+class Google_Service_SQLAdmin_Instances_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a Cloud SQL instance as a clone of the source instance.
+   * (instances.cloneInstances)
+   *
+   * @param string $project Project ID of the source as well as the clone Cloud
+   * SQL instance.
+   * @param string $instance The ID of the Cloud SQL instance to be cloned
+   * (source). This does not include the project ID.
+   * @param Google_InstancesCloneRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function cloneInstances($project, $instance, Google_Service_SQLAdmin_InstancesCloneRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('clone', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Deletes a Cloud SQL instance. (instances.delete)
+   *
+   * @param string $project Project ID of the project that contains the instance
+   * to be deleted.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function delete($project, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Exports data from a Cloud SQL instance to a Google Cloud Storage bucket as a
+   * MySQL dump file. (instances.export)
+   *
+   * @param string $project Project ID of the project that contains the instance
+   * to be exported.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param Google_InstancesExportRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function export($project, $instance, Google_Service_SQLAdmin_InstancesExportRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('export', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Failover the instance to its failover replica instance. (instances.failover)
+   *
+   * @param string $project ID of the project that contains the read replica.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param Google_InstancesFailoverRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function failover($project, $instance, Google_Service_SQLAdmin_InstancesFailoverRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('failover', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Retrieves a resource containing information about a Cloud SQL instance.
+   * (instances.get)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Database instance ID. This does not include the
+   * project ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_DatabaseInstance
+   */
+  public function get($project, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_SQLAdmin_DatabaseInstance");
+  }
+
+  /**
+   * Imports data into a Cloud SQL instance from a MySQL dump file in Google Cloud
+   * Storage. (instances.import)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param Google_InstancesImportRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function import($project, $instance, Google_Service_SQLAdmin_InstancesImportRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('import', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Creates a new Cloud SQL instance. (instances.insert)
+   *
+   * @param string $project Project ID of the project to which the newly created
+   * Cloud SQL instances should belong.
+   * @param Google_DatabaseInstance $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function insert($project, Google_Service_SQLAdmin_DatabaseInstance $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Lists instances under a given project in the alphabetical order of the
+   * instance name. (instances.listInstances)
+   *
+   * @param string $project Project ID of the project for which to list Cloud SQL
+   * instances.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A previously-returned page token representing
+   * part of the larger set of results to view.
+   * @opt_param string maxResults The maximum number of results to return per
+   * response.
+   * @return Google_Service_SQLAdmin_InstancesListResponse
+   */
+  public function listInstances($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_SQLAdmin_InstancesListResponse");
+  }
+
+  /**
+   * Updates settings of a Cloud SQL instance. Caution: This is not a partial
+   * update, so you must include values for all the settings that you want to
+   * retain. For partial updates, use patch.. This method supports patch
+   * semantics. (instances.patch)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param Google_DatabaseInstance $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function patch($project, $instance, Google_Service_SQLAdmin_DatabaseInstance $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Promotes the read replica instance to be a stand-alone Cloud SQL instance.
+   * (instances.promoteReplica)
+   *
+   * @param string $project ID of the project that contains the read replica.
+   * @param string $instance Cloud SQL read replica instance name.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function promoteReplica($project, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('promoteReplica', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Deletes all client certificates and generates a new server SSL certificate
+   * for the instance. The changes will not take effect until the instance is
+   * restarted. Existing instances without a server certificate will need to call
+   * this once to set a server certificate. (instances.resetSslConfig)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function resetSslConfig($project, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('resetSslConfig', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Restarts a Cloud SQL instance. (instances.restart)
+   *
+   * @param string $project Project ID of the project that contains the instance
+   * to be restarted.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function restart($project, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('restart', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Restores a backup of a Cloud SQL instance. (instances.restoreBackup)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param Google_InstancesRestoreBackupRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function restoreBackup($project, $instance, Google_Service_SQLAdmin_InstancesRestoreBackupRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('restoreBackup', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Starts the replication in the read replica instance. (instances.startReplica)
+   *
+   * @param string $project ID of the project that contains the read replica.
+   * @param string $instance Cloud SQL read replica instance name.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function startReplica($project, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('startReplica', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Stops the replication in the read replica instance. (instances.stopReplica)
+   *
+   * @param string $project ID of the project that contains the read replica.
+   * @param string $instance Cloud SQL read replica instance name.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function stopReplica($project, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('stopReplica', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Updates settings of a Cloud SQL instance. Caution: This is not a partial
+   * update, so you must include values for all the settings that you want to
+   * retain. For partial updates, use patch. (instances.update)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param Google_DatabaseInstance $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function update($project, $instance, Google_Service_SQLAdmin_DatabaseInstance $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+}
+
+/**
+ * The "operations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $sqladminService = new Google_Service_SQLAdmin(...);
+ *   $operations = $sqladminService->operations;
+ *  </code>
+ */
+class Google_Service_SQLAdmin_Operations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves an instance operation that has been performed on an instance.
+   * (operations.get)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $operation Instance operation ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function get($project, $operation, $optParams = array())
+  {
+    $params = array('project' => $project, 'operation' => $operation);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Lists all instance operations that have been performed on the given Cloud SQL
+   * instance in the reverse chronological order of the start time.
+   * (operations.listOperations)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string maxResults Maximum number of operations per response.
+   * @opt_param string pageToken A previously-returned page token representing
+   * part of the larger set of results to view.
+   * @return Google_Service_SQLAdmin_OperationsListResponse
+   */
+  public function listOperations($project, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_SQLAdmin_OperationsListResponse");
+  }
+}
+
+/**
+ * The "sslCerts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $sqladminService = new Google_Service_SQLAdmin(...);
+ *   $sslCerts = $sqladminService->sslCerts;
+ *  </code>
+ */
+class Google_Service_SQLAdmin_SslCerts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Generates a short-lived X509 certificate containing the provided public key
+   * and signed by a private key specific to the target instance. Users may use
+   * the certificate to authenticate as themselves when connecting to the
+   * database. (sslCerts.createEphemeral)
+   *
+   * @param string $project Project ID of the Cloud SQL project.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param Google_SslCertsCreateEphemeralRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_SslCert
+   */
+  public function createEphemeral($project, $instance, Google_Service_SQLAdmin_SslCertsCreateEphemeralRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('createEphemeral', array($params), "Google_Service_SQLAdmin_SslCert");
+  }
+
+  /**
+   * Deletes the SSL certificate. The change will not take effect until the
+   * instance is restarted. (sslCerts.delete)
+   *
+   * @param string $project Project ID of the project that contains the instance
+   * to be deleted.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param string $sha1Fingerprint Sha1 FingerPrint.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function delete($project, $instance, $sha1Fingerprint, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'sha1Fingerprint' => $sha1Fingerprint);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Retrieves a particular SSL certificate. Does not include the private key
+   * (required for usage). The private key must be saved from the response to
+   * initial creation. (sslCerts.get)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param string $sha1Fingerprint Sha1 FingerPrint.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_SslCert
+   */
+  public function get($project, $instance, $sha1Fingerprint, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'sha1Fingerprint' => $sha1Fingerprint);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_SQLAdmin_SslCert");
+  }
+
+  /**
+   * Creates an SSL certificate and returns it along with the private key and
+   * server certificate authority. The new certificate will not be usable until
+   * the instance is restarted. (sslCerts.insert)
+   *
+   * @param string $project Project ID of the project to which the newly created
+   * Cloud SQL instances should belong.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param Google_SslCertsInsertRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_SslCertsInsertResponse
+   */
+  public function insert($project, $instance, Google_Service_SQLAdmin_SslCertsInsertRequest $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_SQLAdmin_SslCertsInsertResponse");
+  }
+
+  /**
+   * Lists all of the current SSL certificates for the instance.
+   * (sslCerts.listSslCerts)
+   *
+   * @param string $project Project ID of the project for which to list Cloud SQL
+   * instances.
+   * @param string $instance Cloud SQL instance ID. This does not include the
+   * project ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_SslCertsListResponse
+   */
+  public function listSslCerts($project, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_SQLAdmin_SslCertsListResponse");
+  }
+}
+
+/**
+ * The "tiers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $sqladminService = new Google_Service_SQLAdmin(...);
+ *   $tiers = $sqladminService->tiers;
+ *  </code>
+ */
+class Google_Service_SQLAdmin_Tiers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Lists all available service tiers for Google Cloud SQL, for example D1, D2.
+   * For related information, see Pricing. (tiers.listTiers)
+   *
+   * @param string $project Project ID of the project for which to list tiers.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_TiersListResponse
+   */
+  public function listTiers($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_SQLAdmin_TiersListResponse");
+  }
+}
+
+/**
+ * The "users" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $sqladminService = new Google_Service_SQLAdmin(...);
+ *   $users = $sqladminService->users;
+ *  </code>
+ */
+class Google_Service_SQLAdmin_Users_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a user from a Cloud SQL instance. (users.delete)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Database instance ID. This does not include the
+   * project ID.
+   * @param string $host Host of the user in the instance.
+   * @param string $name Name of the user in the instance.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function delete($project, $instance, $host, $name, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'host' => $host, 'name' => $name);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Creates a new user in a Cloud SQL instance. (users.insert)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Database instance ID. This does not include the
+   * project ID.
+   * @param Google_User $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function insert($project, $instance, Google_Service_SQLAdmin_User $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+
+  /**
+   * Lists users in the specified Cloud SQL instance. (users.listUsers)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Database instance ID. This does not include the
+   * project ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_UsersListResponse
+   */
+  public function listUsers($project, $instance, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_SQLAdmin_UsersListResponse");
+  }
+
+  /**
+   * Updates an existing user in a Cloud SQL instance. (users.update)
+   *
+   * @param string $project Project ID of the project that contains the instance.
+   * @param string $instance Database instance ID. This does not include the
+   * project ID.
+   * @param string $host Host of the user in the instance.
+   * @param string $name Name of the user in the instance.
+   * @param Google_User $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SQLAdmin_Operation
+   */
+  public function update($project, $instance, $host, $name, Google_Service_SQLAdmin_User $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'instance' => $instance, 'host' => $host, 'name' => $name, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_SQLAdmin_Operation");
+  }
+}
+
+
+
+
+class Google_Service_SQLAdmin_AclEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $expirationTime;
+  public $kind;
+  public $name;
+  public $value;
+
+
+  public function setExpirationTime($expirationTime)
+  {
+    $this->expirationTime = $expirationTime;
+  }
+  public function getExpirationTime()
+  {
+    return $this->expirationTime;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_SQLAdmin_BackupConfiguration extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $binaryLogEnabled;
+  public $enabled;
+  public $kind;
+  public $startTime;
+
+
+  public function setBinaryLogEnabled($binaryLogEnabled)
+  {
+    $this->binaryLogEnabled = $binaryLogEnabled;
+  }
+  public function getBinaryLogEnabled()
+  {
+    return $this->binaryLogEnabled;
+  }
+  public function setEnabled($enabled)
+  {
+    $this->enabled = $enabled;
+  }
+  public function getEnabled()
+  {
+    return $this->enabled;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+}
+
+class Google_Service_SQLAdmin_BackupRun extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $endTime;
+  public $enqueuedTime;
+  protected $errorType = 'Google_Service_SQLAdmin_OperationError';
+  protected $errorDataType = '';
+  public $id;
+  public $instance;
+  public $kind;
+  public $selfLink;
+  public $startTime;
+  public $status;
+  public $windowStartTime;
+
+
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setEnqueuedTime($enqueuedTime)
+  {
+    $this->enqueuedTime = $enqueuedTime;
+  }
+  public function getEnqueuedTime()
+  {
+    return $this->enqueuedTime;
+  }
+  public function setError(Google_Service_SQLAdmin_OperationError $error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInstance($instance)
+  {
+    $this->instance = $instance;
+  }
+  public function getInstance()
+  {
+    return $this->instance;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setWindowStartTime($windowStartTime)
+  {
+    $this->windowStartTime = $windowStartTime;
+  }
+  public function getWindowStartTime()
+  {
+    return $this->windowStartTime;
+  }
+}
+
+class Google_Service_SQLAdmin_BackupRunsListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_SQLAdmin_BackupRun';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_SQLAdmin_BinLogCoordinates extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $binLogFileName;
+  public $binLogPosition;
+  public $kind;
+
+
+  public function setBinLogFileName($binLogFileName)
+  {
+    $this->binLogFileName = $binLogFileName;
+  }
+  public function getBinLogFileName()
+  {
+    return $this->binLogFileName;
+  }
+  public function setBinLogPosition($binLogPosition)
+  {
+    $this->binLogPosition = $binLogPosition;
+  }
+  public function getBinLogPosition()
+  {
+    return $this->binLogPosition;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_SQLAdmin_CloneContext extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $binLogCoordinatesType = 'Google_Service_SQLAdmin_BinLogCoordinates';
+  protected $binLogCoordinatesDataType = '';
+  public $destinationInstanceName;
+  public $kind;
+
+
+  public function setBinLogCoordinates(Google_Service_SQLAdmin_BinLogCoordinates $binLogCoordinates)
+  {
+    $this->binLogCoordinates = $binLogCoordinates;
+  }
+  public function getBinLogCoordinates()
+  {
+    return $this->binLogCoordinates;
+  }
+  public function setDestinationInstanceName($destinationInstanceName)
+  {
+    $this->destinationInstanceName = $destinationInstanceName;
+  }
+  public function getDestinationInstanceName()
+  {
+    return $this->destinationInstanceName;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_SQLAdmin_Database extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $charset;
+  public $collation;
+  public $etag;
+  public $instance;
+  public $kind;
+  public $name;
+  public $project;
+  public $selfLink;
+
+
+  public function setCharset($charset)
+  {
+    $this->charset = $charset;
+  }
+  public function getCharset()
+  {
+    return $this->charset;
+  }
+  public function setCollation($collation)
+  {
+    $this->collation = $collation;
+  }
+  public function getCollation()
+  {
+    return $this->collation;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setInstance($instance)
+  {
+    $this->instance = $instance;
+  }
+  public function getInstance()
+  {
+    return $this->instance;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProject($project)
+  {
+    $this->project = $project;
+  }
+  public function getProject()
+  {
+    return $this->project;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_SQLAdmin_DatabaseFlags extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $value;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_SQLAdmin_DatabaseInstance extends Google_Collection
+{
+  protected $collection_key = 'replicaNames';
+  protected $internal_gapi_mappings = array(
+  );
+  public $currentDiskSize;
+  public $databaseVersion;
+  public $etag;
+  public $instanceType;
+  protected $ipAddressesType = 'Google_Service_SQLAdmin_IpMapping';
+  protected $ipAddressesDataType = 'array';
+  public $ipv6Address;
+  public $kind;
+  public $masterInstanceName;
+  public $maxDiskSize;
+  public $name;
+  protected $onPremisesConfigurationType = 'Google_Service_SQLAdmin_OnPremisesConfiguration';
+  protected $onPremisesConfigurationDataType = '';
+  public $project;
+  public $region;
+  protected $replicaConfigurationType = 'Google_Service_SQLAdmin_ReplicaConfiguration';
+  protected $replicaConfigurationDataType = '';
+  public $replicaNames;
+  public $selfLink;
+  protected $serverCaCertType = 'Google_Service_SQLAdmin_SslCert';
+  protected $serverCaCertDataType = '';
+  public $serviceAccountEmailAddress;
+  protected $settingsType = 'Google_Service_SQLAdmin_Settings';
+  protected $settingsDataType = '';
+  public $state;
+
+
+  public function setCurrentDiskSize($currentDiskSize)
+  {
+    $this->currentDiskSize = $currentDiskSize;
+  }
+  public function getCurrentDiskSize()
+  {
+    return $this->currentDiskSize;
+  }
+  public function setDatabaseVersion($databaseVersion)
+  {
+    $this->databaseVersion = $databaseVersion;
+  }
+  public function getDatabaseVersion()
+  {
+    return $this->databaseVersion;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setInstanceType($instanceType)
+  {
+    $this->instanceType = $instanceType;
+  }
+  public function getInstanceType()
+  {
+    return $this->instanceType;
+  }
+  public function setIpAddresses($ipAddresses)
+  {
+    $this->ipAddresses = $ipAddresses;
+  }
+  public function getIpAddresses()
+  {
+    return $this->ipAddresses;
+  }
+  public function setIpv6Address($ipv6Address)
+  {
+    $this->ipv6Address = $ipv6Address;
+  }
+  public function getIpv6Address()
+  {
+    return $this->ipv6Address;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMasterInstanceName($masterInstanceName)
+  {
+    $this->masterInstanceName = $masterInstanceName;
+  }
+  public function getMasterInstanceName()
+  {
+    return $this->masterInstanceName;
+  }
+  public function setMaxDiskSize($maxDiskSize)
+  {
+    $this->maxDiskSize = $maxDiskSize;
+  }
+  public function getMaxDiskSize()
+  {
+    return $this->maxDiskSize;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOnPremisesConfiguration(Google_Service_SQLAdmin_OnPremisesConfiguration $onPremisesConfiguration)
+  {
+    $this->onPremisesConfiguration = $onPremisesConfiguration;
+  }
+  public function getOnPremisesConfiguration()
+  {
+    return $this->onPremisesConfiguration;
+  }
+  public function setProject($project)
+  {
+    $this->project = $project;
+  }
+  public function getProject()
+  {
+    return $this->project;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setReplicaConfiguration(Google_Service_SQLAdmin_ReplicaConfiguration $replicaConfiguration)
+  {
+    $this->replicaConfiguration = $replicaConfiguration;
+  }
+  public function getReplicaConfiguration()
+  {
+    return $this->replicaConfiguration;
+  }
+  public function setReplicaNames($replicaNames)
+  {
+    $this->replicaNames = $replicaNames;
+  }
+  public function getReplicaNames()
+  {
+    return $this->replicaNames;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setServerCaCert(Google_Service_SQLAdmin_SslCert $serverCaCert)
+  {
+    $this->serverCaCert = $serverCaCert;
+  }
+  public function getServerCaCert()
+  {
+    return $this->serverCaCert;
+  }
+  public function setServiceAccountEmailAddress($serviceAccountEmailAddress)
+  {
+    $this->serviceAccountEmailAddress = $serviceAccountEmailAddress;
+  }
+  public function getServiceAccountEmailAddress()
+  {
+    return $this->serviceAccountEmailAddress;
+  }
+  public function setSettings(Google_Service_SQLAdmin_Settings $settings)
+  {
+    $this->settings = $settings;
+  }
+  public function getSettings()
+  {
+    return $this->settings;
+  }
+  public function setState($state)
+  {
+    $this->state = $state;
+  }
+  public function getState()
+  {
+    return $this->state;
+  }
+}
+
+class Google_Service_SQLAdmin_DatabasesListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_SQLAdmin_Database';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_SQLAdmin_ExportContext extends Google_Collection
+{
+  protected $collection_key = 'databases';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $csvExportOptionsType = 'Google_Service_SQLAdmin_ExportContextCsvExportOptions';
+  protected $csvExportOptionsDataType = '';
+  public $databases;
+  public $fileType;
+  public $kind;
+  protected $sqlExportOptionsType = 'Google_Service_SQLAdmin_ExportContextSqlExportOptions';
+  protected $sqlExportOptionsDataType = '';
+  public $uri;
+
+
+  public function setCsvExportOptions(Google_Service_SQLAdmin_ExportContextCsvExportOptions $csvExportOptions)
+  {
+    $this->csvExportOptions = $csvExportOptions;
+  }
+  public function getCsvExportOptions()
+  {
+    return $this->csvExportOptions;
+  }
+  public function setDatabases($databases)
+  {
+    $this->databases = $databases;
+  }
+  public function getDatabases()
+  {
+    return $this->databases;
+  }
+  public function setFileType($fileType)
+  {
+    $this->fileType = $fileType;
+  }
+  public function getFileType()
+  {
+    return $this->fileType;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSqlExportOptions(Google_Service_SQLAdmin_ExportContextSqlExportOptions $sqlExportOptions)
+  {
+    $this->sqlExportOptions = $sqlExportOptions;
+  }
+  public function getSqlExportOptions()
+  {
+    return $this->sqlExportOptions;
+  }
+  public function setUri($uri)
+  {
+    $this->uri = $uri;
+  }
+  public function getUri()
+  {
+    return $this->uri;
+  }
+}
+
+class Google_Service_SQLAdmin_ExportContextCsvExportOptions extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $selectQuery;
+
+
+  public function setSelectQuery($selectQuery)
+  {
+    $this->selectQuery = $selectQuery;
+  }
+  public function getSelectQuery()
+  {
+    return $this->selectQuery;
+  }
+}
+
+class Google_Service_SQLAdmin_ExportContextSqlExportOptions extends Google_Collection
+{
+  protected $collection_key = 'tables';
+  protected $internal_gapi_mappings = array(
+  );
+  public $schemaOnly;
+  public $tables;
+
+
+  public function setSchemaOnly($schemaOnly)
+  {
+    $this->schemaOnly = $schemaOnly;
+  }
+  public function getSchemaOnly()
+  {
+    return $this->schemaOnly;
+  }
+  public function setTables($tables)
+  {
+    $this->tables = $tables;
+  }
+  public function getTables()
+  {
+    return $this->tables;
+  }
+}
+
+class Google_Service_SQLAdmin_FailoverContext extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $settingsVersion;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSettingsVersion($settingsVersion)
+  {
+    $this->settingsVersion = $settingsVersion;
+  }
+  public function getSettingsVersion()
+  {
+    return $this->settingsVersion;
+  }
+}
+
+class Google_Service_SQLAdmin_Flag extends Google_Collection
+{
+  protected $collection_key = 'appliesTo';
+  protected $internal_gapi_mappings = array(
+  );
+  public $allowedStringValues;
+  public $appliesTo;
+  public $kind;
+  public $maxValue;
+  public $minValue;
+  public $name;
+  public $type;
+
+
+  public function setAllowedStringValues($allowedStringValues)
+  {
+    $this->allowedStringValues = $allowedStringValues;
+  }
+  public function getAllowedStringValues()
+  {
+    return $this->allowedStringValues;
+  }
+  public function setAppliesTo($appliesTo)
+  {
+    $this->appliesTo = $appliesTo;
+  }
+  public function getAppliesTo()
+  {
+    return $this->appliesTo;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMaxValue($maxValue)
+  {
+    $this->maxValue = $maxValue;
+  }
+  public function getMaxValue()
+  {
+    return $this->maxValue;
+  }
+  public function setMinValue($minValue)
+  {
+    $this->minValue = $minValue;
+  }
+  public function getMinValue()
+  {
+    return $this->minValue;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_SQLAdmin_FlagsListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_SQLAdmin_Flag';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_SQLAdmin_ImportContext extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $csvImportOptionsType = 'Google_Service_SQLAdmin_ImportContextCsvImportOptions';
+  protected $csvImportOptionsDataType = '';
+  public $database;
+  public $fileType;
+  public $kind;
+  public $uri;
+
+
+  public function setCsvImportOptions(Google_Service_SQLAdmin_ImportContextCsvImportOptions $csvImportOptions)
+  {
+    $this->csvImportOptions = $csvImportOptions;
+  }
+  public function getCsvImportOptions()
+  {
+    return $this->csvImportOptions;
+  }
+  public function setDatabase($database)
+  {
+    $this->database = $database;
+  }
+  public function getDatabase()
+  {
+    return $this->database;
+  }
+  public function setFileType($fileType)
+  {
+    $this->fileType = $fileType;
+  }
+  public function getFileType()
+  {
+    return $this->fileType;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUri($uri)
+  {
+    $this->uri = $uri;
+  }
+  public function getUri()
+  {
+    return $this->uri;
+  }
+}
+
+class Google_Service_SQLAdmin_ImportContextCsvImportOptions extends Google_Collection
+{
+  protected $collection_key = 'columns';
+  protected $internal_gapi_mappings = array(
+  );
+  public $columns;
+  public $table;
+
+
+  public function setColumns($columns)
+  {
+    $this->columns = $columns;
+  }
+  public function getColumns()
+  {
+    return $this->columns;
+  }
+  public function setTable($table)
+  {
+    $this->table = $table;
+  }
+  public function getTable()
+  {
+    return $this->table;
+  }
+}
+
+class Google_Service_SQLAdmin_InstancesCloneRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $cloneContextType = 'Google_Service_SQLAdmin_CloneContext';
+  protected $cloneContextDataType = '';
+
+
+  public function setCloneContext(Google_Service_SQLAdmin_CloneContext $cloneContext)
+  {
+    $this->cloneContext = $cloneContext;
+  }
+  public function getCloneContext()
+  {
+    return $this->cloneContext;
+  }
+}
+
+class Google_Service_SQLAdmin_InstancesExportRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $exportContextType = 'Google_Service_SQLAdmin_ExportContext';
+  protected $exportContextDataType = '';
+
+
+  public function setExportContext(Google_Service_SQLAdmin_ExportContext $exportContext)
+  {
+    $this->exportContext = $exportContext;
+  }
+  public function getExportContext()
+  {
+    return $this->exportContext;
+  }
+}
+
+class Google_Service_SQLAdmin_InstancesFailoverRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $failoverContextType = 'Google_Service_SQLAdmin_FailoverContext';
+  protected $failoverContextDataType = '';
+
+
+  public function setFailoverContext(Google_Service_SQLAdmin_FailoverContext $failoverContext)
+  {
+    $this->failoverContext = $failoverContext;
+  }
+  public function getFailoverContext()
+  {
+    return $this->failoverContext;
+  }
+}
+
+class Google_Service_SQLAdmin_InstancesImportRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $importContextType = 'Google_Service_SQLAdmin_ImportContext';
+  protected $importContextDataType = '';
+
+
+  public function setImportContext(Google_Service_SQLAdmin_ImportContext $importContext)
+  {
+    $this->importContext = $importContext;
+  }
+  public function getImportContext()
+  {
+    return $this->importContext;
+  }
+}
+
+class Google_Service_SQLAdmin_InstancesListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_SQLAdmin_DatabaseInstance';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_SQLAdmin_InstancesRestoreBackupRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $restoreBackupContextType = 'Google_Service_SQLAdmin_RestoreBackupContext';
+  protected $restoreBackupContextDataType = '';
+
+
+  public function setRestoreBackupContext(Google_Service_SQLAdmin_RestoreBackupContext $restoreBackupContext)
+  {
+    $this->restoreBackupContext = $restoreBackupContext;
+  }
+  public function getRestoreBackupContext()
+  {
+    return $this->restoreBackupContext;
+  }
+}
+
+class Google_Service_SQLAdmin_IpConfiguration extends Google_Collection
+{
+  protected $collection_key = 'authorizedNetworks';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $authorizedNetworksType = 'Google_Service_SQLAdmin_AclEntry';
+  protected $authorizedNetworksDataType = 'array';
+  public $ipv4Enabled;
+  public $requireSsl;
+
+
+  public function setAuthorizedNetworks($authorizedNetworks)
+  {
+    $this->authorizedNetworks = $authorizedNetworks;
+  }
+  public function getAuthorizedNetworks()
+  {
+    return $this->authorizedNetworks;
+  }
+  public function setIpv4Enabled($ipv4Enabled)
+  {
+    $this->ipv4Enabled = $ipv4Enabled;
+  }
+  public function getIpv4Enabled()
+  {
+    return $this->ipv4Enabled;
+  }
+  public function setRequireSsl($requireSsl)
+  {
+    $this->requireSsl = $requireSsl;
+  }
+  public function getRequireSsl()
+  {
+    return $this->requireSsl;
+  }
+}
+
+class Google_Service_SQLAdmin_IpMapping extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $ipAddress;
+  public $timeToRetire;
+
+
+  public function setIpAddress($ipAddress)
+  {
+    $this->ipAddress = $ipAddress;
+  }
+  public function getIpAddress()
+  {
+    return $this->ipAddress;
+  }
+  public function setTimeToRetire($timeToRetire)
+  {
+    $this->timeToRetire = $timeToRetire;
+  }
+  public function getTimeToRetire()
+  {
+    return $this->timeToRetire;
+  }
+}
+
+class Google_Service_SQLAdmin_LocationPreference extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $followGaeApplication;
+  public $kind;
+  public $zone;
+
+
+  public function setFollowGaeApplication($followGaeApplication)
+  {
+    $this->followGaeApplication = $followGaeApplication;
+  }
+  public function getFollowGaeApplication()
+  {
+    return $this->followGaeApplication;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setZone($zone)
+  {
+    $this->zone = $zone;
+  }
+  public function getZone()
+  {
+    return $this->zone;
+  }
+}
+
+class Google_Service_SQLAdmin_MySqlReplicaConfiguration extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $caCertificate;
+  public $clientCertificate;
+  public $clientKey;
+  public $connectRetryInterval;
+  public $dumpFilePath;
+  public $kind;
+  public $masterHeartbeatPeriod;
+  public $password;
+  public $sslCipher;
+  public $username;
+  public $verifyServerCertificate;
+
+
+  public function setCaCertificate($caCertificate)
+  {
+    $this->caCertificate = $caCertificate;
+  }
+  public function getCaCertificate()
+  {
+    return $this->caCertificate;
+  }
+  public function setClientCertificate($clientCertificate)
+  {
+    $this->clientCertificate = $clientCertificate;
+  }
+  public function getClientCertificate()
+  {
+    return $this->clientCertificate;
+  }
+  public function setClientKey($clientKey)
+  {
+    $this->clientKey = $clientKey;
+  }
+  public function getClientKey()
+  {
+    return $this->clientKey;
+  }
+  public function setConnectRetryInterval($connectRetryInterval)
+  {
+    $this->connectRetryInterval = $connectRetryInterval;
+  }
+  public function getConnectRetryInterval()
+  {
+    return $this->connectRetryInterval;
+  }
+  public function setDumpFilePath($dumpFilePath)
+  {
+    $this->dumpFilePath = $dumpFilePath;
+  }
+  public function getDumpFilePath()
+  {
+    return $this->dumpFilePath;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMasterHeartbeatPeriod($masterHeartbeatPeriod)
+  {
+    $this->masterHeartbeatPeriod = $masterHeartbeatPeriod;
+  }
+  public function getMasterHeartbeatPeriod()
+  {
+    return $this->masterHeartbeatPeriod;
+  }
+  public function setPassword($password)
+  {
+    $this->password = $password;
+  }
+  public function getPassword()
+  {
+    return $this->password;
+  }
+  public function setSslCipher($sslCipher)
+  {
+    $this->sslCipher = $sslCipher;
+  }
+  public function getSslCipher()
+  {
+    return $this->sslCipher;
+  }
+  public function setUsername($username)
+  {
+    $this->username = $username;
+  }
+  public function getUsername()
+  {
+    return $this->username;
+  }
+  public function setVerifyServerCertificate($verifyServerCertificate)
+  {
+    $this->verifyServerCertificate = $verifyServerCertificate;
+  }
+  public function getVerifyServerCertificate()
+  {
+    return $this->verifyServerCertificate;
+  }
+}
+
+class Google_Service_SQLAdmin_OnPremisesConfiguration extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $hostPort;
+  public $kind;
+
+
+  public function setHostPort($hostPort)
+  {
+    $this->hostPort = $hostPort;
+  }
+  public function getHostPort()
+  {
+    return $this->hostPort;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_SQLAdmin_Operation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $endTime;
+  protected $errorType = 'Google_Service_SQLAdmin_OperationErrors';
+  protected $errorDataType = '';
+  protected $exportContextType = 'Google_Service_SQLAdmin_ExportContext';
+  protected $exportContextDataType = '';
+  protected $importContextType = 'Google_Service_SQLAdmin_ImportContext';
+  protected $importContextDataType = '';
+  public $insertTime;
+  public $kind;
+  public $name;
+  public $operationType;
+  public $selfLink;
+  public $startTime;
+  public $status;
+  public $targetId;
+  public $targetLink;
+  public $targetProject;
+  public $user;
+
+
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setError(Google_Service_SQLAdmin_OperationErrors $error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setExportContext(Google_Service_SQLAdmin_ExportContext $exportContext)
+  {
+    $this->exportContext = $exportContext;
+  }
+  public function getExportContext()
+  {
+    return $this->exportContext;
+  }
+  public function setImportContext(Google_Service_SQLAdmin_ImportContext $importContext)
+  {
+    $this->importContext = $importContext;
+  }
+  public function getImportContext()
+  {
+    return $this->importContext;
+  }
+  public function setInsertTime($insertTime)
+  {
+    $this->insertTime = $insertTime;
+  }
+  public function getInsertTime()
+  {
+    return $this->insertTime;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOperationType($operationType)
+  {
+    $this->operationType = $operationType;
+  }
+  public function getOperationType()
+  {
+    return $this->operationType;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setTargetId($targetId)
+  {
+    $this->targetId = $targetId;
+  }
+  public function getTargetId()
+  {
+    return $this->targetId;
+  }
+  public function setTargetLink($targetLink)
+  {
+    $this->targetLink = $targetLink;
+  }
+  public function getTargetLink()
+  {
+    return $this->targetLink;
+  }
+  public function setTargetProject($targetProject)
+  {
+    $this->targetProject = $targetProject;
+  }
+  public function getTargetProject()
+  {
+    return $this->targetProject;
+  }
+  public function setUser($user)
+  {
+    $this->user = $user;
+  }
+  public function getUser()
+  {
+    return $this->user;
+  }
+}
+
+class Google_Service_SQLAdmin_OperationError extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $kind;
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_SQLAdmin_OperationErrors extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $errorsType = 'Google_Service_SQLAdmin_OperationError';
+  protected $errorsDataType = 'array';
+  public $kind;
+
+
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_SQLAdmin_OperationsListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_SQLAdmin_Operation';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_SQLAdmin_ReplicaConfiguration extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $failoverTarget;
+  public $kind;
+  protected $mysqlReplicaConfigurationType = 'Google_Service_SQLAdmin_MySqlReplicaConfiguration';
+  protected $mysqlReplicaConfigurationDataType = '';
+
+
+  public function setFailoverTarget($failoverTarget)
+  {
+    $this->failoverTarget = $failoverTarget;
+  }
+  public function getFailoverTarget()
+  {
+    return $this->failoverTarget;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMysqlReplicaConfiguration(Google_Service_SQLAdmin_MySqlReplicaConfiguration $mysqlReplicaConfiguration)
+  {
+    $this->mysqlReplicaConfiguration = $mysqlReplicaConfiguration;
+  }
+  public function getMysqlReplicaConfiguration()
+  {
+    return $this->mysqlReplicaConfiguration;
+  }
+}
+
+class Google_Service_SQLAdmin_RestoreBackupContext extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $backupRunId;
+  public $instanceId;
+  public $kind;
+
+
+  public function setBackupRunId($backupRunId)
+  {
+    $this->backupRunId = $backupRunId;
+  }
+  public function getBackupRunId()
+  {
+    return $this->backupRunId;
+  }
+  public function setInstanceId($instanceId)
+  {
+    $this->instanceId = $instanceId;
+  }
+  public function getInstanceId()
+  {
+    return $this->instanceId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_SQLAdmin_Settings extends Google_Collection
+{
+  protected $collection_key = 'databaseFlags';
+  protected $internal_gapi_mappings = array(
+  );
+  public $activationPolicy;
+  public $authorizedGaeApplications;
+  protected $backupConfigurationType = 'Google_Service_SQLAdmin_BackupConfiguration';
+  protected $backupConfigurationDataType = '';
+  public $crashSafeReplicationEnabled;
+  public $dataDiskSizeGb;
+  protected $databaseFlagsType = 'Google_Service_SQLAdmin_DatabaseFlags';
+  protected $databaseFlagsDataType = 'array';
+  public $databaseReplicationEnabled;
+  protected $ipConfigurationType = 'Google_Service_SQLAdmin_IpConfiguration';
+  protected $ipConfigurationDataType = '';
+  public $kind;
+  protected $locationPreferenceType = 'Google_Service_SQLAdmin_LocationPreference';
+  protected $locationPreferenceDataType = '';
+  public $pricingPlan;
+  public $replicationType;
+  public $settingsVersion;
+  public $tier;
+
+
+  public function setActivationPolicy($activationPolicy)
+  {
+    $this->activationPolicy = $activationPolicy;
+  }
+  public function getActivationPolicy()
+  {
+    return $this->activationPolicy;
+  }
+  public function setAuthorizedGaeApplications($authorizedGaeApplications)
+  {
+    $this->authorizedGaeApplications = $authorizedGaeApplications;
+  }
+  public function getAuthorizedGaeApplications()
+  {
+    return $this->authorizedGaeApplications;
+  }
+  public function setBackupConfiguration(Google_Service_SQLAdmin_BackupConfiguration $backupConfiguration)
+  {
+    $this->backupConfiguration = $backupConfiguration;
+  }
+  public function getBackupConfiguration()
+  {
+    return $this->backupConfiguration;
+  }
+  public function setCrashSafeReplicationEnabled($crashSafeReplicationEnabled)
+  {
+    $this->crashSafeReplicationEnabled = $crashSafeReplicationEnabled;
+  }
+  public function getCrashSafeReplicationEnabled()
+  {
+    return $this->crashSafeReplicationEnabled;
+  }
+  public function setDataDiskSizeGb($dataDiskSizeGb)
+  {
+    $this->dataDiskSizeGb = $dataDiskSizeGb;
+  }
+  public function getDataDiskSizeGb()
+  {
+    return $this->dataDiskSizeGb;
+  }
+  public function setDatabaseFlags($databaseFlags)
+  {
+    $this->databaseFlags = $databaseFlags;
+  }
+  public function getDatabaseFlags()
+  {
+    return $this->databaseFlags;
+  }
+  public function setDatabaseReplicationEnabled($databaseReplicationEnabled)
+  {
+    $this->databaseReplicationEnabled = $databaseReplicationEnabled;
+  }
+  public function getDatabaseReplicationEnabled()
+  {
+    return $this->databaseReplicationEnabled;
+  }
+  public function setIpConfiguration(Google_Service_SQLAdmin_IpConfiguration $ipConfiguration)
+  {
+    $this->ipConfiguration = $ipConfiguration;
+  }
+  public function getIpConfiguration()
+  {
+    return $this->ipConfiguration;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocationPreference(Google_Service_SQLAdmin_LocationPreference $locationPreference)
+  {
+    $this->locationPreference = $locationPreference;
+  }
+  public function getLocationPreference()
+  {
+    return $this->locationPreference;
+  }
+  public function setPricingPlan($pricingPlan)
+  {
+    $this->pricingPlan = $pricingPlan;
+  }
+  public function getPricingPlan()
+  {
+    return $this->pricingPlan;
+  }
+  public function setReplicationType($replicationType)
+  {
+    $this->replicationType = $replicationType;
+  }
+  public function getReplicationType()
+  {
+    return $this->replicationType;
+  }
+  public function setSettingsVersion($settingsVersion)
+  {
+    $this->settingsVersion = $settingsVersion;
+  }
+  public function getSettingsVersion()
+  {
+    return $this->settingsVersion;
+  }
+  public function setTier($tier)
+  {
+    $this->tier = $tier;
+  }
+  public function getTier()
+  {
+    return $this->tier;
+  }
+}
+
+class Google_Service_SQLAdmin_SslCert extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $cert;
+  public $certSerialNumber;
+  public $commonName;
+  public $createTime;
+  public $expirationTime;
+  public $instance;
+  public $kind;
+  public $selfLink;
+  public $sha1Fingerprint;
+
+
+  public function setCert($cert)
+  {
+    $this->cert = $cert;
+  }
+  public function getCert()
+  {
+    return $this->cert;
+  }
+  public function setCertSerialNumber($certSerialNumber)
+  {
+    $this->certSerialNumber = $certSerialNumber;
+  }
+  public function getCertSerialNumber()
+  {
+    return $this->certSerialNumber;
+  }
+  public function setCommonName($commonName)
+  {
+    $this->commonName = $commonName;
+  }
+  public function getCommonName()
+  {
+    return $this->commonName;
+  }
+  public function setCreateTime($createTime)
+  {
+    $this->createTime = $createTime;
+  }
+  public function getCreateTime()
+  {
+    return $this->createTime;
+  }
+  public function setExpirationTime($expirationTime)
+  {
+    $this->expirationTime = $expirationTime;
+  }
+  public function getExpirationTime()
+  {
+    return $this->expirationTime;
+  }
+  public function setInstance($instance)
+  {
+    $this->instance = $instance;
+  }
+  public function getInstance()
+  {
+    return $this->instance;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setSha1Fingerprint($sha1Fingerprint)
+  {
+    $this->sha1Fingerprint = $sha1Fingerprint;
+  }
+  public function getSha1Fingerprint()
+  {
+    return $this->sha1Fingerprint;
+  }
+}
+
+class Google_Service_SQLAdmin_SslCertDetail extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $certInfoType = 'Google_Service_SQLAdmin_SslCert';
+  protected $certInfoDataType = '';
+  public $certPrivateKey;
+
+
+  public function setCertInfo(Google_Service_SQLAdmin_SslCert $certInfo)
+  {
+    $this->certInfo = $certInfo;
+  }
+  public function getCertInfo()
+  {
+    return $this->certInfo;
+  }
+  public function setCertPrivateKey($certPrivateKey)
+  {
+    $this->certPrivateKey = $certPrivateKey;
+  }
+  public function getCertPrivateKey()
+  {
+    return $this->certPrivateKey;
+  }
+}
+
+class Google_Service_SQLAdmin_SslCertsCreateEphemeralRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "publicKey" => "public_key",
+  );
+  public $publicKey;
+
+
+  public function setPublicKey($publicKey)
+  {
+    $this->publicKey = $publicKey;
+  }
+  public function getPublicKey()
+  {
+    return $this->publicKey;
+  }
+}
+
+class Google_Service_SQLAdmin_SslCertsInsertRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $commonName;
+
+
+  public function setCommonName($commonName)
+  {
+    $this->commonName = $commonName;
+  }
+  public function getCommonName()
+  {
+    return $this->commonName;
+  }
+}
+
+class Google_Service_SQLAdmin_SslCertsInsertResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $clientCertType = 'Google_Service_SQLAdmin_SslCertDetail';
+  protected $clientCertDataType = '';
+  public $kind;
+  protected $serverCaCertType = 'Google_Service_SQLAdmin_SslCert';
+  protected $serverCaCertDataType = '';
+
+
+  public function setClientCert(Google_Service_SQLAdmin_SslCertDetail $clientCert)
+  {
+    $this->clientCert = $clientCert;
+  }
+  public function getClientCert()
+  {
+    return $this->clientCert;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setServerCaCert(Google_Service_SQLAdmin_SslCert $serverCaCert)
+  {
+    $this->serverCaCert = $serverCaCert;
+  }
+  public function getServerCaCert()
+  {
+    return $this->serverCaCert;
+  }
+}
+
+class Google_Service_SQLAdmin_SslCertsListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_SQLAdmin_SslCert';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_SQLAdmin_Tier extends Google_Collection
+{
+  protected $collection_key = 'region';
+  protected $internal_gapi_mappings = array(
+        "diskQuota" => "DiskQuota",
+        "rAM" => "RAM",
+  );
+  public $diskQuota;
+  public $rAM;
+  public $kind;
+  public $region;
+  public $tier;
+
+
+  public function setDiskQuota($diskQuota)
+  {
+    $this->diskQuota = $diskQuota;
+  }
+  public function getDiskQuota()
+  {
+    return $this->diskQuota;
+  }
+  public function setRAM($rAM)
+  {
+    $this->rAM = $rAM;
+  }
+  public function getRAM()
+  {
+    return $this->rAM;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setTier($tier)
+  {
+    $this->tier = $tier;
+  }
+  public function getTier()
+  {
+    return $this->tier;
+  }
+}
+
+class Google_Service_SQLAdmin_TiersListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_SQLAdmin_Tier';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_SQLAdmin_User extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $host;
+  public $instance;
+  public $kind;
+  public $name;
+  public $password;
+  public $project;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setHost($host)
+  {
+    $this->host = $host;
+  }
+  public function getHost()
+  {
+    return $this->host;
+  }
+  public function setInstance($instance)
+  {
+    $this->instance = $instance;
+  }
+  public function getInstance()
+  {
+    return $this->instance;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPassword($password)
+  {
+    $this->password = $password;
+  }
+  public function getPassword()
+  {
+    return $this->password;
+  }
+  public function setProject($project)
+  {
+    $this->project = $project;
+  }
+  public function getProject()
+  {
+    return $this->project;
+  }
+}
+
+class Google_Service_SQLAdmin_UsersListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_SQLAdmin_User';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Script.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Script.php
@@ -1,0 +1,368 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Script (v1).
+ *
+ * <p>
+ * An API for executing Google Apps Script projects.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/apps-script/execution/rest/v1/run" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Script extends Google_Service
+{
+  /** View and manage your mail. */
+  const MAIL_GOOGLE_COM =
+      "https://mail.google.com/";
+  /** Manage your calendars. */
+  const WWW_GOOGLE_COM_CALENDAR_FEEDS =
+      "https://www.google.com/calendar/feeds";
+  /** Manage your contacts. */
+  const WWW_GOOGLE_COM_M8_FEEDS =
+      "https://www.google.com/m8/feeds";
+  /** View and manage the provisioning of groups on your domain. */
+  const ADMIN_DIRECTORY_GROUP =
+      "https://www.googleapis.com/auth/admin.directory.group";
+  /** View and manage the provisioning of users on your domain. */
+  const ADMIN_DIRECTORY_USER =
+      "https://www.googleapis.com/auth/admin.directory.user";
+  /** View and manage the files in your Google Drive. */
+  const DRIVE =
+      "https://www.googleapis.com/auth/drive";
+  /** View and manage your forms in Google Drive. */
+  const FORMS =
+      "https://www.googleapis.com/auth/forms";
+  /** View and manage forms that this application has been installed in. */
+  const FORMS_CURRENTONLY =
+      "https://www.googleapis.com/auth/forms.currentonly";
+  /** View and manage your Google Groups. */
+  const GROUPS =
+      "https://www.googleapis.com/auth/groups";
+  /** View your email address. */
+  const USERINFO_EMAIL =
+      "https://www.googleapis.com/auth/userinfo.email";
+
+  public $scripts;
+  
+
+  /**
+   * Constructs the internal representation of the Script service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://script.googleapis.com/';
+    $this->servicePath = '';
+    $this->version = 'v1';
+    $this->serviceName = 'script';
+
+    $this->scripts = new Google_Service_Script_Scripts_Resource(
+        $this,
+        $this->serviceName,
+        'scripts',
+        array(
+          'methods' => array(
+            'run' => array(
+              'path' => 'v1/scripts/{scriptId}:run',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'scriptId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "scripts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $scriptService = new Google_Service_Script(...);
+ *   $scripts = $scriptService->scripts;
+ *  </code>
+ */
+class Google_Service_Script_Scripts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Runs a function in an Apps Script project that has been deployed for use with
+   * the Apps Script Execution API. This method requires authorization with an
+   * OAuth 2.0 token that includes at least one of the scopes listed in the
+   * [Authentication](#authentication) section; script projects that do not
+   * require authorization cannot be executed through this API. To find the
+   * correct scopes to include in the authentication token, open the project in
+   * the script editor, then select **File > Project properties** and click the
+   * **Scopes** tab. (scripts.run)
+   *
+   * @param string $scriptId The project key of the script to be executed. To find
+   * the project key, open the project in the script editor, then select **File >
+   * Project properties**.
+   * @param Google_ExecutionRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Script_Operation
+   */
+  public function run($scriptId, Google_Service_Script_ExecutionRequest $postBody, $optParams = array())
+  {
+    $params = array('scriptId' => $scriptId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('run', array($params), "Google_Service_Script_Operation");
+  }
+}
+
+
+
+
+class Google_Service_Script_ExecutionError extends Google_Collection
+{
+  protected $collection_key = 'scriptStackTraceElements';
+  protected $internal_gapi_mappings = array(
+  );
+  public $errorMessage;
+  public $errorType;
+  protected $scriptStackTraceElementsType = 'Google_Service_Script_ScriptStackTraceElement';
+  protected $scriptStackTraceElementsDataType = 'array';
+
+
+  public function setErrorMessage($errorMessage)
+  {
+    $this->errorMessage = $errorMessage;
+  }
+  public function getErrorMessage()
+  {
+    return $this->errorMessage;
+  }
+  public function setErrorType($errorType)
+  {
+    $this->errorType = $errorType;
+  }
+  public function getErrorType()
+  {
+    return $this->errorType;
+  }
+  public function setScriptStackTraceElements($scriptStackTraceElements)
+  {
+    $this->scriptStackTraceElements = $scriptStackTraceElements;
+  }
+  public function getScriptStackTraceElements()
+  {
+    return $this->scriptStackTraceElements;
+  }
+}
+
+class Google_Service_Script_ExecutionRequest extends Google_Collection
+{
+  protected $collection_key = 'parameters';
+  protected $internal_gapi_mappings = array(
+  );
+  public $devMode;
+  public $function;
+  public $parameters;
+  public $sessionState;
+
+
+  public function setDevMode($devMode)
+  {
+    $this->devMode = $devMode;
+  }
+  public function getDevMode()
+  {
+    return $this->devMode;
+  }
+  public function setFunction($function)
+  {
+    $this->function = $function;
+  }
+  public function getFunction()
+  {
+    return $this->function;
+  }
+  public function setParameters($parameters)
+  {
+    $this->parameters = $parameters;
+  }
+  public function getParameters()
+  {
+    return $this->parameters;
+  }
+  public function setSessionState($sessionState)
+  {
+    $this->sessionState = $sessionState;
+  }
+  public function getSessionState()
+  {
+    return $this->sessionState;
+  }
+}
+
+class Google_Service_Script_ExecutionResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $result;
+
+
+  public function setResult($result)
+  {
+    $this->result = $result;
+  }
+  public function getResult()
+  {
+    return $this->result;
+  }
+}
+
+class Google_Service_Script_Operation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $done;
+  protected $errorType = 'Google_Service_Script_Status';
+  protected $errorDataType = '';
+  public $metadata;
+  public $name;
+  public $response;
+
+
+  public function setDone($done)
+  {
+    $this->done = $done;
+  }
+  public function getDone()
+  {
+    return $this->done;
+  }
+  public function setError(Google_Service_Script_Status $error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setMetadata($metadata)
+  {
+    $this->metadata = $metadata;
+  }
+  public function getMetadata()
+  {
+    return $this->metadata;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setResponse($response)
+  {
+    $this->response = $response;
+  }
+  public function getResponse()
+  {
+    return $this->response;
+  }
+}
+
+class Google_Service_Script_OperationMetadata extends Google_Model
+{
+}
+
+class Google_Service_Script_OperationResponse extends Google_Model
+{
+}
+
+class Google_Service_Script_ScriptStackTraceElement extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $function;
+  public $lineNumber;
+
+
+  public function setFunction($function)
+  {
+    $this->function = $function;
+  }
+  public function getFunction()
+  {
+    return $this->function;
+  }
+  public function setLineNumber($lineNumber)
+  {
+    $this->lineNumber = $lineNumber;
+  }
+  public function getLineNumber()
+  {
+    return $this->lineNumber;
+  }
+}
+
+class Google_Service_Script_Status extends Google_Collection
+{
+  protected $collection_key = 'details';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $details;
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setDetails($details)
+  {
+    $this->details = $details;
+  }
+  public function getDetails()
+  {
+    return $this->details;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Script_StatusDetails extends Google_Model
+{
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/ShoppingContent.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/ShoppingContent.php
@@ -1,0 +1,9176 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for ShoppingContent (v2).
+ *
+ * <p>
+ * Manage product items, inventory, and Merchant Center accounts for Google
+ * Shopping.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/shopping-content" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_ShoppingContent extends Google_Service
+{
+  /** Manage your product listings and accounts for Google Shopping. */
+  const CONTENT =
+      "https://www.googleapis.com/auth/content";
+
+  public $accounts;
+  public $accountshipping;
+  public $accountstatuses;
+  public $accounttax;
+  public $datafeeds;
+  public $datafeedstatuses;
+  public $inventory;
+  public $orders;
+  public $products;
+  public $productstatuses;
+  
+
+  /**
+   * Constructs the internal representation of the ShoppingContent service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'content/v2/';
+    $this->version = 'v2';
+    $this->serviceName = 'content';
+
+    $this->accounts = new Google_Service_ShoppingContent_Accounts_Resource(
+        $this,
+        $this->serviceName,
+        'accounts',
+        array(
+          'methods' => array(
+            'authinfo' => array(
+              'path' => 'accounts/authinfo',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),'custombatch' => array(
+              'path' => 'accounts/batch',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{merchantId}/accounts/{accountId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{merchantId}/accounts/{accountId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{merchantId}/accounts',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{merchantId}/accounts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{merchantId}/accounts/{accountId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{merchantId}/accounts/{accountId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accountshipping = new Google_Service_ShoppingContent_Accountshipping_Resource(
+        $this,
+        $this->serviceName,
+        'accountshipping',
+        array(
+          'methods' => array(
+            'custombatch' => array(
+              'path' => 'accountshipping/batch',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{merchantId}/accountshipping/{accountId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{merchantId}/accountshipping',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{merchantId}/accountshipping/{accountId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{merchantId}/accountshipping/{accountId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accountstatuses = new Google_Service_ShoppingContent_Accountstatuses_Resource(
+        $this,
+        $this->serviceName,
+        'accountstatuses',
+        array(
+          'methods' => array(
+            'custombatch' => array(
+              'path' => 'accountstatuses/batch',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'get' => array(
+              'path' => '{merchantId}/accountstatuses/{accountId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{merchantId}/accountstatuses',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounttax = new Google_Service_ShoppingContent_Accounttax_Resource(
+        $this,
+        $this->serviceName,
+        'accounttax',
+        array(
+          'methods' => array(
+            'custombatch' => array(
+              'path' => 'accounttax/batch',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{merchantId}/accounttax/{accountId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{merchantId}/accounttax',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{merchantId}/accounttax/{accountId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{merchantId}/accounttax/{accountId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->datafeeds = new Google_Service_ShoppingContent_Datafeeds_Resource(
+        $this,
+        $this->serviceName,
+        'datafeeds',
+        array(
+          'methods' => array(
+            'custombatch' => array(
+              'path' => 'datafeeds/batch',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{merchantId}/datafeeds/{datafeedId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datafeedId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{merchantId}/datafeeds/{datafeedId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datafeedId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{merchantId}/datafeeds',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{merchantId}/datafeeds',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{merchantId}/datafeeds/{datafeedId}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datafeedId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{merchantId}/datafeeds/{datafeedId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datafeedId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->datafeedstatuses = new Google_Service_ShoppingContent_Datafeedstatuses_Resource(
+        $this,
+        $this->serviceName,
+        'datafeedstatuses',
+        array(
+          'methods' => array(
+            'custombatch' => array(
+              'path' => 'datafeedstatuses/batch',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'get' => array(
+              'path' => '{merchantId}/datafeedstatuses/{datafeedId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'datafeedId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{merchantId}/datafeedstatuses',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->inventory = new Google_Service_ShoppingContent_Inventory_Resource(
+        $this,
+        $this->serviceName,
+        'inventory',
+        array(
+          'methods' => array(
+            'custombatch' => array(
+              'path' => 'inventory/batch',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'set' => array(
+              'path' => '{merchantId}/inventory/{storeCode}/products/{productId}',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'storeCode' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'productId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->orders = new Google_Service_ShoppingContent_Orders_Resource(
+        $this,
+        $this->serviceName,
+        'orders',
+        array(
+          'methods' => array(
+            'acknowledge' => array(
+              'path' => '{merchantId}/orders/{orderId}/acknowledge',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'advancetestorder' => array(
+              'path' => '{merchantId}/testorders/{orderId}/advance',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'cancel' => array(
+              'path' => '{merchantId}/orders/{orderId}/cancel',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'cancellineitem' => array(
+              'path' => '{merchantId}/orders/{orderId}/cancelLineItem',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'createtestorder' => array(
+              'path' => '{merchantId}/testorders',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'custombatch' => array(
+              'path' => 'orders/batch',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'get' => array(
+              'path' => '{merchantId}/orders/{orderId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getbymerchantorderid' => array(
+              'path' => '{merchantId}/ordersbymerchantid/{merchantOrderId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'merchantOrderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'gettestordertemplate' => array(
+              'path' => '{merchantId}/testordertemplates/{templateName}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'templateName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{merchantId}/orders',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'placedDateEnd' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'acknowledged' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'placedDateStart' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'statuses' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),'refund' => array(
+              'path' => '{merchantId}/orders/{orderId}/refund',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'returnlineitem' => array(
+              'path' => '{merchantId}/orders/{orderId}/returnLineItem',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'shiplineitems' => array(
+              'path' => '{merchantId}/orders/{orderId}/shipLineItems',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'updatemerchantorderid' => array(
+              'path' => '{merchantId}/orders/{orderId}/updateMerchantOrderId',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'updateshipment' => array(
+              'path' => '{merchantId}/orders/{orderId}/updateShipment',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'orderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->products = new Google_Service_ShoppingContent_Products_Resource(
+        $this,
+        $this->serviceName,
+        'products',
+        array(
+          'methods' => array(
+            'custombatch' => array(
+              'path' => 'products/batch',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => '{merchantId}/products/{productId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'productId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{merchantId}/products/{productId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'productId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{merchantId}/products',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dryRun' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{merchantId}/products',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->productstatuses = new Google_Service_ShoppingContent_Productstatuses_Resource(
+        $this,
+        $this->serviceName,
+        'productstatuses',
+        array(
+          'methods' => array(
+            'custombatch' => array(
+              'path' => 'productstatuses/batch',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'get' => array(
+              'path' => '{merchantId}/productstatuses/{productId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'productId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{merchantId}/productstatuses',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'merchantId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "accounts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $contentService = new Google_Service_ShoppingContent(...);
+ *   $accounts = $contentService->accounts;
+ *  </code>
+ */
+class Google_Service_ShoppingContent_Accounts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns information about the authenticated user. (accounts.authinfo)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_AccountsAuthInfoResponse
+   */
+  public function authinfo($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('authinfo', array($params), "Google_Service_ShoppingContent_AccountsAuthInfoResponse");
+  }
+
+  /**
+   * Retrieves, inserts, updates, and deletes multiple Merchant Center
+   * (sub-)accounts in a single request. (accounts.custombatch)
+   *
+   * @param Google_AccountsCustomBatchRequest $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   * @return Google_Service_ShoppingContent_AccountsCustomBatchResponse
+   */
+  public function custombatch(Google_Service_ShoppingContent_AccountsCustomBatchRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('custombatch', array($params), "Google_Service_ShoppingContent_AccountsCustomBatchResponse");
+  }
+
+  /**
+   * Deletes a Merchant Center sub-account. (accounts.delete)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $accountId The ID of the account.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   */
+  public function delete($merchantId, $accountId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves a Merchant Center account. (accounts.get)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $accountId The ID of the account.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_Account
+   */
+  public function get($merchantId, $accountId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_ShoppingContent_Account");
+  }
+
+  /**
+   * Creates a Merchant Center sub-account. (accounts.insert)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param Google_Account $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   * @return Google_Service_ShoppingContent_Account
+   */
+  public function insert($merchantId, Google_Service_ShoppingContent_Account $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_ShoppingContent_Account");
+  }
+
+  /**
+   * Lists the sub-accounts in your Merchant Center account.
+   * (accounts.listAccounts)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param string maxResults The maximum number of accounts to return in the
+   * response, used for paging.
+   * @return Google_Service_ShoppingContent_AccountsListResponse
+   */
+  public function listAccounts($merchantId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_ShoppingContent_AccountsListResponse");
+  }
+
+  /**
+   * Updates a Merchant Center account. This method supports patch semantics.
+   * (accounts.patch)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $accountId The ID of the account.
+   * @param Google_Account $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   * @return Google_Service_ShoppingContent_Account
+   */
+  public function patch($merchantId, $accountId, Google_Service_ShoppingContent_Account $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'accountId' => $accountId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_ShoppingContent_Account");
+  }
+
+  /**
+   * Updates a Merchant Center account. (accounts.update)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $accountId The ID of the account.
+   * @param Google_Account $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   * @return Google_Service_ShoppingContent_Account
+   */
+  public function update($merchantId, $accountId, Google_Service_ShoppingContent_Account $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'accountId' => $accountId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_ShoppingContent_Account");
+  }
+}
+
+/**
+ * The "accountshipping" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $contentService = new Google_Service_ShoppingContent(...);
+ *   $accountshipping = $contentService->accountshipping;
+ *  </code>
+ */
+class Google_Service_ShoppingContent_Accountshipping_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves and updates the shipping settings of multiple accounts in a single
+   * request. (accountshipping.custombatch)
+   *
+   * @param Google_AccountshippingCustomBatchRequest $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   * @return Google_Service_ShoppingContent_AccountshippingCustomBatchResponse
+   */
+  public function custombatch(Google_Service_ShoppingContent_AccountshippingCustomBatchRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('custombatch', array($params), "Google_Service_ShoppingContent_AccountshippingCustomBatchResponse");
+  }
+
+  /**
+   * Retrieves the shipping settings of the account. (accountshipping.get)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $accountId The ID of the account for which to get/update
+   * account shipping settings.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_AccountShipping
+   */
+  public function get($merchantId, $accountId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_ShoppingContent_AccountShipping");
+  }
+
+  /**
+   * Lists the shipping settings of the sub-accounts in your Merchant Center
+   * account. (accountshipping.listAccountshipping)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param string maxResults The maximum number of shipping settings to
+   * return in the response, used for paging.
+   * @return Google_Service_ShoppingContent_AccountshippingListResponse
+   */
+  public function listAccountshipping($merchantId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_ShoppingContent_AccountshippingListResponse");
+  }
+
+  /**
+   * Updates the shipping settings of the account. This method supports patch
+   * semantics. (accountshipping.patch)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $accountId The ID of the account for which to get/update
+   * account shipping settings.
+   * @param Google_AccountShipping $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   * @return Google_Service_ShoppingContent_AccountShipping
+   */
+  public function patch($merchantId, $accountId, Google_Service_ShoppingContent_AccountShipping $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'accountId' => $accountId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_ShoppingContent_AccountShipping");
+  }
+
+  /**
+   * Updates the shipping settings of the account. (accountshipping.update)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $accountId The ID of the account for which to get/update
+   * account shipping settings.
+   * @param Google_AccountShipping $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   * @return Google_Service_ShoppingContent_AccountShipping
+   */
+  public function update($merchantId, $accountId, Google_Service_ShoppingContent_AccountShipping $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'accountId' => $accountId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_ShoppingContent_AccountShipping");
+  }
+}
+
+/**
+ * The "accountstatuses" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $contentService = new Google_Service_ShoppingContent(...);
+ *   $accountstatuses = $contentService->accountstatuses;
+ *  </code>
+ */
+class Google_Service_ShoppingContent_Accountstatuses_Resource extends Google_Service_Resource
+{
+
+  /**
+   * (accountstatuses.custombatch)
+   *
+   * @param Google_AccountstatusesCustomBatchRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_AccountstatusesCustomBatchResponse
+   */
+  public function custombatch(Google_Service_ShoppingContent_AccountstatusesCustomBatchRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('custombatch', array($params), "Google_Service_ShoppingContent_AccountstatusesCustomBatchResponse");
+  }
+
+  /**
+   * Retrieves the status of a Merchant Center account. (accountstatuses.get)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $accountId The ID of the account.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_AccountStatus
+   */
+  public function get($merchantId, $accountId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_ShoppingContent_AccountStatus");
+  }
+
+  /**
+   * Lists the statuses of the sub-accounts in your Merchant Center account.
+   * (accountstatuses.listAccountstatuses)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param string maxResults The maximum number of account statuses to return
+   * in the response, used for paging.
+   * @return Google_Service_ShoppingContent_AccountstatusesListResponse
+   */
+  public function listAccountstatuses($merchantId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_ShoppingContent_AccountstatusesListResponse");
+  }
+}
+
+/**
+ * The "accounttax" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $contentService = new Google_Service_ShoppingContent(...);
+ *   $accounttax = $contentService->accounttax;
+ *  </code>
+ */
+class Google_Service_ShoppingContent_Accounttax_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves and updates tax settings of multiple accounts in a single request.
+   * (accounttax.custombatch)
+   *
+   * @param Google_AccounttaxCustomBatchRequest $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   * @return Google_Service_ShoppingContent_AccounttaxCustomBatchResponse
+   */
+  public function custombatch(Google_Service_ShoppingContent_AccounttaxCustomBatchRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('custombatch', array($params), "Google_Service_ShoppingContent_AccounttaxCustomBatchResponse");
+  }
+
+  /**
+   * Retrieves the tax settings of the account. (accounttax.get)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $accountId The ID of the account for which to get/update
+   * account tax settings.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_AccountTax
+   */
+  public function get($merchantId, $accountId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_ShoppingContent_AccountTax");
+  }
+
+  /**
+   * Lists the tax settings of the sub-accounts in your Merchant Center account.
+   * (accounttax.listAccounttax)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param string maxResults The maximum number of tax settings to return in
+   * the response, used for paging.
+   * @return Google_Service_ShoppingContent_AccounttaxListResponse
+   */
+  public function listAccounttax($merchantId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_ShoppingContent_AccounttaxListResponse");
+  }
+
+  /**
+   * Updates the tax settings of the account. This method supports patch
+   * semantics. (accounttax.patch)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $accountId The ID of the account for which to get/update
+   * account tax settings.
+   * @param Google_AccountTax $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   * @return Google_Service_ShoppingContent_AccountTax
+   */
+  public function patch($merchantId, $accountId, Google_Service_ShoppingContent_AccountTax $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'accountId' => $accountId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_ShoppingContent_AccountTax");
+  }
+
+  /**
+   * Updates the tax settings of the account. (accounttax.update)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $accountId The ID of the account for which to get/update
+   * account tax settings.
+   * @param Google_AccountTax $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   * @return Google_Service_ShoppingContent_AccountTax
+   */
+  public function update($merchantId, $accountId, Google_Service_ShoppingContent_AccountTax $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'accountId' => $accountId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_ShoppingContent_AccountTax");
+  }
+}
+
+/**
+ * The "datafeeds" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $contentService = new Google_Service_ShoppingContent(...);
+ *   $datafeeds = $contentService->datafeeds;
+ *  </code>
+ */
+class Google_Service_ShoppingContent_Datafeeds_Resource extends Google_Service_Resource
+{
+
+  /**
+   * (datafeeds.custombatch)
+   *
+   * @param Google_DatafeedsCustomBatchRequest $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   * @return Google_Service_ShoppingContent_DatafeedsCustomBatchResponse
+   */
+  public function custombatch(Google_Service_ShoppingContent_DatafeedsCustomBatchRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('custombatch', array($params), "Google_Service_ShoppingContent_DatafeedsCustomBatchResponse");
+  }
+
+  /**
+   * Deletes a datafeed from your Merchant Center account. (datafeeds.delete)
+   *
+   * @param string $merchantId
+   * @param string $datafeedId
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   */
+  public function delete($merchantId, $datafeedId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'datafeedId' => $datafeedId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves a datafeed from your Merchant Center account. (datafeeds.get)
+   *
+   * @param string $merchantId
+   * @param string $datafeedId
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_Datafeed
+   */
+  public function get($merchantId, $datafeedId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'datafeedId' => $datafeedId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_ShoppingContent_Datafeed");
+  }
+
+  /**
+   * Registers a datafeed with your Merchant Center account. (datafeeds.insert)
+   *
+   * @param string $merchantId
+   * @param Google_Datafeed $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   * @return Google_Service_ShoppingContent_Datafeed
+   */
+  public function insert($merchantId, Google_Service_ShoppingContent_Datafeed $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_ShoppingContent_Datafeed");
+  }
+
+  /**
+   * Lists the datafeeds in your Merchant Center account.
+   * (datafeeds.listDatafeeds)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param string maxResults The maximum number of products to return in the
+   * response, used for paging.
+   * @return Google_Service_ShoppingContent_DatafeedsListResponse
+   */
+  public function listDatafeeds($merchantId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_ShoppingContent_DatafeedsListResponse");
+  }
+
+  /**
+   * Updates a datafeed of your Merchant Center account. This method supports
+   * patch semantics. (datafeeds.patch)
+   *
+   * @param string $merchantId
+   * @param string $datafeedId
+   * @param Google_Datafeed $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   * @return Google_Service_ShoppingContent_Datafeed
+   */
+  public function patch($merchantId, $datafeedId, Google_Service_ShoppingContent_Datafeed $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'datafeedId' => $datafeedId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_ShoppingContent_Datafeed");
+  }
+
+  /**
+   * Updates a datafeed of your Merchant Center account. (datafeeds.update)
+   *
+   * @param string $merchantId
+   * @param string $datafeedId
+   * @param Google_Datafeed $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   * @return Google_Service_ShoppingContent_Datafeed
+   */
+  public function update($merchantId, $datafeedId, Google_Service_ShoppingContent_Datafeed $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'datafeedId' => $datafeedId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_ShoppingContent_Datafeed");
+  }
+}
+
+/**
+ * The "datafeedstatuses" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $contentService = new Google_Service_ShoppingContent(...);
+ *   $datafeedstatuses = $contentService->datafeedstatuses;
+ *  </code>
+ */
+class Google_Service_ShoppingContent_Datafeedstatuses_Resource extends Google_Service_Resource
+{
+
+  /**
+   * (datafeedstatuses.custombatch)
+   *
+   * @param Google_DatafeedstatusesCustomBatchRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_DatafeedstatusesCustomBatchResponse
+   */
+  public function custombatch(Google_Service_ShoppingContent_DatafeedstatusesCustomBatchRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('custombatch', array($params), "Google_Service_ShoppingContent_DatafeedstatusesCustomBatchResponse");
+  }
+
+  /**
+   * Retrieves the status of a datafeed from your Merchant Center account.
+   * (datafeedstatuses.get)
+   *
+   * @param string $merchantId
+   * @param string $datafeedId
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_DatafeedStatus
+   */
+  public function get($merchantId, $datafeedId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'datafeedId' => $datafeedId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_ShoppingContent_DatafeedStatus");
+  }
+
+  /**
+   * Lists the statuses of the datafeeds in your Merchant Center account.
+   * (datafeedstatuses.listDatafeedstatuses)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param string maxResults The maximum number of products to return in the
+   * response, used for paging.
+   * @return Google_Service_ShoppingContent_DatafeedstatusesListResponse
+   */
+  public function listDatafeedstatuses($merchantId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_ShoppingContent_DatafeedstatusesListResponse");
+  }
+}
+
+/**
+ * The "inventory" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $contentService = new Google_Service_ShoppingContent(...);
+ *   $inventory = $contentService->inventory;
+ *  </code>
+ */
+class Google_Service_ShoppingContent_Inventory_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Updates price and availability for multiple products or stores in a single
+   * request. This operation does not update the expiration date of the products.
+   * (inventory.custombatch)
+   *
+   * @param Google_InventoryCustomBatchRequest $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   * @return Google_Service_ShoppingContent_InventoryCustomBatchResponse
+   */
+  public function custombatch(Google_Service_ShoppingContent_InventoryCustomBatchRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('custombatch', array($params), "Google_Service_ShoppingContent_InventoryCustomBatchResponse");
+  }
+
+  /**
+   * Updates price and availability of a product in your Merchant Center account.
+   * This operation does not update the expiration date of the product.
+   * (inventory.set)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $storeCode The code of the store for which to update price and
+   * availability. Use online to update price and availability of an online
+   * product.
+   * @param string $productId The ID of the product for which to update price and
+   * availability.
+   * @param Google_InventorySetRequest $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   * @return Google_Service_ShoppingContent_InventorySetResponse
+   */
+  public function set($merchantId, $storeCode, $productId, Google_Service_ShoppingContent_InventorySetRequest $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'storeCode' => $storeCode, 'productId' => $productId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('set', array($params), "Google_Service_ShoppingContent_InventorySetResponse");
+  }
+}
+
+/**
+ * The "orders" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $contentService = new Google_Service_ShoppingContent(...);
+ *   $orders = $contentService->orders;
+ *  </code>
+ */
+class Google_Service_ShoppingContent_Orders_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Marks an order as acknowledged. (orders.acknowledge)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $orderId The ID of the order.
+   * @param Google_OrdersAcknowledgeRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_OrdersAcknowledgeResponse
+   */
+  public function acknowledge($merchantId, $orderId, Google_Service_ShoppingContent_OrdersAcknowledgeRequest $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'orderId' => $orderId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('acknowledge', array($params), "Google_Service_ShoppingContent_OrdersAcknowledgeResponse");
+  }
+
+  /**
+   * Sandbox only. Moves a test order from state "inProgress" to state
+   * "pendingShipment". (orders.advancetestorder)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $orderId The ID of the test order to modify.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_OrdersAdvanceTestOrderResponse
+   */
+  public function advancetestorder($merchantId, $orderId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'orderId' => $orderId);
+    $params = array_merge($params, $optParams);
+    return $this->call('advancetestorder', array($params), "Google_Service_ShoppingContent_OrdersAdvanceTestOrderResponse");
+  }
+
+  /**
+   * Cancels all line items in an order. (orders.cancel)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $orderId The ID of the order to cancel.
+   * @param Google_OrdersCancelRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_OrdersCancelResponse
+   */
+  public function cancel($merchantId, $orderId, Google_Service_ShoppingContent_OrdersCancelRequest $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'orderId' => $orderId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('cancel', array($params), "Google_Service_ShoppingContent_OrdersCancelResponse");
+  }
+
+  /**
+   * Cancels a line item. (orders.cancellineitem)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $orderId The ID of the order.
+   * @param Google_OrdersCancelLineItemRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_OrdersCancelLineItemResponse
+   */
+  public function cancellineitem($merchantId, $orderId, Google_Service_ShoppingContent_OrdersCancelLineItemRequest $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'orderId' => $orderId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('cancellineitem', array($params), "Google_Service_ShoppingContent_OrdersCancelLineItemResponse");
+  }
+
+  /**
+   * Sandbox only. Creates a test order. (orders.createtestorder)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param Google_OrdersCreateTestOrderRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_OrdersCreateTestOrderResponse
+   */
+  public function createtestorder($merchantId, Google_Service_ShoppingContent_OrdersCreateTestOrderRequest $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('createtestorder', array($params), "Google_Service_ShoppingContent_OrdersCreateTestOrderResponse");
+  }
+
+  /**
+   * Retrieves or modifies multiple orders in a single request.
+   * (orders.custombatch)
+   *
+   * @param Google_OrdersCustomBatchRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_OrdersCustomBatchResponse
+   */
+  public function custombatch(Google_Service_ShoppingContent_OrdersCustomBatchRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('custombatch', array($params), "Google_Service_ShoppingContent_OrdersCustomBatchResponse");
+  }
+
+  /**
+   * Retrieves an order from your Merchant Center account. (orders.get)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $orderId The ID of the order.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_Order
+   */
+  public function get($merchantId, $orderId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'orderId' => $orderId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_ShoppingContent_Order");
+  }
+
+  /**
+   * Retrieves an order using merchant order id. (orders.getbymerchantorderid)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $merchantOrderId The merchant order id to be looked for.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_OrdersGetByMerchantOrderIdResponse
+   */
+  public function getbymerchantorderid($merchantId, $merchantOrderId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'merchantOrderId' => $merchantOrderId);
+    $params = array_merge($params, $optParams);
+    return $this->call('getbymerchantorderid', array($params), "Google_Service_ShoppingContent_OrdersGetByMerchantOrderIdResponse");
+  }
+
+  /**
+   * Sandbox only. Retrieves an order template that can be used to quickly create
+   * a new order in sandbox. (orders.gettestordertemplate)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $templateName The name of the template to retrieve.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_OrdersGetTestOrderTemplateResponse
+   */
+  public function gettestordertemplate($merchantId, $templateName, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'templateName' => $templateName);
+    $params = array_merge($params, $optParams);
+    return $this->call('gettestordertemplate', array($params), "Google_Service_ShoppingContent_OrdersGetTestOrderTemplateResponse");
+  }
+
+  /**
+   * Lists the orders in your Merchant Center account. (orders.listOrders)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string orderBy The ordering of the returned list. The only
+   * supported value are placedDate desc and placedDate asc for now, which returns
+   * orders sorted by placement date. "placedDate desc" stands for listing orders
+   * by placement date, from oldest to most recent. "placedDate asc" stands for
+   * listing orders by placement date, from most recent to oldest. In future
+   * releases we'll support other sorting criteria.
+   * @opt_param string placedDateEnd Obtains orders placed before this date
+   * (exclusively), in ISO 8601 format.
+   * @opt_param bool acknowledged Obtains orders that match the acknowledgement
+   * status. When set to true, obtains orders that have been acknowledged. When
+   * false, obtains orders that have not been acknowledged. We recommend using
+   * this filter set to false, in conjunction with the acknowledge call, such that
+   * only un-acknowledged orders are returned.
+   * @opt_param string maxResults The maximum number of orders to return in the
+   * response, used for paging. The default value is 25 orders per page, and the
+   * maximum allowed value is 250 orders per page. Known issue: All List calls
+   * will return all Orders without limit regardless of the value of this field.
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param string placedDateStart Obtains orders placed after this date
+   * (inclusively), in ISO 8601 format.
+   * @opt_param string statuses Obtains orders that match any of the specified
+   * statuses. Multiple values can be specified with comma separation.
+   * Additionally, please note that active is a shortcut for pendingShipment and
+   * partiallyShipped, and completed is a shortcut for shipped ,
+   * partiallyDelivered, delivered, partiallyReturned, returned, and canceled.
+   * @return Google_Service_ShoppingContent_OrdersListResponse
+   */
+  public function listOrders($merchantId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_ShoppingContent_OrdersListResponse");
+  }
+
+  /**
+   * Refund a portion of the order, up to the full amount paid. (orders.refund)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $orderId The ID of the order to refund.
+   * @param Google_OrdersRefundRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_OrdersRefundResponse
+   */
+  public function refund($merchantId, $orderId, Google_Service_ShoppingContent_OrdersRefundRequest $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'orderId' => $orderId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('refund', array($params), "Google_Service_ShoppingContent_OrdersRefundResponse");
+  }
+
+  /**
+   * Returns a line item. (orders.returnlineitem)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $orderId The ID of the order.
+   * @param Google_OrdersReturnLineItemRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_OrdersReturnLineItemResponse
+   */
+  public function returnlineitem($merchantId, $orderId, Google_Service_ShoppingContent_OrdersReturnLineItemRequest $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'orderId' => $orderId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('returnlineitem', array($params), "Google_Service_ShoppingContent_OrdersReturnLineItemResponse");
+  }
+
+  /**
+   * Marks line item(s) as shipped. (orders.shiplineitems)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $orderId The ID of the order.
+   * @param Google_OrdersShipLineItemsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_OrdersShipLineItemsResponse
+   */
+  public function shiplineitems($merchantId, $orderId, Google_Service_ShoppingContent_OrdersShipLineItemsRequest $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'orderId' => $orderId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('shiplineitems', array($params), "Google_Service_ShoppingContent_OrdersShipLineItemsResponse");
+  }
+
+  /**
+   * Updates the merchant order ID for a given order.
+   * (orders.updatemerchantorderid)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $orderId The ID of the order.
+   * @param Google_OrdersUpdateMerchantOrderIdRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_OrdersUpdateMerchantOrderIdResponse
+   */
+  public function updatemerchantorderid($merchantId, $orderId, Google_Service_ShoppingContent_OrdersUpdateMerchantOrderIdRequest $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'orderId' => $orderId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('updatemerchantorderid', array($params), "Google_Service_ShoppingContent_OrdersUpdateMerchantOrderIdResponse");
+  }
+
+  /**
+   * Updates a shipment's status, carrier, and/or tracking ID.
+   * (orders.updateshipment)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $orderId The ID of the order.
+   * @param Google_OrdersUpdateShipmentRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_OrdersUpdateShipmentResponse
+   */
+  public function updateshipment($merchantId, $orderId, Google_Service_ShoppingContent_OrdersUpdateShipmentRequest $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'orderId' => $orderId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('updateshipment', array($params), "Google_Service_ShoppingContent_OrdersUpdateShipmentResponse");
+  }
+}
+
+/**
+ * The "products" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $contentService = new Google_Service_ShoppingContent(...);
+ *   $products = $contentService->products;
+ *  </code>
+ */
+class Google_Service_ShoppingContent_Products_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves, inserts, and deletes multiple products in a single request.
+   * (products.custombatch)
+   *
+   * @param Google_ProductsCustomBatchRequest $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   * @return Google_Service_ShoppingContent_ProductsCustomBatchResponse
+   */
+  public function custombatch(Google_Service_ShoppingContent_ProductsCustomBatchRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('custombatch', array($params), "Google_Service_ShoppingContent_ProductsCustomBatchResponse");
+  }
+
+  /**
+   * Deletes a product from your Merchant Center account. (products.delete)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $productId The ID of the product.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   */
+  public function delete($merchantId, $productId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'productId' => $productId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves a product from your Merchant Center account. (products.get)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $productId The ID of the product.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_Product
+   */
+  public function get($merchantId, $productId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'productId' => $productId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_ShoppingContent_Product");
+  }
+
+  /**
+   * Uploads a product to your Merchant Center account. (products.insert)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param Google_Product $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool dryRun Flag to run the request in dry-run mode.
+   * @return Google_Service_ShoppingContent_Product
+   */
+  public function insert($merchantId, Google_Service_ShoppingContent_Product $postBody, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_ShoppingContent_Product");
+  }
+
+  /**
+   * Lists the products in your Merchant Center account. (products.listProducts)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param string maxResults The maximum number of products to return in the
+   * response, used for paging.
+   * @return Google_Service_ShoppingContent_ProductsListResponse
+   */
+  public function listProducts($merchantId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_ShoppingContent_ProductsListResponse");
+  }
+}
+
+/**
+ * The "productstatuses" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $contentService = new Google_Service_ShoppingContent(...);
+ *   $productstatuses = $contentService->productstatuses;
+ *  </code>
+ */
+class Google_Service_ShoppingContent_Productstatuses_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the statuses of multiple products in a single request.
+   * (productstatuses.custombatch)
+   *
+   * @param Google_ProductstatusesCustomBatchRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_ProductstatusesCustomBatchResponse
+   */
+  public function custombatch(Google_Service_ShoppingContent_ProductstatusesCustomBatchRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('custombatch', array($params), "Google_Service_ShoppingContent_ProductstatusesCustomBatchResponse");
+  }
+
+  /**
+   * Gets the status of a product from your Merchant Center account.
+   * (productstatuses.get)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param string $productId The ID of the product.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_ShoppingContent_ProductStatus
+   */
+  public function get($merchantId, $productId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId, 'productId' => $productId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_ShoppingContent_ProductStatus");
+  }
+
+  /**
+   * Lists the statuses of the products in your Merchant Center account.
+   * (productstatuses.listProductstatuses)
+   *
+   * @param string $merchantId The ID of the managing account.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken The token returned by the previous request.
+   * @opt_param string maxResults The maximum number of product statuses to return
+   * in the response, used for paging.
+   * @return Google_Service_ShoppingContent_ProductstatusesListResponse
+   */
+  public function listProductstatuses($merchantId, $optParams = array())
+  {
+    $params = array('merchantId' => $merchantId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_ShoppingContent_ProductstatusesListResponse");
+  }
+}
+
+
+
+
+class Google_Service_ShoppingContent_Account extends Google_Collection
+{
+  protected $collection_key = 'users';
+  protected $internal_gapi_mappings = array(
+  );
+  public $adultContent;
+  protected $adwordsLinksType = 'Google_Service_ShoppingContent_AccountAdwordsLink';
+  protected $adwordsLinksDataType = 'array';
+  public $id;
+  public $kind;
+  public $name;
+  public $reviewsUrl;
+  public $sellerId;
+  protected $usersType = 'Google_Service_ShoppingContent_AccountUser';
+  protected $usersDataType = 'array';
+  public $websiteUrl;
+
+
+  public function setAdultContent($adultContent)
+  {
+    $this->adultContent = $adultContent;
+  }
+  public function getAdultContent()
+  {
+    return $this->adultContent;
+  }
+  public function setAdwordsLinks($adwordsLinks)
+  {
+    $this->adwordsLinks = $adwordsLinks;
+  }
+  public function getAdwordsLinks()
+  {
+    return $this->adwordsLinks;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setReviewsUrl($reviewsUrl)
+  {
+    $this->reviewsUrl = $reviewsUrl;
+  }
+  public function getReviewsUrl()
+  {
+    return $this->reviewsUrl;
+  }
+  public function setSellerId($sellerId)
+  {
+    $this->sellerId = $sellerId;
+  }
+  public function getSellerId()
+  {
+    return $this->sellerId;
+  }
+  public function setUsers($users)
+  {
+    $this->users = $users;
+  }
+  public function getUsers()
+  {
+    return $this->users;
+  }
+  public function setWebsiteUrl($websiteUrl)
+  {
+    $this->websiteUrl = $websiteUrl;
+  }
+  public function getWebsiteUrl()
+  {
+    return $this->websiteUrl;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountAdwordsLink extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $adwordsId;
+  public $status;
+
+
+  public function setAdwordsId($adwordsId)
+  {
+    $this->adwordsId = $adwordsId;
+  }
+  public function getAdwordsId()
+  {
+    return $this->adwordsId;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountIdentifier extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $aggregatorId;
+  public $merchantId;
+
+
+  public function setAggregatorId($aggregatorId)
+  {
+    $this->aggregatorId = $aggregatorId;
+  }
+  public function getAggregatorId()
+  {
+    return $this->aggregatorId;
+  }
+  public function setMerchantId($merchantId)
+  {
+    $this->merchantId = $merchantId;
+  }
+  public function getMerchantId()
+  {
+    return $this->merchantId;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountShipping extends Google_Collection
+{
+  protected $collection_key = 'services';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  protected $carrierRatesType = 'Google_Service_ShoppingContent_AccountShippingCarrierRate';
+  protected $carrierRatesDataType = 'array';
+  public $kind;
+  protected $locationGroupsType = 'Google_Service_ShoppingContent_AccountShippingLocationGroup';
+  protected $locationGroupsDataType = 'array';
+  protected $rateTablesType = 'Google_Service_ShoppingContent_AccountShippingRateTable';
+  protected $rateTablesDataType = 'array';
+  protected $servicesType = 'Google_Service_ShoppingContent_AccountShippingShippingService';
+  protected $servicesDataType = 'array';
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setCarrierRates($carrierRates)
+  {
+    $this->carrierRates = $carrierRates;
+  }
+  public function getCarrierRates()
+  {
+    return $this->carrierRates;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocationGroups($locationGroups)
+  {
+    $this->locationGroups = $locationGroups;
+  }
+  public function getLocationGroups()
+  {
+    return $this->locationGroups;
+  }
+  public function setRateTables($rateTables)
+  {
+    $this->rateTables = $rateTables;
+  }
+  public function getRateTables()
+  {
+    return $this->rateTables;
+  }
+  public function setServices($services)
+  {
+    $this->services = $services;
+  }
+  public function getServices()
+  {
+    return $this->services;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountShippingCarrierRate extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $carrier;
+  public $carrierService;
+  protected $modifierFlatRateType = 'Google_Service_ShoppingContent_Price';
+  protected $modifierFlatRateDataType = '';
+  public $modifierPercent;
+  public $name;
+  public $saleCountry;
+  public $shippingOrigin;
+
+
+  public function setCarrier($carrier)
+  {
+    $this->carrier = $carrier;
+  }
+  public function getCarrier()
+  {
+    return $this->carrier;
+  }
+  public function setCarrierService($carrierService)
+  {
+    $this->carrierService = $carrierService;
+  }
+  public function getCarrierService()
+  {
+    return $this->carrierService;
+  }
+  public function setModifierFlatRate(Google_Service_ShoppingContent_Price $modifierFlatRate)
+  {
+    $this->modifierFlatRate = $modifierFlatRate;
+  }
+  public function getModifierFlatRate()
+  {
+    return $this->modifierFlatRate;
+  }
+  public function setModifierPercent($modifierPercent)
+  {
+    $this->modifierPercent = $modifierPercent;
+  }
+  public function getModifierPercent()
+  {
+    return $this->modifierPercent;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSaleCountry($saleCountry)
+  {
+    $this->saleCountry = $saleCountry;
+  }
+  public function getSaleCountry()
+  {
+    return $this->saleCountry;
+  }
+  public function setShippingOrigin($shippingOrigin)
+  {
+    $this->shippingOrigin = $shippingOrigin;
+  }
+  public function getShippingOrigin()
+  {
+    return $this->shippingOrigin;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountShippingCondition extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $deliveryLocationGroup;
+  public $deliveryLocationId;
+  public $deliveryPostalCode;
+  protected $deliveryPostalCodeRangeType = 'Google_Service_ShoppingContent_AccountShippingPostalCodeRange';
+  protected $deliveryPostalCodeRangeDataType = '';
+  protected $priceMaxType = 'Google_Service_ShoppingContent_Price';
+  protected $priceMaxDataType = '';
+  public $shippingLabel;
+  protected $weightMaxType = 'Google_Service_ShoppingContent_Weight';
+  protected $weightMaxDataType = '';
+
+
+  public function setDeliveryLocationGroup($deliveryLocationGroup)
+  {
+    $this->deliveryLocationGroup = $deliveryLocationGroup;
+  }
+  public function getDeliveryLocationGroup()
+  {
+    return $this->deliveryLocationGroup;
+  }
+  public function setDeliveryLocationId($deliveryLocationId)
+  {
+    $this->deliveryLocationId = $deliveryLocationId;
+  }
+  public function getDeliveryLocationId()
+  {
+    return $this->deliveryLocationId;
+  }
+  public function setDeliveryPostalCode($deliveryPostalCode)
+  {
+    $this->deliveryPostalCode = $deliveryPostalCode;
+  }
+  public function getDeliveryPostalCode()
+  {
+    return $this->deliveryPostalCode;
+  }
+  public function setDeliveryPostalCodeRange(Google_Service_ShoppingContent_AccountShippingPostalCodeRange $deliveryPostalCodeRange)
+  {
+    $this->deliveryPostalCodeRange = $deliveryPostalCodeRange;
+  }
+  public function getDeliveryPostalCodeRange()
+  {
+    return $this->deliveryPostalCodeRange;
+  }
+  public function setPriceMax(Google_Service_ShoppingContent_Price $priceMax)
+  {
+    $this->priceMax = $priceMax;
+  }
+  public function getPriceMax()
+  {
+    return $this->priceMax;
+  }
+  public function setShippingLabel($shippingLabel)
+  {
+    $this->shippingLabel = $shippingLabel;
+  }
+  public function getShippingLabel()
+  {
+    return $this->shippingLabel;
+  }
+  public function setWeightMax(Google_Service_ShoppingContent_Weight $weightMax)
+  {
+    $this->weightMax = $weightMax;
+  }
+  public function getWeightMax()
+  {
+    return $this->weightMax;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountShippingLocationGroup extends Google_Collection
+{
+  protected $collection_key = 'postalCodes';
+  protected $internal_gapi_mappings = array(
+  );
+  public $country;
+  public $locationIds;
+  public $name;
+  protected $postalCodeRangesType = 'Google_Service_ShoppingContent_AccountShippingPostalCodeRange';
+  protected $postalCodeRangesDataType = 'array';
+  public $postalCodes;
+
+
+  public function setCountry($country)
+  {
+    $this->country = $country;
+  }
+  public function getCountry()
+  {
+    return $this->country;
+  }
+  public function setLocationIds($locationIds)
+  {
+    $this->locationIds = $locationIds;
+  }
+  public function getLocationIds()
+  {
+    return $this->locationIds;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPostalCodeRanges($postalCodeRanges)
+  {
+    $this->postalCodeRanges = $postalCodeRanges;
+  }
+  public function getPostalCodeRanges()
+  {
+    return $this->postalCodeRanges;
+  }
+  public function setPostalCodes($postalCodes)
+  {
+    $this->postalCodes = $postalCodes;
+  }
+  public function getPostalCodes()
+  {
+    return $this->postalCodes;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountShippingPostalCodeRange extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $end;
+  public $start;
+
+
+  public function setEnd($end)
+  {
+    $this->end = $end;
+  }
+  public function getEnd()
+  {
+    return $this->end;
+  }
+  public function setStart($start)
+  {
+    $this->start = $start;
+  }
+  public function getStart()
+  {
+    return $this->start;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountShippingRateTable extends Google_Collection
+{
+  protected $collection_key = 'content';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $contentType = 'Google_Service_ShoppingContent_AccountShippingRateTableCell';
+  protected $contentDataType = 'array';
+  public $name;
+  public $saleCountry;
+
+
+  public function setContent($content)
+  {
+    $this->content = $content;
+  }
+  public function getContent()
+  {
+    return $this->content;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSaleCountry($saleCountry)
+  {
+    $this->saleCountry = $saleCountry;
+  }
+  public function getSaleCountry()
+  {
+    return $this->saleCountry;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountShippingRateTableCell extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $conditionType = 'Google_Service_ShoppingContent_AccountShippingCondition';
+  protected $conditionDataType = '';
+  protected $rateType = 'Google_Service_ShoppingContent_Price';
+  protected $rateDataType = '';
+
+
+  public function setCondition(Google_Service_ShoppingContent_AccountShippingCondition $condition)
+  {
+    $this->condition = $condition;
+  }
+  public function getCondition()
+  {
+    return $this->condition;
+  }
+  public function setRate(Google_Service_ShoppingContent_Price $rate)
+  {
+    $this->rate = $rate;
+  }
+  public function getRate()
+  {
+    return $this->rate;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountShippingShippingService extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $active;
+  protected $calculationMethodType = 'Google_Service_ShoppingContent_AccountShippingShippingServiceCalculationMethod';
+  protected $calculationMethodDataType = '';
+  protected $costRuleTreeType = 'Google_Service_ShoppingContent_AccountShippingShippingServiceCostRule';
+  protected $costRuleTreeDataType = '';
+  public $name;
+  public $saleCountry;
+
+
+  public function setActive($active)
+  {
+    $this->active = $active;
+  }
+  public function getActive()
+  {
+    return $this->active;
+  }
+  public function setCalculationMethod(Google_Service_ShoppingContent_AccountShippingShippingServiceCalculationMethod $calculationMethod)
+  {
+    $this->calculationMethod = $calculationMethod;
+  }
+  public function getCalculationMethod()
+  {
+    return $this->calculationMethod;
+  }
+  public function setCostRuleTree(Google_Service_ShoppingContent_AccountShippingShippingServiceCostRule $costRuleTree)
+  {
+    $this->costRuleTree = $costRuleTree;
+  }
+  public function getCostRuleTree()
+  {
+    return $this->costRuleTree;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setSaleCountry($saleCountry)
+  {
+    $this->saleCountry = $saleCountry;
+  }
+  public function getSaleCountry()
+  {
+    return $this->saleCountry;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountShippingShippingServiceCalculationMethod extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $carrierRate;
+  public $excluded;
+  protected $flatRateType = 'Google_Service_ShoppingContent_Price';
+  protected $flatRateDataType = '';
+  public $percentageRate;
+  public $rateTable;
+
+
+  public function setCarrierRate($carrierRate)
+  {
+    $this->carrierRate = $carrierRate;
+  }
+  public function getCarrierRate()
+  {
+    return $this->carrierRate;
+  }
+  public function setExcluded($excluded)
+  {
+    $this->excluded = $excluded;
+  }
+  public function getExcluded()
+  {
+    return $this->excluded;
+  }
+  public function setFlatRate(Google_Service_ShoppingContent_Price $flatRate)
+  {
+    $this->flatRate = $flatRate;
+  }
+  public function getFlatRate()
+  {
+    return $this->flatRate;
+  }
+  public function setPercentageRate($percentageRate)
+  {
+    $this->percentageRate = $percentageRate;
+  }
+  public function getPercentageRate()
+  {
+    return $this->percentageRate;
+  }
+  public function setRateTable($rateTable)
+  {
+    $this->rateTable = $rateTable;
+  }
+  public function getRateTable()
+  {
+    return $this->rateTable;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountShippingShippingServiceCostRule extends Google_Collection
+{
+  protected $collection_key = 'children';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $calculationMethodType = 'Google_Service_ShoppingContent_AccountShippingShippingServiceCalculationMethod';
+  protected $calculationMethodDataType = '';
+  protected $childrenType = 'Google_Service_ShoppingContent_AccountShippingShippingServiceCostRule';
+  protected $childrenDataType = 'array';
+  protected $conditionType = 'Google_Service_ShoppingContent_AccountShippingCondition';
+  protected $conditionDataType = '';
+
+
+  public function setCalculationMethod(Google_Service_ShoppingContent_AccountShippingShippingServiceCalculationMethod $calculationMethod)
+  {
+    $this->calculationMethod = $calculationMethod;
+  }
+  public function getCalculationMethod()
+  {
+    return $this->calculationMethod;
+  }
+  public function setChildren($children)
+  {
+    $this->children = $children;
+  }
+  public function getChildren()
+  {
+    return $this->children;
+  }
+  public function setCondition(Google_Service_ShoppingContent_AccountShippingCondition $condition)
+  {
+    $this->condition = $condition;
+  }
+  public function getCondition()
+  {
+    return $this->condition;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountStatus extends Google_Collection
+{
+  protected $collection_key = 'dataQualityIssues';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  protected $dataQualityIssuesType = 'Google_Service_ShoppingContent_AccountStatusDataQualityIssue';
+  protected $dataQualityIssuesDataType = 'array';
+  public $kind;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setDataQualityIssues($dataQualityIssues)
+  {
+    $this->dataQualityIssues = $dataQualityIssues;
+  }
+  public function getDataQualityIssues()
+  {
+    return $this->dataQualityIssues;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountStatusDataQualityIssue extends Google_Collection
+{
+  protected $collection_key = 'exampleItems';
+  protected $internal_gapi_mappings = array(
+  );
+  public $country;
+  public $displayedValue;
+  protected $exampleItemsType = 'Google_Service_ShoppingContent_AccountStatusExampleItem';
+  protected $exampleItemsDataType = 'array';
+  public $id;
+  public $lastChecked;
+  public $numItems;
+  public $severity;
+  public $submittedValue;
+
+
+  public function setCountry($country)
+  {
+    $this->country = $country;
+  }
+  public function getCountry()
+  {
+    return $this->country;
+  }
+  public function setDisplayedValue($displayedValue)
+  {
+    $this->displayedValue = $displayedValue;
+  }
+  public function getDisplayedValue()
+  {
+    return $this->displayedValue;
+  }
+  public function setExampleItems($exampleItems)
+  {
+    $this->exampleItems = $exampleItems;
+  }
+  public function getExampleItems()
+  {
+    return $this->exampleItems;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLastChecked($lastChecked)
+  {
+    $this->lastChecked = $lastChecked;
+  }
+  public function getLastChecked()
+  {
+    return $this->lastChecked;
+  }
+  public function setNumItems($numItems)
+  {
+    $this->numItems = $numItems;
+  }
+  public function getNumItems()
+  {
+    return $this->numItems;
+  }
+  public function setSeverity($severity)
+  {
+    $this->severity = $severity;
+  }
+  public function getSeverity()
+  {
+    return $this->severity;
+  }
+  public function setSubmittedValue($submittedValue)
+  {
+    $this->submittedValue = $submittedValue;
+  }
+  public function getSubmittedValue()
+  {
+    return $this->submittedValue;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountStatusExampleItem extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $itemId;
+  public $link;
+  public $submittedValue;
+  public $title;
+  public $valueOnLandingPage;
+
+
+  public function setItemId($itemId)
+  {
+    $this->itemId = $itemId;
+  }
+  public function getItemId()
+  {
+    return $this->itemId;
+  }
+  public function setLink($link)
+  {
+    $this->link = $link;
+  }
+  public function getLink()
+  {
+    return $this->link;
+  }
+  public function setSubmittedValue($submittedValue)
+  {
+    $this->submittedValue = $submittedValue;
+  }
+  public function getSubmittedValue()
+  {
+    return $this->submittedValue;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setValueOnLandingPage($valueOnLandingPage)
+  {
+    $this->valueOnLandingPage = $valueOnLandingPage;
+  }
+  public function getValueOnLandingPage()
+  {
+    return $this->valueOnLandingPage;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountTax extends Google_Collection
+{
+  protected $collection_key = 'rules';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $kind;
+  protected $rulesType = 'Google_Service_ShoppingContent_AccountTaxTaxRule';
+  protected $rulesDataType = 'array';
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRules($rules)
+  {
+    $this->rules = $rules;
+  }
+  public function getRules()
+  {
+    return $this->rules;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountTaxTaxRule extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $country;
+  public $locationId;
+  public $ratePercent;
+  public $shippingTaxed;
+  public $useGlobalRate;
+
+
+  public function setCountry($country)
+  {
+    $this->country = $country;
+  }
+  public function getCountry()
+  {
+    return $this->country;
+  }
+  public function setLocationId($locationId)
+  {
+    $this->locationId = $locationId;
+  }
+  public function getLocationId()
+  {
+    return $this->locationId;
+  }
+  public function setRatePercent($ratePercent)
+  {
+    $this->ratePercent = $ratePercent;
+  }
+  public function getRatePercent()
+  {
+    return $this->ratePercent;
+  }
+  public function setShippingTaxed($shippingTaxed)
+  {
+    $this->shippingTaxed = $shippingTaxed;
+  }
+  public function getShippingTaxed()
+  {
+    return $this->shippingTaxed;
+  }
+  public function setUseGlobalRate($useGlobalRate)
+  {
+    $this->useGlobalRate = $useGlobalRate;
+  }
+  public function getUseGlobalRate()
+  {
+    return $this->useGlobalRate;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountUser extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $admin;
+  public $emailAddress;
+
+
+  public function setAdmin($admin)
+  {
+    $this->admin = $admin;
+  }
+  public function getAdmin()
+  {
+    return $this->admin;
+  }
+  public function setEmailAddress($emailAddress)
+  {
+    $this->emailAddress = $emailAddress;
+  }
+  public function getEmailAddress()
+  {
+    return $this->emailAddress;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountsAuthInfoResponse extends Google_Collection
+{
+  protected $collection_key = 'accountIdentifiers';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accountIdentifiersType = 'Google_Service_ShoppingContent_AccountIdentifier';
+  protected $accountIdentifiersDataType = 'array';
+  public $kind;
+
+
+  public function setAccountIdentifiers($accountIdentifiers)
+  {
+    $this->accountIdentifiers = $accountIdentifiers;
+  }
+  public function getAccountIdentifiers()
+  {
+    return $this->accountIdentifiers;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountsCustomBatchRequest extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_AccountsCustomBatchRequestEntry';
+  protected $entriesDataType = 'array';
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountsCustomBatchRequestEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accountType = 'Google_Service_ShoppingContent_Account';
+  protected $accountDataType = '';
+  public $accountId;
+  public $batchId;
+  public $merchantId;
+  public $method;
+
+
+  public function setAccount(Google_Service_ShoppingContent_Account $account)
+  {
+    $this->account = $account;
+  }
+  public function getAccount()
+  {
+    return $this->account;
+  }
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setMerchantId($merchantId)
+  {
+    $this->merchantId = $merchantId;
+  }
+  public function getMerchantId()
+  {
+    return $this->merchantId;
+  }
+  public function setMethod($method)
+  {
+    $this->method = $method;
+  }
+  public function getMethod()
+  {
+    return $this->method;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountsCustomBatchResponse extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_AccountsCustomBatchResponseEntry';
+  protected $entriesDataType = 'array';
+  public $kind;
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountsCustomBatchResponseEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accountType = 'Google_Service_ShoppingContent_Account';
+  protected $accountDataType = '';
+  public $batchId;
+  protected $errorsType = 'Google_Service_ShoppingContent_Errors';
+  protected $errorsDataType = '';
+  public $kind;
+
+
+  public function setAccount(Google_Service_ShoppingContent_Account $account)
+  {
+    $this->account = $account;
+  }
+  public function getAccount()
+  {
+    return $this->account;
+  }
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setErrors(Google_Service_ShoppingContent_Errors $errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountsListResponse extends Google_Collection
+{
+  protected $collection_key = 'resources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $resourcesType = 'Google_Service_ShoppingContent_Account';
+  protected $resourcesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setResources($resources)
+  {
+    $this->resources = $resources;
+  }
+  public function getResources()
+  {
+    return $this->resources;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountshippingCustomBatchRequest extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_AccountshippingCustomBatchRequestEntry';
+  protected $entriesDataType = 'array';
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountshippingCustomBatchRequestEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  protected $accountShippingType = 'Google_Service_ShoppingContent_AccountShipping';
+  protected $accountShippingDataType = '';
+  public $batchId;
+  public $merchantId;
+  public $method;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAccountShipping(Google_Service_ShoppingContent_AccountShipping $accountShipping)
+  {
+    $this->accountShipping = $accountShipping;
+  }
+  public function getAccountShipping()
+  {
+    return $this->accountShipping;
+  }
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setMerchantId($merchantId)
+  {
+    $this->merchantId = $merchantId;
+  }
+  public function getMerchantId()
+  {
+    return $this->merchantId;
+  }
+  public function setMethod($method)
+  {
+    $this->method = $method;
+  }
+  public function getMethod()
+  {
+    return $this->method;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountshippingCustomBatchResponse extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_AccountshippingCustomBatchResponseEntry';
+  protected $entriesDataType = 'array';
+  public $kind;
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountshippingCustomBatchResponseEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accountShippingType = 'Google_Service_ShoppingContent_AccountShipping';
+  protected $accountShippingDataType = '';
+  public $batchId;
+  protected $errorsType = 'Google_Service_ShoppingContent_Errors';
+  protected $errorsDataType = '';
+  public $kind;
+
+
+  public function setAccountShipping(Google_Service_ShoppingContent_AccountShipping $accountShipping)
+  {
+    $this->accountShipping = $accountShipping;
+  }
+  public function getAccountShipping()
+  {
+    return $this->accountShipping;
+  }
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setErrors(Google_Service_ShoppingContent_Errors $errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountshippingListResponse extends Google_Collection
+{
+  protected $collection_key = 'resources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $resourcesType = 'Google_Service_ShoppingContent_AccountShipping';
+  protected $resourcesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setResources($resources)
+  {
+    $this->resources = $resources;
+  }
+  public function getResources()
+  {
+    return $this->resources;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountstatusesCustomBatchRequest extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_AccountstatusesCustomBatchRequestEntry';
+  protected $entriesDataType = 'array';
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountstatusesCustomBatchRequestEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $batchId;
+  public $merchantId;
+  public $method;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setMerchantId($merchantId)
+  {
+    $this->merchantId = $merchantId;
+  }
+  public function getMerchantId()
+  {
+    return $this->merchantId;
+  }
+  public function setMethod($method)
+  {
+    $this->method = $method;
+  }
+  public function getMethod()
+  {
+    return $this->method;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountstatusesCustomBatchResponse extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_AccountstatusesCustomBatchResponseEntry';
+  protected $entriesDataType = 'array';
+  public $kind;
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountstatusesCustomBatchResponseEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accountStatusType = 'Google_Service_ShoppingContent_AccountStatus';
+  protected $accountStatusDataType = '';
+  public $batchId;
+  protected $errorsType = 'Google_Service_ShoppingContent_Errors';
+  protected $errorsDataType = '';
+
+
+  public function setAccountStatus(Google_Service_ShoppingContent_AccountStatus $accountStatus)
+  {
+    $this->accountStatus = $accountStatus;
+  }
+  public function getAccountStatus()
+  {
+    return $this->accountStatus;
+  }
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setErrors(Google_Service_ShoppingContent_Errors $errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+}
+
+class Google_Service_ShoppingContent_AccountstatusesListResponse extends Google_Collection
+{
+  protected $collection_key = 'resources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $resourcesType = 'Google_Service_ShoppingContent_AccountStatus';
+  protected $resourcesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setResources($resources)
+  {
+    $this->resources = $resources;
+  }
+  public function getResources()
+  {
+    return $this->resources;
+  }
+}
+
+class Google_Service_ShoppingContent_AccounttaxCustomBatchRequest extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_AccounttaxCustomBatchRequestEntry';
+  protected $entriesDataType = 'array';
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+}
+
+class Google_Service_ShoppingContent_AccounttaxCustomBatchRequestEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  protected $accountTaxType = 'Google_Service_ShoppingContent_AccountTax';
+  protected $accountTaxDataType = '';
+  public $batchId;
+  public $merchantId;
+  public $method;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAccountTax(Google_Service_ShoppingContent_AccountTax $accountTax)
+  {
+    $this->accountTax = $accountTax;
+  }
+  public function getAccountTax()
+  {
+    return $this->accountTax;
+  }
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setMerchantId($merchantId)
+  {
+    $this->merchantId = $merchantId;
+  }
+  public function getMerchantId()
+  {
+    return $this->merchantId;
+  }
+  public function setMethod($method)
+  {
+    $this->method = $method;
+  }
+  public function getMethod()
+  {
+    return $this->method;
+  }
+}
+
+class Google_Service_ShoppingContent_AccounttaxCustomBatchResponse extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_AccounttaxCustomBatchResponseEntry';
+  protected $entriesDataType = 'array';
+  public $kind;
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_AccounttaxCustomBatchResponseEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accountTaxType = 'Google_Service_ShoppingContent_AccountTax';
+  protected $accountTaxDataType = '';
+  public $batchId;
+  protected $errorsType = 'Google_Service_ShoppingContent_Errors';
+  protected $errorsDataType = '';
+  public $kind;
+
+
+  public function setAccountTax(Google_Service_ShoppingContent_AccountTax $accountTax)
+  {
+    $this->accountTax = $accountTax;
+  }
+  public function getAccountTax()
+  {
+    return $this->accountTax;
+  }
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setErrors(Google_Service_ShoppingContent_Errors $errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_AccounttaxListResponse extends Google_Collection
+{
+  protected $collection_key = 'resources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $resourcesType = 'Google_Service_ShoppingContent_AccountTax';
+  protected $resourcesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setResources($resources)
+  {
+    $this->resources = $resources;
+  }
+  public function getResources()
+  {
+    return $this->resources;
+  }
+}
+
+class Google_Service_ShoppingContent_Datafeed extends Google_Collection
+{
+  protected $collection_key = 'intendedDestinations';
+  protected $internal_gapi_mappings = array(
+  );
+  public $attributeLanguage;
+  public $contentLanguage;
+  public $contentType;
+  protected $fetchScheduleType = 'Google_Service_ShoppingContent_DatafeedFetchSchedule';
+  protected $fetchScheduleDataType = '';
+  public $fileName;
+  protected $formatType = 'Google_Service_ShoppingContent_DatafeedFormat';
+  protected $formatDataType = '';
+  public $id;
+  public $intendedDestinations;
+  public $kind;
+  public $name;
+  public $targetCountry;
+
+
+  public function setAttributeLanguage($attributeLanguage)
+  {
+    $this->attributeLanguage = $attributeLanguage;
+  }
+  public function getAttributeLanguage()
+  {
+    return $this->attributeLanguage;
+  }
+  public function setContentLanguage($contentLanguage)
+  {
+    $this->contentLanguage = $contentLanguage;
+  }
+  public function getContentLanguage()
+  {
+    return $this->contentLanguage;
+  }
+  public function setContentType($contentType)
+  {
+    $this->contentType = $contentType;
+  }
+  public function getContentType()
+  {
+    return $this->contentType;
+  }
+  public function setFetchSchedule(Google_Service_ShoppingContent_DatafeedFetchSchedule $fetchSchedule)
+  {
+    $this->fetchSchedule = $fetchSchedule;
+  }
+  public function getFetchSchedule()
+  {
+    return $this->fetchSchedule;
+  }
+  public function setFileName($fileName)
+  {
+    $this->fileName = $fileName;
+  }
+  public function getFileName()
+  {
+    return $this->fileName;
+  }
+  public function setFormat(Google_Service_ShoppingContent_DatafeedFormat $format)
+  {
+    $this->format = $format;
+  }
+  public function getFormat()
+  {
+    return $this->format;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIntendedDestinations($intendedDestinations)
+  {
+    $this->intendedDestinations = $intendedDestinations;
+  }
+  public function getIntendedDestinations()
+  {
+    return $this->intendedDestinations;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setTargetCountry($targetCountry)
+  {
+    $this->targetCountry = $targetCountry;
+  }
+  public function getTargetCountry()
+  {
+    return $this->targetCountry;
+  }
+}
+
+class Google_Service_ShoppingContent_DatafeedFetchSchedule extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $dayOfMonth;
+  public $fetchUrl;
+  public $hour;
+  public $password;
+  public $timeZone;
+  public $username;
+  public $weekday;
+
+
+  public function setDayOfMonth($dayOfMonth)
+  {
+    $this->dayOfMonth = $dayOfMonth;
+  }
+  public function getDayOfMonth()
+  {
+    return $this->dayOfMonth;
+  }
+  public function setFetchUrl($fetchUrl)
+  {
+    $this->fetchUrl = $fetchUrl;
+  }
+  public function getFetchUrl()
+  {
+    return $this->fetchUrl;
+  }
+  public function setHour($hour)
+  {
+    $this->hour = $hour;
+  }
+  public function getHour()
+  {
+    return $this->hour;
+  }
+  public function setPassword($password)
+  {
+    $this->password = $password;
+  }
+  public function getPassword()
+  {
+    return $this->password;
+  }
+  public function setTimeZone($timeZone)
+  {
+    $this->timeZone = $timeZone;
+  }
+  public function getTimeZone()
+  {
+    return $this->timeZone;
+  }
+  public function setUsername($username)
+  {
+    $this->username = $username;
+  }
+  public function getUsername()
+  {
+    return $this->username;
+  }
+  public function setWeekday($weekday)
+  {
+    $this->weekday = $weekday;
+  }
+  public function getWeekday()
+  {
+    return $this->weekday;
+  }
+}
+
+class Google_Service_ShoppingContent_DatafeedFormat extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $columnDelimiter;
+  public $fileEncoding;
+  public $quotingMode;
+
+
+  public function setColumnDelimiter($columnDelimiter)
+  {
+    $this->columnDelimiter = $columnDelimiter;
+  }
+  public function getColumnDelimiter()
+  {
+    return $this->columnDelimiter;
+  }
+  public function setFileEncoding($fileEncoding)
+  {
+    $this->fileEncoding = $fileEncoding;
+  }
+  public function getFileEncoding()
+  {
+    return $this->fileEncoding;
+  }
+  public function setQuotingMode($quotingMode)
+  {
+    $this->quotingMode = $quotingMode;
+  }
+  public function getQuotingMode()
+  {
+    return $this->quotingMode;
+  }
+}
+
+class Google_Service_ShoppingContent_DatafeedStatus extends Google_Collection
+{
+  protected $collection_key = 'warnings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $datafeedId;
+  protected $errorsType = 'Google_Service_ShoppingContent_DatafeedStatusError';
+  protected $errorsDataType = 'array';
+  public $itemsTotal;
+  public $itemsValid;
+  public $kind;
+  public $lastUploadDate;
+  public $processingStatus;
+  protected $warningsType = 'Google_Service_ShoppingContent_DatafeedStatusError';
+  protected $warningsDataType = 'array';
+
+
+  public function setDatafeedId($datafeedId)
+  {
+    $this->datafeedId = $datafeedId;
+  }
+  public function getDatafeedId()
+  {
+    return $this->datafeedId;
+  }
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setItemsTotal($itemsTotal)
+  {
+    $this->itemsTotal = $itemsTotal;
+  }
+  public function getItemsTotal()
+  {
+    return $this->itemsTotal;
+  }
+  public function setItemsValid($itemsValid)
+  {
+    $this->itemsValid = $itemsValid;
+  }
+  public function getItemsValid()
+  {
+    return $this->itemsValid;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastUploadDate($lastUploadDate)
+  {
+    $this->lastUploadDate = $lastUploadDate;
+  }
+  public function getLastUploadDate()
+  {
+    return $this->lastUploadDate;
+  }
+  public function setProcessingStatus($processingStatus)
+  {
+    $this->processingStatus = $processingStatus;
+  }
+  public function getProcessingStatus()
+  {
+    return $this->processingStatus;
+  }
+  public function setWarnings($warnings)
+  {
+    $this->warnings = $warnings;
+  }
+  public function getWarnings()
+  {
+    return $this->warnings;
+  }
+}
+
+class Google_Service_ShoppingContent_DatafeedStatusError extends Google_Collection
+{
+  protected $collection_key = 'examples';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $count;
+  protected $examplesType = 'Google_Service_ShoppingContent_DatafeedStatusExample';
+  protected $examplesDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setCount($count)
+  {
+    $this->count = $count;
+  }
+  public function getCount()
+  {
+    return $this->count;
+  }
+  public function setExamples($examples)
+  {
+    $this->examples = $examples;
+  }
+  public function getExamples()
+  {
+    return $this->examples;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_ShoppingContent_DatafeedStatusExample extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $itemId;
+  public $lineNumber;
+  public $value;
+
+
+  public function setItemId($itemId)
+  {
+    $this->itemId = $itemId;
+  }
+  public function getItemId()
+  {
+    return $this->itemId;
+  }
+  public function setLineNumber($lineNumber)
+  {
+    $this->lineNumber = $lineNumber;
+  }
+  public function getLineNumber()
+  {
+    return $this->lineNumber;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_ShoppingContent_DatafeedsCustomBatchRequest extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_DatafeedsCustomBatchRequestEntry';
+  protected $entriesDataType = 'array';
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+}
+
+class Google_Service_ShoppingContent_DatafeedsCustomBatchRequestEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $batchId;
+  protected $datafeedType = 'Google_Service_ShoppingContent_Datafeed';
+  protected $datafeedDataType = '';
+  public $datafeedId;
+  public $merchantId;
+  public $method;
+
+
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setDatafeed(Google_Service_ShoppingContent_Datafeed $datafeed)
+  {
+    $this->datafeed = $datafeed;
+  }
+  public function getDatafeed()
+  {
+    return $this->datafeed;
+  }
+  public function setDatafeedId($datafeedId)
+  {
+    $this->datafeedId = $datafeedId;
+  }
+  public function getDatafeedId()
+  {
+    return $this->datafeedId;
+  }
+  public function setMerchantId($merchantId)
+  {
+    $this->merchantId = $merchantId;
+  }
+  public function getMerchantId()
+  {
+    return $this->merchantId;
+  }
+  public function setMethod($method)
+  {
+    $this->method = $method;
+  }
+  public function getMethod()
+  {
+    return $this->method;
+  }
+}
+
+class Google_Service_ShoppingContent_DatafeedsCustomBatchResponse extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_DatafeedsCustomBatchResponseEntry';
+  protected $entriesDataType = 'array';
+  public $kind;
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_DatafeedsCustomBatchResponseEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $batchId;
+  protected $datafeedType = 'Google_Service_ShoppingContent_Datafeed';
+  protected $datafeedDataType = '';
+  protected $errorsType = 'Google_Service_ShoppingContent_Errors';
+  protected $errorsDataType = '';
+
+
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setDatafeed(Google_Service_ShoppingContent_Datafeed $datafeed)
+  {
+    $this->datafeed = $datafeed;
+  }
+  public function getDatafeed()
+  {
+    return $this->datafeed;
+  }
+  public function setErrors(Google_Service_ShoppingContent_Errors $errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+}
+
+class Google_Service_ShoppingContent_DatafeedsListResponse extends Google_Collection
+{
+  protected $collection_key = 'resources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $resourcesType = 'Google_Service_ShoppingContent_Datafeed';
+  protected $resourcesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setResources($resources)
+  {
+    $this->resources = $resources;
+  }
+  public function getResources()
+  {
+    return $this->resources;
+  }
+}
+
+class Google_Service_ShoppingContent_DatafeedstatusesCustomBatchRequest extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_DatafeedstatusesCustomBatchRequestEntry';
+  protected $entriesDataType = 'array';
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+}
+
+class Google_Service_ShoppingContent_DatafeedstatusesCustomBatchRequestEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $batchId;
+  public $datafeedId;
+  public $merchantId;
+  public $method;
+
+
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setDatafeedId($datafeedId)
+  {
+    $this->datafeedId = $datafeedId;
+  }
+  public function getDatafeedId()
+  {
+    return $this->datafeedId;
+  }
+  public function setMerchantId($merchantId)
+  {
+    $this->merchantId = $merchantId;
+  }
+  public function getMerchantId()
+  {
+    return $this->merchantId;
+  }
+  public function setMethod($method)
+  {
+    $this->method = $method;
+  }
+  public function getMethod()
+  {
+    return $this->method;
+  }
+}
+
+class Google_Service_ShoppingContent_DatafeedstatusesCustomBatchResponse extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_DatafeedstatusesCustomBatchResponseEntry';
+  protected $entriesDataType = 'array';
+  public $kind;
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_DatafeedstatusesCustomBatchResponseEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $batchId;
+  protected $datafeedStatusType = 'Google_Service_ShoppingContent_DatafeedStatus';
+  protected $datafeedStatusDataType = '';
+  protected $errorsType = 'Google_Service_ShoppingContent_Errors';
+  protected $errorsDataType = '';
+
+
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setDatafeedStatus(Google_Service_ShoppingContent_DatafeedStatus $datafeedStatus)
+  {
+    $this->datafeedStatus = $datafeedStatus;
+  }
+  public function getDatafeedStatus()
+  {
+    return $this->datafeedStatus;
+  }
+  public function setErrors(Google_Service_ShoppingContent_Errors $errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+}
+
+class Google_Service_ShoppingContent_DatafeedstatusesListResponse extends Google_Collection
+{
+  protected $collection_key = 'resources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $resourcesType = 'Google_Service_ShoppingContent_DatafeedStatus';
+  protected $resourcesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setResources($resources)
+  {
+    $this->resources = $resources;
+  }
+  public function getResources()
+  {
+    return $this->resources;
+  }
+}
+
+class Google_Service_ShoppingContent_Error extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $domain;
+  public $message;
+  public $reason;
+
+
+  public function setDomain($domain)
+  {
+    $this->domain = $domain;
+  }
+  public function getDomain()
+  {
+    return $this->domain;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+}
+
+class Google_Service_ShoppingContent_Errors extends Google_Collection
+{
+  protected $collection_key = 'errors';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  protected $errorsType = 'Google_Service_ShoppingContent_Error';
+  protected $errorsDataType = 'array';
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_ShoppingContent_Inventory extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $availability;
+  public $kind;
+  protected $priceType = 'Google_Service_ShoppingContent_Price';
+  protected $priceDataType = '';
+  public $quantity;
+  protected $salePriceType = 'Google_Service_ShoppingContent_Price';
+  protected $salePriceDataType = '';
+  public $salePriceEffectiveDate;
+  public $sellOnGoogleQuantity;
+
+
+  public function setAvailability($availability)
+  {
+    $this->availability = $availability;
+  }
+  public function getAvailability()
+  {
+    return $this->availability;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPrice(Google_Service_ShoppingContent_Price $price)
+  {
+    $this->price = $price;
+  }
+  public function getPrice()
+  {
+    return $this->price;
+  }
+  public function setQuantity($quantity)
+  {
+    $this->quantity = $quantity;
+  }
+  public function getQuantity()
+  {
+    return $this->quantity;
+  }
+  public function setSalePrice(Google_Service_ShoppingContent_Price $salePrice)
+  {
+    $this->salePrice = $salePrice;
+  }
+  public function getSalePrice()
+  {
+    return $this->salePrice;
+  }
+  public function setSalePriceEffectiveDate($salePriceEffectiveDate)
+  {
+    $this->salePriceEffectiveDate = $salePriceEffectiveDate;
+  }
+  public function getSalePriceEffectiveDate()
+  {
+    return $this->salePriceEffectiveDate;
+  }
+  public function setSellOnGoogleQuantity($sellOnGoogleQuantity)
+  {
+    $this->sellOnGoogleQuantity = $sellOnGoogleQuantity;
+  }
+  public function getSellOnGoogleQuantity()
+  {
+    return $this->sellOnGoogleQuantity;
+  }
+}
+
+class Google_Service_ShoppingContent_InventoryCustomBatchRequest extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_InventoryCustomBatchRequestEntry';
+  protected $entriesDataType = 'array';
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+}
+
+class Google_Service_ShoppingContent_InventoryCustomBatchRequestEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $batchId;
+  protected $inventoryType = 'Google_Service_ShoppingContent_Inventory';
+  protected $inventoryDataType = '';
+  public $merchantId;
+  public $productId;
+  public $storeCode;
+
+
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setInventory(Google_Service_ShoppingContent_Inventory $inventory)
+  {
+    $this->inventory = $inventory;
+  }
+  public function getInventory()
+  {
+    return $this->inventory;
+  }
+  public function setMerchantId($merchantId)
+  {
+    $this->merchantId = $merchantId;
+  }
+  public function getMerchantId()
+  {
+    return $this->merchantId;
+  }
+  public function setProductId($productId)
+  {
+    $this->productId = $productId;
+  }
+  public function getProductId()
+  {
+    return $this->productId;
+  }
+  public function setStoreCode($storeCode)
+  {
+    $this->storeCode = $storeCode;
+  }
+  public function getStoreCode()
+  {
+    return $this->storeCode;
+  }
+}
+
+class Google_Service_ShoppingContent_InventoryCustomBatchResponse extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_InventoryCustomBatchResponseEntry';
+  protected $entriesDataType = 'array';
+  public $kind;
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_InventoryCustomBatchResponseEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $batchId;
+  protected $errorsType = 'Google_Service_ShoppingContent_Errors';
+  protected $errorsDataType = '';
+  public $kind;
+
+
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setErrors(Google_Service_ShoppingContent_Errors $errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_InventorySetRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $availability;
+  protected $priceType = 'Google_Service_ShoppingContent_Price';
+  protected $priceDataType = '';
+  public $quantity;
+  protected $salePriceType = 'Google_Service_ShoppingContent_Price';
+  protected $salePriceDataType = '';
+  public $salePriceEffectiveDate;
+  public $sellOnGoogleQuantity;
+
+
+  public function setAvailability($availability)
+  {
+    $this->availability = $availability;
+  }
+  public function getAvailability()
+  {
+    return $this->availability;
+  }
+  public function setPrice(Google_Service_ShoppingContent_Price $price)
+  {
+    $this->price = $price;
+  }
+  public function getPrice()
+  {
+    return $this->price;
+  }
+  public function setQuantity($quantity)
+  {
+    $this->quantity = $quantity;
+  }
+  public function getQuantity()
+  {
+    return $this->quantity;
+  }
+  public function setSalePrice(Google_Service_ShoppingContent_Price $salePrice)
+  {
+    $this->salePrice = $salePrice;
+  }
+  public function getSalePrice()
+  {
+    return $this->salePrice;
+  }
+  public function setSalePriceEffectiveDate($salePriceEffectiveDate)
+  {
+    $this->salePriceEffectiveDate = $salePriceEffectiveDate;
+  }
+  public function getSalePriceEffectiveDate()
+  {
+    return $this->salePriceEffectiveDate;
+  }
+  public function setSellOnGoogleQuantity($sellOnGoogleQuantity)
+  {
+    $this->sellOnGoogleQuantity = $sellOnGoogleQuantity;
+  }
+  public function getSellOnGoogleQuantity()
+  {
+    return $this->sellOnGoogleQuantity;
+  }
+}
+
+class Google_Service_ShoppingContent_InventorySetResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_LoyaltyPoints extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $pointsValue;
+  public $ratio;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setPointsValue($pointsValue)
+  {
+    $this->pointsValue = $pointsValue;
+  }
+  public function getPointsValue()
+  {
+    return $this->pointsValue;
+  }
+  public function setRatio($ratio)
+  {
+    $this->ratio = $ratio;
+  }
+  public function getRatio()
+  {
+    return $this->ratio;
+  }
+}
+
+class Google_Service_ShoppingContent_Order extends Google_Collection
+{
+  protected $collection_key = 'shipments';
+  protected $internal_gapi_mappings = array(
+  );
+  public $acknowledged;
+  protected $customerType = 'Google_Service_ShoppingContent_OrderCustomer';
+  protected $customerDataType = '';
+  protected $deliveryDetailsType = 'Google_Service_ShoppingContent_OrderDeliveryDetails';
+  protected $deliveryDetailsDataType = '';
+  public $id;
+  public $kind;
+  protected $lineItemsType = 'Google_Service_ShoppingContent_OrderLineItem';
+  protected $lineItemsDataType = 'array';
+  public $merchantId;
+  public $merchantOrderId;
+  protected $netAmountType = 'Google_Service_ShoppingContent_Price';
+  protected $netAmountDataType = '';
+  protected $paymentMethodType = 'Google_Service_ShoppingContent_OrderPaymentMethod';
+  protected $paymentMethodDataType = '';
+  public $paymentStatus;
+  public $placedDate;
+  protected $refundsType = 'Google_Service_ShoppingContent_OrderRefund';
+  protected $refundsDataType = 'array';
+  protected $shipmentsType = 'Google_Service_ShoppingContent_OrderShipment';
+  protected $shipmentsDataType = 'array';
+  protected $shippingCostType = 'Google_Service_ShoppingContent_Price';
+  protected $shippingCostDataType = '';
+  protected $shippingCostTaxType = 'Google_Service_ShoppingContent_Price';
+  protected $shippingCostTaxDataType = '';
+  public $shippingOption;
+  public $status;
+
+
+  public function setAcknowledged($acknowledged)
+  {
+    $this->acknowledged = $acknowledged;
+  }
+  public function getAcknowledged()
+  {
+    return $this->acknowledged;
+  }
+  public function setCustomer(Google_Service_ShoppingContent_OrderCustomer $customer)
+  {
+    $this->customer = $customer;
+  }
+  public function getCustomer()
+  {
+    return $this->customer;
+  }
+  public function setDeliveryDetails(Google_Service_ShoppingContent_OrderDeliveryDetails $deliveryDetails)
+  {
+    $this->deliveryDetails = $deliveryDetails;
+  }
+  public function getDeliveryDetails()
+  {
+    return $this->deliveryDetails;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLineItems($lineItems)
+  {
+    $this->lineItems = $lineItems;
+  }
+  public function getLineItems()
+  {
+    return $this->lineItems;
+  }
+  public function setMerchantId($merchantId)
+  {
+    $this->merchantId = $merchantId;
+  }
+  public function getMerchantId()
+  {
+    return $this->merchantId;
+  }
+  public function setMerchantOrderId($merchantOrderId)
+  {
+    $this->merchantOrderId = $merchantOrderId;
+  }
+  public function getMerchantOrderId()
+  {
+    return $this->merchantOrderId;
+  }
+  public function setNetAmount(Google_Service_ShoppingContent_Price $netAmount)
+  {
+    $this->netAmount = $netAmount;
+  }
+  public function getNetAmount()
+  {
+    return $this->netAmount;
+  }
+  public function setPaymentMethod(Google_Service_ShoppingContent_OrderPaymentMethod $paymentMethod)
+  {
+    $this->paymentMethod = $paymentMethod;
+  }
+  public function getPaymentMethod()
+  {
+    return $this->paymentMethod;
+  }
+  public function setPaymentStatus($paymentStatus)
+  {
+    $this->paymentStatus = $paymentStatus;
+  }
+  public function getPaymentStatus()
+  {
+    return $this->paymentStatus;
+  }
+  public function setPlacedDate($placedDate)
+  {
+    $this->placedDate = $placedDate;
+  }
+  public function getPlacedDate()
+  {
+    return $this->placedDate;
+  }
+  public function setRefunds($refunds)
+  {
+    $this->refunds = $refunds;
+  }
+  public function getRefunds()
+  {
+    return $this->refunds;
+  }
+  public function setShipments($shipments)
+  {
+    $this->shipments = $shipments;
+  }
+  public function getShipments()
+  {
+    return $this->shipments;
+  }
+  public function setShippingCost(Google_Service_ShoppingContent_Price $shippingCost)
+  {
+    $this->shippingCost = $shippingCost;
+  }
+  public function getShippingCost()
+  {
+    return $this->shippingCost;
+  }
+  public function setShippingCostTax(Google_Service_ShoppingContent_Price $shippingCostTax)
+  {
+    $this->shippingCostTax = $shippingCostTax;
+  }
+  public function getShippingCostTax()
+  {
+    return $this->shippingCostTax;
+  }
+  public function setShippingOption($shippingOption)
+  {
+    $this->shippingOption = $shippingOption;
+  }
+  public function getShippingOption()
+  {
+    return $this->shippingOption;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_ShoppingContent_OrderAddress extends Google_Collection
+{
+  protected $collection_key = 'streetAddress';
+  protected $internal_gapi_mappings = array(
+  );
+  public $country;
+  public $fullAddress;
+  public $isPostOfficeBox;
+  public $locality;
+  public $postalCode;
+  public $recipientName;
+  public $region;
+  public $streetAddress;
+
+
+  public function setCountry($country)
+  {
+    $this->country = $country;
+  }
+  public function getCountry()
+  {
+    return $this->country;
+  }
+  public function setFullAddress($fullAddress)
+  {
+    $this->fullAddress = $fullAddress;
+  }
+  public function getFullAddress()
+  {
+    return $this->fullAddress;
+  }
+  public function setIsPostOfficeBox($isPostOfficeBox)
+  {
+    $this->isPostOfficeBox = $isPostOfficeBox;
+  }
+  public function getIsPostOfficeBox()
+  {
+    return $this->isPostOfficeBox;
+  }
+  public function setLocality($locality)
+  {
+    $this->locality = $locality;
+  }
+  public function getLocality()
+  {
+    return $this->locality;
+  }
+  public function setPostalCode($postalCode)
+  {
+    $this->postalCode = $postalCode;
+  }
+  public function getPostalCode()
+  {
+    return $this->postalCode;
+  }
+  public function setRecipientName($recipientName)
+  {
+    $this->recipientName = $recipientName;
+  }
+  public function getRecipientName()
+  {
+    return $this->recipientName;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setStreetAddress($streetAddress)
+  {
+    $this->streetAddress = $streetAddress;
+  }
+  public function getStreetAddress()
+  {
+    return $this->streetAddress;
+  }
+}
+
+class Google_Service_ShoppingContent_OrderCancellation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $actor;
+  public $creationDate;
+  public $quantity;
+  public $reason;
+  public $reasonText;
+
+
+  public function setActor($actor)
+  {
+    $this->actor = $actor;
+  }
+  public function getActor()
+  {
+    return $this->actor;
+  }
+  public function setCreationDate($creationDate)
+  {
+    $this->creationDate = $creationDate;
+  }
+  public function getCreationDate()
+  {
+    return $this->creationDate;
+  }
+  public function setQuantity($quantity)
+  {
+    $this->quantity = $quantity;
+  }
+  public function getQuantity()
+  {
+    return $this->quantity;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+  public function setReasonText($reasonText)
+  {
+    $this->reasonText = $reasonText;
+  }
+  public function getReasonText()
+  {
+    return $this->reasonText;
+  }
+}
+
+class Google_Service_ShoppingContent_OrderCustomer extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $email;
+  public $explicitMarketingPreference;
+  public $fullName;
+
+
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setExplicitMarketingPreference($explicitMarketingPreference)
+  {
+    $this->explicitMarketingPreference = $explicitMarketingPreference;
+  }
+  public function getExplicitMarketingPreference()
+  {
+    return $this->explicitMarketingPreference;
+  }
+  public function setFullName($fullName)
+  {
+    $this->fullName = $fullName;
+  }
+  public function getFullName()
+  {
+    return $this->fullName;
+  }
+}
+
+class Google_Service_ShoppingContent_OrderDeliveryDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $addressType = 'Google_Service_ShoppingContent_OrderAddress';
+  protected $addressDataType = '';
+  public $phoneNumber;
+
+
+  public function setAddress(Google_Service_ShoppingContent_OrderAddress $address)
+  {
+    $this->address = $address;
+  }
+  public function getAddress()
+  {
+    return $this->address;
+  }
+  public function setPhoneNumber($phoneNumber)
+  {
+    $this->phoneNumber = $phoneNumber;
+  }
+  public function getPhoneNumber()
+  {
+    return $this->phoneNumber;
+  }
+}
+
+class Google_Service_ShoppingContent_OrderLineItem extends Google_Collection
+{
+  protected $collection_key = 'returns';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $cancellationsType = 'Google_Service_ShoppingContent_OrderCancellation';
+  protected $cancellationsDataType = 'array';
+  public $id;
+  protected $priceType = 'Google_Service_ShoppingContent_Price';
+  protected $priceDataType = '';
+  protected $productType = 'Google_Service_ShoppingContent_OrderLineItemProduct';
+  protected $productDataType = '';
+  public $quantityCanceled;
+  public $quantityDelivered;
+  public $quantityOrdered;
+  public $quantityPending;
+  public $quantityReturned;
+  public $quantityShipped;
+  protected $returnInfoType = 'Google_Service_ShoppingContent_OrderLineItemReturnInfo';
+  protected $returnInfoDataType = '';
+  protected $returnsType = 'Google_Service_ShoppingContent_OrderReturn';
+  protected $returnsDataType = 'array';
+  protected $shippingDetailsType = 'Google_Service_ShoppingContent_OrderLineItemShippingDetails';
+  protected $shippingDetailsDataType = '';
+  protected $taxType = 'Google_Service_ShoppingContent_Price';
+  protected $taxDataType = '';
+
+
+  public function setCancellations($cancellations)
+  {
+    $this->cancellations = $cancellations;
+  }
+  public function getCancellations()
+  {
+    return $this->cancellations;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setPrice(Google_Service_ShoppingContent_Price $price)
+  {
+    $this->price = $price;
+  }
+  public function getPrice()
+  {
+    return $this->price;
+  }
+  public function setProduct(Google_Service_ShoppingContent_OrderLineItemProduct $product)
+  {
+    $this->product = $product;
+  }
+  public function getProduct()
+  {
+    return $this->product;
+  }
+  public function setQuantityCanceled($quantityCanceled)
+  {
+    $this->quantityCanceled = $quantityCanceled;
+  }
+  public function getQuantityCanceled()
+  {
+    return $this->quantityCanceled;
+  }
+  public function setQuantityDelivered($quantityDelivered)
+  {
+    $this->quantityDelivered = $quantityDelivered;
+  }
+  public function getQuantityDelivered()
+  {
+    return $this->quantityDelivered;
+  }
+  public function setQuantityOrdered($quantityOrdered)
+  {
+    $this->quantityOrdered = $quantityOrdered;
+  }
+  public function getQuantityOrdered()
+  {
+    return $this->quantityOrdered;
+  }
+  public function setQuantityPending($quantityPending)
+  {
+    $this->quantityPending = $quantityPending;
+  }
+  public function getQuantityPending()
+  {
+    return $this->quantityPending;
+  }
+  public function setQuantityReturned($quantityReturned)
+  {
+    $this->quantityReturned = $quantityReturned;
+  }
+  public function getQuantityReturned()
+  {
+    return $this->quantityReturned;
+  }
+  public function setQuantityShipped($quantityShipped)
+  {
+    $this->quantityShipped = $quantityShipped;
+  }
+  public function getQuantityShipped()
+  {
+    return $this->quantityShipped;
+  }
+  public function setReturnInfo(Google_Service_ShoppingContent_OrderLineItemReturnInfo $returnInfo)
+  {
+    $this->returnInfo = $returnInfo;
+  }
+  public function getReturnInfo()
+  {
+    return $this->returnInfo;
+  }
+  public function setReturns($returns)
+  {
+    $this->returns = $returns;
+  }
+  public function getReturns()
+  {
+    return $this->returns;
+  }
+  public function setShippingDetails(Google_Service_ShoppingContent_OrderLineItemShippingDetails $shippingDetails)
+  {
+    $this->shippingDetails = $shippingDetails;
+  }
+  public function getShippingDetails()
+  {
+    return $this->shippingDetails;
+  }
+  public function setTax(Google_Service_ShoppingContent_Price $tax)
+  {
+    $this->tax = $tax;
+  }
+  public function getTax()
+  {
+    return $this->tax;
+  }
+}
+
+class Google_Service_ShoppingContent_OrderLineItemProduct extends Google_Collection
+{
+  protected $collection_key = 'variantAttributes';
+  protected $internal_gapi_mappings = array(
+  );
+  public $brand;
+  public $channel;
+  public $condition;
+  public $contentLanguage;
+  public $gtin;
+  public $id;
+  public $imageLink;
+  public $itemGroupId;
+  public $mpn;
+  public $offerId;
+  protected $priceType = 'Google_Service_ShoppingContent_Price';
+  protected $priceDataType = '';
+  public $shownImage;
+  public $targetCountry;
+  public $title;
+  protected $variantAttributesType = 'Google_Service_ShoppingContent_OrderLineItemProductVariantAttribute';
+  protected $variantAttributesDataType = 'array';
+
+
+  public function setBrand($brand)
+  {
+    $this->brand = $brand;
+  }
+  public function getBrand()
+  {
+    return $this->brand;
+  }
+  public function setChannel($channel)
+  {
+    $this->channel = $channel;
+  }
+  public function getChannel()
+  {
+    return $this->channel;
+  }
+  public function setCondition($condition)
+  {
+    $this->condition = $condition;
+  }
+  public function getCondition()
+  {
+    return $this->condition;
+  }
+  public function setContentLanguage($contentLanguage)
+  {
+    $this->contentLanguage = $contentLanguage;
+  }
+  public function getContentLanguage()
+  {
+    return $this->contentLanguage;
+  }
+  public function setGtin($gtin)
+  {
+    $this->gtin = $gtin;
+  }
+  public function getGtin()
+  {
+    return $this->gtin;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setImageLink($imageLink)
+  {
+    $this->imageLink = $imageLink;
+  }
+  public function getImageLink()
+  {
+    return $this->imageLink;
+  }
+  public function setItemGroupId($itemGroupId)
+  {
+    $this->itemGroupId = $itemGroupId;
+  }
+  public function getItemGroupId()
+  {
+    return $this->itemGroupId;
+  }
+  public function setMpn($mpn)
+  {
+    $this->mpn = $mpn;
+  }
+  public function getMpn()
+  {
+    return $this->mpn;
+  }
+  public function setOfferId($offerId)
+  {
+    $this->offerId = $offerId;
+  }
+  public function getOfferId()
+  {
+    return $this->offerId;
+  }
+  public function setPrice(Google_Service_ShoppingContent_Price $price)
+  {
+    $this->price = $price;
+  }
+  public function getPrice()
+  {
+    return $this->price;
+  }
+  public function setShownImage($shownImage)
+  {
+    $this->shownImage = $shownImage;
+  }
+  public function getShownImage()
+  {
+    return $this->shownImage;
+  }
+  public function setTargetCountry($targetCountry)
+  {
+    $this->targetCountry = $targetCountry;
+  }
+  public function getTargetCountry()
+  {
+    return $this->targetCountry;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setVariantAttributes($variantAttributes)
+  {
+    $this->variantAttributes = $variantAttributes;
+  }
+  public function getVariantAttributes()
+  {
+    return $this->variantAttributes;
+  }
+}
+
+class Google_Service_ShoppingContent_OrderLineItemProductVariantAttribute extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $dimension;
+  public $value;
+
+
+  public function setDimension($dimension)
+  {
+    $this->dimension = $dimension;
+  }
+  public function getDimension()
+  {
+    return $this->dimension;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_ShoppingContent_OrderLineItemReturnInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $daysToReturn;
+  public $isReturnable;
+  public $policyUrl;
+
+
+  public function setDaysToReturn($daysToReturn)
+  {
+    $this->daysToReturn = $daysToReturn;
+  }
+  public function getDaysToReturn()
+  {
+    return $this->daysToReturn;
+  }
+  public function setIsReturnable($isReturnable)
+  {
+    $this->isReturnable = $isReturnable;
+  }
+  public function getIsReturnable()
+  {
+    return $this->isReturnable;
+  }
+  public function setPolicyUrl($policyUrl)
+  {
+    $this->policyUrl = $policyUrl;
+  }
+  public function getPolicyUrl()
+  {
+    return $this->policyUrl;
+  }
+}
+
+class Google_Service_ShoppingContent_OrderLineItemShippingDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $deliverByDate;
+  protected $methodType = 'Google_Service_ShoppingContent_OrderLineItemShippingDetailsMethod';
+  protected $methodDataType = '';
+  public $shipByDate;
+
+
+  public function setDeliverByDate($deliverByDate)
+  {
+    $this->deliverByDate = $deliverByDate;
+  }
+  public function getDeliverByDate()
+  {
+    return $this->deliverByDate;
+  }
+  public function setMethod(Google_Service_ShoppingContent_OrderLineItemShippingDetailsMethod $method)
+  {
+    $this->method = $method;
+  }
+  public function getMethod()
+  {
+    return $this->method;
+  }
+  public function setShipByDate($shipByDate)
+  {
+    $this->shipByDate = $shipByDate;
+  }
+  public function getShipByDate()
+  {
+    return $this->shipByDate;
+  }
+}
+
+class Google_Service_ShoppingContent_OrderLineItemShippingDetailsMethod extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $carrier;
+  public $maxDaysInTransit;
+  public $methodName;
+  public $minDaysInTransit;
+
+
+  public function setCarrier($carrier)
+  {
+    $this->carrier = $carrier;
+  }
+  public function getCarrier()
+  {
+    return $this->carrier;
+  }
+  public function setMaxDaysInTransit($maxDaysInTransit)
+  {
+    $this->maxDaysInTransit = $maxDaysInTransit;
+  }
+  public function getMaxDaysInTransit()
+  {
+    return $this->maxDaysInTransit;
+  }
+  public function setMethodName($methodName)
+  {
+    $this->methodName = $methodName;
+  }
+  public function getMethodName()
+  {
+    return $this->methodName;
+  }
+  public function setMinDaysInTransit($minDaysInTransit)
+  {
+    $this->minDaysInTransit = $minDaysInTransit;
+  }
+  public function getMinDaysInTransit()
+  {
+    return $this->minDaysInTransit;
+  }
+}
+
+class Google_Service_ShoppingContent_OrderPaymentMethod extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $billingAddressType = 'Google_Service_ShoppingContent_OrderAddress';
+  protected $billingAddressDataType = '';
+  public $expirationMonth;
+  public $expirationYear;
+  public $lastFourDigits;
+  public $phoneNumber;
+  public $type;
+
+
+  public function setBillingAddress(Google_Service_ShoppingContent_OrderAddress $billingAddress)
+  {
+    $this->billingAddress = $billingAddress;
+  }
+  public function getBillingAddress()
+  {
+    return $this->billingAddress;
+  }
+  public function setExpirationMonth($expirationMonth)
+  {
+    $this->expirationMonth = $expirationMonth;
+  }
+  public function getExpirationMonth()
+  {
+    return $this->expirationMonth;
+  }
+  public function setExpirationYear($expirationYear)
+  {
+    $this->expirationYear = $expirationYear;
+  }
+  public function getExpirationYear()
+  {
+    return $this->expirationYear;
+  }
+  public function setLastFourDigits($lastFourDigits)
+  {
+    $this->lastFourDigits = $lastFourDigits;
+  }
+  public function getLastFourDigits()
+  {
+    return $this->lastFourDigits;
+  }
+  public function setPhoneNumber($phoneNumber)
+  {
+    $this->phoneNumber = $phoneNumber;
+  }
+  public function getPhoneNumber()
+  {
+    return $this->phoneNumber;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_ShoppingContent_OrderRefund extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $actor;
+  protected $amountType = 'Google_Service_ShoppingContent_Price';
+  protected $amountDataType = '';
+  public $creationDate;
+  public $reason;
+  public $reasonText;
+
+
+  public function setActor($actor)
+  {
+    $this->actor = $actor;
+  }
+  public function getActor()
+  {
+    return $this->actor;
+  }
+  public function setAmount(Google_Service_ShoppingContent_Price $amount)
+  {
+    $this->amount = $amount;
+  }
+  public function getAmount()
+  {
+    return $this->amount;
+  }
+  public function setCreationDate($creationDate)
+  {
+    $this->creationDate = $creationDate;
+  }
+  public function getCreationDate()
+  {
+    return $this->creationDate;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+  public function setReasonText($reasonText)
+  {
+    $this->reasonText = $reasonText;
+  }
+  public function getReasonText()
+  {
+    return $this->reasonText;
+  }
+}
+
+class Google_Service_ShoppingContent_OrderReturn extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $actor;
+  public $creationDate;
+  public $quantity;
+  public $reason;
+  public $reasonText;
+
+
+  public function setActor($actor)
+  {
+    $this->actor = $actor;
+  }
+  public function getActor()
+  {
+    return $this->actor;
+  }
+  public function setCreationDate($creationDate)
+  {
+    $this->creationDate = $creationDate;
+  }
+  public function getCreationDate()
+  {
+    return $this->creationDate;
+  }
+  public function setQuantity($quantity)
+  {
+    $this->quantity = $quantity;
+  }
+  public function getQuantity()
+  {
+    return $this->quantity;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+  public function setReasonText($reasonText)
+  {
+    $this->reasonText = $reasonText;
+  }
+  public function getReasonText()
+  {
+    return $this->reasonText;
+  }
+}
+
+class Google_Service_ShoppingContent_OrderShipment extends Google_Collection
+{
+  protected $collection_key = 'lineItems';
+  protected $internal_gapi_mappings = array(
+  );
+  public $carrier;
+  public $creationDate;
+  public $deliveryDate;
+  public $id;
+  protected $lineItemsType = 'Google_Service_ShoppingContent_OrderShipmentLineItemShipment';
+  protected $lineItemsDataType = 'array';
+  public $status;
+  public $trackingId;
+
+
+  public function setCarrier($carrier)
+  {
+    $this->carrier = $carrier;
+  }
+  public function getCarrier()
+  {
+    return $this->carrier;
+  }
+  public function setCreationDate($creationDate)
+  {
+    $this->creationDate = $creationDate;
+  }
+  public function getCreationDate()
+  {
+    return $this->creationDate;
+  }
+  public function setDeliveryDate($deliveryDate)
+  {
+    $this->deliveryDate = $deliveryDate;
+  }
+  public function getDeliveryDate()
+  {
+    return $this->deliveryDate;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLineItems($lineItems)
+  {
+    $this->lineItems = $lineItems;
+  }
+  public function getLineItems()
+  {
+    return $this->lineItems;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setTrackingId($trackingId)
+  {
+    $this->trackingId = $trackingId;
+  }
+  public function getTrackingId()
+  {
+    return $this->trackingId;
+  }
+}
+
+class Google_Service_ShoppingContent_OrderShipmentLineItemShipment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $lineItemId;
+  public $quantity;
+
+
+  public function setLineItemId($lineItemId)
+  {
+    $this->lineItemId = $lineItemId;
+  }
+  public function getLineItemId()
+  {
+    return $this->lineItemId;
+  }
+  public function setQuantity($quantity)
+  {
+    $this->quantity = $quantity;
+  }
+  public function getQuantity()
+  {
+    return $this->quantity;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersAcknowledgeRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $operationId;
+
+
+  public function setOperationId($operationId)
+  {
+    $this->operationId = $operationId;
+  }
+  public function getOperationId()
+  {
+    return $this->operationId;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersAcknowledgeResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $executionStatus;
+  public $kind;
+
+
+  public function setExecutionStatus($executionStatus)
+  {
+    $this->executionStatus = $executionStatus;
+  }
+  public function getExecutionStatus()
+  {
+    return $this->executionStatus;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersAdvanceTestOrderResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersCancelLineItemRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $lineItemId;
+  public $operationId;
+  public $quantity;
+  public $reason;
+  public $reasonText;
+
+
+  public function setLineItemId($lineItemId)
+  {
+    $this->lineItemId = $lineItemId;
+  }
+  public function getLineItemId()
+  {
+    return $this->lineItemId;
+  }
+  public function setOperationId($operationId)
+  {
+    $this->operationId = $operationId;
+  }
+  public function getOperationId()
+  {
+    return $this->operationId;
+  }
+  public function setQuantity($quantity)
+  {
+    $this->quantity = $quantity;
+  }
+  public function getQuantity()
+  {
+    return $this->quantity;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+  public function setReasonText($reasonText)
+  {
+    $this->reasonText = $reasonText;
+  }
+  public function getReasonText()
+  {
+    return $this->reasonText;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersCancelLineItemResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $executionStatus;
+  public $kind;
+
+
+  public function setExecutionStatus($executionStatus)
+  {
+    $this->executionStatus = $executionStatus;
+  }
+  public function getExecutionStatus()
+  {
+    return $this->executionStatus;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersCancelRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $operationId;
+  public $reason;
+  public $reasonText;
+
+
+  public function setOperationId($operationId)
+  {
+    $this->operationId = $operationId;
+  }
+  public function getOperationId()
+  {
+    return $this->operationId;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+  public function setReasonText($reasonText)
+  {
+    $this->reasonText = $reasonText;
+  }
+  public function getReasonText()
+  {
+    return $this->reasonText;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersCancelResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $executionStatus;
+  public $kind;
+
+
+  public function setExecutionStatus($executionStatus)
+  {
+    $this->executionStatus = $executionStatus;
+  }
+  public function getExecutionStatus()
+  {
+    return $this->executionStatus;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersCreateTestOrderRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $templateName;
+  protected $testOrderType = 'Google_Service_ShoppingContent_TestOrder';
+  protected $testOrderDataType = '';
+
+
+  public function setTemplateName($templateName)
+  {
+    $this->templateName = $templateName;
+  }
+  public function getTemplateName()
+  {
+    return $this->templateName;
+  }
+  public function setTestOrder(Google_Service_ShoppingContent_TestOrder $testOrder)
+  {
+    $this->testOrder = $testOrder;
+  }
+  public function getTestOrder()
+  {
+    return $this->testOrder;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersCreateTestOrderResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $orderId;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setOrderId($orderId)
+  {
+    $this->orderId = $orderId;
+  }
+  public function getOrderId()
+  {
+    return $this->orderId;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersCustomBatchRequest extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_OrdersCustomBatchRequestEntry';
+  protected $entriesDataType = 'array';
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersCustomBatchRequestEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $batchId;
+  protected $cancelType = 'Google_Service_ShoppingContent_OrdersCustomBatchRequestEntryCancel';
+  protected $cancelDataType = '';
+  protected $cancelLineItemType = 'Google_Service_ShoppingContent_OrdersCustomBatchRequestEntryCancelLineItem';
+  protected $cancelLineItemDataType = '';
+  public $merchantId;
+  public $merchantOrderId;
+  public $method;
+  public $operationId;
+  public $orderId;
+  protected $refundType = 'Google_Service_ShoppingContent_OrdersCustomBatchRequestEntryRefund';
+  protected $refundDataType = '';
+  protected $returnLineItemType = 'Google_Service_ShoppingContent_OrdersCustomBatchRequestEntryReturnLineItem';
+  protected $returnLineItemDataType = '';
+  protected $shipLineItemsType = 'Google_Service_ShoppingContent_OrdersCustomBatchRequestEntryShipLineItems';
+  protected $shipLineItemsDataType = '';
+  protected $updateShipmentType = 'Google_Service_ShoppingContent_OrdersCustomBatchRequestEntryUpdateShipment';
+  protected $updateShipmentDataType = '';
+
+
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setCancel(Google_Service_ShoppingContent_OrdersCustomBatchRequestEntryCancel $cancel)
+  {
+    $this->cancel = $cancel;
+  }
+  public function getCancel()
+  {
+    return $this->cancel;
+  }
+  public function setCancelLineItem(Google_Service_ShoppingContent_OrdersCustomBatchRequestEntryCancelLineItem $cancelLineItem)
+  {
+    $this->cancelLineItem = $cancelLineItem;
+  }
+  public function getCancelLineItem()
+  {
+    return $this->cancelLineItem;
+  }
+  public function setMerchantId($merchantId)
+  {
+    $this->merchantId = $merchantId;
+  }
+  public function getMerchantId()
+  {
+    return $this->merchantId;
+  }
+  public function setMerchantOrderId($merchantOrderId)
+  {
+    $this->merchantOrderId = $merchantOrderId;
+  }
+  public function getMerchantOrderId()
+  {
+    return $this->merchantOrderId;
+  }
+  public function setMethod($method)
+  {
+    $this->method = $method;
+  }
+  public function getMethod()
+  {
+    return $this->method;
+  }
+  public function setOperationId($operationId)
+  {
+    $this->operationId = $operationId;
+  }
+  public function getOperationId()
+  {
+    return $this->operationId;
+  }
+  public function setOrderId($orderId)
+  {
+    $this->orderId = $orderId;
+  }
+  public function getOrderId()
+  {
+    return $this->orderId;
+  }
+  public function setRefund(Google_Service_ShoppingContent_OrdersCustomBatchRequestEntryRefund $refund)
+  {
+    $this->refund = $refund;
+  }
+  public function getRefund()
+  {
+    return $this->refund;
+  }
+  public function setReturnLineItem(Google_Service_ShoppingContent_OrdersCustomBatchRequestEntryReturnLineItem $returnLineItem)
+  {
+    $this->returnLineItem = $returnLineItem;
+  }
+  public function getReturnLineItem()
+  {
+    return $this->returnLineItem;
+  }
+  public function setShipLineItems(Google_Service_ShoppingContent_OrdersCustomBatchRequestEntryShipLineItems $shipLineItems)
+  {
+    $this->shipLineItems = $shipLineItems;
+  }
+  public function getShipLineItems()
+  {
+    return $this->shipLineItems;
+  }
+  public function setUpdateShipment(Google_Service_ShoppingContent_OrdersCustomBatchRequestEntryUpdateShipment $updateShipment)
+  {
+    $this->updateShipment = $updateShipment;
+  }
+  public function getUpdateShipment()
+  {
+    return $this->updateShipment;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersCustomBatchRequestEntryCancel extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $reason;
+  public $reasonText;
+
+
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+  public function setReasonText($reasonText)
+  {
+    $this->reasonText = $reasonText;
+  }
+  public function getReasonText()
+  {
+    return $this->reasonText;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersCustomBatchRequestEntryCancelLineItem extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $lineItemId;
+  public $quantity;
+  public $reason;
+  public $reasonText;
+
+
+  public function setLineItemId($lineItemId)
+  {
+    $this->lineItemId = $lineItemId;
+  }
+  public function getLineItemId()
+  {
+    return $this->lineItemId;
+  }
+  public function setQuantity($quantity)
+  {
+    $this->quantity = $quantity;
+  }
+  public function getQuantity()
+  {
+    return $this->quantity;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+  public function setReasonText($reasonText)
+  {
+    $this->reasonText = $reasonText;
+  }
+  public function getReasonText()
+  {
+    return $this->reasonText;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersCustomBatchRequestEntryRefund extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $amountType = 'Google_Service_ShoppingContent_Price';
+  protected $amountDataType = '';
+  public $reason;
+  public $reasonText;
+
+
+  public function setAmount(Google_Service_ShoppingContent_Price $amount)
+  {
+    $this->amount = $amount;
+  }
+  public function getAmount()
+  {
+    return $this->amount;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+  public function setReasonText($reasonText)
+  {
+    $this->reasonText = $reasonText;
+  }
+  public function getReasonText()
+  {
+    return $this->reasonText;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersCustomBatchRequestEntryReturnLineItem extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $lineItemId;
+  public $quantity;
+  public $reason;
+  public $reasonText;
+
+
+  public function setLineItemId($lineItemId)
+  {
+    $this->lineItemId = $lineItemId;
+  }
+  public function getLineItemId()
+  {
+    return $this->lineItemId;
+  }
+  public function setQuantity($quantity)
+  {
+    $this->quantity = $quantity;
+  }
+  public function getQuantity()
+  {
+    return $this->quantity;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+  public function setReasonText($reasonText)
+  {
+    $this->reasonText = $reasonText;
+  }
+  public function getReasonText()
+  {
+    return $this->reasonText;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersCustomBatchRequestEntryShipLineItems extends Google_Collection
+{
+  protected $collection_key = 'lineItems';
+  protected $internal_gapi_mappings = array(
+  );
+  public $carrier;
+  protected $lineItemsType = 'Google_Service_ShoppingContent_OrderShipmentLineItemShipment';
+  protected $lineItemsDataType = 'array';
+  public $shipmentId;
+  public $trackingId;
+
+
+  public function setCarrier($carrier)
+  {
+    $this->carrier = $carrier;
+  }
+  public function getCarrier()
+  {
+    return $this->carrier;
+  }
+  public function setLineItems($lineItems)
+  {
+    $this->lineItems = $lineItems;
+  }
+  public function getLineItems()
+  {
+    return $this->lineItems;
+  }
+  public function setShipmentId($shipmentId)
+  {
+    $this->shipmentId = $shipmentId;
+  }
+  public function getShipmentId()
+  {
+    return $this->shipmentId;
+  }
+  public function setTrackingId($trackingId)
+  {
+    $this->trackingId = $trackingId;
+  }
+  public function getTrackingId()
+  {
+    return $this->trackingId;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersCustomBatchRequestEntryUpdateShipment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $carrier;
+  public $shipmentId;
+  public $status;
+  public $trackingId;
+
+
+  public function setCarrier($carrier)
+  {
+    $this->carrier = $carrier;
+  }
+  public function getCarrier()
+  {
+    return $this->carrier;
+  }
+  public function setShipmentId($shipmentId)
+  {
+    $this->shipmentId = $shipmentId;
+  }
+  public function getShipmentId()
+  {
+    return $this->shipmentId;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setTrackingId($trackingId)
+  {
+    $this->trackingId = $trackingId;
+  }
+  public function getTrackingId()
+  {
+    return $this->trackingId;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersCustomBatchResponse extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_OrdersCustomBatchResponseEntry';
+  protected $entriesDataType = 'array';
+  public $kind;
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersCustomBatchResponseEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $batchId;
+  protected $errorsType = 'Google_Service_ShoppingContent_Errors';
+  protected $errorsDataType = '';
+  public $executionStatus;
+  public $kind;
+  protected $orderType = 'Google_Service_ShoppingContent_Order';
+  protected $orderDataType = '';
+
+
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setErrors(Google_Service_ShoppingContent_Errors $errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setExecutionStatus($executionStatus)
+  {
+    $this->executionStatus = $executionStatus;
+  }
+  public function getExecutionStatus()
+  {
+    return $this->executionStatus;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setOrder(Google_Service_ShoppingContent_Order $order)
+  {
+    $this->order = $order;
+  }
+  public function getOrder()
+  {
+    return $this->order;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersGetByMerchantOrderIdResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $orderType = 'Google_Service_ShoppingContent_Order';
+  protected $orderDataType = '';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setOrder(Google_Service_ShoppingContent_Order $order)
+  {
+    $this->order = $order;
+  }
+  public function getOrder()
+  {
+    return $this->order;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersGetTestOrderTemplateResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  protected $templateType = 'Google_Service_ShoppingContent_TestOrder';
+  protected $templateDataType = '';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setTemplate(Google_Service_ShoppingContent_TestOrder $template)
+  {
+    $this->template = $template;
+  }
+  public function getTemplate()
+  {
+    return $this->template;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersListResponse extends Google_Collection
+{
+  protected $collection_key = 'resources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $resourcesType = 'Google_Service_ShoppingContent_Order';
+  protected $resourcesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setResources($resources)
+  {
+    $this->resources = $resources;
+  }
+  public function getResources()
+  {
+    return $this->resources;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersRefundRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $amountType = 'Google_Service_ShoppingContent_Price';
+  protected $amountDataType = '';
+  public $operationId;
+  public $reason;
+  public $reasonText;
+
+
+  public function setAmount(Google_Service_ShoppingContent_Price $amount)
+  {
+    $this->amount = $amount;
+  }
+  public function getAmount()
+  {
+    return $this->amount;
+  }
+  public function setOperationId($operationId)
+  {
+    $this->operationId = $operationId;
+  }
+  public function getOperationId()
+  {
+    return $this->operationId;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+  public function setReasonText($reasonText)
+  {
+    $this->reasonText = $reasonText;
+  }
+  public function getReasonText()
+  {
+    return $this->reasonText;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersRefundResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $executionStatus;
+  public $kind;
+
+
+  public function setExecutionStatus($executionStatus)
+  {
+    $this->executionStatus = $executionStatus;
+  }
+  public function getExecutionStatus()
+  {
+    return $this->executionStatus;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersReturnLineItemRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $lineItemId;
+  public $operationId;
+  public $quantity;
+  public $reason;
+  public $reasonText;
+
+
+  public function setLineItemId($lineItemId)
+  {
+    $this->lineItemId = $lineItemId;
+  }
+  public function getLineItemId()
+  {
+    return $this->lineItemId;
+  }
+  public function setOperationId($operationId)
+  {
+    $this->operationId = $operationId;
+  }
+  public function getOperationId()
+  {
+    return $this->operationId;
+  }
+  public function setQuantity($quantity)
+  {
+    $this->quantity = $quantity;
+  }
+  public function getQuantity()
+  {
+    return $this->quantity;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+  public function setReasonText($reasonText)
+  {
+    $this->reasonText = $reasonText;
+  }
+  public function getReasonText()
+  {
+    return $this->reasonText;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersReturnLineItemResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $executionStatus;
+  public $kind;
+
+
+  public function setExecutionStatus($executionStatus)
+  {
+    $this->executionStatus = $executionStatus;
+  }
+  public function getExecutionStatus()
+  {
+    return $this->executionStatus;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersShipLineItemsRequest extends Google_Collection
+{
+  protected $collection_key = 'lineItems';
+  protected $internal_gapi_mappings = array(
+  );
+  public $carrier;
+  protected $lineItemsType = 'Google_Service_ShoppingContent_OrderShipmentLineItemShipment';
+  protected $lineItemsDataType = 'array';
+  public $operationId;
+  public $shipmentId;
+  public $trackingId;
+
+
+  public function setCarrier($carrier)
+  {
+    $this->carrier = $carrier;
+  }
+  public function getCarrier()
+  {
+    return $this->carrier;
+  }
+  public function setLineItems($lineItems)
+  {
+    $this->lineItems = $lineItems;
+  }
+  public function getLineItems()
+  {
+    return $this->lineItems;
+  }
+  public function setOperationId($operationId)
+  {
+    $this->operationId = $operationId;
+  }
+  public function getOperationId()
+  {
+    return $this->operationId;
+  }
+  public function setShipmentId($shipmentId)
+  {
+    $this->shipmentId = $shipmentId;
+  }
+  public function getShipmentId()
+  {
+    return $this->shipmentId;
+  }
+  public function setTrackingId($trackingId)
+  {
+    $this->trackingId = $trackingId;
+  }
+  public function getTrackingId()
+  {
+    return $this->trackingId;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersShipLineItemsResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $executionStatus;
+  public $kind;
+
+
+  public function setExecutionStatus($executionStatus)
+  {
+    $this->executionStatus = $executionStatus;
+  }
+  public function getExecutionStatus()
+  {
+    return $this->executionStatus;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersUpdateMerchantOrderIdRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $merchantOrderId;
+  public $operationId;
+
+
+  public function setMerchantOrderId($merchantOrderId)
+  {
+    $this->merchantOrderId = $merchantOrderId;
+  }
+  public function getMerchantOrderId()
+  {
+    return $this->merchantOrderId;
+  }
+  public function setOperationId($operationId)
+  {
+    $this->operationId = $operationId;
+  }
+  public function getOperationId()
+  {
+    return $this->operationId;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersUpdateMerchantOrderIdResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $executionStatus;
+  public $kind;
+
+
+  public function setExecutionStatus($executionStatus)
+  {
+    $this->executionStatus = $executionStatus;
+  }
+  public function getExecutionStatus()
+  {
+    return $this->executionStatus;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersUpdateShipmentRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $carrier;
+  public $operationId;
+  public $shipmentId;
+  public $status;
+  public $trackingId;
+
+
+  public function setCarrier($carrier)
+  {
+    $this->carrier = $carrier;
+  }
+  public function getCarrier()
+  {
+    return $this->carrier;
+  }
+  public function setOperationId($operationId)
+  {
+    $this->operationId = $operationId;
+  }
+  public function getOperationId()
+  {
+    return $this->operationId;
+  }
+  public function setShipmentId($shipmentId)
+  {
+    $this->shipmentId = $shipmentId;
+  }
+  public function getShipmentId()
+  {
+    return $this->shipmentId;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setTrackingId($trackingId)
+  {
+    $this->trackingId = $trackingId;
+  }
+  public function getTrackingId()
+  {
+    return $this->trackingId;
+  }
+}
+
+class Google_Service_ShoppingContent_OrdersUpdateShipmentResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $executionStatus;
+  public $kind;
+
+
+  public function setExecutionStatus($executionStatus)
+  {
+    $this->executionStatus = $executionStatus;
+  }
+  public function getExecutionStatus()
+  {
+    return $this->executionStatus;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_Price extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $currency;
+  public $value;
+
+
+  public function setCurrency($currency)
+  {
+    $this->currency = $currency;
+  }
+  public function getCurrency()
+  {
+    return $this->currency;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_ShoppingContent_Product extends Google_Collection
+{
+  protected $collection_key = 'warnings';
+  protected $internal_gapi_mappings = array(
+  );
+  public $additionalImageLinks;
+  public $adult;
+  public $adwordsGrouping;
+  public $adwordsLabels;
+  public $adwordsRedirect;
+  public $ageGroup;
+  protected $aspectsType = 'Google_Service_ShoppingContent_ProductAspect';
+  protected $aspectsDataType = 'array';
+  public $availability;
+  public $availabilityDate;
+  public $brand;
+  public $channel;
+  public $color;
+  public $condition;
+  public $contentLanguage;
+  protected $customAttributesType = 'Google_Service_ShoppingContent_ProductCustomAttribute';
+  protected $customAttributesDataType = 'array';
+  protected $customGroupsType = 'Google_Service_ShoppingContent_ProductCustomGroup';
+  protected $customGroupsDataType = 'array';
+  public $customLabel0;
+  public $customLabel1;
+  public $customLabel2;
+  public $customLabel3;
+  public $customLabel4;
+  public $description;
+  protected $destinationsType = 'Google_Service_ShoppingContent_ProductDestination';
+  protected $destinationsDataType = 'array';
+  public $displayAdsId;
+  public $displayAdsLink;
+  public $displayAdsSimilarIds;
+  public $displayAdsTitle;
+  public $displayAdsValue;
+  public $energyEfficiencyClass;
+  public $expirationDate;
+  public $gender;
+  public $googleProductCategory;
+  public $gtin;
+  public $id;
+  public $identifierExists;
+  public $imageLink;
+  protected $installmentType = 'Google_Service_ShoppingContent_ProductInstallment';
+  protected $installmentDataType = '';
+  public $isBundle;
+  public $itemGroupId;
+  public $kind;
+  public $link;
+  protected $loyaltyPointsType = 'Google_Service_ShoppingContent_LoyaltyPoints';
+  protected $loyaltyPointsDataType = '';
+  public $material;
+  public $mobileLink;
+  public $mpn;
+  public $multipack;
+  public $offerId;
+  public $onlineOnly;
+  public $pattern;
+  protected $priceType = 'Google_Service_ShoppingContent_Price';
+  protected $priceDataType = '';
+  public $productType;
+  protected $salePriceType = 'Google_Service_ShoppingContent_Price';
+  protected $salePriceDataType = '';
+  public $salePriceEffectiveDate;
+  public $sellOnGoogleQuantity;
+  protected $shippingType = 'Google_Service_ShoppingContent_ProductShipping';
+  protected $shippingDataType = 'array';
+  protected $shippingHeightType = 'Google_Service_ShoppingContent_ProductShippingDimension';
+  protected $shippingHeightDataType = '';
+  public $shippingLabel;
+  protected $shippingLengthType = 'Google_Service_ShoppingContent_ProductShippingDimension';
+  protected $shippingLengthDataType = '';
+  protected $shippingWeightType = 'Google_Service_ShoppingContent_ProductShippingWeight';
+  protected $shippingWeightDataType = '';
+  protected $shippingWidthType = 'Google_Service_ShoppingContent_ProductShippingDimension';
+  protected $shippingWidthDataType = '';
+  public $sizeSystem;
+  public $sizeType;
+  public $sizes;
+  public $targetCountry;
+  protected $taxesType = 'Google_Service_ShoppingContent_ProductTax';
+  protected $taxesDataType = 'array';
+  public $title;
+  protected $unitPricingBaseMeasureType = 'Google_Service_ShoppingContent_ProductUnitPricingBaseMeasure';
+  protected $unitPricingBaseMeasureDataType = '';
+  protected $unitPricingMeasureType = 'Google_Service_ShoppingContent_ProductUnitPricingMeasure';
+  protected $unitPricingMeasureDataType = '';
+  public $validatedDestinations;
+  protected $warningsType = 'Google_Service_ShoppingContent_Error';
+  protected $warningsDataType = 'array';
+
+
+  public function setAdditionalImageLinks($additionalImageLinks)
+  {
+    $this->additionalImageLinks = $additionalImageLinks;
+  }
+  public function getAdditionalImageLinks()
+  {
+    return $this->additionalImageLinks;
+  }
+  public function setAdult($adult)
+  {
+    $this->adult = $adult;
+  }
+  public function getAdult()
+  {
+    return $this->adult;
+  }
+  public function setAdwordsGrouping($adwordsGrouping)
+  {
+    $this->adwordsGrouping = $adwordsGrouping;
+  }
+  public function getAdwordsGrouping()
+  {
+    return $this->adwordsGrouping;
+  }
+  public function setAdwordsLabels($adwordsLabels)
+  {
+    $this->adwordsLabels = $adwordsLabels;
+  }
+  public function getAdwordsLabels()
+  {
+    return $this->adwordsLabels;
+  }
+  public function setAdwordsRedirect($adwordsRedirect)
+  {
+    $this->adwordsRedirect = $adwordsRedirect;
+  }
+  public function getAdwordsRedirect()
+  {
+    return $this->adwordsRedirect;
+  }
+  public function setAgeGroup($ageGroup)
+  {
+    $this->ageGroup = $ageGroup;
+  }
+  public function getAgeGroup()
+  {
+    return $this->ageGroup;
+  }
+  public function setAspects($aspects)
+  {
+    $this->aspects = $aspects;
+  }
+  public function getAspects()
+  {
+    return $this->aspects;
+  }
+  public function setAvailability($availability)
+  {
+    $this->availability = $availability;
+  }
+  public function getAvailability()
+  {
+    return $this->availability;
+  }
+  public function setAvailabilityDate($availabilityDate)
+  {
+    $this->availabilityDate = $availabilityDate;
+  }
+  public function getAvailabilityDate()
+  {
+    return $this->availabilityDate;
+  }
+  public function setBrand($brand)
+  {
+    $this->brand = $brand;
+  }
+  public function getBrand()
+  {
+    return $this->brand;
+  }
+  public function setChannel($channel)
+  {
+    $this->channel = $channel;
+  }
+  public function getChannel()
+  {
+    return $this->channel;
+  }
+  public function setColor($color)
+  {
+    $this->color = $color;
+  }
+  public function getColor()
+  {
+    return $this->color;
+  }
+  public function setCondition($condition)
+  {
+    $this->condition = $condition;
+  }
+  public function getCondition()
+  {
+    return $this->condition;
+  }
+  public function setContentLanguage($contentLanguage)
+  {
+    $this->contentLanguage = $contentLanguage;
+  }
+  public function getContentLanguage()
+  {
+    return $this->contentLanguage;
+  }
+  public function setCustomAttributes($customAttributes)
+  {
+    $this->customAttributes = $customAttributes;
+  }
+  public function getCustomAttributes()
+  {
+    return $this->customAttributes;
+  }
+  public function setCustomGroups($customGroups)
+  {
+    $this->customGroups = $customGroups;
+  }
+  public function getCustomGroups()
+  {
+    return $this->customGroups;
+  }
+  public function setCustomLabel0($customLabel0)
+  {
+    $this->customLabel0 = $customLabel0;
+  }
+  public function getCustomLabel0()
+  {
+    return $this->customLabel0;
+  }
+  public function setCustomLabel1($customLabel1)
+  {
+    $this->customLabel1 = $customLabel1;
+  }
+  public function getCustomLabel1()
+  {
+    return $this->customLabel1;
+  }
+  public function setCustomLabel2($customLabel2)
+  {
+    $this->customLabel2 = $customLabel2;
+  }
+  public function getCustomLabel2()
+  {
+    return $this->customLabel2;
+  }
+  public function setCustomLabel3($customLabel3)
+  {
+    $this->customLabel3 = $customLabel3;
+  }
+  public function getCustomLabel3()
+  {
+    return $this->customLabel3;
+  }
+  public function setCustomLabel4($customLabel4)
+  {
+    $this->customLabel4 = $customLabel4;
+  }
+  public function getCustomLabel4()
+  {
+    return $this->customLabel4;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setDestinations($destinations)
+  {
+    $this->destinations = $destinations;
+  }
+  public function getDestinations()
+  {
+    return $this->destinations;
+  }
+  public function setDisplayAdsId($displayAdsId)
+  {
+    $this->displayAdsId = $displayAdsId;
+  }
+  public function getDisplayAdsId()
+  {
+    return $this->displayAdsId;
+  }
+  public function setDisplayAdsLink($displayAdsLink)
+  {
+    $this->displayAdsLink = $displayAdsLink;
+  }
+  public function getDisplayAdsLink()
+  {
+    return $this->displayAdsLink;
+  }
+  public function setDisplayAdsSimilarIds($displayAdsSimilarIds)
+  {
+    $this->displayAdsSimilarIds = $displayAdsSimilarIds;
+  }
+  public function getDisplayAdsSimilarIds()
+  {
+    return $this->displayAdsSimilarIds;
+  }
+  public function setDisplayAdsTitle($displayAdsTitle)
+  {
+    $this->displayAdsTitle = $displayAdsTitle;
+  }
+  public function getDisplayAdsTitle()
+  {
+    return $this->displayAdsTitle;
+  }
+  public function setDisplayAdsValue($displayAdsValue)
+  {
+    $this->displayAdsValue = $displayAdsValue;
+  }
+  public function getDisplayAdsValue()
+  {
+    return $this->displayAdsValue;
+  }
+  public function setEnergyEfficiencyClass($energyEfficiencyClass)
+  {
+    $this->energyEfficiencyClass = $energyEfficiencyClass;
+  }
+  public function getEnergyEfficiencyClass()
+  {
+    return $this->energyEfficiencyClass;
+  }
+  public function setExpirationDate($expirationDate)
+  {
+    $this->expirationDate = $expirationDate;
+  }
+  public function getExpirationDate()
+  {
+    return $this->expirationDate;
+  }
+  public function setGender($gender)
+  {
+    $this->gender = $gender;
+  }
+  public function getGender()
+  {
+    return $this->gender;
+  }
+  public function setGoogleProductCategory($googleProductCategory)
+  {
+    $this->googleProductCategory = $googleProductCategory;
+  }
+  public function getGoogleProductCategory()
+  {
+    return $this->googleProductCategory;
+  }
+  public function setGtin($gtin)
+  {
+    $this->gtin = $gtin;
+  }
+  public function getGtin()
+  {
+    return $this->gtin;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setIdentifierExists($identifierExists)
+  {
+    $this->identifierExists = $identifierExists;
+  }
+  public function getIdentifierExists()
+  {
+    return $this->identifierExists;
+  }
+  public function setImageLink($imageLink)
+  {
+    $this->imageLink = $imageLink;
+  }
+  public function getImageLink()
+  {
+    return $this->imageLink;
+  }
+  public function setInstallment(Google_Service_ShoppingContent_ProductInstallment $installment)
+  {
+    $this->installment = $installment;
+  }
+  public function getInstallment()
+  {
+    return $this->installment;
+  }
+  public function setIsBundle($isBundle)
+  {
+    $this->isBundle = $isBundle;
+  }
+  public function getIsBundle()
+  {
+    return $this->isBundle;
+  }
+  public function setItemGroupId($itemGroupId)
+  {
+    $this->itemGroupId = $itemGroupId;
+  }
+  public function getItemGroupId()
+  {
+    return $this->itemGroupId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLink($link)
+  {
+    $this->link = $link;
+  }
+  public function getLink()
+  {
+    return $this->link;
+  }
+  public function setLoyaltyPoints(Google_Service_ShoppingContent_LoyaltyPoints $loyaltyPoints)
+  {
+    $this->loyaltyPoints = $loyaltyPoints;
+  }
+  public function getLoyaltyPoints()
+  {
+    return $this->loyaltyPoints;
+  }
+  public function setMaterial($material)
+  {
+    $this->material = $material;
+  }
+  public function getMaterial()
+  {
+    return $this->material;
+  }
+  public function setMobileLink($mobileLink)
+  {
+    $this->mobileLink = $mobileLink;
+  }
+  public function getMobileLink()
+  {
+    return $this->mobileLink;
+  }
+  public function setMpn($mpn)
+  {
+    $this->mpn = $mpn;
+  }
+  public function getMpn()
+  {
+    return $this->mpn;
+  }
+  public function setMultipack($multipack)
+  {
+    $this->multipack = $multipack;
+  }
+  public function getMultipack()
+  {
+    return $this->multipack;
+  }
+  public function setOfferId($offerId)
+  {
+    $this->offerId = $offerId;
+  }
+  public function getOfferId()
+  {
+    return $this->offerId;
+  }
+  public function setOnlineOnly($onlineOnly)
+  {
+    $this->onlineOnly = $onlineOnly;
+  }
+  public function getOnlineOnly()
+  {
+    return $this->onlineOnly;
+  }
+  public function setPattern($pattern)
+  {
+    $this->pattern = $pattern;
+  }
+  public function getPattern()
+  {
+    return $this->pattern;
+  }
+  public function setPrice(Google_Service_ShoppingContent_Price $price)
+  {
+    $this->price = $price;
+  }
+  public function getPrice()
+  {
+    return $this->price;
+  }
+  public function setProductType($productType)
+  {
+    $this->productType = $productType;
+  }
+  public function getProductType()
+  {
+    return $this->productType;
+  }
+  public function setSalePrice(Google_Service_ShoppingContent_Price $salePrice)
+  {
+    $this->salePrice = $salePrice;
+  }
+  public function getSalePrice()
+  {
+    return $this->salePrice;
+  }
+  public function setSalePriceEffectiveDate($salePriceEffectiveDate)
+  {
+    $this->salePriceEffectiveDate = $salePriceEffectiveDate;
+  }
+  public function getSalePriceEffectiveDate()
+  {
+    return $this->salePriceEffectiveDate;
+  }
+  public function setSellOnGoogleQuantity($sellOnGoogleQuantity)
+  {
+    $this->sellOnGoogleQuantity = $sellOnGoogleQuantity;
+  }
+  public function getSellOnGoogleQuantity()
+  {
+    return $this->sellOnGoogleQuantity;
+  }
+  public function setShipping($shipping)
+  {
+    $this->shipping = $shipping;
+  }
+  public function getShipping()
+  {
+    return $this->shipping;
+  }
+  public function setShippingHeight(Google_Service_ShoppingContent_ProductShippingDimension $shippingHeight)
+  {
+    $this->shippingHeight = $shippingHeight;
+  }
+  public function getShippingHeight()
+  {
+    return $this->shippingHeight;
+  }
+  public function setShippingLabel($shippingLabel)
+  {
+    $this->shippingLabel = $shippingLabel;
+  }
+  public function getShippingLabel()
+  {
+    return $this->shippingLabel;
+  }
+  public function setShippingLength(Google_Service_ShoppingContent_ProductShippingDimension $shippingLength)
+  {
+    $this->shippingLength = $shippingLength;
+  }
+  public function getShippingLength()
+  {
+    return $this->shippingLength;
+  }
+  public function setShippingWeight(Google_Service_ShoppingContent_ProductShippingWeight $shippingWeight)
+  {
+    $this->shippingWeight = $shippingWeight;
+  }
+  public function getShippingWeight()
+  {
+    return $this->shippingWeight;
+  }
+  public function setShippingWidth(Google_Service_ShoppingContent_ProductShippingDimension $shippingWidth)
+  {
+    $this->shippingWidth = $shippingWidth;
+  }
+  public function getShippingWidth()
+  {
+    return $this->shippingWidth;
+  }
+  public function setSizeSystem($sizeSystem)
+  {
+    $this->sizeSystem = $sizeSystem;
+  }
+  public function getSizeSystem()
+  {
+    return $this->sizeSystem;
+  }
+  public function setSizeType($sizeType)
+  {
+    $this->sizeType = $sizeType;
+  }
+  public function getSizeType()
+  {
+    return $this->sizeType;
+  }
+  public function setSizes($sizes)
+  {
+    $this->sizes = $sizes;
+  }
+  public function getSizes()
+  {
+    return $this->sizes;
+  }
+  public function setTargetCountry($targetCountry)
+  {
+    $this->targetCountry = $targetCountry;
+  }
+  public function getTargetCountry()
+  {
+    return $this->targetCountry;
+  }
+  public function setTaxes($taxes)
+  {
+    $this->taxes = $taxes;
+  }
+  public function getTaxes()
+  {
+    return $this->taxes;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setUnitPricingBaseMeasure(Google_Service_ShoppingContent_ProductUnitPricingBaseMeasure $unitPricingBaseMeasure)
+  {
+    $this->unitPricingBaseMeasure = $unitPricingBaseMeasure;
+  }
+  public function getUnitPricingBaseMeasure()
+  {
+    return $this->unitPricingBaseMeasure;
+  }
+  public function setUnitPricingMeasure(Google_Service_ShoppingContent_ProductUnitPricingMeasure $unitPricingMeasure)
+  {
+    $this->unitPricingMeasure = $unitPricingMeasure;
+  }
+  public function getUnitPricingMeasure()
+  {
+    return $this->unitPricingMeasure;
+  }
+  public function setValidatedDestinations($validatedDestinations)
+  {
+    $this->validatedDestinations = $validatedDestinations;
+  }
+  public function getValidatedDestinations()
+  {
+    return $this->validatedDestinations;
+  }
+  public function setWarnings($warnings)
+  {
+    $this->warnings = $warnings;
+  }
+  public function getWarnings()
+  {
+    return $this->warnings;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductAspect extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $aspectName;
+  public $destinationName;
+  public $intention;
+
+
+  public function setAspectName($aspectName)
+  {
+    $this->aspectName = $aspectName;
+  }
+  public function getAspectName()
+  {
+    return $this->aspectName;
+  }
+  public function setDestinationName($destinationName)
+  {
+    $this->destinationName = $destinationName;
+  }
+  public function getDestinationName()
+  {
+    return $this->destinationName;
+  }
+  public function setIntention($intention)
+  {
+    $this->intention = $intention;
+  }
+  public function getIntention()
+  {
+    return $this->intention;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductCustomAttribute extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $type;
+  public $unit;
+  public $value;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUnit($unit)
+  {
+    $this->unit = $unit;
+  }
+  public function getUnit()
+  {
+    return $this->unit;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductCustomGroup extends Google_Collection
+{
+  protected $collection_key = 'attributes';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $attributesType = 'Google_Service_ShoppingContent_ProductCustomAttribute';
+  protected $attributesDataType = 'array';
+  public $name;
+
+
+  public function setAttributes($attributes)
+  {
+    $this->attributes = $attributes;
+  }
+  public function getAttributes()
+  {
+    return $this->attributes;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductDestination extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $destinationName;
+  public $intention;
+
+
+  public function setDestinationName($destinationName)
+  {
+    $this->destinationName = $destinationName;
+  }
+  public function getDestinationName()
+  {
+    return $this->destinationName;
+  }
+  public function setIntention($intention)
+  {
+    $this->intention = $intention;
+  }
+  public function getIntention()
+  {
+    return $this->intention;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductInstallment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $amountType = 'Google_Service_ShoppingContent_Price';
+  protected $amountDataType = '';
+  public $months;
+
+
+  public function setAmount(Google_Service_ShoppingContent_Price $amount)
+  {
+    $this->amount = $amount;
+  }
+  public function getAmount()
+  {
+    return $this->amount;
+  }
+  public function setMonths($months)
+  {
+    $this->months = $months;
+  }
+  public function getMonths()
+  {
+    return $this->months;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductShipping extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $country;
+  public $locationGroupName;
+  public $locationId;
+  public $postalCode;
+  protected $priceType = 'Google_Service_ShoppingContent_Price';
+  protected $priceDataType = '';
+  public $region;
+  public $service;
+
+
+  public function setCountry($country)
+  {
+    $this->country = $country;
+  }
+  public function getCountry()
+  {
+    return $this->country;
+  }
+  public function setLocationGroupName($locationGroupName)
+  {
+    $this->locationGroupName = $locationGroupName;
+  }
+  public function getLocationGroupName()
+  {
+    return $this->locationGroupName;
+  }
+  public function setLocationId($locationId)
+  {
+    $this->locationId = $locationId;
+  }
+  public function getLocationId()
+  {
+    return $this->locationId;
+  }
+  public function setPostalCode($postalCode)
+  {
+    $this->postalCode = $postalCode;
+  }
+  public function getPostalCode()
+  {
+    return $this->postalCode;
+  }
+  public function setPrice(Google_Service_ShoppingContent_Price $price)
+  {
+    $this->price = $price;
+  }
+  public function getPrice()
+  {
+    return $this->price;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setService($service)
+  {
+    $this->service = $service;
+  }
+  public function getService()
+  {
+    return $this->service;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductShippingDimension extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $unit;
+  public $value;
+
+
+  public function setUnit($unit)
+  {
+    $this->unit = $unit;
+  }
+  public function getUnit()
+  {
+    return $this->unit;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductShippingWeight extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $unit;
+  public $value;
+
+
+  public function setUnit($unit)
+  {
+    $this->unit = $unit;
+  }
+  public function getUnit()
+  {
+    return $this->unit;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductStatus extends Google_Collection
+{
+  protected $collection_key = 'destinationStatuses';
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationDate;
+  protected $dataQualityIssuesType = 'Google_Service_ShoppingContent_ProductStatusDataQualityIssue';
+  protected $dataQualityIssuesDataType = 'array';
+  protected $destinationStatusesType = 'Google_Service_ShoppingContent_ProductStatusDestinationStatus';
+  protected $destinationStatusesDataType = 'array';
+  public $googleExpirationDate;
+  public $kind;
+  public $lastUpdateDate;
+  public $link;
+  public $productId;
+  public $title;
+
+
+  public function setCreationDate($creationDate)
+  {
+    $this->creationDate = $creationDate;
+  }
+  public function getCreationDate()
+  {
+    return $this->creationDate;
+  }
+  public function setDataQualityIssues($dataQualityIssues)
+  {
+    $this->dataQualityIssues = $dataQualityIssues;
+  }
+  public function getDataQualityIssues()
+  {
+    return $this->dataQualityIssues;
+  }
+  public function setDestinationStatuses($destinationStatuses)
+  {
+    $this->destinationStatuses = $destinationStatuses;
+  }
+  public function getDestinationStatuses()
+  {
+    return $this->destinationStatuses;
+  }
+  public function setGoogleExpirationDate($googleExpirationDate)
+  {
+    $this->googleExpirationDate = $googleExpirationDate;
+  }
+  public function getGoogleExpirationDate()
+  {
+    return $this->googleExpirationDate;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastUpdateDate($lastUpdateDate)
+  {
+    $this->lastUpdateDate = $lastUpdateDate;
+  }
+  public function getLastUpdateDate()
+  {
+    return $this->lastUpdateDate;
+  }
+  public function setLink($link)
+  {
+    $this->link = $link;
+  }
+  public function getLink()
+  {
+    return $this->link;
+  }
+  public function setProductId($productId)
+  {
+    $this->productId = $productId;
+  }
+  public function getProductId()
+  {
+    return $this->productId;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductStatusDataQualityIssue extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $detail;
+  public $fetchStatus;
+  public $id;
+  public $location;
+  public $severity;
+  public $timestamp;
+  public $valueOnLandingPage;
+  public $valueProvided;
+
+
+  public function setDetail($detail)
+  {
+    $this->detail = $detail;
+  }
+  public function getDetail()
+  {
+    return $this->detail;
+  }
+  public function setFetchStatus($fetchStatus)
+  {
+    $this->fetchStatus = $fetchStatus;
+  }
+  public function getFetchStatus()
+  {
+    return $this->fetchStatus;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setSeverity($severity)
+  {
+    $this->severity = $severity;
+  }
+  public function getSeverity()
+  {
+    return $this->severity;
+  }
+  public function setTimestamp($timestamp)
+  {
+    $this->timestamp = $timestamp;
+  }
+  public function getTimestamp()
+  {
+    return $this->timestamp;
+  }
+  public function setValueOnLandingPage($valueOnLandingPage)
+  {
+    $this->valueOnLandingPage = $valueOnLandingPage;
+  }
+  public function getValueOnLandingPage()
+  {
+    return $this->valueOnLandingPage;
+  }
+  public function setValueProvided($valueProvided)
+  {
+    $this->valueProvided = $valueProvided;
+  }
+  public function getValueProvided()
+  {
+    return $this->valueProvided;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductStatusDestinationStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $approvalStatus;
+  public $destination;
+  public $intention;
+
+
+  public function setApprovalStatus($approvalStatus)
+  {
+    $this->approvalStatus = $approvalStatus;
+  }
+  public function getApprovalStatus()
+  {
+    return $this->approvalStatus;
+  }
+  public function setDestination($destination)
+  {
+    $this->destination = $destination;
+  }
+  public function getDestination()
+  {
+    return $this->destination;
+  }
+  public function setIntention($intention)
+  {
+    $this->intention = $intention;
+  }
+  public function getIntention()
+  {
+    return $this->intention;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductTax extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $country;
+  public $locationId;
+  public $postalCode;
+  public $rate;
+  public $region;
+  public $taxShip;
+
+
+  public function setCountry($country)
+  {
+    $this->country = $country;
+  }
+  public function getCountry()
+  {
+    return $this->country;
+  }
+  public function setLocationId($locationId)
+  {
+    $this->locationId = $locationId;
+  }
+  public function getLocationId()
+  {
+    return $this->locationId;
+  }
+  public function setPostalCode($postalCode)
+  {
+    $this->postalCode = $postalCode;
+  }
+  public function getPostalCode()
+  {
+    return $this->postalCode;
+  }
+  public function setRate($rate)
+  {
+    $this->rate = $rate;
+  }
+  public function getRate()
+  {
+    return $this->rate;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setTaxShip($taxShip)
+  {
+    $this->taxShip = $taxShip;
+  }
+  public function getTaxShip()
+  {
+    return $this->taxShip;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductUnitPricingBaseMeasure extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $unit;
+  public $value;
+
+
+  public function setUnit($unit)
+  {
+    $this->unit = $unit;
+  }
+  public function getUnit()
+  {
+    return $this->unit;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductUnitPricingMeasure extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $unit;
+  public $value;
+
+
+  public function setUnit($unit)
+  {
+    $this->unit = $unit;
+  }
+  public function getUnit()
+  {
+    return $this->unit;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductsCustomBatchRequest extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_ProductsCustomBatchRequestEntry';
+  protected $entriesDataType = 'array';
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductsCustomBatchRequestEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $batchId;
+  public $merchantId;
+  public $method;
+  protected $productType = 'Google_Service_ShoppingContent_Product';
+  protected $productDataType = '';
+  public $productId;
+
+
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setMerchantId($merchantId)
+  {
+    $this->merchantId = $merchantId;
+  }
+  public function getMerchantId()
+  {
+    return $this->merchantId;
+  }
+  public function setMethod($method)
+  {
+    $this->method = $method;
+  }
+  public function getMethod()
+  {
+    return $this->method;
+  }
+  public function setProduct(Google_Service_ShoppingContent_Product $product)
+  {
+    $this->product = $product;
+  }
+  public function getProduct()
+  {
+    return $this->product;
+  }
+  public function setProductId($productId)
+  {
+    $this->productId = $productId;
+  }
+  public function getProductId()
+  {
+    return $this->productId;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductsCustomBatchResponse extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_ProductsCustomBatchResponseEntry';
+  protected $entriesDataType = 'array';
+  public $kind;
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductsCustomBatchResponseEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $batchId;
+  protected $errorsType = 'Google_Service_ShoppingContent_Errors';
+  protected $errorsDataType = '';
+  public $kind;
+  protected $productType = 'Google_Service_ShoppingContent_Product';
+  protected $productDataType = '';
+
+
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setErrors(Google_Service_ShoppingContent_Errors $errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProduct(Google_Service_ShoppingContent_Product $product)
+  {
+    $this->product = $product;
+  }
+  public function getProduct()
+  {
+    return $this->product;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductsListResponse extends Google_Collection
+{
+  protected $collection_key = 'resources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $resourcesType = 'Google_Service_ShoppingContent_Product';
+  protected $resourcesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setResources($resources)
+  {
+    $this->resources = $resources;
+  }
+  public function getResources()
+  {
+    return $this->resources;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductstatusesCustomBatchRequest extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_ProductstatusesCustomBatchRequestEntry';
+  protected $entriesDataType = 'array';
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductstatusesCustomBatchRequestEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $batchId;
+  public $merchantId;
+  public $method;
+  public $productId;
+
+
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setMerchantId($merchantId)
+  {
+    $this->merchantId = $merchantId;
+  }
+  public function getMerchantId()
+  {
+    return $this->merchantId;
+  }
+  public function setMethod($method)
+  {
+    $this->method = $method;
+  }
+  public function getMethod()
+  {
+    return $this->method;
+  }
+  public function setProductId($productId)
+  {
+    $this->productId = $productId;
+  }
+  public function getProductId()
+  {
+    return $this->productId;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductstatusesCustomBatchResponse extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $entriesType = 'Google_Service_ShoppingContent_ProductstatusesCustomBatchResponseEntry';
+  protected $entriesDataType = 'array';
+  public $kind;
+
+
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductstatusesCustomBatchResponseEntry extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $batchId;
+  protected $errorsType = 'Google_Service_ShoppingContent_Errors';
+  protected $errorsDataType = '';
+  public $kind;
+  protected $productStatusType = 'Google_Service_ShoppingContent_ProductStatus';
+  protected $productStatusDataType = '';
+
+
+  public function setBatchId($batchId)
+  {
+    $this->batchId = $batchId;
+  }
+  public function getBatchId()
+  {
+    return $this->batchId;
+  }
+  public function setErrors(Google_Service_ShoppingContent_Errors $errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProductStatus(Google_Service_ShoppingContent_ProductStatus $productStatus)
+  {
+    $this->productStatus = $productStatus;
+  }
+  public function getProductStatus()
+  {
+    return $this->productStatus;
+  }
+}
+
+class Google_Service_ShoppingContent_ProductstatusesListResponse extends Google_Collection
+{
+  protected $collection_key = 'resources';
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $nextPageToken;
+  protected $resourcesType = 'Google_Service_ShoppingContent_ProductStatus';
+  protected $resourcesDataType = 'array';
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setResources($resources)
+  {
+    $this->resources = $resources;
+  }
+  public function getResources()
+  {
+    return $this->resources;
+  }
+}
+
+class Google_Service_ShoppingContent_TestOrder extends Google_Collection
+{
+  protected $collection_key = 'lineItems';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $customerType = 'Google_Service_ShoppingContent_TestOrderCustomer';
+  protected $customerDataType = '';
+  public $kind;
+  protected $lineItemsType = 'Google_Service_ShoppingContent_TestOrderLineItem';
+  protected $lineItemsDataType = 'array';
+  protected $paymentMethodType = 'Google_Service_ShoppingContent_TestOrderPaymentMethod';
+  protected $paymentMethodDataType = '';
+  public $predefinedDeliveryAddress;
+  protected $shippingCostType = 'Google_Service_ShoppingContent_Price';
+  protected $shippingCostDataType = '';
+  protected $shippingCostTaxType = 'Google_Service_ShoppingContent_Price';
+  protected $shippingCostTaxDataType = '';
+  public $shippingOption;
+
+
+  public function setCustomer(Google_Service_ShoppingContent_TestOrderCustomer $customer)
+  {
+    $this->customer = $customer;
+  }
+  public function getCustomer()
+  {
+    return $this->customer;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLineItems($lineItems)
+  {
+    $this->lineItems = $lineItems;
+  }
+  public function getLineItems()
+  {
+    return $this->lineItems;
+  }
+  public function setPaymentMethod(Google_Service_ShoppingContent_TestOrderPaymentMethod $paymentMethod)
+  {
+    $this->paymentMethod = $paymentMethod;
+  }
+  public function getPaymentMethod()
+  {
+    return $this->paymentMethod;
+  }
+  public function setPredefinedDeliveryAddress($predefinedDeliveryAddress)
+  {
+    $this->predefinedDeliveryAddress = $predefinedDeliveryAddress;
+  }
+  public function getPredefinedDeliveryAddress()
+  {
+    return $this->predefinedDeliveryAddress;
+  }
+  public function setShippingCost(Google_Service_ShoppingContent_Price $shippingCost)
+  {
+    $this->shippingCost = $shippingCost;
+  }
+  public function getShippingCost()
+  {
+    return $this->shippingCost;
+  }
+  public function setShippingCostTax(Google_Service_ShoppingContent_Price $shippingCostTax)
+  {
+    $this->shippingCostTax = $shippingCostTax;
+  }
+  public function getShippingCostTax()
+  {
+    return $this->shippingCostTax;
+  }
+  public function setShippingOption($shippingOption)
+  {
+    $this->shippingOption = $shippingOption;
+  }
+  public function getShippingOption()
+  {
+    return $this->shippingOption;
+  }
+}
+
+class Google_Service_ShoppingContent_TestOrderCustomer extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $email;
+  public $explicitMarketingPreference;
+  public $fullName;
+
+
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setExplicitMarketingPreference($explicitMarketingPreference)
+  {
+    $this->explicitMarketingPreference = $explicitMarketingPreference;
+  }
+  public function getExplicitMarketingPreference()
+  {
+    return $this->explicitMarketingPreference;
+  }
+  public function setFullName($fullName)
+  {
+    $this->fullName = $fullName;
+  }
+  public function getFullName()
+  {
+    return $this->fullName;
+  }
+}
+
+class Google_Service_ShoppingContent_TestOrderLineItem extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $productType = 'Google_Service_ShoppingContent_TestOrderLineItemProduct';
+  protected $productDataType = '';
+  public $quantityOrdered;
+  protected $returnInfoType = 'Google_Service_ShoppingContent_OrderLineItemReturnInfo';
+  protected $returnInfoDataType = '';
+  protected $shippingDetailsType = 'Google_Service_ShoppingContent_OrderLineItemShippingDetails';
+  protected $shippingDetailsDataType = '';
+  protected $unitTaxType = 'Google_Service_ShoppingContent_Price';
+  protected $unitTaxDataType = '';
+
+
+  public function setProduct(Google_Service_ShoppingContent_TestOrderLineItemProduct $product)
+  {
+    $this->product = $product;
+  }
+  public function getProduct()
+  {
+    return $this->product;
+  }
+  public function setQuantityOrdered($quantityOrdered)
+  {
+    $this->quantityOrdered = $quantityOrdered;
+  }
+  public function getQuantityOrdered()
+  {
+    return $this->quantityOrdered;
+  }
+  public function setReturnInfo(Google_Service_ShoppingContent_OrderLineItemReturnInfo $returnInfo)
+  {
+    $this->returnInfo = $returnInfo;
+  }
+  public function getReturnInfo()
+  {
+    return $this->returnInfo;
+  }
+  public function setShippingDetails(Google_Service_ShoppingContent_OrderLineItemShippingDetails $shippingDetails)
+  {
+    $this->shippingDetails = $shippingDetails;
+  }
+  public function getShippingDetails()
+  {
+    return $this->shippingDetails;
+  }
+  public function setUnitTax(Google_Service_ShoppingContent_Price $unitTax)
+  {
+    $this->unitTax = $unitTax;
+  }
+  public function getUnitTax()
+  {
+    return $this->unitTax;
+  }
+}
+
+class Google_Service_ShoppingContent_TestOrderLineItemProduct extends Google_Collection
+{
+  protected $collection_key = 'variantAttributes';
+  protected $internal_gapi_mappings = array(
+  );
+  public $brand;
+  public $channel;
+  public $condition;
+  public $contentLanguage;
+  public $gtin;
+  public $imageLink;
+  public $itemGroupId;
+  public $mpn;
+  public $offerId;
+  protected $priceType = 'Google_Service_ShoppingContent_Price';
+  protected $priceDataType = '';
+  public $targetCountry;
+  public $title;
+  protected $variantAttributesType = 'Google_Service_ShoppingContent_OrderLineItemProductVariantAttribute';
+  protected $variantAttributesDataType = 'array';
+
+
+  public function setBrand($brand)
+  {
+    $this->brand = $brand;
+  }
+  public function getBrand()
+  {
+    return $this->brand;
+  }
+  public function setChannel($channel)
+  {
+    $this->channel = $channel;
+  }
+  public function getChannel()
+  {
+    return $this->channel;
+  }
+  public function setCondition($condition)
+  {
+    $this->condition = $condition;
+  }
+  public function getCondition()
+  {
+    return $this->condition;
+  }
+  public function setContentLanguage($contentLanguage)
+  {
+    $this->contentLanguage = $contentLanguage;
+  }
+  public function getContentLanguage()
+  {
+    return $this->contentLanguage;
+  }
+  public function setGtin($gtin)
+  {
+    $this->gtin = $gtin;
+  }
+  public function getGtin()
+  {
+    return $this->gtin;
+  }
+  public function setImageLink($imageLink)
+  {
+    $this->imageLink = $imageLink;
+  }
+  public function getImageLink()
+  {
+    return $this->imageLink;
+  }
+  public function setItemGroupId($itemGroupId)
+  {
+    $this->itemGroupId = $itemGroupId;
+  }
+  public function getItemGroupId()
+  {
+    return $this->itemGroupId;
+  }
+  public function setMpn($mpn)
+  {
+    $this->mpn = $mpn;
+  }
+  public function getMpn()
+  {
+    return $this->mpn;
+  }
+  public function setOfferId($offerId)
+  {
+    $this->offerId = $offerId;
+  }
+  public function getOfferId()
+  {
+    return $this->offerId;
+  }
+  public function setPrice(Google_Service_ShoppingContent_Price $price)
+  {
+    $this->price = $price;
+  }
+  public function getPrice()
+  {
+    return $this->price;
+  }
+  public function setTargetCountry($targetCountry)
+  {
+    $this->targetCountry = $targetCountry;
+  }
+  public function getTargetCountry()
+  {
+    return $this->targetCountry;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setVariantAttributes($variantAttributes)
+  {
+    $this->variantAttributes = $variantAttributes;
+  }
+  public function getVariantAttributes()
+  {
+    return $this->variantAttributes;
+  }
+}
+
+class Google_Service_ShoppingContent_TestOrderPaymentMethod extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $expirationMonth;
+  public $expirationYear;
+  public $lastFourDigits;
+  public $predefinedBillingAddress;
+  public $type;
+
+
+  public function setExpirationMonth($expirationMonth)
+  {
+    $this->expirationMonth = $expirationMonth;
+  }
+  public function getExpirationMonth()
+  {
+    return $this->expirationMonth;
+  }
+  public function setExpirationYear($expirationYear)
+  {
+    $this->expirationYear = $expirationYear;
+  }
+  public function getExpirationYear()
+  {
+    return $this->expirationYear;
+  }
+  public function setLastFourDigits($lastFourDigits)
+  {
+    $this->lastFourDigits = $lastFourDigits;
+  }
+  public function getLastFourDigits()
+  {
+    return $this->lastFourDigits;
+  }
+  public function setPredefinedBillingAddress($predefinedBillingAddress)
+  {
+    $this->predefinedBillingAddress = $predefinedBillingAddress;
+  }
+  public function getPredefinedBillingAddress()
+  {
+    return $this->predefinedBillingAddress;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_ShoppingContent_Weight extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $unit;
+  public $value;
+
+
+  public function setUnit($unit)
+  {
+    $this->unit = $unit;
+  }
+  public function getUnit()
+  {
+    return $this->unit;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/SiteVerification.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/SiteVerification.php
@@ -1,0 +1,405 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for SiteVerification (v1).
+ *
+ * <p>
+ * Lets you programatically verify ownership of websites or domains with Google.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/site-verification/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_SiteVerification extends Google_Service
+{
+  /** Manage the list of sites and domains you control. */
+  const SITEVERIFICATION =
+      "https://www.googleapis.com/auth/siteverification";
+  /** Manage your new site verifications with Google. */
+  const SITEVERIFICATION_VERIFY_ONLY =
+      "https://www.googleapis.com/auth/siteverification.verify_only";
+
+  public $webResource;
+  
+
+  /**
+   * Constructs the internal representation of the SiteVerification service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'siteVerification/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'siteVerification';
+
+    $this->webResource = new Google_Service_SiteVerification_WebResource_Resource(
+        $this,
+        $this->serviceName,
+        'webResource',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'webResource/{id}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'webResource/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'getToken' => array(
+              'path' => 'token',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'insert' => array(
+              'path' => 'webResource',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'verificationMethod' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'webResource',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),'patch' => array(
+              'path' => 'webResource/{id}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'webResource/{id}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "webResource" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $siteVerificationService = new Google_Service_SiteVerification(...);
+ *   $webResource = $siteVerificationService->webResource;
+ *  </code>
+ */
+class Google_Service_SiteVerification_WebResource_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Relinquish ownership of a website or domain. (webResource.delete)
+   *
+   * @param string $id The id of a verified site or domain.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Get the most current data for a website or domain. (webResource.get)
+   *
+   * @param string $id The id of a verified site or domain.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SiteVerification_SiteVerificationWebResourceResource
+   */
+  public function get($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_SiteVerification_SiteVerificationWebResourceResource");
+  }
+
+  /**
+   * Get a verification token for placing on a website or domain.
+   * (webResource.getToken)
+   *
+   * @param Google_SiteVerificationWebResourceGettokenRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SiteVerification_SiteVerificationWebResourceGettokenResponse
+   */
+  public function getToken(Google_Service_SiteVerification_SiteVerificationWebResourceGettokenRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('getToken', array($params), "Google_Service_SiteVerification_SiteVerificationWebResourceGettokenResponse");
+  }
+
+  /**
+   * Attempt verification of a website or domain. (webResource.insert)
+   *
+   * @param string $verificationMethod The method to use for verifying a site or
+   * domain.
+   * @param Google_SiteVerificationWebResourceResource $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SiteVerification_SiteVerificationWebResourceResource
+   */
+  public function insert($verificationMethod, Google_Service_SiteVerification_SiteVerificationWebResourceResource $postBody, $optParams = array())
+  {
+    $params = array('verificationMethod' => $verificationMethod, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_SiteVerification_SiteVerificationWebResourceResource");
+  }
+
+  /**
+   * Get the list of your verified websites and domains.
+   * (webResource.listWebResource)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SiteVerification_SiteVerificationWebResourceListResponse
+   */
+  public function listWebResource($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_SiteVerification_SiteVerificationWebResourceListResponse");
+  }
+
+  /**
+   * Modify the list of owners for your website or domain. This method supports
+   * patch semantics. (webResource.patch)
+   *
+   * @param string $id The id of a verified site or domain.
+   * @param Google_SiteVerificationWebResourceResource $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SiteVerification_SiteVerificationWebResourceResource
+   */
+  public function patch($id, Google_Service_SiteVerification_SiteVerificationWebResourceResource $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_SiteVerification_SiteVerificationWebResourceResource");
+  }
+
+  /**
+   * Modify the list of owners for your website or domain. (webResource.update)
+   *
+   * @param string $id The id of a verified site or domain.
+   * @param Google_SiteVerificationWebResourceResource $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_SiteVerification_SiteVerificationWebResourceResource
+   */
+  public function update($id, Google_Service_SiteVerification_SiteVerificationWebResourceResource $postBody, $optParams = array())
+  {
+    $params = array('id' => $id, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_SiteVerification_SiteVerificationWebResourceResource");
+  }
+}
+
+
+
+
+class Google_Service_SiteVerification_SiteVerificationWebResourceGettokenRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $siteType = 'Google_Service_SiteVerification_SiteVerificationWebResourceGettokenRequestSite';
+  protected $siteDataType = '';
+  public $verificationMethod;
+
+
+  public function setSite(Google_Service_SiteVerification_SiteVerificationWebResourceGettokenRequestSite $site)
+  {
+    $this->site = $site;
+  }
+  public function getSite()
+  {
+    return $this->site;
+  }
+  public function setVerificationMethod($verificationMethod)
+  {
+    $this->verificationMethod = $verificationMethod;
+  }
+  public function getVerificationMethod()
+  {
+    return $this->verificationMethod;
+  }
+}
+
+class Google_Service_SiteVerification_SiteVerificationWebResourceGettokenRequestSite extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $identifier;
+  public $type;
+
+
+  public function setIdentifier($identifier)
+  {
+    $this->identifier = $identifier;
+  }
+  public function getIdentifier()
+  {
+    return $this->identifier;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_SiteVerification_SiteVerificationWebResourceGettokenResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $method;
+  public $token;
+
+
+  public function setMethod($method)
+  {
+    $this->method = $method;
+  }
+  public function getMethod()
+  {
+    return $this->method;
+  }
+  public function setToken($token)
+  {
+    $this->token = $token;
+  }
+  public function getToken()
+  {
+    return $this->token;
+  }
+}
+
+class Google_Service_SiteVerification_SiteVerificationWebResourceListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_SiteVerification_SiteVerificationWebResourceResource';
+  protected $itemsDataType = 'array';
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+}
+
+class Google_Service_SiteVerification_SiteVerificationWebResourceResource extends Google_Collection
+{
+  protected $collection_key = 'owners';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $owners;
+  protected $siteType = 'Google_Service_SiteVerification_SiteVerificationWebResourceResourceSite';
+  protected $siteDataType = '';
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setOwners($owners)
+  {
+    $this->owners = $owners;
+  }
+  public function getOwners()
+  {
+    return $this->owners;
+  }
+  public function setSite(Google_Service_SiteVerification_SiteVerificationWebResourceResourceSite $site)
+  {
+    $this->site = $site;
+  }
+  public function getSite()
+  {
+    return $this->site;
+  }
+}
+
+class Google_Service_SiteVerification_SiteVerificationWebResourceResourceSite extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $identifier;
+  public $type;
+
+
+  public function setIdentifier($identifier)
+  {
+    $this->identifier = $identifier;
+  }
+  public function getIdentifier()
+  {
+    return $this->identifier;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Spectrum.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Spectrum.php
@@ -1,0 +1,1752 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Spectrum (v1explorer).
+ *
+ * <p>
+ * API for spectrum-management functions.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="http://developers.google.com/spectrum" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Spectrum extends Google_Service
+{
+
+
+  public $paws;
+  
+
+  /**
+   * Constructs the internal representation of the Spectrum service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'spectrum/v1explorer/paws/';
+    $this->version = 'v1explorer';
+    $this->serviceName = 'spectrum';
+
+    $this->paws = new Google_Service_Spectrum_Paws_Resource(
+        $this,
+        $this->serviceName,
+        'paws',
+        array(
+          'methods' => array(
+            'getSpectrum' => array(
+              'path' => 'getSpectrum',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'getSpectrumBatch' => array(
+              'path' => 'getSpectrumBatch',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'init' => array(
+              'path' => 'init',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'notifySpectrumUse' => array(
+              'path' => 'notifySpectrumUse',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'register' => array(
+              'path' => 'register',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'verifyDevice' => array(
+              'path' => 'verifyDevice',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "paws" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $spectrumService = new Google_Service_Spectrum(...);
+ *   $paws = $spectrumService->paws;
+ *  </code>
+ */
+class Google_Service_Spectrum_Paws_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Requests information about the available spectrum for a device at a location.
+   * Requests from a fixed-mode device must include owner information so the
+   * device can be registered with the database. (paws.getSpectrum)
+   *
+   * @param Google_PawsGetSpectrumRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Spectrum_PawsGetSpectrumResponse
+   */
+  public function getSpectrum(Google_Service_Spectrum_PawsGetSpectrumRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('getSpectrum', array($params), "Google_Service_Spectrum_PawsGetSpectrumResponse");
+  }
+
+  /**
+   * The Google Spectrum Database does not support batch requests, so this method
+   * always yields an UNIMPLEMENTED error. (paws.getSpectrumBatch)
+   *
+   * @param Google_PawsGetSpectrumBatchRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Spectrum_PawsGetSpectrumBatchResponse
+   */
+  public function getSpectrumBatch(Google_Service_Spectrum_PawsGetSpectrumBatchRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('getSpectrumBatch', array($params), "Google_Service_Spectrum_PawsGetSpectrumBatchResponse");
+  }
+
+  /**
+   * Initializes the connection between a white space device and the database.
+   * (paws.init)
+   *
+   * @param Google_PawsInitRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Spectrum_PawsInitResponse
+   */
+  public function init(Google_Service_Spectrum_PawsInitRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('init', array($params), "Google_Service_Spectrum_PawsInitResponse");
+  }
+
+  /**
+   * Notifies the database that the device has selected certain frequency ranges
+   * for transmission. Only to be invoked when required by the regulator. The
+   * Google Spectrum Database does not operate in domains that require
+   * notification, so this always yields an UNIMPLEMENTED error.
+   * (paws.notifySpectrumUse)
+   *
+   * @param Google_PawsNotifySpectrumUseRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Spectrum_PawsNotifySpectrumUseResponse
+   */
+  public function notifySpectrumUse(Google_Service_Spectrum_PawsNotifySpectrumUseRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('notifySpectrumUse', array($params), "Google_Service_Spectrum_PawsNotifySpectrumUseResponse");
+  }
+
+  /**
+   * The Google Spectrum Database implements registration in the getSpectrum
+   * method. As such this always returns an UNIMPLEMENTED error. (paws.register)
+   *
+   * @param Google_PawsRegisterRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Spectrum_PawsRegisterResponse
+   */
+  public function register(Google_Service_Spectrum_PawsRegisterRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('register', array($params), "Google_Service_Spectrum_PawsRegisterResponse");
+  }
+
+  /**
+   * Validates a device for white space use in accordance with regulatory rules.
+   * The Google Spectrum Database does not support master/slave configurations, so
+   * this always yields an UNIMPLEMENTED error. (paws.verifyDevice)
+   *
+   * @param Google_PawsVerifyDeviceRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Spectrum_PawsVerifyDeviceResponse
+   */
+  public function verifyDevice(Google_Service_Spectrum_PawsVerifyDeviceRequest $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('verifyDevice', array($params), "Google_Service_Spectrum_PawsVerifyDeviceResponse");
+  }
+}
+
+
+
+
+class Google_Service_Spectrum_AntennaCharacteristics extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $heightType;
+  public $heightUncertainty;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setHeightType($heightType)
+  {
+    $this->heightType = $heightType;
+  }
+  public function getHeightType()
+  {
+    return $this->heightType;
+  }
+  public function setHeightUncertainty($heightUncertainty)
+  {
+    $this->heightUncertainty = $heightUncertainty;
+  }
+  public function getHeightUncertainty()
+  {
+    return $this->heightUncertainty;
+  }
+}
+
+class Google_Service_Spectrum_DatabaseSpec extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $uri;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setUri($uri)
+  {
+    $this->uri = $uri;
+  }
+  public function getUri()
+  {
+    return $this->uri;
+  }
+}
+
+class Google_Service_Spectrum_DbUpdateSpec extends Google_Collection
+{
+  protected $collection_key = 'databases';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $databasesType = 'Google_Service_Spectrum_DatabaseSpec';
+  protected $databasesDataType = 'array';
+
+
+  public function setDatabases($databases)
+  {
+    $this->databases = $databases;
+  }
+  public function getDatabases()
+  {
+    return $this->databases;
+  }
+}
+
+class Google_Service_Spectrum_DeviceCapabilities extends Google_Collection
+{
+  protected $collection_key = 'frequencyRanges';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $frequencyRangesType = 'Google_Service_Spectrum_FrequencyRange';
+  protected $frequencyRangesDataType = 'array';
+
+
+  public function setFrequencyRanges($frequencyRanges)
+  {
+    $this->frequencyRanges = $frequencyRanges;
+  }
+  public function getFrequencyRanges()
+  {
+    return $this->frequencyRanges;
+  }
+}
+
+class Google_Service_Spectrum_DeviceDescriptor extends Google_Collection
+{
+  protected $collection_key = 'rulesetIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etsiEnDeviceCategory;
+  public $etsiEnDeviceEmissionsClass;
+  public $etsiEnDeviceType;
+  public $etsiEnTechnologyId;
+  public $fccId;
+  public $fccTvbdDeviceType;
+  public $manufacturerId;
+  public $modelId;
+  public $rulesetIds;
+  public $serialNumber;
+
+
+  public function setEtsiEnDeviceCategory($etsiEnDeviceCategory)
+  {
+    $this->etsiEnDeviceCategory = $etsiEnDeviceCategory;
+  }
+  public function getEtsiEnDeviceCategory()
+  {
+    return $this->etsiEnDeviceCategory;
+  }
+  public function setEtsiEnDeviceEmissionsClass($etsiEnDeviceEmissionsClass)
+  {
+    $this->etsiEnDeviceEmissionsClass = $etsiEnDeviceEmissionsClass;
+  }
+  public function getEtsiEnDeviceEmissionsClass()
+  {
+    return $this->etsiEnDeviceEmissionsClass;
+  }
+  public function setEtsiEnDeviceType($etsiEnDeviceType)
+  {
+    $this->etsiEnDeviceType = $etsiEnDeviceType;
+  }
+  public function getEtsiEnDeviceType()
+  {
+    return $this->etsiEnDeviceType;
+  }
+  public function setEtsiEnTechnologyId($etsiEnTechnologyId)
+  {
+    $this->etsiEnTechnologyId = $etsiEnTechnologyId;
+  }
+  public function getEtsiEnTechnologyId()
+  {
+    return $this->etsiEnTechnologyId;
+  }
+  public function setFccId($fccId)
+  {
+    $this->fccId = $fccId;
+  }
+  public function getFccId()
+  {
+    return $this->fccId;
+  }
+  public function setFccTvbdDeviceType($fccTvbdDeviceType)
+  {
+    $this->fccTvbdDeviceType = $fccTvbdDeviceType;
+  }
+  public function getFccTvbdDeviceType()
+  {
+    return $this->fccTvbdDeviceType;
+  }
+  public function setManufacturerId($manufacturerId)
+  {
+    $this->manufacturerId = $manufacturerId;
+  }
+  public function getManufacturerId()
+  {
+    return $this->manufacturerId;
+  }
+  public function setModelId($modelId)
+  {
+    $this->modelId = $modelId;
+  }
+  public function getModelId()
+  {
+    return $this->modelId;
+  }
+  public function setRulesetIds($rulesetIds)
+  {
+    $this->rulesetIds = $rulesetIds;
+  }
+  public function getRulesetIds()
+  {
+    return $this->rulesetIds;
+  }
+  public function setSerialNumber($serialNumber)
+  {
+    $this->serialNumber = $serialNumber;
+  }
+  public function getSerialNumber()
+  {
+    return $this->serialNumber;
+  }
+}
+
+class Google_Service_Spectrum_DeviceOwner extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $operatorType = 'Google_Service_Spectrum_Vcard';
+  protected $operatorDataType = '';
+  protected $ownerType = 'Google_Service_Spectrum_Vcard';
+  protected $ownerDataType = '';
+
+
+  public function setOperator(Google_Service_Spectrum_Vcard $operator)
+  {
+    $this->operator = $operator;
+  }
+  public function getOperator()
+  {
+    return $this->operator;
+  }
+  public function setOwner(Google_Service_Spectrum_Vcard $owner)
+  {
+    $this->owner = $owner;
+  }
+  public function getOwner()
+  {
+    return $this->owner;
+  }
+}
+
+class Google_Service_Spectrum_DeviceValidity extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $deviceDescType = 'Google_Service_Spectrum_DeviceDescriptor';
+  protected $deviceDescDataType = '';
+  public $isValid;
+  public $reason;
+
+
+  public function setDeviceDesc(Google_Service_Spectrum_DeviceDescriptor $deviceDesc)
+  {
+    $this->deviceDesc = $deviceDesc;
+  }
+  public function getDeviceDesc()
+  {
+    return $this->deviceDesc;
+  }
+  public function setIsValid($isValid)
+  {
+    $this->isValid = $isValid;
+  }
+  public function getIsValid()
+  {
+    return $this->isValid;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+}
+
+class Google_Service_Spectrum_EventTime extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $startTime;
+  public $stopTime;
+
+
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+  public function setStopTime($stopTime)
+  {
+    $this->stopTime = $stopTime;
+  }
+  public function getStopTime()
+  {
+    return $this->stopTime;
+  }
+}
+
+class Google_Service_Spectrum_FrequencyRange extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $channelId;
+  public $maxPowerDBm;
+  public $startHz;
+  public $stopHz;
+
+
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setMaxPowerDBm($maxPowerDBm)
+  {
+    $this->maxPowerDBm = $maxPowerDBm;
+  }
+  public function getMaxPowerDBm()
+  {
+    return $this->maxPowerDBm;
+  }
+  public function setStartHz($startHz)
+  {
+    $this->startHz = $startHz;
+  }
+  public function getStartHz()
+  {
+    return $this->startHz;
+  }
+  public function setStopHz($stopHz)
+  {
+    $this->stopHz = $stopHz;
+  }
+  public function getStopHz()
+  {
+    return $this->stopHz;
+  }
+}
+
+class Google_Service_Spectrum_GeoLocation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $confidence;
+  protected $pointType = 'Google_Service_Spectrum_GeoLocationEllipse';
+  protected $pointDataType = '';
+  protected $regionType = 'Google_Service_Spectrum_GeoLocationPolygon';
+  protected $regionDataType = '';
+
+
+  public function setConfidence($confidence)
+  {
+    $this->confidence = $confidence;
+  }
+  public function getConfidence()
+  {
+    return $this->confidence;
+  }
+  public function setPoint(Google_Service_Spectrum_GeoLocationEllipse $point)
+  {
+    $this->point = $point;
+  }
+  public function getPoint()
+  {
+    return $this->point;
+  }
+  public function setRegion(Google_Service_Spectrum_GeoLocationPolygon $region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+}
+
+class Google_Service_Spectrum_GeoLocationEllipse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $centerType = 'Google_Service_Spectrum_GeoLocationPoint';
+  protected $centerDataType = '';
+  public $orientation;
+  public $semiMajorAxis;
+  public $semiMinorAxis;
+
+
+  public function setCenter(Google_Service_Spectrum_GeoLocationPoint $center)
+  {
+    $this->center = $center;
+  }
+  public function getCenter()
+  {
+    return $this->center;
+  }
+  public function setOrientation($orientation)
+  {
+    $this->orientation = $orientation;
+  }
+  public function getOrientation()
+  {
+    return $this->orientation;
+  }
+  public function setSemiMajorAxis($semiMajorAxis)
+  {
+    $this->semiMajorAxis = $semiMajorAxis;
+  }
+  public function getSemiMajorAxis()
+  {
+    return $this->semiMajorAxis;
+  }
+  public function setSemiMinorAxis($semiMinorAxis)
+  {
+    $this->semiMinorAxis = $semiMinorAxis;
+  }
+  public function getSemiMinorAxis()
+  {
+    return $this->semiMinorAxis;
+  }
+}
+
+class Google_Service_Spectrum_GeoLocationPoint extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $latitude;
+  public $longitude;
+
+
+  public function setLatitude($latitude)
+  {
+    $this->latitude = $latitude;
+  }
+  public function getLatitude()
+  {
+    return $this->latitude;
+  }
+  public function setLongitude($longitude)
+  {
+    $this->longitude = $longitude;
+  }
+  public function getLongitude()
+  {
+    return $this->longitude;
+  }
+}
+
+class Google_Service_Spectrum_GeoLocationPolygon extends Google_Collection
+{
+  protected $collection_key = 'exterior';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $exteriorType = 'Google_Service_Spectrum_GeoLocationPoint';
+  protected $exteriorDataType = 'array';
+
+
+  public function setExterior($exterior)
+  {
+    $this->exterior = $exterior;
+  }
+  public function getExterior()
+  {
+    return $this->exterior;
+  }
+}
+
+class Google_Service_Spectrum_GeoSpectrumSchedule extends Google_Collection
+{
+  protected $collection_key = 'spectrumSchedules';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $locationType = 'Google_Service_Spectrum_GeoLocation';
+  protected $locationDataType = '';
+  protected $spectrumSchedulesType = 'Google_Service_Spectrum_SpectrumSchedule';
+  protected $spectrumSchedulesDataType = 'array';
+
+
+  public function setLocation(Google_Service_Spectrum_GeoLocation $location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setSpectrumSchedules($spectrumSchedules)
+  {
+    $this->spectrumSchedules = $spectrumSchedules;
+  }
+  public function getSpectrumSchedules()
+  {
+    return $this->spectrumSchedules;
+  }
+}
+
+class Google_Service_Spectrum_PawsGetSpectrumBatchRequest extends Google_Collection
+{
+  protected $collection_key = 'locations';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $antennaType = 'Google_Service_Spectrum_AntennaCharacteristics';
+  protected $antennaDataType = '';
+  protected $capabilitiesType = 'Google_Service_Spectrum_DeviceCapabilities';
+  protected $capabilitiesDataType = '';
+  protected $deviceDescType = 'Google_Service_Spectrum_DeviceDescriptor';
+  protected $deviceDescDataType = '';
+  protected $locationsType = 'Google_Service_Spectrum_GeoLocation';
+  protected $locationsDataType = 'array';
+  protected $masterDeviceDescType = 'Google_Service_Spectrum_DeviceDescriptor';
+  protected $masterDeviceDescDataType = '';
+  protected $ownerType = 'Google_Service_Spectrum_DeviceOwner';
+  protected $ownerDataType = '';
+  public $requestType;
+  public $type;
+  public $version;
+
+
+  public function setAntenna(Google_Service_Spectrum_AntennaCharacteristics $antenna)
+  {
+    $this->antenna = $antenna;
+  }
+  public function getAntenna()
+  {
+    return $this->antenna;
+  }
+  public function setCapabilities(Google_Service_Spectrum_DeviceCapabilities $capabilities)
+  {
+    $this->capabilities = $capabilities;
+  }
+  public function getCapabilities()
+  {
+    return $this->capabilities;
+  }
+  public function setDeviceDesc(Google_Service_Spectrum_DeviceDescriptor $deviceDesc)
+  {
+    $this->deviceDesc = $deviceDesc;
+  }
+  public function getDeviceDesc()
+  {
+    return $this->deviceDesc;
+  }
+  public function setLocations($locations)
+  {
+    $this->locations = $locations;
+  }
+  public function getLocations()
+  {
+    return $this->locations;
+  }
+  public function setMasterDeviceDesc(Google_Service_Spectrum_DeviceDescriptor $masterDeviceDesc)
+  {
+    $this->masterDeviceDesc = $masterDeviceDesc;
+  }
+  public function getMasterDeviceDesc()
+  {
+    return $this->masterDeviceDesc;
+  }
+  public function setOwner(Google_Service_Spectrum_DeviceOwner $owner)
+  {
+    $this->owner = $owner;
+  }
+  public function getOwner()
+  {
+    return $this->owner;
+  }
+  public function setRequestType($requestType)
+  {
+    $this->requestType = $requestType;
+  }
+  public function getRequestType()
+  {
+    return $this->requestType;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Spectrum_PawsGetSpectrumBatchResponse extends Google_Collection
+{
+  protected $collection_key = 'geoSpectrumSchedules';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $databaseChangeType = 'Google_Service_Spectrum_DbUpdateSpec';
+  protected $databaseChangeDataType = '';
+  protected $deviceDescType = 'Google_Service_Spectrum_DeviceDescriptor';
+  protected $deviceDescDataType = '';
+  protected $geoSpectrumSchedulesType = 'Google_Service_Spectrum_GeoSpectrumSchedule';
+  protected $geoSpectrumSchedulesDataType = 'array';
+  public $kind;
+  public $maxContiguousBwHz;
+  public $maxTotalBwHz;
+  public $needsSpectrumReport;
+  protected $rulesetInfoType = 'Google_Service_Spectrum_RulesetInfo';
+  protected $rulesetInfoDataType = '';
+  public $timestamp;
+  public $type;
+  public $version;
+
+
+  public function setDatabaseChange(Google_Service_Spectrum_DbUpdateSpec $databaseChange)
+  {
+    $this->databaseChange = $databaseChange;
+  }
+  public function getDatabaseChange()
+  {
+    return $this->databaseChange;
+  }
+  public function setDeviceDesc(Google_Service_Spectrum_DeviceDescriptor $deviceDesc)
+  {
+    $this->deviceDesc = $deviceDesc;
+  }
+  public function getDeviceDesc()
+  {
+    return $this->deviceDesc;
+  }
+  public function setGeoSpectrumSchedules($geoSpectrumSchedules)
+  {
+    $this->geoSpectrumSchedules = $geoSpectrumSchedules;
+  }
+  public function getGeoSpectrumSchedules()
+  {
+    return $this->geoSpectrumSchedules;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMaxContiguousBwHz($maxContiguousBwHz)
+  {
+    $this->maxContiguousBwHz = $maxContiguousBwHz;
+  }
+  public function getMaxContiguousBwHz()
+  {
+    return $this->maxContiguousBwHz;
+  }
+  public function setMaxTotalBwHz($maxTotalBwHz)
+  {
+    $this->maxTotalBwHz = $maxTotalBwHz;
+  }
+  public function getMaxTotalBwHz()
+  {
+    return $this->maxTotalBwHz;
+  }
+  public function setNeedsSpectrumReport($needsSpectrumReport)
+  {
+    $this->needsSpectrumReport = $needsSpectrumReport;
+  }
+  public function getNeedsSpectrumReport()
+  {
+    return $this->needsSpectrumReport;
+  }
+  public function setRulesetInfo(Google_Service_Spectrum_RulesetInfo $rulesetInfo)
+  {
+    $this->rulesetInfo = $rulesetInfo;
+  }
+  public function getRulesetInfo()
+  {
+    return $this->rulesetInfo;
+  }
+  public function setTimestamp($timestamp)
+  {
+    $this->timestamp = $timestamp;
+  }
+  public function getTimestamp()
+  {
+    return $this->timestamp;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Spectrum_PawsGetSpectrumRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $antennaType = 'Google_Service_Spectrum_AntennaCharacteristics';
+  protected $antennaDataType = '';
+  protected $capabilitiesType = 'Google_Service_Spectrum_DeviceCapabilities';
+  protected $capabilitiesDataType = '';
+  protected $deviceDescType = 'Google_Service_Spectrum_DeviceDescriptor';
+  protected $deviceDescDataType = '';
+  protected $locationType = 'Google_Service_Spectrum_GeoLocation';
+  protected $locationDataType = '';
+  protected $masterDeviceDescType = 'Google_Service_Spectrum_DeviceDescriptor';
+  protected $masterDeviceDescDataType = '';
+  protected $ownerType = 'Google_Service_Spectrum_DeviceOwner';
+  protected $ownerDataType = '';
+  public $requestType;
+  public $type;
+  public $version;
+
+
+  public function setAntenna(Google_Service_Spectrum_AntennaCharacteristics $antenna)
+  {
+    $this->antenna = $antenna;
+  }
+  public function getAntenna()
+  {
+    return $this->antenna;
+  }
+  public function setCapabilities(Google_Service_Spectrum_DeviceCapabilities $capabilities)
+  {
+    $this->capabilities = $capabilities;
+  }
+  public function getCapabilities()
+  {
+    return $this->capabilities;
+  }
+  public function setDeviceDesc(Google_Service_Spectrum_DeviceDescriptor $deviceDesc)
+  {
+    $this->deviceDesc = $deviceDesc;
+  }
+  public function getDeviceDesc()
+  {
+    return $this->deviceDesc;
+  }
+  public function setLocation(Google_Service_Spectrum_GeoLocation $location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setMasterDeviceDesc(Google_Service_Spectrum_DeviceDescriptor $masterDeviceDesc)
+  {
+    $this->masterDeviceDesc = $masterDeviceDesc;
+  }
+  public function getMasterDeviceDesc()
+  {
+    return $this->masterDeviceDesc;
+  }
+  public function setOwner(Google_Service_Spectrum_DeviceOwner $owner)
+  {
+    $this->owner = $owner;
+  }
+  public function getOwner()
+  {
+    return $this->owner;
+  }
+  public function setRequestType($requestType)
+  {
+    $this->requestType = $requestType;
+  }
+  public function getRequestType()
+  {
+    return $this->requestType;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Spectrum_PawsGetSpectrumResponse extends Google_Collection
+{
+  protected $collection_key = 'spectrumSchedules';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $databaseChangeType = 'Google_Service_Spectrum_DbUpdateSpec';
+  protected $databaseChangeDataType = '';
+  protected $deviceDescType = 'Google_Service_Spectrum_DeviceDescriptor';
+  protected $deviceDescDataType = '';
+  public $kind;
+  public $maxContiguousBwHz;
+  public $maxTotalBwHz;
+  public $needsSpectrumReport;
+  protected $rulesetInfoType = 'Google_Service_Spectrum_RulesetInfo';
+  protected $rulesetInfoDataType = '';
+  protected $spectrumSchedulesType = 'Google_Service_Spectrum_SpectrumSchedule';
+  protected $spectrumSchedulesDataType = 'array';
+  public $timestamp;
+  public $type;
+  public $version;
+
+
+  public function setDatabaseChange(Google_Service_Spectrum_DbUpdateSpec $databaseChange)
+  {
+    $this->databaseChange = $databaseChange;
+  }
+  public function getDatabaseChange()
+  {
+    return $this->databaseChange;
+  }
+  public function setDeviceDesc(Google_Service_Spectrum_DeviceDescriptor $deviceDesc)
+  {
+    $this->deviceDesc = $deviceDesc;
+  }
+  public function getDeviceDesc()
+  {
+    return $this->deviceDesc;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMaxContiguousBwHz($maxContiguousBwHz)
+  {
+    $this->maxContiguousBwHz = $maxContiguousBwHz;
+  }
+  public function getMaxContiguousBwHz()
+  {
+    return $this->maxContiguousBwHz;
+  }
+  public function setMaxTotalBwHz($maxTotalBwHz)
+  {
+    $this->maxTotalBwHz = $maxTotalBwHz;
+  }
+  public function getMaxTotalBwHz()
+  {
+    return $this->maxTotalBwHz;
+  }
+  public function setNeedsSpectrumReport($needsSpectrumReport)
+  {
+    $this->needsSpectrumReport = $needsSpectrumReport;
+  }
+  public function getNeedsSpectrumReport()
+  {
+    return $this->needsSpectrumReport;
+  }
+  public function setRulesetInfo(Google_Service_Spectrum_RulesetInfo $rulesetInfo)
+  {
+    $this->rulesetInfo = $rulesetInfo;
+  }
+  public function getRulesetInfo()
+  {
+    return $this->rulesetInfo;
+  }
+  public function setSpectrumSchedules($spectrumSchedules)
+  {
+    $this->spectrumSchedules = $spectrumSchedules;
+  }
+  public function getSpectrumSchedules()
+  {
+    return $this->spectrumSchedules;
+  }
+  public function setTimestamp($timestamp)
+  {
+    $this->timestamp = $timestamp;
+  }
+  public function getTimestamp()
+  {
+    return $this->timestamp;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Spectrum_PawsInitRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $deviceDescType = 'Google_Service_Spectrum_DeviceDescriptor';
+  protected $deviceDescDataType = '';
+  protected $locationType = 'Google_Service_Spectrum_GeoLocation';
+  protected $locationDataType = '';
+  public $type;
+  public $version;
+
+
+  public function setDeviceDesc(Google_Service_Spectrum_DeviceDescriptor $deviceDesc)
+  {
+    $this->deviceDesc = $deviceDesc;
+  }
+  public function getDeviceDesc()
+  {
+    return $this->deviceDesc;
+  }
+  public function setLocation(Google_Service_Spectrum_GeoLocation $location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Spectrum_PawsInitResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $databaseChangeType = 'Google_Service_Spectrum_DbUpdateSpec';
+  protected $databaseChangeDataType = '';
+  public $kind;
+  protected $rulesetInfoType = 'Google_Service_Spectrum_RulesetInfo';
+  protected $rulesetInfoDataType = '';
+  public $type;
+  public $version;
+
+
+  public function setDatabaseChange(Google_Service_Spectrum_DbUpdateSpec $databaseChange)
+  {
+    $this->databaseChange = $databaseChange;
+  }
+  public function getDatabaseChange()
+  {
+    return $this->databaseChange;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRulesetInfo(Google_Service_Spectrum_RulesetInfo $rulesetInfo)
+  {
+    $this->rulesetInfo = $rulesetInfo;
+  }
+  public function getRulesetInfo()
+  {
+    return $this->rulesetInfo;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Spectrum_PawsNotifySpectrumUseRequest extends Google_Collection
+{
+  protected $collection_key = 'spectra';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $deviceDescType = 'Google_Service_Spectrum_DeviceDescriptor';
+  protected $deviceDescDataType = '';
+  protected $locationType = 'Google_Service_Spectrum_GeoLocation';
+  protected $locationDataType = '';
+  protected $spectraType = 'Google_Service_Spectrum_SpectrumMessage';
+  protected $spectraDataType = 'array';
+  public $type;
+  public $version;
+
+
+  public function setDeviceDesc(Google_Service_Spectrum_DeviceDescriptor $deviceDesc)
+  {
+    $this->deviceDesc = $deviceDesc;
+  }
+  public function getDeviceDesc()
+  {
+    return $this->deviceDesc;
+  }
+  public function setLocation(Google_Service_Spectrum_GeoLocation $location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setSpectra($spectra)
+  {
+    $this->spectra = $spectra;
+  }
+  public function getSpectra()
+  {
+    return $this->spectra;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Spectrum_PawsNotifySpectrumUseResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $kind;
+  public $type;
+  public $version;
+
+
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Spectrum_PawsRegisterRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $antennaType = 'Google_Service_Spectrum_AntennaCharacteristics';
+  protected $antennaDataType = '';
+  protected $deviceDescType = 'Google_Service_Spectrum_DeviceDescriptor';
+  protected $deviceDescDataType = '';
+  protected $deviceOwnerType = 'Google_Service_Spectrum_DeviceOwner';
+  protected $deviceOwnerDataType = '';
+  protected $locationType = 'Google_Service_Spectrum_GeoLocation';
+  protected $locationDataType = '';
+  public $type;
+  public $version;
+
+
+  public function setAntenna(Google_Service_Spectrum_AntennaCharacteristics $antenna)
+  {
+    $this->antenna = $antenna;
+  }
+  public function getAntenna()
+  {
+    return $this->antenna;
+  }
+  public function setDeviceDesc(Google_Service_Spectrum_DeviceDescriptor $deviceDesc)
+  {
+    $this->deviceDesc = $deviceDesc;
+  }
+  public function getDeviceDesc()
+  {
+    return $this->deviceDesc;
+  }
+  public function setDeviceOwner(Google_Service_Spectrum_DeviceOwner $deviceOwner)
+  {
+    $this->deviceOwner = $deviceOwner;
+  }
+  public function getDeviceOwner()
+  {
+    return $this->deviceOwner;
+  }
+  public function setLocation(Google_Service_Spectrum_GeoLocation $location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Spectrum_PawsRegisterResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $databaseChangeType = 'Google_Service_Spectrum_DbUpdateSpec';
+  protected $databaseChangeDataType = '';
+  public $kind;
+  public $type;
+  public $version;
+
+
+  public function setDatabaseChange(Google_Service_Spectrum_DbUpdateSpec $databaseChange)
+  {
+    $this->databaseChange = $databaseChange;
+  }
+  public function getDatabaseChange()
+  {
+    return $this->databaseChange;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Spectrum_PawsVerifyDeviceRequest extends Google_Collection
+{
+  protected $collection_key = 'deviceDescs';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $deviceDescsType = 'Google_Service_Spectrum_DeviceDescriptor';
+  protected $deviceDescsDataType = 'array';
+  public $type;
+  public $version;
+
+
+  public function setDeviceDescs($deviceDescs)
+  {
+    $this->deviceDescs = $deviceDescs;
+  }
+  public function getDeviceDescs()
+  {
+    return $this->deviceDescs;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Spectrum_PawsVerifyDeviceResponse extends Google_Collection
+{
+  protected $collection_key = 'deviceValidities';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $databaseChangeType = 'Google_Service_Spectrum_DbUpdateSpec';
+  protected $databaseChangeDataType = '';
+  protected $deviceValiditiesType = 'Google_Service_Spectrum_DeviceValidity';
+  protected $deviceValiditiesDataType = 'array';
+  public $kind;
+  public $type;
+  public $version;
+
+
+  public function setDatabaseChange(Google_Service_Spectrum_DbUpdateSpec $databaseChange)
+  {
+    $this->databaseChange = $databaseChange;
+  }
+  public function getDatabaseChange()
+  {
+    return $this->databaseChange;
+  }
+  public function setDeviceValidities($deviceValidities)
+  {
+    $this->deviceValidities = $deviceValidities;
+  }
+  public function getDeviceValidities()
+  {
+    return $this->deviceValidities;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Spectrum_RulesetInfo extends Google_Collection
+{
+  protected $collection_key = 'rulesetIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $authority;
+  public $maxLocationChange;
+  public $maxPollingSecs;
+  public $rulesetIds;
+
+
+  public function setAuthority($authority)
+  {
+    $this->authority = $authority;
+  }
+  public function getAuthority()
+  {
+    return $this->authority;
+  }
+  public function setMaxLocationChange($maxLocationChange)
+  {
+    $this->maxLocationChange = $maxLocationChange;
+  }
+  public function getMaxLocationChange()
+  {
+    return $this->maxLocationChange;
+  }
+  public function setMaxPollingSecs($maxPollingSecs)
+  {
+    $this->maxPollingSecs = $maxPollingSecs;
+  }
+  public function getMaxPollingSecs()
+  {
+    return $this->maxPollingSecs;
+  }
+  public function setRulesetIds($rulesetIds)
+  {
+    $this->rulesetIds = $rulesetIds;
+  }
+  public function getRulesetIds()
+  {
+    return $this->rulesetIds;
+  }
+}
+
+class Google_Service_Spectrum_SpectrumMessage extends Google_Collection
+{
+  protected $collection_key = 'frequencyRanges';
+  protected $internal_gapi_mappings = array(
+  );
+  public $bandwidth;
+  protected $frequencyRangesType = 'Google_Service_Spectrum_FrequencyRange';
+  protected $frequencyRangesDataType = 'array';
+
+
+  public function setBandwidth($bandwidth)
+  {
+    $this->bandwidth = $bandwidth;
+  }
+  public function getBandwidth()
+  {
+    return $this->bandwidth;
+  }
+  public function setFrequencyRanges($frequencyRanges)
+  {
+    $this->frequencyRanges = $frequencyRanges;
+  }
+  public function getFrequencyRanges()
+  {
+    return $this->frequencyRanges;
+  }
+}
+
+class Google_Service_Spectrum_SpectrumSchedule extends Google_Collection
+{
+  protected $collection_key = 'spectra';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $eventTimeType = 'Google_Service_Spectrum_EventTime';
+  protected $eventTimeDataType = '';
+  protected $spectraType = 'Google_Service_Spectrum_SpectrumMessage';
+  protected $spectraDataType = 'array';
+
+
+  public function setEventTime(Google_Service_Spectrum_EventTime $eventTime)
+  {
+    $this->eventTime = $eventTime;
+  }
+  public function getEventTime()
+  {
+    return $this->eventTime;
+  }
+  public function setSpectra($spectra)
+  {
+    $this->spectra = $spectra;
+  }
+  public function getSpectra()
+  {
+    return $this->spectra;
+  }
+}
+
+class Google_Service_Spectrum_Vcard extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $adrType = 'Google_Service_Spectrum_VcardAddress';
+  protected $adrDataType = '';
+  protected $emailType = 'Google_Service_Spectrum_VcardTypedText';
+  protected $emailDataType = '';
+  public $fn;
+  protected $orgType = 'Google_Service_Spectrum_VcardTypedText';
+  protected $orgDataType = '';
+  protected $telType = 'Google_Service_Spectrum_VcardTelephone';
+  protected $telDataType = '';
+
+
+  public function setAdr(Google_Service_Spectrum_VcardAddress $adr)
+  {
+    $this->adr = $adr;
+  }
+  public function getAdr()
+  {
+    return $this->adr;
+  }
+  public function setEmail(Google_Service_Spectrum_VcardTypedText $email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setFn($fn)
+  {
+    $this->fn = $fn;
+  }
+  public function getFn()
+  {
+    return $this->fn;
+  }
+  public function setOrg(Google_Service_Spectrum_VcardTypedText $org)
+  {
+    $this->org = $org;
+  }
+  public function getOrg()
+  {
+    return $this->org;
+  }
+  public function setTel(Google_Service_Spectrum_VcardTelephone $tel)
+  {
+    $this->tel = $tel;
+  }
+  public function getTel()
+  {
+    return $this->tel;
+  }
+}
+
+class Google_Service_Spectrum_VcardAddress extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $country;
+  public $locality;
+  public $pobox;
+  public $region;
+  public $street;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setCountry($country)
+  {
+    $this->country = $country;
+  }
+  public function getCountry()
+  {
+    return $this->country;
+  }
+  public function setLocality($locality)
+  {
+    $this->locality = $locality;
+  }
+  public function getLocality()
+  {
+    return $this->locality;
+  }
+  public function setPobox($pobox)
+  {
+    $this->pobox = $pobox;
+  }
+  public function getPobox()
+  {
+    return $this->pobox;
+  }
+  public function setRegion($region)
+  {
+    $this->region = $region;
+  }
+  public function getRegion()
+  {
+    return $this->region;
+  }
+  public function setStreet($street)
+  {
+    $this->street = $street;
+  }
+  public function getStreet()
+  {
+    return $this->street;
+  }
+}
+
+class Google_Service_Spectrum_VcardTelephone extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $uri;
+
+
+  public function setUri($uri)
+  {
+    $this->uri = $uri;
+  }
+  public function getUri()
+  {
+    return $this->uri;
+  }
+}
+
+class Google_Service_Spectrum_VcardTypedText extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $text;
+
+
+  public function setText($text)
+  {
+    $this->text = $text;
+  }
+  public function getText()
+  {
+    return $this->text;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Storage.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Storage.php
@@ -1,0 +1,3350 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Storage (v1).
+ *
+ * <p>
+ * Lets you store and retrieve potentially-large, immutable data objects.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/storage/docs/json_api/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Storage extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+  /** View your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM_READ_ONLY =
+      "https://www.googleapis.com/auth/cloud-platform.read-only";
+  /** Manage your data and permissions in Google Cloud Storage. */
+  const DEVSTORAGE_FULL_CONTROL =
+      "https://www.googleapis.com/auth/devstorage.full_control";
+  /** View your data in Google Cloud Storage. */
+  const DEVSTORAGE_READ_ONLY =
+      "https://www.googleapis.com/auth/devstorage.read_only";
+  /** Manage your data in Google Cloud Storage. */
+  const DEVSTORAGE_READ_WRITE =
+      "https://www.googleapis.com/auth/devstorage.read_write";
+
+  public $bucketAccessControls;
+  public $buckets;
+  public $channels;
+  public $defaultObjectAccessControls;
+  public $objectAccessControls;
+  public $objects;
+  
+
+  /**
+   * Constructs the internal representation of the Storage service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'storage/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'storage';
+
+    $this->bucketAccessControls = new Google_Service_Storage_BucketAccessControls_Resource(
+        $this,
+        $this->serviceName,
+        'bucketAccessControls',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'b/{bucket}/acl/{entity}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'entity' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'b/{bucket}/acl/{entity}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'entity' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'b/{bucket}/acl',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'b/{bucket}/acl',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'b/{bucket}/acl/{entity}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'entity' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'b/{bucket}/acl/{entity}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'entity' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->buckets = new Google_Service_Storage_Buckets_Resource(
+        $this,
+        $this->serviceName,
+        'buckets',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'b/{bucket}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ifMetagenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'b/{bucket}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ifMetagenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'b',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'predefinedAcl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'predefinedDefaultObjectAcl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'b',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'prefix' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'b/{bucket}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'predefinedDefaultObjectAcl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'predefinedAcl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'b/{bucket}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'predefinedDefaultObjectAcl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'predefinedAcl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->channels = new Google_Service_Storage_Channels_Resource(
+        $this,
+        $this->serviceName,
+        'channels',
+        array(
+          'methods' => array(
+            'stop' => array(
+              'path' => 'channels/stop',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->defaultObjectAccessControls = new Google_Service_Storage_DefaultObjectAccessControls_Resource(
+        $this,
+        $this->serviceName,
+        'defaultObjectAccessControls',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'b/{bucket}/defaultObjectAcl/{entity}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'entity' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'b/{bucket}/defaultObjectAcl/{entity}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'entity' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'b/{bucket}/defaultObjectAcl',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'b/{bucket}/defaultObjectAcl',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ifMetagenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'b/{bucket}/defaultObjectAcl/{entity}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'entity' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'b/{bucket}/defaultObjectAcl/{entity}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'entity' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->objectAccessControls = new Google_Service_Storage_ObjectAccessControls_Resource(
+        $this,
+        $this->serviceName,
+        'objectAccessControls',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'b/{bucket}/o/{object}/acl/{entity}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'object' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'entity' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'generation' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'b/{bucket}/o/{object}/acl/{entity}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'object' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'entity' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'generation' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'b/{bucket}/o/{object}/acl',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'object' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'generation' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'b/{bucket}/o/{object}/acl',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'object' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'generation' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'b/{bucket}/o/{object}/acl/{entity}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'object' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'entity' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'generation' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'b/{bucket}/o/{object}/acl/{entity}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'object' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'entity' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'generation' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->objects = new Google_Service_Storage_Objects_Resource(
+        $this,
+        $this->serviceName,
+        'objects',
+        array(
+          'methods' => array(
+            'compose' => array(
+              'path' => 'b/{destinationBucket}/o/{destinationObject}/compose',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'destinationBucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'destinationObject' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ifGenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'destinationPredefinedAcl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'copy' => array(
+              'path' => 'b/{sourceBucket}/o/{sourceObject}/copyTo/b/{destinationBucket}/o/{destinationObject}',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'sourceBucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sourceObject' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'destinationBucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'destinationObject' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ifSourceGenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifGenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifSourceMetagenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sourceGeneration' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'destinationPredefinedAcl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifSourceGenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifSourceMetagenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifGenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'b/{bucket}/o/{object}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'object' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ifGenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'generation' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifGenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'b/{bucket}/o/{object}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'object' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ifGenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'generation' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifGenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'b/{bucket}/o',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'predefinedAcl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifGenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'contentEncoding' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifGenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'name' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'b/{bucket}/o',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'versions' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'prefix' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'delimiter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'b/{bucket}/o/{object}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'object' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'predefinedAcl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifGenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'generation' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifGenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'rewrite' => array(
+              'path' => 'b/{sourceBucket}/o/{sourceObject}/rewriteTo/b/{destinationBucket}/o/{destinationObject}',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'sourceBucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sourceObject' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'destinationBucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'destinationObject' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'ifSourceGenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifGenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'rewriteToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifSourceMetagenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sourceGeneration' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'destinationPredefinedAcl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifSourceGenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxBytesRewrittenPerCall' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifSourceMetagenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifGenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'b/{bucket}/o/{object}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'object' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'predefinedAcl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifGenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'generation' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifGenerationMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'ifMetagenerationNotMatch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'watchAll' => array(
+              'path' => 'b/{bucket}/o/watch',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'bucket' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'versions' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'prefix' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'delimiter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "bucketAccessControls" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $storageService = new Google_Service_Storage(...);
+ *   $bucketAccessControls = $storageService->bucketAccessControls;
+ *  </code>
+ */
+class Google_Service_Storage_BucketAccessControls_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Permanently deletes the ACL entry for the specified entity on the specified
+   * bucket. (bucketAccessControls.delete)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param string $entity The entity holding the permission. Can be user-userId,
+   * user-emailAddress, group-groupId, group-emailAddress, allUsers, or
+   * allAuthenticatedUsers.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($bucket, $entity, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'entity' => $entity);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Returns the ACL entry for the specified entity on the specified bucket.
+   * (bucketAccessControls.get)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param string $entity The entity holding the permission. Can be user-userId,
+   * user-emailAddress, group-groupId, group-emailAddress, allUsers, or
+   * allAuthenticatedUsers.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Storage_BucketAccessControl
+   */
+  public function get($bucket, $entity, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'entity' => $entity);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Storage_BucketAccessControl");
+  }
+
+  /**
+   * Creates a new ACL entry on the specified bucket.
+   * (bucketAccessControls.insert)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param Google_BucketAccessControl $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Storage_BucketAccessControl
+   */
+  public function insert($bucket, Google_Service_Storage_BucketAccessControl $postBody, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Storage_BucketAccessControl");
+  }
+
+  /**
+   * Retrieves ACL entries on the specified bucket.
+   * (bucketAccessControls.listBucketAccessControls)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Storage_BucketAccessControls
+   */
+  public function listBucketAccessControls($bucket, $optParams = array())
+  {
+    $params = array('bucket' => $bucket);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Storage_BucketAccessControls");
+  }
+
+  /**
+   * Updates an ACL entry on the specified bucket. This method supports patch
+   * semantics. (bucketAccessControls.patch)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param string $entity The entity holding the permission. Can be user-userId,
+   * user-emailAddress, group-groupId, group-emailAddress, allUsers, or
+   * allAuthenticatedUsers.
+   * @param Google_BucketAccessControl $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Storage_BucketAccessControl
+   */
+  public function patch($bucket, $entity, Google_Service_Storage_BucketAccessControl $postBody, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'entity' => $entity, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Storage_BucketAccessControl");
+  }
+
+  /**
+   * Updates an ACL entry on the specified bucket. (bucketAccessControls.update)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param string $entity The entity holding the permission. Can be user-userId,
+   * user-emailAddress, group-groupId, group-emailAddress, allUsers, or
+   * allAuthenticatedUsers.
+   * @param Google_BucketAccessControl $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Storage_BucketAccessControl
+   */
+  public function update($bucket, $entity, Google_Service_Storage_BucketAccessControl $postBody, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'entity' => $entity, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Storage_BucketAccessControl");
+  }
+}
+
+/**
+ * The "buckets" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $storageService = new Google_Service_Storage(...);
+ *   $buckets = $storageService->buckets;
+ *  </code>
+ */
+class Google_Service_Storage_Buckets_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Permanently deletes an empty bucket. (buckets.delete)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string ifMetagenerationMatch If set, only deletes the bucket if
+   * its metageneration matches this value.
+   * @opt_param string ifMetagenerationNotMatch If set, only deletes the bucket if
+   * its metageneration does not match this value.
+   */
+  public function delete($bucket, $optParams = array())
+  {
+    $params = array('bucket' => $bucket);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Returns metadata for the specified bucket. (buckets.get)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string ifMetagenerationMatch Makes the return of the bucket
+   * metadata conditional on whether the bucket's current metageneration matches
+   * the given value.
+   * @opt_param string ifMetagenerationNotMatch Makes the return of the bucket
+   * metadata conditional on whether the bucket's current metageneration does not
+   * match the given value.
+   * @opt_param string projection Set of properties to return. Defaults to noAcl.
+   * @return Google_Service_Storage_Bucket
+   */
+  public function get($bucket, $optParams = array())
+  {
+    $params = array('bucket' => $bucket);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Storage_Bucket");
+  }
+
+  /**
+   * Creates a new bucket. (buckets.insert)
+   *
+   * @param string $project A valid API project identifier.
+   * @param Google_Bucket $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string predefinedAcl Apply a predefined set of access controls to
+   * this bucket.
+   * @opt_param string projection Set of properties to return. Defaults to noAcl,
+   * unless the bucket resource specifies acl or defaultObjectAcl properties, when
+   * it defaults to full.
+   * @opt_param string predefinedDefaultObjectAcl Apply a predefined set of
+   * default object access controls to this bucket.
+   * @return Google_Service_Storage_Bucket
+   */
+  public function insert($project, Google_Service_Storage_Bucket $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Storage_Bucket");
+  }
+
+  /**
+   * Retrieves a list of buckets for a given project. (buckets.listBuckets)
+   *
+   * @param string $project A valid API project identifier.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A previously-returned page token representing
+   * part of the larger set of results to view.
+   * @opt_param string prefix Filter results to buckets whose names begin with
+   * this prefix.
+   * @opt_param string projection Set of properties to return. Defaults to noAcl.
+   * @opt_param string maxResults Maximum number of buckets to return.
+   * @return Google_Service_Storage_Buckets
+   */
+  public function listBuckets($project, $optParams = array())
+  {
+    $params = array('project' => $project);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Storage_Buckets");
+  }
+
+  /**
+   * Updates a bucket. This method supports patch semantics. (buckets.patch)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param Google_Bucket $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string projection Set of properties to return. Defaults to full.
+   * @opt_param string ifMetagenerationMatch Makes the return of the bucket
+   * metadata conditional on whether the bucket's current metageneration matches
+   * the given value.
+   * @opt_param string predefinedDefaultObjectAcl Apply a predefined set of
+   * default object access controls to this bucket.
+   * @opt_param string predefinedAcl Apply a predefined set of access controls to
+   * this bucket.
+   * @opt_param string ifMetagenerationNotMatch Makes the return of the bucket
+   * metadata conditional on whether the bucket's current metageneration does not
+   * match the given value.
+   * @return Google_Service_Storage_Bucket
+   */
+  public function patch($bucket, Google_Service_Storage_Bucket $postBody, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Storage_Bucket");
+  }
+
+  /**
+   * Updates a bucket. (buckets.update)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param Google_Bucket $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string projection Set of properties to return. Defaults to full.
+   * @opt_param string ifMetagenerationMatch Makes the return of the bucket
+   * metadata conditional on whether the bucket's current metageneration matches
+   * the given value.
+   * @opt_param string predefinedDefaultObjectAcl Apply a predefined set of
+   * default object access controls to this bucket.
+   * @opt_param string predefinedAcl Apply a predefined set of access controls to
+   * this bucket.
+   * @opt_param string ifMetagenerationNotMatch Makes the return of the bucket
+   * metadata conditional on whether the bucket's current metageneration does not
+   * match the given value.
+   * @return Google_Service_Storage_Bucket
+   */
+  public function update($bucket, Google_Service_Storage_Bucket $postBody, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Storage_Bucket");
+  }
+}
+
+/**
+ * The "channels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $storageService = new Google_Service_Storage(...);
+ *   $channels = $storageService->channels;
+ *  </code>
+ */
+class Google_Service_Storage_Channels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Stop watching resources through this channel (channels.stop)
+   *
+   * @param Google_Channel $postBody
+   * @param array $optParams Optional parameters.
+   */
+  public function stop(Google_Service_Storage_Channel $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('stop', array($params));
+  }
+}
+
+/**
+ * The "defaultObjectAccessControls" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $storageService = new Google_Service_Storage(...);
+ *   $defaultObjectAccessControls = $storageService->defaultObjectAccessControls;
+ *  </code>
+ */
+class Google_Service_Storage_DefaultObjectAccessControls_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Permanently deletes the default object ACL entry for the specified entity on
+   * the specified bucket. (defaultObjectAccessControls.delete)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param string $entity The entity holding the permission. Can be user-userId,
+   * user-emailAddress, group-groupId, group-emailAddress, allUsers, or
+   * allAuthenticatedUsers.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($bucket, $entity, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'entity' => $entity);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Returns the default object ACL entry for the specified entity on the
+   * specified bucket. (defaultObjectAccessControls.get)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param string $entity The entity holding the permission. Can be user-userId,
+   * user-emailAddress, group-groupId, group-emailAddress, allUsers, or
+   * allAuthenticatedUsers.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Storage_ObjectAccessControl
+   */
+  public function get($bucket, $entity, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'entity' => $entity);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Storage_ObjectAccessControl");
+  }
+
+  /**
+   * Creates a new default object ACL entry on the specified bucket.
+   * (defaultObjectAccessControls.insert)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param Google_ObjectAccessControl $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Storage_ObjectAccessControl
+   */
+  public function insert($bucket, Google_Service_Storage_ObjectAccessControl $postBody, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Storage_ObjectAccessControl");
+  }
+
+  /**
+   * Retrieves default object ACL entries on the specified bucket.
+   * (defaultObjectAccessControls.listDefaultObjectAccessControls)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string ifMetagenerationMatch If present, only return default ACL
+   * listing if the bucket's current metageneration matches this value.
+   * @opt_param string ifMetagenerationNotMatch If present, only return default
+   * ACL listing if the bucket's current metageneration does not match the given
+   * value.
+   * @return Google_Service_Storage_ObjectAccessControls
+   */
+  public function listDefaultObjectAccessControls($bucket, $optParams = array())
+  {
+    $params = array('bucket' => $bucket);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Storage_ObjectAccessControls");
+  }
+
+  /**
+   * Updates a default object ACL entry on the specified bucket. This method
+   * supports patch semantics. (defaultObjectAccessControls.patch)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param string $entity The entity holding the permission. Can be user-userId,
+   * user-emailAddress, group-groupId, group-emailAddress, allUsers, or
+   * allAuthenticatedUsers.
+   * @param Google_ObjectAccessControl $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Storage_ObjectAccessControl
+   */
+  public function patch($bucket, $entity, Google_Service_Storage_ObjectAccessControl $postBody, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'entity' => $entity, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Storage_ObjectAccessControl");
+  }
+
+  /**
+   * Updates a default object ACL entry on the specified bucket.
+   * (defaultObjectAccessControls.update)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param string $entity The entity holding the permission. Can be user-userId,
+   * user-emailAddress, group-groupId, group-emailAddress, allUsers, or
+   * allAuthenticatedUsers.
+   * @param Google_ObjectAccessControl $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Storage_ObjectAccessControl
+   */
+  public function update($bucket, $entity, Google_Service_Storage_ObjectAccessControl $postBody, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'entity' => $entity, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Storage_ObjectAccessControl");
+  }
+}
+
+/**
+ * The "objectAccessControls" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $storageService = new Google_Service_Storage(...);
+ *   $objectAccessControls = $storageService->objectAccessControls;
+ *  </code>
+ */
+class Google_Service_Storage_ObjectAccessControls_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Permanently deletes the ACL entry for the specified entity on the specified
+   * object. (objectAccessControls.delete)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param string $object Name of the object. For information about how to URL
+   * encode object names to be path safe, see Encoding URI Path Parts.
+   * @param string $entity The entity holding the permission. Can be user-userId,
+   * user-emailAddress, group-groupId, group-emailAddress, allUsers, or
+   * allAuthenticatedUsers.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string generation If present, selects a specific revision of this
+   * object (as opposed to the latest version, the default).
+   */
+  public function delete($bucket, $object, $entity, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'object' => $object, 'entity' => $entity);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Returns the ACL entry for the specified entity on the specified object.
+   * (objectAccessControls.get)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param string $object Name of the object. For information about how to URL
+   * encode object names to be path safe, see Encoding URI Path Parts.
+   * @param string $entity The entity holding the permission. Can be user-userId,
+   * user-emailAddress, group-groupId, group-emailAddress, allUsers, or
+   * allAuthenticatedUsers.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string generation If present, selects a specific revision of this
+   * object (as opposed to the latest version, the default).
+   * @return Google_Service_Storage_ObjectAccessControl
+   */
+  public function get($bucket, $object, $entity, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'object' => $object, 'entity' => $entity);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Storage_ObjectAccessControl");
+  }
+
+  /**
+   * Creates a new ACL entry on the specified object.
+   * (objectAccessControls.insert)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param string $object Name of the object. For information about how to URL
+   * encode object names to be path safe, see Encoding URI Path Parts.
+   * @param Google_ObjectAccessControl $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string generation If present, selects a specific revision of this
+   * object (as opposed to the latest version, the default).
+   * @return Google_Service_Storage_ObjectAccessControl
+   */
+  public function insert($bucket, $object, Google_Service_Storage_ObjectAccessControl $postBody, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'object' => $object, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Storage_ObjectAccessControl");
+  }
+
+  /**
+   * Retrieves ACL entries on the specified object.
+   * (objectAccessControls.listObjectAccessControls)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param string $object Name of the object. For information about how to URL
+   * encode object names to be path safe, see Encoding URI Path Parts.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string generation If present, selects a specific revision of this
+   * object (as opposed to the latest version, the default).
+   * @return Google_Service_Storage_ObjectAccessControls
+   */
+  public function listObjectAccessControls($bucket, $object, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'object' => $object);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Storage_ObjectAccessControls");
+  }
+
+  /**
+   * Updates an ACL entry on the specified object. This method supports patch
+   * semantics. (objectAccessControls.patch)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param string $object Name of the object. For information about how to URL
+   * encode object names to be path safe, see Encoding URI Path Parts.
+   * @param string $entity The entity holding the permission. Can be user-userId,
+   * user-emailAddress, group-groupId, group-emailAddress, allUsers, or
+   * allAuthenticatedUsers.
+   * @param Google_ObjectAccessControl $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string generation If present, selects a specific revision of this
+   * object (as opposed to the latest version, the default).
+   * @return Google_Service_Storage_ObjectAccessControl
+   */
+  public function patch($bucket, $object, $entity, Google_Service_Storage_ObjectAccessControl $postBody, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'object' => $object, 'entity' => $entity, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Storage_ObjectAccessControl");
+  }
+
+  /**
+   * Updates an ACL entry on the specified object. (objectAccessControls.update)
+   *
+   * @param string $bucket Name of a bucket.
+   * @param string $object Name of the object. For information about how to URL
+   * encode object names to be path safe, see Encoding URI Path Parts.
+   * @param string $entity The entity holding the permission. Can be user-userId,
+   * user-emailAddress, group-groupId, group-emailAddress, allUsers, or
+   * allAuthenticatedUsers.
+   * @param Google_ObjectAccessControl $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string generation If present, selects a specific revision of this
+   * object (as opposed to the latest version, the default).
+   * @return Google_Service_Storage_ObjectAccessControl
+   */
+  public function update($bucket, $object, $entity, Google_Service_Storage_ObjectAccessControl $postBody, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'object' => $object, 'entity' => $entity, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Storage_ObjectAccessControl");
+  }
+}
+
+/**
+ * The "objects" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $storageService = new Google_Service_Storage(...);
+ *   $objects = $storageService->objects;
+ *  </code>
+ */
+class Google_Service_Storage_Objects_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Concatenates a list of existing objects into a new object in the same bucket.
+   * (objects.compose)
+   *
+   * @param string $destinationBucket Name of the bucket in which to store the new
+   * object.
+   * @param string $destinationObject Name of the new object. For information
+   * about how to URL encode object names to be path safe, see Encoding URI Path
+   * Parts.
+   * @param Google_ComposeRequest $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string ifGenerationMatch Makes the operation conditional on
+   * whether the object's current generation matches the given value.
+   * @opt_param string ifMetagenerationMatch Makes the operation conditional on
+   * whether the object's current metageneration matches the given value.
+   * @opt_param string destinationPredefinedAcl Apply a predefined set of access
+   * controls to the destination object.
+   * @return Google_Service_Storage_StorageObject
+   */
+  public function compose($destinationBucket, $destinationObject, Google_Service_Storage_ComposeRequest $postBody, $optParams = array())
+  {
+    $params = array('destinationBucket' => $destinationBucket, 'destinationObject' => $destinationObject, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('compose', array($params), "Google_Service_Storage_StorageObject");
+  }
+
+  /**
+   * Copies a source object to a destination object. Optionally overrides
+   * metadata. (objects.copy)
+   *
+   * @param string $sourceBucket Name of the bucket in which to find the source
+   * object.
+   * @param string $sourceObject Name of the source object. For information about
+   * how to URL encode object names to be path safe, see Encoding URI Path Parts.
+   * @param string $destinationBucket Name of the bucket in which to store the new
+   * object. Overrides the provided object metadata's bucket value, if any.For
+   * information about how to URL encode object names to be path safe, see
+   * Encoding URI Path Parts.
+   * @param string $destinationObject Name of the new object. Required when the
+   * object metadata is not otherwise provided. Overrides the object metadata's
+   * name value, if any.
+   * @param Google_StorageObject $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string ifSourceGenerationNotMatch Makes the operation conditional
+   * on whether the source object's generation does not match the given value.
+   * @opt_param string ifGenerationNotMatch Makes the operation conditional on
+   * whether the destination object's current generation does not match the given
+   * value.
+   * @opt_param string ifSourceMetagenerationNotMatch Makes the operation
+   * conditional on whether the source object's current metageneration does not
+   * match the given value.
+   * @opt_param string ifMetagenerationMatch Makes the operation conditional on
+   * whether the destination object's current metageneration matches the given
+   * value.
+   * @opt_param string sourceGeneration If present, selects a specific revision of
+   * the source object (as opposed to the latest version, the default).
+   * @opt_param string destinationPredefinedAcl Apply a predefined set of access
+   * controls to the destination object.
+   * @opt_param string ifSourceGenerationMatch Makes the operation conditional on
+   * whether the source object's generation matches the given value.
+   * @opt_param string ifSourceMetagenerationMatch Makes the operation conditional
+   * on whether the source object's current metageneration matches the given
+   * value.
+   * @opt_param string ifGenerationMatch Makes the operation conditional on
+   * whether the destination object's current generation matches the given value.
+   * @opt_param string ifMetagenerationNotMatch Makes the operation conditional on
+   * whether the destination object's current metageneration does not match the
+   * given value.
+   * @opt_param string projection Set of properties to return. Defaults to noAcl,
+   * unless the object resource specifies the acl property, when it defaults to
+   * full.
+   * @return Google_Service_Storage_StorageObject
+   */
+  public function copy($sourceBucket, $sourceObject, $destinationBucket, $destinationObject, Google_Service_Storage_StorageObject $postBody, $optParams = array())
+  {
+    $params = array('sourceBucket' => $sourceBucket, 'sourceObject' => $sourceObject, 'destinationBucket' => $destinationBucket, 'destinationObject' => $destinationObject, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('copy', array($params), "Google_Service_Storage_StorageObject");
+  }
+
+  /**
+   * Deletes an object and its metadata. Deletions are permanent if versioning is
+   * not enabled for the bucket, or if the generation parameter is used.
+   * (objects.delete)
+   *
+   * @param string $bucket Name of the bucket in which the object resides.
+   * @param string $object Name of the object. For information about how to URL
+   * encode object names to be path safe, see Encoding URI Path Parts.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string ifGenerationNotMatch Makes the operation conditional on
+   * whether the object's current generation does not match the given value.
+   * @opt_param string generation If present, permanently deletes a specific
+   * revision of this object (as opposed to the latest version, the default).
+   * @opt_param string ifMetagenerationMatch Makes the operation conditional on
+   * whether the object's current metageneration matches the given value.
+   * @opt_param string ifGenerationMatch Makes the operation conditional on
+   * whether the object's current generation matches the given value.
+   * @opt_param string ifMetagenerationNotMatch Makes the operation conditional on
+   * whether the object's current metageneration does not match the given value.
+   */
+  public function delete($bucket, $object, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'object' => $object);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves an object or its metadata. (objects.get)
+   *
+   * @param string $bucket Name of the bucket in which the object resides.
+   * @param string $object Name of the object. For information about how to URL
+   * encode object names to be path safe, see Encoding URI Path Parts.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string ifGenerationNotMatch Makes the operation conditional on
+   * whether the object's generation does not match the given value.
+   * @opt_param string generation If present, selects a specific revision of this
+   * object (as opposed to the latest version, the default).
+   * @opt_param string ifMetagenerationMatch Makes the operation conditional on
+   * whether the object's current metageneration matches the given value.
+   * @opt_param string ifGenerationMatch Makes the operation conditional on
+   * whether the object's generation matches the given value.
+   * @opt_param string ifMetagenerationNotMatch Makes the operation conditional on
+   * whether the object's current metageneration does not match the given value.
+   * @opt_param string projection Set of properties to return. Defaults to noAcl.
+   * @return Google_Service_Storage_StorageObject
+   */
+  public function get($bucket, $object, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'object' => $object);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Storage_StorageObject");
+  }
+
+  /**
+   * Stores a new object and metadata. (objects.insert)
+   *
+   * @param string $bucket Name of the bucket in which to store the new object.
+   * Overrides the provided object metadata's bucket value, if any.
+   * @param Google_StorageObject $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string predefinedAcl Apply a predefined set of access controls to
+   * this object.
+   * @opt_param string projection Set of properties to return. Defaults to noAcl,
+   * unless the object resource specifies the acl property, when it defaults to
+   * full.
+   * @opt_param string ifGenerationNotMatch Makes the operation conditional on
+   * whether the object's current generation does not match the given value.
+   * @opt_param string ifMetagenerationMatch Makes the operation conditional on
+   * whether the object's current metageneration matches the given value.
+   * @opt_param string contentEncoding If set, sets the contentEncoding property
+   * of the final object to this value. Setting this parameter is equivalent to
+   * setting the contentEncoding metadata property. This can be useful when
+   * uploading an object with uploadType=media to indicate the encoding of the
+   * content being uploaded.
+   * @opt_param string ifGenerationMatch Makes the operation conditional on
+   * whether the object's current generation matches the given value.
+   * @opt_param string ifMetagenerationNotMatch Makes the operation conditional on
+   * whether the object's current metageneration does not match the given value.
+   * @opt_param string name Name of the object. Required when the object metadata
+   * is not otherwise provided. Overrides the object metadata's name value, if
+   * any. For information about how to URL encode object names to be path safe,
+   * see Encoding URI Path Parts.
+   * @return Google_Service_Storage_StorageObject
+   */
+  public function insert($bucket, Google_Service_Storage_StorageObject $postBody, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Storage_StorageObject");
+  }
+
+  /**
+   * Retrieves a list of objects matching the criteria. (objects.listObjects)
+   *
+   * @param string $bucket Name of the bucket in which to look for objects.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string projection Set of properties to return. Defaults to noAcl.
+   * @opt_param bool versions If true, lists all versions of an object as distinct
+   * results. The default is false. For more information, see Object Versioning.
+   * @opt_param string prefix Filter results to objects whose names begin with
+   * this prefix.
+   * @opt_param string maxResults Maximum number of items plus prefixes to return.
+   * As duplicate prefixes are omitted, fewer total results may be returned than
+   * requested. The default value of this parameter is 1,000 items.
+   * @opt_param string pageToken A previously-returned page token representing
+   * part of the larger set of results to view.
+   * @opt_param string delimiter Returns results in a directory-like mode. items
+   * will contain only objects whose names, aside from the prefix, do not contain
+   * delimiter. Objects whose names, aside from the prefix, contain delimiter will
+   * have their name, truncated after the delimiter, returned in prefixes.
+   * Duplicate prefixes are omitted.
+   * @return Google_Service_Storage_Objects
+   */
+  public function listObjects($bucket, $optParams = array())
+  {
+    $params = array('bucket' => $bucket);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Storage_Objects");
+  }
+
+  /**
+   * Updates an object's metadata. This method supports patch semantics.
+   * (objects.patch)
+   *
+   * @param string $bucket Name of the bucket in which the object resides.
+   * @param string $object Name of the object. For information about how to URL
+   * encode object names to be path safe, see Encoding URI Path Parts.
+   * @param Google_StorageObject $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string predefinedAcl Apply a predefined set of access controls to
+   * this object.
+   * @opt_param string ifGenerationNotMatch Makes the operation conditional on
+   * whether the object's current generation does not match the given value.
+   * @opt_param string generation If present, selects a specific revision of this
+   * object (as opposed to the latest version, the default).
+   * @opt_param string ifMetagenerationMatch Makes the operation conditional on
+   * whether the object's current metageneration matches the given value.
+   * @opt_param string ifGenerationMatch Makes the operation conditional on
+   * whether the object's current generation matches the given value.
+   * @opt_param string ifMetagenerationNotMatch Makes the operation conditional on
+   * whether the object's current metageneration does not match the given value.
+   * @opt_param string projection Set of properties to return. Defaults to full.
+   * @return Google_Service_Storage_StorageObject
+   */
+  public function patch($bucket, $object, Google_Service_Storage_StorageObject $postBody, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'object' => $object, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Storage_StorageObject");
+  }
+
+  /**
+   * Rewrites a source object to a destination object. Optionally overrides
+   * metadata. (objects.rewrite)
+   *
+   * @param string $sourceBucket Name of the bucket in which to find the source
+   * object.
+   * @param string $sourceObject Name of the source object. For information about
+   * how to URL encode object names to be path safe, see Encoding URI Path Parts.
+   * @param string $destinationBucket Name of the bucket in which to store the new
+   * object. Overrides the provided object metadata's bucket value, if any.
+   * @param string $destinationObject Name of the new object. Required when the
+   * object metadata is not otherwise provided. Overrides the object metadata's
+   * name value, if any. For information about how to URL encode object names to
+   * be path safe, see Encoding URI Path Parts.
+   * @param Google_StorageObject $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string ifSourceGenerationNotMatch Makes the operation conditional
+   * on whether the source object's generation does not match the given value.
+   * @opt_param string ifGenerationNotMatch Makes the operation conditional on
+   * whether the destination object's current generation does not match the given
+   * value.
+   * @opt_param string rewriteToken Include this field (from the previous rewrite
+   * response) on each rewrite request after the first one, until the rewrite
+   * response 'done' flag is true. Calls that provide a rewriteToken can omit all
+   * other request fields, but if included those fields must match the values
+   * provided in the first rewrite request.
+   * @opt_param string ifSourceMetagenerationNotMatch Makes the operation
+   * conditional on whether the source object's current metageneration does not
+   * match the given value.
+   * @opt_param string ifMetagenerationMatch Makes the operation conditional on
+   * whether the destination object's current metageneration matches the given
+   * value.
+   * @opt_param string sourceGeneration If present, selects a specific revision of
+   * the source object (as opposed to the latest version, the default).
+   * @opt_param string destinationPredefinedAcl Apply a predefined set of access
+   * controls to the destination object.
+   * @opt_param string ifSourceGenerationMatch Makes the operation conditional on
+   * whether the source object's generation matches the given value.
+   * @opt_param string maxBytesRewrittenPerCall The maximum number of bytes that
+   * will be rewritten per rewrite request. Most callers shouldn't need to specify
+   * this parameter - it is primarily in place to support testing. If specified
+   * the value must be an integral multiple of 1 MiB (1048576). Also, this only
+   * applies to requests where the source and destination span locations and/or
+   * storage classes. Finally, this value must not change across rewrite calls
+   * else you'll get an error that the rewriteToken is invalid.
+   * @opt_param string ifSourceMetagenerationMatch Makes the operation conditional
+   * on whether the source object's current metageneration matches the given
+   * value.
+   * @opt_param string ifGenerationMatch Makes the operation conditional on
+   * whether the destination object's current generation matches the given value.
+   * @opt_param string ifMetagenerationNotMatch Makes the operation conditional on
+   * whether the destination object's current metageneration does not match the
+   * given value.
+   * @opt_param string projection Set of properties to return. Defaults to noAcl,
+   * unless the object resource specifies the acl property, when it defaults to
+   * full.
+   * @return Google_Service_Storage_RewriteResponse
+   */
+  public function rewrite($sourceBucket, $sourceObject, $destinationBucket, $destinationObject, Google_Service_Storage_StorageObject $postBody, $optParams = array())
+  {
+    $params = array('sourceBucket' => $sourceBucket, 'sourceObject' => $sourceObject, 'destinationBucket' => $destinationBucket, 'destinationObject' => $destinationObject, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('rewrite', array($params), "Google_Service_Storage_RewriteResponse");
+  }
+
+  /**
+   * Updates an object's metadata. (objects.update)
+   *
+   * @param string $bucket Name of the bucket in which the object resides.
+   * @param string $object Name of the object. For information about how to URL
+   * encode object names to be path safe, see Encoding URI Path Parts.
+   * @param Google_StorageObject $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string predefinedAcl Apply a predefined set of access controls to
+   * this object.
+   * @opt_param string ifGenerationNotMatch Makes the operation conditional on
+   * whether the object's current generation does not match the given value.
+   * @opt_param string generation If present, selects a specific revision of this
+   * object (as opposed to the latest version, the default).
+   * @opt_param string ifMetagenerationMatch Makes the operation conditional on
+   * whether the object's current metageneration matches the given value.
+   * @opt_param string ifGenerationMatch Makes the operation conditional on
+   * whether the object's current generation matches the given value.
+   * @opt_param string ifMetagenerationNotMatch Makes the operation conditional on
+   * whether the object's current metageneration does not match the given value.
+   * @opt_param string projection Set of properties to return. Defaults to full.
+   * @return Google_Service_Storage_StorageObject
+   */
+  public function update($bucket, $object, Google_Service_Storage_StorageObject $postBody, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'object' => $object, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Storage_StorageObject");
+  }
+
+  /**
+   * Watch for changes on all objects in a bucket. (objects.watchAll)
+   *
+   * @param string $bucket Name of the bucket in which to look for objects.
+   * @param Google_Channel $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string projection Set of properties to return. Defaults to noAcl.
+   * @opt_param bool versions If true, lists all versions of an object as distinct
+   * results. The default is false. For more information, see Object Versioning.
+   * @opt_param string prefix Filter results to objects whose names begin with
+   * this prefix.
+   * @opt_param string maxResults Maximum number of items plus prefixes to return.
+   * As duplicate prefixes are omitted, fewer total results may be returned than
+   * requested. The default value of this parameter is 1,000 items.
+   * @opt_param string pageToken A previously-returned page token representing
+   * part of the larger set of results to view.
+   * @opt_param string delimiter Returns results in a directory-like mode. items
+   * will contain only objects whose names, aside from the prefix, do not contain
+   * delimiter. Objects whose names, aside from the prefix, contain delimiter will
+   * have their name, truncated after the delimiter, returned in prefixes.
+   * Duplicate prefixes are omitted.
+   * @return Google_Service_Storage_Channel
+   */
+  public function watchAll($bucket, Google_Service_Storage_Channel $postBody, $optParams = array())
+  {
+    $params = array('bucket' => $bucket, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('watchAll', array($params), "Google_Service_Storage_Channel");
+  }
+}
+
+
+
+
+class Google_Service_Storage_Bucket extends Google_Collection
+{
+  protected $collection_key = 'defaultObjectAcl';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $aclType = 'Google_Service_Storage_BucketAccessControl';
+  protected $aclDataType = 'array';
+  protected $corsType = 'Google_Service_Storage_BucketCors';
+  protected $corsDataType = 'array';
+  protected $defaultObjectAclType = 'Google_Service_Storage_ObjectAccessControl';
+  protected $defaultObjectAclDataType = 'array';
+  public $etag;
+  public $id;
+  public $kind;
+  protected $lifecycleType = 'Google_Service_Storage_BucketLifecycle';
+  protected $lifecycleDataType = '';
+  public $location;
+  protected $loggingType = 'Google_Service_Storage_BucketLogging';
+  protected $loggingDataType = '';
+  public $metageneration;
+  public $name;
+  protected $ownerType = 'Google_Service_Storage_BucketOwner';
+  protected $ownerDataType = '';
+  public $projectNumber;
+  public $selfLink;
+  public $storageClass;
+  public $timeCreated;
+  public $updated;
+  protected $versioningType = 'Google_Service_Storage_BucketVersioning';
+  protected $versioningDataType = '';
+  protected $websiteType = 'Google_Service_Storage_BucketWebsite';
+  protected $websiteDataType = '';
+
+
+  public function setAcl($acl)
+  {
+    $this->acl = $acl;
+  }
+  public function getAcl()
+  {
+    return $this->acl;
+  }
+  public function setCors($cors)
+  {
+    $this->cors = $cors;
+  }
+  public function getCors()
+  {
+    return $this->cors;
+  }
+  public function setDefaultObjectAcl($defaultObjectAcl)
+  {
+    $this->defaultObjectAcl = $defaultObjectAcl;
+  }
+  public function getDefaultObjectAcl()
+  {
+    return $this->defaultObjectAcl;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLifecycle(Google_Service_Storage_BucketLifecycle $lifecycle)
+  {
+    $this->lifecycle = $lifecycle;
+  }
+  public function getLifecycle()
+  {
+    return $this->lifecycle;
+  }
+  public function setLocation($location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setLogging(Google_Service_Storage_BucketLogging $logging)
+  {
+    $this->logging = $logging;
+  }
+  public function getLogging()
+  {
+    return $this->logging;
+  }
+  public function setMetageneration($metageneration)
+  {
+    $this->metageneration = $metageneration;
+  }
+  public function getMetageneration()
+  {
+    return $this->metageneration;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOwner(Google_Service_Storage_BucketOwner $owner)
+  {
+    $this->owner = $owner;
+  }
+  public function getOwner()
+  {
+    return $this->owner;
+  }
+  public function setProjectNumber($projectNumber)
+  {
+    $this->projectNumber = $projectNumber;
+  }
+  public function getProjectNumber()
+  {
+    return $this->projectNumber;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStorageClass($storageClass)
+  {
+    $this->storageClass = $storageClass;
+  }
+  public function getStorageClass()
+  {
+    return $this->storageClass;
+  }
+  public function setTimeCreated($timeCreated)
+  {
+    $this->timeCreated = $timeCreated;
+  }
+  public function getTimeCreated()
+  {
+    return $this->timeCreated;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+  public function setVersioning(Google_Service_Storage_BucketVersioning $versioning)
+  {
+    $this->versioning = $versioning;
+  }
+  public function getVersioning()
+  {
+    return $this->versioning;
+  }
+  public function setWebsite(Google_Service_Storage_BucketWebsite $website)
+  {
+    $this->website = $website;
+  }
+  public function getWebsite()
+  {
+    return $this->website;
+  }
+}
+
+class Google_Service_Storage_BucketAccessControl extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $bucket;
+  public $domain;
+  public $email;
+  public $entity;
+  public $entityId;
+  public $etag;
+  public $id;
+  public $kind;
+  protected $projectTeamType = 'Google_Service_Storage_BucketAccessControlProjectTeam';
+  protected $projectTeamDataType = '';
+  public $role;
+  public $selfLink;
+
+
+  public function setBucket($bucket)
+  {
+    $this->bucket = $bucket;
+  }
+  public function getBucket()
+  {
+    return $this->bucket;
+  }
+  public function setDomain($domain)
+  {
+    $this->domain = $domain;
+  }
+  public function getDomain()
+  {
+    return $this->domain;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setEntity($entity)
+  {
+    $this->entity = $entity;
+  }
+  public function getEntity()
+  {
+    return $this->entity;
+  }
+  public function setEntityId($entityId)
+  {
+    $this->entityId = $entityId;
+  }
+  public function getEntityId()
+  {
+    return $this->entityId;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setProjectTeam(Google_Service_Storage_BucketAccessControlProjectTeam $projectTeam)
+  {
+    $this->projectTeam = $projectTeam;
+  }
+  public function getProjectTeam()
+  {
+    return $this->projectTeam;
+  }
+  public function setRole($role)
+  {
+    $this->role = $role;
+  }
+  public function getRole()
+  {
+    return $this->role;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Storage_BucketAccessControlProjectTeam extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $projectNumber;
+  public $team;
+
+
+  public function setProjectNumber($projectNumber)
+  {
+    $this->projectNumber = $projectNumber;
+  }
+  public function getProjectNumber()
+  {
+    return $this->projectNumber;
+  }
+  public function setTeam($team)
+  {
+    $this->team = $team;
+  }
+  public function getTeam()
+  {
+    return $this->team;
+  }
+}
+
+class Google_Service_Storage_BucketAccessControls extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Storage_BucketAccessControl';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Storage_BucketCors extends Google_Collection
+{
+  protected $collection_key = 'responseHeader';
+  protected $internal_gapi_mappings = array(
+  );
+  public $maxAgeSeconds;
+  public $method;
+  public $origin;
+  public $responseHeader;
+
+
+  public function setMaxAgeSeconds($maxAgeSeconds)
+  {
+    $this->maxAgeSeconds = $maxAgeSeconds;
+  }
+  public function getMaxAgeSeconds()
+  {
+    return $this->maxAgeSeconds;
+  }
+  public function setMethod($method)
+  {
+    $this->method = $method;
+  }
+  public function getMethod()
+  {
+    return $this->method;
+  }
+  public function setOrigin($origin)
+  {
+    $this->origin = $origin;
+  }
+  public function getOrigin()
+  {
+    return $this->origin;
+  }
+  public function setResponseHeader($responseHeader)
+  {
+    $this->responseHeader = $responseHeader;
+  }
+  public function getResponseHeader()
+  {
+    return $this->responseHeader;
+  }
+}
+
+class Google_Service_Storage_BucketLifecycle extends Google_Collection
+{
+  protected $collection_key = 'rule';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $ruleType = 'Google_Service_Storage_BucketLifecycleRule';
+  protected $ruleDataType = 'array';
+
+
+  public function setRule($rule)
+  {
+    $this->rule = $rule;
+  }
+  public function getRule()
+  {
+    return $this->rule;
+  }
+}
+
+class Google_Service_Storage_BucketLifecycleRule extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $actionType = 'Google_Service_Storage_BucketLifecycleRuleAction';
+  protected $actionDataType = '';
+  protected $conditionType = 'Google_Service_Storage_BucketLifecycleRuleCondition';
+  protected $conditionDataType = '';
+
+
+  public function setAction(Google_Service_Storage_BucketLifecycleRuleAction $action)
+  {
+    $this->action = $action;
+  }
+  public function getAction()
+  {
+    return $this->action;
+  }
+  public function setCondition(Google_Service_Storage_BucketLifecycleRuleCondition $condition)
+  {
+    $this->condition = $condition;
+  }
+  public function getCondition()
+  {
+    return $this->condition;
+  }
+}
+
+class Google_Service_Storage_BucketLifecycleRuleAction extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $type;
+
+
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Storage_BucketLifecycleRuleCondition extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $age;
+  public $createdBefore;
+  public $isLive;
+  public $numNewerVersions;
+
+
+  public function setAge($age)
+  {
+    $this->age = $age;
+  }
+  public function getAge()
+  {
+    return $this->age;
+  }
+  public function setCreatedBefore($createdBefore)
+  {
+    $this->createdBefore = $createdBefore;
+  }
+  public function getCreatedBefore()
+  {
+    return $this->createdBefore;
+  }
+  public function setIsLive($isLive)
+  {
+    $this->isLive = $isLive;
+  }
+  public function getIsLive()
+  {
+    return $this->isLive;
+  }
+  public function setNumNewerVersions($numNewerVersions)
+  {
+    $this->numNewerVersions = $numNewerVersions;
+  }
+  public function getNumNewerVersions()
+  {
+    return $this->numNewerVersions;
+  }
+}
+
+class Google_Service_Storage_BucketLogging extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $logBucket;
+  public $logObjectPrefix;
+
+
+  public function setLogBucket($logBucket)
+  {
+    $this->logBucket = $logBucket;
+  }
+  public function getLogBucket()
+  {
+    return $this->logBucket;
+  }
+  public function setLogObjectPrefix($logObjectPrefix)
+  {
+    $this->logObjectPrefix = $logObjectPrefix;
+  }
+  public function getLogObjectPrefix()
+  {
+    return $this->logObjectPrefix;
+  }
+}
+
+class Google_Service_Storage_BucketOwner extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $entity;
+  public $entityId;
+
+
+  public function setEntity($entity)
+  {
+    $this->entity = $entity;
+  }
+  public function getEntity()
+  {
+    return $this->entity;
+  }
+  public function setEntityId($entityId)
+  {
+    $this->entityId = $entityId;
+  }
+  public function getEntityId()
+  {
+    return $this->entityId;
+  }
+}
+
+class Google_Service_Storage_BucketVersioning extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $enabled;
+
+
+  public function setEnabled($enabled)
+  {
+    $this->enabled = $enabled;
+  }
+  public function getEnabled()
+  {
+    return $this->enabled;
+  }
+}
+
+class Google_Service_Storage_BucketWebsite extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $mainPageSuffix;
+  public $notFoundPage;
+
+
+  public function setMainPageSuffix($mainPageSuffix)
+  {
+    $this->mainPageSuffix = $mainPageSuffix;
+  }
+  public function getMainPageSuffix()
+  {
+    return $this->mainPageSuffix;
+  }
+  public function setNotFoundPage($notFoundPage)
+  {
+    $this->notFoundPage = $notFoundPage;
+  }
+  public function getNotFoundPage()
+  {
+    return $this->notFoundPage;
+  }
+}
+
+class Google_Service_Storage_Buckets extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Storage_Bucket';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Storage_Channel extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $address;
+  public $expiration;
+  public $id;
+  public $kind;
+  public $params;
+  public $payload;
+  public $resourceId;
+  public $resourceUri;
+  public $token;
+  public $type;
+
+
+  public function setAddress($address)
+  {
+    $this->address = $address;
+  }
+  public function getAddress()
+  {
+    return $this->address;
+  }
+  public function setExpiration($expiration)
+  {
+    $this->expiration = $expiration;
+  }
+  public function getExpiration()
+  {
+    return $this->expiration;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setParams($params)
+  {
+    $this->params = $params;
+  }
+  public function getParams()
+  {
+    return $this->params;
+  }
+  public function setPayload($payload)
+  {
+    $this->payload = $payload;
+  }
+  public function getPayload()
+  {
+    return $this->payload;
+  }
+  public function setResourceId($resourceId)
+  {
+    $this->resourceId = $resourceId;
+  }
+  public function getResourceId()
+  {
+    return $this->resourceId;
+  }
+  public function setResourceUri($resourceUri)
+  {
+    $this->resourceUri = $resourceUri;
+  }
+  public function getResourceUri()
+  {
+    return $this->resourceUri;
+  }
+  public function setToken($token)
+  {
+    $this->token = $token;
+  }
+  public function getToken()
+  {
+    return $this->token;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Storage_ChannelParams extends Google_Model
+{
+}
+
+class Google_Service_Storage_ComposeRequest extends Google_Collection
+{
+  protected $collection_key = 'sourceObjects';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $destinationType = 'Google_Service_Storage_StorageObject';
+  protected $destinationDataType = '';
+  public $kind;
+  protected $sourceObjectsType = 'Google_Service_Storage_ComposeRequestSourceObjects';
+  protected $sourceObjectsDataType = 'array';
+
+
+  public function setDestination(Google_Service_Storage_StorageObject $destination)
+  {
+    $this->destination = $destination;
+  }
+  public function getDestination()
+  {
+    return $this->destination;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSourceObjects($sourceObjects)
+  {
+    $this->sourceObjects = $sourceObjects;
+  }
+  public function getSourceObjects()
+  {
+    return $this->sourceObjects;
+  }
+}
+
+class Google_Service_Storage_ComposeRequestSourceObjects extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $generation;
+  public $name;
+  protected $objectPreconditionsType = 'Google_Service_Storage_ComposeRequestSourceObjectsObjectPreconditions';
+  protected $objectPreconditionsDataType = '';
+
+
+  public function setGeneration($generation)
+  {
+    $this->generation = $generation;
+  }
+  public function getGeneration()
+  {
+    return $this->generation;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setObjectPreconditions(Google_Service_Storage_ComposeRequestSourceObjectsObjectPreconditions $objectPreconditions)
+  {
+    $this->objectPreconditions = $objectPreconditions;
+  }
+  public function getObjectPreconditions()
+  {
+    return $this->objectPreconditions;
+  }
+}
+
+class Google_Service_Storage_ComposeRequestSourceObjectsObjectPreconditions extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $ifGenerationMatch;
+
+
+  public function setIfGenerationMatch($ifGenerationMatch)
+  {
+    $this->ifGenerationMatch = $ifGenerationMatch;
+  }
+  public function getIfGenerationMatch()
+  {
+    return $this->ifGenerationMatch;
+  }
+}
+
+class Google_Service_Storage_ObjectAccessControl extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $bucket;
+  public $domain;
+  public $email;
+  public $entity;
+  public $entityId;
+  public $etag;
+  public $generation;
+  public $id;
+  public $kind;
+  public $object;
+  protected $projectTeamType = 'Google_Service_Storage_ObjectAccessControlProjectTeam';
+  protected $projectTeamDataType = '';
+  public $role;
+  public $selfLink;
+
+
+  public function setBucket($bucket)
+  {
+    $this->bucket = $bucket;
+  }
+  public function getBucket()
+  {
+    return $this->bucket;
+  }
+  public function setDomain($domain)
+  {
+    $this->domain = $domain;
+  }
+  public function getDomain()
+  {
+    return $this->domain;
+  }
+  public function setEmail($email)
+  {
+    $this->email = $email;
+  }
+  public function getEmail()
+  {
+    return $this->email;
+  }
+  public function setEntity($entity)
+  {
+    $this->entity = $entity;
+  }
+  public function getEntity()
+  {
+    return $this->entity;
+  }
+  public function setEntityId($entityId)
+  {
+    $this->entityId = $entityId;
+  }
+  public function getEntityId()
+  {
+    return $this->entityId;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setGeneration($generation)
+  {
+    $this->generation = $generation;
+  }
+  public function getGeneration()
+  {
+    return $this->generation;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setObject($object)
+  {
+    $this->object = $object;
+  }
+  public function getObject()
+  {
+    return $this->object;
+  }
+  public function setProjectTeam(Google_Service_Storage_ObjectAccessControlProjectTeam $projectTeam)
+  {
+    $this->projectTeam = $projectTeam;
+  }
+  public function getProjectTeam()
+  {
+    return $this->projectTeam;
+  }
+  public function setRole($role)
+  {
+    $this->role = $role;
+  }
+  public function getRole()
+  {
+    return $this->role;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+}
+
+class Google_Service_Storage_ObjectAccessControlProjectTeam extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $projectNumber;
+  public $team;
+
+
+  public function setProjectNumber($projectNumber)
+  {
+    $this->projectNumber = $projectNumber;
+  }
+  public function getProjectNumber()
+  {
+    return $this->projectNumber;
+  }
+  public function setTeam($team)
+  {
+    $this->team = $team;
+  }
+  public function getTeam()
+  {
+    return $this->team;
+  }
+}
+
+class Google_Service_Storage_ObjectAccessControls extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $items;
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Storage_Objects extends Google_Collection
+{
+  protected $collection_key = 'prefixes';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Storage_StorageObject';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  public $prefixes;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPrefixes($prefixes)
+  {
+    $this->prefixes = $prefixes;
+  }
+  public function getPrefixes()
+  {
+    return $this->prefixes;
+  }
+}
+
+class Google_Service_Storage_RewriteResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $done;
+  public $kind;
+  public $objectSize;
+  protected $resourceType = 'Google_Service_Storage_StorageObject';
+  protected $resourceDataType = '';
+  public $rewriteToken;
+  public $totalBytesRewritten;
+
+
+  public function setDone($done)
+  {
+    $this->done = $done;
+  }
+  public function getDone()
+  {
+    return $this->done;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setObjectSize($objectSize)
+  {
+    $this->objectSize = $objectSize;
+  }
+  public function getObjectSize()
+  {
+    return $this->objectSize;
+  }
+  public function setResource(Google_Service_Storage_StorageObject $resource)
+  {
+    $this->resource = $resource;
+  }
+  public function getResource()
+  {
+    return $this->resource;
+  }
+  public function setRewriteToken($rewriteToken)
+  {
+    $this->rewriteToken = $rewriteToken;
+  }
+  public function getRewriteToken()
+  {
+    return $this->rewriteToken;
+  }
+  public function setTotalBytesRewritten($totalBytesRewritten)
+  {
+    $this->totalBytesRewritten = $totalBytesRewritten;
+  }
+  public function getTotalBytesRewritten()
+  {
+    return $this->totalBytesRewritten;
+  }
+}
+
+class Google_Service_Storage_StorageObject extends Google_Collection
+{
+  protected $collection_key = 'acl';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $aclType = 'Google_Service_Storage_ObjectAccessControl';
+  protected $aclDataType = 'array';
+  public $bucket;
+  public $cacheControl;
+  public $componentCount;
+  public $contentDisposition;
+  public $contentEncoding;
+  public $contentLanguage;
+  public $contentType;
+  public $crc32c;
+  public $etag;
+  public $generation;
+  public $id;
+  public $kind;
+  public $md5Hash;
+  public $mediaLink;
+  public $metadata;
+  public $metageneration;
+  public $name;
+  protected $ownerType = 'Google_Service_Storage_StorageObjectOwner';
+  protected $ownerDataType = '';
+  public $selfLink;
+  public $size;
+  public $storageClass;
+  public $timeCreated;
+  public $timeDeleted;
+  public $updated;
+
+
+  public function setAcl($acl)
+  {
+    $this->acl = $acl;
+  }
+  public function getAcl()
+  {
+    return $this->acl;
+  }
+  public function setBucket($bucket)
+  {
+    $this->bucket = $bucket;
+  }
+  public function getBucket()
+  {
+    return $this->bucket;
+  }
+  public function setCacheControl($cacheControl)
+  {
+    $this->cacheControl = $cacheControl;
+  }
+  public function getCacheControl()
+  {
+    return $this->cacheControl;
+  }
+  public function setComponentCount($componentCount)
+  {
+    $this->componentCount = $componentCount;
+  }
+  public function getComponentCount()
+  {
+    return $this->componentCount;
+  }
+  public function setContentDisposition($contentDisposition)
+  {
+    $this->contentDisposition = $contentDisposition;
+  }
+  public function getContentDisposition()
+  {
+    return $this->contentDisposition;
+  }
+  public function setContentEncoding($contentEncoding)
+  {
+    $this->contentEncoding = $contentEncoding;
+  }
+  public function getContentEncoding()
+  {
+    return $this->contentEncoding;
+  }
+  public function setContentLanguage($contentLanguage)
+  {
+    $this->contentLanguage = $contentLanguage;
+  }
+  public function getContentLanguage()
+  {
+    return $this->contentLanguage;
+  }
+  public function setContentType($contentType)
+  {
+    $this->contentType = $contentType;
+  }
+  public function getContentType()
+  {
+    return $this->contentType;
+  }
+  public function setCrc32c($crc32c)
+  {
+    $this->crc32c = $crc32c;
+  }
+  public function getCrc32c()
+  {
+    return $this->crc32c;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setGeneration($generation)
+  {
+    $this->generation = $generation;
+  }
+  public function getGeneration()
+  {
+    return $this->generation;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMd5Hash($md5Hash)
+  {
+    $this->md5Hash = $md5Hash;
+  }
+  public function getMd5Hash()
+  {
+    return $this->md5Hash;
+  }
+  public function setMediaLink($mediaLink)
+  {
+    $this->mediaLink = $mediaLink;
+  }
+  public function getMediaLink()
+  {
+    return $this->mediaLink;
+  }
+  public function setMetadata($metadata)
+  {
+    $this->metadata = $metadata;
+  }
+  public function getMetadata()
+  {
+    return $this->metadata;
+  }
+  public function setMetageneration($metageneration)
+  {
+    $this->metageneration = $metageneration;
+  }
+  public function getMetageneration()
+  {
+    return $this->metageneration;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setOwner(Google_Service_Storage_StorageObjectOwner $owner)
+  {
+    $this->owner = $owner;
+  }
+  public function getOwner()
+  {
+    return $this->owner;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setSize($size)
+  {
+    $this->size = $size;
+  }
+  public function getSize()
+  {
+    return $this->size;
+  }
+  public function setStorageClass($storageClass)
+  {
+    $this->storageClass = $storageClass;
+  }
+  public function getStorageClass()
+  {
+    return $this->storageClass;
+  }
+  public function setTimeCreated($timeCreated)
+  {
+    $this->timeCreated = $timeCreated;
+  }
+  public function getTimeCreated()
+  {
+    return $this->timeCreated;
+  }
+  public function setTimeDeleted($timeDeleted)
+  {
+    $this->timeDeleted = $timeDeleted;
+  }
+  public function getTimeDeleted()
+  {
+    return $this->timeDeleted;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+}
+
+class Google_Service_Storage_StorageObjectMetadata extends Google_Model
+{
+}
+
+class Google_Service_Storage_StorageObjectOwner extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $entity;
+  public $entityId;
+
+
+  public function setEntity($entity)
+  {
+    $this->entity = $entity;
+  }
+  public function getEntity()
+  {
+    return $this->entity;
+  }
+  public function setEntityId($entityId)
+  {
+    $this->entityId = $entityId;
+  }
+  public function getEntityId()
+  {
+    return $this->entityId;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Storagetransfer.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Storagetransfer.php
@@ -1,0 +1,1475 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Storagetransfer (v1).
+ *
+ * <p>
+ * Transfers data from external data sources to a Google Cloud Storage bucket or
+ * between Google Cloud Storage buckets.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://cloud.google.com/storage/transfer" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Storagetransfer extends Google_Service
+{
+  /** View and manage your data across Google Cloud Platform services. */
+  const CLOUD_PLATFORM =
+      "https://www.googleapis.com/auth/cloud-platform";
+
+  public $googleServiceAccounts;
+  public $transferJobs;
+  public $transferOperations;
+  public $v1;
+  
+
+  /**
+   * Constructs the internal representation of the Storagetransfer service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://storagetransfer.googleapis.com/';
+    $this->servicePath = '';
+    $this->version = 'v1';
+    $this->serviceName = 'storagetransfer';
+
+    $this->googleServiceAccounts = new Google_Service_Storagetransfer_GoogleServiceAccounts_Resource(
+        $this,
+        $this->serviceName,
+        'googleServiceAccounts',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'v1/googleServiceAccounts/{projectId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->transferJobs = new Google_Service_Storagetransfer_TransferJobs_Resource(
+        $this,
+        $this->serviceName,
+        'transferJobs',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'v1/transferJobs',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'get' => array(
+              'path' => 'v1/{+jobName}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'jobName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'projectId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1/transferJobs',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'v1/{+jobName}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'jobName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->transferOperations = new Google_Service_Storagetransfer_TransferOperations_Resource(
+        $this,
+        $this->serviceName,
+        'transferOperations',
+        array(
+          'methods' => array(
+            'cancel' => array(
+              'path' => 'v1/{+name}:cancel',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'name' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'v1/{+name}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'name' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v1/{+name}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'name' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1/{+name}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'name' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'filter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),'pause' => array(
+              'path' => 'v1/{+name}:pause',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'name' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'resume' => array(
+              'path' => 'v1/{+name}:resume',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'name' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->v1 = new Google_Service_Storagetransfer_V1_Resource(
+        $this,
+        $this->serviceName,
+        'v1',
+        array(
+          'methods' => array(
+            'getGoogleServiceAccount' => array(
+              'path' => 'v1:getGoogleServiceAccount',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'projectId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "googleServiceAccounts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $storagetransferService = new Google_Service_Storagetransfer(...);
+ *   $googleServiceAccounts = $storagetransferService->googleServiceAccounts;
+ *  </code>
+ */
+class Google_Service_Storagetransfer_GoogleServiceAccounts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns the Google service account that is used by Storage Transfer Service
+   * to access buckets in the project where transfers run or in other projects.
+   * Each Google service account is associated with one Google Developers Console
+   * project. Users should add this service account to the Google Cloud Storage
+   * bucket ACLs to grant access to Storage Transfer Service. This service account
+   * is created and owned by Storage Transfer Service and can only be used by
+   * Storage Transfer Service. (googleServiceAccounts.get)
+   *
+   * @param string $projectId The ID of the Google Developers Console project that
+   * the Google service account is associated with. Required.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Storagetransfer_GoogleServiceAccount
+   */
+  public function get($projectId, $optParams = array())
+  {
+    $params = array('projectId' => $projectId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Storagetransfer_GoogleServiceAccount");
+  }
+}
+
+/**
+ * The "transferJobs" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $storagetransferService = new Google_Service_Storagetransfer(...);
+ *   $transferJobs = $storagetransferService->transferJobs;
+ *  </code>
+ */
+class Google_Service_Storagetransfer_TransferJobs_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a transfer job that runs periodically. (transferJobs.create)
+   *
+   * @param Google_TransferJob $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Storagetransfer_TransferJob
+   */
+  public function create(Google_Service_Storagetransfer_TransferJob $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_Storagetransfer_TransferJob");
+  }
+
+  /**
+   * Gets a transfer job. (transferJobs.get)
+   *
+   * @param string $jobName The job to get. Required.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string projectId The ID of the Google Developers Console project
+   * that owns the job. Required.
+   * @return Google_Service_Storagetransfer_TransferJob
+   */
+  public function get($jobName, $optParams = array())
+  {
+    $params = array('jobName' => $jobName);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Storagetransfer_TransferJob");
+  }
+
+  /**
+   * Lists transfer jobs. (transferJobs.listTransferJobs)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter A list of query parameters specified as JSON text in
+   * the form of {"`project_id`":"my_project_id",
+   * "`job_names`":["jobid1","jobid2",...],
+   * "`job_statuses`":["status1","status2",...]}. Since `job_names` and
+   * `job_statuses` support multiple values, their values must be specified with
+   * array notation. `project_id` is required. `job_names` and `job_statuses` are
+   * optional. The valid values for `job_statuses` are case-insensitive:
+   * `ENABLED`, `DISABLED`, and `DELETED`.
+   * @opt_param string pageToken The list page token.
+   * @opt_param int pageSize The list page size. The max allowed value is 256.
+   * @return Google_Service_Storagetransfer_ListTransferJobsResponse
+   */
+  public function listTransferJobs($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Storagetransfer_ListTransferJobsResponse");
+  }
+
+  /**
+   * Updates a transfer job. Updating a job's transfer spec does not affect
+   * transfer operations that are running already. Updating the scheduling of a
+   * job is not allowed. (transferJobs.patch)
+   *
+   * @param string $jobName The name of job to update. Required.
+   * @param Google_UpdateTransferJobRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Storagetransfer_TransferJob
+   */
+  public function patch($jobName, Google_Service_Storagetransfer_UpdateTransferJobRequest $postBody, $optParams = array())
+  {
+    $params = array('jobName' => $jobName, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Storagetransfer_TransferJob");
+  }
+}
+
+/**
+ * The "transferOperations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $storagetransferService = new Google_Service_Storagetransfer(...);
+ *   $transferOperations = $storagetransferService->transferOperations;
+ *  </code>
+ */
+class Google_Service_Storagetransfer_TransferOperations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Cancels a transfer. Use the get method to check whether the cancellation
+   * succeeded or whether the operation completed despite cancellation.
+   * (transferOperations.cancel)
+   *
+   * @param string $name The name of the operation resource to be cancelled.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Storagetransfer_Empty
+   */
+  public function cancel($name, $optParams = array())
+  {
+    $params = array('name' => $name);
+    $params = array_merge($params, $optParams);
+    return $this->call('cancel', array($params), "Google_Service_Storagetransfer_Empty");
+  }
+
+  /**
+   * This method is not supported and the server returns `UNIMPLEMENTED`.
+   * (transferOperations.delete)
+   *
+   * @param string $name The name of the operation resource to be deleted.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Storagetransfer_Empty
+   */
+  public function delete($name, $optParams = array())
+  {
+    $params = array('name' => $name);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_Storagetransfer_Empty");
+  }
+
+  /**
+   * Gets the latest state of a long-running operation. Clients can use this
+   * method to poll the operation result at intervals as recommended by the API
+   * service. (transferOperations.get)
+   *
+   * @param string $name The name of the operation resource.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Storagetransfer_Operation
+   */
+  public function get($name, $optParams = array())
+  {
+    $params = array('name' => $name);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Storagetransfer_Operation");
+  }
+
+  /**
+   * Lists operations that match the specified filter in the request. If the
+   * server doesn't support this method, it returns `UNIMPLEMENTED`. NOTE: the
+   * `name` binding below allows API services to override the binding to use
+   * different resource name schemes, such as `users/operations`.
+   * (transferOperations.listTransferOperations)
+   *
+   * @param string $name The value `transferOperations`.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string filter The standard list filter.
+   * @opt_param string pageToken The standard list page token.
+   * @opt_param int pageSize The standard list page size.
+   * @return Google_Service_Storagetransfer_ListOperationsResponse
+   */
+  public function listTransferOperations($name, $optParams = array())
+  {
+    $params = array('name' => $name);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Storagetransfer_ListOperationsResponse");
+  }
+
+  /**
+   * Pauses a transfer operation. (transferOperations.pause)
+   *
+   * @param string $name The name of the transfer operation. Required.
+   * @param Google_PauseTransferOperationRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Storagetransfer_Empty
+   */
+  public function pause($name, Google_Service_Storagetransfer_PauseTransferOperationRequest $postBody, $optParams = array())
+  {
+    $params = array('name' => $name, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('pause', array($params), "Google_Service_Storagetransfer_Empty");
+  }
+
+  /**
+   * Resumes a transfer operation that is paused. (transferOperations.resume)
+   *
+   * @param string $name The name of the transfer operation. Required.
+   * @param Google_ResumeTransferOperationRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Storagetransfer_Empty
+   */
+  public function resume($name, Google_Service_Storagetransfer_ResumeTransferOperationRequest $postBody, $optParams = array())
+  {
+    $params = array('name' => $name, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('resume', array($params), "Google_Service_Storagetransfer_Empty");
+  }
+}
+
+/**
+ * The "v1" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $storagetransferService = new Google_Service_Storagetransfer(...);
+ *   $v1 = $storagetransferService->v1;
+ *  </code>
+ */
+class Google_Service_Storagetransfer_V1_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns the Google service account that is used by Storage Transfer Service
+   * to access buckets in the project where transfers run or in other projects.
+   * Each Google service account is associated with one Google Developers Console
+   * project. Users should add this service account to the Google Cloud Storage
+   * bucket ACLs to grant access to Storage Transfer Service. This service account
+   * is created and owned by Storage Transfer Service and can only be used by
+   * Storage Transfer Service. (v1.getGoogleServiceAccount)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string projectId The ID of the Google Developers Console project
+   * that the Google service account is associated with. Required.
+   * @return Google_Service_Storagetransfer_GoogleServiceAccount
+   */
+  public function getGoogleServiceAccount($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('getGoogleServiceAccount', array($params), "Google_Service_Storagetransfer_GoogleServiceAccount");
+  }
+}
+
+
+
+
+class Google_Service_Storagetransfer_AwsAccessKey extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accessKeyId;
+  public $secretAccessKey;
+
+
+  public function setAccessKeyId($accessKeyId)
+  {
+    $this->accessKeyId = $accessKeyId;
+  }
+  public function getAccessKeyId()
+  {
+    return $this->accessKeyId;
+  }
+  public function setSecretAccessKey($secretAccessKey)
+  {
+    $this->secretAccessKey = $secretAccessKey;
+  }
+  public function getSecretAccessKey()
+  {
+    return $this->secretAccessKey;
+  }
+}
+
+class Google_Service_Storagetransfer_AwsS3Data extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $awsAccessKeyType = 'Google_Service_Storagetransfer_AwsAccessKey';
+  protected $awsAccessKeyDataType = '';
+  public $bucketName;
+
+
+  public function setAwsAccessKey(Google_Service_Storagetransfer_AwsAccessKey $awsAccessKey)
+  {
+    $this->awsAccessKey = $awsAccessKey;
+  }
+  public function getAwsAccessKey()
+  {
+    return $this->awsAccessKey;
+  }
+  public function setBucketName($bucketName)
+  {
+    $this->bucketName = $bucketName;
+  }
+  public function getBucketName()
+  {
+    return $this->bucketName;
+  }
+}
+
+class Google_Service_Storagetransfer_Date extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $day;
+  public $month;
+  public $year;
+
+
+  public function setDay($day)
+  {
+    $this->day = $day;
+  }
+  public function getDay()
+  {
+    return $this->day;
+  }
+  public function setMonth($month)
+  {
+    $this->month = $month;
+  }
+  public function getMonth()
+  {
+    return $this->month;
+  }
+  public function setYear($year)
+  {
+    $this->year = $year;
+  }
+  public function getYear()
+  {
+    return $this->year;
+  }
+}
+
+class Google_Service_Storagetransfer_Empty extends Google_Model
+{
+}
+
+class Google_Service_Storagetransfer_ErrorLogEntry extends Google_Collection
+{
+  protected $collection_key = 'errorDetails';
+  protected $internal_gapi_mappings = array(
+  );
+  public $errorDetails;
+  public $url;
+
+
+  public function setErrorDetails($errorDetails)
+  {
+    $this->errorDetails = $errorDetails;
+  }
+  public function getErrorDetails()
+  {
+    return $this->errorDetails;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_Storagetransfer_ErrorSummary extends Google_Collection
+{
+  protected $collection_key = 'errorLogEntries';
+  protected $internal_gapi_mappings = array(
+  );
+  public $errorCode;
+  public $errorCount;
+  protected $errorLogEntriesType = 'Google_Service_Storagetransfer_ErrorLogEntry';
+  protected $errorLogEntriesDataType = 'array';
+
+
+  public function setErrorCode($errorCode)
+  {
+    $this->errorCode = $errorCode;
+  }
+  public function getErrorCode()
+  {
+    return $this->errorCode;
+  }
+  public function setErrorCount($errorCount)
+  {
+    $this->errorCount = $errorCount;
+  }
+  public function getErrorCount()
+  {
+    return $this->errorCount;
+  }
+  public function setErrorLogEntries($errorLogEntries)
+  {
+    $this->errorLogEntries = $errorLogEntries;
+  }
+  public function getErrorLogEntries()
+  {
+    return $this->errorLogEntries;
+  }
+}
+
+class Google_Service_Storagetransfer_GcsData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $bucketName;
+
+
+  public function setBucketName($bucketName)
+  {
+    $this->bucketName = $bucketName;
+  }
+  public function getBucketName()
+  {
+    return $this->bucketName;
+  }
+}
+
+class Google_Service_Storagetransfer_GoogleServiceAccount extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountEmail;
+
+
+  public function setAccountEmail($accountEmail)
+  {
+    $this->accountEmail = $accountEmail;
+  }
+  public function getAccountEmail()
+  {
+    return $this->accountEmail;
+  }
+}
+
+class Google_Service_Storagetransfer_HttpData extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $listUrl;
+
+
+  public function setListUrl($listUrl)
+  {
+    $this->listUrl = $listUrl;
+  }
+  public function getListUrl()
+  {
+    return $this->listUrl;
+  }
+}
+
+class Google_Service_Storagetransfer_ListOperationsResponse extends Google_Collection
+{
+  protected $collection_key = 'operations';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $operationsType = 'Google_Service_Storagetransfer_Operation';
+  protected $operationsDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setOperations($operations)
+  {
+    $this->operations = $operations;
+  }
+  public function getOperations()
+  {
+    return $this->operations;
+  }
+}
+
+class Google_Service_Storagetransfer_ListTransferJobsResponse extends Google_Collection
+{
+  protected $collection_key = 'transferJobs';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $transferJobsType = 'Google_Service_Storagetransfer_TransferJob';
+  protected $transferJobsDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTransferJobs($transferJobs)
+  {
+    $this->transferJobs = $transferJobs;
+  }
+  public function getTransferJobs()
+  {
+    return $this->transferJobs;
+  }
+}
+
+class Google_Service_Storagetransfer_ObjectConditions extends Google_Collection
+{
+  protected $collection_key = 'includePrefixes';
+  protected $internal_gapi_mappings = array(
+  );
+  public $excludePrefixes;
+  public $includePrefixes;
+  public $maxTimeElapsedSinceLastModification;
+  public $minTimeElapsedSinceLastModification;
+
+
+  public function setExcludePrefixes($excludePrefixes)
+  {
+    $this->excludePrefixes = $excludePrefixes;
+  }
+  public function getExcludePrefixes()
+  {
+    return $this->excludePrefixes;
+  }
+  public function setIncludePrefixes($includePrefixes)
+  {
+    $this->includePrefixes = $includePrefixes;
+  }
+  public function getIncludePrefixes()
+  {
+    return $this->includePrefixes;
+  }
+  public function setMaxTimeElapsedSinceLastModification($maxTimeElapsedSinceLastModification)
+  {
+    $this->maxTimeElapsedSinceLastModification = $maxTimeElapsedSinceLastModification;
+  }
+  public function getMaxTimeElapsedSinceLastModification()
+  {
+    return $this->maxTimeElapsedSinceLastModification;
+  }
+  public function setMinTimeElapsedSinceLastModification($minTimeElapsedSinceLastModification)
+  {
+    $this->minTimeElapsedSinceLastModification = $minTimeElapsedSinceLastModification;
+  }
+  public function getMinTimeElapsedSinceLastModification()
+  {
+    return $this->minTimeElapsedSinceLastModification;
+  }
+}
+
+class Google_Service_Storagetransfer_Operation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $done;
+  protected $errorType = 'Google_Service_Storagetransfer_Status';
+  protected $errorDataType = '';
+  public $metadata;
+  public $name;
+  public $response;
+
+
+  public function setDone($done)
+  {
+    $this->done = $done;
+  }
+  public function getDone()
+  {
+    return $this->done;
+  }
+  public function setError(Google_Service_Storagetransfer_Status $error)
+  {
+    $this->error = $error;
+  }
+  public function getError()
+  {
+    return $this->error;
+  }
+  public function setMetadata($metadata)
+  {
+    $this->metadata = $metadata;
+  }
+  public function getMetadata()
+  {
+    return $this->metadata;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setResponse($response)
+  {
+    $this->response = $response;
+  }
+  public function getResponse()
+  {
+    return $this->response;
+  }
+}
+
+class Google_Service_Storagetransfer_OperationMetadata extends Google_Model
+{
+}
+
+class Google_Service_Storagetransfer_OperationResponse extends Google_Model
+{
+}
+
+class Google_Service_Storagetransfer_PauseTransferOperationRequest extends Google_Model
+{
+}
+
+class Google_Service_Storagetransfer_ResumeTransferOperationRequest extends Google_Model
+{
+}
+
+class Google_Service_Storagetransfer_Schedule extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $scheduleEndDateType = 'Google_Service_Storagetransfer_Date';
+  protected $scheduleEndDateDataType = '';
+  protected $scheduleStartDateType = 'Google_Service_Storagetransfer_Date';
+  protected $scheduleStartDateDataType = '';
+  protected $startTimeOfDayType = 'Google_Service_Storagetransfer_TimeOfDay';
+  protected $startTimeOfDayDataType = '';
+
+
+  public function setScheduleEndDate(Google_Service_Storagetransfer_Date $scheduleEndDate)
+  {
+    $this->scheduleEndDate = $scheduleEndDate;
+  }
+  public function getScheduleEndDate()
+  {
+    return $this->scheduleEndDate;
+  }
+  public function setScheduleStartDate(Google_Service_Storagetransfer_Date $scheduleStartDate)
+  {
+    $this->scheduleStartDate = $scheduleStartDate;
+  }
+  public function getScheduleStartDate()
+  {
+    return $this->scheduleStartDate;
+  }
+  public function setStartTimeOfDay(Google_Service_Storagetransfer_TimeOfDay $startTimeOfDay)
+  {
+    $this->startTimeOfDay = $startTimeOfDay;
+  }
+  public function getStartTimeOfDay()
+  {
+    return $this->startTimeOfDay;
+  }
+}
+
+class Google_Service_Storagetransfer_Status extends Google_Collection
+{
+  protected $collection_key = 'details';
+  protected $internal_gapi_mappings = array(
+  );
+  public $code;
+  public $details;
+  public $message;
+
+
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  public function getCode()
+  {
+    return $this->code;
+  }
+  public function setDetails($details)
+  {
+    $this->details = $details;
+  }
+  public function getDetails()
+  {
+    return $this->details;
+  }
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+class Google_Service_Storagetransfer_StatusDetails extends Google_Model
+{
+}
+
+class Google_Service_Storagetransfer_TimeOfDay extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $hours;
+  public $minutes;
+  public $nanos;
+  public $seconds;
+
+
+  public function setHours($hours)
+  {
+    $this->hours = $hours;
+  }
+  public function getHours()
+  {
+    return $this->hours;
+  }
+  public function setMinutes($minutes)
+  {
+    $this->minutes = $minutes;
+  }
+  public function getMinutes()
+  {
+    return $this->minutes;
+  }
+  public function setNanos($nanos)
+  {
+    $this->nanos = $nanos;
+  }
+  public function getNanos()
+  {
+    return $this->nanos;
+  }
+  public function setSeconds($seconds)
+  {
+    $this->seconds = $seconds;
+  }
+  public function getSeconds()
+  {
+    return $this->seconds;
+  }
+}
+
+class Google_Service_Storagetransfer_TransferCounters extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $bytesCopiedToSink;
+  public $bytesDeletedFromSink;
+  public $bytesDeletedFromSource;
+  public $bytesFailedToDeleteFromSink;
+  public $bytesFoundFromSource;
+  public $bytesFoundOnlyFromSink;
+  public $bytesFromSourceFailed;
+  public $bytesFromSourceSkippedBySync;
+  public $objectsCopiedToSink;
+  public $objectsDeletedFromSink;
+  public $objectsDeletedFromSource;
+  public $objectsFailedToDeleteFromSink;
+  public $objectsFoundFromSource;
+  public $objectsFoundOnlyFromSink;
+  public $objectsFromSourceFailed;
+  public $objectsFromSourceSkippedBySync;
+
+
+  public function setBytesCopiedToSink($bytesCopiedToSink)
+  {
+    $this->bytesCopiedToSink = $bytesCopiedToSink;
+  }
+  public function getBytesCopiedToSink()
+  {
+    return $this->bytesCopiedToSink;
+  }
+  public function setBytesDeletedFromSink($bytesDeletedFromSink)
+  {
+    $this->bytesDeletedFromSink = $bytesDeletedFromSink;
+  }
+  public function getBytesDeletedFromSink()
+  {
+    return $this->bytesDeletedFromSink;
+  }
+  public function setBytesDeletedFromSource($bytesDeletedFromSource)
+  {
+    $this->bytesDeletedFromSource = $bytesDeletedFromSource;
+  }
+  public function getBytesDeletedFromSource()
+  {
+    return $this->bytesDeletedFromSource;
+  }
+  public function setBytesFailedToDeleteFromSink($bytesFailedToDeleteFromSink)
+  {
+    $this->bytesFailedToDeleteFromSink = $bytesFailedToDeleteFromSink;
+  }
+  public function getBytesFailedToDeleteFromSink()
+  {
+    return $this->bytesFailedToDeleteFromSink;
+  }
+  public function setBytesFoundFromSource($bytesFoundFromSource)
+  {
+    $this->bytesFoundFromSource = $bytesFoundFromSource;
+  }
+  public function getBytesFoundFromSource()
+  {
+    return $this->bytesFoundFromSource;
+  }
+  public function setBytesFoundOnlyFromSink($bytesFoundOnlyFromSink)
+  {
+    $this->bytesFoundOnlyFromSink = $bytesFoundOnlyFromSink;
+  }
+  public function getBytesFoundOnlyFromSink()
+  {
+    return $this->bytesFoundOnlyFromSink;
+  }
+  public function setBytesFromSourceFailed($bytesFromSourceFailed)
+  {
+    $this->bytesFromSourceFailed = $bytesFromSourceFailed;
+  }
+  public function getBytesFromSourceFailed()
+  {
+    return $this->bytesFromSourceFailed;
+  }
+  public function setBytesFromSourceSkippedBySync($bytesFromSourceSkippedBySync)
+  {
+    $this->bytesFromSourceSkippedBySync = $bytesFromSourceSkippedBySync;
+  }
+  public function getBytesFromSourceSkippedBySync()
+  {
+    return $this->bytesFromSourceSkippedBySync;
+  }
+  public function setObjectsCopiedToSink($objectsCopiedToSink)
+  {
+    $this->objectsCopiedToSink = $objectsCopiedToSink;
+  }
+  public function getObjectsCopiedToSink()
+  {
+    return $this->objectsCopiedToSink;
+  }
+  public function setObjectsDeletedFromSink($objectsDeletedFromSink)
+  {
+    $this->objectsDeletedFromSink = $objectsDeletedFromSink;
+  }
+  public function getObjectsDeletedFromSink()
+  {
+    return $this->objectsDeletedFromSink;
+  }
+  public function setObjectsDeletedFromSource($objectsDeletedFromSource)
+  {
+    $this->objectsDeletedFromSource = $objectsDeletedFromSource;
+  }
+  public function getObjectsDeletedFromSource()
+  {
+    return $this->objectsDeletedFromSource;
+  }
+  public function setObjectsFailedToDeleteFromSink($objectsFailedToDeleteFromSink)
+  {
+    $this->objectsFailedToDeleteFromSink = $objectsFailedToDeleteFromSink;
+  }
+  public function getObjectsFailedToDeleteFromSink()
+  {
+    return $this->objectsFailedToDeleteFromSink;
+  }
+  public function setObjectsFoundFromSource($objectsFoundFromSource)
+  {
+    $this->objectsFoundFromSource = $objectsFoundFromSource;
+  }
+  public function getObjectsFoundFromSource()
+  {
+    return $this->objectsFoundFromSource;
+  }
+  public function setObjectsFoundOnlyFromSink($objectsFoundOnlyFromSink)
+  {
+    $this->objectsFoundOnlyFromSink = $objectsFoundOnlyFromSink;
+  }
+  public function getObjectsFoundOnlyFromSink()
+  {
+    return $this->objectsFoundOnlyFromSink;
+  }
+  public function setObjectsFromSourceFailed($objectsFromSourceFailed)
+  {
+    $this->objectsFromSourceFailed = $objectsFromSourceFailed;
+  }
+  public function getObjectsFromSourceFailed()
+  {
+    return $this->objectsFromSourceFailed;
+  }
+  public function setObjectsFromSourceSkippedBySync($objectsFromSourceSkippedBySync)
+  {
+    $this->objectsFromSourceSkippedBySync = $objectsFromSourceSkippedBySync;
+  }
+  public function getObjectsFromSourceSkippedBySync()
+  {
+    return $this->objectsFromSourceSkippedBySync;
+  }
+}
+
+class Google_Service_Storagetransfer_TransferJob extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $creationTime;
+  public $deletionTime;
+  public $description;
+  public $lastModificationTime;
+  public $name;
+  public $projectId;
+  protected $scheduleType = 'Google_Service_Storagetransfer_Schedule';
+  protected $scheduleDataType = '';
+  public $status;
+  protected $transferSpecType = 'Google_Service_Storagetransfer_TransferSpec';
+  protected $transferSpecDataType = '';
+
+
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setDeletionTime($deletionTime)
+  {
+    $this->deletionTime = $deletionTime;
+  }
+  public function getDeletionTime()
+  {
+    return $this->deletionTime;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setLastModificationTime($lastModificationTime)
+  {
+    $this->lastModificationTime = $lastModificationTime;
+  }
+  public function getLastModificationTime()
+  {
+    return $this->lastModificationTime;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setSchedule(Google_Service_Storagetransfer_Schedule $schedule)
+  {
+    $this->schedule = $schedule;
+  }
+  public function getSchedule()
+  {
+    return $this->schedule;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setTransferSpec(Google_Service_Storagetransfer_TransferSpec $transferSpec)
+  {
+    $this->transferSpec = $transferSpec;
+  }
+  public function getTransferSpec()
+  {
+    return $this->transferSpec;
+  }
+}
+
+class Google_Service_Storagetransfer_TransferOperation extends Google_Collection
+{
+  protected $collection_key = 'errorBreakdowns';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $countersType = 'Google_Service_Storagetransfer_TransferCounters';
+  protected $countersDataType = '';
+  public $endTime;
+  protected $errorBreakdownsType = 'Google_Service_Storagetransfer_ErrorSummary';
+  protected $errorBreakdownsDataType = 'array';
+  public $name;
+  public $projectId;
+  public $startTime;
+  public $status;
+  public $transferJobName;
+  protected $transferSpecType = 'Google_Service_Storagetransfer_TransferSpec';
+  protected $transferSpecDataType = '';
+
+
+  public function setCounters(Google_Service_Storagetransfer_TransferCounters $counters)
+  {
+    $this->counters = $counters;
+  }
+  public function getCounters()
+  {
+    return $this->counters;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setErrorBreakdowns($errorBreakdowns)
+  {
+    $this->errorBreakdowns = $errorBreakdowns;
+  }
+  public function getErrorBreakdowns()
+  {
+    return $this->errorBreakdowns;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setTransferJobName($transferJobName)
+  {
+    $this->transferJobName = $transferJobName;
+  }
+  public function getTransferJobName()
+  {
+    return $this->transferJobName;
+  }
+  public function setTransferSpec(Google_Service_Storagetransfer_TransferSpec $transferSpec)
+  {
+    $this->transferSpec = $transferSpec;
+  }
+  public function getTransferSpec()
+  {
+    return $this->transferSpec;
+  }
+}
+
+class Google_Service_Storagetransfer_TransferOptions extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $deleteObjectsFromSourceAfterTransfer;
+  public $deleteObjectsUniqueInSink;
+  public $overwriteObjectsAlreadyExistingInSink;
+
+
+  public function setDeleteObjectsFromSourceAfterTransfer($deleteObjectsFromSourceAfterTransfer)
+  {
+    $this->deleteObjectsFromSourceAfterTransfer = $deleteObjectsFromSourceAfterTransfer;
+  }
+  public function getDeleteObjectsFromSourceAfterTransfer()
+  {
+    return $this->deleteObjectsFromSourceAfterTransfer;
+  }
+  public function setDeleteObjectsUniqueInSink($deleteObjectsUniqueInSink)
+  {
+    $this->deleteObjectsUniqueInSink = $deleteObjectsUniqueInSink;
+  }
+  public function getDeleteObjectsUniqueInSink()
+  {
+    return $this->deleteObjectsUniqueInSink;
+  }
+  public function setOverwriteObjectsAlreadyExistingInSink($overwriteObjectsAlreadyExistingInSink)
+  {
+    $this->overwriteObjectsAlreadyExistingInSink = $overwriteObjectsAlreadyExistingInSink;
+  }
+  public function getOverwriteObjectsAlreadyExistingInSink()
+  {
+    return $this->overwriteObjectsAlreadyExistingInSink;
+  }
+}
+
+class Google_Service_Storagetransfer_TransferSpec extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $awsS3DataSourceType = 'Google_Service_Storagetransfer_AwsS3Data';
+  protected $awsS3DataSourceDataType = '';
+  protected $gcsDataSinkType = 'Google_Service_Storagetransfer_GcsData';
+  protected $gcsDataSinkDataType = '';
+  protected $gcsDataSourceType = 'Google_Service_Storagetransfer_GcsData';
+  protected $gcsDataSourceDataType = '';
+  protected $httpDataSourceType = 'Google_Service_Storagetransfer_HttpData';
+  protected $httpDataSourceDataType = '';
+  protected $objectConditionsType = 'Google_Service_Storagetransfer_ObjectConditions';
+  protected $objectConditionsDataType = '';
+  protected $transferOptionsType = 'Google_Service_Storagetransfer_TransferOptions';
+  protected $transferOptionsDataType = '';
+
+
+  public function setAwsS3DataSource(Google_Service_Storagetransfer_AwsS3Data $awsS3DataSource)
+  {
+    $this->awsS3DataSource = $awsS3DataSource;
+  }
+  public function getAwsS3DataSource()
+  {
+    return $this->awsS3DataSource;
+  }
+  public function setGcsDataSink(Google_Service_Storagetransfer_GcsData $gcsDataSink)
+  {
+    $this->gcsDataSink = $gcsDataSink;
+  }
+  public function getGcsDataSink()
+  {
+    return $this->gcsDataSink;
+  }
+  public function setGcsDataSource(Google_Service_Storagetransfer_GcsData $gcsDataSource)
+  {
+    $this->gcsDataSource = $gcsDataSource;
+  }
+  public function getGcsDataSource()
+  {
+    return $this->gcsDataSource;
+  }
+  public function setHttpDataSource(Google_Service_Storagetransfer_HttpData $httpDataSource)
+  {
+    $this->httpDataSource = $httpDataSource;
+  }
+  public function getHttpDataSource()
+  {
+    return $this->httpDataSource;
+  }
+  public function setObjectConditions(Google_Service_Storagetransfer_ObjectConditions $objectConditions)
+  {
+    $this->objectConditions = $objectConditions;
+  }
+  public function getObjectConditions()
+  {
+    return $this->objectConditions;
+  }
+  public function setTransferOptions(Google_Service_Storagetransfer_TransferOptions $transferOptions)
+  {
+    $this->transferOptions = $transferOptions;
+  }
+  public function getTransferOptions()
+  {
+    return $this->transferOptions;
+  }
+}
+
+class Google_Service_Storagetransfer_UpdateTransferJobRequest extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $projectId;
+  protected $transferJobType = 'Google_Service_Storagetransfer_TransferJob';
+  protected $transferJobDataType = '';
+  public $updateTransferJobFieldMask;
+
+
+  public function setProjectId($projectId)
+  {
+    $this->projectId = $projectId;
+  }
+  public function getProjectId()
+  {
+    return $this->projectId;
+  }
+  public function setTransferJob(Google_Service_Storagetransfer_TransferJob $transferJob)
+  {
+    $this->transferJob = $transferJob;
+  }
+  public function getTransferJob()
+  {
+    return $this->transferJob;
+  }
+  public function setUpdateTransferJobFieldMask($updateTransferJobFieldMask)
+  {
+    $this->updateTransferJobFieldMask = $updateTransferJobFieldMask;
+  }
+  public function getUpdateTransferJobFieldMask()
+  {
+    return $this->updateTransferJobFieldMask;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/TagManager.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/TagManager.php
@@ -1,0 +1,3445 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for TagManager (v1).
+ *
+ * <p>
+ * API for accessing Tag Manager accounts and containers.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/tag-manager/api/v1/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_TagManager extends Google_Service
+{
+  /** Delete your Google Tag Manager containers. */
+  const TAGMANAGER_DELETE_CONTAINERS =
+      "https://www.googleapis.com/auth/tagmanager.delete.containers";
+  /** Manage your Google Tag Manager containers. */
+  const TAGMANAGER_EDIT_CONTAINERS =
+      "https://www.googleapis.com/auth/tagmanager.edit.containers";
+  /** Manage your Google Tag Manager container versions. */
+  const TAGMANAGER_EDIT_CONTAINERVERSIONS =
+      "https://www.googleapis.com/auth/tagmanager.edit.containerversions";
+  /** Manage your Google Tag Manager accounts. */
+  const TAGMANAGER_MANAGE_ACCOUNTS =
+      "https://www.googleapis.com/auth/tagmanager.manage.accounts";
+  /** Manage user permissions of your Google Tag Manager data. */
+  const TAGMANAGER_MANAGE_USERS =
+      "https://www.googleapis.com/auth/tagmanager.manage.users";
+  /** Publish your Google Tag Manager containers. */
+  const TAGMANAGER_PUBLISH =
+      "https://www.googleapis.com/auth/tagmanager.publish";
+  /** View your Google Tag Manager containers. */
+  const TAGMANAGER_READONLY =
+      "https://www.googleapis.com/auth/tagmanager.readonly";
+
+  public $accounts;
+  public $accounts_containers;
+  public $accounts_containers_folders;
+  public $accounts_containers_folders_entities;
+  public $accounts_containers_move_folders;
+  public $accounts_containers_tags;
+  public $accounts_containers_triggers;
+  public $accounts_containers_variables;
+  public $accounts_containers_versions;
+  public $accounts_permissions;
+  
+
+  /**
+   * Constructs the internal representation of the TagManager service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'tagmanager/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'tagmanager';
+
+    $this->accounts = new Google_Service_TagManager_Accounts_Resource(
+        $this,
+        $this->serviceName,
+        'accounts',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'accounts/{accountId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),'update' => array(
+              'path' => 'accounts/{accountId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'fingerprint' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_containers = new Google_Service_TagManager_AccountsContainers_Resource(
+        $this,
+        $this->serviceName,
+        'containers',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'accounts/{accountId}/containers',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts/{accountId}/containers',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'fingerprint' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_containers_folders = new Google_Service_TagManager_AccountsContainersFolders_Resource(
+        $this,
+        $this->serviceName,
+        'folders',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/folders',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/folders/{folderId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'folderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/folders/{folderId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'folderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/folders',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/folders/{folderId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'folderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'fingerprint' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_containers_folders_entities = new Google_Service_TagManager_AccountsContainersFoldersEntities_Resource(
+        $this,
+        $this->serviceName,
+        'entities',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/folders/{folderId}/entities',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'folderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_containers_move_folders = new Google_Service_TagManager_AccountsContainersMoveFolders_Resource(
+        $this,
+        $this->serviceName,
+        'move_folders',
+        array(
+          'methods' => array(
+            'update' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/move_folders/{folderId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'folderId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'variableId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'tagId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+                'triggerId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_containers_tags = new Google_Service_TagManager_AccountsContainersTags_Resource(
+        $this,
+        $this->serviceName,
+        'tags',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/tags',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/tags/{tagId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'tagId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/tags/{tagId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'tagId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/tags',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/tags/{tagId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'tagId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'fingerprint' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_containers_triggers = new Google_Service_TagManager_AccountsContainersTriggers_Resource(
+        $this,
+        $this->serviceName,
+        'triggers',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/triggers',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/triggers/{triggerId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'triggerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/triggers/{triggerId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'triggerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/triggers',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/triggers/{triggerId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'triggerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'fingerprint' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_containers_variables = new Google_Service_TagManager_AccountsContainersVariables_Resource(
+        $this,
+        $this->serviceName,
+        'variables',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/variables',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/variables/{variableId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'variableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/variables/{variableId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'variableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/variables',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/variables/{variableId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'variableId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'fingerprint' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_containers_versions = new Google_Service_TagManager_AccountsContainersVersions_Resource(
+        $this,
+        $this->serviceName,
+        'versions',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/versions',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/versions/{containerVersionId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerVersionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/versions/{containerVersionId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerVersionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/versions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'headers' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'publish' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/versions/{containerVersionId}/publish',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerVersionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'fingerprint' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'restore' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/versions/{containerVersionId}/restore',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerVersionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'undelete' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/versions/{containerVersionId}/undelete',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerVersionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'accounts/{accountId}/containers/{containerId}/versions/{containerVersionId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'containerVersionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'fingerprint' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->accounts_permissions = new Google_Service_TagManager_AccountsPermissions_Resource(
+        $this,
+        $this->serviceName,
+        'permissions',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'accounts/{accountId}/permissions',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'accounts/{accountId}/permissions/{permissionId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'permissionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'accounts/{accountId}/permissions/{permissionId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'permissionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'accounts/{accountId}/permissions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'accounts/{accountId}/permissions/{permissionId}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'accountId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'permissionId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "accounts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $tagmanagerService = new Google_Service_TagManager(...);
+ *   $accounts = $tagmanagerService->accounts;
+ *  </code>
+ */
+class Google_Service_TagManager_Accounts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets a GTM Account. (accounts.get)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_Account
+   */
+  public function get($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_TagManager_Account");
+  }
+
+  /**
+   * Lists all GTM Accounts that a user has access to. (accounts.listAccounts)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_ListAccountsResponse
+   */
+  public function listAccounts($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_TagManager_ListAccountsResponse");
+  }
+
+  /**
+   * Updates a GTM Account. (accounts.update)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param Google_Account $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string fingerprint When provided, this fingerprint must match the
+   * fingerprint of the account in storage.
+   * @return Google_Service_TagManager_Account
+   */
+  public function update($accountId, Google_Service_TagManager_Account $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_TagManager_Account");
+  }
+}
+
+/**
+ * The "containers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $tagmanagerService = new Google_Service_TagManager(...);
+ *   $containers = $tagmanagerService->containers;
+ *  </code>
+ */
+class Google_Service_TagManager_AccountsContainers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a Container. (containers.create)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param Google_Container $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_Container
+   */
+  public function create($accountId, Google_Service_TagManager_Container $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_TagManager_Container");
+  }
+
+  /**
+   * Deletes a Container. (containers.delete)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($accountId, $containerId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets a Container. (containers.get)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_Container
+   */
+  public function get($accountId, $containerId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_TagManager_Container");
+  }
+
+  /**
+   * Lists all Containers that belongs to a GTM Account.
+   * (containers.listAccountsContainers)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_ListContainersResponse
+   */
+  public function listAccountsContainers($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_TagManager_ListContainersResponse");
+  }
+
+  /**
+   * Updates a Container. (containers.update)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param Google_Container $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string fingerprint When provided, this fingerprint must match the
+   * fingerprint of the container in storage.
+   * @return Google_Service_TagManager_Container
+   */
+  public function update($accountId, $containerId, Google_Service_TagManager_Container $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_TagManager_Container");
+  }
+}
+
+/**
+ * The "folders" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $tagmanagerService = new Google_Service_TagManager(...);
+ *   $folders = $tagmanagerService->folders;
+ *  </code>
+ */
+class Google_Service_TagManager_AccountsContainersFolders_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a GTM Folder. (folders.create)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param Google_Folder $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_Folder
+   */
+  public function create($accountId, $containerId, Google_Service_TagManager_Folder $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_TagManager_Folder");
+  }
+
+  /**
+   * Deletes a GTM Folder. (folders.delete)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $folderId The GTM Folder ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($accountId, $containerId, $folderId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'folderId' => $folderId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets a GTM Folder. (folders.get)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $folderId The GTM Folder ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_Folder
+   */
+  public function get($accountId, $containerId, $folderId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'folderId' => $folderId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_TagManager_Folder");
+  }
+
+  /**
+   * Lists all GTM Folders of a Container. (folders.listAccountsContainersFolders)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_ListFoldersResponse
+   */
+  public function listAccountsContainersFolders($accountId, $containerId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_TagManager_ListFoldersResponse");
+  }
+
+  /**
+   * Updates a GTM Folder. (folders.update)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $folderId The GTM Folder ID.
+   * @param Google_Folder $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string fingerprint When provided, this fingerprint must match the
+   * fingerprint of the folder in storage.
+   * @return Google_Service_TagManager_Folder
+   */
+  public function update($accountId, $containerId, $folderId, Google_Service_TagManager_Folder $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'folderId' => $folderId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_TagManager_Folder");
+  }
+}
+
+/**
+ * The "entities" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $tagmanagerService = new Google_Service_TagManager(...);
+ *   $entities = $tagmanagerService->entities;
+ *  </code>
+ */
+class Google_Service_TagManager_AccountsContainersFoldersEntities_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List all entities in a GTM Folder.
+   * (entities.listAccountsContainersFoldersEntities)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $folderId The GTM Folder ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_FolderEntities
+   */
+  public function listAccountsContainersFoldersEntities($accountId, $containerId, $folderId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'folderId' => $folderId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_TagManager_FolderEntities");
+  }
+}
+/**
+ * The "move_folders" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $tagmanagerService = new Google_Service_TagManager(...);
+ *   $move_folders = $tagmanagerService->move_folders;
+ *  </code>
+ */
+class Google_Service_TagManager_AccountsContainersMoveFolders_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Moves entities to a GTM Folder. (move_folders.update)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $folderId The GTM Folder ID.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string variableId The variables to be moved to the folder.
+   * @opt_param string tagId The tags to be moved to the folder.
+   * @opt_param string triggerId The triggers to be moved to the folder.
+   */
+  public function update($accountId, $containerId, $folderId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'folderId' => $folderId);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params));
+  }
+}
+/**
+ * The "tags" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $tagmanagerService = new Google_Service_TagManager(...);
+ *   $tags = $tagmanagerService->tags;
+ *  </code>
+ */
+class Google_Service_TagManager_AccountsContainersTags_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a GTM Tag. (tags.create)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param Google_Tag $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_Tag
+   */
+  public function create($accountId, $containerId, Google_Service_TagManager_Tag $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_TagManager_Tag");
+  }
+
+  /**
+   * Deletes a GTM Tag. (tags.delete)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $tagId The GTM Tag ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($accountId, $containerId, $tagId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'tagId' => $tagId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets a GTM Tag. (tags.get)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $tagId The GTM Tag ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_Tag
+   */
+  public function get($accountId, $containerId, $tagId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'tagId' => $tagId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_TagManager_Tag");
+  }
+
+  /**
+   * Lists all GTM Tags of a Container. (tags.listAccountsContainersTags)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_ListTagsResponse
+   */
+  public function listAccountsContainersTags($accountId, $containerId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_TagManager_ListTagsResponse");
+  }
+
+  /**
+   * Updates a GTM Tag. (tags.update)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $tagId The GTM Tag ID.
+   * @param Google_Tag $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string fingerprint When provided, this fingerprint must match the
+   * fingerprint of the tag in storage.
+   * @return Google_Service_TagManager_Tag
+   */
+  public function update($accountId, $containerId, $tagId, Google_Service_TagManager_Tag $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'tagId' => $tagId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_TagManager_Tag");
+  }
+}
+/**
+ * The "triggers" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $tagmanagerService = new Google_Service_TagManager(...);
+ *   $triggers = $tagmanagerService->triggers;
+ *  </code>
+ */
+class Google_Service_TagManager_AccountsContainersTriggers_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a GTM Trigger. (triggers.create)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param Google_Trigger $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_Trigger
+   */
+  public function create($accountId, $containerId, Google_Service_TagManager_Trigger $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_TagManager_Trigger");
+  }
+
+  /**
+   * Deletes a GTM Trigger. (triggers.delete)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $triggerId The GTM Trigger ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($accountId, $containerId, $triggerId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'triggerId' => $triggerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets a GTM Trigger. (triggers.get)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $triggerId The GTM Trigger ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_Trigger
+   */
+  public function get($accountId, $containerId, $triggerId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'triggerId' => $triggerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_TagManager_Trigger");
+  }
+
+  /**
+   * Lists all GTM Triggers of a Container.
+   * (triggers.listAccountsContainersTriggers)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_ListTriggersResponse
+   */
+  public function listAccountsContainersTriggers($accountId, $containerId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_TagManager_ListTriggersResponse");
+  }
+
+  /**
+   * Updates a GTM Trigger. (triggers.update)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $triggerId The GTM Trigger ID.
+   * @param Google_Trigger $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string fingerprint When provided, this fingerprint must match the
+   * fingerprint of the trigger in storage.
+   * @return Google_Service_TagManager_Trigger
+   */
+  public function update($accountId, $containerId, $triggerId, Google_Service_TagManager_Trigger $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'triggerId' => $triggerId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_TagManager_Trigger");
+  }
+}
+/**
+ * The "variables" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $tagmanagerService = new Google_Service_TagManager(...);
+ *   $variables = $tagmanagerService->variables;
+ *  </code>
+ */
+class Google_Service_TagManager_AccountsContainersVariables_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a GTM Variable. (variables.create)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param Google_Variable $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_Variable
+   */
+  public function create($accountId, $containerId, Google_Service_TagManager_Variable $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_TagManager_Variable");
+  }
+
+  /**
+   * Deletes a GTM Variable. (variables.delete)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $variableId The GTM Variable ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($accountId, $containerId, $variableId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'variableId' => $variableId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets a GTM Variable. (variables.get)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $variableId The GTM Variable ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_Variable
+   */
+  public function get($accountId, $containerId, $variableId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'variableId' => $variableId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_TagManager_Variable");
+  }
+
+  /**
+   * Lists all GTM Variables of a Container.
+   * (variables.listAccountsContainersVariables)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_ListVariablesResponse
+   */
+  public function listAccountsContainersVariables($accountId, $containerId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_TagManager_ListVariablesResponse");
+  }
+
+  /**
+   * Updates a GTM Variable. (variables.update)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $variableId The GTM Variable ID.
+   * @param Google_Variable $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string fingerprint When provided, this fingerprint must match the
+   * fingerprint of the variable in storage.
+   * @return Google_Service_TagManager_Variable
+   */
+  public function update($accountId, $containerId, $variableId, Google_Service_TagManager_Variable $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'variableId' => $variableId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_TagManager_Variable");
+  }
+}
+/**
+ * The "versions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $tagmanagerService = new Google_Service_TagManager(...);
+ *   $versions = $tagmanagerService->versions;
+ *  </code>
+ */
+class Google_Service_TagManager_AccountsContainersVersions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a Container Version. (versions.create)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param Google_CreateContainerVersionRequestVersionOptions $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_CreateContainerVersionResponse
+   */
+  public function create($accountId, $containerId, Google_Service_TagManager_CreateContainerVersionRequestVersionOptions $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_TagManager_CreateContainerVersionResponse");
+  }
+
+  /**
+   * Deletes a Container Version. (versions.delete)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $containerVersionId The GTM Container Version ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($accountId, $containerId, $containerVersionId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'containerVersionId' => $containerVersionId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets a Container Version. (versions.get)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $containerVersionId The GTM Container Version ID. Specify
+   * published to retrieve the currently published version.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_ContainerVersion
+   */
+  public function get($accountId, $containerId, $containerVersionId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'containerVersionId' => $containerVersionId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_TagManager_ContainerVersion");
+  }
+
+  /**
+   * Lists all Container Versions of a GTM Container.
+   * (versions.listAccountsContainersVersions)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool headers Retrieve headers only when true.
+   * @return Google_Service_TagManager_ListContainerVersionsResponse
+   */
+  public function listAccountsContainersVersions($accountId, $containerId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_TagManager_ListContainerVersionsResponse");
+  }
+
+  /**
+   * Publishes a Container Version. (versions.publish)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $containerVersionId The GTM Container Version ID.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string fingerprint When provided, this fingerprint must match the
+   * fingerprint of the container version in storage.
+   * @return Google_Service_TagManager_PublishContainerVersionResponse
+   */
+  public function publish($accountId, $containerId, $containerVersionId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'containerVersionId' => $containerVersionId);
+    $params = array_merge($params, $optParams);
+    return $this->call('publish', array($params), "Google_Service_TagManager_PublishContainerVersionResponse");
+  }
+
+  /**
+   * Restores a Container Version. This will overwrite the container's current
+   * configuration (including its variables, triggers and tags). The operation
+   * will not have any effect on the version that is being served (i.e. the
+   * published version). (versions.restore)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $containerVersionId The GTM Container Version ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_ContainerVersion
+   */
+  public function restore($accountId, $containerId, $containerVersionId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'containerVersionId' => $containerVersionId);
+    $params = array_merge($params, $optParams);
+    return $this->call('restore', array($params), "Google_Service_TagManager_ContainerVersion");
+  }
+
+  /**
+   * Undeletes a Container Version. (versions.undelete)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $containerVersionId The GTM Container Version ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_ContainerVersion
+   */
+  public function undelete($accountId, $containerId, $containerVersionId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'containerVersionId' => $containerVersionId);
+    $params = array_merge($params, $optParams);
+    return $this->call('undelete', array($params), "Google_Service_TagManager_ContainerVersion");
+  }
+
+  /**
+   * Updates a Container Version. (versions.update)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $containerId The GTM Container ID.
+   * @param string $containerVersionId The GTM Container Version ID.
+   * @param Google_ContainerVersion $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string fingerprint When provided, this fingerprint must match the
+   * fingerprint of the container version in storage.
+   * @return Google_Service_TagManager_ContainerVersion
+   */
+  public function update($accountId, $containerId, $containerVersionId, Google_Service_TagManager_ContainerVersion $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'containerId' => $containerId, 'containerVersionId' => $containerVersionId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_TagManager_ContainerVersion");
+  }
+}
+/**
+ * The "permissions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $tagmanagerService = new Google_Service_TagManager(...);
+ *   $permissions = $tagmanagerService->permissions;
+ *  </code>
+ */
+class Google_Service_TagManager_AccountsPermissions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a user's Account & Container Permissions. (permissions.create)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param Google_UserAccess $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_UserAccess
+   */
+  public function create($accountId, Google_Service_TagManager_UserAccess $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_TagManager_UserAccess");
+  }
+
+  /**
+   * Removes a user from the account, revoking access to it and all of its
+   * containers. (permissions.delete)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $permissionId The GTM User ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($accountId, $permissionId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'permissionId' => $permissionId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Gets a user's Account & Container Permissions. (permissions.get)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $permissionId The GTM User ID.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_UserAccess
+   */
+  public function get($accountId, $permissionId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'permissionId' => $permissionId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_TagManager_UserAccess");
+  }
+
+  /**
+   * List all users that have access to the account along with Account and
+   * Container Permissions granted to each of them.
+   * (permissions.listAccountsPermissions)
+   *
+   * @param string $accountId The GTM Account ID. @required
+   * tagmanager.accounts.permissions.list
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_ListAccountUsersResponse
+   */
+  public function listAccountsPermissions($accountId, $optParams = array())
+  {
+    $params = array('accountId' => $accountId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_TagManager_ListAccountUsersResponse");
+  }
+
+  /**
+   * Updates a user's Account & Container Permissions. (permissions.update)
+   *
+   * @param string $accountId The GTM Account ID.
+   * @param string $permissionId The GTM User ID.
+   * @param Google_UserAccess $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_TagManager_UserAccess
+   */
+  public function update($accountId, $permissionId, Google_Service_TagManager_UserAccess $postBody, $optParams = array())
+  {
+    $params = array('accountId' => $accountId, 'permissionId' => $permissionId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_TagManager_UserAccess");
+  }
+}
+
+
+
+
+class Google_Service_TagManager_Account extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $fingerprint;
+  public $name;
+  public $shareData;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setShareData($shareData)
+  {
+    $this->shareData = $shareData;
+  }
+  public function getShareData()
+  {
+    return $this->shareData;
+  }
+}
+
+class Google_Service_TagManager_AccountAccess extends Google_Collection
+{
+  protected $collection_key = 'permission';
+  protected $internal_gapi_mappings = array(
+  );
+  public $permission;
+
+
+  public function setPermission($permission)
+  {
+    $this->permission = $permission;
+  }
+  public function getPermission()
+  {
+    return $this->permission;
+  }
+}
+
+class Google_Service_TagManager_Condition extends Google_Collection
+{
+  protected $collection_key = 'parameter';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $parameterType = 'Google_Service_TagManager_Parameter';
+  protected $parameterDataType = 'array';
+  public $type;
+
+
+  public function setParameter($parameter)
+  {
+    $this->parameter = $parameter;
+  }
+  public function getParameter()
+  {
+    return $this->parameter;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_TagManager_Container extends Google_Collection
+{
+  protected $collection_key = 'usageContext';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $containerId;
+  public $domainName;
+  public $enabledBuiltInVariable;
+  public $fingerprint;
+  public $name;
+  public $notes;
+  public $publicId;
+  public $timeZoneCountryId;
+  public $timeZoneId;
+  public $usageContext;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setContainerId($containerId)
+  {
+    $this->containerId = $containerId;
+  }
+  public function getContainerId()
+  {
+    return $this->containerId;
+  }
+  public function setDomainName($domainName)
+  {
+    $this->domainName = $domainName;
+  }
+  public function getDomainName()
+  {
+    return $this->domainName;
+  }
+  public function setEnabledBuiltInVariable($enabledBuiltInVariable)
+  {
+    $this->enabledBuiltInVariable = $enabledBuiltInVariable;
+  }
+  public function getEnabledBuiltInVariable()
+  {
+    return $this->enabledBuiltInVariable;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNotes($notes)
+  {
+    $this->notes = $notes;
+  }
+  public function getNotes()
+  {
+    return $this->notes;
+  }
+  public function setPublicId($publicId)
+  {
+    $this->publicId = $publicId;
+  }
+  public function getPublicId()
+  {
+    return $this->publicId;
+  }
+  public function setTimeZoneCountryId($timeZoneCountryId)
+  {
+    $this->timeZoneCountryId = $timeZoneCountryId;
+  }
+  public function getTimeZoneCountryId()
+  {
+    return $this->timeZoneCountryId;
+  }
+  public function setTimeZoneId($timeZoneId)
+  {
+    $this->timeZoneId = $timeZoneId;
+  }
+  public function getTimeZoneId()
+  {
+    return $this->timeZoneId;
+  }
+  public function setUsageContext($usageContext)
+  {
+    $this->usageContext = $usageContext;
+  }
+  public function getUsageContext()
+  {
+    return $this->usageContext;
+  }
+}
+
+class Google_Service_TagManager_ContainerAccess extends Google_Collection
+{
+  protected $collection_key = 'permission';
+  protected $internal_gapi_mappings = array(
+  );
+  public $containerId;
+  public $permission;
+
+
+  public function setContainerId($containerId)
+  {
+    $this->containerId = $containerId;
+  }
+  public function getContainerId()
+  {
+    return $this->containerId;
+  }
+  public function setPermission($permission)
+  {
+    $this->permission = $permission;
+  }
+  public function getPermission()
+  {
+    return $this->permission;
+  }
+}
+
+class Google_Service_TagManager_ContainerVersion extends Google_Collection
+{
+  protected $collection_key = 'variable';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  protected $containerType = 'Google_Service_TagManager_Container';
+  protected $containerDataType = '';
+  public $containerId;
+  public $containerVersionId;
+  public $deleted;
+  public $fingerprint;
+  protected $folderType = 'Google_Service_TagManager_Folder';
+  protected $folderDataType = 'array';
+  protected $macroType = 'Google_Service_TagManager_Macro';
+  protected $macroDataType = 'array';
+  public $name;
+  public $notes;
+  protected $ruleType = 'Google_Service_TagManager_Rule';
+  protected $ruleDataType = 'array';
+  protected $tagType = 'Google_Service_TagManager_Tag';
+  protected $tagDataType = 'array';
+  protected $triggerType = 'Google_Service_TagManager_Trigger';
+  protected $triggerDataType = 'array';
+  protected $variableType = 'Google_Service_TagManager_Variable';
+  protected $variableDataType = 'array';
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setContainer(Google_Service_TagManager_Container $container)
+  {
+    $this->container = $container;
+  }
+  public function getContainer()
+  {
+    return $this->container;
+  }
+  public function setContainerId($containerId)
+  {
+    $this->containerId = $containerId;
+  }
+  public function getContainerId()
+  {
+    return $this->containerId;
+  }
+  public function setContainerVersionId($containerVersionId)
+  {
+    $this->containerVersionId = $containerVersionId;
+  }
+  public function getContainerVersionId()
+  {
+    return $this->containerVersionId;
+  }
+  public function setDeleted($deleted)
+  {
+    $this->deleted = $deleted;
+  }
+  public function getDeleted()
+  {
+    return $this->deleted;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setFolder($folder)
+  {
+    $this->folder = $folder;
+  }
+  public function getFolder()
+  {
+    return $this->folder;
+  }
+  public function setMacro($macro)
+  {
+    $this->macro = $macro;
+  }
+  public function getMacro()
+  {
+    return $this->macro;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNotes($notes)
+  {
+    $this->notes = $notes;
+  }
+  public function getNotes()
+  {
+    return $this->notes;
+  }
+  public function setRule($rule)
+  {
+    $this->rule = $rule;
+  }
+  public function getRule()
+  {
+    return $this->rule;
+  }
+  public function setTag($tag)
+  {
+    $this->tag = $tag;
+  }
+  public function getTag()
+  {
+    return $this->tag;
+  }
+  public function setTrigger($trigger)
+  {
+    $this->trigger = $trigger;
+  }
+  public function getTrigger()
+  {
+    return $this->trigger;
+  }
+  public function setVariable($variable)
+  {
+    $this->variable = $variable;
+  }
+  public function getVariable()
+  {
+    return $this->variable;
+  }
+}
+
+class Google_Service_TagManager_ContainerVersionHeader extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $containerId;
+  public $containerVersionId;
+  public $deleted;
+  public $name;
+  public $numMacros;
+  public $numRules;
+  public $numTags;
+  public $numTriggers;
+  public $numVariables;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setContainerId($containerId)
+  {
+    $this->containerId = $containerId;
+  }
+  public function getContainerId()
+  {
+    return $this->containerId;
+  }
+  public function setContainerVersionId($containerVersionId)
+  {
+    $this->containerVersionId = $containerVersionId;
+  }
+  public function getContainerVersionId()
+  {
+    return $this->containerVersionId;
+  }
+  public function setDeleted($deleted)
+  {
+    $this->deleted = $deleted;
+  }
+  public function getDeleted()
+  {
+    return $this->deleted;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNumMacros($numMacros)
+  {
+    $this->numMacros = $numMacros;
+  }
+  public function getNumMacros()
+  {
+    return $this->numMacros;
+  }
+  public function setNumRules($numRules)
+  {
+    $this->numRules = $numRules;
+  }
+  public function getNumRules()
+  {
+    return $this->numRules;
+  }
+  public function setNumTags($numTags)
+  {
+    $this->numTags = $numTags;
+  }
+  public function getNumTags()
+  {
+    return $this->numTags;
+  }
+  public function setNumTriggers($numTriggers)
+  {
+    $this->numTriggers = $numTriggers;
+  }
+  public function getNumTriggers()
+  {
+    return $this->numTriggers;
+  }
+  public function setNumVariables($numVariables)
+  {
+    $this->numVariables = $numVariables;
+  }
+  public function getNumVariables()
+  {
+    return $this->numVariables;
+  }
+}
+
+class Google_Service_TagManager_CreateContainerVersionRequestVersionOptions extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $notes;
+  public $quickPreview;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNotes($notes)
+  {
+    $this->notes = $notes;
+  }
+  public function getNotes()
+  {
+    return $this->notes;
+  }
+  public function setQuickPreview($quickPreview)
+  {
+    $this->quickPreview = $quickPreview;
+  }
+  public function getQuickPreview()
+  {
+    return $this->quickPreview;
+  }
+}
+
+class Google_Service_TagManager_CreateContainerVersionResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $compilerError;
+  protected $containerVersionType = 'Google_Service_TagManager_ContainerVersion';
+  protected $containerVersionDataType = '';
+
+
+  public function setCompilerError($compilerError)
+  {
+    $this->compilerError = $compilerError;
+  }
+  public function getCompilerError()
+  {
+    return $this->compilerError;
+  }
+  public function setContainerVersion(Google_Service_TagManager_ContainerVersion $containerVersion)
+  {
+    $this->containerVersion = $containerVersion;
+  }
+  public function getContainerVersion()
+  {
+    return $this->containerVersion;
+  }
+}
+
+class Google_Service_TagManager_Folder extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $containerId;
+  public $fingerprint;
+  public $folderId;
+  public $name;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setContainerId($containerId)
+  {
+    $this->containerId = $containerId;
+  }
+  public function getContainerId()
+  {
+    return $this->containerId;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setFolderId($folderId)
+  {
+    $this->folderId = $folderId;
+  }
+  public function getFolderId()
+  {
+    return $this->folderId;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_TagManager_FolderEntities extends Google_Collection
+{
+  protected $collection_key = 'variable';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $tagType = 'Google_Service_TagManager_Tag';
+  protected $tagDataType = 'array';
+  protected $triggerType = 'Google_Service_TagManager_Trigger';
+  protected $triggerDataType = 'array';
+  protected $variableType = 'Google_Service_TagManager_Variable';
+  protected $variableDataType = 'array';
+
+
+  public function setTag($tag)
+  {
+    $this->tag = $tag;
+  }
+  public function getTag()
+  {
+    return $this->tag;
+  }
+  public function setTrigger($trigger)
+  {
+    $this->trigger = $trigger;
+  }
+  public function getTrigger()
+  {
+    return $this->trigger;
+  }
+  public function setVariable($variable)
+  {
+    $this->variable = $variable;
+  }
+  public function getVariable()
+  {
+    return $this->variable;
+  }
+}
+
+class Google_Service_TagManager_ListAccountUsersResponse extends Google_Collection
+{
+  protected $collection_key = 'userAccess';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $userAccessType = 'Google_Service_TagManager_UserAccess';
+  protected $userAccessDataType = 'array';
+
+
+  public function setUserAccess($userAccess)
+  {
+    $this->userAccess = $userAccess;
+  }
+  public function getUserAccess()
+  {
+    return $this->userAccess;
+  }
+}
+
+class Google_Service_TagManager_ListAccountsResponse extends Google_Collection
+{
+  protected $collection_key = 'accounts';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accountsType = 'Google_Service_TagManager_Account';
+  protected $accountsDataType = 'array';
+
+
+  public function setAccounts($accounts)
+  {
+    $this->accounts = $accounts;
+  }
+  public function getAccounts()
+  {
+    return $this->accounts;
+  }
+}
+
+class Google_Service_TagManager_ListContainerVersionsResponse extends Google_Collection
+{
+  protected $collection_key = 'containerVersionHeader';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $containerVersionType = 'Google_Service_TagManager_ContainerVersion';
+  protected $containerVersionDataType = 'array';
+  protected $containerVersionHeaderType = 'Google_Service_TagManager_ContainerVersionHeader';
+  protected $containerVersionHeaderDataType = 'array';
+
+
+  public function setContainerVersion($containerVersion)
+  {
+    $this->containerVersion = $containerVersion;
+  }
+  public function getContainerVersion()
+  {
+    return $this->containerVersion;
+  }
+  public function setContainerVersionHeader($containerVersionHeader)
+  {
+    $this->containerVersionHeader = $containerVersionHeader;
+  }
+  public function getContainerVersionHeader()
+  {
+    return $this->containerVersionHeader;
+  }
+}
+
+class Google_Service_TagManager_ListContainersResponse extends Google_Collection
+{
+  protected $collection_key = 'containers';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $containersType = 'Google_Service_TagManager_Container';
+  protected $containersDataType = 'array';
+
+
+  public function setContainers($containers)
+  {
+    $this->containers = $containers;
+  }
+  public function getContainers()
+  {
+    return $this->containers;
+  }
+}
+
+class Google_Service_TagManager_ListFoldersResponse extends Google_Collection
+{
+  protected $collection_key = 'folders';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $foldersType = 'Google_Service_TagManager_Folder';
+  protected $foldersDataType = 'array';
+
+
+  public function setFolders($folders)
+  {
+    $this->folders = $folders;
+  }
+  public function getFolders()
+  {
+    return $this->folders;
+  }
+}
+
+class Google_Service_TagManager_ListTagsResponse extends Google_Collection
+{
+  protected $collection_key = 'tags';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $tagsType = 'Google_Service_TagManager_Tag';
+  protected $tagsDataType = 'array';
+
+
+  public function setTags($tags)
+  {
+    $this->tags = $tags;
+  }
+  public function getTags()
+  {
+    return $this->tags;
+  }
+}
+
+class Google_Service_TagManager_ListTriggersResponse extends Google_Collection
+{
+  protected $collection_key = 'triggers';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $triggersType = 'Google_Service_TagManager_Trigger';
+  protected $triggersDataType = 'array';
+
+
+  public function setTriggers($triggers)
+  {
+    $this->triggers = $triggers;
+  }
+  public function getTriggers()
+  {
+    return $this->triggers;
+  }
+}
+
+class Google_Service_TagManager_ListVariablesResponse extends Google_Collection
+{
+  protected $collection_key = 'variables';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $variablesType = 'Google_Service_TagManager_Variable';
+  protected $variablesDataType = 'array';
+
+
+  public function setVariables($variables)
+  {
+    $this->variables = $variables;
+  }
+  public function getVariables()
+  {
+    return $this->variables;
+  }
+}
+
+class Google_Service_TagManager_Macro extends Google_Collection
+{
+  protected $collection_key = 'parameter';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $containerId;
+  public $disablingRuleId;
+  public $enablingRuleId;
+  public $fingerprint;
+  public $macroId;
+  public $name;
+  public $notes;
+  protected $parameterType = 'Google_Service_TagManager_Parameter';
+  protected $parameterDataType = 'array';
+  public $parentFolderId;
+  public $scheduleEndMs;
+  public $scheduleStartMs;
+  public $type;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setContainerId($containerId)
+  {
+    $this->containerId = $containerId;
+  }
+  public function getContainerId()
+  {
+    return $this->containerId;
+  }
+  public function setDisablingRuleId($disablingRuleId)
+  {
+    $this->disablingRuleId = $disablingRuleId;
+  }
+  public function getDisablingRuleId()
+  {
+    return $this->disablingRuleId;
+  }
+  public function setEnablingRuleId($enablingRuleId)
+  {
+    $this->enablingRuleId = $enablingRuleId;
+  }
+  public function getEnablingRuleId()
+  {
+    return $this->enablingRuleId;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setMacroId($macroId)
+  {
+    $this->macroId = $macroId;
+  }
+  public function getMacroId()
+  {
+    return $this->macroId;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNotes($notes)
+  {
+    $this->notes = $notes;
+  }
+  public function getNotes()
+  {
+    return $this->notes;
+  }
+  public function setParameter($parameter)
+  {
+    $this->parameter = $parameter;
+  }
+  public function getParameter()
+  {
+    return $this->parameter;
+  }
+  public function setParentFolderId($parentFolderId)
+  {
+    $this->parentFolderId = $parentFolderId;
+  }
+  public function getParentFolderId()
+  {
+    return $this->parentFolderId;
+  }
+  public function setScheduleEndMs($scheduleEndMs)
+  {
+    $this->scheduleEndMs = $scheduleEndMs;
+  }
+  public function getScheduleEndMs()
+  {
+    return $this->scheduleEndMs;
+  }
+  public function setScheduleStartMs($scheduleStartMs)
+  {
+    $this->scheduleStartMs = $scheduleStartMs;
+  }
+  public function getScheduleStartMs()
+  {
+    return $this->scheduleStartMs;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_TagManager_Parameter extends Google_Collection
+{
+  protected $collection_key = 'map';
+  protected $internal_gapi_mappings = array(
+  );
+  public $key;
+  protected $listType = 'Google_Service_TagManager_Parameter';
+  protected $listDataType = 'array';
+  protected $mapType = 'Google_Service_TagManager_Parameter';
+  protected $mapDataType = 'array';
+  public $type;
+  public $value;
+
+
+  public function setKey($key)
+  {
+    $this->key = $key;
+  }
+  public function getKey()
+  {
+    return $this->key;
+  }
+  public function setList($list)
+  {
+    $this->list = $list;
+  }
+  public function getList()
+  {
+    return $this->list;
+  }
+  public function setMap($map)
+  {
+    $this->map = $map;
+  }
+  public function getMap()
+  {
+    return $this->map;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_TagManager_PublishContainerVersionResponse extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $compilerError;
+  protected $containerVersionType = 'Google_Service_TagManager_ContainerVersion';
+  protected $containerVersionDataType = '';
+
+
+  public function setCompilerError($compilerError)
+  {
+    $this->compilerError = $compilerError;
+  }
+  public function getCompilerError()
+  {
+    return $this->compilerError;
+  }
+  public function setContainerVersion(Google_Service_TagManager_ContainerVersion $containerVersion)
+  {
+    $this->containerVersion = $containerVersion;
+  }
+  public function getContainerVersion()
+  {
+    return $this->containerVersion;
+  }
+}
+
+class Google_Service_TagManager_Rule extends Google_Collection
+{
+  protected $collection_key = 'condition';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  protected $conditionType = 'Google_Service_TagManager_Condition';
+  protected $conditionDataType = 'array';
+  public $containerId;
+  public $fingerprint;
+  public $name;
+  public $notes;
+  public $ruleId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setCondition($condition)
+  {
+    $this->condition = $condition;
+  }
+  public function getCondition()
+  {
+    return $this->condition;
+  }
+  public function setContainerId($containerId)
+  {
+    $this->containerId = $containerId;
+  }
+  public function getContainerId()
+  {
+    return $this->containerId;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNotes($notes)
+  {
+    $this->notes = $notes;
+  }
+  public function getNotes()
+  {
+    return $this->notes;
+  }
+  public function setRuleId($ruleId)
+  {
+    $this->ruleId = $ruleId;
+  }
+  public function getRuleId()
+  {
+    return $this->ruleId;
+  }
+}
+
+class Google_Service_TagManager_SetupTag extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $stopOnSetupFailure;
+  public $tagName;
+
+
+  public function setStopOnSetupFailure($stopOnSetupFailure)
+  {
+    $this->stopOnSetupFailure = $stopOnSetupFailure;
+  }
+  public function getStopOnSetupFailure()
+  {
+    return $this->stopOnSetupFailure;
+  }
+  public function setTagName($tagName)
+  {
+    $this->tagName = $tagName;
+  }
+  public function getTagName()
+  {
+    return $this->tagName;
+  }
+}
+
+class Google_Service_TagManager_Tag extends Google_Collection
+{
+  protected $collection_key = 'teardownTag';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $blockingRuleId;
+  public $blockingTriggerId;
+  public $containerId;
+  public $fingerprint;
+  public $firingRuleId;
+  public $firingTriggerId;
+  public $liveOnly;
+  public $name;
+  public $notes;
+  protected $parameterType = 'Google_Service_TagManager_Parameter';
+  protected $parameterDataType = 'array';
+  public $parentFolderId;
+  protected $priorityType = 'Google_Service_TagManager_Parameter';
+  protected $priorityDataType = '';
+  public $scheduleEndMs;
+  public $scheduleStartMs;
+  protected $setupTagType = 'Google_Service_TagManager_SetupTag';
+  protected $setupTagDataType = 'array';
+  public $tagFiringOption;
+  public $tagId;
+  protected $teardownTagType = 'Google_Service_TagManager_TeardownTag';
+  protected $teardownTagDataType = 'array';
+  public $type;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setBlockingRuleId($blockingRuleId)
+  {
+    $this->blockingRuleId = $blockingRuleId;
+  }
+  public function getBlockingRuleId()
+  {
+    return $this->blockingRuleId;
+  }
+  public function setBlockingTriggerId($blockingTriggerId)
+  {
+    $this->blockingTriggerId = $blockingTriggerId;
+  }
+  public function getBlockingTriggerId()
+  {
+    return $this->blockingTriggerId;
+  }
+  public function setContainerId($containerId)
+  {
+    $this->containerId = $containerId;
+  }
+  public function getContainerId()
+  {
+    return $this->containerId;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setFiringRuleId($firingRuleId)
+  {
+    $this->firingRuleId = $firingRuleId;
+  }
+  public function getFiringRuleId()
+  {
+    return $this->firingRuleId;
+  }
+  public function setFiringTriggerId($firingTriggerId)
+  {
+    $this->firingTriggerId = $firingTriggerId;
+  }
+  public function getFiringTriggerId()
+  {
+    return $this->firingTriggerId;
+  }
+  public function setLiveOnly($liveOnly)
+  {
+    $this->liveOnly = $liveOnly;
+  }
+  public function getLiveOnly()
+  {
+    return $this->liveOnly;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNotes($notes)
+  {
+    $this->notes = $notes;
+  }
+  public function getNotes()
+  {
+    return $this->notes;
+  }
+  public function setParameter($parameter)
+  {
+    $this->parameter = $parameter;
+  }
+  public function getParameter()
+  {
+    return $this->parameter;
+  }
+  public function setParentFolderId($parentFolderId)
+  {
+    $this->parentFolderId = $parentFolderId;
+  }
+  public function getParentFolderId()
+  {
+    return $this->parentFolderId;
+  }
+  public function setPriority(Google_Service_TagManager_Parameter $priority)
+  {
+    $this->priority = $priority;
+  }
+  public function getPriority()
+  {
+    return $this->priority;
+  }
+  public function setScheduleEndMs($scheduleEndMs)
+  {
+    $this->scheduleEndMs = $scheduleEndMs;
+  }
+  public function getScheduleEndMs()
+  {
+    return $this->scheduleEndMs;
+  }
+  public function setScheduleStartMs($scheduleStartMs)
+  {
+    $this->scheduleStartMs = $scheduleStartMs;
+  }
+  public function getScheduleStartMs()
+  {
+    return $this->scheduleStartMs;
+  }
+  public function setSetupTag($setupTag)
+  {
+    $this->setupTag = $setupTag;
+  }
+  public function getSetupTag()
+  {
+    return $this->setupTag;
+  }
+  public function setTagFiringOption($tagFiringOption)
+  {
+    $this->tagFiringOption = $tagFiringOption;
+  }
+  public function getTagFiringOption()
+  {
+    return $this->tagFiringOption;
+  }
+  public function setTagId($tagId)
+  {
+    $this->tagId = $tagId;
+  }
+  public function getTagId()
+  {
+    return $this->tagId;
+  }
+  public function setTeardownTag($teardownTag)
+  {
+    $this->teardownTag = $teardownTag;
+  }
+  public function getTeardownTag()
+  {
+    return $this->teardownTag;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_TagManager_TeardownTag extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $stopTeardownOnFailure;
+  public $tagName;
+
+
+  public function setStopTeardownOnFailure($stopTeardownOnFailure)
+  {
+    $this->stopTeardownOnFailure = $stopTeardownOnFailure;
+  }
+  public function getStopTeardownOnFailure()
+  {
+    return $this->stopTeardownOnFailure;
+  }
+  public function setTagName($tagName)
+  {
+    $this->tagName = $tagName;
+  }
+  public function getTagName()
+  {
+    return $this->tagName;
+  }
+}
+
+class Google_Service_TagManager_Trigger extends Google_Collection
+{
+  protected $collection_key = 'filter';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  protected $autoEventFilterType = 'Google_Service_TagManager_Condition';
+  protected $autoEventFilterDataType = 'array';
+  protected $checkValidationType = 'Google_Service_TagManager_Parameter';
+  protected $checkValidationDataType = '';
+  public $containerId;
+  protected $customEventFilterType = 'Google_Service_TagManager_Condition';
+  protected $customEventFilterDataType = 'array';
+  protected $enableAllVideosType = 'Google_Service_TagManager_Parameter';
+  protected $enableAllVideosDataType = '';
+  protected $eventNameType = 'Google_Service_TagManager_Parameter';
+  protected $eventNameDataType = '';
+  protected $filterType = 'Google_Service_TagManager_Condition';
+  protected $filterDataType = 'array';
+  public $fingerprint;
+  protected $intervalType = 'Google_Service_TagManager_Parameter';
+  protected $intervalDataType = '';
+  protected $limitType = 'Google_Service_TagManager_Parameter';
+  protected $limitDataType = '';
+  public $name;
+  public $parentFolderId;
+  public $triggerId;
+  public $type;
+  protected $uniqueTriggerIdType = 'Google_Service_TagManager_Parameter';
+  protected $uniqueTriggerIdDataType = '';
+  protected $videoPercentageListType = 'Google_Service_TagManager_Parameter';
+  protected $videoPercentageListDataType = '';
+  protected $waitForTagsType = 'Google_Service_TagManager_Parameter';
+  protected $waitForTagsDataType = '';
+  protected $waitForTagsTimeoutType = 'Google_Service_TagManager_Parameter';
+  protected $waitForTagsTimeoutDataType = '';
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setAutoEventFilter($autoEventFilter)
+  {
+    $this->autoEventFilter = $autoEventFilter;
+  }
+  public function getAutoEventFilter()
+  {
+    return $this->autoEventFilter;
+  }
+  public function setCheckValidation(Google_Service_TagManager_Parameter $checkValidation)
+  {
+    $this->checkValidation = $checkValidation;
+  }
+  public function getCheckValidation()
+  {
+    return $this->checkValidation;
+  }
+  public function setContainerId($containerId)
+  {
+    $this->containerId = $containerId;
+  }
+  public function getContainerId()
+  {
+    return $this->containerId;
+  }
+  public function setCustomEventFilter($customEventFilter)
+  {
+    $this->customEventFilter = $customEventFilter;
+  }
+  public function getCustomEventFilter()
+  {
+    return $this->customEventFilter;
+  }
+  public function setEnableAllVideos(Google_Service_TagManager_Parameter $enableAllVideos)
+  {
+    $this->enableAllVideos = $enableAllVideos;
+  }
+  public function getEnableAllVideos()
+  {
+    return $this->enableAllVideos;
+  }
+  public function setEventName(Google_Service_TagManager_Parameter $eventName)
+  {
+    $this->eventName = $eventName;
+  }
+  public function getEventName()
+  {
+    return $this->eventName;
+  }
+  public function setFilter($filter)
+  {
+    $this->filter = $filter;
+  }
+  public function getFilter()
+  {
+    return $this->filter;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setInterval(Google_Service_TagManager_Parameter $interval)
+  {
+    $this->interval = $interval;
+  }
+  public function getInterval()
+  {
+    return $this->interval;
+  }
+  public function setLimit(Google_Service_TagManager_Parameter $limit)
+  {
+    $this->limit = $limit;
+  }
+  public function getLimit()
+  {
+    return $this->limit;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setParentFolderId($parentFolderId)
+  {
+    $this->parentFolderId = $parentFolderId;
+  }
+  public function getParentFolderId()
+  {
+    return $this->parentFolderId;
+  }
+  public function setTriggerId($triggerId)
+  {
+    $this->triggerId = $triggerId;
+  }
+  public function getTriggerId()
+  {
+    return $this->triggerId;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUniqueTriggerId(Google_Service_TagManager_Parameter $uniqueTriggerId)
+  {
+    $this->uniqueTriggerId = $uniqueTriggerId;
+  }
+  public function getUniqueTriggerId()
+  {
+    return $this->uniqueTriggerId;
+  }
+  public function setVideoPercentageList(Google_Service_TagManager_Parameter $videoPercentageList)
+  {
+    $this->videoPercentageList = $videoPercentageList;
+  }
+  public function getVideoPercentageList()
+  {
+    return $this->videoPercentageList;
+  }
+  public function setWaitForTags(Google_Service_TagManager_Parameter $waitForTags)
+  {
+    $this->waitForTags = $waitForTags;
+  }
+  public function getWaitForTags()
+  {
+    return $this->waitForTags;
+  }
+  public function setWaitForTagsTimeout(Google_Service_TagManager_Parameter $waitForTagsTimeout)
+  {
+    $this->waitForTagsTimeout = $waitForTagsTimeout;
+  }
+  public function getWaitForTagsTimeout()
+  {
+    return $this->waitForTagsTimeout;
+  }
+}
+
+class Google_Service_TagManager_UserAccess extends Google_Collection
+{
+  protected $collection_key = 'containerAccess';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accountAccessType = 'Google_Service_TagManager_AccountAccess';
+  protected $accountAccessDataType = '';
+  public $accountId;
+  protected $containerAccessType = 'Google_Service_TagManager_ContainerAccess';
+  protected $containerAccessDataType = 'array';
+  public $emailAddress;
+  public $permissionId;
+
+
+  public function setAccountAccess(Google_Service_TagManager_AccountAccess $accountAccess)
+  {
+    $this->accountAccess = $accountAccess;
+  }
+  public function getAccountAccess()
+  {
+    return $this->accountAccess;
+  }
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setContainerAccess($containerAccess)
+  {
+    $this->containerAccess = $containerAccess;
+  }
+  public function getContainerAccess()
+  {
+    return $this->containerAccess;
+  }
+  public function setEmailAddress($emailAddress)
+  {
+    $this->emailAddress = $emailAddress;
+  }
+  public function getEmailAddress()
+  {
+    return $this->emailAddress;
+  }
+  public function setPermissionId($permissionId)
+  {
+    $this->permissionId = $permissionId;
+  }
+  public function getPermissionId()
+  {
+    return $this->permissionId;
+  }
+}
+
+class Google_Service_TagManager_Variable extends Google_Collection
+{
+  protected $collection_key = 'parameter';
+  protected $internal_gapi_mappings = array(
+  );
+  public $accountId;
+  public $containerId;
+  public $disablingTriggerId;
+  public $enablingTriggerId;
+  public $fingerprint;
+  public $name;
+  public $notes;
+  protected $parameterType = 'Google_Service_TagManager_Parameter';
+  protected $parameterDataType = 'array';
+  public $parentFolderId;
+  public $scheduleEndMs;
+  public $scheduleStartMs;
+  public $type;
+  public $variableId;
+
+
+  public function setAccountId($accountId)
+  {
+    $this->accountId = $accountId;
+  }
+  public function getAccountId()
+  {
+    return $this->accountId;
+  }
+  public function setContainerId($containerId)
+  {
+    $this->containerId = $containerId;
+  }
+  public function getContainerId()
+  {
+    return $this->containerId;
+  }
+  public function setDisablingTriggerId($disablingTriggerId)
+  {
+    $this->disablingTriggerId = $disablingTriggerId;
+  }
+  public function getDisablingTriggerId()
+  {
+    return $this->disablingTriggerId;
+  }
+  public function setEnablingTriggerId($enablingTriggerId)
+  {
+    $this->enablingTriggerId = $enablingTriggerId;
+  }
+  public function getEnablingTriggerId()
+  {
+    return $this->enablingTriggerId;
+  }
+  public function setFingerprint($fingerprint)
+  {
+    $this->fingerprint = $fingerprint;
+  }
+  public function getFingerprint()
+  {
+    return $this->fingerprint;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setNotes($notes)
+  {
+    $this->notes = $notes;
+  }
+  public function getNotes()
+  {
+    return $this->notes;
+  }
+  public function setParameter($parameter)
+  {
+    $this->parameter = $parameter;
+  }
+  public function getParameter()
+  {
+    return $this->parameter;
+  }
+  public function setParentFolderId($parentFolderId)
+  {
+    $this->parentFolderId = $parentFolderId;
+  }
+  public function getParentFolderId()
+  {
+    return $this->parentFolderId;
+  }
+  public function setScheduleEndMs($scheduleEndMs)
+  {
+    $this->scheduleEndMs = $scheduleEndMs;
+  }
+  public function getScheduleEndMs()
+  {
+    return $this->scheduleEndMs;
+  }
+  public function setScheduleStartMs($scheduleStartMs)
+  {
+    $this->scheduleStartMs = $scheduleStartMs;
+  }
+  public function getScheduleStartMs()
+  {
+    return $this->scheduleStartMs;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVariableId($variableId)
+  {
+    $this->variableId = $variableId;
+  }
+  public function getVariableId()
+  {
+    return $this->variableId;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Taskqueue.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Taskqueue.php
@@ -1,0 +1,690 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Taskqueue (v1beta2).
+ *
+ * <p>
+ * Lets you access a Google App Engine Pull Task Queue over REST.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/appengine/docs/python/taskqueue/rest" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Taskqueue extends Google_Service
+{
+  /** Manage your Tasks and Taskqueues. */
+  const TASKQUEUE =
+      "https://www.googleapis.com/auth/taskqueue";
+  /** Consume Tasks from your Taskqueues. */
+  const TASKQUEUE_CONSUMER =
+      "https://www.googleapis.com/auth/taskqueue.consumer";
+
+  public $taskqueues;
+  public $tasks;
+  
+
+  /**
+   * Constructs the internal representation of the Taskqueue service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'taskqueue/v1beta2/projects/';
+    $this->version = 'v1beta2';
+    $this->serviceName = 'taskqueue';
+
+    $this->taskqueues = new Google_Service_Taskqueue_Taskqueues_Resource(
+        $this,
+        $this->serviceName,
+        'taskqueues',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => '{project}/taskqueues/{taskqueue}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'taskqueue' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'getStats' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->tasks = new Google_Service_Taskqueue_Tasks_Resource(
+        $this,
+        $this->serviceName,
+        'tasks',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => '{project}/taskqueues/{taskqueue}/tasks/{task}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'taskqueue' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'task' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => '{project}/taskqueues/{taskqueue}/tasks/{task}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'taskqueue' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'task' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => '{project}/taskqueues/{taskqueue}/tasks',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'taskqueue' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'lease' => array(
+              'path' => '{project}/taskqueues/{taskqueue}/tasks/lease',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'taskqueue' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'numTasks' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'leaseSecs' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+                'groupByTag' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'tag' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => '{project}/taskqueues/{taskqueue}/tasks',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'taskqueue' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'patch' => array(
+              'path' => '{project}/taskqueues/{taskqueue}/tasks/{task}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'taskqueue' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'task' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'newLeaseSeconds' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => '{project}/taskqueues/{taskqueue}/tasks/{task}',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'project' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'taskqueue' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'task' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'newLeaseSeconds' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "taskqueues" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $taskqueueService = new Google_Service_Taskqueue(...);
+ *   $taskqueues = $taskqueueService->taskqueues;
+ *  </code>
+ */
+class Google_Service_Taskqueue_Taskqueues_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Get detailed information about a TaskQueue. (taskqueues.get)
+   *
+   * @param string $project The project under which the queue lies.
+   * @param string $taskqueue The id of the taskqueue to get the properties of.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool getStats Whether to get stats. Optional.
+   * @return Google_Service_Taskqueue_TaskQueue
+   */
+  public function get($project, $taskqueue, $optParams = array())
+  {
+    $params = array('project' => $project, 'taskqueue' => $taskqueue);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Taskqueue_TaskQueue");
+  }
+}
+
+/**
+ * The "tasks" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $taskqueueService = new Google_Service_Taskqueue(...);
+ *   $tasks = $taskqueueService->tasks;
+ *  </code>
+ */
+class Google_Service_Taskqueue_Tasks_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Delete a task from a TaskQueue. (tasks.delete)
+   *
+   * @param string $project The project under which the queue lies.
+   * @param string $taskqueue The taskqueue to delete a task from.
+   * @param string $task The id of the task to delete.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($project, $taskqueue, $task, $optParams = array())
+  {
+    $params = array('project' => $project, 'taskqueue' => $taskqueue, 'task' => $task);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Get a particular task from a TaskQueue. (tasks.get)
+   *
+   * @param string $project The project under which the queue lies.
+   * @param string $taskqueue The taskqueue in which the task belongs.
+   * @param string $task The task to get properties of.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Taskqueue_Task
+   */
+  public function get($project, $taskqueue, $task, $optParams = array())
+  {
+    $params = array('project' => $project, 'taskqueue' => $taskqueue, 'task' => $task);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Taskqueue_Task");
+  }
+
+  /**
+   * Insert a new task in a TaskQueue (tasks.insert)
+   *
+   * @param string $project The project under which the queue lies
+   * @param string $taskqueue The taskqueue to insert the task into
+   * @param Google_Task $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Taskqueue_Task
+   */
+  public function insert($project, $taskqueue, Google_Service_Taskqueue_Task $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'taskqueue' => $taskqueue, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Taskqueue_Task");
+  }
+
+  /**
+   * Lease 1 or more tasks from a TaskQueue. (tasks.lease)
+   *
+   * @param string $project The project under which the queue lies.
+   * @param string $taskqueue The taskqueue to lease a task from.
+   * @param int $numTasks The number of tasks to lease.
+   * @param int $leaseSecs The lease in seconds.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool groupByTag When true, all returned tasks will have the same
+   * tag
+   * @opt_param string tag The tag allowed for tasks in the response. Must only be
+   * specified if group_by_tag is true. If group_by_tag is true and tag is not
+   * specified the tag will be that of the oldest task by eta, i.e. the first
+   * available tag
+   * @return Google_Service_Taskqueue_Tasks
+   */
+  public function lease($project, $taskqueue, $numTasks, $leaseSecs, $optParams = array())
+  {
+    $params = array('project' => $project, 'taskqueue' => $taskqueue, 'numTasks' => $numTasks, 'leaseSecs' => $leaseSecs);
+    $params = array_merge($params, $optParams);
+    return $this->call('lease', array($params), "Google_Service_Taskqueue_Tasks");
+  }
+
+  /**
+   * List Tasks in a TaskQueue (tasks.listTasks)
+   *
+   * @param string $project The project under which the queue lies.
+   * @param string $taskqueue The id of the taskqueue to list tasks from.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Taskqueue_Tasks2
+   */
+  public function listTasks($project, $taskqueue, $optParams = array())
+  {
+    $params = array('project' => $project, 'taskqueue' => $taskqueue);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Taskqueue_Tasks2");
+  }
+
+  /**
+   * Update tasks that are leased out of a TaskQueue. This method supports patch
+   * semantics. (tasks.patch)
+   *
+   * @param string $project The project under which the queue lies.
+   * @param string $taskqueue
+   * @param string $task
+   * @param int $newLeaseSeconds The new lease in seconds.
+   * @param Google_Task $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Taskqueue_Task
+   */
+  public function patch($project, $taskqueue, $task, $newLeaseSeconds, Google_Service_Taskqueue_Task $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'taskqueue' => $taskqueue, 'task' => $task, 'newLeaseSeconds' => $newLeaseSeconds, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Taskqueue_Task");
+  }
+
+  /**
+   * Update tasks that are leased out of a TaskQueue. (tasks.update)
+   *
+   * @param string $project The project under which the queue lies.
+   * @param string $taskqueue
+   * @param string $task
+   * @param int $newLeaseSeconds The new lease in seconds.
+   * @param Google_Task $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Taskqueue_Task
+   */
+  public function update($project, $taskqueue, $task, $newLeaseSeconds, Google_Service_Taskqueue_Task $postBody, $optParams = array())
+  {
+    $params = array('project' => $project, 'taskqueue' => $taskqueue, 'task' => $task, 'newLeaseSeconds' => $newLeaseSeconds, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Taskqueue_Task");
+  }
+}
+
+
+
+
+class Google_Service_Taskqueue_Task extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "retryCount" => "retry_count",
+  );
+  public $enqueueTimestamp;
+  public $id;
+  public $kind;
+  public $leaseTimestamp;
+  public $payloadBase64;
+  public $queueName;
+  public $retryCount;
+  public $tag;
+
+
+  public function setEnqueueTimestamp($enqueueTimestamp)
+  {
+    $this->enqueueTimestamp = $enqueueTimestamp;
+  }
+  public function getEnqueueTimestamp()
+  {
+    return $this->enqueueTimestamp;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLeaseTimestamp($leaseTimestamp)
+  {
+    $this->leaseTimestamp = $leaseTimestamp;
+  }
+  public function getLeaseTimestamp()
+  {
+    return $this->leaseTimestamp;
+  }
+  public function setPayloadBase64($payloadBase64)
+  {
+    $this->payloadBase64 = $payloadBase64;
+  }
+  public function getPayloadBase64()
+  {
+    return $this->payloadBase64;
+  }
+  public function setQueueName($queueName)
+  {
+    $this->queueName = $queueName;
+  }
+  public function getQueueName()
+  {
+    return $this->queueName;
+  }
+  public function setRetryCount($retryCount)
+  {
+    $this->retryCount = $retryCount;
+  }
+  public function getRetryCount()
+  {
+    return $this->retryCount;
+  }
+  public function setTag($tag)
+  {
+    $this->tag = $tag;
+  }
+  public function getTag()
+  {
+    return $this->tag;
+  }
+}
+
+class Google_Service_Taskqueue_TaskQueue extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $aclType = 'Google_Service_Taskqueue_TaskQueueAcl';
+  protected $aclDataType = '';
+  public $id;
+  public $kind;
+  public $maxLeases;
+  protected $statsType = 'Google_Service_Taskqueue_TaskQueueStats';
+  protected $statsDataType = '';
+
+
+  public function setAcl(Google_Service_Taskqueue_TaskQueueAcl $acl)
+  {
+    $this->acl = $acl;
+  }
+  public function getAcl()
+  {
+    return $this->acl;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setMaxLeases($maxLeases)
+  {
+    $this->maxLeases = $maxLeases;
+  }
+  public function getMaxLeases()
+  {
+    return $this->maxLeases;
+  }
+  public function setStats(Google_Service_Taskqueue_TaskQueueStats $stats)
+  {
+    $this->stats = $stats;
+  }
+  public function getStats()
+  {
+    return $this->stats;
+  }
+}
+
+class Google_Service_Taskqueue_TaskQueueAcl extends Google_Collection
+{
+  protected $collection_key = 'producerEmails';
+  protected $internal_gapi_mappings = array(
+  );
+  public $adminEmails;
+  public $consumerEmails;
+  public $producerEmails;
+
+
+  public function setAdminEmails($adminEmails)
+  {
+    $this->adminEmails = $adminEmails;
+  }
+  public function getAdminEmails()
+  {
+    return $this->adminEmails;
+  }
+  public function setConsumerEmails($consumerEmails)
+  {
+    $this->consumerEmails = $consumerEmails;
+  }
+  public function getConsumerEmails()
+  {
+    return $this->consumerEmails;
+  }
+  public function setProducerEmails($producerEmails)
+  {
+    $this->producerEmails = $producerEmails;
+  }
+  public function getProducerEmails()
+  {
+    return $this->producerEmails;
+  }
+}
+
+class Google_Service_Taskqueue_TaskQueueStats extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $leasedLastHour;
+  public $leasedLastMinute;
+  public $oldestTask;
+  public $totalTasks;
+
+
+  public function setLeasedLastHour($leasedLastHour)
+  {
+    $this->leasedLastHour = $leasedLastHour;
+  }
+  public function getLeasedLastHour()
+  {
+    return $this->leasedLastHour;
+  }
+  public function setLeasedLastMinute($leasedLastMinute)
+  {
+    $this->leasedLastMinute = $leasedLastMinute;
+  }
+  public function getLeasedLastMinute()
+  {
+    return $this->leasedLastMinute;
+  }
+  public function setOldestTask($oldestTask)
+  {
+    $this->oldestTask = $oldestTask;
+  }
+  public function getOldestTask()
+  {
+    return $this->oldestTask;
+  }
+  public function setTotalTasks($totalTasks)
+  {
+    $this->totalTasks = $totalTasks;
+  }
+  public function getTotalTasks()
+  {
+    return $this->totalTasks;
+  }
+}
+
+class Google_Service_Taskqueue_Tasks extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Taskqueue_Task';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_Taskqueue_Tasks2 extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Taskqueue_Task';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Tasks.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Tasks.php
@@ -1,0 +1,908 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Tasks (v1).
+ *
+ * <p>
+ * Lets you manage your tasks and task lists.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/google-apps/tasks/firstapp" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Tasks extends Google_Service
+{
+  /** Manage your tasks. */
+  const TASKS =
+      "https://www.googleapis.com/auth/tasks";
+  /** View your tasks. */
+  const TASKS_READONLY =
+      "https://www.googleapis.com/auth/tasks.readonly";
+
+  public $tasklists;
+  public $tasks;
+  
+
+  /**
+   * Constructs the internal representation of the Tasks service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'tasks/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'tasks';
+
+    $this->tasklists = new Google_Service_Tasks_Tasklists_Resource(
+        $this,
+        $this->serviceName,
+        'tasklists',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'users/@me/lists/{tasklist}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'tasklist' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'users/@me/lists/{tasklist}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'tasklist' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'users/@me/lists',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'list' => array(
+              'path' => 'users/@me/lists',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'users/@me/lists/{tasklist}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'tasklist' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'users/@me/lists/{tasklist}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'tasklist' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->tasks = new Google_Service_Tasks_Tasks_Resource(
+        $this,
+        $this->serviceName,
+        'tasks',
+        array(
+          'methods' => array(
+            'clear' => array(
+              'path' => 'lists/{tasklist}/clear',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'tasklist' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'lists/{tasklist}/tasks/{task}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'tasklist' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'task' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'lists/{tasklist}/tasks/{task}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'tasklist' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'task' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'lists/{tasklist}/tasks',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'tasklist' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'parent' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'previous' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'lists/{tasklist}/tasks',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'tasklist' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'dueMax' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'showDeleted' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'updatedMin' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'completedMin' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'showCompleted' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'completedMax' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'showHidden' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'dueMin' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'move' => array(
+              'path' => 'lists/{tasklist}/tasks/{task}/move',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'tasklist' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'task' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'parent' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'previous' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'patch' => array(
+              'path' => 'lists/{tasklist}/tasks/{task}',
+              'httpMethod' => 'PATCH',
+              'parameters' => array(
+                'tasklist' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'task' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'lists/{tasklist}/tasks/{task}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'tasklist' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'task' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "tasklists" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $tasksService = new Google_Service_Tasks(...);
+ *   $tasklists = $tasksService->tasklists;
+ *  </code>
+ */
+class Google_Service_Tasks_Tasklists_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes the authenticated user's specified task list. (tasklists.delete)
+   *
+   * @param string $tasklist Task list identifier.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($tasklist, $optParams = array())
+  {
+    $params = array('tasklist' => $tasklist);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Returns the authenticated user's specified task list. (tasklists.get)
+   *
+   * @param string $tasklist Task list identifier.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Tasks_TaskList
+   */
+  public function get($tasklist, $optParams = array())
+  {
+    $params = array('tasklist' => $tasklist);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Tasks_TaskList");
+  }
+
+  /**
+   * Creates a new task list and adds it to the authenticated user's task lists.
+   * (tasklists.insert)
+   *
+   * @param Google_TaskList $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Tasks_TaskList
+   */
+  public function insert(Google_Service_Tasks_TaskList $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Tasks_TaskList");
+  }
+
+  /**
+   * Returns all the authenticated user's task lists. (tasklists.listTasklists)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken Token specifying the result page to return.
+   * Optional.
+   * @opt_param string maxResults Maximum number of task lists returned on one
+   * page. Optional. The default is 100.
+   * @return Google_Service_Tasks_TaskLists
+   */
+  public function listTasklists($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Tasks_TaskLists");
+  }
+
+  /**
+   * Updates the authenticated user's specified task list. This method supports
+   * patch semantics. (tasklists.patch)
+   *
+   * @param string $tasklist Task list identifier.
+   * @param Google_TaskList $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Tasks_TaskList
+   */
+  public function patch($tasklist, Google_Service_Tasks_TaskList $postBody, $optParams = array())
+  {
+    $params = array('tasklist' => $tasklist, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Tasks_TaskList");
+  }
+
+  /**
+   * Updates the authenticated user's specified task list. (tasklists.update)
+   *
+   * @param string $tasklist Task list identifier.
+   * @param Google_TaskList $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Tasks_TaskList
+   */
+  public function update($tasklist, Google_Service_Tasks_TaskList $postBody, $optParams = array())
+  {
+    $params = array('tasklist' => $tasklist, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Tasks_TaskList");
+  }
+}
+
+/**
+ * The "tasks" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $tasksService = new Google_Service_Tasks(...);
+ *   $tasks = $tasksService->tasks;
+ *  </code>
+ */
+class Google_Service_Tasks_Tasks_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Clears all completed tasks from the specified task list. The affected tasks
+   * will be marked as 'hidden' and no longer be returned by default when
+   * retrieving all tasks for a task list. (tasks.clear)
+   *
+   * @param string $tasklist Task list identifier.
+   * @param array $optParams Optional parameters.
+   */
+  public function clear($tasklist, $optParams = array())
+  {
+    $params = array('tasklist' => $tasklist);
+    $params = array_merge($params, $optParams);
+    return $this->call('clear', array($params));
+  }
+
+  /**
+   * Deletes the specified task from the task list. (tasks.delete)
+   *
+   * @param string $tasklist Task list identifier.
+   * @param string $task Task identifier.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($tasklist, $task, $optParams = array())
+  {
+    $params = array('tasklist' => $tasklist, 'task' => $task);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Returns the specified task. (tasks.get)
+   *
+   * @param string $tasklist Task list identifier.
+   * @param string $task Task identifier.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Tasks_Task
+   */
+  public function get($tasklist, $task, $optParams = array())
+  {
+    $params = array('tasklist' => $tasklist, 'task' => $task);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Tasks_Task");
+  }
+
+  /**
+   * Creates a new task on the specified task list. (tasks.insert)
+   *
+   * @param string $tasklist Task list identifier.
+   * @param Google_Task $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string parent Parent task identifier. If the task is created at
+   * the top level, this parameter is omitted. Optional.
+   * @opt_param string previous Previous sibling task identifier. If the task is
+   * created at the first position among its siblings, this parameter is omitted.
+   * Optional.
+   * @return Google_Service_Tasks_Task
+   */
+  public function insert($tasklist, Google_Service_Tasks_Task $postBody, $optParams = array())
+  {
+    $params = array('tasklist' => $tasklist, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Tasks_Task");
+  }
+
+  /**
+   * Returns all tasks in the specified task list. (tasks.listTasks)
+   *
+   * @param string $tasklist Task list identifier.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string dueMax Upper bound for a task's due date (as a RFC 3339
+   * timestamp) to filter by. Optional. The default is not to filter by due date.
+   * @opt_param bool showDeleted Flag indicating whether deleted tasks are
+   * returned in the result. Optional. The default is False.
+   * @opt_param string updatedMin Lower bound for a task's last modification time
+   * (as a RFC 3339 timestamp) to filter by. Optional. The default is not to
+   * filter by last modification time.
+   * @opt_param string completedMin Lower bound for a task's completion date (as a
+   * RFC 3339 timestamp) to filter by. Optional. The default is not to filter by
+   * completion date.
+   * @opt_param string maxResults Maximum number of task lists returned on one
+   * page. Optional. The default is 100.
+   * @opt_param bool showCompleted Flag indicating whether completed tasks are
+   * returned in the result. Optional. The default is True.
+   * @opt_param string pageToken Token specifying the result page to return.
+   * Optional.
+   * @opt_param string completedMax Upper bound for a task's completion date (as a
+   * RFC 3339 timestamp) to filter by. Optional. The default is not to filter by
+   * completion date.
+   * @opt_param bool showHidden Flag indicating whether hidden tasks are returned
+   * in the result. Optional. The default is False.
+   * @opt_param string dueMin Lower bound for a task's due date (as a RFC 3339
+   * timestamp) to filter by. Optional. The default is not to filter by due date.
+   * @return Google_Service_Tasks_Tasks
+   */
+  public function listTasks($tasklist, $optParams = array())
+  {
+    $params = array('tasklist' => $tasklist);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Tasks_Tasks");
+  }
+
+  /**
+   * Moves the specified task to another position in the task list. This can
+   * include putting it as a child task under a new parent and/or move it to a
+   * different position among its sibling tasks. (tasks.move)
+   *
+   * @param string $tasklist Task list identifier.
+   * @param string $task Task identifier.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string parent New parent task identifier. If the task is moved to
+   * the top level, this parameter is omitted. Optional.
+   * @opt_param string previous New previous sibling task identifier. If the task
+   * is moved to the first position among its siblings, this parameter is omitted.
+   * Optional.
+   * @return Google_Service_Tasks_Task
+   */
+  public function move($tasklist, $task, $optParams = array())
+  {
+    $params = array('tasklist' => $tasklist, 'task' => $task);
+    $params = array_merge($params, $optParams);
+    return $this->call('move', array($params), "Google_Service_Tasks_Task");
+  }
+
+  /**
+   * Updates the specified task. This method supports patch semantics.
+   * (tasks.patch)
+   *
+   * @param string $tasklist Task list identifier.
+   * @param string $task Task identifier.
+   * @param Google_Task $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Tasks_Task
+   */
+  public function patch($tasklist, $task, Google_Service_Tasks_Task $postBody, $optParams = array())
+  {
+    $params = array('tasklist' => $tasklist, 'task' => $task, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', array($params), "Google_Service_Tasks_Task");
+  }
+
+  /**
+   * Updates the specified task. (tasks.update)
+   *
+   * @param string $tasklist Task list identifier.
+   * @param string $task Task identifier.
+   * @param Google_Task $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Tasks_Task
+   */
+  public function update($tasklist, $task, Google_Service_Tasks_Task $postBody, $optParams = array())
+  {
+    $params = array('tasklist' => $tasklist, 'task' => $task, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_Tasks_Task");
+  }
+}
+
+
+
+
+class Google_Service_Tasks_Task extends Google_Collection
+{
+  protected $collection_key = 'links';
+  protected $internal_gapi_mappings = array(
+  );
+  public $completed;
+  public $deleted;
+  public $due;
+  public $etag;
+  public $hidden;
+  public $id;
+  public $kind;
+  protected $linksType = 'Google_Service_Tasks_TaskLinks';
+  protected $linksDataType = 'array';
+  public $notes;
+  public $parent;
+  public $position;
+  public $selfLink;
+  public $status;
+  public $title;
+  public $updated;
+
+
+  public function setCompleted($completed)
+  {
+    $this->completed = $completed;
+  }
+  public function getCompleted()
+  {
+    return $this->completed;
+  }
+  public function setDeleted($deleted)
+  {
+    $this->deleted = $deleted;
+  }
+  public function getDeleted()
+  {
+    return $this->deleted;
+  }
+  public function setDue($due)
+  {
+    $this->due = $due;
+  }
+  public function getDue()
+  {
+    return $this->due;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setHidden($hidden)
+  {
+    $this->hidden = $hidden;
+  }
+  public function getHidden()
+  {
+    return $this->hidden;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLinks($links)
+  {
+    $this->links = $links;
+  }
+  public function getLinks()
+  {
+    return $this->links;
+  }
+  public function setNotes($notes)
+  {
+    $this->notes = $notes;
+  }
+  public function getNotes()
+  {
+    return $this->notes;
+  }
+  public function setParent($parent)
+  {
+    $this->parent = $parent;
+  }
+  public function getParent()
+  {
+    return $this->parent;
+  }
+  public function setPosition($position)
+  {
+    $this->position = $position;
+  }
+  public function getPosition()
+  {
+    return $this->position;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+}
+
+class Google_Service_Tasks_TaskLinks extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $link;
+  public $type;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setLink($link)
+  {
+    $this->link = $link;
+  }
+  public function getLink()
+  {
+    return $this->link;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_Tasks_TaskList extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $id;
+  public $kind;
+  public $selfLink;
+  public $title;
+  public $updated;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSelfLink($selfLink)
+  {
+    $this->selfLink = $selfLink;
+  }
+  public function getSelfLink()
+  {
+    return $this->selfLink;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setUpdated($updated)
+  {
+    $this->updated = $updated;
+  }
+  public function getUpdated()
+  {
+    return $this->updated;
+  }
+}
+
+class Google_Service_Tasks_TaskLists extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Tasks_TaskList';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_Tasks_Tasks extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_Tasks_Task';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Translate.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Translate.php
@@ -1,0 +1,369 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Translate (v2).
+ *
+ * <p>
+ * Lets you translate text from one language to another</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/translate/v2/using_rest" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Translate extends Google_Service
+{
+
+
+  public $detections;
+  public $languages;
+  public $translations;
+  
+
+  /**
+   * Constructs the internal representation of the Translate service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'language/translate/';
+    $this->version = 'v2';
+    $this->serviceName = 'translate';
+
+    $this->detections = new Google_Service_Translate_Detections_Resource(
+        $this,
+        $this->serviceName,
+        'detections',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'v2/detect',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'q' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->languages = new Google_Service_Translate_Languages_Resource(
+        $this,
+        $this->serviceName,
+        'languages',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'v2/languages',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'target' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->translations = new Google_Service_Translate_Translations_Resource(
+        $this,
+        $this->serviceName,
+        'translations',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'v2',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'q' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                  'required' => true,
+                ),
+                'target' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'format' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'cid' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "detections" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $translateService = new Google_Service_Translate(...);
+ *   $detections = $translateService->detections;
+ *  </code>
+ */
+class Google_Service_Translate_Detections_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Detect the language of text. (detections.listDetections)
+   *
+   * @param string $q The text to detect
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Translate_DetectionsListResponse
+   */
+  public function listDetections($q, $optParams = array())
+  {
+    $params = array('q' => $q);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Translate_DetectionsListResponse");
+  }
+}
+
+/**
+ * The "languages" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $translateService = new Google_Service_Translate(...);
+ *   $languages = $translateService->languages;
+ *  </code>
+ */
+class Google_Service_Translate_Languages_Resource extends Google_Service_Resource
+{
+
+  /**
+   * List the source/target languages supported by the API
+   * (languages.listLanguages)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string target the language and collation in which the localized
+   * results should be returned
+   * @return Google_Service_Translate_LanguagesListResponse
+   */
+  public function listLanguages($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Translate_LanguagesListResponse");
+  }
+}
+
+/**
+ * The "translations" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $translateService = new Google_Service_Translate(...);
+ *   $translations = $translateService->translations;
+ *  </code>
+ */
+class Google_Service_Translate_Translations_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns text translations from one language to another.
+   * (translations.listTranslations)
+   *
+   * @param string $q The text to translate
+   * @param string $target The target language into which the text should be
+   * translated
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string source The source language of the text
+   * @opt_param string format The format of the text
+   * @opt_param string cid The customization id for translate
+   * @return Google_Service_Translate_TranslationsListResponse
+   */
+  public function listTranslations($q, $target, $optParams = array())
+  {
+    $params = array('q' => $q, 'target' => $target);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Translate_TranslationsListResponse");
+  }
+}
+
+
+
+
+class Google_Service_Translate_DetectionsListResponse extends Google_Collection
+{
+  protected $collection_key = 'detections';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $detectionsType = 'Google_Service_Translate_DetectionsResourceItems';
+  protected $detectionsDataType = 'array';
+
+
+  public function setDetections($detections)
+  {
+    $this->detections = $detections;
+  }
+  public function getDetections()
+  {
+    return $this->detections;
+  }
+}
+
+class Google_Service_Translate_DetectionsResourceItems extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $confidence;
+  public $isReliable;
+  public $language;
+
+
+  public function setConfidence($confidence)
+  {
+    $this->confidence = $confidence;
+  }
+  public function getConfidence()
+  {
+    return $this->confidence;
+  }
+  public function setIsReliable($isReliable)
+  {
+    $this->isReliable = $isReliable;
+  }
+  public function getIsReliable()
+  {
+    return $this->isReliable;
+  }
+  public function setLanguage($language)
+  {
+    $this->language = $language;
+  }
+  public function getLanguage()
+  {
+    return $this->language;
+  }
+}
+
+class Google_Service_Translate_LanguagesListResponse extends Google_Collection
+{
+  protected $collection_key = 'languages';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $languagesType = 'Google_Service_Translate_LanguagesResource';
+  protected $languagesDataType = 'array';
+
+
+  public function setLanguages($languages)
+  {
+    $this->languages = $languages;
+  }
+  public function getLanguages()
+  {
+    return $this->languages;
+  }
+}
+
+class Google_Service_Translate_LanguagesResource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $language;
+  public $name;
+
+
+  public function setLanguage($language)
+  {
+    $this->language = $language;
+  }
+  public function getLanguage()
+  {
+    return $this->language;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_Translate_TranslationsListResponse extends Google_Collection
+{
+  protected $collection_key = 'translations';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $translationsType = 'Google_Service_Translate_TranslationsResource';
+  protected $translationsDataType = 'array';
+
+
+  public function setTranslations($translations)
+  {
+    $this->translations = $translations;
+  }
+  public function getTranslations()
+  {
+    return $this->translations;
+  }
+}
+
+class Google_Service_Translate_TranslationsResource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $detectedSourceLanguage;
+  public $translatedText;
+
+
+  public function setDetectedSourceLanguage($detectedSourceLanguage)
+  {
+    $this->detectedSourceLanguage = $detectedSourceLanguage;
+  }
+  public function getDetectedSourceLanguage()
+  {
+    return $this->detectedSourceLanguage;
+  }
+  public function setTranslatedText($translatedText)
+  {
+    $this->translatedText = $translatedText;
+  }
+  public function getTranslatedText()
+  {
+    return $this->translatedText;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Urlshortener.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Urlshortener.php
@@ -1,0 +1,427 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Urlshortener (v1).
+ *
+ * <p>
+ * Lets you create, inspect, and manage goo.gl short URLs</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/url-shortener/v1/getting_started" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Urlshortener extends Google_Service
+{
+  /** Manage your goo.gl short URLs. */
+  const URLSHORTENER =
+      "https://www.googleapis.com/auth/urlshortener";
+
+  public $url;
+  
+
+  /**
+   * Constructs the internal representation of the Urlshortener service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'urlshortener/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'urlshortener';
+
+    $this->url = new Google_Service_Urlshortener_Url_Resource(
+        $this,
+        $this->serviceName,
+        'url',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'url',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'shortUrl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'url',
+              'httpMethod' => 'POST',
+              'parameters' => array(),
+            ),'list' => array(
+              'path' => 'url/history',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'start-token' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'projection' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "url" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $urlshortenerService = new Google_Service_Urlshortener(...);
+ *   $url = $urlshortenerService->url;
+ *  </code>
+ */
+class Google_Service_Urlshortener_Url_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Expands a short URL or gets creation time and analytics. (url.get)
+   *
+   * @param string $shortUrl The short URL, including the protocol.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string projection Additional information to return.
+   * @return Google_Service_Urlshortener_Url
+   */
+  public function get($shortUrl, $optParams = array())
+  {
+    $params = array('shortUrl' => $shortUrl);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Urlshortener_Url");
+  }
+
+  /**
+   * Creates a new short URL. (url.insert)
+   *
+   * @param Google_Url $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Urlshortener_Url
+   */
+  public function insert(Google_Service_Urlshortener_Url $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_Urlshortener_Url");
+  }
+
+  /**
+   * Retrieves a list of URLs shortened by a user. (url.listUrl)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string start-token Token for requesting successive pages of
+   * results.
+   * @opt_param string projection Additional information to return.
+   * @return Google_Service_Urlshortener_UrlHistory
+   */
+  public function listUrl($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Urlshortener_UrlHistory");
+  }
+}
+
+
+
+
+class Google_Service_Urlshortener_AnalyticsSnapshot extends Google_Collection
+{
+  protected $collection_key = 'referrers';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $browsersType = 'Google_Service_Urlshortener_StringCount';
+  protected $browsersDataType = 'array';
+  protected $countriesType = 'Google_Service_Urlshortener_StringCount';
+  protected $countriesDataType = 'array';
+  public $longUrlClicks;
+  protected $platformsType = 'Google_Service_Urlshortener_StringCount';
+  protected $platformsDataType = 'array';
+  protected $referrersType = 'Google_Service_Urlshortener_StringCount';
+  protected $referrersDataType = 'array';
+  public $shortUrlClicks;
+
+
+  public function setBrowsers($browsers)
+  {
+    $this->browsers = $browsers;
+  }
+  public function getBrowsers()
+  {
+    return $this->browsers;
+  }
+  public function setCountries($countries)
+  {
+    $this->countries = $countries;
+  }
+  public function getCountries()
+  {
+    return $this->countries;
+  }
+  public function setLongUrlClicks($longUrlClicks)
+  {
+    $this->longUrlClicks = $longUrlClicks;
+  }
+  public function getLongUrlClicks()
+  {
+    return $this->longUrlClicks;
+  }
+  public function setPlatforms($platforms)
+  {
+    $this->platforms = $platforms;
+  }
+  public function getPlatforms()
+  {
+    return $this->platforms;
+  }
+  public function setReferrers($referrers)
+  {
+    $this->referrers = $referrers;
+  }
+  public function getReferrers()
+  {
+    return $this->referrers;
+  }
+  public function setShortUrlClicks($shortUrlClicks)
+  {
+    $this->shortUrlClicks = $shortUrlClicks;
+  }
+  public function getShortUrlClicks()
+  {
+    return $this->shortUrlClicks;
+  }
+}
+
+class Google_Service_Urlshortener_AnalyticsSummary extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $allTimeType = 'Google_Service_Urlshortener_AnalyticsSnapshot';
+  protected $allTimeDataType = '';
+  protected $dayType = 'Google_Service_Urlshortener_AnalyticsSnapshot';
+  protected $dayDataType = '';
+  protected $monthType = 'Google_Service_Urlshortener_AnalyticsSnapshot';
+  protected $monthDataType = '';
+  protected $twoHoursType = 'Google_Service_Urlshortener_AnalyticsSnapshot';
+  protected $twoHoursDataType = '';
+  protected $weekType = 'Google_Service_Urlshortener_AnalyticsSnapshot';
+  protected $weekDataType = '';
+
+
+  public function setAllTime(Google_Service_Urlshortener_AnalyticsSnapshot $allTime)
+  {
+    $this->allTime = $allTime;
+  }
+  public function getAllTime()
+  {
+    return $this->allTime;
+  }
+  public function setDay(Google_Service_Urlshortener_AnalyticsSnapshot $day)
+  {
+    $this->day = $day;
+  }
+  public function getDay()
+  {
+    return $this->day;
+  }
+  public function setMonth(Google_Service_Urlshortener_AnalyticsSnapshot $month)
+  {
+    $this->month = $month;
+  }
+  public function getMonth()
+  {
+    return $this->month;
+  }
+  public function setTwoHours(Google_Service_Urlshortener_AnalyticsSnapshot $twoHours)
+  {
+    $this->twoHours = $twoHours;
+  }
+  public function getTwoHours()
+  {
+    return $this->twoHours;
+  }
+  public function setWeek(Google_Service_Urlshortener_AnalyticsSnapshot $week)
+  {
+    $this->week = $week;
+  }
+  public function getWeek()
+  {
+    return $this->week;
+  }
+}
+
+class Google_Service_Urlshortener_StringCount extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $count;
+  public $id;
+
+
+  public function setCount($count)
+  {
+    $this->count = $count;
+  }
+  public function getCount()
+  {
+    return $this->count;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+}
+
+class Google_Service_Urlshortener_Url extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $analyticsType = 'Google_Service_Urlshortener_AnalyticsSummary';
+  protected $analyticsDataType = '';
+  public $created;
+  public $id;
+  public $kind;
+  public $longUrl;
+  public $status;
+
+
+  public function setAnalytics(Google_Service_Urlshortener_AnalyticsSummary $analytics)
+  {
+    $this->analytics = $analytics;
+  }
+  public function getAnalytics()
+  {
+    return $this->analytics;
+  }
+  public function setCreated($created)
+  {
+    $this->created = $created;
+  }
+  public function getCreated()
+  {
+    return $this->created;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLongUrl($longUrl)
+  {
+    $this->longUrl = $longUrl;
+  }
+  public function getLongUrl()
+  {
+    return $this->longUrl;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_Urlshortener_UrlHistory extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Urlshortener_Url';
+  protected $itemsDataType = 'array';
+  public $itemsPerPage;
+  public $kind;
+  public $nextPageToken;
+  public $totalItems;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setItemsPerPage($itemsPerPage)
+  {
+    $this->itemsPerPage = $itemsPerPage;
+  }
+  public function getItemsPerPage()
+  {
+    return $this->itemsPerPage;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setTotalItems($totalItems)
+  {
+    $this->totalItems = $totalItems;
+  }
+  public function getTotalItems()
+  {
+    return $this->totalItems;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Webfonts.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Webfonts.php
@@ -1,0 +1,216 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Webfonts (v1).
+ *
+ * <p>
+ * The Google Fonts Developer API.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/fonts/docs/developer_api" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Webfonts extends Google_Service
+{
+
+
+  public $webfonts;
+  
+
+  /**
+   * Constructs the internal representation of the Webfonts service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'webfonts/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'webfonts';
+
+    $this->webfonts = new Google_Service_Webfonts_Webfonts_Resource(
+        $this,
+        $this->serviceName,
+        'webfonts',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'webfonts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'sort' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "webfonts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $webfontsService = new Google_Service_Webfonts(...);
+ *   $webfonts = $webfontsService->webfonts;
+ *  </code>
+ */
+class Google_Service_Webfonts_Webfonts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves the list of fonts currently served by the Google Fonts Developer
+   * API (webfonts.listWebfonts)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string sort Enables sorting of the list
+   * @return Google_Service_Webfonts_WebfontList
+   */
+  public function listWebfonts($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Webfonts_WebfontList");
+  }
+}
+
+
+
+
+class Google_Service_Webfonts_Webfont extends Google_Collection
+{
+  protected $collection_key = 'variants';
+  protected $internal_gapi_mappings = array(
+  );
+  public $category;
+  public $family;
+  public $files;
+  public $kind;
+  public $lastModified;
+  public $subsets;
+  public $variants;
+  public $version;
+
+
+  public function setCategory($category)
+  {
+    $this->category = $category;
+  }
+  public function getCategory()
+  {
+    return $this->category;
+  }
+  public function setFamily($family)
+  {
+    $this->family = $family;
+  }
+  public function getFamily()
+  {
+    return $this->family;
+  }
+  public function setFiles($files)
+  {
+    $this->files = $files;
+  }
+  public function getFiles()
+  {
+    return $this->files;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLastModified($lastModified)
+  {
+    $this->lastModified = $lastModified;
+  }
+  public function getLastModified()
+  {
+    return $this->lastModified;
+  }
+  public function setSubsets($subsets)
+  {
+    $this->subsets = $subsets;
+  }
+  public function getSubsets()
+  {
+    return $this->subsets;
+  }
+  public function setVariants($variants)
+  {
+    $this->variants = $variants;
+  }
+  public function getVariants()
+  {
+    return $this->variants;
+  }
+  public function setVersion($version)
+  {
+    $this->version = $version;
+  }
+  public function getVersion()
+  {
+    return $this->version;
+  }
+}
+
+class Google_Service_Webfonts_WebfontFiles extends Google_Model
+{
+}
+
+class Google_Service_Webfonts_WebfontList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_Webfonts_Webfont';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Webmasters.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Webmasters.php
@@ -1,0 +1,1201 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for Webmasters (v3).
+ *
+ * <p>
+ * Lets you view Google Webmaster Tools data for your verified sites.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/webmaster-tools/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_Webmasters extends Google_Service
+{
+  /** View and modify Webmaster Tools data for your verified sites. */
+  const WEBMASTERS =
+      "https://www.googleapis.com/auth/webmasters";
+  /** View Webmaster Tools data for your verified sites. */
+  const WEBMASTERS_READONLY =
+      "https://www.googleapis.com/auth/webmasters.readonly";
+
+  public $searchanalytics;
+  public $sitemaps;
+  public $sites;
+  public $urlcrawlerrorscounts;
+  public $urlcrawlerrorssamples;
+  
+
+  /**
+   * Constructs the internal representation of the Webmasters service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'webmasters/v3/';
+    $this->version = 'v3';
+    $this->serviceName = 'webmasters';
+
+    $this->searchanalytics = new Google_Service_Webmasters_Searchanalytics_Resource(
+        $this,
+        $this->serviceName,
+        'searchanalytics',
+        array(
+          'methods' => array(
+            'query' => array(
+              'path' => 'sites/{siteUrl}/searchAnalytics/query',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'siteUrl' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->sitemaps = new Google_Service_Webmasters_Sitemaps_Resource(
+        $this,
+        $this->serviceName,
+        'sitemaps',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'sites/{siteUrl}/sitemaps/{feedpath}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'siteUrl' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'feedpath' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'sites/{siteUrl}/sitemaps/{feedpath}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'siteUrl' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'feedpath' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'sites/{siteUrl}/sitemaps',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'siteUrl' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'sitemapIndex' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'submit' => array(
+              'path' => 'sites/{siteUrl}/sitemaps/{feedpath}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'siteUrl' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'feedpath' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->sites = new Google_Service_Webmasters_Sites_Resource(
+        $this,
+        $this->serviceName,
+        'sites',
+        array(
+          'methods' => array(
+            'add' => array(
+              'path' => 'sites/{siteUrl}',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'siteUrl' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'sites/{siteUrl}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'siteUrl' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'sites/{siteUrl}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'siteUrl' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'sites',
+              'httpMethod' => 'GET',
+              'parameters' => array(),
+            ),
+          )
+        )
+    );
+    $this->urlcrawlerrorscounts = new Google_Service_Webmasters_Urlcrawlerrorscounts_Resource(
+        $this,
+        $this->serviceName,
+        'urlcrawlerrorscounts',
+        array(
+          'methods' => array(
+            'query' => array(
+              'path' => 'sites/{siteUrl}/urlCrawlErrorsCounts/query',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'siteUrl' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'category' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'platform' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'latestCountsOnly' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->urlcrawlerrorssamples = new Google_Service_Webmasters_Urlcrawlerrorssamples_Resource(
+        $this,
+        $this->serviceName,
+        'urlcrawlerrorssamples',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'sites/{siteUrl}/urlCrawlErrorsSamples/{url}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'siteUrl' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'url' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'category' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'platform' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'sites/{siteUrl}/urlCrawlErrorsSamples',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'siteUrl' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'category' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'platform' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'markAsFixed' => array(
+              'path' => 'sites/{siteUrl}/urlCrawlErrorsSamples/{url}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'siteUrl' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'url' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'category' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'platform' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "searchanalytics" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $webmastersService = new Google_Service_Webmasters(...);
+ *   $searchanalytics = $webmastersService->searchanalytics;
+ *  </code>
+ */
+class Google_Service_Webmasters_Searchanalytics_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Query your data with filters and parameters that you define. Returns zero or
+   * more rows grouped by the row keys that you define. You must define a date
+   * range of one or more days.
+   *
+   * When date is one of the group by values, any days without data are omitted
+   * from the result list. If you need to know which days have data, issue a broad
+   * date range query grouped by date for any metric, and see which day rows are
+   * returned. (searchanalytics.query)
+   *
+   * @param string $siteUrl The site's URL, including protocol. For example:
+   * http://www.example.com/
+   * @param Google_SearchAnalyticsQueryRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Webmasters_SearchAnalyticsQueryResponse
+   */
+  public function query($siteUrl, Google_Service_Webmasters_SearchAnalyticsQueryRequest $postBody, $optParams = array())
+  {
+    $params = array('siteUrl' => $siteUrl, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('query', array($params), "Google_Service_Webmasters_SearchAnalyticsQueryResponse");
+  }
+}
+
+/**
+ * The "sitemaps" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $webmastersService = new Google_Service_Webmasters(...);
+ *   $sitemaps = $webmastersService->sitemaps;
+ *  </code>
+ */
+class Google_Service_Webmasters_Sitemaps_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a sitemap from this site. (sitemaps.delete)
+   *
+   * @param string $siteUrl The site's URL, including protocol. For example:
+   * http://www.example.com/
+   * @param string $feedpath The URL of the actual sitemap. For example:
+   * http://www.example.com/sitemap.xml
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($siteUrl, $feedpath, $optParams = array())
+  {
+    $params = array('siteUrl' => $siteUrl, 'feedpath' => $feedpath);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves information about a specific sitemap. (sitemaps.get)
+   *
+   * @param string $siteUrl The site's URL, including protocol. For example:
+   * http://www.example.com/
+   * @param string $feedpath The URL of the actual sitemap. For example:
+   * http://www.example.com/sitemap.xml
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Webmasters_WmxSitemap
+   */
+  public function get($siteUrl, $feedpath, $optParams = array())
+  {
+    $params = array('siteUrl' => $siteUrl, 'feedpath' => $feedpath);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Webmasters_WmxSitemap");
+  }
+
+  /**
+   * Lists the sitemaps-entries submitted for this site, or included in the
+   * sitemap index file (if sitemapIndex is specified in the request).
+   * (sitemaps.listSitemaps)
+   *
+   * @param string $siteUrl The site's URL, including protocol. For example:
+   * http://www.example.com/
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string sitemapIndex A URL of a site's sitemap index. For example:
+   * http://www.example.com/sitemapindex.xml
+   * @return Google_Service_Webmasters_SitemapsListResponse
+   */
+  public function listSitemaps($siteUrl, $optParams = array())
+  {
+    $params = array('siteUrl' => $siteUrl);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Webmasters_SitemapsListResponse");
+  }
+
+  /**
+   * Submits a sitemap for a site. (sitemaps.submit)
+   *
+   * @param string $siteUrl The site's URL, including protocol. For example:
+   * http://www.example.com/
+   * @param string $feedpath The URL of the sitemap to add. For example:
+   * http://www.example.com/sitemap.xml
+   * @param array $optParams Optional parameters.
+   */
+  public function submit($siteUrl, $feedpath, $optParams = array())
+  {
+    $params = array('siteUrl' => $siteUrl, 'feedpath' => $feedpath);
+    $params = array_merge($params, $optParams);
+    return $this->call('submit', array($params));
+  }
+}
+
+/**
+ * The "sites" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $webmastersService = new Google_Service_Webmasters(...);
+ *   $sites = $webmastersService->sites;
+ *  </code>
+ */
+class Google_Service_Webmasters_Sites_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Adds a site to the set of the user's sites in Webmaster Tools. (sites.add)
+   *
+   * @param string $siteUrl The URL of the site to add.
+   * @param array $optParams Optional parameters.
+   */
+  public function add($siteUrl, $optParams = array())
+  {
+    $params = array('siteUrl' => $siteUrl);
+    $params = array_merge($params, $optParams);
+    return $this->call('add', array($params));
+  }
+
+  /**
+   * Removes a site from the set of the user's Webmaster Tools sites.
+   * (sites.delete)
+   *
+   * @param string $siteUrl The URI of the property as defined in Search Console.
+   * Examples: http://www.example.com/ or android-app://com.example/
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($siteUrl, $optParams = array())
+  {
+    $params = array('siteUrl' => $siteUrl);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves information about specific site. (sites.get)
+   *
+   * @param string $siteUrl The URI of the property as defined in Search Console.
+   * Examples: http://www.example.com/ or android-app://com.example/
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Webmasters_WmxSite
+   */
+  public function get($siteUrl, $optParams = array())
+  {
+    $params = array('siteUrl' => $siteUrl);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Webmasters_WmxSite");
+  }
+
+  /**
+   * Lists the user's Webmaster Tools sites. (sites.listSites)
+   *
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Webmasters_SitesListResponse
+   */
+  public function listSites($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Webmasters_SitesListResponse");
+  }
+}
+
+/**
+ * The "urlcrawlerrorscounts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $webmastersService = new Google_Service_Webmasters(...);
+ *   $urlcrawlerrorscounts = $webmastersService->urlcrawlerrorscounts;
+ *  </code>
+ */
+class Google_Service_Webmasters_Urlcrawlerrorscounts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a time series of the number of URL crawl errors per error category
+   * and platform. (urlcrawlerrorscounts.query)
+   *
+   * @param string $siteUrl The site's URL, including protocol. For example:
+   * http://www.example.com/
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string category The crawl error category. For example:
+   * serverError. If not specified, returns results for all categories.
+   * @opt_param string platform The user agent type (platform) that made the
+   * request. For example: web. If not specified, returns results for all
+   * platforms.
+   * @opt_param bool latestCountsOnly If true, returns only the latest crawl error
+   * counts.
+   * @return Google_Service_Webmasters_UrlCrawlErrorsCountsQueryResponse
+   */
+  public function query($siteUrl, $optParams = array())
+  {
+    $params = array('siteUrl' => $siteUrl);
+    $params = array_merge($params, $optParams);
+    return $this->call('query', array($params), "Google_Service_Webmasters_UrlCrawlErrorsCountsQueryResponse");
+  }
+}
+
+/**
+ * The "urlcrawlerrorssamples" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $webmastersService = new Google_Service_Webmasters(...);
+ *   $urlcrawlerrorssamples = $webmastersService->urlcrawlerrorssamples;
+ *  </code>
+ */
+class Google_Service_Webmasters_Urlcrawlerrorssamples_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves details about crawl errors for a site's sample URL.
+   * (urlcrawlerrorssamples.get)
+   *
+   * @param string $siteUrl The site's URL, including protocol. For example:
+   * http://www.example.com/
+   * @param string $url The relative path (without the site) of the sample URL. It
+   * must be one of the URLs returned by list(). For example, for the URL
+   * https://www.example.com/pagename on the site https://www.example.com/, the
+   * url value is pagename
+   * @param string $category The crawl error category. For example:
+   * authPermissions
+   * @param string $platform The user agent type (platform) that made the request.
+   * For example: web
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Webmasters_UrlCrawlErrorsSample
+   */
+  public function get($siteUrl, $url, $category, $platform, $optParams = array())
+  {
+    $params = array('siteUrl' => $siteUrl, 'url' => $url, 'category' => $category, 'platform' => $platform);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_Webmasters_UrlCrawlErrorsSample");
+  }
+
+  /**
+   * Lists a site's sample URLs for the specified crawl error category and
+   * platform. (urlcrawlerrorssamples.listUrlcrawlerrorssamples)
+   *
+   * @param string $siteUrl The site's URL, including protocol. For example:
+   * http://www.example.com/
+   * @param string $category The crawl error category. For example:
+   * authPermissions
+   * @param string $platform The user agent type (platform) that made the request.
+   * For example: web
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_Webmasters_UrlCrawlErrorsSamplesListResponse
+   */
+  public function listUrlcrawlerrorssamples($siteUrl, $category, $platform, $optParams = array())
+  {
+    $params = array('siteUrl' => $siteUrl, 'category' => $category, 'platform' => $platform);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_Webmasters_UrlCrawlErrorsSamplesListResponse");
+  }
+
+  /**
+   * Marks the provided site's sample URL as fixed, and removes it from the
+   * samples list. (urlcrawlerrorssamples.markAsFixed)
+   *
+   * @param string $siteUrl The site's URL, including protocol. For example:
+   * http://www.example.com/
+   * @param string $url The relative path (without the site) of the sample URL. It
+   * must be one of the URLs returned by list(). For example, for the URL
+   * https://www.example.com/pagename on the site https://www.example.com/, the
+   * url value is pagename
+   * @param string $category The crawl error category. For example:
+   * authPermissions
+   * @param string $platform The user agent type (platform) that made the request.
+   * For example: web
+   * @param array $optParams Optional parameters.
+   */
+  public function markAsFixed($siteUrl, $url, $category, $platform, $optParams = array())
+  {
+    $params = array('siteUrl' => $siteUrl, 'url' => $url, 'category' => $category, 'platform' => $platform);
+    $params = array_merge($params, $optParams);
+    return $this->call('markAsFixed', array($params));
+  }
+}
+
+
+
+
+class Google_Service_Webmasters_ApiDataRow extends Google_Collection
+{
+  protected $collection_key = 'keys';
+  protected $internal_gapi_mappings = array(
+  );
+  public $clicks;
+  public $ctr;
+  public $impressions;
+  public $keys;
+  public $position;
+
+
+  public function setClicks($clicks)
+  {
+    $this->clicks = $clicks;
+  }
+  public function getClicks()
+  {
+    return $this->clicks;
+  }
+  public function setCtr($ctr)
+  {
+    $this->ctr = $ctr;
+  }
+  public function getCtr()
+  {
+    return $this->ctr;
+  }
+  public function setImpressions($impressions)
+  {
+    $this->impressions = $impressions;
+  }
+  public function getImpressions()
+  {
+    return $this->impressions;
+  }
+  public function setKeys($keys)
+  {
+    $this->keys = $keys;
+  }
+  public function getKeys()
+  {
+    return $this->keys;
+  }
+  public function setPosition($position)
+  {
+    $this->position = $position;
+  }
+  public function getPosition()
+  {
+    return $this->position;
+  }
+}
+
+class Google_Service_Webmasters_ApiDimensionFilter extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $dimension;
+  public $expression;
+  public $operator;
+
+
+  public function setDimension($dimension)
+  {
+    $this->dimension = $dimension;
+  }
+  public function getDimension()
+  {
+    return $this->dimension;
+  }
+  public function setExpression($expression)
+  {
+    $this->expression = $expression;
+  }
+  public function getExpression()
+  {
+    return $this->expression;
+  }
+  public function setOperator($operator)
+  {
+    $this->operator = $operator;
+  }
+  public function getOperator()
+  {
+    return $this->operator;
+  }
+}
+
+class Google_Service_Webmasters_ApiDimensionFilterGroup extends Google_Collection
+{
+  protected $collection_key = 'filters';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $filtersType = 'Google_Service_Webmasters_ApiDimensionFilter';
+  protected $filtersDataType = 'array';
+  public $groupType;
+
+
+  public function setFilters($filters)
+  {
+    $this->filters = $filters;
+  }
+  public function getFilters()
+  {
+    return $this->filters;
+  }
+  public function setGroupType($groupType)
+  {
+    $this->groupType = $groupType;
+  }
+  public function getGroupType()
+  {
+    return $this->groupType;
+  }
+}
+
+class Google_Service_Webmasters_SearchAnalyticsQueryRequest extends Google_Collection
+{
+  protected $collection_key = 'dimensions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $aggregationType;
+  protected $dimensionFilterGroupsType = 'Google_Service_Webmasters_ApiDimensionFilterGroup';
+  protected $dimensionFilterGroupsDataType = 'array';
+  public $dimensions;
+  public $endDate;
+  public $rowLimit;
+  public $searchType;
+  public $startDate;
+
+
+  public function setAggregationType($aggregationType)
+  {
+    $this->aggregationType = $aggregationType;
+  }
+  public function getAggregationType()
+  {
+    return $this->aggregationType;
+  }
+  public function setDimensionFilterGroups($dimensionFilterGroups)
+  {
+    $this->dimensionFilterGroups = $dimensionFilterGroups;
+  }
+  public function getDimensionFilterGroups()
+  {
+    return $this->dimensionFilterGroups;
+  }
+  public function setDimensions($dimensions)
+  {
+    $this->dimensions = $dimensions;
+  }
+  public function getDimensions()
+  {
+    return $this->dimensions;
+  }
+  public function setEndDate($endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  public function setRowLimit($rowLimit)
+  {
+    $this->rowLimit = $rowLimit;
+  }
+  public function getRowLimit()
+  {
+    return $this->rowLimit;
+  }
+  public function setSearchType($searchType)
+  {
+    $this->searchType = $searchType;
+  }
+  public function getSearchType()
+  {
+    return $this->searchType;
+  }
+  public function setStartDate($startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+}
+
+class Google_Service_Webmasters_SearchAnalyticsQueryResponse extends Google_Collection
+{
+  protected $collection_key = 'rows';
+  protected $internal_gapi_mappings = array(
+  );
+  public $responseAggregationType;
+  protected $rowsType = 'Google_Service_Webmasters_ApiDataRow';
+  protected $rowsDataType = 'array';
+
+
+  public function setResponseAggregationType($responseAggregationType)
+  {
+    $this->responseAggregationType = $responseAggregationType;
+  }
+  public function getResponseAggregationType()
+  {
+    return $this->responseAggregationType;
+  }
+  public function setRows($rows)
+  {
+    $this->rows = $rows;
+  }
+  public function getRows()
+  {
+    return $this->rows;
+  }
+}
+
+class Google_Service_Webmasters_SitemapsListResponse extends Google_Collection
+{
+  protected $collection_key = 'sitemap';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $sitemapType = 'Google_Service_Webmasters_WmxSitemap';
+  protected $sitemapDataType = 'array';
+
+
+  public function setSitemap($sitemap)
+  {
+    $this->sitemap = $sitemap;
+  }
+  public function getSitemap()
+  {
+    return $this->sitemap;
+  }
+}
+
+class Google_Service_Webmasters_SitesListResponse extends Google_Collection
+{
+  protected $collection_key = 'siteEntry';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $siteEntryType = 'Google_Service_Webmasters_WmxSite';
+  protected $siteEntryDataType = 'array';
+
+
+  public function setSiteEntry($siteEntry)
+  {
+    $this->siteEntry = $siteEntry;
+  }
+  public function getSiteEntry()
+  {
+    return $this->siteEntry;
+  }
+}
+
+class Google_Service_Webmasters_UrlCrawlErrorCount extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $count;
+  public $timestamp;
+
+
+  public function setCount($count)
+  {
+    $this->count = $count;
+  }
+  public function getCount()
+  {
+    return $this->count;
+  }
+  public function setTimestamp($timestamp)
+  {
+    $this->timestamp = $timestamp;
+  }
+  public function getTimestamp()
+  {
+    return $this->timestamp;
+  }
+}
+
+class Google_Service_Webmasters_UrlCrawlErrorCountsPerType extends Google_Collection
+{
+  protected $collection_key = 'entries';
+  protected $internal_gapi_mappings = array(
+  );
+  public $category;
+  protected $entriesType = 'Google_Service_Webmasters_UrlCrawlErrorCount';
+  protected $entriesDataType = 'array';
+  public $platform;
+
+
+  public function setCategory($category)
+  {
+    $this->category = $category;
+  }
+  public function getCategory()
+  {
+    return $this->category;
+  }
+  public function setEntries($entries)
+  {
+    $this->entries = $entries;
+  }
+  public function getEntries()
+  {
+    return $this->entries;
+  }
+  public function setPlatform($platform)
+  {
+    $this->platform = $platform;
+  }
+  public function getPlatform()
+  {
+    return $this->platform;
+  }
+}
+
+class Google_Service_Webmasters_UrlCrawlErrorsCountsQueryResponse extends Google_Collection
+{
+  protected $collection_key = 'countPerTypes';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $countPerTypesType = 'Google_Service_Webmasters_UrlCrawlErrorCountsPerType';
+  protected $countPerTypesDataType = 'array';
+
+
+  public function setCountPerTypes($countPerTypes)
+  {
+    $this->countPerTypes = $countPerTypes;
+  }
+  public function getCountPerTypes()
+  {
+    return $this->countPerTypes;
+  }
+}
+
+class Google_Service_Webmasters_UrlCrawlErrorsSample extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+        "firstDetected" => "first_detected",
+        "lastCrawled" => "last_crawled",
+  );
+  public $firstDetected;
+  public $lastCrawled;
+  public $pageUrl;
+  public $responseCode;
+  protected $urlDetailsType = 'Google_Service_Webmasters_UrlSampleDetails';
+  protected $urlDetailsDataType = '';
+
+
+  public function setFirstDetected($firstDetected)
+  {
+    $this->firstDetected = $firstDetected;
+  }
+  public function getFirstDetected()
+  {
+    return $this->firstDetected;
+  }
+  public function setLastCrawled($lastCrawled)
+  {
+    $this->lastCrawled = $lastCrawled;
+  }
+  public function getLastCrawled()
+  {
+    return $this->lastCrawled;
+  }
+  public function setPageUrl($pageUrl)
+  {
+    $this->pageUrl = $pageUrl;
+  }
+  public function getPageUrl()
+  {
+    return $this->pageUrl;
+  }
+  public function setResponseCode($responseCode)
+  {
+    $this->responseCode = $responseCode;
+  }
+  public function getResponseCode()
+  {
+    return $this->responseCode;
+  }
+  public function setUrlDetails(Google_Service_Webmasters_UrlSampleDetails $urlDetails)
+  {
+    $this->urlDetails = $urlDetails;
+  }
+  public function getUrlDetails()
+  {
+    return $this->urlDetails;
+  }
+}
+
+class Google_Service_Webmasters_UrlCrawlErrorsSamplesListResponse extends Google_Collection
+{
+  protected $collection_key = 'urlCrawlErrorSample';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $urlCrawlErrorSampleType = 'Google_Service_Webmasters_UrlCrawlErrorsSample';
+  protected $urlCrawlErrorSampleDataType = 'array';
+
+
+  public function setUrlCrawlErrorSample($urlCrawlErrorSample)
+  {
+    $this->urlCrawlErrorSample = $urlCrawlErrorSample;
+  }
+  public function getUrlCrawlErrorSample()
+  {
+    return $this->urlCrawlErrorSample;
+  }
+}
+
+class Google_Service_Webmasters_UrlSampleDetails extends Google_Collection
+{
+  protected $collection_key = 'linkedFromUrls';
+  protected $internal_gapi_mappings = array(
+  );
+  public $containingSitemaps;
+  public $linkedFromUrls;
+
+
+  public function setContainingSitemaps($containingSitemaps)
+  {
+    $this->containingSitemaps = $containingSitemaps;
+  }
+  public function getContainingSitemaps()
+  {
+    return $this->containingSitemaps;
+  }
+  public function setLinkedFromUrls($linkedFromUrls)
+  {
+    $this->linkedFromUrls = $linkedFromUrls;
+  }
+  public function getLinkedFromUrls()
+  {
+    return $this->linkedFromUrls;
+  }
+}
+
+class Google_Service_Webmasters_WmxSite extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $permissionLevel;
+  public $siteUrl;
+
+
+  public function setPermissionLevel($permissionLevel)
+  {
+    $this->permissionLevel = $permissionLevel;
+  }
+  public function getPermissionLevel()
+  {
+    return $this->permissionLevel;
+  }
+  public function setSiteUrl($siteUrl)
+  {
+    $this->siteUrl = $siteUrl;
+  }
+  public function getSiteUrl()
+  {
+    return $this->siteUrl;
+  }
+}
+
+class Google_Service_Webmasters_WmxSitemap extends Google_Collection
+{
+  protected $collection_key = 'contents';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $contentsType = 'Google_Service_Webmasters_WmxSitemapContent';
+  protected $contentsDataType = 'array';
+  public $errors;
+  public $isPending;
+  public $isSitemapsIndex;
+  public $lastDownloaded;
+  public $lastSubmitted;
+  public $path;
+  public $type;
+  public $warnings;
+
+
+  public function setContents($contents)
+  {
+    $this->contents = $contents;
+  }
+  public function getContents()
+  {
+    return $this->contents;
+  }
+  public function setErrors($errors)
+  {
+    $this->errors = $errors;
+  }
+  public function getErrors()
+  {
+    return $this->errors;
+  }
+  public function setIsPending($isPending)
+  {
+    $this->isPending = $isPending;
+  }
+  public function getIsPending()
+  {
+    return $this->isPending;
+  }
+  public function setIsSitemapsIndex($isSitemapsIndex)
+  {
+    $this->isSitemapsIndex = $isSitemapsIndex;
+  }
+  public function getIsSitemapsIndex()
+  {
+    return $this->isSitemapsIndex;
+  }
+  public function setLastDownloaded($lastDownloaded)
+  {
+    $this->lastDownloaded = $lastDownloaded;
+  }
+  public function getLastDownloaded()
+  {
+    return $this->lastDownloaded;
+  }
+  public function setLastSubmitted($lastSubmitted)
+  {
+    $this->lastSubmitted = $lastSubmitted;
+  }
+  public function getLastSubmitted()
+  {
+    return $this->lastSubmitted;
+  }
+  public function setPath($path)
+  {
+    $this->path = $path;
+  }
+  public function getPath()
+  {
+    return $this->path;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setWarnings($warnings)
+  {
+    $this->warnings = $warnings;
+  }
+  public function getWarnings()
+  {
+    return $this->warnings;
+  }
+}
+
+class Google_Service_Webmasters_WmxSitemapContent extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $indexed;
+  public $submitted;
+  public $type;
+
+
+  public function setIndexed($indexed)
+  {
+    $this->indexed = $indexed;
+  }
+  public function getIndexed()
+  {
+    return $this->indexed;
+  }
+  public function setSubmitted($submitted)
+  {
+    $this->submitted = $submitted;
+  }
+  public function getSubmitted()
+  {
+    return $this->submitted;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/YouTube.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/YouTube.php
@@ -1,0 +1,12992 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for YouTube (v3).
+ *
+ * <p>
+ * Programmatic access to YouTube features.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/youtube/v3" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_YouTube extends Google_Service
+{
+  /** Manage your YouTube account. */
+  const YOUTUBE =
+      "https://www.googleapis.com/auth/youtube";
+  /** Manage your YouTube account. */
+  const YOUTUBE_FORCE_SSL =
+      "https://www.googleapis.com/auth/youtube.force-ssl";
+  /** View your YouTube account. */
+  const YOUTUBE_READONLY =
+      "https://www.googleapis.com/auth/youtube.readonly";
+  /** Manage your YouTube videos. */
+  const YOUTUBE_UPLOAD =
+      "https://www.googleapis.com/auth/youtube.upload";
+  /** View and manage your assets and associated content on YouTube. */
+  const YOUTUBEPARTNER =
+      "https://www.googleapis.com/auth/youtubepartner";
+  /** View private information of your YouTube channel relevant during the audit process with a YouTube partner. */
+  const YOUTUBEPARTNER_CHANNEL_AUDIT =
+      "https://www.googleapis.com/auth/youtubepartner-channel-audit";
+
+  public $activities;
+  public $captions;
+  public $channelBanners;
+  public $channelSections;
+  public $channels;
+  public $commentThreads;
+  public $comments;
+  public $guideCategories;
+  public $i18nLanguages;
+  public $i18nRegions;
+  public $liveBroadcasts;
+  public $liveStreams;
+  public $playlistItems;
+  public $playlists;
+  public $search;
+  public $subscriptions;
+  public $thumbnails;
+  public $videoAbuseReportReasons;
+  public $videoCategories;
+  public $videos;
+  public $watermarks;
+  
+
+  /**
+   * Constructs the internal representation of the YouTube service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'youtube/v3/';
+    $this->version = 'v3';
+    $this->serviceName = 'youtube';
+
+    $this->activities = new Google_Service_YouTube_Activities_Resource(
+        $this,
+        $this->serviceName,
+        'activities',
+        array(
+          'methods' => array(
+            'insert' => array(
+              'path' => 'activities',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'activities',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'regionCode' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'publishedBefore' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'channelId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'mine' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'home' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'publishedAfter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->captions = new Google_Service_YouTube_Captions_Resource(
+        $this,
+        $this->serviceName,
+        'captions',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'captions',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOf' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'download' => array(
+              'path' => 'captions/{id}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'tfmt' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOf' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'tlang' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'captions',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOf' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sync' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'captions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'videoId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOf' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'captions',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOf' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'sync' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->channelBanners = new Google_Service_YouTube_ChannelBanners_Resource(
+        $this,
+        $this->serviceName,
+        'channelBanners',
+        array(
+          'methods' => array(
+            'insert' => array(
+              'path' => 'channelBanners/insert',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->channelSections = new Google_Service_YouTube_ChannelSections_Resource(
+        $this,
+        $this->serviceName,
+        'channelSections',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'channelSections',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'channelSections',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwnerChannel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'channelSections',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'channelId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'mine' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'hl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'channelSections',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->channels = new Google_Service_YouTube_Channels_Resource(
+        $this,
+        $this->serviceName,
+        'channels',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'channels',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'managedByMe' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'forUsername' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'mine' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'mySubscribers' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'hl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'categoryId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'channels',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->commentThreads = new Google_Service_YouTube_CommentThreads_Resource(
+        $this,
+        $this->serviceName,
+        'commentThreads',
+        array(
+          'methods' => array(
+            'insert' => array(
+              'path' => 'commentThreads',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'commentThreads',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'searchTerms' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'allThreadsRelatedToChannelId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'channelId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'videoId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'moderationStatus' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'textFormat' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'order' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'commentThreads',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->comments = new Google_Service_YouTube_Comments_Resource(
+        $this,
+        $this->serviceName,
+        'comments',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'comments',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'comments',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'comments',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'parentId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'textFormat' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'markAsSpam' => array(
+              'path' => 'comments/markAsSpam',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'setModerationStatus' => array(
+              'path' => 'comments/setModerationStatus',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'moderationStatus' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'banAuthor' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'comments',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->guideCategories = new Google_Service_YouTube_GuideCategories_Resource(
+        $this,
+        $this->serviceName,
+        'guideCategories',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'guideCategories',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'regionCode' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'hl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->i18nLanguages = new Google_Service_YouTube_I18nLanguages_Resource(
+        $this,
+        $this->serviceName,
+        'i18nLanguages',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'i18nLanguages',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'hl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->i18nRegions = new Google_Service_YouTube_I18nRegions_Resource(
+        $this,
+        $this->serviceName,
+        'i18nRegions',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'i18nRegions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'hl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->liveBroadcasts = new Google_Service_YouTube_LiveBroadcasts_Resource(
+        $this,
+        $this->serviceName,
+        'liveBroadcasts',
+        array(
+          'methods' => array(
+            'bind' => array(
+              'path' => 'liveBroadcasts/bind',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwnerChannel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'streamId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'bind_direct' => array(
+              'path' => 'liveBroadcasts/bind/direct',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwnerChannel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'streamId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'control' => array(
+              'path' => 'liveBroadcasts/control',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'displaySlate' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'onBehalfOfContentOwnerChannel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'offsetTimeMs' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'walltime' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'liveBroadcasts',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwnerChannel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'liveBroadcasts',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwnerChannel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'liveBroadcasts',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'broadcastStatus' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwnerChannel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'mine' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'transition' => array(
+              'path' => 'liveBroadcasts/transition',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'broadcastStatus' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwnerChannel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'liveBroadcasts',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwnerChannel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->liveStreams = new Google_Service_YouTube_LiveStreams_Resource(
+        $this,
+        $this->serviceName,
+        'liveStreams',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'liveStreams',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwnerChannel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'liveStreams',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwnerChannel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'liveStreams',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwnerChannel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'mine' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'liveStreams',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwnerChannel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->playlistItems = new Google_Service_YouTube_PlaylistItems_Resource(
+        $this,
+        $this->serviceName,
+        'playlistItems',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'playlistItems',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'playlistItems',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'playlistItems',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'playlistId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'videoId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'playlistItems',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->playlists = new Google_Service_YouTube_Playlists_Resource(
+        $this,
+        $this->serviceName,
+        'playlists',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'playlists',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'playlists',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwnerChannel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'playlists',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwnerChannel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'channelId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'mine' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'hl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'playlists',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->search = new Google_Service_YouTube_Search_Resource(
+        $this,
+        $this->serviceName,
+        'search',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'search',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'eventType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'channelId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'forDeveloper' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'videoSyndicated' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'channelType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'videoCaption' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'publishedAfter' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'forContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'regionCode' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'location' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'locationRadius' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'videoType' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'type' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'topicId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'publishedBefore' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'videoDimension' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'videoLicense' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'relatedToVideoId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'videoDefinition' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'videoDuration' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'relevanceLanguage' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'forMine' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'q' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'safeSearch' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'videoEmbeddable' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'videoCategoryId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'order' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->subscriptions = new Google_Service_YouTube_Subscriptions_Resource(
+        $this,
+        $this->serviceName,
+        'subscriptions',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'subscriptions',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'subscriptions',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'subscriptions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwnerChannel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'channelId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'mine' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'forChannelId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'mySubscribers' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'order' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->thumbnails = new Google_Service_YouTube_Thumbnails_Resource(
+        $this,
+        $this->serviceName,
+        'thumbnails',
+        array(
+          'methods' => array(
+            'set' => array(
+              'path' => 'thumbnails/set',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'videoId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->videoAbuseReportReasons = new Google_Service_YouTube_VideoAbuseReportReasons_Resource(
+        $this,
+        $this->serviceName,
+        'videoAbuseReportReasons',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'videoAbuseReportReasons',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'hl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->videoCategories = new Google_Service_YouTube_VideoCategories_Resource(
+        $this,
+        $this->serviceName,
+        'videoCategories',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'videoCategories',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'regionCode' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'hl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->videos = new Google_Service_YouTube_Videos_Resource(
+        $this,
+        $this->serviceName,
+        'videos',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'videos',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'getRating' => array(
+              'path' => 'videos/getRating',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'videos',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'stabilize' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'onBehalfOfContentOwnerChannel' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'notifySubscribers' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+                'autoLevels' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'videos',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'regionCode' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'locale' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'videoCategoryId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'chart' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'hl' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'myRating' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'rate' => array(
+              'path' => 'videos/rate',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'rating' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),'reportAbuse' => array(
+              'path' => 'videos/reportAbuse',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'videos',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'part' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->watermarks = new Google_Service_YouTube_Watermarks_Resource(
+        $this,
+        $this->serviceName,
+        'watermarks',
+        array(
+          'methods' => array(
+            'set' => array(
+              'path' => 'watermarks/set',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'channelId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'unset' => array(
+              'path' => 'watermarks/unset',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'channelId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "activities" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $activities = $youtubeService->activities;
+ *  </code>
+ */
+class Google_Service_YouTube_Activities_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Posts a bulletin for a specific channel. (The user submitting the request
+   * must be authorized to act on the channel's behalf.)
+   *
+   * Note: Even though an activity resource can contain information about actions
+   * like a user rating a video or marking a video as a favorite, you need to use
+   * other API methods to generate those activity resources. For example, you
+   * would use the API's videos.rate() method to rate a video and the
+   * playlistItems.insert() method to mark a video as a favorite.
+   * (activities.insert)
+   *
+   * @param string $part The part parameter serves two purposes in this operation.
+   * It identifies the properties that the write operation will set as well as the
+   * properties that the API response will include.
+   * @param Google_Activity $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_YouTube_Activity
+   */
+  public function insert($part, Google_Service_YouTube_Activity $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_YouTube_Activity");
+  }
+
+  /**
+   * Returns a list of channel activity events that match the request criteria.
+   * For example, you can retrieve events associated with a particular channel,
+   * events associated with the user's subscriptions and Google+ friends, or the
+   * YouTube home page feed, which is customized for each user.
+   * (activities.listActivities)
+   *
+   * @param string $part The part parameter specifies a comma-separated list of
+   * one or more activity resource properties that the API response will include.
+   *
+   * If the parameter identifies a property that contains child properties, the
+   * child properties will be included in the response. For example, in an
+   * activity resource, the snippet property contains other properties that
+   * identify the type of activity, a display title for the activity, and so
+   * forth. If you set part=snippet, the API response will also contain all of
+   * those nested properties.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string regionCode The regionCode parameter instructs the API to
+   * return results for the specified country. The parameter value is an ISO
+   * 3166-1 alpha-2 country code. YouTube uses this value when the authorized
+   * user's previous activity on YouTube does not provide enough information to
+   * generate the activity feed.
+   * @opt_param string publishedBefore The publishedBefore parameter specifies the
+   * date and time before which an activity must have occurred for that activity
+   * to be included in the API response. If the parameter value specifies a day,
+   * but not a time, then any activities that occurred that day will be excluded
+   * from the result set. The value is specified in ISO 8601 (YYYY-MM-
+   * DDThh:mm:ss.sZ) format.
+   * @opt_param string channelId The channelId parameter specifies a unique
+   * YouTube channel ID. The API will then return a list of that channel's
+   * activities.
+   * @opt_param bool mine Set this parameter's value to true to retrieve a feed of
+   * the authenticated user's activities.
+   * @opt_param string maxResults The maxResults parameter specifies the maximum
+   * number of items that should be returned in the result set.
+   * @opt_param string pageToken The pageToken parameter identifies a specific
+   * page in the result set that should be returned. In an API response, the
+   * nextPageToken and prevPageToken properties identify other pages that could be
+   * retrieved.
+   * @opt_param bool home Set this parameter's value to true to retrieve the
+   * activity feed that displays on the YouTube home page for the currently
+   * authenticated user.
+   * @opt_param string publishedAfter The publishedAfter parameter specifies the
+   * earliest date and time that an activity could have occurred for that activity
+   * to be included in the API response. If the parameter value specifies a day,
+   * but not a time, then any activities that occurred that day will be included
+   * in the result set. The value is specified in ISO 8601 (YYYY-MM-
+   * DDThh:mm:ss.sZ) format.
+   * @return Google_Service_YouTube_ActivityListResponse
+   */
+  public function listActivities($part, $optParams = array())
+  {
+    $params = array('part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTube_ActivityListResponse");
+  }
+}
+
+/**
+ * The "captions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $captions = $youtubeService->captions;
+ *  </code>
+ */
+class Google_Service_YouTube_Captions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a specified caption track. (captions.delete)
+   *
+   * @param string $id The id parameter identifies the caption track that is being
+   * deleted. The value is a caption track ID as identified by the id property in
+   * a caption resource.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOf ID of the Google+ Page for the channel that the
+   * request is be on behalf of
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The actual CMS
+   * account that the user authenticates with must be linked to the specified
+   * YouTube content owner.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Downloads a caption track. The caption track is returned in its original
+   * format unless the request specifies a value for the tfmt parameter and in its
+   * original language unless the request specifies a value for the tlang
+   * parameter. (captions.download)
+   *
+   * @param string $id The id parameter identifies the caption track that is being
+   * retrieved. The value is a caption track ID as identified by the id property
+   * in a caption resource.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string tfmt The tfmt parameter specifies that the caption track
+   * should be returned in a specific format. If the parameter is not included in
+   * the request, the track is returned in its original format.
+   * @opt_param string onBehalfOf ID of the Google+ Page for the channel that the
+   * request is be on behalf of
+   * @opt_param string tlang The tlang parameter specifies that the API response
+   * should return a translation of the specified caption track. The parameter
+   * value is an ISO 639-1 two-letter language code that identifies the desired
+   * caption language. The translation is generated by using machine translation,
+   * such as Google Translate.
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The actual CMS
+   * account that the user authenticates with must be linked to the specified
+   * YouTube content owner.
+   */
+  public function download($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('download', array($params));
+  }
+
+  /**
+   * Uploads a caption track. (captions.insert)
+   *
+   * @param string $part The part parameter specifies the caption resource parts
+   * that the API response will include. Set the parameter value to snippet.
+   * @param Google_Caption $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOf ID of the Google+ Page for the channel that the
+   * request is be on behalf of
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The actual CMS
+   * account that the user authenticates with must be linked to the specified
+   * YouTube content owner.
+   * @opt_param bool sync The sync parameter indicates whether YouTube should
+   * automatically synchronize the caption file with the audio track of the video.
+   * If you set the value to true, YouTube will disregard any time codes that are
+   * in the uploaded caption file and generate new time codes for the captions.
+   *
+   * You should set the sync parameter to true if you are uploading a transcript,
+   * which has no time codes, or if you suspect the time codes in your file are
+   * incorrect and want YouTube to try to fix them.
+   * @return Google_Service_YouTube_Caption
+   */
+  public function insert($part, Google_Service_YouTube_Caption $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_YouTube_Caption");
+  }
+
+  /**
+   * Returns a list of caption tracks that are associated with a specified video.
+   * Note that the API response does not contain the actual captions and that the
+   * captions.download method provides the ability to retrieve a caption track.
+   * (captions.listCaptions)
+   *
+   * @param string $part The part parameter specifies a comma-separated list of
+   * one or more caption resource parts that the API response will include. The
+   * part names that you can include in the parameter value are id and snippet.
+   * @param string $videoId The videoId parameter specifies the YouTube video ID
+   * of the video for which the API should return caption tracks.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOf ID of the Google+ Page for the channel that the
+   * request is on behalf of.
+   * @opt_param string id The id parameter specifies a comma-separated list of IDs
+   * that identify the caption resources that should be retrieved. Each ID must
+   * identify a caption track associated with the specified video.
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The actual CMS
+   * account that the user authenticates with must be linked to the specified
+   * YouTube content owner.
+   * @return Google_Service_YouTube_CaptionListResponse
+   */
+  public function listCaptions($part, $videoId, $optParams = array())
+  {
+    $params = array('part' => $part, 'videoId' => $videoId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTube_CaptionListResponse");
+  }
+
+  /**
+   * Updates a caption track. When updating a caption track, you can change the
+   * track's draft status, upload a new caption file for the track, or both.
+   * (captions.update)
+   *
+   * @param string $part The part parameter serves two purposes in this operation.
+   * It identifies the properties that the write operation will set as well as the
+   * properties that the API response will include. Set the property value to
+   * snippet if you are updating the track's draft status. Otherwise, set the
+   * property value to id.
+   * @param Google_Caption $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOf ID of the Google+ Page for the channel that the
+   * request is be on behalf of
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The actual CMS
+   * account that the user authenticates with must be linked to the specified
+   * YouTube content owner.
+   * @opt_param bool sync Note: The API server only processes the parameter value
+   * if the request contains an updated caption file.
+   *
+   * The sync parameter indicates whether YouTube should automatically synchronize
+   * the caption file with the audio track of the video. If you set the value to
+   * true, YouTube will automatically synchronize the caption track with the audio
+   * track.
+   * @return Google_Service_YouTube_Caption
+   */
+  public function update($part, Google_Service_YouTube_Caption $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_YouTube_Caption");
+  }
+}
+
+/**
+ * The "channelBanners" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $channelBanners = $youtubeService->channelBanners;
+ *  </code>
+ */
+class Google_Service_YouTube_ChannelBanners_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Uploads a channel banner image to YouTube. This method represents the first
+   * two steps in a three-step process to update the banner image for a channel:
+   *
+   * - Call the channelBanners.insert method to upload the binary image data to
+   * YouTube. The image must have a 16:9 aspect ratio and be at least 2120x1192
+   * pixels. - Extract the url property's value from the response that the API
+   * returns for step 1. - Call the channels.update method to update the channel's
+   * branding settings. Set the brandingSettings.image.bannerExternalUrl
+   * property's value to the URL obtained in step 2. (channelBanners.insert)
+   *
+   * @param Google_ChannelBannerResource $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @return Google_Service_YouTube_ChannelBannerResource
+   */
+  public function insert(Google_Service_YouTube_ChannelBannerResource $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_YouTube_ChannelBannerResource");
+  }
+}
+
+/**
+ * The "channelSections" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $channelSections = $youtubeService->channelSections;
+ *  </code>
+ */
+class Google_Service_YouTube_ChannelSections_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a channelSection. (channelSections.delete)
+   *
+   * @param string $id The id parameter specifies the YouTube channelSection ID
+   * for the resource that is being deleted. In a channelSection resource, the id
+   * property specifies the YouTube channelSection ID.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Adds a channelSection for the authenticated user's channel.
+   * (channelSections.insert)
+   *
+   * @param string $part The part parameter serves two purposes in this operation.
+   * It identifies the properties that the write operation will set as well as the
+   * properties that the API response will include.
+   *
+   * The part names that you can include in the parameter value are snippet and
+   * contentDetails.
+   * @param Google_ChannelSection $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwnerChannel This parameter can only be
+   * used in a properly authorized request. Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwnerChannel parameter specifies the YouTube channel ID
+   * of the channel to which a video is being added. This parameter is required
+   * when a request specifies a value for the onBehalfOfContentOwner parameter,
+   * and it can only be used in conjunction with that parameter. In addition, the
+   * request must be authorized using a CMS account that is linked to the content
+   * owner that the onBehalfOfContentOwner parameter specifies. Finally, the
+   * channel that the onBehalfOfContentOwnerChannel parameter value specifies must
+   * be linked to the content owner that the onBehalfOfContentOwner parameter
+   * specifies.
+   *
+   * This parameter is intended for YouTube content partners that own and manage
+   * many different YouTube channels. It allows content owners to authenticate
+   * once and perform actions on behalf of the channel specified in the parameter
+   * value, without having to provide authentication credentials for each separate
+   * channel.
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @return Google_Service_YouTube_ChannelSection
+   */
+  public function insert($part, Google_Service_YouTube_ChannelSection $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_YouTube_ChannelSection");
+  }
+
+  /**
+   * Returns channelSection resources that match the API request criteria.
+   * (channelSections.listChannelSections)
+   *
+   * @param string $part The part parameter specifies a comma-separated list of
+   * one or more channelSection resource properties that the API response will
+   * include. The part names that you can include in the parameter value are id,
+   * snippet, and contentDetails.
+   *
+   * If the parameter identifies a property that contains child properties, the
+   * child properties will be included in the response. For example, in a
+   * channelSection resource, the snippet property contains other properties, such
+   * as a display title for the channelSection. If you set part=snippet, the API
+   * response will also contain all of those nested properties.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @opt_param string channelId The channelId parameter specifies a YouTube
+   * channel ID. The API will only return that channel's channelSections.
+   * @opt_param bool mine Set this parameter's value to true to retrieve a feed of
+   * the authenticated user's channelSections.
+   * @opt_param string hl The hl parameter indicates that the snippet.localized
+   * property values in the returned channelSection resources should be in the
+   * specified language if localized values for that language are available. For
+   * example, if the API request specifies hl=de, the snippet.localized properties
+   * in the API response will contain German titles if German titles are
+   * available. Channel owners can provide localized channel section titles using
+   * either the channelSections.insert or channelSections.update method.
+   * @opt_param string id The id parameter specifies a comma-separated list of the
+   * YouTube channelSection ID(s) for the resource(s) that are being retrieved. In
+   * a channelSection resource, the id property specifies the YouTube
+   * channelSection ID.
+   * @return Google_Service_YouTube_ChannelSectionListResponse
+   */
+  public function listChannelSections($part, $optParams = array())
+  {
+    $params = array('part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTube_ChannelSectionListResponse");
+  }
+
+  /**
+   * Update a channelSection. (channelSections.update)
+   *
+   * @param string $part The part parameter serves two purposes in this operation.
+   * It identifies the properties that the write operation will set as well as the
+   * properties that the API response will include.
+   *
+   * The part names that you can include in the parameter value are snippet and
+   * contentDetails.
+   * @param Google_ChannelSection $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @return Google_Service_YouTube_ChannelSection
+   */
+  public function update($part, Google_Service_YouTube_ChannelSection $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_YouTube_ChannelSection");
+  }
+}
+
+/**
+ * The "channels" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $channels = $youtubeService->channels;
+ *  </code>
+ */
+class Google_Service_YouTube_Channels_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns a collection of zero or more channel resources that match the request
+   * criteria. (channels.listChannels)
+   *
+   * @param string $part The part parameter specifies a comma-separated list of
+   * one or more channel resource properties that the API response will include.
+   *
+   * If the parameter identifies a property that contains child properties, the
+   * child properties will be included in the response. For example, in a channel
+   * resource, the contentDetails property contains other properties, such as the
+   * uploads properties. As such, if you set part=contentDetails, the API response
+   * will also contain all of those nested properties.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool managedByMe Note: This parameter is intended exclusively for
+   * YouTube content partners.
+   *
+   * Set this parameter's value to true to instruct the API to only return
+   * channels managed by the content owner that the onBehalfOfContentOwner
+   * parameter specifies. The user must be authenticated as a CMS account linked
+   * to the specified content owner and onBehalfOfContentOwner must be provided.
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @opt_param string forUsername The forUsername parameter specifies a YouTube
+   * username, thereby requesting the channel associated with that username.
+   * @opt_param bool mine Set this parameter's value to true to instruct the API
+   * to only return channels owned by the authenticated user.
+   * @opt_param string maxResults The maxResults parameter specifies the maximum
+   * number of items that should be returned in the result set.
+   * @opt_param string id The id parameter specifies a comma-separated list of the
+   * YouTube channel ID(s) for the resource(s) that are being retrieved. In a
+   * channel resource, the id property specifies the channel's YouTube channel ID.
+   * @opt_param string pageToken The pageToken parameter identifies a specific
+   * page in the result set that should be returned. In an API response, the
+   * nextPageToken and prevPageToken properties identify other pages that could be
+   * retrieved.
+   * @opt_param bool mySubscribers Use the subscriptions.list method and its
+   * mySubscribers parameter to retrieve a list of subscribers to the
+   * authenticated user's channel.
+   * @opt_param string hl The hl parameter should be used for filter out the
+   * properties that are not in the given language. Used for the brandingSettings
+   * part.
+   * @opt_param string categoryId The categoryId parameter specifies a YouTube
+   * guide category, thereby requesting YouTube channels associated with that
+   * category.
+   * @return Google_Service_YouTube_ChannelListResponse
+   */
+  public function listChannels($part, $optParams = array())
+  {
+    $params = array('part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTube_ChannelListResponse");
+  }
+
+  /**
+   * Updates a channel's metadata. Note that this method currently only supports
+   * updates to the channel resource's brandingSettings and invideoPromotion
+   * objects and their child properties. (channels.update)
+   *
+   * @param string $part The part parameter serves two purposes in this operation.
+   * It identifies the properties that the write operation will set as well as the
+   * properties that the API response will include.
+   *
+   * The API currently only allows the parameter value to be set to either
+   * brandingSettings or invideoPromotion. (You cannot update both of those parts
+   * with a single request.)
+   *
+   * Note that this method overrides the existing values for all of the mutable
+   * properties that are contained in any parts that the parameter value
+   * specifies.
+   * @param Google_Channel $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner The onBehalfOfContentOwner parameter
+   * indicates that the authenticated user is acting on behalf of the content
+   * owner specified in the parameter value. This parameter is intended for
+   * YouTube content partners that own and manage many different YouTube channels.
+   * It allows content owners to authenticate once and get access to all their
+   * video and channel data, without having to provide authentication credentials
+   * for each individual channel. The actual CMS account that the user
+   * authenticates with needs to be linked to the specified YouTube content owner.
+   * @return Google_Service_YouTube_Channel
+   */
+  public function update($part, Google_Service_YouTube_Channel $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_YouTube_Channel");
+  }
+}
+
+/**
+ * The "commentThreads" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $commentThreads = $youtubeService->commentThreads;
+ *  </code>
+ */
+class Google_Service_YouTube_CommentThreads_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a new top-level comment. To add a reply to an existing comment, use
+   * the comments.insert method instead. (commentThreads.insert)
+   *
+   * @param string $part The part parameter identifies the properties that the API
+   * response will include. Set the parameter value to snippet. The snippet part
+   * has a quota cost of 2 units.
+   * @param Google_CommentThread $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_YouTube_CommentThread
+   */
+  public function insert($part, Google_Service_YouTube_CommentThread $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_YouTube_CommentThread");
+  }
+
+  /**
+   * Returns a list of comment threads that match the API request parameters.
+   * (commentThreads.listCommentThreads)
+   *
+   * @param string $part The part parameter specifies a comma-separated list of
+   * one or more commentThread resource properties that the API response will
+   * include.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string searchTerms The searchTerms parameter instructs the API to
+   * limit the API response to only contain comments that contain the specified
+   * search terms.
+   *
+   * Note: This parameter is not supported for use in conjunction with the id
+   * parameter.
+   * @opt_param string allThreadsRelatedToChannelId The
+   * allThreadsRelatedToChannelId parameter instructs the API to return all
+   * comment threads associated with the specified channel. The response can
+   * include comments about the channel or about the channel's videos.
+   * @opt_param string channelId The channelId parameter instructs the API to
+   * return comment threads containing comments about the specified channel. (The
+   * response will not include comments left on videos that the channel uploaded.)
+   * @opt_param string videoId The videoId parameter instructs the API to return
+   * comment threads associated with the specified video ID.
+   * @opt_param string maxResults The maxResults parameter specifies the maximum
+   * number of items that should be returned in the result set.
+   *
+   * Note: This parameter is not supported for use in conjunction with the id
+   * parameter.
+   * @opt_param string id The id parameter specifies a comma-separated list of
+   * comment thread IDs for the resources that should be retrieved.
+   * @opt_param string pageToken The pageToken parameter identifies a specific
+   * page in the result set that should be returned. In an API response, the
+   * nextPageToken property identifies the next page of the result that can be
+   * retrieved.
+   *
+   * Note: This parameter is not supported for use in conjunction with the id
+   * parameter.
+   * @opt_param string moderationStatus Set this parameter to limit the returned
+   * comment threads to a particular moderation state.
+   *
+   * Note: This parameter is not supported for use in conjunction with the id
+   * parameter.
+   * @opt_param string textFormat Set this parameter's value to html or plainText
+   * to instruct the API to return the comments left by users in html formatted or
+   * in plain text.
+   * @opt_param string order The order parameter specifies the order in which the
+   * API response should list comment threads. Valid values are: - time - Comment
+   * threads are ordered by time. This is the default behavior. - relevance -
+   * Comment threads are ordered by relevance.Note: This parameter is not
+   * supported for use in conjunction with the id parameter.
+   * @return Google_Service_YouTube_CommentThreadListResponse
+   */
+  public function listCommentThreads($part, $optParams = array())
+  {
+    $params = array('part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTube_CommentThreadListResponse");
+  }
+
+  /**
+   * Modifies the top-level comment in a comment thread. (commentThreads.update)
+   *
+   * @param string $part The part parameter specifies a comma-separated list of
+   * commentThread resource properties that the API response will include. You
+   * must at least include the snippet part in the parameter value since that part
+   * contains all of the properties that the API request can update.
+   * @param Google_CommentThread $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_YouTube_CommentThread
+   */
+  public function update($part, Google_Service_YouTube_CommentThread $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_YouTube_CommentThread");
+  }
+}
+
+/**
+ * The "comments" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $comments = $youtubeService->comments;
+ *  </code>
+ */
+class Google_Service_YouTube_Comments_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a comment. (comments.delete)
+   *
+   * @param string $id The id parameter specifies the comment ID for the resource
+   * that is being deleted.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Creates a reply to an existing comment. Note: To create a top-level comment,
+   * use the commentThreads.insert method. (comments.insert)
+   *
+   * @param string $part The part parameter identifies the properties that the API
+   * response will include. Set the parameter value to snippet. The snippet part
+   * has a quota cost of 2 units.
+   * @param Google_Comment $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_YouTube_Comment
+   */
+  public function insert($part, Google_Service_YouTube_Comment $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_YouTube_Comment");
+  }
+
+  /**
+   * Returns a list of comments that match the API request parameters.
+   * (comments.listComments)
+   *
+   * @param string $part The part parameter specifies a comma-separated list of
+   * one or more comment resource properties that the API response will include.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string maxResults The maxResults parameter specifies the maximum
+   * number of items that should be returned in the result set.
+   *
+   * Note: This parameter is not supported for use in conjunction with the id
+   * parameter.
+   * @opt_param string pageToken The pageToken parameter identifies a specific
+   * page in the result set that should be returned. In an API response, the
+   * nextPageToken property identifies the next page of the result that can be
+   * retrieved.
+   *
+   * Note: This parameter is not supported for use in conjunction with the id
+   * parameter.
+   * @opt_param string parentId The parentId parameter specifies the ID of the
+   * comment for which replies should be retrieved.
+   *
+   * Note: YouTube currently supports replies only for top-level comments.
+   * However, replies to replies may be supported in the future.
+   * @opt_param string textFormat This parameter indicates whether the API should
+   * return comments formatted as HTML or as plain text.
+   * @opt_param string id The id parameter specifies a comma-separated list of
+   * comment IDs for the resources that are being retrieved. In a comment
+   * resource, the id property specifies the comment's ID.
+   * @return Google_Service_YouTube_CommentListResponse
+   */
+  public function listComments($part, $optParams = array())
+  {
+    $params = array('part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTube_CommentListResponse");
+  }
+
+  /**
+   * Expresses the caller's opinion that one or more comments should be flagged as
+   * spam. (comments.markAsSpam)
+   *
+   * @param string $id The id parameter specifies a comma-separated list of IDs of
+   * comments that the caller believes should be classified as spam.
+   * @param array $optParams Optional parameters.
+   */
+  public function markAsSpam($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('markAsSpam', array($params));
+  }
+
+  /**
+   * Sets the moderation status of one or more comments. The API request must be
+   * authorized by the owner of the channel or video associated with the comments.
+   * (comments.setModerationStatus)
+   *
+   * @param string $id The id parameter specifies a comma-separated list of IDs
+   * that identify the comments for which you are updating the moderation status.
+   * @param string $moderationStatus Identifies the new moderation status of the
+   * specified comments.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool banAuthor The banAuthor parameter lets you indicate that you
+   * want to automatically reject any additional comments written by the comment's
+   * author. Set the parameter value to true to ban the author.
+   *
+   * Note: This parameter is only valid if the moderationStatus parameter is also
+   * set to rejected.
+   */
+  public function setModerationStatus($id, $moderationStatus, $optParams = array())
+  {
+    $params = array('id' => $id, 'moderationStatus' => $moderationStatus);
+    $params = array_merge($params, $optParams);
+    return $this->call('setModerationStatus', array($params));
+  }
+
+  /**
+   * Modifies a comment. (comments.update)
+   *
+   * @param string $part The part parameter identifies the properties that the API
+   * response will include. You must at least include the snippet part in the
+   * parameter value since that part contains all of the properties that the API
+   * request can update.
+   * @param Google_Comment $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_YouTube_Comment
+   */
+  public function update($part, Google_Service_YouTube_Comment $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_YouTube_Comment");
+  }
+}
+
+/**
+ * The "guideCategories" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $guideCategories = $youtubeService->guideCategories;
+ *  </code>
+ */
+class Google_Service_YouTube_GuideCategories_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns a list of categories that can be associated with YouTube channels.
+   * (guideCategories.listGuideCategories)
+   *
+   * @param string $part The part parameter specifies the guideCategory resource
+   * properties that the API response will include. Set the parameter value to
+   * snippet.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string regionCode The regionCode parameter instructs the API to
+   * return the list of guide categories available in the specified country. The
+   * parameter value is an ISO 3166-1 alpha-2 country code.
+   * @opt_param string id The id parameter specifies a comma-separated list of the
+   * YouTube channel category ID(s) for the resource(s) that are being retrieved.
+   * In a guideCategory resource, the id property specifies the YouTube channel
+   * category ID.
+   * @opt_param string hl The hl parameter specifies the language that will be
+   * used for text values in the API response.
+   * @return Google_Service_YouTube_GuideCategoryListResponse
+   */
+  public function listGuideCategories($part, $optParams = array())
+  {
+    $params = array('part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTube_GuideCategoryListResponse");
+  }
+}
+
+/**
+ * The "i18nLanguages" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $i18nLanguages = $youtubeService->i18nLanguages;
+ *  </code>
+ */
+class Google_Service_YouTube_I18nLanguages_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns a list of application languages that the YouTube website supports.
+   * (i18nLanguages.listI18nLanguages)
+   *
+   * @param string $part The part parameter specifies the i18nLanguage resource
+   * properties that the API response will include. Set the parameter value to
+   * snippet.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string hl The hl parameter specifies the language that should be
+   * used for text values in the API response.
+   * @return Google_Service_YouTube_I18nLanguageListResponse
+   */
+  public function listI18nLanguages($part, $optParams = array())
+  {
+    $params = array('part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTube_I18nLanguageListResponse");
+  }
+}
+
+/**
+ * The "i18nRegions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $i18nRegions = $youtubeService->i18nRegions;
+ *  </code>
+ */
+class Google_Service_YouTube_I18nRegions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns a list of content regions that the YouTube website supports.
+   * (i18nRegions.listI18nRegions)
+   *
+   * @param string $part The part parameter specifies the i18nRegion resource
+   * properties that the API response will include. Set the parameter value to
+   * snippet.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string hl The hl parameter specifies the language that should be
+   * used for text values in the API response.
+   * @return Google_Service_YouTube_I18nRegionListResponse
+   */
+  public function listI18nRegions($part, $optParams = array())
+  {
+    $params = array('part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTube_I18nRegionListResponse");
+  }
+}
+
+/**
+ * The "liveBroadcasts" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $liveBroadcasts = $youtubeService->liveBroadcasts;
+ *  </code>
+ */
+class Google_Service_YouTube_LiveBroadcasts_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Binds a YouTube broadcast to a stream or removes an existing binding between
+   * a broadcast and a stream. A broadcast can only be bound to one video stream,
+   * though a video stream may be bound to more than one broadcast.
+   * (liveBroadcasts.bind)
+   *
+   * @param string $id The id parameter specifies the unique ID of the broadcast
+   * that is being bound to a video stream.
+   * @param string $part The part parameter specifies a comma-separated list of
+   * one or more liveBroadcast resource properties that the API response will
+   * include. The part names that you can include in the parameter value are id,
+   * snippet, contentDetails, and status.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwnerChannel This parameter can only be
+   * used in a properly authorized request. Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwnerChannel parameter specifies the YouTube channel ID
+   * of the channel to which a video is being added. This parameter is required
+   * when a request specifies a value for the onBehalfOfContentOwner parameter,
+   * and it can only be used in conjunction with that parameter. In addition, the
+   * request must be authorized using a CMS account that is linked to the content
+   * owner that the onBehalfOfContentOwner parameter specifies. Finally, the
+   * channel that the onBehalfOfContentOwnerChannel parameter value specifies must
+   * be linked to the content owner that the onBehalfOfContentOwner parameter
+   * specifies.
+   *
+   * This parameter is intended for YouTube content partners that own and manage
+   * many different YouTube channels. It allows content owners to authenticate
+   * once and perform actions on behalf of the channel specified in the parameter
+   * value, without having to provide authentication credentials for each separate
+   * channel.
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @opt_param string streamId The streamId parameter specifies the unique ID of
+   * the video stream that is being bound to a broadcast. If this parameter is
+   * omitted, the API will remove any existing binding between the broadcast and a
+   * video stream.
+   * @return Google_Service_YouTube_LiveBroadcast
+   */
+  public function bind($id, $part, $optParams = array())
+  {
+    $params = array('id' => $id, 'part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('bind', array($params), "Google_Service_YouTube_LiveBroadcast");
+  }
+
+  /**
+   * Binds a YouTube broadcast to a stream or removes an existing binding between
+   * a broadcast and a stream. A broadcast can only be bound to one video stream,
+   * though a video stream may be bound to more than one broadcast.
+   * (liveBroadcasts.bind_direct)
+   *
+   * @param string $id The id parameter specifies the unique ID of the broadcast
+   * that is being bound to a video stream.
+   * @param string $part The part parameter specifies a comma-separated list of
+   * one or more liveBroadcast resource properties that the API response will
+   * include. The part names that you can include in the parameter value are id,
+   * snippet, contentDetails, and status.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwnerChannel This parameter can only be
+   * used in a properly authorized request. Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwnerChannel parameter specifies the YouTube channel ID
+   * of the channel to which a video is being added. This parameter is required
+   * when a request specifies a value for the onBehalfOfContentOwner parameter,
+   * and it can only be used in conjunction with that parameter. In addition, the
+   * request must be authorized using a CMS account that is linked to the content
+   * owner that the onBehalfOfContentOwner parameter specifies. Finally, the
+   * channel that the onBehalfOfContentOwnerChannel parameter value specifies must
+   * be linked to the content owner that the onBehalfOfContentOwner parameter
+   * specifies.
+   *
+   * This parameter is intended for YouTube content partners that own and manage
+   * many different YouTube channels. It allows content owners to authenticate
+   * once and perform actions on behalf of the channel specified in the parameter
+   * value, without having to provide authentication credentials for each separate
+   * channel.
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @opt_param string streamId The streamId parameter specifies the unique ID of
+   * the video stream that is being bound to a broadcast. If this parameter is
+   * omitted, the API will remove any existing binding between the broadcast and a
+   * video stream.
+   * @return Google_Service_YouTube_LiveBroadcast
+   */
+  public function bind_direct($id, $part, $optParams = array())
+  {
+    $params = array('id' => $id, 'part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('bind_direct', array($params), "Google_Service_YouTube_LiveBroadcast");
+  }
+
+  /**
+   * Controls the settings for a slate that can be displayed in the broadcast
+   * stream. (liveBroadcasts.control)
+   *
+   * @param string $id The id parameter specifies the YouTube live broadcast ID
+   * that uniquely identifies the broadcast in which the slate is being updated.
+   * @param string $part The part parameter specifies a comma-separated list of
+   * one or more liveBroadcast resource properties that the API response will
+   * include. The part names that you can include in the parameter value are id,
+   * snippet, contentDetails, and status.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @opt_param bool displaySlate The displaySlate parameter specifies whether the
+   * slate is being enabled or disabled.
+   * @opt_param string onBehalfOfContentOwnerChannel This parameter can only be
+   * used in a properly authorized request. Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwnerChannel parameter specifies the YouTube channel ID
+   * of the channel to which a video is being added. This parameter is required
+   * when a request specifies a value for the onBehalfOfContentOwner parameter,
+   * and it can only be used in conjunction with that parameter. In addition, the
+   * request must be authorized using a CMS account that is linked to the content
+   * owner that the onBehalfOfContentOwner parameter specifies. Finally, the
+   * channel that the onBehalfOfContentOwnerChannel parameter value specifies must
+   * be linked to the content owner that the onBehalfOfContentOwner parameter
+   * specifies.
+   *
+   * This parameter is intended for YouTube content partners that own and manage
+   * many different YouTube channels. It allows content owners to authenticate
+   * once and perform actions on behalf of the channel specified in the parameter
+   * value, without having to provide authentication credentials for each separate
+   * channel.
+   * @opt_param string offsetTimeMs The offsetTimeMs parameter specifies a
+   * positive time offset when the specified slate change will occur. The value is
+   * measured in milliseconds from the beginning of the broadcast's monitor
+   * stream, which is the time that the testing phase for the broadcast began.
+   * Even though it is specified in milliseconds, the value is actually an
+   * approximation, and YouTube completes the requested action as closely as
+   * possible to that time.
+   *
+   * If you do not specify a value for this parameter, then YouTube performs the
+   * action as soon as possible. See the Getting started guide for more details.
+   *
+   * Important: You should only specify a value for this parameter if your
+   * broadcast stream is delayed.
+   * @opt_param string walltime The walltime parameter specifies the wall clock
+   * time at which the specified slate change will occur. The value is specified
+   * in ISO 8601 (YYYY-MM-DDThh:mm:ss.sssZ) format.
+   * @return Google_Service_YouTube_LiveBroadcast
+   */
+  public function control($id, $part, $optParams = array())
+  {
+    $params = array('id' => $id, 'part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('control', array($params), "Google_Service_YouTube_LiveBroadcast");
+  }
+
+  /**
+   * Deletes a broadcast. (liveBroadcasts.delete)
+   *
+   * @param string $id The id parameter specifies the YouTube live broadcast ID
+   * for the resource that is being deleted.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwnerChannel This parameter can only be
+   * used in a properly authorized request. Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwnerChannel parameter specifies the YouTube channel ID
+   * of the channel to which a video is being added. This parameter is required
+   * when a request specifies a value for the onBehalfOfContentOwner parameter,
+   * and it can only be used in conjunction with that parameter. In addition, the
+   * request must be authorized using a CMS account that is linked to the content
+   * owner that the onBehalfOfContentOwner parameter specifies. Finally, the
+   * channel that the onBehalfOfContentOwnerChannel parameter value specifies must
+   * be linked to the content owner that the onBehalfOfContentOwner parameter
+   * specifies.
+   *
+   * This parameter is intended for YouTube content partners that own and manage
+   * many different YouTube channels. It allows content owners to authenticate
+   * once and perform actions on behalf of the channel specified in the parameter
+   * value, without having to provide authentication credentials for each separate
+   * channel.
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Creates a broadcast. (liveBroadcasts.insert)
+   *
+   * @param string $part The part parameter serves two purposes in this operation.
+   * It identifies the properties that the write operation will set as well as the
+   * properties that the API response will include.
+   *
+   * The part properties that you can include in the parameter value are id,
+   * snippet, contentDetails, and status.
+   * @param Google_LiveBroadcast $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwnerChannel This parameter can only be
+   * used in a properly authorized request. Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwnerChannel parameter specifies the YouTube channel ID
+   * of the channel to which a video is being added. This parameter is required
+   * when a request specifies a value for the onBehalfOfContentOwner parameter,
+   * and it can only be used in conjunction with that parameter. In addition, the
+   * request must be authorized using a CMS account that is linked to the content
+   * owner that the onBehalfOfContentOwner parameter specifies. Finally, the
+   * channel that the onBehalfOfContentOwnerChannel parameter value specifies must
+   * be linked to the content owner that the onBehalfOfContentOwner parameter
+   * specifies.
+   *
+   * This parameter is intended for YouTube content partners that own and manage
+   * many different YouTube channels. It allows content owners to authenticate
+   * once and perform actions on behalf of the channel specified in the parameter
+   * value, without having to provide authentication credentials for each separate
+   * channel.
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @return Google_Service_YouTube_LiveBroadcast
+   */
+  public function insert($part, Google_Service_YouTube_LiveBroadcast $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_YouTube_LiveBroadcast");
+  }
+
+  /**
+   * Returns a list of YouTube broadcasts that match the API request parameters.
+   * (liveBroadcasts.listLiveBroadcasts)
+   *
+   * @param string $part The part parameter specifies a comma-separated list of
+   * one or more liveBroadcast resource properties that the API response will
+   * include. The part names that you can include in the parameter value are id,
+   * snippet, contentDetails, and status.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string broadcastStatus The broadcastStatus parameter filters the
+   * API response to only include broadcasts with the specified status.
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @opt_param string onBehalfOfContentOwnerChannel This parameter can only be
+   * used in a properly authorized request. Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwnerChannel parameter specifies the YouTube channel ID
+   * of the channel to which a video is being added. This parameter is required
+   * when a request specifies a value for the onBehalfOfContentOwner parameter,
+   * and it can only be used in conjunction with that parameter. In addition, the
+   * request must be authorized using a CMS account that is linked to the content
+   * owner that the onBehalfOfContentOwner parameter specifies. Finally, the
+   * channel that the onBehalfOfContentOwnerChannel parameter value specifies must
+   * be linked to the content owner that the onBehalfOfContentOwner parameter
+   * specifies.
+   *
+   * This parameter is intended for YouTube content partners that own and manage
+   * many different YouTube channels. It allows content owners to authenticate
+   * once and perform actions on behalf of the channel specified in the parameter
+   * value, without having to provide authentication credentials for each separate
+   * channel.
+   * @opt_param bool mine The mine parameter can be used to instruct the API to
+   * only return broadcasts owned by the authenticated user. Set the parameter
+   * value to true to only retrieve your own broadcasts.
+   * @opt_param string maxResults The maxResults parameter specifies the maximum
+   * number of items that should be returned in the result set.
+   * @opt_param string pageToken The pageToken parameter identifies a specific
+   * page in the result set that should be returned. In an API response, the
+   * nextPageToken and prevPageToken properties identify other pages that could be
+   * retrieved.
+   * @opt_param string id The id parameter specifies a comma-separated list of
+   * YouTube broadcast IDs that identify the broadcasts being retrieved. In a
+   * liveBroadcast resource, the id property specifies the broadcast's ID.
+   * @return Google_Service_YouTube_LiveBroadcastListResponse
+   */
+  public function listLiveBroadcasts($part, $optParams = array())
+  {
+    $params = array('part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTube_LiveBroadcastListResponse");
+  }
+
+  /**
+   * Changes the status of a YouTube live broadcast and initiates any processes
+   * associated with the new status. For example, when you transition a
+   * broadcast's status to testing, YouTube starts to transmit video to that
+   * broadcast's monitor stream. Before calling this method, you should confirm
+   * that the value of the status.streamStatus property for the stream bound to
+   * your broadcast is active. (liveBroadcasts.transition)
+   *
+   * @param string $broadcastStatus The broadcastStatus parameter identifies the
+   * state to which the broadcast is changing. Note that to transition a broadcast
+   * to either the testing or live state, the status.streamStatus must be active
+   * for the stream that the broadcast is bound to.
+   * @param string $id The id parameter specifies the unique ID of the broadcast
+   * that is transitioning to another status.
+   * @param string $part The part parameter specifies a comma-separated list of
+   * one or more liveBroadcast resource properties that the API response will
+   * include. The part names that you can include in the parameter value are id,
+   * snippet, contentDetails, and status.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwnerChannel This parameter can only be
+   * used in a properly authorized request. Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwnerChannel parameter specifies the YouTube channel ID
+   * of the channel to which a video is being added. This parameter is required
+   * when a request specifies a value for the onBehalfOfContentOwner parameter,
+   * and it can only be used in conjunction with that parameter. In addition, the
+   * request must be authorized using a CMS account that is linked to the content
+   * owner that the onBehalfOfContentOwner parameter specifies. Finally, the
+   * channel that the onBehalfOfContentOwnerChannel parameter value specifies must
+   * be linked to the content owner that the onBehalfOfContentOwner parameter
+   * specifies.
+   *
+   * This parameter is intended for YouTube content partners that own and manage
+   * many different YouTube channels. It allows content owners to authenticate
+   * once and perform actions on behalf of the channel specified in the parameter
+   * value, without having to provide authentication credentials for each separate
+   * channel.
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @return Google_Service_YouTube_LiveBroadcast
+   */
+  public function transition($broadcastStatus, $id, $part, $optParams = array())
+  {
+    $params = array('broadcastStatus' => $broadcastStatus, 'id' => $id, 'part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('transition', array($params), "Google_Service_YouTube_LiveBroadcast");
+  }
+
+  /**
+   * Updates a broadcast. For example, you could modify the broadcast settings
+   * defined in the liveBroadcast resource's contentDetails object.
+   * (liveBroadcasts.update)
+   *
+   * @param string $part The part parameter serves two purposes in this operation.
+   * It identifies the properties that the write operation will set as well as the
+   * properties that the API response will include.
+   *
+   * The part properties that you can include in the parameter value are id,
+   * snippet, contentDetails, and status.
+   *
+   * Note that this method will override the existing values for all of the
+   * mutable properties that are contained in any parts that the parameter value
+   * specifies. For example, a broadcast's privacy status is defined in the status
+   * part. As such, if your request is updating a private or unlisted broadcast,
+   * and the request's part parameter value includes the status part, the
+   * broadcast's privacy setting will be updated to whatever value the request
+   * body specifies. If the request body does not specify a value, the existing
+   * privacy setting will be removed and the broadcast will revert to the default
+   * privacy setting.
+   * @param Google_LiveBroadcast $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwnerChannel This parameter can only be
+   * used in a properly authorized request. Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwnerChannel parameter specifies the YouTube channel ID
+   * of the channel to which a video is being added. This parameter is required
+   * when a request specifies a value for the onBehalfOfContentOwner parameter,
+   * and it can only be used in conjunction with that parameter. In addition, the
+   * request must be authorized using a CMS account that is linked to the content
+   * owner that the onBehalfOfContentOwner parameter specifies. Finally, the
+   * channel that the onBehalfOfContentOwnerChannel parameter value specifies must
+   * be linked to the content owner that the onBehalfOfContentOwner parameter
+   * specifies.
+   *
+   * This parameter is intended for YouTube content partners that own and manage
+   * many different YouTube channels. It allows content owners to authenticate
+   * once and perform actions on behalf of the channel specified in the parameter
+   * value, without having to provide authentication credentials for each separate
+   * channel.
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @return Google_Service_YouTube_LiveBroadcast
+   */
+  public function update($part, Google_Service_YouTube_LiveBroadcast $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_YouTube_LiveBroadcast");
+  }
+}
+
+/**
+ * The "liveStreams" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $liveStreams = $youtubeService->liveStreams;
+ *  </code>
+ */
+class Google_Service_YouTube_LiveStreams_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a video stream. (liveStreams.delete)
+   *
+   * @param string $id The id parameter specifies the YouTube live stream ID for
+   * the resource that is being deleted.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwnerChannel This parameter can only be
+   * used in a properly authorized request. Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwnerChannel parameter specifies the YouTube channel ID
+   * of the channel to which a video is being added. This parameter is required
+   * when a request specifies a value for the onBehalfOfContentOwner parameter,
+   * and it can only be used in conjunction with that parameter. In addition, the
+   * request must be authorized using a CMS account that is linked to the content
+   * owner that the onBehalfOfContentOwner parameter specifies. Finally, the
+   * channel that the onBehalfOfContentOwnerChannel parameter value specifies must
+   * be linked to the content owner that the onBehalfOfContentOwner parameter
+   * specifies.
+   *
+   * This parameter is intended for YouTube content partners that own and manage
+   * many different YouTube channels. It allows content owners to authenticate
+   * once and perform actions on behalf of the channel specified in the parameter
+   * value, without having to provide authentication credentials for each separate
+   * channel.
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Creates a video stream. The stream enables you to send your video to YouTube,
+   * which can then broadcast the video to your audience. (liveStreams.insert)
+   *
+   * @param string $part The part parameter serves two purposes in this operation.
+   * It identifies the properties that the write operation will set as well as the
+   * properties that the API response will include.
+   *
+   * The part properties that you can include in the parameter value are id,
+   * snippet, cdn, and status.
+   * @param Google_LiveStream $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwnerChannel This parameter can only be
+   * used in a properly authorized request. Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwnerChannel parameter specifies the YouTube channel ID
+   * of the channel to which a video is being added. This parameter is required
+   * when a request specifies a value for the onBehalfOfContentOwner parameter,
+   * and it can only be used in conjunction with that parameter. In addition, the
+   * request must be authorized using a CMS account that is linked to the content
+   * owner that the onBehalfOfContentOwner parameter specifies. Finally, the
+   * channel that the onBehalfOfContentOwnerChannel parameter value specifies must
+   * be linked to the content owner that the onBehalfOfContentOwner parameter
+   * specifies.
+   *
+   * This parameter is intended for YouTube content partners that own and manage
+   * many different YouTube channels. It allows content owners to authenticate
+   * once and perform actions on behalf of the channel specified in the parameter
+   * value, without having to provide authentication credentials for each separate
+   * channel.
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @return Google_Service_YouTube_LiveStream
+   */
+  public function insert($part, Google_Service_YouTube_LiveStream $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_YouTube_LiveStream");
+  }
+
+  /**
+   * Returns a list of video streams that match the API request parameters.
+   * (liveStreams.listLiveStreams)
+   *
+   * @param string $part The part parameter specifies a comma-separated list of
+   * one or more liveStream resource properties that the API response will
+   * include. The part names that you can include in the parameter value are id,
+   * snippet, cdn, and status.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @opt_param string onBehalfOfContentOwnerChannel This parameter can only be
+   * used in a properly authorized request. Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwnerChannel parameter specifies the YouTube channel ID
+   * of the channel to which a video is being added. This parameter is required
+   * when a request specifies a value for the onBehalfOfContentOwner parameter,
+   * and it can only be used in conjunction with that parameter. In addition, the
+   * request must be authorized using a CMS account that is linked to the content
+   * owner that the onBehalfOfContentOwner parameter specifies. Finally, the
+   * channel that the onBehalfOfContentOwnerChannel parameter value specifies must
+   * be linked to the content owner that the onBehalfOfContentOwner parameter
+   * specifies.
+   *
+   * This parameter is intended for YouTube content partners that own and manage
+   * many different YouTube channels. It allows content owners to authenticate
+   * once and perform actions on behalf of the channel specified in the parameter
+   * value, without having to provide authentication credentials for each separate
+   * channel.
+   * @opt_param bool mine The mine parameter can be used to instruct the API to
+   * only return streams owned by the authenticated user. Set the parameter value
+   * to true to only retrieve your own streams.
+   * @opt_param string maxResults The maxResults parameter specifies the maximum
+   * number of items that should be returned in the result set.
+   * @opt_param string pageToken The pageToken parameter identifies a specific
+   * page in the result set that should be returned. In an API response, the
+   * nextPageToken and prevPageToken properties identify other pages that could be
+   * retrieved.
+   * @opt_param string id The id parameter specifies a comma-separated list of
+   * YouTube stream IDs that identify the streams being retrieved. In a liveStream
+   * resource, the id property specifies the stream's ID.
+   * @return Google_Service_YouTube_LiveStreamListResponse
+   */
+  public function listLiveStreams($part, $optParams = array())
+  {
+    $params = array('part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTube_LiveStreamListResponse");
+  }
+
+  /**
+   * Updates a video stream. If the properties that you want to change cannot be
+   * updated, then you need to create a new stream with the proper settings.
+   * (liveStreams.update)
+   *
+   * @param string $part The part parameter serves two purposes in this operation.
+   * It identifies the properties that the write operation will set as well as the
+   * properties that the API response will include.
+   *
+   * The part properties that you can include in the parameter value are id,
+   * snippet, cdn, and status.
+   *
+   * Note that this method will override the existing values for all of the
+   * mutable properties that are contained in any parts that the parameter value
+   * specifies. If the request body does not specify a value for a mutable
+   * property, the existing value for that property will be removed.
+   * @param Google_LiveStream $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwnerChannel This parameter can only be
+   * used in a properly authorized request. Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwnerChannel parameter specifies the YouTube channel ID
+   * of the channel to which a video is being added. This parameter is required
+   * when a request specifies a value for the onBehalfOfContentOwner parameter,
+   * and it can only be used in conjunction with that parameter. In addition, the
+   * request must be authorized using a CMS account that is linked to the content
+   * owner that the onBehalfOfContentOwner parameter specifies. Finally, the
+   * channel that the onBehalfOfContentOwnerChannel parameter value specifies must
+   * be linked to the content owner that the onBehalfOfContentOwner parameter
+   * specifies.
+   *
+   * This parameter is intended for YouTube content partners that own and manage
+   * many different YouTube channels. It allows content owners to authenticate
+   * once and perform actions on behalf of the channel specified in the parameter
+   * value, without having to provide authentication credentials for each separate
+   * channel.
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @return Google_Service_YouTube_LiveStream
+   */
+  public function update($part, Google_Service_YouTube_LiveStream $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_YouTube_LiveStream");
+  }
+}
+
+/**
+ * The "playlistItems" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $playlistItems = $youtubeService->playlistItems;
+ *  </code>
+ */
+class Google_Service_YouTube_PlaylistItems_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a playlist item. (playlistItems.delete)
+   *
+   * @param string $id The id parameter specifies the YouTube playlist item ID for
+   * the playlist item that is being deleted. In a playlistItem resource, the id
+   * property specifies the playlist item's ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Adds a resource to a playlist. (playlistItems.insert)
+   *
+   * @param string $part The part parameter serves two purposes in this operation.
+   * It identifies the properties that the write operation will set as well as the
+   * properties that the API response will include.
+   * @param Google_PlaylistItem $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @return Google_Service_YouTube_PlaylistItem
+   */
+  public function insert($part, Google_Service_YouTube_PlaylistItem $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_YouTube_PlaylistItem");
+  }
+
+  /**
+   * Returns a collection of playlist items that match the API request parameters.
+   * You can retrieve all of the playlist items in a specified playlist or
+   * retrieve one or more playlist items by their unique IDs.
+   * (playlistItems.listPlaylistItems)
+   *
+   * @param string $part The part parameter specifies a comma-separated list of
+   * one or more playlistItem resource properties that the API response will
+   * include.
+   *
+   * If the parameter identifies a property that contains child properties, the
+   * child properties will be included in the response. For example, in a
+   * playlistItem resource, the snippet property contains numerous fields,
+   * including the title, description, position, and resourceId properties. As
+   * such, if you set part=snippet, the API response will contain all of those
+   * properties.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @opt_param string playlistId The playlistId parameter specifies the unique ID
+   * of the playlist for which you want to retrieve playlist items. Note that even
+   * though this is an optional parameter, every request to retrieve playlist
+   * items must specify a value for either the id parameter or the playlistId
+   * parameter.
+   * @opt_param string videoId The videoId parameter specifies that the request
+   * should return only the playlist items that contain the specified video.
+   * @opt_param string maxResults The maxResults parameter specifies the maximum
+   * number of items that should be returned in the result set.
+   * @opt_param string pageToken The pageToken parameter identifies a specific
+   * page in the result set that should be returned. In an API response, the
+   * nextPageToken and prevPageToken properties identify other pages that could be
+   * retrieved.
+   * @opt_param string id The id parameter specifies a comma-separated list of one
+   * or more unique playlist item IDs.
+   * @return Google_Service_YouTube_PlaylistItemListResponse
+   */
+  public function listPlaylistItems($part, $optParams = array())
+  {
+    $params = array('part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTube_PlaylistItemListResponse");
+  }
+
+  /**
+   * Modifies a playlist item. For example, you could update the item's position
+   * in the playlist. (playlistItems.update)
+   *
+   * @param string $part The part parameter serves two purposes in this operation.
+   * It identifies the properties that the write operation will set as well as the
+   * properties that the API response will include.
+   *
+   * Note that this method will override the existing values for all of the
+   * mutable properties that are contained in any parts that the parameter value
+   * specifies. For example, a playlist item can specify a start time and end
+   * time, which identify the times portion of the video that should play when
+   * users watch the video in the playlist. If your request is updating a playlist
+   * item that sets these values, and the request's part parameter value includes
+   * the contentDetails part, the playlist item's start and end times will be
+   * updated to whatever value the request body specifies. If the request body
+   * does not specify values, the existing start and end times will be removed and
+   * replaced with the default settings.
+   * @param Google_PlaylistItem $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_YouTube_PlaylistItem
+   */
+  public function update($part, Google_Service_YouTube_PlaylistItem $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_YouTube_PlaylistItem");
+  }
+}
+
+/**
+ * The "playlists" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $playlists = $youtubeService->playlists;
+ *  </code>
+ */
+class Google_Service_YouTube_Playlists_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a playlist. (playlists.delete)
+   *
+   * @param string $id The id parameter specifies the YouTube playlist ID for the
+   * playlist that is being deleted. In a playlist resource, the id property
+   * specifies the playlist's ID.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Creates a playlist. (playlists.insert)
+   *
+   * @param string $part The part parameter serves two purposes in this operation.
+   * It identifies the properties that the write operation will set as well as the
+   * properties that the API response will include.
+   * @param Google_Playlist $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwnerChannel This parameter can only be
+   * used in a properly authorized request. Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwnerChannel parameter specifies the YouTube channel ID
+   * of the channel to which a video is being added. This parameter is required
+   * when a request specifies a value for the onBehalfOfContentOwner parameter,
+   * and it can only be used in conjunction with that parameter. In addition, the
+   * request must be authorized using a CMS account that is linked to the content
+   * owner that the onBehalfOfContentOwner parameter specifies. Finally, the
+   * channel that the onBehalfOfContentOwnerChannel parameter value specifies must
+   * be linked to the content owner that the onBehalfOfContentOwner parameter
+   * specifies.
+   *
+   * This parameter is intended for YouTube content partners that own and manage
+   * many different YouTube channels. It allows content owners to authenticate
+   * once and perform actions on behalf of the channel specified in the parameter
+   * value, without having to provide authentication credentials for each separate
+   * channel.
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @return Google_Service_YouTube_Playlist
+   */
+  public function insert($part, Google_Service_YouTube_Playlist $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_YouTube_Playlist");
+  }
+
+  /**
+   * Returns a collection of playlists that match the API request parameters. For
+   * example, you can retrieve all playlists that the authenticated user owns, or
+   * you can retrieve one or more playlists by their unique IDs.
+   * (playlists.listPlaylists)
+   *
+   * @param string $part The part parameter specifies a comma-separated list of
+   * one or more playlist resource properties that the API response will include.
+   *
+   * If the parameter identifies a property that contains child properties, the
+   * child properties will be included in the response. For example, in a playlist
+   * resource, the snippet property contains properties like author, title,
+   * description, tags, and timeCreated. As such, if you set part=snippet, the API
+   * response will contain all of those properties.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @opt_param string onBehalfOfContentOwnerChannel This parameter can only be
+   * used in a properly authorized request. Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwnerChannel parameter specifies the YouTube channel ID
+   * of the channel to which a video is being added. This parameter is required
+   * when a request specifies a value for the onBehalfOfContentOwner parameter,
+   * and it can only be used in conjunction with that parameter. In addition, the
+   * request must be authorized using a CMS account that is linked to the content
+   * owner that the onBehalfOfContentOwner parameter specifies. Finally, the
+   * channel that the onBehalfOfContentOwnerChannel parameter value specifies must
+   * be linked to the content owner that the onBehalfOfContentOwner parameter
+   * specifies.
+   *
+   * This parameter is intended for YouTube content partners that own and manage
+   * many different YouTube channels. It allows content owners to authenticate
+   * once and perform actions on behalf of the channel specified in the parameter
+   * value, without having to provide authentication credentials for each separate
+   * channel.
+   * @opt_param string channelId This value indicates that the API should only
+   * return the specified channel's playlists.
+   * @opt_param bool mine Set this parameter's value to true to instruct the API
+   * to only return playlists owned by the authenticated user.
+   * @opt_param string maxResults The maxResults parameter specifies the maximum
+   * number of items that should be returned in the result set.
+   * @opt_param string pageToken The pageToken parameter identifies a specific
+   * page in the result set that should be returned. In an API response, the
+   * nextPageToken and prevPageToken properties identify other pages that could be
+   * retrieved.
+   * @opt_param string hl The hl parameter should be used for filter out the
+   * properties that are not in the given language. Used for the snippet part.
+   * @opt_param string id The id parameter specifies a comma-separated list of the
+   * YouTube playlist ID(s) for the resource(s) that are being retrieved. In a
+   * playlist resource, the id property specifies the playlist's YouTube playlist
+   * ID.
+   * @return Google_Service_YouTube_PlaylistListResponse
+   */
+  public function listPlaylists($part, $optParams = array())
+  {
+    $params = array('part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTube_PlaylistListResponse");
+  }
+
+  /**
+   * Modifies a playlist. For example, you could change a playlist's title,
+   * description, or privacy status. (playlists.update)
+   *
+   * @param string $part The part parameter serves two purposes in this operation.
+   * It identifies the properties that the write operation will set as well as the
+   * properties that the API response will include.
+   *
+   * Note that this method will override the existing values for mutable
+   * properties that are contained in any parts that the request body specifies.
+   * For example, a playlist's description is contained in the snippet part, which
+   * must be included in the request body. If the request does not specify a value
+   * for the snippet.description property, the playlist's existing description
+   * will be deleted.
+   * @param Google_Playlist $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @return Google_Service_YouTube_Playlist
+   */
+  public function update($part, Google_Service_YouTube_Playlist $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_YouTube_Playlist");
+  }
+}
+
+/**
+ * The "search" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $search = $youtubeService->search;
+ *  </code>
+ */
+class Google_Service_YouTube_Search_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns a collection of search results that match the query parameters
+   * specified in the API request. By default, a search result set identifies
+   * matching video, channel, and playlist resources, but you can also configure
+   * queries to only retrieve a specific type of resource. (search.listSearch)
+   *
+   * @param string $part The part parameter specifies a comma-separated list of
+   * one or more search resource properties that the API response will include.
+   * Set the parameter value to snippet.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string eventType The eventType parameter restricts a search to
+   * broadcast events. If you specify a value for this parameter, you must also
+   * set the type parameter's value to video.
+   * @opt_param string channelId The channelId parameter indicates that the API
+   * response should only contain resources created by the channel
+   * @opt_param bool forDeveloper The forDeveloper parameter restricts the search
+   * to only retrieve videos uploaded via the developer's application or website.
+   * The API server uses the request's authorization credentials to identify the
+   * developer. Therefore, a developer can restrict results to videos uploaded
+   * through the developer's own app or website but not to videos uploaded through
+   * other apps or sites.
+   * @opt_param string videoSyndicated The videoSyndicated parameter lets you to
+   * restrict a search to only videos that can be played outside youtube.com. If
+   * you specify a value for this parameter, you must also set the type
+   * parameter's value to video.
+   * @opt_param string channelType The channelType parameter lets you restrict a
+   * search to a particular type of channel.
+   * @opt_param string videoCaption The videoCaption parameter indicates whether
+   * the API should filter video search results based on whether they have
+   * captions. If you specify a value for this parameter, you must also set the
+   * type parameter's value to video.
+   * @opt_param string publishedAfter The publishedAfter parameter indicates that
+   * the API response should only contain resources created after the specified
+   * time. The value is an RFC 3339 formatted date-time value
+   * (1970-01-01T00:00:00Z).
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @opt_param string pageToken The pageToken parameter identifies a specific
+   * page in the result set that should be returned. In an API response, the
+   * nextPageToken and prevPageToken properties identify other pages that could be
+   * retrieved.
+   * @opt_param bool forContentOwner Note: This parameter is intended exclusively
+   * for YouTube content partners.
+   *
+   * The forContentOwner parameter restricts the search to only retrieve resources
+   * owned by the content owner specified by the onBehalfOfContentOwner parameter.
+   * The user must be authenticated using a CMS account linked to the specified
+   * content owner and onBehalfOfContentOwner must be provided.
+   * @opt_param string regionCode The regionCode parameter instructs the API to
+   * return search results for the specified country. The parameter value is an
+   * ISO 3166-1 alpha-2 country code.
+   * @opt_param string location The location parameter, in conjunction with the
+   * locationRadius parameter, defines a circular geographic area and also
+   * restricts a search to videos that specify, in their metadata, a geographic
+   * location that falls within that area. The parameter value is a string that
+   * specifies latitude/longitude coordinates e.g. (37.42307,-122.08427).
+   *
+   * - The location parameter value identifies the point at the center of the
+   * area. - The locationRadius parameter specifies the maximum distance that the
+   * location associated with a video can be from that point for the video to
+   * still be included in the search results.The API returns an error if your
+   * request specifies a value for the location parameter but does not also
+   * specify a value for the locationRadius parameter.
+   * @opt_param string locationRadius The locationRadius parameter, in conjunction
+   * with the location parameter, defines a circular geographic area.
+   *
+   * The parameter value must be a floating point number followed by a measurement
+   * unit. Valid measurement units are m, km, ft, and mi. For example, valid
+   * parameter values include 1500m, 5km, 10000ft, and 0.75mi. The API does not
+   * support locationRadius parameter values larger than 1000 kilometers.
+   *
+   * Note: See the definition of the location parameter for more information.
+   * @opt_param string videoType The videoType parameter lets you restrict a
+   * search to a particular type of videos. If you specify a value for this
+   * parameter, you must also set the type parameter's value to video.
+   * @opt_param string type The type parameter restricts a search query to only
+   * retrieve a particular type of resource. The value is a comma-separated list
+   * of resource types.
+   * @opt_param string topicId The topicId parameter indicates that the API
+   * response should only contain resources associated with the specified topic.
+   * The value identifies a Freebase topic ID.
+   * @opt_param string publishedBefore The publishedBefore parameter indicates
+   * that the API response should only contain resources created before the
+   * specified time. The value is an RFC 3339 formatted date-time value
+   * (1970-01-01T00:00:00Z).
+   * @opt_param string videoDimension The videoDimension parameter lets you
+   * restrict a search to only retrieve 2D or 3D videos. If you specify a value
+   * for this parameter, you must also set the type parameter's value to video.
+   * @opt_param string videoLicense The videoLicense parameter filters search
+   * results to only include videos with a particular license. YouTube lets video
+   * uploaders choose to attach either the Creative Commons license or the
+   * standard YouTube license to each of their videos. If you specify a value for
+   * this parameter, you must also set the type parameter's value to video.
+   * @opt_param string maxResults The maxResults parameter specifies the maximum
+   * number of items that should be returned in the result set.
+   * @opt_param string relatedToVideoId The relatedToVideoId parameter retrieves a
+   * list of videos that are related to the video that the parameter value
+   * identifies. The parameter value must be set to a YouTube video ID and, if you
+   * are using this parameter, the type parameter must be set to video.
+   * @opt_param string videoDefinition The videoDefinition parameter lets you
+   * restrict a search to only include either high definition (HD) or standard
+   * definition (SD) videos. HD videos are available for playback in at least
+   * 720p, though higher resolutions, like 1080p, might also be available. If you
+   * specify a value for this parameter, you must also set the type parameter's
+   * value to video.
+   * @opt_param string videoDuration The videoDuration parameter filters video
+   * search results based on their duration. If you specify a value for this
+   * parameter, you must also set the type parameter's value to video.
+   * @opt_param string relevanceLanguage The relevanceLanguage parameter instructs
+   * the API to return search results that are most relevant to the specified
+   * language. The parameter value is typically an ISO 639-1 two-letter language
+   * code. However, you should use the values zh-Hans for simplified Chinese and
+   * zh-Hant for traditional Chinese. Please note that results in other languages
+   * will still be returned if they are highly relevant to the search query term.
+   * @opt_param bool forMine The forMine parameter restricts the search to only
+   * retrieve videos owned by the authenticated user. If you set this parameter to
+   * true, then the type parameter's value must also be set to video.
+   * @opt_param string q The q parameter specifies the query term to search for.
+   *
+   * Your request can also use the Boolean NOT (-) and OR (|) operators to exclude
+   * videos or to find videos that are associated with one of several search
+   * terms. For example, to search for videos matching either "boating" or
+   * "sailing", set the q parameter value to boating|sailing. Similarly, to search
+   * for videos matching either "boating" or "sailing" but not "fishing", set the
+   * q parameter value to boating|sailing -fishing. Note that the pipe character
+   * must be URL-escaped when it is sent in your API request. The URL-escaped
+   * value for the pipe character is %7C.
+   * @opt_param string safeSearch The safeSearch parameter indicates whether the
+   * search results should include restricted content as well as standard content.
+   * @opt_param string videoEmbeddable The videoEmbeddable parameter lets you to
+   * restrict a search to only videos that can be embedded into a webpage. If you
+   * specify a value for this parameter, you must also set the type parameter's
+   * value to video.
+   * @opt_param string videoCategoryId The videoCategoryId parameter filters video
+   * search results based on their category. If you specify a value for this
+   * parameter, you must also set the type parameter's value to video.
+   * @opt_param string order The order parameter specifies the method that will be
+   * used to order resources in the API response.
+   * @return Google_Service_YouTube_SearchListResponse
+   */
+  public function listSearch($part, $optParams = array())
+  {
+    $params = array('part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTube_SearchListResponse");
+  }
+}
+
+/**
+ * The "subscriptions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $subscriptions = $youtubeService->subscriptions;
+ *  </code>
+ */
+class Google_Service_YouTube_Subscriptions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a subscription. (subscriptions.delete)
+   *
+   * @param string $id The id parameter specifies the YouTube subscription ID for
+   * the resource that is being deleted. In a subscription resource, the id
+   * property specifies the YouTube subscription ID.
+   * @param array $optParams Optional parameters.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Adds a subscription for the authenticated user's channel.
+   * (subscriptions.insert)
+   *
+   * @param string $part The part parameter serves two purposes in this operation.
+   * It identifies the properties that the write operation will set as well as the
+   * properties that the API response will include.
+   * @param Google_Subscription $postBody
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_YouTube_Subscription
+   */
+  public function insert($part, Google_Service_YouTube_Subscription $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_YouTube_Subscription");
+  }
+
+  /**
+   * Returns subscription resources that match the API request criteria.
+   * (subscriptions.listSubscriptions)
+   *
+   * @param string $part The part parameter specifies a comma-separated list of
+   * one or more subscription resource properties that the API response will
+   * include.
+   *
+   * If the parameter identifies a property that contains child properties, the
+   * child properties will be included in the response. For example, in a
+   * subscription resource, the snippet property contains other properties, such
+   * as a display title for the subscription. If you set part=snippet, the API
+   * response will also contain all of those nested properties.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @opt_param string onBehalfOfContentOwnerChannel This parameter can only be
+   * used in a properly authorized request. Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwnerChannel parameter specifies the YouTube channel ID
+   * of the channel to which a video is being added. This parameter is required
+   * when a request specifies a value for the onBehalfOfContentOwner parameter,
+   * and it can only be used in conjunction with that parameter. In addition, the
+   * request must be authorized using a CMS account that is linked to the content
+   * owner that the onBehalfOfContentOwner parameter specifies. Finally, the
+   * channel that the onBehalfOfContentOwnerChannel parameter value specifies must
+   * be linked to the content owner that the onBehalfOfContentOwner parameter
+   * specifies.
+   *
+   * This parameter is intended for YouTube content partners that own and manage
+   * many different YouTube channels. It allows content owners to authenticate
+   * once and perform actions on behalf of the channel specified in the parameter
+   * value, without having to provide authentication credentials for each separate
+   * channel.
+   * @opt_param string channelId The channelId parameter specifies a YouTube
+   * channel ID. The API will only return that channel's subscriptions.
+   * @opt_param bool mine Set this parameter's value to true to retrieve a feed of
+   * the authenticated user's subscriptions.
+   * @opt_param string maxResults The maxResults parameter specifies the maximum
+   * number of items that should be returned in the result set.
+   * @opt_param string forChannelId The forChannelId parameter specifies a comma-
+   * separated list of channel IDs. The API response will then only contain
+   * subscriptions matching those channels.
+   * @opt_param string pageToken The pageToken parameter identifies a specific
+   * page in the result set that should be returned. In an API response, the
+   * nextPageToken and prevPageToken properties identify other pages that could be
+   * retrieved.
+   * @opt_param bool mySubscribers Set this parameter's value to true to retrieve
+   * a feed of the subscribers of the authenticated user.
+   * @opt_param string order The order parameter specifies the method that will be
+   * used to sort resources in the API response.
+   * @opt_param string id The id parameter specifies a comma-separated list of the
+   * YouTube subscription ID(s) for the resource(s) that are being retrieved. In a
+   * subscription resource, the id property specifies the YouTube subscription ID.
+   * @return Google_Service_YouTube_SubscriptionListResponse
+   */
+  public function listSubscriptions($part, $optParams = array())
+  {
+    $params = array('part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTube_SubscriptionListResponse");
+  }
+}
+
+/**
+ * The "thumbnails" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $thumbnails = $youtubeService->thumbnails;
+ *  </code>
+ */
+class Google_Service_YouTube_Thumbnails_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Uploads a custom video thumbnail to YouTube and sets it for a video.
+   * (thumbnails.set)
+   *
+   * @param string $videoId The videoId parameter specifies a YouTube video ID for
+   * which the custom video thumbnail is being provided.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The actual CMS
+   * account that the user authenticates with must be linked to the specified
+   * YouTube content owner.
+   * @return Google_Service_YouTube_ThumbnailSetResponse
+   */
+  public function set($videoId, $optParams = array())
+  {
+    $params = array('videoId' => $videoId);
+    $params = array_merge($params, $optParams);
+    return $this->call('set', array($params), "Google_Service_YouTube_ThumbnailSetResponse");
+  }
+}
+
+/**
+ * The "videoAbuseReportReasons" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $videoAbuseReportReasons = $youtubeService->videoAbuseReportReasons;
+ *  </code>
+ */
+class Google_Service_YouTube_VideoAbuseReportReasons_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns a list of abuse reasons that can be used for reporting abusive
+   * videos. (videoAbuseReportReasons.listVideoAbuseReportReasons)
+   *
+   * @param string $part The part parameter specifies the videoCategory resource
+   * parts that the API response will include. Supported values are id and
+   * snippet.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string hl The hl parameter specifies the language that should be
+   * used for text values in the API response.
+   * @return Google_Service_YouTube_VideoAbuseReportReasonListResponse
+   */
+  public function listVideoAbuseReportReasons($part, $optParams = array())
+  {
+    $params = array('part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTube_VideoAbuseReportReasonListResponse");
+  }
+}
+
+/**
+ * The "videoCategories" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $videoCategories = $youtubeService->videoCategories;
+ *  </code>
+ */
+class Google_Service_YouTube_VideoCategories_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Returns a list of categories that can be associated with YouTube videos.
+   * (videoCategories.listVideoCategories)
+   *
+   * @param string $part The part parameter specifies the videoCategory resource
+   * properties that the API response will include. Set the parameter value to
+   * snippet.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string regionCode The regionCode parameter instructs the API to
+   * return the list of video categories available in the specified country. The
+   * parameter value is an ISO 3166-1 alpha-2 country code.
+   * @opt_param string id The id parameter specifies a comma-separated list of
+   * video category IDs for the resources that you are retrieving.
+   * @opt_param string hl The hl parameter specifies the language that should be
+   * used for text values in the API response.
+   * @return Google_Service_YouTube_VideoCategoryListResponse
+   */
+  public function listVideoCategories($part, $optParams = array())
+  {
+    $params = array('part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTube_VideoCategoryListResponse");
+  }
+}
+
+/**
+ * The "videos" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $videos = $youtubeService->videos;
+ *  </code>
+ */
+class Google_Service_YouTube_Videos_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a YouTube video. (videos.delete)
+   *
+   * @param string $id The id parameter specifies the YouTube video ID for the
+   * resource that is being deleted. In a video resource, the id property
+   * specifies the video's ID.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The actual CMS
+   * account that the user authenticates with must be linked to the specified
+   * YouTube content owner.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Retrieves the ratings that the authorized user gave to a list of specified
+   * videos. (videos.getRating)
+   *
+   * @param string $id The id parameter specifies a comma-separated list of the
+   * YouTube video ID(s) for the resource(s) for which you are retrieving rating
+   * data. In a video resource, the id property specifies the video's ID.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @return Google_Service_YouTube_VideoGetRatingResponse
+   */
+  public function getRating($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('getRating', array($params), "Google_Service_YouTube_VideoGetRatingResponse");
+  }
+
+  /**
+   * Uploads a video to YouTube and optionally sets the video's metadata.
+   * (videos.insert)
+   *
+   * @param string $part The part parameter serves two purposes in this operation.
+   * It identifies the properties that the write operation will set as well as the
+   * properties that the API response will include.
+   *
+   * Note that not all parts contain properties that can be set when inserting or
+   * updating a video. For example, the statistics object encapsulates statistics
+   * that YouTube calculates for a video and does not contain values that you can
+   * set or modify. If the parameter value specifies a part that does not contain
+   * mutable values, that part will still be included in the API response.
+   * @param Google_Video $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @opt_param bool stabilize The stabilize parameter indicates whether YouTube
+   * should adjust the video to remove shaky camera motions.
+   * @opt_param string onBehalfOfContentOwnerChannel This parameter can only be
+   * used in a properly authorized request. Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwnerChannel parameter specifies the YouTube channel ID
+   * of the channel to which a video is being added. This parameter is required
+   * when a request specifies a value for the onBehalfOfContentOwner parameter,
+   * and it can only be used in conjunction with that parameter. In addition, the
+   * request must be authorized using a CMS account that is linked to the content
+   * owner that the onBehalfOfContentOwner parameter specifies. Finally, the
+   * channel that the onBehalfOfContentOwnerChannel parameter value specifies must
+   * be linked to the content owner that the onBehalfOfContentOwner parameter
+   * specifies.
+   *
+   * This parameter is intended for YouTube content partners that own and manage
+   * many different YouTube channels. It allows content owners to authenticate
+   * once and perform actions on behalf of the channel specified in the parameter
+   * value, without having to provide authentication credentials for each separate
+   * channel.
+   * @opt_param bool notifySubscribers The notifySubscribers parameter indicates
+   * whether YouTube should send a notification about the new video to users who
+   * subscribe to the video's channel. A parameter value of True indicates that
+   * subscribers will be notified of newly uploaded videos. However, a channel
+   * owner who is uploading many videos might prefer to set the value to False to
+   * avoid sending a notification about each new video to the channel's
+   * subscribers.
+   * @opt_param bool autoLevels The autoLevels parameter indicates whether YouTube
+   * should automatically enhance the video's lighting and color.
+   * @return Google_Service_YouTube_Video
+   */
+  public function insert($part, Google_Service_YouTube_Video $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_YouTube_Video");
+  }
+
+  /**
+   * Returns a list of videos that match the API request parameters.
+   * (videos.listVideos)
+   *
+   * @param string $part The part parameter specifies a comma-separated list of
+   * one or more video resource properties that the API response will include.
+   *
+   * If the parameter identifies a property that contains child properties, the
+   * child properties will be included in the response. For example, in a video
+   * resource, the snippet property contains the channelId, title, description,
+   * tags, and categoryId properties. As such, if you set part=snippet, the API
+   * response will contain all of those properties.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @opt_param string regionCode The regionCode parameter instructs the API to
+   * select a video chart available in the specified region. This parameter can
+   * only be used in conjunction with the chart parameter. The parameter value is
+   * an ISO 3166-1 alpha-2 country code.
+   * @opt_param string locale DEPRECATED
+   * @opt_param string videoCategoryId The videoCategoryId parameter identifies
+   * the video category for which the chart should be retrieved. This parameter
+   * can only be used in conjunction with the chart parameter. By default, charts
+   * are not restricted to a particular category.
+   * @opt_param string chart The chart parameter identifies the chart that you
+   * want to retrieve.
+   * @opt_param string maxResults The maxResults parameter specifies the maximum
+   * number of items that should be returned in the result set.
+   *
+   * Note: This parameter is supported for use in conjunction with the myRating
+   * parameter, but it is not supported for use in conjunction with the id
+   * parameter.
+   * @opt_param string pageToken The pageToken parameter identifies a specific
+   * page in the result set that should be returned. In an API response, the
+   * nextPageToken and prevPageToken properties identify other pages that could be
+   * retrieved.
+   *
+   * Note: This parameter is supported for use in conjunction with the myRating
+   * parameter, but it is not supported for use in conjunction with the id
+   * parameter.
+   * @opt_param string hl The hl parameter instructs the API to retrieve localized
+   * resource metadata for a specific application language that the YouTube
+   * website supports. The parameter value must be a language code included in the
+   * list returned by the i18nLanguages.list method.
+   *
+   * If localized resource details are available in that language, the resource's
+   * snippet.localized object will contain the localized values. However, if
+   * localized details are not available, the snippet.localized object will
+   * contain resource details in the resource's default language.
+   * @opt_param string myRating Set this parameter's value to like or dislike to
+   * instruct the API to only return videos liked or disliked by the authenticated
+   * user.
+   * @opt_param string id The id parameter specifies a comma-separated list of the
+   * YouTube video ID(s) for the resource(s) that are being retrieved. In a video
+   * resource, the id property specifies the video's ID.
+   * @return Google_Service_YouTube_VideoListResponse
+   */
+  public function listVideos($part, $optParams = array())
+  {
+    $params = array('part' => $part);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTube_VideoListResponse");
+  }
+
+  /**
+   * Add a like or dislike rating to a video or remove a rating from a video.
+   * (videos.rate)
+   *
+   * @param string $id The id parameter specifies the YouTube video ID of the
+   * video that is being rated or having its rating removed.
+   * @param string $rating Specifies the rating to record.
+   * @param array $optParams Optional parameters.
+   */
+  public function rate($id, $rating, $optParams = array())
+  {
+    $params = array('id' => $id, 'rating' => $rating);
+    $params = array_merge($params, $optParams);
+    return $this->call('rate', array($params));
+  }
+
+  /**
+   * Report abuse for a video. (videos.reportAbuse)
+   *
+   * @param Google_VideoAbuseReport $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   */
+  public function reportAbuse(Google_Service_YouTube_VideoAbuseReport $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('reportAbuse', array($params));
+  }
+
+  /**
+   * Updates a video's metadata. (videos.update)
+   *
+   * @param string $part The part parameter serves two purposes in this operation.
+   * It identifies the properties that the write operation will set as well as the
+   * properties that the API response will include.
+   *
+   * Note that this method will override the existing values for all of the
+   * mutable properties that are contained in any parts that the parameter value
+   * specifies. For example, a video's privacy setting is contained in the status
+   * part. As such, if your request is updating a private video, and the request's
+   * part parameter value includes the status part, the video's privacy setting
+   * will be updated to whatever value the request body specifies. If the request
+   * body does not specify a value, the existing privacy setting will be removed
+   * and the video will revert to the default privacy setting.
+   *
+   * In addition, not all parts contain properties that can be set when inserting
+   * or updating a video. For example, the statistics object encapsulates
+   * statistics that YouTube calculates for a video and does not contain values
+   * that you can set or modify. If the parameter value specifies a part that does
+   * not contain mutable values, that part will still be included in the API
+   * response.
+   * @param Google_Video $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The actual CMS
+   * account that the user authenticates with must be linked to the specified
+   * YouTube content owner.
+   * @return Google_Service_YouTube_Video
+   */
+  public function update($part, Google_Service_YouTube_Video $postBody, $optParams = array())
+  {
+    $params = array('part' => $part, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_YouTube_Video");
+  }
+}
+
+/**
+ * The "watermarks" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeService = new Google_Service_YouTube(...);
+ *   $watermarks = $youtubeService->watermarks;
+ *  </code>
+ */
+class Google_Service_YouTube_Watermarks_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Uploads a watermark image to YouTube and sets it for a channel.
+   * (watermarks.set)
+   *
+   * @param string $channelId The channelId parameter specifies the YouTube
+   * channel ID for which the watermark is being provided.
+   * @param Google_InvideoBranding $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   */
+  public function set($channelId, Google_Service_YouTube_InvideoBranding $postBody, $optParams = array())
+  {
+    $params = array('channelId' => $channelId, 'postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('set', array($params));
+  }
+
+  /**
+   * Deletes a channel's watermark image. (watermarks.unsetWatermarks)
+   *
+   * @param string $channelId The channelId parameter specifies the YouTube
+   * channel ID for which the watermark is being unset.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   */
+  public function unsetWatermarks($channelId, $optParams = array())
+  {
+    $params = array('channelId' => $channelId);
+    $params = array_merge($params, $optParams);
+    return $this->call('unset', array($params));
+  }
+}
+
+
+
+
+class Google_Service_YouTube_AccessPolicy extends Google_Collection
+{
+  protected $collection_key = 'exception';
+  protected $internal_gapi_mappings = array(
+  );
+  public $allowed;
+  public $exception;
+
+
+  public function setAllowed($allowed)
+  {
+    $this->allowed = $allowed;
+  }
+  public function getAllowed()
+  {
+    return $this->allowed;
+  }
+  public function setException($exception)
+  {
+    $this->exception = $exception;
+  }
+  public function getException()
+  {
+    return $this->exception;
+  }
+}
+
+class Google_Service_YouTube_Activity extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $contentDetailsType = 'Google_Service_YouTube_ActivityContentDetails';
+  protected $contentDetailsDataType = '';
+  public $etag;
+  public $id;
+  public $kind;
+  protected $snippetType = 'Google_Service_YouTube_ActivitySnippet';
+  protected $snippetDataType = '';
+
+
+  public function setContentDetails(Google_Service_YouTube_ActivityContentDetails $contentDetails)
+  {
+    $this->contentDetails = $contentDetails;
+  }
+  public function getContentDetails()
+  {
+    return $this->contentDetails;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSnippet(Google_Service_YouTube_ActivitySnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+}
+
+class Google_Service_YouTube_ActivityContentDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $bulletinType = 'Google_Service_YouTube_ActivityContentDetailsBulletin';
+  protected $bulletinDataType = '';
+  protected $channelItemType = 'Google_Service_YouTube_ActivityContentDetailsChannelItem';
+  protected $channelItemDataType = '';
+  protected $commentType = 'Google_Service_YouTube_ActivityContentDetailsComment';
+  protected $commentDataType = '';
+  protected $favoriteType = 'Google_Service_YouTube_ActivityContentDetailsFavorite';
+  protected $favoriteDataType = '';
+  protected $likeType = 'Google_Service_YouTube_ActivityContentDetailsLike';
+  protected $likeDataType = '';
+  protected $playlistItemType = 'Google_Service_YouTube_ActivityContentDetailsPlaylistItem';
+  protected $playlistItemDataType = '';
+  protected $promotedItemType = 'Google_Service_YouTube_ActivityContentDetailsPromotedItem';
+  protected $promotedItemDataType = '';
+  protected $recommendationType = 'Google_Service_YouTube_ActivityContentDetailsRecommendation';
+  protected $recommendationDataType = '';
+  protected $socialType = 'Google_Service_YouTube_ActivityContentDetailsSocial';
+  protected $socialDataType = '';
+  protected $subscriptionType = 'Google_Service_YouTube_ActivityContentDetailsSubscription';
+  protected $subscriptionDataType = '';
+  protected $uploadType = 'Google_Service_YouTube_ActivityContentDetailsUpload';
+  protected $uploadDataType = '';
+
+
+  public function setBulletin(Google_Service_YouTube_ActivityContentDetailsBulletin $bulletin)
+  {
+    $this->bulletin = $bulletin;
+  }
+  public function getBulletin()
+  {
+    return $this->bulletin;
+  }
+  public function setChannelItem(Google_Service_YouTube_ActivityContentDetailsChannelItem $channelItem)
+  {
+    $this->channelItem = $channelItem;
+  }
+  public function getChannelItem()
+  {
+    return $this->channelItem;
+  }
+  public function setComment(Google_Service_YouTube_ActivityContentDetailsComment $comment)
+  {
+    $this->comment = $comment;
+  }
+  public function getComment()
+  {
+    return $this->comment;
+  }
+  public function setFavorite(Google_Service_YouTube_ActivityContentDetailsFavorite $favorite)
+  {
+    $this->favorite = $favorite;
+  }
+  public function getFavorite()
+  {
+    return $this->favorite;
+  }
+  public function setLike(Google_Service_YouTube_ActivityContentDetailsLike $like)
+  {
+    $this->like = $like;
+  }
+  public function getLike()
+  {
+    return $this->like;
+  }
+  public function setPlaylistItem(Google_Service_YouTube_ActivityContentDetailsPlaylistItem $playlistItem)
+  {
+    $this->playlistItem = $playlistItem;
+  }
+  public function getPlaylistItem()
+  {
+    return $this->playlistItem;
+  }
+  public function setPromotedItem(Google_Service_YouTube_ActivityContentDetailsPromotedItem $promotedItem)
+  {
+    $this->promotedItem = $promotedItem;
+  }
+  public function getPromotedItem()
+  {
+    return $this->promotedItem;
+  }
+  public function setRecommendation(Google_Service_YouTube_ActivityContentDetailsRecommendation $recommendation)
+  {
+    $this->recommendation = $recommendation;
+  }
+  public function getRecommendation()
+  {
+    return $this->recommendation;
+  }
+  public function setSocial(Google_Service_YouTube_ActivityContentDetailsSocial $social)
+  {
+    $this->social = $social;
+  }
+  public function getSocial()
+  {
+    return $this->social;
+  }
+  public function setSubscription(Google_Service_YouTube_ActivityContentDetailsSubscription $subscription)
+  {
+    $this->subscription = $subscription;
+  }
+  public function getSubscription()
+  {
+    return $this->subscription;
+  }
+  public function setUpload(Google_Service_YouTube_ActivityContentDetailsUpload $upload)
+  {
+    $this->upload = $upload;
+  }
+  public function getUpload()
+  {
+    return $this->upload;
+  }
+}
+
+class Google_Service_YouTube_ActivityContentDetailsBulletin extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $resourceIdType = 'Google_Service_YouTube_ResourceId';
+  protected $resourceIdDataType = '';
+
+
+  public function setResourceId(Google_Service_YouTube_ResourceId $resourceId)
+  {
+    $this->resourceId = $resourceId;
+  }
+  public function getResourceId()
+  {
+    return $this->resourceId;
+  }
+}
+
+class Google_Service_YouTube_ActivityContentDetailsChannelItem extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $resourceIdType = 'Google_Service_YouTube_ResourceId';
+  protected $resourceIdDataType = '';
+
+
+  public function setResourceId(Google_Service_YouTube_ResourceId $resourceId)
+  {
+    $this->resourceId = $resourceId;
+  }
+  public function getResourceId()
+  {
+    return $this->resourceId;
+  }
+}
+
+class Google_Service_YouTube_ActivityContentDetailsComment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $resourceIdType = 'Google_Service_YouTube_ResourceId';
+  protected $resourceIdDataType = '';
+
+
+  public function setResourceId(Google_Service_YouTube_ResourceId $resourceId)
+  {
+    $this->resourceId = $resourceId;
+  }
+  public function getResourceId()
+  {
+    return $this->resourceId;
+  }
+}
+
+class Google_Service_YouTube_ActivityContentDetailsFavorite extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $resourceIdType = 'Google_Service_YouTube_ResourceId';
+  protected $resourceIdDataType = '';
+
+
+  public function setResourceId(Google_Service_YouTube_ResourceId $resourceId)
+  {
+    $this->resourceId = $resourceId;
+  }
+  public function getResourceId()
+  {
+    return $this->resourceId;
+  }
+}
+
+class Google_Service_YouTube_ActivityContentDetailsLike extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $resourceIdType = 'Google_Service_YouTube_ResourceId';
+  protected $resourceIdDataType = '';
+
+
+  public function setResourceId(Google_Service_YouTube_ResourceId $resourceId)
+  {
+    $this->resourceId = $resourceId;
+  }
+  public function getResourceId()
+  {
+    return $this->resourceId;
+  }
+}
+
+class Google_Service_YouTube_ActivityContentDetailsPlaylistItem extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $playlistId;
+  public $playlistItemId;
+  protected $resourceIdType = 'Google_Service_YouTube_ResourceId';
+  protected $resourceIdDataType = '';
+
+
+  public function setPlaylistId($playlistId)
+  {
+    $this->playlistId = $playlistId;
+  }
+  public function getPlaylistId()
+  {
+    return $this->playlistId;
+  }
+  public function setPlaylistItemId($playlistItemId)
+  {
+    $this->playlistItemId = $playlistItemId;
+  }
+  public function getPlaylistItemId()
+  {
+    return $this->playlistItemId;
+  }
+  public function setResourceId(Google_Service_YouTube_ResourceId $resourceId)
+  {
+    $this->resourceId = $resourceId;
+  }
+  public function getResourceId()
+  {
+    return $this->resourceId;
+  }
+}
+
+class Google_Service_YouTube_ActivityContentDetailsPromotedItem extends Google_Collection
+{
+  protected $collection_key = 'impressionUrl';
+  protected $internal_gapi_mappings = array(
+  );
+  public $adTag;
+  public $clickTrackingUrl;
+  public $creativeViewUrl;
+  public $ctaType;
+  public $customCtaButtonText;
+  public $descriptionText;
+  public $destinationUrl;
+  public $forecastingUrl;
+  public $impressionUrl;
+  public $videoId;
+
+
+  public function setAdTag($adTag)
+  {
+    $this->adTag = $adTag;
+  }
+  public function getAdTag()
+  {
+    return $this->adTag;
+  }
+  public function setClickTrackingUrl($clickTrackingUrl)
+  {
+    $this->clickTrackingUrl = $clickTrackingUrl;
+  }
+  public function getClickTrackingUrl()
+  {
+    return $this->clickTrackingUrl;
+  }
+  public function setCreativeViewUrl($creativeViewUrl)
+  {
+    $this->creativeViewUrl = $creativeViewUrl;
+  }
+  public function getCreativeViewUrl()
+  {
+    return $this->creativeViewUrl;
+  }
+  public function setCtaType($ctaType)
+  {
+    $this->ctaType = $ctaType;
+  }
+  public function getCtaType()
+  {
+    return $this->ctaType;
+  }
+  public function setCustomCtaButtonText($customCtaButtonText)
+  {
+    $this->customCtaButtonText = $customCtaButtonText;
+  }
+  public function getCustomCtaButtonText()
+  {
+    return $this->customCtaButtonText;
+  }
+  public function setDescriptionText($descriptionText)
+  {
+    $this->descriptionText = $descriptionText;
+  }
+  public function getDescriptionText()
+  {
+    return $this->descriptionText;
+  }
+  public function setDestinationUrl($destinationUrl)
+  {
+    $this->destinationUrl = $destinationUrl;
+  }
+  public function getDestinationUrl()
+  {
+    return $this->destinationUrl;
+  }
+  public function setForecastingUrl($forecastingUrl)
+  {
+    $this->forecastingUrl = $forecastingUrl;
+  }
+  public function getForecastingUrl()
+  {
+    return $this->forecastingUrl;
+  }
+  public function setImpressionUrl($impressionUrl)
+  {
+    $this->impressionUrl = $impressionUrl;
+  }
+  public function getImpressionUrl()
+  {
+    return $this->impressionUrl;
+  }
+  public function setVideoId($videoId)
+  {
+    $this->videoId = $videoId;
+  }
+  public function getVideoId()
+  {
+    return $this->videoId;
+  }
+}
+
+class Google_Service_YouTube_ActivityContentDetailsRecommendation extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $reason;
+  protected $resourceIdType = 'Google_Service_YouTube_ResourceId';
+  protected $resourceIdDataType = '';
+  protected $seedResourceIdType = 'Google_Service_YouTube_ResourceId';
+  protected $seedResourceIdDataType = '';
+
+
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+  public function setResourceId(Google_Service_YouTube_ResourceId $resourceId)
+  {
+    $this->resourceId = $resourceId;
+  }
+  public function getResourceId()
+  {
+    return $this->resourceId;
+  }
+  public function setSeedResourceId(Google_Service_YouTube_ResourceId $seedResourceId)
+  {
+    $this->seedResourceId = $seedResourceId;
+  }
+  public function getSeedResourceId()
+  {
+    return $this->seedResourceId;
+  }
+}
+
+class Google_Service_YouTube_ActivityContentDetailsSocial extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $author;
+  public $imageUrl;
+  public $referenceUrl;
+  protected $resourceIdType = 'Google_Service_YouTube_ResourceId';
+  protected $resourceIdDataType = '';
+  public $type;
+
+
+  public function setAuthor($author)
+  {
+    $this->author = $author;
+  }
+  public function getAuthor()
+  {
+    return $this->author;
+  }
+  public function setImageUrl($imageUrl)
+  {
+    $this->imageUrl = $imageUrl;
+  }
+  public function getImageUrl()
+  {
+    return $this->imageUrl;
+  }
+  public function setReferenceUrl($referenceUrl)
+  {
+    $this->referenceUrl = $referenceUrl;
+  }
+  public function getReferenceUrl()
+  {
+    return $this->referenceUrl;
+  }
+  public function setResourceId(Google_Service_YouTube_ResourceId $resourceId)
+  {
+    $this->resourceId = $resourceId;
+  }
+  public function getResourceId()
+  {
+    return $this->resourceId;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_YouTube_ActivityContentDetailsSubscription extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $resourceIdType = 'Google_Service_YouTube_ResourceId';
+  protected $resourceIdDataType = '';
+
+
+  public function setResourceId(Google_Service_YouTube_ResourceId $resourceId)
+  {
+    $this->resourceId = $resourceId;
+  }
+  public function getResourceId()
+  {
+    return $this->resourceId;
+  }
+}
+
+class Google_Service_YouTube_ActivityContentDetailsUpload extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $videoId;
+
+
+  public function setVideoId($videoId)
+  {
+    $this->videoId = $videoId;
+  }
+  public function getVideoId()
+  {
+    return $this->videoId;
+  }
+}
+
+class Google_Service_YouTube_ActivityListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_Activity';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  protected $pageInfoType = 'Google_Service_YouTube_PageInfo';
+  protected $pageInfoDataType = '';
+  public $prevPageToken;
+  protected $tokenPaginationType = 'Google_Service_YouTube_TokenPagination';
+  protected $tokenPaginationDataType = '';
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPageInfo(Google_Service_YouTube_PageInfo $pageInfo)
+  {
+    $this->pageInfo = $pageInfo;
+  }
+  public function getPageInfo()
+  {
+    return $this->pageInfo;
+  }
+  public function setPrevPageToken($prevPageToken)
+  {
+    $this->prevPageToken = $prevPageToken;
+  }
+  public function getPrevPageToken()
+  {
+    return $this->prevPageToken;
+  }
+  public function setTokenPagination(Google_Service_YouTube_TokenPagination $tokenPagination)
+  {
+    $this->tokenPagination = $tokenPagination;
+  }
+  public function getTokenPagination()
+  {
+    return $this->tokenPagination;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_ActivitySnippet extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $channelId;
+  public $channelTitle;
+  public $description;
+  public $groupId;
+  public $publishedAt;
+  protected $thumbnailsType = 'Google_Service_YouTube_ThumbnailDetails';
+  protected $thumbnailsDataType = '';
+  public $title;
+  public $type;
+
+
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setChannelTitle($channelTitle)
+  {
+    $this->channelTitle = $channelTitle;
+  }
+  public function getChannelTitle()
+  {
+    return $this->channelTitle;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setGroupId($groupId)
+  {
+    $this->groupId = $groupId;
+  }
+  public function getGroupId()
+  {
+    return $this->groupId;
+  }
+  public function setPublishedAt($publishedAt)
+  {
+    $this->publishedAt = $publishedAt;
+  }
+  public function getPublishedAt()
+  {
+    return $this->publishedAt;
+  }
+  public function setThumbnails(Google_Service_YouTube_ThumbnailDetails $thumbnails)
+  {
+    $this->thumbnails = $thumbnails;
+  }
+  public function getThumbnails()
+  {
+    return $this->thumbnails;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_YouTube_Caption extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $id;
+  public $kind;
+  protected $snippetType = 'Google_Service_YouTube_CaptionSnippet';
+  protected $snippetDataType = '';
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSnippet(Google_Service_YouTube_CaptionSnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+}
+
+class Google_Service_YouTube_CaptionListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_Caption';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_CaptionSnippet extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $audioTrackType;
+  public $failureReason;
+  public $isAutoSynced;
+  public $isCC;
+  public $isDraft;
+  public $isEasyReader;
+  public $isLarge;
+  public $language;
+  public $lastUpdated;
+  public $name;
+  public $status;
+  public $trackKind;
+  public $videoId;
+
+
+  public function setAudioTrackType($audioTrackType)
+  {
+    $this->audioTrackType = $audioTrackType;
+  }
+  public function getAudioTrackType()
+  {
+    return $this->audioTrackType;
+  }
+  public function setFailureReason($failureReason)
+  {
+    $this->failureReason = $failureReason;
+  }
+  public function getFailureReason()
+  {
+    return $this->failureReason;
+  }
+  public function setIsAutoSynced($isAutoSynced)
+  {
+    $this->isAutoSynced = $isAutoSynced;
+  }
+  public function getIsAutoSynced()
+  {
+    return $this->isAutoSynced;
+  }
+  public function setIsCC($isCC)
+  {
+    $this->isCC = $isCC;
+  }
+  public function getIsCC()
+  {
+    return $this->isCC;
+  }
+  public function setIsDraft($isDraft)
+  {
+    $this->isDraft = $isDraft;
+  }
+  public function getIsDraft()
+  {
+    return $this->isDraft;
+  }
+  public function setIsEasyReader($isEasyReader)
+  {
+    $this->isEasyReader = $isEasyReader;
+  }
+  public function getIsEasyReader()
+  {
+    return $this->isEasyReader;
+  }
+  public function setIsLarge($isLarge)
+  {
+    $this->isLarge = $isLarge;
+  }
+  public function getIsLarge()
+  {
+    return $this->isLarge;
+  }
+  public function setLanguage($language)
+  {
+    $this->language = $language;
+  }
+  public function getLanguage()
+  {
+    return $this->language;
+  }
+  public function setLastUpdated($lastUpdated)
+  {
+    $this->lastUpdated = $lastUpdated;
+  }
+  public function getLastUpdated()
+  {
+    return $this->lastUpdated;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setTrackKind($trackKind)
+  {
+    $this->trackKind = $trackKind;
+  }
+  public function getTrackKind()
+  {
+    return $this->trackKind;
+  }
+  public function setVideoId($videoId)
+  {
+    $this->videoId = $videoId;
+  }
+  public function getVideoId()
+  {
+    return $this->videoId;
+  }
+}
+
+class Google_Service_YouTube_CdnSettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $format;
+  protected $ingestionInfoType = 'Google_Service_YouTube_IngestionInfo';
+  protected $ingestionInfoDataType = '';
+  public $ingestionType;
+
+
+  public function setFormat($format)
+  {
+    $this->format = $format;
+  }
+  public function getFormat()
+  {
+    return $this->format;
+  }
+  public function setIngestionInfo(Google_Service_YouTube_IngestionInfo $ingestionInfo)
+  {
+    $this->ingestionInfo = $ingestionInfo;
+  }
+  public function getIngestionInfo()
+  {
+    return $this->ingestionInfo;
+  }
+  public function setIngestionType($ingestionType)
+  {
+    $this->ingestionType = $ingestionType;
+  }
+  public function getIngestionType()
+  {
+    return $this->ingestionType;
+  }
+}
+
+class Google_Service_YouTube_Channel extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $auditDetailsType = 'Google_Service_YouTube_ChannelAuditDetails';
+  protected $auditDetailsDataType = '';
+  protected $brandingSettingsType = 'Google_Service_YouTube_ChannelBrandingSettings';
+  protected $brandingSettingsDataType = '';
+  protected $contentDetailsType = 'Google_Service_YouTube_ChannelContentDetails';
+  protected $contentDetailsDataType = '';
+  protected $contentOwnerDetailsType = 'Google_Service_YouTube_ChannelContentOwnerDetails';
+  protected $contentOwnerDetailsDataType = '';
+  protected $conversionPingsType = 'Google_Service_YouTube_ChannelConversionPings';
+  protected $conversionPingsDataType = '';
+  public $etag;
+  public $id;
+  protected $invideoPromotionType = 'Google_Service_YouTube_InvideoPromotion';
+  protected $invideoPromotionDataType = '';
+  public $kind;
+  protected $localizationsType = 'Google_Service_YouTube_ChannelLocalization';
+  protected $localizationsDataType = 'map';
+  protected $snippetType = 'Google_Service_YouTube_ChannelSnippet';
+  protected $snippetDataType = '';
+  protected $statisticsType = 'Google_Service_YouTube_ChannelStatistics';
+  protected $statisticsDataType = '';
+  protected $statusType = 'Google_Service_YouTube_ChannelStatus';
+  protected $statusDataType = '';
+  protected $topicDetailsType = 'Google_Service_YouTube_ChannelTopicDetails';
+  protected $topicDetailsDataType = '';
+
+
+  public function setAuditDetails(Google_Service_YouTube_ChannelAuditDetails $auditDetails)
+  {
+    $this->auditDetails = $auditDetails;
+  }
+  public function getAuditDetails()
+  {
+    return $this->auditDetails;
+  }
+  public function setBrandingSettings(Google_Service_YouTube_ChannelBrandingSettings $brandingSettings)
+  {
+    $this->brandingSettings = $brandingSettings;
+  }
+  public function getBrandingSettings()
+  {
+    return $this->brandingSettings;
+  }
+  public function setContentDetails(Google_Service_YouTube_ChannelContentDetails $contentDetails)
+  {
+    $this->contentDetails = $contentDetails;
+  }
+  public function getContentDetails()
+  {
+    return $this->contentDetails;
+  }
+  public function setContentOwnerDetails(Google_Service_YouTube_ChannelContentOwnerDetails $contentOwnerDetails)
+  {
+    $this->contentOwnerDetails = $contentOwnerDetails;
+  }
+  public function getContentOwnerDetails()
+  {
+    return $this->contentOwnerDetails;
+  }
+  public function setConversionPings(Google_Service_YouTube_ChannelConversionPings $conversionPings)
+  {
+    $this->conversionPings = $conversionPings;
+  }
+  public function getConversionPings()
+  {
+    return $this->conversionPings;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setInvideoPromotion(Google_Service_YouTube_InvideoPromotion $invideoPromotion)
+  {
+    $this->invideoPromotion = $invideoPromotion;
+  }
+  public function getInvideoPromotion()
+  {
+    return $this->invideoPromotion;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocalizations($localizations)
+  {
+    $this->localizations = $localizations;
+  }
+  public function getLocalizations()
+  {
+    return $this->localizations;
+  }
+  public function setSnippet(Google_Service_YouTube_ChannelSnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+  public function setStatistics(Google_Service_YouTube_ChannelStatistics $statistics)
+  {
+    $this->statistics = $statistics;
+  }
+  public function getStatistics()
+  {
+    return $this->statistics;
+  }
+  public function setStatus(Google_Service_YouTube_ChannelStatus $status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setTopicDetails(Google_Service_YouTube_ChannelTopicDetails $topicDetails)
+  {
+    $this->topicDetails = $topicDetails;
+  }
+  public function getTopicDetails()
+  {
+    return $this->topicDetails;
+  }
+}
+
+class Google_Service_YouTube_ChannelAuditDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $communityGuidelinesGoodStanding;
+  public $contentIdClaimsGoodStanding;
+  public $copyrightStrikesGoodStanding;
+  public $overallGoodStanding;
+
+
+  public function setCommunityGuidelinesGoodStanding($communityGuidelinesGoodStanding)
+  {
+    $this->communityGuidelinesGoodStanding = $communityGuidelinesGoodStanding;
+  }
+  public function getCommunityGuidelinesGoodStanding()
+  {
+    return $this->communityGuidelinesGoodStanding;
+  }
+  public function setContentIdClaimsGoodStanding($contentIdClaimsGoodStanding)
+  {
+    $this->contentIdClaimsGoodStanding = $contentIdClaimsGoodStanding;
+  }
+  public function getContentIdClaimsGoodStanding()
+  {
+    return $this->contentIdClaimsGoodStanding;
+  }
+  public function setCopyrightStrikesGoodStanding($copyrightStrikesGoodStanding)
+  {
+    $this->copyrightStrikesGoodStanding = $copyrightStrikesGoodStanding;
+  }
+  public function getCopyrightStrikesGoodStanding()
+  {
+    return $this->copyrightStrikesGoodStanding;
+  }
+  public function setOverallGoodStanding($overallGoodStanding)
+  {
+    $this->overallGoodStanding = $overallGoodStanding;
+  }
+  public function getOverallGoodStanding()
+  {
+    return $this->overallGoodStanding;
+  }
+}
+
+class Google_Service_YouTube_ChannelBannerResource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $kind;
+  public $url;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+}
+
+class Google_Service_YouTube_ChannelBrandingSettings extends Google_Collection
+{
+  protected $collection_key = 'hints';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $channelType = 'Google_Service_YouTube_ChannelSettings';
+  protected $channelDataType = '';
+  protected $hintsType = 'Google_Service_YouTube_PropertyValue';
+  protected $hintsDataType = 'array';
+  protected $imageType = 'Google_Service_YouTube_ImageSettings';
+  protected $imageDataType = '';
+  protected $watchType = 'Google_Service_YouTube_WatchSettings';
+  protected $watchDataType = '';
+
+
+  public function setChannel(Google_Service_YouTube_ChannelSettings $channel)
+  {
+    $this->channel = $channel;
+  }
+  public function getChannel()
+  {
+    return $this->channel;
+  }
+  public function setHints($hints)
+  {
+    $this->hints = $hints;
+  }
+  public function getHints()
+  {
+    return $this->hints;
+  }
+  public function setImage(Google_Service_YouTube_ImageSettings $image)
+  {
+    $this->image = $image;
+  }
+  public function getImage()
+  {
+    return $this->image;
+  }
+  public function setWatch(Google_Service_YouTube_WatchSettings $watch)
+  {
+    $this->watch = $watch;
+  }
+  public function getWatch()
+  {
+    return $this->watch;
+  }
+}
+
+class Google_Service_YouTube_ChannelContentDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $googlePlusUserId;
+  protected $relatedPlaylistsType = 'Google_Service_YouTube_ChannelContentDetailsRelatedPlaylists';
+  protected $relatedPlaylistsDataType = '';
+
+
+  public function setGooglePlusUserId($googlePlusUserId)
+  {
+    $this->googlePlusUserId = $googlePlusUserId;
+  }
+  public function getGooglePlusUserId()
+  {
+    return $this->googlePlusUserId;
+  }
+  public function setRelatedPlaylists(Google_Service_YouTube_ChannelContentDetailsRelatedPlaylists $relatedPlaylists)
+  {
+    $this->relatedPlaylists = $relatedPlaylists;
+  }
+  public function getRelatedPlaylists()
+  {
+    return $this->relatedPlaylists;
+  }
+}
+
+class Google_Service_YouTube_ChannelContentDetailsRelatedPlaylists extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $favorites;
+  public $likes;
+  public $uploads;
+  public $watchHistory;
+  public $watchLater;
+
+
+  public function setFavorites($favorites)
+  {
+    $this->favorites = $favorites;
+  }
+  public function getFavorites()
+  {
+    return $this->favorites;
+  }
+  public function setLikes($likes)
+  {
+    $this->likes = $likes;
+  }
+  public function getLikes()
+  {
+    return $this->likes;
+  }
+  public function setUploads($uploads)
+  {
+    $this->uploads = $uploads;
+  }
+  public function getUploads()
+  {
+    return $this->uploads;
+  }
+  public function setWatchHistory($watchHistory)
+  {
+    $this->watchHistory = $watchHistory;
+  }
+  public function getWatchHistory()
+  {
+    return $this->watchHistory;
+  }
+  public function setWatchLater($watchLater)
+  {
+    $this->watchLater = $watchLater;
+  }
+  public function getWatchLater()
+  {
+    return $this->watchLater;
+  }
+}
+
+class Google_Service_YouTube_ChannelContentOwnerDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $contentOwner;
+  public $timeLinked;
+
+
+  public function setContentOwner($contentOwner)
+  {
+    $this->contentOwner = $contentOwner;
+  }
+  public function getContentOwner()
+  {
+    return $this->contentOwner;
+  }
+  public function setTimeLinked($timeLinked)
+  {
+    $this->timeLinked = $timeLinked;
+  }
+  public function getTimeLinked()
+  {
+    return $this->timeLinked;
+  }
+}
+
+class Google_Service_YouTube_ChannelConversionPing extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $context;
+  public $conversionUrl;
+
+
+  public function setContext($context)
+  {
+    $this->context = $context;
+  }
+  public function getContext()
+  {
+    return $this->context;
+  }
+  public function setConversionUrl($conversionUrl)
+  {
+    $this->conversionUrl = $conversionUrl;
+  }
+  public function getConversionUrl()
+  {
+    return $this->conversionUrl;
+  }
+}
+
+class Google_Service_YouTube_ChannelConversionPings extends Google_Collection
+{
+  protected $collection_key = 'pings';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $pingsType = 'Google_Service_YouTube_ChannelConversionPing';
+  protected $pingsDataType = 'array';
+
+
+  public function setPings($pings)
+  {
+    $this->pings = $pings;
+  }
+  public function getPings()
+  {
+    return $this->pings;
+  }
+}
+
+class Google_Service_YouTube_ChannelId extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $value;
+
+
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_YouTube_ChannelListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_Channel';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  protected $pageInfoType = 'Google_Service_YouTube_PageInfo';
+  protected $pageInfoDataType = '';
+  public $prevPageToken;
+  protected $tokenPaginationType = 'Google_Service_YouTube_TokenPagination';
+  protected $tokenPaginationDataType = '';
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPageInfo(Google_Service_YouTube_PageInfo $pageInfo)
+  {
+    $this->pageInfo = $pageInfo;
+  }
+  public function getPageInfo()
+  {
+    return $this->pageInfo;
+  }
+  public function setPrevPageToken($prevPageToken)
+  {
+    $this->prevPageToken = $prevPageToken;
+  }
+  public function getPrevPageToken()
+  {
+    return $this->prevPageToken;
+  }
+  public function setTokenPagination(Google_Service_YouTube_TokenPagination $tokenPagination)
+  {
+    $this->tokenPagination = $tokenPagination;
+  }
+  public function getTokenPagination()
+  {
+    return $this->tokenPagination;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_ChannelLocalization extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $title;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_YouTube_ChannelLocalizations extends Google_Model
+{
+}
+
+class Google_Service_YouTube_ChannelSection extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $contentDetailsType = 'Google_Service_YouTube_ChannelSectionContentDetails';
+  protected $contentDetailsDataType = '';
+  public $etag;
+  public $id;
+  public $kind;
+  protected $localizationsType = 'Google_Service_YouTube_ChannelSectionLocalization';
+  protected $localizationsDataType = 'map';
+  protected $snippetType = 'Google_Service_YouTube_ChannelSectionSnippet';
+  protected $snippetDataType = '';
+  protected $targetingType = 'Google_Service_YouTube_ChannelSectionTargeting';
+  protected $targetingDataType = '';
+
+
+  public function setContentDetails(Google_Service_YouTube_ChannelSectionContentDetails $contentDetails)
+  {
+    $this->contentDetails = $contentDetails;
+  }
+  public function getContentDetails()
+  {
+    return $this->contentDetails;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocalizations($localizations)
+  {
+    $this->localizations = $localizations;
+  }
+  public function getLocalizations()
+  {
+    return $this->localizations;
+  }
+  public function setSnippet(Google_Service_YouTube_ChannelSectionSnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+  public function setTargeting(Google_Service_YouTube_ChannelSectionTargeting $targeting)
+  {
+    $this->targeting = $targeting;
+  }
+  public function getTargeting()
+  {
+    return $this->targeting;
+  }
+}
+
+class Google_Service_YouTube_ChannelSectionContentDetails extends Google_Collection
+{
+  protected $collection_key = 'playlists';
+  protected $internal_gapi_mappings = array(
+  );
+  public $channels;
+  public $playlists;
+
+
+  public function setChannels($channels)
+  {
+    $this->channels = $channels;
+  }
+  public function getChannels()
+  {
+    return $this->channels;
+  }
+  public function setPlaylists($playlists)
+  {
+    $this->playlists = $playlists;
+  }
+  public function getPlaylists()
+  {
+    return $this->playlists;
+  }
+}
+
+class Google_Service_YouTube_ChannelSectionListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_ChannelSection';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_ChannelSectionLocalization extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $title;
+
+
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_YouTube_ChannelSectionLocalizations extends Google_Model
+{
+}
+
+class Google_Service_YouTube_ChannelSectionSnippet extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $channelId;
+  public $defaultLanguage;
+  protected $localizedType = 'Google_Service_YouTube_ChannelSectionLocalization';
+  protected $localizedDataType = '';
+  public $position;
+  public $style;
+  public $title;
+  public $type;
+
+
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setDefaultLanguage($defaultLanguage)
+  {
+    $this->defaultLanguage = $defaultLanguage;
+  }
+  public function getDefaultLanguage()
+  {
+    return $this->defaultLanguage;
+  }
+  public function setLocalized(Google_Service_YouTube_ChannelSectionLocalization $localized)
+  {
+    $this->localized = $localized;
+  }
+  public function getLocalized()
+  {
+    return $this->localized;
+  }
+  public function setPosition($position)
+  {
+    $this->position = $position;
+  }
+  public function getPosition()
+  {
+    return $this->position;
+  }
+  public function setStyle($style)
+  {
+    $this->style = $style;
+  }
+  public function getStyle()
+  {
+    return $this->style;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_YouTube_ChannelSectionTargeting extends Google_Collection
+{
+  protected $collection_key = 'regions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $countries;
+  public $languages;
+  public $regions;
+
+
+  public function setCountries($countries)
+  {
+    $this->countries = $countries;
+  }
+  public function getCountries()
+  {
+    return $this->countries;
+  }
+  public function setLanguages($languages)
+  {
+    $this->languages = $languages;
+  }
+  public function getLanguages()
+  {
+    return $this->languages;
+  }
+  public function setRegions($regions)
+  {
+    $this->regions = $regions;
+  }
+  public function getRegions()
+  {
+    return $this->regions;
+  }
+}
+
+class Google_Service_YouTube_ChannelSettings extends Google_Collection
+{
+  protected $collection_key = 'featuredChannelsUrls';
+  protected $internal_gapi_mappings = array(
+  );
+  public $country;
+  public $defaultLanguage;
+  public $defaultTab;
+  public $description;
+  public $featuredChannelsTitle;
+  public $featuredChannelsUrls;
+  public $keywords;
+  public $moderateComments;
+  public $profileColor;
+  public $showBrowseView;
+  public $showRelatedChannels;
+  public $title;
+  public $trackingAnalyticsAccountId;
+  public $unsubscribedTrailer;
+
+
+  public function setCountry($country)
+  {
+    $this->country = $country;
+  }
+  public function getCountry()
+  {
+    return $this->country;
+  }
+  public function setDefaultLanguage($defaultLanguage)
+  {
+    $this->defaultLanguage = $defaultLanguage;
+  }
+  public function getDefaultLanguage()
+  {
+    return $this->defaultLanguage;
+  }
+  public function setDefaultTab($defaultTab)
+  {
+    $this->defaultTab = $defaultTab;
+  }
+  public function getDefaultTab()
+  {
+    return $this->defaultTab;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setFeaturedChannelsTitle($featuredChannelsTitle)
+  {
+    $this->featuredChannelsTitle = $featuredChannelsTitle;
+  }
+  public function getFeaturedChannelsTitle()
+  {
+    return $this->featuredChannelsTitle;
+  }
+  public function setFeaturedChannelsUrls($featuredChannelsUrls)
+  {
+    $this->featuredChannelsUrls = $featuredChannelsUrls;
+  }
+  public function getFeaturedChannelsUrls()
+  {
+    return $this->featuredChannelsUrls;
+  }
+  public function setKeywords($keywords)
+  {
+    $this->keywords = $keywords;
+  }
+  public function getKeywords()
+  {
+    return $this->keywords;
+  }
+  public function setModerateComments($moderateComments)
+  {
+    $this->moderateComments = $moderateComments;
+  }
+  public function getModerateComments()
+  {
+    return $this->moderateComments;
+  }
+  public function setProfileColor($profileColor)
+  {
+    $this->profileColor = $profileColor;
+  }
+  public function getProfileColor()
+  {
+    return $this->profileColor;
+  }
+  public function setShowBrowseView($showBrowseView)
+  {
+    $this->showBrowseView = $showBrowseView;
+  }
+  public function getShowBrowseView()
+  {
+    return $this->showBrowseView;
+  }
+  public function setShowRelatedChannels($showRelatedChannels)
+  {
+    $this->showRelatedChannels = $showRelatedChannels;
+  }
+  public function getShowRelatedChannels()
+  {
+    return $this->showRelatedChannels;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+  public function setTrackingAnalyticsAccountId($trackingAnalyticsAccountId)
+  {
+    $this->trackingAnalyticsAccountId = $trackingAnalyticsAccountId;
+  }
+  public function getTrackingAnalyticsAccountId()
+  {
+    return $this->trackingAnalyticsAccountId;
+  }
+  public function setUnsubscribedTrailer($unsubscribedTrailer)
+  {
+    $this->unsubscribedTrailer = $unsubscribedTrailer;
+  }
+  public function getUnsubscribedTrailer()
+  {
+    return $this->unsubscribedTrailer;
+  }
+}
+
+class Google_Service_YouTube_ChannelSnippet extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $country;
+  public $defaultLanguage;
+  public $description;
+  protected $localizedType = 'Google_Service_YouTube_ChannelLocalization';
+  protected $localizedDataType = '';
+  public $publishedAt;
+  protected $thumbnailsType = 'Google_Service_YouTube_ThumbnailDetails';
+  protected $thumbnailsDataType = '';
+  public $title;
+
+
+  public function setCountry($country)
+  {
+    $this->country = $country;
+  }
+  public function getCountry()
+  {
+    return $this->country;
+  }
+  public function setDefaultLanguage($defaultLanguage)
+  {
+    $this->defaultLanguage = $defaultLanguage;
+  }
+  public function getDefaultLanguage()
+  {
+    return $this->defaultLanguage;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setLocalized(Google_Service_YouTube_ChannelLocalization $localized)
+  {
+    $this->localized = $localized;
+  }
+  public function getLocalized()
+  {
+    return $this->localized;
+  }
+  public function setPublishedAt($publishedAt)
+  {
+    $this->publishedAt = $publishedAt;
+  }
+  public function getPublishedAt()
+  {
+    return $this->publishedAt;
+  }
+  public function setThumbnails(Google_Service_YouTube_ThumbnailDetails $thumbnails)
+  {
+    $this->thumbnails = $thumbnails;
+  }
+  public function getThumbnails()
+  {
+    return $this->thumbnails;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_YouTube_ChannelStatistics extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $commentCount;
+  public $hiddenSubscriberCount;
+  public $subscriberCount;
+  public $videoCount;
+  public $viewCount;
+
+
+  public function setCommentCount($commentCount)
+  {
+    $this->commentCount = $commentCount;
+  }
+  public function getCommentCount()
+  {
+    return $this->commentCount;
+  }
+  public function setHiddenSubscriberCount($hiddenSubscriberCount)
+  {
+    $this->hiddenSubscriberCount = $hiddenSubscriberCount;
+  }
+  public function getHiddenSubscriberCount()
+  {
+    return $this->hiddenSubscriberCount;
+  }
+  public function setSubscriberCount($subscriberCount)
+  {
+    $this->subscriberCount = $subscriberCount;
+  }
+  public function getSubscriberCount()
+  {
+    return $this->subscriberCount;
+  }
+  public function setVideoCount($videoCount)
+  {
+    $this->videoCount = $videoCount;
+  }
+  public function getVideoCount()
+  {
+    return $this->videoCount;
+  }
+  public function setViewCount($viewCount)
+  {
+    $this->viewCount = $viewCount;
+  }
+  public function getViewCount()
+  {
+    return $this->viewCount;
+  }
+}
+
+class Google_Service_YouTube_ChannelStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $isLinked;
+  public $longUploadsStatus;
+  public $privacyStatus;
+
+
+  public function setIsLinked($isLinked)
+  {
+    $this->isLinked = $isLinked;
+  }
+  public function getIsLinked()
+  {
+    return $this->isLinked;
+  }
+  public function setLongUploadsStatus($longUploadsStatus)
+  {
+    $this->longUploadsStatus = $longUploadsStatus;
+  }
+  public function getLongUploadsStatus()
+  {
+    return $this->longUploadsStatus;
+  }
+  public function setPrivacyStatus($privacyStatus)
+  {
+    $this->privacyStatus = $privacyStatus;
+  }
+  public function getPrivacyStatus()
+  {
+    return $this->privacyStatus;
+  }
+}
+
+class Google_Service_YouTube_ChannelTopicDetails extends Google_Collection
+{
+  protected $collection_key = 'topicIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $topicIds;
+
+
+  public function setTopicIds($topicIds)
+  {
+    $this->topicIds = $topicIds;
+  }
+  public function getTopicIds()
+  {
+    return $this->topicIds;
+  }
+}
+
+class Google_Service_YouTube_Comment extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $id;
+  public $kind;
+  protected $snippetType = 'Google_Service_YouTube_CommentSnippet';
+  protected $snippetDataType = '';
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSnippet(Google_Service_YouTube_CommentSnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+}
+
+class Google_Service_YouTube_CommentListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_Comment';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  protected $pageInfoType = 'Google_Service_YouTube_PageInfo';
+  protected $pageInfoDataType = '';
+  protected $tokenPaginationType = 'Google_Service_YouTube_TokenPagination';
+  protected $tokenPaginationDataType = '';
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPageInfo(Google_Service_YouTube_PageInfo $pageInfo)
+  {
+    $this->pageInfo = $pageInfo;
+  }
+  public function getPageInfo()
+  {
+    return $this->pageInfo;
+  }
+  public function setTokenPagination(Google_Service_YouTube_TokenPagination $tokenPagination)
+  {
+    $this->tokenPagination = $tokenPagination;
+  }
+  public function getTokenPagination()
+  {
+    return $this->tokenPagination;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_CommentSnippet extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $authorChannelIdType = 'Google_Service_YouTube_ChannelId';
+  protected $authorChannelIdDataType = '';
+  public $authorChannelUrl;
+  public $authorDisplayName;
+  public $authorGoogleplusProfileUrl;
+  public $authorProfileImageUrl;
+  public $canRate;
+  public $channelId;
+  public $likeCount;
+  public $moderationStatus;
+  public $parentId;
+  public $publishedAt;
+  public $textDisplay;
+  public $textOriginal;
+  public $updatedAt;
+  public $videoId;
+  public $viewerRating;
+
+
+  public function setAuthorChannelId(Google_Service_YouTube_ChannelId $authorChannelId)
+  {
+    $this->authorChannelId = $authorChannelId;
+  }
+  public function getAuthorChannelId()
+  {
+    return $this->authorChannelId;
+  }
+  public function setAuthorChannelUrl($authorChannelUrl)
+  {
+    $this->authorChannelUrl = $authorChannelUrl;
+  }
+  public function getAuthorChannelUrl()
+  {
+    return $this->authorChannelUrl;
+  }
+  public function setAuthorDisplayName($authorDisplayName)
+  {
+    $this->authorDisplayName = $authorDisplayName;
+  }
+  public function getAuthorDisplayName()
+  {
+    return $this->authorDisplayName;
+  }
+  public function setAuthorGoogleplusProfileUrl($authorGoogleplusProfileUrl)
+  {
+    $this->authorGoogleplusProfileUrl = $authorGoogleplusProfileUrl;
+  }
+  public function getAuthorGoogleplusProfileUrl()
+  {
+    return $this->authorGoogleplusProfileUrl;
+  }
+  public function setAuthorProfileImageUrl($authorProfileImageUrl)
+  {
+    $this->authorProfileImageUrl = $authorProfileImageUrl;
+  }
+  public function getAuthorProfileImageUrl()
+  {
+    return $this->authorProfileImageUrl;
+  }
+  public function setCanRate($canRate)
+  {
+    $this->canRate = $canRate;
+  }
+  public function getCanRate()
+  {
+    return $this->canRate;
+  }
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setLikeCount($likeCount)
+  {
+    $this->likeCount = $likeCount;
+  }
+  public function getLikeCount()
+  {
+    return $this->likeCount;
+  }
+  public function setModerationStatus($moderationStatus)
+  {
+    $this->moderationStatus = $moderationStatus;
+  }
+  public function getModerationStatus()
+  {
+    return $this->moderationStatus;
+  }
+  public function setParentId($parentId)
+  {
+    $this->parentId = $parentId;
+  }
+  public function getParentId()
+  {
+    return $this->parentId;
+  }
+  public function setPublishedAt($publishedAt)
+  {
+    $this->publishedAt = $publishedAt;
+  }
+  public function getPublishedAt()
+  {
+    return $this->publishedAt;
+  }
+  public function setTextDisplay($textDisplay)
+  {
+    $this->textDisplay = $textDisplay;
+  }
+  public function getTextDisplay()
+  {
+    return $this->textDisplay;
+  }
+  public function setTextOriginal($textOriginal)
+  {
+    $this->textOriginal = $textOriginal;
+  }
+  public function getTextOriginal()
+  {
+    return $this->textOriginal;
+  }
+  public function setUpdatedAt($updatedAt)
+  {
+    $this->updatedAt = $updatedAt;
+  }
+  public function getUpdatedAt()
+  {
+    return $this->updatedAt;
+  }
+  public function setVideoId($videoId)
+  {
+    $this->videoId = $videoId;
+  }
+  public function getVideoId()
+  {
+    return $this->videoId;
+  }
+  public function setViewerRating($viewerRating)
+  {
+    $this->viewerRating = $viewerRating;
+  }
+  public function getViewerRating()
+  {
+    return $this->viewerRating;
+  }
+}
+
+class Google_Service_YouTube_CommentThread extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $id;
+  public $kind;
+  protected $repliesType = 'Google_Service_YouTube_CommentThreadReplies';
+  protected $repliesDataType = '';
+  protected $snippetType = 'Google_Service_YouTube_CommentThreadSnippet';
+  protected $snippetDataType = '';
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setReplies(Google_Service_YouTube_CommentThreadReplies $replies)
+  {
+    $this->replies = $replies;
+  }
+  public function getReplies()
+  {
+    return $this->replies;
+  }
+  public function setSnippet(Google_Service_YouTube_CommentThreadSnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+}
+
+class Google_Service_YouTube_CommentThreadListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_CommentThread';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  protected $pageInfoType = 'Google_Service_YouTube_PageInfo';
+  protected $pageInfoDataType = '';
+  protected $tokenPaginationType = 'Google_Service_YouTube_TokenPagination';
+  protected $tokenPaginationDataType = '';
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPageInfo(Google_Service_YouTube_PageInfo $pageInfo)
+  {
+    $this->pageInfo = $pageInfo;
+  }
+  public function getPageInfo()
+  {
+    return $this->pageInfo;
+  }
+  public function setTokenPagination(Google_Service_YouTube_TokenPagination $tokenPagination)
+  {
+    $this->tokenPagination = $tokenPagination;
+  }
+  public function getTokenPagination()
+  {
+    return $this->tokenPagination;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_CommentThreadReplies extends Google_Collection
+{
+  protected $collection_key = 'comments';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $commentsType = 'Google_Service_YouTube_Comment';
+  protected $commentsDataType = 'array';
+
+
+  public function setComments($comments)
+  {
+    $this->comments = $comments;
+  }
+  public function getComments()
+  {
+    return $this->comments;
+  }
+}
+
+class Google_Service_YouTube_CommentThreadSnippet extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $canReply;
+  public $channelId;
+  public $isPublic;
+  protected $topLevelCommentType = 'Google_Service_YouTube_Comment';
+  protected $topLevelCommentDataType = '';
+  public $totalReplyCount;
+  public $videoId;
+
+
+  public function setCanReply($canReply)
+  {
+    $this->canReply = $canReply;
+  }
+  public function getCanReply()
+  {
+    return $this->canReply;
+  }
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setIsPublic($isPublic)
+  {
+    $this->isPublic = $isPublic;
+  }
+  public function getIsPublic()
+  {
+    return $this->isPublic;
+  }
+  public function setTopLevelComment(Google_Service_YouTube_Comment $topLevelComment)
+  {
+    $this->topLevelComment = $topLevelComment;
+  }
+  public function getTopLevelComment()
+  {
+    return $this->topLevelComment;
+  }
+  public function setTotalReplyCount($totalReplyCount)
+  {
+    $this->totalReplyCount = $totalReplyCount;
+  }
+  public function getTotalReplyCount()
+  {
+    return $this->totalReplyCount;
+  }
+  public function setVideoId($videoId)
+  {
+    $this->videoId = $videoId;
+  }
+  public function getVideoId()
+  {
+    return $this->videoId;
+  }
+}
+
+class Google_Service_YouTube_ContentRating extends Google_Collection
+{
+  protected $collection_key = 'djctqRatingReasons';
+  protected $internal_gapi_mappings = array(
+  );
+  public $acbRating;
+  public $agcomRating;
+  public $anatelRating;
+  public $bbfcRating;
+  public $bfvcRating;
+  public $bmukkRating;
+  public $catvRating;
+  public $catvfrRating;
+  public $cbfcRating;
+  public $cccRating;
+  public $cceRating;
+  public $chfilmRating;
+  public $chvrsRating;
+  public $cicfRating;
+  public $cnaRating;
+  public $cncRating;
+  public $csaRating;
+  public $cscfRating;
+  public $czfilmRating;
+  public $djctqRating;
+  public $djctqRatingReasons;
+  public $eefilmRating;
+  public $egfilmRating;
+  public $eirinRating;
+  public $fcbmRating;
+  public $fcoRating;
+  public $fmocRating;
+  public $fpbRating;
+  public $fskRating;
+  public $grfilmRating;
+  public $icaaRating;
+  public $ifcoRating;
+  public $ilfilmRating;
+  public $incaaRating;
+  public $kfcbRating;
+  public $kijkwijzerRating;
+  public $kmrbRating;
+  public $lsfRating;
+  public $mccaaRating;
+  public $mccypRating;
+  public $mdaRating;
+  public $medietilsynetRating;
+  public $mekuRating;
+  public $mibacRating;
+  public $mocRating;
+  public $moctwRating;
+  public $mpaaRating;
+  public $mtrcbRating;
+  public $nbcRating;
+  public $nbcplRating;
+  public $nfrcRating;
+  public $nfvcbRating;
+  public $nkclvRating;
+  public $oflcRating;
+  public $pefilmRating;
+  public $rcnofRating;
+  public $resorteviolenciaRating;
+  public $rtcRating;
+  public $rteRating;
+  public $russiaRating;
+  public $skfilmRating;
+  public $smaisRating;
+  public $smsaRating;
+  public $tvpgRating;
+  public $ytRating;
+
+
+  public function setAcbRating($acbRating)
+  {
+    $this->acbRating = $acbRating;
+  }
+  public function getAcbRating()
+  {
+    return $this->acbRating;
+  }
+  public function setAgcomRating($agcomRating)
+  {
+    $this->agcomRating = $agcomRating;
+  }
+  public function getAgcomRating()
+  {
+    return $this->agcomRating;
+  }
+  public function setAnatelRating($anatelRating)
+  {
+    $this->anatelRating = $anatelRating;
+  }
+  public function getAnatelRating()
+  {
+    return $this->anatelRating;
+  }
+  public function setBbfcRating($bbfcRating)
+  {
+    $this->bbfcRating = $bbfcRating;
+  }
+  public function getBbfcRating()
+  {
+    return $this->bbfcRating;
+  }
+  public function setBfvcRating($bfvcRating)
+  {
+    $this->bfvcRating = $bfvcRating;
+  }
+  public function getBfvcRating()
+  {
+    return $this->bfvcRating;
+  }
+  public function setBmukkRating($bmukkRating)
+  {
+    $this->bmukkRating = $bmukkRating;
+  }
+  public function getBmukkRating()
+  {
+    return $this->bmukkRating;
+  }
+  public function setCatvRating($catvRating)
+  {
+    $this->catvRating = $catvRating;
+  }
+  public function getCatvRating()
+  {
+    return $this->catvRating;
+  }
+  public function setCatvfrRating($catvfrRating)
+  {
+    $this->catvfrRating = $catvfrRating;
+  }
+  public function getCatvfrRating()
+  {
+    return $this->catvfrRating;
+  }
+  public function setCbfcRating($cbfcRating)
+  {
+    $this->cbfcRating = $cbfcRating;
+  }
+  public function getCbfcRating()
+  {
+    return $this->cbfcRating;
+  }
+  public function setCccRating($cccRating)
+  {
+    $this->cccRating = $cccRating;
+  }
+  public function getCccRating()
+  {
+    return $this->cccRating;
+  }
+  public function setCceRating($cceRating)
+  {
+    $this->cceRating = $cceRating;
+  }
+  public function getCceRating()
+  {
+    return $this->cceRating;
+  }
+  public function setChfilmRating($chfilmRating)
+  {
+    $this->chfilmRating = $chfilmRating;
+  }
+  public function getChfilmRating()
+  {
+    return $this->chfilmRating;
+  }
+  public function setChvrsRating($chvrsRating)
+  {
+    $this->chvrsRating = $chvrsRating;
+  }
+  public function getChvrsRating()
+  {
+    return $this->chvrsRating;
+  }
+  public function setCicfRating($cicfRating)
+  {
+    $this->cicfRating = $cicfRating;
+  }
+  public function getCicfRating()
+  {
+    return $this->cicfRating;
+  }
+  public function setCnaRating($cnaRating)
+  {
+    $this->cnaRating = $cnaRating;
+  }
+  public function getCnaRating()
+  {
+    return $this->cnaRating;
+  }
+  public function setCncRating($cncRating)
+  {
+    $this->cncRating = $cncRating;
+  }
+  public function getCncRating()
+  {
+    return $this->cncRating;
+  }
+  public function setCsaRating($csaRating)
+  {
+    $this->csaRating = $csaRating;
+  }
+  public function getCsaRating()
+  {
+    return $this->csaRating;
+  }
+  public function setCscfRating($cscfRating)
+  {
+    $this->cscfRating = $cscfRating;
+  }
+  public function getCscfRating()
+  {
+    return $this->cscfRating;
+  }
+  public function setCzfilmRating($czfilmRating)
+  {
+    $this->czfilmRating = $czfilmRating;
+  }
+  public function getCzfilmRating()
+  {
+    return $this->czfilmRating;
+  }
+  public function setDjctqRating($djctqRating)
+  {
+    $this->djctqRating = $djctqRating;
+  }
+  public function getDjctqRating()
+  {
+    return $this->djctqRating;
+  }
+  public function setDjctqRatingReasons($djctqRatingReasons)
+  {
+    $this->djctqRatingReasons = $djctqRatingReasons;
+  }
+  public function getDjctqRatingReasons()
+  {
+    return $this->djctqRatingReasons;
+  }
+  public function setEefilmRating($eefilmRating)
+  {
+    $this->eefilmRating = $eefilmRating;
+  }
+  public function getEefilmRating()
+  {
+    return $this->eefilmRating;
+  }
+  public function setEgfilmRating($egfilmRating)
+  {
+    $this->egfilmRating = $egfilmRating;
+  }
+  public function getEgfilmRating()
+  {
+    return $this->egfilmRating;
+  }
+  public function setEirinRating($eirinRating)
+  {
+    $this->eirinRating = $eirinRating;
+  }
+  public function getEirinRating()
+  {
+    return $this->eirinRating;
+  }
+  public function setFcbmRating($fcbmRating)
+  {
+    $this->fcbmRating = $fcbmRating;
+  }
+  public function getFcbmRating()
+  {
+    return $this->fcbmRating;
+  }
+  public function setFcoRating($fcoRating)
+  {
+    $this->fcoRating = $fcoRating;
+  }
+  public function getFcoRating()
+  {
+    return $this->fcoRating;
+  }
+  public function setFmocRating($fmocRating)
+  {
+    $this->fmocRating = $fmocRating;
+  }
+  public function getFmocRating()
+  {
+    return $this->fmocRating;
+  }
+  public function setFpbRating($fpbRating)
+  {
+    $this->fpbRating = $fpbRating;
+  }
+  public function getFpbRating()
+  {
+    return $this->fpbRating;
+  }
+  public function setFskRating($fskRating)
+  {
+    $this->fskRating = $fskRating;
+  }
+  public function getFskRating()
+  {
+    return $this->fskRating;
+  }
+  public function setGrfilmRating($grfilmRating)
+  {
+    $this->grfilmRating = $grfilmRating;
+  }
+  public function getGrfilmRating()
+  {
+    return $this->grfilmRating;
+  }
+  public function setIcaaRating($icaaRating)
+  {
+    $this->icaaRating = $icaaRating;
+  }
+  public function getIcaaRating()
+  {
+    return $this->icaaRating;
+  }
+  public function setIfcoRating($ifcoRating)
+  {
+    $this->ifcoRating = $ifcoRating;
+  }
+  public function getIfcoRating()
+  {
+    return $this->ifcoRating;
+  }
+  public function setIlfilmRating($ilfilmRating)
+  {
+    $this->ilfilmRating = $ilfilmRating;
+  }
+  public function getIlfilmRating()
+  {
+    return $this->ilfilmRating;
+  }
+  public function setIncaaRating($incaaRating)
+  {
+    $this->incaaRating = $incaaRating;
+  }
+  public function getIncaaRating()
+  {
+    return $this->incaaRating;
+  }
+  public function setKfcbRating($kfcbRating)
+  {
+    $this->kfcbRating = $kfcbRating;
+  }
+  public function getKfcbRating()
+  {
+    return $this->kfcbRating;
+  }
+  public function setKijkwijzerRating($kijkwijzerRating)
+  {
+    $this->kijkwijzerRating = $kijkwijzerRating;
+  }
+  public function getKijkwijzerRating()
+  {
+    return $this->kijkwijzerRating;
+  }
+  public function setKmrbRating($kmrbRating)
+  {
+    $this->kmrbRating = $kmrbRating;
+  }
+  public function getKmrbRating()
+  {
+    return $this->kmrbRating;
+  }
+  public function setLsfRating($lsfRating)
+  {
+    $this->lsfRating = $lsfRating;
+  }
+  public function getLsfRating()
+  {
+    return $this->lsfRating;
+  }
+  public function setMccaaRating($mccaaRating)
+  {
+    $this->mccaaRating = $mccaaRating;
+  }
+  public function getMccaaRating()
+  {
+    return $this->mccaaRating;
+  }
+  public function setMccypRating($mccypRating)
+  {
+    $this->mccypRating = $mccypRating;
+  }
+  public function getMccypRating()
+  {
+    return $this->mccypRating;
+  }
+  public function setMdaRating($mdaRating)
+  {
+    $this->mdaRating = $mdaRating;
+  }
+  public function getMdaRating()
+  {
+    return $this->mdaRating;
+  }
+  public function setMedietilsynetRating($medietilsynetRating)
+  {
+    $this->medietilsynetRating = $medietilsynetRating;
+  }
+  public function getMedietilsynetRating()
+  {
+    return $this->medietilsynetRating;
+  }
+  public function setMekuRating($mekuRating)
+  {
+    $this->mekuRating = $mekuRating;
+  }
+  public function getMekuRating()
+  {
+    return $this->mekuRating;
+  }
+  public function setMibacRating($mibacRating)
+  {
+    $this->mibacRating = $mibacRating;
+  }
+  public function getMibacRating()
+  {
+    return $this->mibacRating;
+  }
+  public function setMocRating($mocRating)
+  {
+    $this->mocRating = $mocRating;
+  }
+  public function getMocRating()
+  {
+    return $this->mocRating;
+  }
+  public function setMoctwRating($moctwRating)
+  {
+    $this->moctwRating = $moctwRating;
+  }
+  public function getMoctwRating()
+  {
+    return $this->moctwRating;
+  }
+  public function setMpaaRating($mpaaRating)
+  {
+    $this->mpaaRating = $mpaaRating;
+  }
+  public function getMpaaRating()
+  {
+    return $this->mpaaRating;
+  }
+  public function setMtrcbRating($mtrcbRating)
+  {
+    $this->mtrcbRating = $mtrcbRating;
+  }
+  public function getMtrcbRating()
+  {
+    return $this->mtrcbRating;
+  }
+  public function setNbcRating($nbcRating)
+  {
+    $this->nbcRating = $nbcRating;
+  }
+  public function getNbcRating()
+  {
+    return $this->nbcRating;
+  }
+  public function setNbcplRating($nbcplRating)
+  {
+    $this->nbcplRating = $nbcplRating;
+  }
+  public function getNbcplRating()
+  {
+    return $this->nbcplRating;
+  }
+  public function setNfrcRating($nfrcRating)
+  {
+    $this->nfrcRating = $nfrcRating;
+  }
+  public function getNfrcRating()
+  {
+    return $this->nfrcRating;
+  }
+  public function setNfvcbRating($nfvcbRating)
+  {
+    $this->nfvcbRating = $nfvcbRating;
+  }
+  public function getNfvcbRating()
+  {
+    return $this->nfvcbRating;
+  }
+  public function setNkclvRating($nkclvRating)
+  {
+    $this->nkclvRating = $nkclvRating;
+  }
+  public function getNkclvRating()
+  {
+    return $this->nkclvRating;
+  }
+  public function setOflcRating($oflcRating)
+  {
+    $this->oflcRating = $oflcRating;
+  }
+  public function getOflcRating()
+  {
+    return $this->oflcRating;
+  }
+  public function setPefilmRating($pefilmRating)
+  {
+    $this->pefilmRating = $pefilmRating;
+  }
+  public function getPefilmRating()
+  {
+    return $this->pefilmRating;
+  }
+  public function setRcnofRating($rcnofRating)
+  {
+    $this->rcnofRating = $rcnofRating;
+  }
+  public function getRcnofRating()
+  {
+    return $this->rcnofRating;
+  }
+  public function setResorteviolenciaRating($resorteviolenciaRating)
+  {
+    $this->resorteviolenciaRating = $resorteviolenciaRating;
+  }
+  public function getResorteviolenciaRating()
+  {
+    return $this->resorteviolenciaRating;
+  }
+  public function setRtcRating($rtcRating)
+  {
+    $this->rtcRating = $rtcRating;
+  }
+  public function getRtcRating()
+  {
+    return $this->rtcRating;
+  }
+  public function setRteRating($rteRating)
+  {
+    $this->rteRating = $rteRating;
+  }
+  public function getRteRating()
+  {
+    return $this->rteRating;
+  }
+  public function setRussiaRating($russiaRating)
+  {
+    $this->russiaRating = $russiaRating;
+  }
+  public function getRussiaRating()
+  {
+    return $this->russiaRating;
+  }
+  public function setSkfilmRating($skfilmRating)
+  {
+    $this->skfilmRating = $skfilmRating;
+  }
+  public function getSkfilmRating()
+  {
+    return $this->skfilmRating;
+  }
+  public function setSmaisRating($smaisRating)
+  {
+    $this->smaisRating = $smaisRating;
+  }
+  public function getSmaisRating()
+  {
+    return $this->smaisRating;
+  }
+  public function setSmsaRating($smsaRating)
+  {
+    $this->smsaRating = $smsaRating;
+  }
+  public function getSmsaRating()
+  {
+    return $this->smsaRating;
+  }
+  public function setTvpgRating($tvpgRating)
+  {
+    $this->tvpgRating = $tvpgRating;
+  }
+  public function getTvpgRating()
+  {
+    return $this->tvpgRating;
+  }
+  public function setYtRating($ytRating)
+  {
+    $this->ytRating = $ytRating;
+  }
+  public function getYtRating()
+  {
+    return $this->ytRating;
+  }
+}
+
+class Google_Service_YouTube_GeoPoint extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $altitude;
+  public $latitude;
+  public $longitude;
+
+
+  public function setAltitude($altitude)
+  {
+    $this->altitude = $altitude;
+  }
+  public function getAltitude()
+  {
+    return $this->altitude;
+  }
+  public function setLatitude($latitude)
+  {
+    $this->latitude = $latitude;
+  }
+  public function getLatitude()
+  {
+    return $this->latitude;
+  }
+  public function setLongitude($longitude)
+  {
+    $this->longitude = $longitude;
+  }
+  public function getLongitude()
+  {
+    return $this->longitude;
+  }
+}
+
+class Google_Service_YouTube_GuideCategory extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $id;
+  public $kind;
+  protected $snippetType = 'Google_Service_YouTube_GuideCategorySnippet';
+  protected $snippetDataType = '';
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSnippet(Google_Service_YouTube_GuideCategorySnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+}
+
+class Google_Service_YouTube_GuideCategoryListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_GuideCategory';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  protected $pageInfoType = 'Google_Service_YouTube_PageInfo';
+  protected $pageInfoDataType = '';
+  public $prevPageToken;
+  protected $tokenPaginationType = 'Google_Service_YouTube_TokenPagination';
+  protected $tokenPaginationDataType = '';
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPageInfo(Google_Service_YouTube_PageInfo $pageInfo)
+  {
+    $this->pageInfo = $pageInfo;
+  }
+  public function getPageInfo()
+  {
+    return $this->pageInfo;
+  }
+  public function setPrevPageToken($prevPageToken)
+  {
+    $this->prevPageToken = $prevPageToken;
+  }
+  public function getPrevPageToken()
+  {
+    return $this->prevPageToken;
+  }
+  public function setTokenPagination(Google_Service_YouTube_TokenPagination $tokenPagination)
+  {
+    $this->tokenPagination = $tokenPagination;
+  }
+  public function getTokenPagination()
+  {
+    return $this->tokenPagination;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_GuideCategorySnippet extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $channelId;
+  public $title;
+
+
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_YouTube_I18nLanguage extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $id;
+  public $kind;
+  protected $snippetType = 'Google_Service_YouTube_I18nLanguageSnippet';
+  protected $snippetDataType = '';
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSnippet(Google_Service_YouTube_I18nLanguageSnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+}
+
+class Google_Service_YouTube_I18nLanguageListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_I18nLanguage';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_I18nLanguageSnippet extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $hl;
+  public $name;
+
+
+  public function setHl($hl)
+  {
+    $this->hl = $hl;
+  }
+  public function getHl()
+  {
+    return $this->hl;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_YouTube_I18nRegion extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $id;
+  public $kind;
+  protected $snippetType = 'Google_Service_YouTube_I18nRegionSnippet';
+  protected $snippetDataType = '';
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSnippet(Google_Service_YouTube_I18nRegionSnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+}
+
+class Google_Service_YouTube_I18nRegionListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_I18nRegion';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_I18nRegionSnippet extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $gl;
+  public $name;
+
+
+  public function setGl($gl)
+  {
+    $this->gl = $gl;
+  }
+  public function getGl()
+  {
+    return $this->gl;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}
+
+class Google_Service_YouTube_ImageSettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $backgroundImageUrlType = 'Google_Service_YouTube_LocalizedProperty';
+  protected $backgroundImageUrlDataType = '';
+  public $bannerExternalUrl;
+  public $bannerImageUrl;
+  public $bannerMobileExtraHdImageUrl;
+  public $bannerMobileHdImageUrl;
+  public $bannerMobileImageUrl;
+  public $bannerMobileLowImageUrl;
+  public $bannerMobileMediumHdImageUrl;
+  public $bannerTabletExtraHdImageUrl;
+  public $bannerTabletHdImageUrl;
+  public $bannerTabletImageUrl;
+  public $bannerTabletLowImageUrl;
+  public $bannerTvHighImageUrl;
+  public $bannerTvImageUrl;
+  public $bannerTvLowImageUrl;
+  public $bannerTvMediumImageUrl;
+  protected $largeBrandedBannerImageImapScriptType = 'Google_Service_YouTube_LocalizedProperty';
+  protected $largeBrandedBannerImageImapScriptDataType = '';
+  protected $largeBrandedBannerImageUrlType = 'Google_Service_YouTube_LocalizedProperty';
+  protected $largeBrandedBannerImageUrlDataType = '';
+  protected $smallBrandedBannerImageImapScriptType = 'Google_Service_YouTube_LocalizedProperty';
+  protected $smallBrandedBannerImageImapScriptDataType = '';
+  protected $smallBrandedBannerImageUrlType = 'Google_Service_YouTube_LocalizedProperty';
+  protected $smallBrandedBannerImageUrlDataType = '';
+  public $trackingImageUrl;
+  public $watchIconImageUrl;
+
+
+  public function setBackgroundImageUrl(Google_Service_YouTube_LocalizedProperty $backgroundImageUrl)
+  {
+    $this->backgroundImageUrl = $backgroundImageUrl;
+  }
+  public function getBackgroundImageUrl()
+  {
+    return $this->backgroundImageUrl;
+  }
+  public function setBannerExternalUrl($bannerExternalUrl)
+  {
+    $this->bannerExternalUrl = $bannerExternalUrl;
+  }
+  public function getBannerExternalUrl()
+  {
+    return $this->bannerExternalUrl;
+  }
+  public function setBannerImageUrl($bannerImageUrl)
+  {
+    $this->bannerImageUrl = $bannerImageUrl;
+  }
+  public function getBannerImageUrl()
+  {
+    return $this->bannerImageUrl;
+  }
+  public function setBannerMobileExtraHdImageUrl($bannerMobileExtraHdImageUrl)
+  {
+    $this->bannerMobileExtraHdImageUrl = $bannerMobileExtraHdImageUrl;
+  }
+  public function getBannerMobileExtraHdImageUrl()
+  {
+    return $this->bannerMobileExtraHdImageUrl;
+  }
+  public function setBannerMobileHdImageUrl($bannerMobileHdImageUrl)
+  {
+    $this->bannerMobileHdImageUrl = $bannerMobileHdImageUrl;
+  }
+  public function getBannerMobileHdImageUrl()
+  {
+    return $this->bannerMobileHdImageUrl;
+  }
+  public function setBannerMobileImageUrl($bannerMobileImageUrl)
+  {
+    $this->bannerMobileImageUrl = $bannerMobileImageUrl;
+  }
+  public function getBannerMobileImageUrl()
+  {
+    return $this->bannerMobileImageUrl;
+  }
+  public function setBannerMobileLowImageUrl($bannerMobileLowImageUrl)
+  {
+    $this->bannerMobileLowImageUrl = $bannerMobileLowImageUrl;
+  }
+  public function getBannerMobileLowImageUrl()
+  {
+    return $this->bannerMobileLowImageUrl;
+  }
+  public function setBannerMobileMediumHdImageUrl($bannerMobileMediumHdImageUrl)
+  {
+    $this->bannerMobileMediumHdImageUrl = $bannerMobileMediumHdImageUrl;
+  }
+  public function getBannerMobileMediumHdImageUrl()
+  {
+    return $this->bannerMobileMediumHdImageUrl;
+  }
+  public function setBannerTabletExtraHdImageUrl($bannerTabletExtraHdImageUrl)
+  {
+    $this->bannerTabletExtraHdImageUrl = $bannerTabletExtraHdImageUrl;
+  }
+  public function getBannerTabletExtraHdImageUrl()
+  {
+    return $this->bannerTabletExtraHdImageUrl;
+  }
+  public function setBannerTabletHdImageUrl($bannerTabletHdImageUrl)
+  {
+    $this->bannerTabletHdImageUrl = $bannerTabletHdImageUrl;
+  }
+  public function getBannerTabletHdImageUrl()
+  {
+    return $this->bannerTabletHdImageUrl;
+  }
+  public function setBannerTabletImageUrl($bannerTabletImageUrl)
+  {
+    $this->bannerTabletImageUrl = $bannerTabletImageUrl;
+  }
+  public function getBannerTabletImageUrl()
+  {
+    return $this->bannerTabletImageUrl;
+  }
+  public function setBannerTabletLowImageUrl($bannerTabletLowImageUrl)
+  {
+    $this->bannerTabletLowImageUrl = $bannerTabletLowImageUrl;
+  }
+  public function getBannerTabletLowImageUrl()
+  {
+    return $this->bannerTabletLowImageUrl;
+  }
+  public function setBannerTvHighImageUrl($bannerTvHighImageUrl)
+  {
+    $this->bannerTvHighImageUrl = $bannerTvHighImageUrl;
+  }
+  public function getBannerTvHighImageUrl()
+  {
+    return $this->bannerTvHighImageUrl;
+  }
+  public function setBannerTvImageUrl($bannerTvImageUrl)
+  {
+    $this->bannerTvImageUrl = $bannerTvImageUrl;
+  }
+  public function getBannerTvImageUrl()
+  {
+    return $this->bannerTvImageUrl;
+  }
+  public function setBannerTvLowImageUrl($bannerTvLowImageUrl)
+  {
+    $this->bannerTvLowImageUrl = $bannerTvLowImageUrl;
+  }
+  public function getBannerTvLowImageUrl()
+  {
+    return $this->bannerTvLowImageUrl;
+  }
+  public function setBannerTvMediumImageUrl($bannerTvMediumImageUrl)
+  {
+    $this->bannerTvMediumImageUrl = $bannerTvMediumImageUrl;
+  }
+  public function getBannerTvMediumImageUrl()
+  {
+    return $this->bannerTvMediumImageUrl;
+  }
+  public function setLargeBrandedBannerImageImapScript(Google_Service_YouTube_LocalizedProperty $largeBrandedBannerImageImapScript)
+  {
+    $this->largeBrandedBannerImageImapScript = $largeBrandedBannerImageImapScript;
+  }
+  public function getLargeBrandedBannerImageImapScript()
+  {
+    return $this->largeBrandedBannerImageImapScript;
+  }
+  public function setLargeBrandedBannerImageUrl(Google_Service_YouTube_LocalizedProperty $largeBrandedBannerImageUrl)
+  {
+    $this->largeBrandedBannerImageUrl = $largeBrandedBannerImageUrl;
+  }
+  public function getLargeBrandedBannerImageUrl()
+  {
+    return $this->largeBrandedBannerImageUrl;
+  }
+  public function setSmallBrandedBannerImageImapScript(Google_Service_YouTube_LocalizedProperty $smallBrandedBannerImageImapScript)
+  {
+    $this->smallBrandedBannerImageImapScript = $smallBrandedBannerImageImapScript;
+  }
+  public function getSmallBrandedBannerImageImapScript()
+  {
+    return $this->smallBrandedBannerImageImapScript;
+  }
+  public function setSmallBrandedBannerImageUrl(Google_Service_YouTube_LocalizedProperty $smallBrandedBannerImageUrl)
+  {
+    $this->smallBrandedBannerImageUrl = $smallBrandedBannerImageUrl;
+  }
+  public function getSmallBrandedBannerImageUrl()
+  {
+    return $this->smallBrandedBannerImageUrl;
+  }
+  public function setTrackingImageUrl($trackingImageUrl)
+  {
+    $this->trackingImageUrl = $trackingImageUrl;
+  }
+  public function getTrackingImageUrl()
+  {
+    return $this->trackingImageUrl;
+  }
+  public function setWatchIconImageUrl($watchIconImageUrl)
+  {
+    $this->watchIconImageUrl = $watchIconImageUrl;
+  }
+  public function getWatchIconImageUrl()
+  {
+    return $this->watchIconImageUrl;
+  }
+}
+
+class Google_Service_YouTube_IngestionInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $backupIngestionAddress;
+  public $ingestionAddress;
+  public $streamName;
+
+
+  public function setBackupIngestionAddress($backupIngestionAddress)
+  {
+    $this->backupIngestionAddress = $backupIngestionAddress;
+  }
+  public function getBackupIngestionAddress()
+  {
+    return $this->backupIngestionAddress;
+  }
+  public function setIngestionAddress($ingestionAddress)
+  {
+    $this->ingestionAddress = $ingestionAddress;
+  }
+  public function getIngestionAddress()
+  {
+    return $this->ingestionAddress;
+  }
+  public function setStreamName($streamName)
+  {
+    $this->streamName = $streamName;
+  }
+  public function getStreamName()
+  {
+    return $this->streamName;
+  }
+}
+
+class Google_Service_YouTube_InvideoBranding extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $imageBytes;
+  public $imageUrl;
+  protected $positionType = 'Google_Service_YouTube_InvideoPosition';
+  protected $positionDataType = '';
+  public $targetChannelId;
+  protected $timingType = 'Google_Service_YouTube_InvideoTiming';
+  protected $timingDataType = '';
+
+
+  public function setImageBytes($imageBytes)
+  {
+    $this->imageBytes = $imageBytes;
+  }
+  public function getImageBytes()
+  {
+    return $this->imageBytes;
+  }
+  public function setImageUrl($imageUrl)
+  {
+    $this->imageUrl = $imageUrl;
+  }
+  public function getImageUrl()
+  {
+    return $this->imageUrl;
+  }
+  public function setPosition(Google_Service_YouTube_InvideoPosition $position)
+  {
+    $this->position = $position;
+  }
+  public function getPosition()
+  {
+    return $this->position;
+  }
+  public function setTargetChannelId($targetChannelId)
+  {
+    $this->targetChannelId = $targetChannelId;
+  }
+  public function getTargetChannelId()
+  {
+    return $this->targetChannelId;
+  }
+  public function setTiming(Google_Service_YouTube_InvideoTiming $timing)
+  {
+    $this->timing = $timing;
+  }
+  public function getTiming()
+  {
+    return $this->timing;
+  }
+}
+
+class Google_Service_YouTube_InvideoPosition extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $cornerPosition;
+  public $type;
+
+
+  public function setCornerPosition($cornerPosition)
+  {
+    $this->cornerPosition = $cornerPosition;
+  }
+  public function getCornerPosition()
+  {
+    return $this->cornerPosition;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_YouTube_InvideoPromotion extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $defaultTimingType = 'Google_Service_YouTube_InvideoTiming';
+  protected $defaultTimingDataType = '';
+  protected $itemsType = 'Google_Service_YouTube_PromotedItem';
+  protected $itemsDataType = 'array';
+  protected $positionType = 'Google_Service_YouTube_InvideoPosition';
+  protected $positionDataType = '';
+  public $useSmartTiming;
+
+
+  public function setDefaultTiming(Google_Service_YouTube_InvideoTiming $defaultTiming)
+  {
+    $this->defaultTiming = $defaultTiming;
+  }
+  public function getDefaultTiming()
+  {
+    return $this->defaultTiming;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setPosition(Google_Service_YouTube_InvideoPosition $position)
+  {
+    $this->position = $position;
+  }
+  public function getPosition()
+  {
+    return $this->position;
+  }
+  public function setUseSmartTiming($useSmartTiming)
+  {
+    $this->useSmartTiming = $useSmartTiming;
+  }
+  public function getUseSmartTiming()
+  {
+    return $this->useSmartTiming;
+  }
+}
+
+class Google_Service_YouTube_InvideoTiming extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $durationMs;
+  public $offsetMs;
+  public $type;
+
+
+  public function setDurationMs($durationMs)
+  {
+    $this->durationMs = $durationMs;
+  }
+  public function getDurationMs()
+  {
+    return $this->durationMs;
+  }
+  public function setOffsetMs($offsetMs)
+  {
+    $this->offsetMs = $offsetMs;
+  }
+  public function getOffsetMs()
+  {
+    return $this->offsetMs;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_YouTube_LanguageTag extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $value;
+
+
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_YouTube_LiveBroadcast extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $contentDetailsType = 'Google_Service_YouTube_LiveBroadcastContentDetails';
+  protected $contentDetailsDataType = '';
+  public $etag;
+  public $id;
+  public $kind;
+  protected $snippetType = 'Google_Service_YouTube_LiveBroadcastSnippet';
+  protected $snippetDataType = '';
+  protected $statisticsType = 'Google_Service_YouTube_LiveBroadcastStatistics';
+  protected $statisticsDataType = '';
+  protected $statusType = 'Google_Service_YouTube_LiveBroadcastStatus';
+  protected $statusDataType = '';
+  protected $topicDetailsType = 'Google_Service_YouTube_LiveBroadcastTopicDetails';
+  protected $topicDetailsDataType = '';
+
+
+  public function setContentDetails(Google_Service_YouTube_LiveBroadcastContentDetails $contentDetails)
+  {
+    $this->contentDetails = $contentDetails;
+  }
+  public function getContentDetails()
+  {
+    return $this->contentDetails;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSnippet(Google_Service_YouTube_LiveBroadcastSnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+  public function setStatistics(Google_Service_YouTube_LiveBroadcastStatistics $statistics)
+  {
+    $this->statistics = $statistics;
+  }
+  public function getStatistics()
+  {
+    return $this->statistics;
+  }
+  public function setStatus(Google_Service_YouTube_LiveBroadcastStatus $status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setTopicDetails(Google_Service_YouTube_LiveBroadcastTopicDetails $topicDetails)
+  {
+    $this->topicDetails = $topicDetails;
+  }
+  public function getTopicDetails()
+  {
+    return $this->topicDetails;
+  }
+}
+
+class Google_Service_YouTube_LiveBroadcastContentDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $boundStreamId;
+  public $enableClosedCaptions;
+  public $enableContentEncryption;
+  public $enableDvr;
+  public $enableEmbed;
+  public $enableLowLatency;
+  protected $monitorStreamType = 'Google_Service_YouTube_MonitorStreamInfo';
+  protected $monitorStreamDataType = '';
+  public $recordFromStart;
+  public $startWithSlate;
+
+
+  public function setBoundStreamId($boundStreamId)
+  {
+    $this->boundStreamId = $boundStreamId;
+  }
+  public function getBoundStreamId()
+  {
+    return $this->boundStreamId;
+  }
+  public function setEnableClosedCaptions($enableClosedCaptions)
+  {
+    $this->enableClosedCaptions = $enableClosedCaptions;
+  }
+  public function getEnableClosedCaptions()
+  {
+    return $this->enableClosedCaptions;
+  }
+  public function setEnableContentEncryption($enableContentEncryption)
+  {
+    $this->enableContentEncryption = $enableContentEncryption;
+  }
+  public function getEnableContentEncryption()
+  {
+    return $this->enableContentEncryption;
+  }
+  public function setEnableDvr($enableDvr)
+  {
+    $this->enableDvr = $enableDvr;
+  }
+  public function getEnableDvr()
+  {
+    return $this->enableDvr;
+  }
+  public function setEnableEmbed($enableEmbed)
+  {
+    $this->enableEmbed = $enableEmbed;
+  }
+  public function getEnableEmbed()
+  {
+    return $this->enableEmbed;
+  }
+  public function setEnableLowLatency($enableLowLatency)
+  {
+    $this->enableLowLatency = $enableLowLatency;
+  }
+  public function getEnableLowLatency()
+  {
+    return $this->enableLowLatency;
+  }
+  public function setMonitorStream(Google_Service_YouTube_MonitorStreamInfo $monitorStream)
+  {
+    $this->monitorStream = $monitorStream;
+  }
+  public function getMonitorStream()
+  {
+    return $this->monitorStream;
+  }
+  public function setRecordFromStart($recordFromStart)
+  {
+    $this->recordFromStart = $recordFromStart;
+  }
+  public function getRecordFromStart()
+  {
+    return $this->recordFromStart;
+  }
+  public function setStartWithSlate($startWithSlate)
+  {
+    $this->startWithSlate = $startWithSlate;
+  }
+  public function getStartWithSlate()
+  {
+    return $this->startWithSlate;
+  }
+}
+
+class Google_Service_YouTube_LiveBroadcastListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_LiveBroadcast';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  protected $pageInfoType = 'Google_Service_YouTube_PageInfo';
+  protected $pageInfoDataType = '';
+  public $prevPageToken;
+  protected $tokenPaginationType = 'Google_Service_YouTube_TokenPagination';
+  protected $tokenPaginationDataType = '';
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPageInfo(Google_Service_YouTube_PageInfo $pageInfo)
+  {
+    $this->pageInfo = $pageInfo;
+  }
+  public function getPageInfo()
+  {
+    return $this->pageInfo;
+  }
+  public function setPrevPageToken($prevPageToken)
+  {
+    $this->prevPageToken = $prevPageToken;
+  }
+  public function getPrevPageToken()
+  {
+    return $this->prevPageToken;
+  }
+  public function setTokenPagination(Google_Service_YouTube_TokenPagination $tokenPagination)
+  {
+    $this->tokenPagination = $tokenPagination;
+  }
+  public function getTokenPagination()
+  {
+    return $this->tokenPagination;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_LiveBroadcastSnippet extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $actualEndTime;
+  public $actualStartTime;
+  public $channelId;
+  public $description;
+  public $isDefaultBroadcast;
+  public $liveChatId;
+  public $publishedAt;
+  public $scheduledEndTime;
+  public $scheduledStartTime;
+  protected $thumbnailsType = 'Google_Service_YouTube_ThumbnailDetails';
+  protected $thumbnailsDataType = '';
+  public $title;
+
+
+  public function setActualEndTime($actualEndTime)
+  {
+    $this->actualEndTime = $actualEndTime;
+  }
+  public function getActualEndTime()
+  {
+    return $this->actualEndTime;
+  }
+  public function setActualStartTime($actualStartTime)
+  {
+    $this->actualStartTime = $actualStartTime;
+  }
+  public function getActualStartTime()
+  {
+    return $this->actualStartTime;
+  }
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setIsDefaultBroadcast($isDefaultBroadcast)
+  {
+    $this->isDefaultBroadcast = $isDefaultBroadcast;
+  }
+  public function getIsDefaultBroadcast()
+  {
+    return $this->isDefaultBroadcast;
+  }
+  public function setLiveChatId($liveChatId)
+  {
+    $this->liveChatId = $liveChatId;
+  }
+  public function getLiveChatId()
+  {
+    return $this->liveChatId;
+  }
+  public function setPublishedAt($publishedAt)
+  {
+    $this->publishedAt = $publishedAt;
+  }
+  public function getPublishedAt()
+  {
+    return $this->publishedAt;
+  }
+  public function setScheduledEndTime($scheduledEndTime)
+  {
+    $this->scheduledEndTime = $scheduledEndTime;
+  }
+  public function getScheduledEndTime()
+  {
+    return $this->scheduledEndTime;
+  }
+  public function setScheduledStartTime($scheduledStartTime)
+  {
+    $this->scheduledStartTime = $scheduledStartTime;
+  }
+  public function getScheduledStartTime()
+  {
+    return $this->scheduledStartTime;
+  }
+  public function setThumbnails(Google_Service_YouTube_ThumbnailDetails $thumbnails)
+  {
+    $this->thumbnails = $thumbnails;
+  }
+  public function getThumbnails()
+  {
+    return $this->thumbnails;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_YouTube_LiveBroadcastStatistics extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $concurrentViewers;
+  public $totalChatCount;
+
+
+  public function setConcurrentViewers($concurrentViewers)
+  {
+    $this->concurrentViewers = $concurrentViewers;
+  }
+  public function getConcurrentViewers()
+  {
+    return $this->concurrentViewers;
+  }
+  public function setTotalChatCount($totalChatCount)
+  {
+    $this->totalChatCount = $totalChatCount;
+  }
+  public function getTotalChatCount()
+  {
+    return $this->totalChatCount;
+  }
+}
+
+class Google_Service_YouTube_LiveBroadcastStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $lifeCycleStatus;
+  public $liveBroadcastPriority;
+  public $privacyStatus;
+  public $recordingStatus;
+
+
+  public function setLifeCycleStatus($lifeCycleStatus)
+  {
+    $this->lifeCycleStatus = $lifeCycleStatus;
+  }
+  public function getLifeCycleStatus()
+  {
+    return $this->lifeCycleStatus;
+  }
+  public function setLiveBroadcastPriority($liveBroadcastPriority)
+  {
+    $this->liveBroadcastPriority = $liveBroadcastPriority;
+  }
+  public function getLiveBroadcastPriority()
+  {
+    return $this->liveBroadcastPriority;
+  }
+  public function setPrivacyStatus($privacyStatus)
+  {
+    $this->privacyStatus = $privacyStatus;
+  }
+  public function getPrivacyStatus()
+  {
+    return $this->privacyStatus;
+  }
+  public function setRecordingStatus($recordingStatus)
+  {
+    $this->recordingStatus = $recordingStatus;
+  }
+  public function getRecordingStatus()
+  {
+    return $this->recordingStatus;
+  }
+}
+
+class Google_Service_YouTube_LiveBroadcastTopic extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $snippetType = 'Google_Service_YouTube_LiveBroadcastTopicSnippet';
+  protected $snippetDataType = '';
+  public $type;
+  public $unmatched;
+
+
+  public function setSnippet(Google_Service_YouTube_LiveBroadcastTopicSnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setUnmatched($unmatched)
+  {
+    $this->unmatched = $unmatched;
+  }
+  public function getUnmatched()
+  {
+    return $this->unmatched;
+  }
+}
+
+class Google_Service_YouTube_LiveBroadcastTopicDetails extends Google_Collection
+{
+  protected $collection_key = 'topics';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $topicsType = 'Google_Service_YouTube_LiveBroadcastTopic';
+  protected $topicsDataType = 'array';
+
+
+  public function setTopics($topics)
+  {
+    $this->topics = $topics;
+  }
+  public function getTopics()
+  {
+    return $this->topics;
+  }
+}
+
+class Google_Service_YouTube_LiveBroadcastTopicSnippet extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $name;
+  public $releaseDate;
+
+
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setReleaseDate($releaseDate)
+  {
+    $this->releaseDate = $releaseDate;
+  }
+  public function getReleaseDate()
+  {
+    return $this->releaseDate;
+  }
+}
+
+class Google_Service_YouTube_LiveStream extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $cdnType = 'Google_Service_YouTube_CdnSettings';
+  protected $cdnDataType = '';
+  protected $contentDetailsType = 'Google_Service_YouTube_LiveStreamContentDetails';
+  protected $contentDetailsDataType = '';
+  public $etag;
+  public $id;
+  public $kind;
+  protected $snippetType = 'Google_Service_YouTube_LiveStreamSnippet';
+  protected $snippetDataType = '';
+  protected $statusType = 'Google_Service_YouTube_LiveStreamStatus';
+  protected $statusDataType = '';
+
+
+  public function setCdn(Google_Service_YouTube_CdnSettings $cdn)
+  {
+    $this->cdn = $cdn;
+  }
+  public function getCdn()
+  {
+    return $this->cdn;
+  }
+  public function setContentDetails(Google_Service_YouTube_LiveStreamContentDetails $contentDetails)
+  {
+    $this->contentDetails = $contentDetails;
+  }
+  public function getContentDetails()
+  {
+    return $this->contentDetails;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSnippet(Google_Service_YouTube_LiveStreamSnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+  public function setStatus(Google_Service_YouTube_LiveStreamStatus $status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_YouTube_LiveStreamConfigurationIssue extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $reason;
+  public $severity;
+  public $type;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setReason($reason)
+  {
+    $this->reason = $reason;
+  }
+  public function getReason()
+  {
+    return $this->reason;
+  }
+  public function setSeverity($severity)
+  {
+    $this->severity = $severity;
+  }
+  public function getSeverity()
+  {
+    return $this->severity;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_YouTube_LiveStreamContentDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $closedCaptionsIngestionUrl;
+  public $isReusable;
+
+
+  public function setClosedCaptionsIngestionUrl($closedCaptionsIngestionUrl)
+  {
+    $this->closedCaptionsIngestionUrl = $closedCaptionsIngestionUrl;
+  }
+  public function getClosedCaptionsIngestionUrl()
+  {
+    return $this->closedCaptionsIngestionUrl;
+  }
+  public function setIsReusable($isReusable)
+  {
+    $this->isReusable = $isReusable;
+  }
+  public function getIsReusable()
+  {
+    return $this->isReusable;
+  }
+}
+
+class Google_Service_YouTube_LiveStreamHealthStatus extends Google_Collection
+{
+  protected $collection_key = 'configurationIssues';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $configurationIssuesType = 'Google_Service_YouTube_LiveStreamConfigurationIssue';
+  protected $configurationIssuesDataType = 'array';
+  public $lastUpdateTimeSeconds;
+  public $status;
+
+
+  public function setConfigurationIssues($configurationIssues)
+  {
+    $this->configurationIssues = $configurationIssues;
+  }
+  public function getConfigurationIssues()
+  {
+    return $this->configurationIssues;
+  }
+  public function setLastUpdateTimeSeconds($lastUpdateTimeSeconds)
+  {
+    $this->lastUpdateTimeSeconds = $lastUpdateTimeSeconds;
+  }
+  public function getLastUpdateTimeSeconds()
+  {
+    return $this->lastUpdateTimeSeconds;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_YouTube_LiveStreamListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_LiveStream';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  protected $pageInfoType = 'Google_Service_YouTube_PageInfo';
+  protected $pageInfoDataType = '';
+  public $prevPageToken;
+  protected $tokenPaginationType = 'Google_Service_YouTube_TokenPagination';
+  protected $tokenPaginationDataType = '';
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPageInfo(Google_Service_YouTube_PageInfo $pageInfo)
+  {
+    $this->pageInfo = $pageInfo;
+  }
+  public function getPageInfo()
+  {
+    return $this->pageInfo;
+  }
+  public function setPrevPageToken($prevPageToken)
+  {
+    $this->prevPageToken = $prevPageToken;
+  }
+  public function getPrevPageToken()
+  {
+    return $this->prevPageToken;
+  }
+  public function setTokenPagination(Google_Service_YouTube_TokenPagination $tokenPagination)
+  {
+    $this->tokenPagination = $tokenPagination;
+  }
+  public function getTokenPagination()
+  {
+    return $this->tokenPagination;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_LiveStreamSnippet extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $channelId;
+  public $description;
+  public $isDefaultStream;
+  public $publishedAt;
+  public $title;
+
+
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setIsDefaultStream($isDefaultStream)
+  {
+    $this->isDefaultStream = $isDefaultStream;
+  }
+  public function getIsDefaultStream()
+  {
+    return $this->isDefaultStream;
+  }
+  public function setPublishedAt($publishedAt)
+  {
+    $this->publishedAt = $publishedAt;
+  }
+  public function getPublishedAt()
+  {
+    return $this->publishedAt;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_YouTube_LiveStreamStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $healthStatusType = 'Google_Service_YouTube_LiveStreamHealthStatus';
+  protected $healthStatusDataType = '';
+  public $streamStatus;
+
+
+  public function setHealthStatus(Google_Service_YouTube_LiveStreamHealthStatus $healthStatus)
+  {
+    $this->healthStatus = $healthStatus;
+  }
+  public function getHealthStatus()
+  {
+    return $this->healthStatus;
+  }
+  public function setStreamStatus($streamStatus)
+  {
+    $this->streamStatus = $streamStatus;
+  }
+  public function getStreamStatus()
+  {
+    return $this->streamStatus;
+  }
+}
+
+class Google_Service_YouTube_LocalizedProperty extends Google_Collection
+{
+  protected $collection_key = 'localized';
+  protected $internal_gapi_mappings = array(
+  );
+  public $default;
+  protected $defaultLanguageType = 'Google_Service_YouTube_LanguageTag';
+  protected $defaultLanguageDataType = '';
+  protected $localizedType = 'Google_Service_YouTube_LocalizedString';
+  protected $localizedDataType = 'array';
+
+
+  public function setDefault($default)
+  {
+    $this->default = $default;
+  }
+  public function getDefault()
+  {
+    return $this->default;
+  }
+  public function setDefaultLanguage(Google_Service_YouTube_LanguageTag $defaultLanguage)
+  {
+    $this->defaultLanguage = $defaultLanguage;
+  }
+  public function getDefaultLanguage()
+  {
+    return $this->defaultLanguage;
+  }
+  public function setLocalized($localized)
+  {
+    $this->localized = $localized;
+  }
+  public function getLocalized()
+  {
+    return $this->localized;
+  }
+}
+
+class Google_Service_YouTube_LocalizedString extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $language;
+  public $value;
+
+
+  public function setLanguage($language)
+  {
+    $this->language = $language;
+  }
+  public function getLanguage()
+  {
+    return $this->language;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_YouTube_MonitorStreamInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $broadcastStreamDelayMs;
+  public $embedHtml;
+  public $enableMonitorStream;
+
+
+  public function setBroadcastStreamDelayMs($broadcastStreamDelayMs)
+  {
+    $this->broadcastStreamDelayMs = $broadcastStreamDelayMs;
+  }
+  public function getBroadcastStreamDelayMs()
+  {
+    return $this->broadcastStreamDelayMs;
+  }
+  public function setEmbedHtml($embedHtml)
+  {
+    $this->embedHtml = $embedHtml;
+  }
+  public function getEmbedHtml()
+  {
+    return $this->embedHtml;
+  }
+  public function setEnableMonitorStream($enableMonitorStream)
+  {
+    $this->enableMonitorStream = $enableMonitorStream;
+  }
+  public function getEnableMonitorStream()
+  {
+    return $this->enableMonitorStream;
+  }
+}
+
+class Google_Service_YouTube_PageInfo extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $resultsPerPage;
+  public $totalResults;
+
+
+  public function setResultsPerPage($resultsPerPage)
+  {
+    $this->resultsPerPage = $resultsPerPage;
+  }
+  public function getResultsPerPage()
+  {
+    return $this->resultsPerPage;
+  }
+  public function setTotalResults($totalResults)
+  {
+    $this->totalResults = $totalResults;
+  }
+  public function getTotalResults()
+  {
+    return $this->totalResults;
+  }
+}
+
+class Google_Service_YouTube_Playlist extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $contentDetailsType = 'Google_Service_YouTube_PlaylistContentDetails';
+  protected $contentDetailsDataType = '';
+  public $etag;
+  public $id;
+  public $kind;
+  protected $localizationsType = 'Google_Service_YouTube_PlaylistLocalization';
+  protected $localizationsDataType = 'map';
+  protected $playerType = 'Google_Service_YouTube_PlaylistPlayer';
+  protected $playerDataType = '';
+  protected $snippetType = 'Google_Service_YouTube_PlaylistSnippet';
+  protected $snippetDataType = '';
+  protected $statusType = 'Google_Service_YouTube_PlaylistStatus';
+  protected $statusDataType = '';
+
+
+  public function setContentDetails(Google_Service_YouTube_PlaylistContentDetails $contentDetails)
+  {
+    $this->contentDetails = $contentDetails;
+  }
+  public function getContentDetails()
+  {
+    return $this->contentDetails;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLocalizations($localizations)
+  {
+    $this->localizations = $localizations;
+  }
+  public function getLocalizations()
+  {
+    return $this->localizations;
+  }
+  public function setPlayer(Google_Service_YouTube_PlaylistPlayer $player)
+  {
+    $this->player = $player;
+  }
+  public function getPlayer()
+  {
+    return $this->player;
+  }
+  public function setSnippet(Google_Service_YouTube_PlaylistSnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+  public function setStatus(Google_Service_YouTube_PlaylistStatus $status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_YouTube_PlaylistContentDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $itemCount;
+
+
+  public function setItemCount($itemCount)
+  {
+    $this->itemCount = $itemCount;
+  }
+  public function getItemCount()
+  {
+    return $this->itemCount;
+  }
+}
+
+class Google_Service_YouTube_PlaylistItem extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $contentDetailsType = 'Google_Service_YouTube_PlaylistItemContentDetails';
+  protected $contentDetailsDataType = '';
+  public $etag;
+  public $id;
+  public $kind;
+  protected $snippetType = 'Google_Service_YouTube_PlaylistItemSnippet';
+  protected $snippetDataType = '';
+  protected $statusType = 'Google_Service_YouTube_PlaylistItemStatus';
+  protected $statusDataType = '';
+
+
+  public function setContentDetails(Google_Service_YouTube_PlaylistItemContentDetails $contentDetails)
+  {
+    $this->contentDetails = $contentDetails;
+  }
+  public function getContentDetails()
+  {
+    return $this->contentDetails;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSnippet(Google_Service_YouTube_PlaylistItemSnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+  public function setStatus(Google_Service_YouTube_PlaylistItemStatus $status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+class Google_Service_YouTube_PlaylistItemContentDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $endAt;
+  public $note;
+  public $startAt;
+  public $videoId;
+
+
+  public function setEndAt($endAt)
+  {
+    $this->endAt = $endAt;
+  }
+  public function getEndAt()
+  {
+    return $this->endAt;
+  }
+  public function setNote($note)
+  {
+    $this->note = $note;
+  }
+  public function getNote()
+  {
+    return $this->note;
+  }
+  public function setStartAt($startAt)
+  {
+    $this->startAt = $startAt;
+  }
+  public function getStartAt()
+  {
+    return $this->startAt;
+  }
+  public function setVideoId($videoId)
+  {
+    $this->videoId = $videoId;
+  }
+  public function getVideoId()
+  {
+    return $this->videoId;
+  }
+}
+
+class Google_Service_YouTube_PlaylistItemListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_PlaylistItem';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  protected $pageInfoType = 'Google_Service_YouTube_PageInfo';
+  protected $pageInfoDataType = '';
+  public $prevPageToken;
+  protected $tokenPaginationType = 'Google_Service_YouTube_TokenPagination';
+  protected $tokenPaginationDataType = '';
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPageInfo(Google_Service_YouTube_PageInfo $pageInfo)
+  {
+    $this->pageInfo = $pageInfo;
+  }
+  public function getPageInfo()
+  {
+    return $this->pageInfo;
+  }
+  public function setPrevPageToken($prevPageToken)
+  {
+    $this->prevPageToken = $prevPageToken;
+  }
+  public function getPrevPageToken()
+  {
+    return $this->prevPageToken;
+  }
+  public function setTokenPagination(Google_Service_YouTube_TokenPagination $tokenPagination)
+  {
+    $this->tokenPagination = $tokenPagination;
+  }
+  public function getTokenPagination()
+  {
+    return $this->tokenPagination;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_PlaylistItemSnippet extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $channelId;
+  public $channelTitle;
+  public $description;
+  public $playlistId;
+  public $position;
+  public $publishedAt;
+  protected $resourceIdType = 'Google_Service_YouTube_ResourceId';
+  protected $resourceIdDataType = '';
+  protected $thumbnailsType = 'Google_Service_YouTube_ThumbnailDetails';
+  protected $thumbnailsDataType = '';
+  public $title;
+
+
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setChannelTitle($channelTitle)
+  {
+    $this->channelTitle = $channelTitle;
+  }
+  public function getChannelTitle()
+  {
+    return $this->channelTitle;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setPlaylistId($playlistId)
+  {
+    $this->playlistId = $playlistId;
+  }
+  public function getPlaylistId()
+  {
+    return $this->playlistId;
+  }
+  public function setPosition($position)
+  {
+    $this->position = $position;
+  }
+  public function getPosition()
+  {
+    return $this->position;
+  }
+  public function setPublishedAt($publishedAt)
+  {
+    $this->publishedAt = $publishedAt;
+  }
+  public function getPublishedAt()
+  {
+    return $this->publishedAt;
+  }
+  public function setResourceId(Google_Service_YouTube_ResourceId $resourceId)
+  {
+    $this->resourceId = $resourceId;
+  }
+  public function getResourceId()
+  {
+    return $this->resourceId;
+  }
+  public function setThumbnails(Google_Service_YouTube_ThumbnailDetails $thumbnails)
+  {
+    $this->thumbnails = $thumbnails;
+  }
+  public function getThumbnails()
+  {
+    return $this->thumbnails;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_YouTube_PlaylistItemStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $privacyStatus;
+
+
+  public function setPrivacyStatus($privacyStatus)
+  {
+    $this->privacyStatus = $privacyStatus;
+  }
+  public function getPrivacyStatus()
+  {
+    return $this->privacyStatus;
+  }
+}
+
+class Google_Service_YouTube_PlaylistListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_Playlist';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  protected $pageInfoType = 'Google_Service_YouTube_PageInfo';
+  protected $pageInfoDataType = '';
+  public $prevPageToken;
+  protected $tokenPaginationType = 'Google_Service_YouTube_TokenPagination';
+  protected $tokenPaginationDataType = '';
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPageInfo(Google_Service_YouTube_PageInfo $pageInfo)
+  {
+    $this->pageInfo = $pageInfo;
+  }
+  public function getPageInfo()
+  {
+    return $this->pageInfo;
+  }
+  public function setPrevPageToken($prevPageToken)
+  {
+    $this->prevPageToken = $prevPageToken;
+  }
+  public function getPrevPageToken()
+  {
+    return $this->prevPageToken;
+  }
+  public function setTokenPagination(Google_Service_YouTube_TokenPagination $tokenPagination)
+  {
+    $this->tokenPagination = $tokenPagination;
+  }
+  public function getTokenPagination()
+  {
+    return $this->tokenPagination;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_PlaylistLocalization extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $title;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_YouTube_PlaylistLocalizations extends Google_Model
+{
+}
+
+class Google_Service_YouTube_PlaylistPlayer extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $embedHtml;
+
+
+  public function setEmbedHtml($embedHtml)
+  {
+    $this->embedHtml = $embedHtml;
+  }
+  public function getEmbedHtml()
+  {
+    return $this->embedHtml;
+  }
+}
+
+class Google_Service_YouTube_PlaylistSnippet extends Google_Collection
+{
+  protected $collection_key = 'tags';
+  protected $internal_gapi_mappings = array(
+  );
+  public $channelId;
+  public $channelTitle;
+  public $defaultLanguage;
+  public $description;
+  protected $localizedType = 'Google_Service_YouTube_PlaylistLocalization';
+  protected $localizedDataType = '';
+  public $publishedAt;
+  public $tags;
+  protected $thumbnailsType = 'Google_Service_YouTube_ThumbnailDetails';
+  protected $thumbnailsDataType = '';
+  public $title;
+
+
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setChannelTitle($channelTitle)
+  {
+    $this->channelTitle = $channelTitle;
+  }
+  public function getChannelTitle()
+  {
+    return $this->channelTitle;
+  }
+  public function setDefaultLanguage($defaultLanguage)
+  {
+    $this->defaultLanguage = $defaultLanguage;
+  }
+  public function getDefaultLanguage()
+  {
+    return $this->defaultLanguage;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setLocalized(Google_Service_YouTube_PlaylistLocalization $localized)
+  {
+    $this->localized = $localized;
+  }
+  public function getLocalized()
+  {
+    return $this->localized;
+  }
+  public function setPublishedAt($publishedAt)
+  {
+    $this->publishedAt = $publishedAt;
+  }
+  public function getPublishedAt()
+  {
+    return $this->publishedAt;
+  }
+  public function setTags($tags)
+  {
+    $this->tags = $tags;
+  }
+  public function getTags()
+  {
+    return $this->tags;
+  }
+  public function setThumbnails(Google_Service_YouTube_ThumbnailDetails $thumbnails)
+  {
+    $this->thumbnails = $thumbnails;
+  }
+  public function getThumbnails()
+  {
+    return $this->thumbnails;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_YouTube_PlaylistStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $privacyStatus;
+
+
+  public function setPrivacyStatus($privacyStatus)
+  {
+    $this->privacyStatus = $privacyStatus;
+  }
+  public function getPrivacyStatus()
+  {
+    return $this->privacyStatus;
+  }
+}
+
+class Google_Service_YouTube_PromotedItem extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $customMessage;
+  protected $idType = 'Google_Service_YouTube_PromotedItemId';
+  protected $idDataType = '';
+  public $promotedByContentOwner;
+  protected $timingType = 'Google_Service_YouTube_InvideoTiming';
+  protected $timingDataType = '';
+
+
+  public function setCustomMessage($customMessage)
+  {
+    $this->customMessage = $customMessage;
+  }
+  public function getCustomMessage()
+  {
+    return $this->customMessage;
+  }
+  public function setId(Google_Service_YouTube_PromotedItemId $id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setPromotedByContentOwner($promotedByContentOwner)
+  {
+    $this->promotedByContentOwner = $promotedByContentOwner;
+  }
+  public function getPromotedByContentOwner()
+  {
+    return $this->promotedByContentOwner;
+  }
+  public function setTiming(Google_Service_YouTube_InvideoTiming $timing)
+  {
+    $this->timing = $timing;
+  }
+  public function getTiming()
+  {
+    return $this->timing;
+  }
+}
+
+class Google_Service_YouTube_PromotedItemId extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $recentlyUploadedBy;
+  public $type;
+  public $videoId;
+  public $websiteUrl;
+
+
+  public function setRecentlyUploadedBy($recentlyUploadedBy)
+  {
+    $this->recentlyUploadedBy = $recentlyUploadedBy;
+  }
+  public function getRecentlyUploadedBy()
+  {
+    return $this->recentlyUploadedBy;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+  public function setVideoId($videoId)
+  {
+    $this->videoId = $videoId;
+  }
+  public function getVideoId()
+  {
+    return $this->videoId;
+  }
+  public function setWebsiteUrl($websiteUrl)
+  {
+    $this->websiteUrl = $websiteUrl;
+  }
+  public function getWebsiteUrl()
+  {
+    return $this->websiteUrl;
+  }
+}
+
+class Google_Service_YouTube_PropertyValue extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $property;
+  public $value;
+
+
+  public function setProperty($property)
+  {
+    $this->property = $property;
+  }
+  public function getProperty()
+  {
+    return $this->property;
+  }
+  public function setValue($value)
+  {
+    $this->value = $value;
+  }
+  public function getValue()
+  {
+    return $this->value;
+  }
+}
+
+class Google_Service_YouTube_ResourceId extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $channelId;
+  public $kind;
+  public $playlistId;
+  public $videoId;
+
+
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setPlaylistId($playlistId)
+  {
+    $this->playlistId = $playlistId;
+  }
+  public function getPlaylistId()
+  {
+    return $this->playlistId;
+  }
+  public function setVideoId($videoId)
+  {
+    $this->videoId = $videoId;
+  }
+  public function getVideoId()
+  {
+    return $this->videoId;
+  }
+}
+
+class Google_Service_YouTube_SearchListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_SearchResult';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  protected $pageInfoType = 'Google_Service_YouTube_PageInfo';
+  protected $pageInfoDataType = '';
+  public $prevPageToken;
+  protected $tokenPaginationType = 'Google_Service_YouTube_TokenPagination';
+  protected $tokenPaginationDataType = '';
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPageInfo(Google_Service_YouTube_PageInfo $pageInfo)
+  {
+    $this->pageInfo = $pageInfo;
+  }
+  public function getPageInfo()
+  {
+    return $this->pageInfo;
+  }
+  public function setPrevPageToken($prevPageToken)
+  {
+    $this->prevPageToken = $prevPageToken;
+  }
+  public function getPrevPageToken()
+  {
+    return $this->prevPageToken;
+  }
+  public function setTokenPagination(Google_Service_YouTube_TokenPagination $tokenPagination)
+  {
+    $this->tokenPagination = $tokenPagination;
+  }
+  public function getTokenPagination()
+  {
+    return $this->tokenPagination;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_SearchResult extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $idType = 'Google_Service_YouTube_ResourceId';
+  protected $idDataType = '';
+  public $kind;
+  protected $snippetType = 'Google_Service_YouTube_SearchResultSnippet';
+  protected $snippetDataType = '';
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId(Google_Service_YouTube_ResourceId $id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSnippet(Google_Service_YouTube_SearchResultSnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+}
+
+class Google_Service_YouTube_SearchResultSnippet extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $channelId;
+  public $channelTitle;
+  public $description;
+  public $liveBroadcastContent;
+  public $publishedAt;
+  protected $thumbnailsType = 'Google_Service_YouTube_ThumbnailDetails';
+  protected $thumbnailsDataType = '';
+  public $title;
+
+
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setChannelTitle($channelTitle)
+  {
+    $this->channelTitle = $channelTitle;
+  }
+  public function getChannelTitle()
+  {
+    return $this->channelTitle;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setLiveBroadcastContent($liveBroadcastContent)
+  {
+    $this->liveBroadcastContent = $liveBroadcastContent;
+  }
+  public function getLiveBroadcastContent()
+  {
+    return $this->liveBroadcastContent;
+  }
+  public function setPublishedAt($publishedAt)
+  {
+    $this->publishedAt = $publishedAt;
+  }
+  public function getPublishedAt()
+  {
+    return $this->publishedAt;
+  }
+  public function setThumbnails(Google_Service_YouTube_ThumbnailDetails $thumbnails)
+  {
+    $this->thumbnails = $thumbnails;
+  }
+  public function getThumbnails()
+  {
+    return $this->thumbnails;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_YouTube_Subscription extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $contentDetailsType = 'Google_Service_YouTube_SubscriptionContentDetails';
+  protected $contentDetailsDataType = '';
+  public $etag;
+  public $id;
+  public $kind;
+  protected $snippetType = 'Google_Service_YouTube_SubscriptionSnippet';
+  protected $snippetDataType = '';
+  protected $subscriberSnippetType = 'Google_Service_YouTube_SubscriptionSubscriberSnippet';
+  protected $subscriberSnippetDataType = '';
+
+
+  public function setContentDetails(Google_Service_YouTube_SubscriptionContentDetails $contentDetails)
+  {
+    $this->contentDetails = $contentDetails;
+  }
+  public function getContentDetails()
+  {
+    return $this->contentDetails;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSnippet(Google_Service_YouTube_SubscriptionSnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+  public function setSubscriberSnippet(Google_Service_YouTube_SubscriptionSubscriberSnippet $subscriberSnippet)
+  {
+    $this->subscriberSnippet = $subscriberSnippet;
+  }
+  public function getSubscriberSnippet()
+  {
+    return $this->subscriberSnippet;
+  }
+}
+
+class Google_Service_YouTube_SubscriptionContentDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $activityType;
+  public $newItemCount;
+  public $totalItemCount;
+
+
+  public function setActivityType($activityType)
+  {
+    $this->activityType = $activityType;
+  }
+  public function getActivityType()
+  {
+    return $this->activityType;
+  }
+  public function setNewItemCount($newItemCount)
+  {
+    $this->newItemCount = $newItemCount;
+  }
+  public function getNewItemCount()
+  {
+    return $this->newItemCount;
+  }
+  public function setTotalItemCount($totalItemCount)
+  {
+    $this->totalItemCount = $totalItemCount;
+  }
+  public function getTotalItemCount()
+  {
+    return $this->totalItemCount;
+  }
+}
+
+class Google_Service_YouTube_SubscriptionListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_Subscription';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  protected $pageInfoType = 'Google_Service_YouTube_PageInfo';
+  protected $pageInfoDataType = '';
+  public $prevPageToken;
+  protected $tokenPaginationType = 'Google_Service_YouTube_TokenPagination';
+  protected $tokenPaginationDataType = '';
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPageInfo(Google_Service_YouTube_PageInfo $pageInfo)
+  {
+    $this->pageInfo = $pageInfo;
+  }
+  public function getPageInfo()
+  {
+    return $this->pageInfo;
+  }
+  public function setPrevPageToken($prevPageToken)
+  {
+    $this->prevPageToken = $prevPageToken;
+  }
+  public function getPrevPageToken()
+  {
+    return $this->prevPageToken;
+  }
+  public function setTokenPagination(Google_Service_YouTube_TokenPagination $tokenPagination)
+  {
+    $this->tokenPagination = $tokenPagination;
+  }
+  public function getTokenPagination()
+  {
+    return $this->tokenPagination;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_SubscriptionSnippet extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $channelId;
+  public $channelTitle;
+  public $description;
+  public $publishedAt;
+  protected $resourceIdType = 'Google_Service_YouTube_ResourceId';
+  protected $resourceIdDataType = '';
+  protected $thumbnailsType = 'Google_Service_YouTube_ThumbnailDetails';
+  protected $thumbnailsDataType = '';
+  public $title;
+
+
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setChannelTitle($channelTitle)
+  {
+    $this->channelTitle = $channelTitle;
+  }
+  public function getChannelTitle()
+  {
+    return $this->channelTitle;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setPublishedAt($publishedAt)
+  {
+    $this->publishedAt = $publishedAt;
+  }
+  public function getPublishedAt()
+  {
+    return $this->publishedAt;
+  }
+  public function setResourceId(Google_Service_YouTube_ResourceId $resourceId)
+  {
+    $this->resourceId = $resourceId;
+  }
+  public function getResourceId()
+  {
+    return $this->resourceId;
+  }
+  public function setThumbnails(Google_Service_YouTube_ThumbnailDetails $thumbnails)
+  {
+    $this->thumbnails = $thumbnails;
+  }
+  public function getThumbnails()
+  {
+    return $this->thumbnails;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_YouTube_SubscriptionSubscriberSnippet extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $channelId;
+  public $description;
+  protected $thumbnailsType = 'Google_Service_YouTube_ThumbnailDetails';
+  protected $thumbnailsDataType = '';
+  public $title;
+
+
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setThumbnails(Google_Service_YouTube_ThumbnailDetails $thumbnails)
+  {
+    $this->thumbnails = $thumbnails;
+  }
+  public function getThumbnails()
+  {
+    return $this->thumbnails;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_YouTube_Thumbnail extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $height;
+  public $url;
+  public $width;
+
+
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  public function setUrl($url)
+  {
+    $this->url = $url;
+  }
+  public function getUrl()
+  {
+    return $this->url;
+  }
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+class Google_Service_YouTube_ThumbnailDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $defaultType = 'Google_Service_YouTube_Thumbnail';
+  protected $defaultDataType = '';
+  protected $highType = 'Google_Service_YouTube_Thumbnail';
+  protected $highDataType = '';
+  protected $maxresType = 'Google_Service_YouTube_Thumbnail';
+  protected $maxresDataType = '';
+  protected $mediumType = 'Google_Service_YouTube_Thumbnail';
+  protected $mediumDataType = '';
+  protected $standardType = 'Google_Service_YouTube_Thumbnail';
+  protected $standardDataType = '';
+
+
+  public function setDefault(Google_Service_YouTube_Thumbnail $default)
+  {
+    $this->default = $default;
+  }
+  public function getDefault()
+  {
+    return $this->default;
+  }
+  public function setHigh(Google_Service_YouTube_Thumbnail $high)
+  {
+    $this->high = $high;
+  }
+  public function getHigh()
+  {
+    return $this->high;
+  }
+  public function setMaxres(Google_Service_YouTube_Thumbnail $maxres)
+  {
+    $this->maxres = $maxres;
+  }
+  public function getMaxres()
+  {
+    return $this->maxres;
+  }
+  public function setMedium(Google_Service_YouTube_Thumbnail $medium)
+  {
+    $this->medium = $medium;
+  }
+  public function getMedium()
+  {
+    return $this->medium;
+  }
+  public function setStandard(Google_Service_YouTube_Thumbnail $standard)
+  {
+    $this->standard = $standard;
+  }
+  public function getStandard()
+  {
+    return $this->standard;
+  }
+}
+
+class Google_Service_YouTube_ThumbnailSetResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_ThumbnailDetails';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_TokenPagination extends Google_Model
+{
+}
+
+class Google_Service_YouTube_Video extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $ageGatingType = 'Google_Service_YouTube_VideoAgeGating';
+  protected $ageGatingDataType = '';
+  protected $contentDetailsType = 'Google_Service_YouTube_VideoContentDetails';
+  protected $contentDetailsDataType = '';
+  protected $conversionPingsType = 'Google_Service_YouTube_VideoConversionPings';
+  protected $conversionPingsDataType = '';
+  public $etag;
+  protected $fileDetailsType = 'Google_Service_YouTube_VideoFileDetails';
+  protected $fileDetailsDataType = '';
+  public $id;
+  public $kind;
+  protected $liveStreamingDetailsType = 'Google_Service_YouTube_VideoLiveStreamingDetails';
+  protected $liveStreamingDetailsDataType = '';
+  protected $localizationsType = 'Google_Service_YouTube_VideoLocalization';
+  protected $localizationsDataType = 'map';
+  protected $monetizationDetailsType = 'Google_Service_YouTube_VideoMonetizationDetails';
+  protected $monetizationDetailsDataType = '';
+  protected $playerType = 'Google_Service_YouTube_VideoPlayer';
+  protected $playerDataType = '';
+  protected $processingDetailsType = 'Google_Service_YouTube_VideoProcessingDetails';
+  protected $processingDetailsDataType = '';
+  protected $projectDetailsType = 'Google_Service_YouTube_VideoProjectDetails';
+  protected $projectDetailsDataType = '';
+  protected $recordingDetailsType = 'Google_Service_YouTube_VideoRecordingDetails';
+  protected $recordingDetailsDataType = '';
+  protected $snippetType = 'Google_Service_YouTube_VideoSnippet';
+  protected $snippetDataType = '';
+  protected $statisticsType = 'Google_Service_YouTube_VideoStatistics';
+  protected $statisticsDataType = '';
+  protected $statusType = 'Google_Service_YouTube_VideoStatus';
+  protected $statusDataType = '';
+  protected $suggestionsType = 'Google_Service_YouTube_VideoSuggestions';
+  protected $suggestionsDataType = '';
+  protected $topicDetailsType = 'Google_Service_YouTube_VideoTopicDetails';
+  protected $topicDetailsDataType = '';
+
+
+  public function setAgeGating(Google_Service_YouTube_VideoAgeGating $ageGating)
+  {
+    $this->ageGating = $ageGating;
+  }
+  public function getAgeGating()
+  {
+    return $this->ageGating;
+  }
+  public function setContentDetails(Google_Service_YouTube_VideoContentDetails $contentDetails)
+  {
+    $this->contentDetails = $contentDetails;
+  }
+  public function getContentDetails()
+  {
+    return $this->contentDetails;
+  }
+  public function setConversionPings(Google_Service_YouTube_VideoConversionPings $conversionPings)
+  {
+    $this->conversionPings = $conversionPings;
+  }
+  public function getConversionPings()
+  {
+    return $this->conversionPings;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setFileDetails(Google_Service_YouTube_VideoFileDetails $fileDetails)
+  {
+    $this->fileDetails = $fileDetails;
+  }
+  public function getFileDetails()
+  {
+    return $this->fileDetails;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setLiveStreamingDetails(Google_Service_YouTube_VideoLiveStreamingDetails $liveStreamingDetails)
+  {
+    $this->liveStreamingDetails = $liveStreamingDetails;
+  }
+  public function getLiveStreamingDetails()
+  {
+    return $this->liveStreamingDetails;
+  }
+  public function setLocalizations($localizations)
+  {
+    $this->localizations = $localizations;
+  }
+  public function getLocalizations()
+  {
+    return $this->localizations;
+  }
+  public function setMonetizationDetails(Google_Service_YouTube_VideoMonetizationDetails $monetizationDetails)
+  {
+    $this->monetizationDetails = $monetizationDetails;
+  }
+  public function getMonetizationDetails()
+  {
+    return $this->monetizationDetails;
+  }
+  public function setPlayer(Google_Service_YouTube_VideoPlayer $player)
+  {
+    $this->player = $player;
+  }
+  public function getPlayer()
+  {
+    return $this->player;
+  }
+  public function setProcessingDetails(Google_Service_YouTube_VideoProcessingDetails $processingDetails)
+  {
+    $this->processingDetails = $processingDetails;
+  }
+  public function getProcessingDetails()
+  {
+    return $this->processingDetails;
+  }
+  public function setProjectDetails(Google_Service_YouTube_VideoProjectDetails $projectDetails)
+  {
+    $this->projectDetails = $projectDetails;
+  }
+  public function getProjectDetails()
+  {
+    return $this->projectDetails;
+  }
+  public function setRecordingDetails(Google_Service_YouTube_VideoRecordingDetails $recordingDetails)
+  {
+    $this->recordingDetails = $recordingDetails;
+  }
+  public function getRecordingDetails()
+  {
+    return $this->recordingDetails;
+  }
+  public function setSnippet(Google_Service_YouTube_VideoSnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+  public function setStatistics(Google_Service_YouTube_VideoStatistics $statistics)
+  {
+    $this->statistics = $statistics;
+  }
+  public function getStatistics()
+  {
+    return $this->statistics;
+  }
+  public function setStatus(Google_Service_YouTube_VideoStatus $status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setSuggestions(Google_Service_YouTube_VideoSuggestions $suggestions)
+  {
+    $this->suggestions = $suggestions;
+  }
+  public function getSuggestions()
+  {
+    return $this->suggestions;
+  }
+  public function setTopicDetails(Google_Service_YouTube_VideoTopicDetails $topicDetails)
+  {
+    $this->topicDetails = $topicDetails;
+  }
+  public function getTopicDetails()
+  {
+    return $this->topicDetails;
+  }
+}
+
+class Google_Service_YouTube_VideoAbuseReport extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $comments;
+  public $language;
+  public $reasonId;
+  public $secondaryReasonId;
+  public $videoId;
+
+
+  public function setComments($comments)
+  {
+    $this->comments = $comments;
+  }
+  public function getComments()
+  {
+    return $this->comments;
+  }
+  public function setLanguage($language)
+  {
+    $this->language = $language;
+  }
+  public function getLanguage()
+  {
+    return $this->language;
+  }
+  public function setReasonId($reasonId)
+  {
+    $this->reasonId = $reasonId;
+  }
+  public function getReasonId()
+  {
+    return $this->reasonId;
+  }
+  public function setSecondaryReasonId($secondaryReasonId)
+  {
+    $this->secondaryReasonId = $secondaryReasonId;
+  }
+  public function getSecondaryReasonId()
+  {
+    return $this->secondaryReasonId;
+  }
+  public function setVideoId($videoId)
+  {
+    $this->videoId = $videoId;
+  }
+  public function getVideoId()
+  {
+    return $this->videoId;
+  }
+}
+
+class Google_Service_YouTube_VideoAbuseReportReason extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $id;
+  public $kind;
+  protected $snippetType = 'Google_Service_YouTube_VideoAbuseReportReasonSnippet';
+  protected $snippetDataType = '';
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSnippet(Google_Service_YouTube_VideoAbuseReportReasonSnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+}
+
+class Google_Service_YouTube_VideoAbuseReportReasonListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_VideoAbuseReportReason';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_VideoAbuseReportReasonSnippet extends Google_Collection
+{
+  protected $collection_key = 'secondaryReasons';
+  protected $internal_gapi_mappings = array(
+  );
+  public $label;
+  protected $secondaryReasonsType = 'Google_Service_YouTube_VideoAbuseReportSecondaryReason';
+  protected $secondaryReasonsDataType = 'array';
+
+
+  public function setLabel($label)
+  {
+    $this->label = $label;
+  }
+  public function getLabel()
+  {
+    return $this->label;
+  }
+  public function setSecondaryReasons($secondaryReasons)
+  {
+    $this->secondaryReasons = $secondaryReasons;
+  }
+  public function getSecondaryReasons()
+  {
+    return $this->secondaryReasons;
+  }
+}
+
+class Google_Service_YouTube_VideoAbuseReportSecondaryReason extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $label;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setLabel($label)
+  {
+    $this->label = $label;
+  }
+  public function getLabel()
+  {
+    return $this->label;
+  }
+}
+
+class Google_Service_YouTube_VideoAgeGating extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $alcoholContent;
+  public $restricted;
+  public $videoGameRating;
+
+
+  public function setAlcoholContent($alcoholContent)
+  {
+    $this->alcoholContent = $alcoholContent;
+  }
+  public function getAlcoholContent()
+  {
+    return $this->alcoholContent;
+  }
+  public function setRestricted($restricted)
+  {
+    $this->restricted = $restricted;
+  }
+  public function getRestricted()
+  {
+    return $this->restricted;
+  }
+  public function setVideoGameRating($videoGameRating)
+  {
+    $this->videoGameRating = $videoGameRating;
+  }
+  public function getVideoGameRating()
+  {
+    return $this->videoGameRating;
+  }
+}
+
+class Google_Service_YouTube_VideoCategory extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $id;
+  public $kind;
+  protected $snippetType = 'Google_Service_YouTube_VideoCategorySnippet';
+  protected $snippetDataType = '';
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSnippet(Google_Service_YouTube_VideoCategorySnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+}
+
+class Google_Service_YouTube_VideoCategoryListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_VideoCategory';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  protected $pageInfoType = 'Google_Service_YouTube_PageInfo';
+  protected $pageInfoDataType = '';
+  public $prevPageToken;
+  protected $tokenPaginationType = 'Google_Service_YouTube_TokenPagination';
+  protected $tokenPaginationDataType = '';
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPageInfo(Google_Service_YouTube_PageInfo $pageInfo)
+  {
+    $this->pageInfo = $pageInfo;
+  }
+  public function getPageInfo()
+  {
+    return $this->pageInfo;
+  }
+  public function setPrevPageToken($prevPageToken)
+  {
+    $this->prevPageToken = $prevPageToken;
+  }
+  public function getPrevPageToken()
+  {
+    return $this->prevPageToken;
+  }
+  public function setTokenPagination(Google_Service_YouTube_TokenPagination $tokenPagination)
+  {
+    $this->tokenPagination = $tokenPagination;
+  }
+  public function getTokenPagination()
+  {
+    return $this->tokenPagination;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_VideoCategorySnippet extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $assignable;
+  public $channelId;
+  public $title;
+
+
+  public function setAssignable($assignable)
+  {
+    $this->assignable = $assignable;
+  }
+  public function getAssignable()
+  {
+    return $this->assignable;
+  }
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_YouTube_VideoContentDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $caption;
+  protected $contentRatingType = 'Google_Service_YouTube_ContentRating';
+  protected $contentRatingDataType = '';
+  protected $countryRestrictionType = 'Google_Service_YouTube_AccessPolicy';
+  protected $countryRestrictionDataType = '';
+  public $definition;
+  public $dimension;
+  public $duration;
+  public $licensedContent;
+  protected $regionRestrictionType = 'Google_Service_YouTube_VideoContentDetailsRegionRestriction';
+  protected $regionRestrictionDataType = '';
+
+
+  public function setCaption($caption)
+  {
+    $this->caption = $caption;
+  }
+  public function getCaption()
+  {
+    return $this->caption;
+  }
+  public function setContentRating(Google_Service_YouTube_ContentRating $contentRating)
+  {
+    $this->contentRating = $contentRating;
+  }
+  public function getContentRating()
+  {
+    return $this->contentRating;
+  }
+  public function setCountryRestriction(Google_Service_YouTube_AccessPolicy $countryRestriction)
+  {
+    $this->countryRestriction = $countryRestriction;
+  }
+  public function getCountryRestriction()
+  {
+    return $this->countryRestriction;
+  }
+  public function setDefinition($definition)
+  {
+    $this->definition = $definition;
+  }
+  public function getDefinition()
+  {
+    return $this->definition;
+  }
+  public function setDimension($dimension)
+  {
+    $this->dimension = $dimension;
+  }
+  public function getDimension()
+  {
+    return $this->dimension;
+  }
+  public function setDuration($duration)
+  {
+    $this->duration = $duration;
+  }
+  public function getDuration()
+  {
+    return $this->duration;
+  }
+  public function setLicensedContent($licensedContent)
+  {
+    $this->licensedContent = $licensedContent;
+  }
+  public function getLicensedContent()
+  {
+    return $this->licensedContent;
+  }
+  public function setRegionRestriction(Google_Service_YouTube_VideoContentDetailsRegionRestriction $regionRestriction)
+  {
+    $this->regionRestriction = $regionRestriction;
+  }
+  public function getRegionRestriction()
+  {
+    return $this->regionRestriction;
+  }
+}
+
+class Google_Service_YouTube_VideoContentDetailsRegionRestriction extends Google_Collection
+{
+  protected $collection_key = 'blocked';
+  protected $internal_gapi_mappings = array(
+  );
+  public $allowed;
+  public $blocked;
+
+
+  public function setAllowed($allowed)
+  {
+    $this->allowed = $allowed;
+  }
+  public function getAllowed()
+  {
+    return $this->allowed;
+  }
+  public function setBlocked($blocked)
+  {
+    $this->blocked = $blocked;
+  }
+  public function getBlocked()
+  {
+    return $this->blocked;
+  }
+}
+
+class Google_Service_YouTube_VideoConversionPing extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $context;
+  public $conversionUrl;
+
+
+  public function setContext($context)
+  {
+    $this->context = $context;
+  }
+  public function getContext()
+  {
+    return $this->context;
+  }
+  public function setConversionUrl($conversionUrl)
+  {
+    $this->conversionUrl = $conversionUrl;
+  }
+  public function getConversionUrl()
+  {
+    return $this->conversionUrl;
+  }
+}
+
+class Google_Service_YouTube_VideoConversionPings extends Google_Collection
+{
+  protected $collection_key = 'pings';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $pingsType = 'Google_Service_YouTube_VideoConversionPing';
+  protected $pingsDataType = 'array';
+
+
+  public function setPings($pings)
+  {
+    $this->pings = $pings;
+  }
+  public function getPings()
+  {
+    return $this->pings;
+  }
+}
+
+class Google_Service_YouTube_VideoFileDetails extends Google_Collection
+{
+  protected $collection_key = 'videoStreams';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $audioStreamsType = 'Google_Service_YouTube_VideoFileDetailsAudioStream';
+  protected $audioStreamsDataType = 'array';
+  public $bitrateBps;
+  public $container;
+  public $creationTime;
+  public $durationMs;
+  public $fileName;
+  public $fileSize;
+  public $fileType;
+  protected $recordingLocationType = 'Google_Service_YouTube_GeoPoint';
+  protected $recordingLocationDataType = '';
+  protected $videoStreamsType = 'Google_Service_YouTube_VideoFileDetailsVideoStream';
+  protected $videoStreamsDataType = 'array';
+
+
+  public function setAudioStreams($audioStreams)
+  {
+    $this->audioStreams = $audioStreams;
+  }
+  public function getAudioStreams()
+  {
+    return $this->audioStreams;
+  }
+  public function setBitrateBps($bitrateBps)
+  {
+    $this->bitrateBps = $bitrateBps;
+  }
+  public function getBitrateBps()
+  {
+    return $this->bitrateBps;
+  }
+  public function setContainer($container)
+  {
+    $this->container = $container;
+  }
+  public function getContainer()
+  {
+    return $this->container;
+  }
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  public function setDurationMs($durationMs)
+  {
+    $this->durationMs = $durationMs;
+  }
+  public function getDurationMs()
+  {
+    return $this->durationMs;
+  }
+  public function setFileName($fileName)
+  {
+    $this->fileName = $fileName;
+  }
+  public function getFileName()
+  {
+    return $this->fileName;
+  }
+  public function setFileSize($fileSize)
+  {
+    $this->fileSize = $fileSize;
+  }
+  public function getFileSize()
+  {
+    return $this->fileSize;
+  }
+  public function setFileType($fileType)
+  {
+    $this->fileType = $fileType;
+  }
+  public function getFileType()
+  {
+    return $this->fileType;
+  }
+  public function setRecordingLocation(Google_Service_YouTube_GeoPoint $recordingLocation)
+  {
+    $this->recordingLocation = $recordingLocation;
+  }
+  public function getRecordingLocation()
+  {
+    return $this->recordingLocation;
+  }
+  public function setVideoStreams($videoStreams)
+  {
+    $this->videoStreams = $videoStreams;
+  }
+  public function getVideoStreams()
+  {
+    return $this->videoStreams;
+  }
+}
+
+class Google_Service_YouTube_VideoFileDetailsAudioStream extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $bitrateBps;
+  public $channelCount;
+  public $codec;
+  public $vendor;
+
+
+  public function setBitrateBps($bitrateBps)
+  {
+    $this->bitrateBps = $bitrateBps;
+  }
+  public function getBitrateBps()
+  {
+    return $this->bitrateBps;
+  }
+  public function setChannelCount($channelCount)
+  {
+    $this->channelCount = $channelCount;
+  }
+  public function getChannelCount()
+  {
+    return $this->channelCount;
+  }
+  public function setCodec($codec)
+  {
+    $this->codec = $codec;
+  }
+  public function getCodec()
+  {
+    return $this->codec;
+  }
+  public function setVendor($vendor)
+  {
+    $this->vendor = $vendor;
+  }
+  public function getVendor()
+  {
+    return $this->vendor;
+  }
+}
+
+class Google_Service_YouTube_VideoFileDetailsVideoStream extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $aspectRatio;
+  public $bitrateBps;
+  public $codec;
+  public $frameRateFps;
+  public $heightPixels;
+  public $rotation;
+  public $vendor;
+  public $widthPixels;
+
+
+  public function setAspectRatio($aspectRatio)
+  {
+    $this->aspectRatio = $aspectRatio;
+  }
+  public function getAspectRatio()
+  {
+    return $this->aspectRatio;
+  }
+  public function setBitrateBps($bitrateBps)
+  {
+    $this->bitrateBps = $bitrateBps;
+  }
+  public function getBitrateBps()
+  {
+    return $this->bitrateBps;
+  }
+  public function setCodec($codec)
+  {
+    $this->codec = $codec;
+  }
+  public function getCodec()
+  {
+    return $this->codec;
+  }
+  public function setFrameRateFps($frameRateFps)
+  {
+    $this->frameRateFps = $frameRateFps;
+  }
+  public function getFrameRateFps()
+  {
+    return $this->frameRateFps;
+  }
+  public function setHeightPixels($heightPixels)
+  {
+    $this->heightPixels = $heightPixels;
+  }
+  public function getHeightPixels()
+  {
+    return $this->heightPixels;
+  }
+  public function setRotation($rotation)
+  {
+    $this->rotation = $rotation;
+  }
+  public function getRotation()
+  {
+    return $this->rotation;
+  }
+  public function setVendor($vendor)
+  {
+    $this->vendor = $vendor;
+  }
+  public function getVendor()
+  {
+    return $this->vendor;
+  }
+  public function setWidthPixels($widthPixels)
+  {
+    $this->widthPixels = $widthPixels;
+  }
+  public function getWidthPixels()
+  {
+    return $this->widthPixels;
+  }
+}
+
+class Google_Service_YouTube_VideoGetRatingResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_VideoRating';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_VideoListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $eventId;
+  protected $itemsType = 'Google_Service_YouTube_Video';
+  protected $itemsDataType = 'array';
+  public $kind;
+  public $nextPageToken;
+  protected $pageInfoType = 'Google_Service_YouTube_PageInfo';
+  protected $pageInfoDataType = '';
+  public $prevPageToken;
+  protected $tokenPaginationType = 'Google_Service_YouTube_TokenPagination';
+  protected $tokenPaginationDataType = '';
+  public $visitorId;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setEventId($eventId)
+  {
+    $this->eventId = $eventId;
+  }
+  public function getEventId()
+  {
+    return $this->eventId;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setPageInfo(Google_Service_YouTube_PageInfo $pageInfo)
+  {
+    $this->pageInfo = $pageInfo;
+  }
+  public function getPageInfo()
+  {
+    return $this->pageInfo;
+  }
+  public function setPrevPageToken($prevPageToken)
+  {
+    $this->prevPageToken = $prevPageToken;
+  }
+  public function getPrevPageToken()
+  {
+    return $this->prevPageToken;
+  }
+  public function setTokenPagination(Google_Service_YouTube_TokenPagination $tokenPagination)
+  {
+    $this->tokenPagination = $tokenPagination;
+  }
+  public function getTokenPagination()
+  {
+    return $this->tokenPagination;
+  }
+  public function setVisitorId($visitorId)
+  {
+    $this->visitorId = $visitorId;
+  }
+  public function getVisitorId()
+  {
+    return $this->visitorId;
+  }
+}
+
+class Google_Service_YouTube_VideoLiveStreamingDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $actualEndTime;
+  public $actualStartTime;
+  public $concurrentViewers;
+  public $scheduledEndTime;
+  public $scheduledStartTime;
+
+
+  public function setActualEndTime($actualEndTime)
+  {
+    $this->actualEndTime = $actualEndTime;
+  }
+  public function getActualEndTime()
+  {
+    return $this->actualEndTime;
+  }
+  public function setActualStartTime($actualStartTime)
+  {
+    $this->actualStartTime = $actualStartTime;
+  }
+  public function getActualStartTime()
+  {
+    return $this->actualStartTime;
+  }
+  public function setConcurrentViewers($concurrentViewers)
+  {
+    $this->concurrentViewers = $concurrentViewers;
+  }
+  public function getConcurrentViewers()
+  {
+    return $this->concurrentViewers;
+  }
+  public function setScheduledEndTime($scheduledEndTime)
+  {
+    $this->scheduledEndTime = $scheduledEndTime;
+  }
+  public function getScheduledEndTime()
+  {
+    return $this->scheduledEndTime;
+  }
+  public function setScheduledStartTime($scheduledStartTime)
+  {
+    $this->scheduledStartTime = $scheduledStartTime;
+  }
+  public function getScheduledStartTime()
+  {
+    return $this->scheduledStartTime;
+  }
+}
+
+class Google_Service_YouTube_VideoLocalization extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $description;
+  public $title;
+
+
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_YouTube_VideoLocalizations extends Google_Model
+{
+}
+
+class Google_Service_YouTube_VideoMonetizationDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $accessType = 'Google_Service_YouTube_AccessPolicy';
+  protected $accessDataType = '';
+
+
+  public function setAccess(Google_Service_YouTube_AccessPolicy $access)
+  {
+    $this->access = $access;
+  }
+  public function getAccess()
+  {
+    return $this->access;
+  }
+}
+
+class Google_Service_YouTube_VideoPlayer extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $embedHtml;
+
+
+  public function setEmbedHtml($embedHtml)
+  {
+    $this->embedHtml = $embedHtml;
+  }
+  public function getEmbedHtml()
+  {
+    return $this->embedHtml;
+  }
+}
+
+class Google_Service_YouTube_VideoProcessingDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $editorSuggestionsAvailability;
+  public $fileDetailsAvailability;
+  public $processingFailureReason;
+  public $processingIssuesAvailability;
+  protected $processingProgressType = 'Google_Service_YouTube_VideoProcessingDetailsProcessingProgress';
+  protected $processingProgressDataType = '';
+  public $processingStatus;
+  public $tagSuggestionsAvailability;
+  public $thumbnailsAvailability;
+
+
+  public function setEditorSuggestionsAvailability($editorSuggestionsAvailability)
+  {
+    $this->editorSuggestionsAvailability = $editorSuggestionsAvailability;
+  }
+  public function getEditorSuggestionsAvailability()
+  {
+    return $this->editorSuggestionsAvailability;
+  }
+  public function setFileDetailsAvailability($fileDetailsAvailability)
+  {
+    $this->fileDetailsAvailability = $fileDetailsAvailability;
+  }
+  public function getFileDetailsAvailability()
+  {
+    return $this->fileDetailsAvailability;
+  }
+  public function setProcessingFailureReason($processingFailureReason)
+  {
+    $this->processingFailureReason = $processingFailureReason;
+  }
+  public function getProcessingFailureReason()
+  {
+    return $this->processingFailureReason;
+  }
+  public function setProcessingIssuesAvailability($processingIssuesAvailability)
+  {
+    $this->processingIssuesAvailability = $processingIssuesAvailability;
+  }
+  public function getProcessingIssuesAvailability()
+  {
+    return $this->processingIssuesAvailability;
+  }
+  public function setProcessingProgress(Google_Service_YouTube_VideoProcessingDetailsProcessingProgress $processingProgress)
+  {
+    $this->processingProgress = $processingProgress;
+  }
+  public function getProcessingProgress()
+  {
+    return $this->processingProgress;
+  }
+  public function setProcessingStatus($processingStatus)
+  {
+    $this->processingStatus = $processingStatus;
+  }
+  public function getProcessingStatus()
+  {
+    return $this->processingStatus;
+  }
+  public function setTagSuggestionsAvailability($tagSuggestionsAvailability)
+  {
+    $this->tagSuggestionsAvailability = $tagSuggestionsAvailability;
+  }
+  public function getTagSuggestionsAvailability()
+  {
+    return $this->tagSuggestionsAvailability;
+  }
+  public function setThumbnailsAvailability($thumbnailsAvailability)
+  {
+    $this->thumbnailsAvailability = $thumbnailsAvailability;
+  }
+  public function getThumbnailsAvailability()
+  {
+    return $this->thumbnailsAvailability;
+  }
+}
+
+class Google_Service_YouTube_VideoProcessingDetailsProcessingProgress extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $partsProcessed;
+  public $partsTotal;
+  public $timeLeftMs;
+
+
+  public function setPartsProcessed($partsProcessed)
+  {
+    $this->partsProcessed = $partsProcessed;
+  }
+  public function getPartsProcessed()
+  {
+    return $this->partsProcessed;
+  }
+  public function setPartsTotal($partsTotal)
+  {
+    $this->partsTotal = $partsTotal;
+  }
+  public function getPartsTotal()
+  {
+    return $this->partsTotal;
+  }
+  public function setTimeLeftMs($timeLeftMs)
+  {
+    $this->timeLeftMs = $timeLeftMs;
+  }
+  public function getTimeLeftMs()
+  {
+    return $this->timeLeftMs;
+  }
+}
+
+class Google_Service_YouTube_VideoProjectDetails extends Google_Collection
+{
+  protected $collection_key = 'tags';
+  protected $internal_gapi_mappings = array(
+  );
+  public $tags;
+
+
+  public function setTags($tags)
+  {
+    $this->tags = $tags;
+  }
+  public function getTags()
+  {
+    return $this->tags;
+  }
+}
+
+class Google_Service_YouTube_VideoRating extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $rating;
+  public $videoId;
+
+
+  public function setRating($rating)
+  {
+    $this->rating = $rating;
+  }
+  public function getRating()
+  {
+    return $this->rating;
+  }
+  public function setVideoId($videoId)
+  {
+    $this->videoId = $videoId;
+  }
+  public function getVideoId()
+  {
+    return $this->videoId;
+  }
+}
+
+class Google_Service_YouTube_VideoRecordingDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $locationType = 'Google_Service_YouTube_GeoPoint';
+  protected $locationDataType = '';
+  public $locationDescription;
+  public $recordingDate;
+
+
+  public function setLocation(Google_Service_YouTube_GeoPoint $location)
+  {
+    $this->location = $location;
+  }
+  public function getLocation()
+  {
+    return $this->location;
+  }
+  public function setLocationDescription($locationDescription)
+  {
+    $this->locationDescription = $locationDescription;
+  }
+  public function getLocationDescription()
+  {
+    return $this->locationDescription;
+  }
+  public function setRecordingDate($recordingDate)
+  {
+    $this->recordingDate = $recordingDate;
+  }
+  public function getRecordingDate()
+  {
+    return $this->recordingDate;
+  }
+}
+
+class Google_Service_YouTube_VideoSnippet extends Google_Collection
+{
+  protected $collection_key = 'tags';
+  protected $internal_gapi_mappings = array(
+  );
+  public $categoryId;
+  public $channelId;
+  public $channelTitle;
+  public $defaultAudioLanguage;
+  public $defaultLanguage;
+  public $description;
+  public $liveBroadcastContent;
+  protected $localizedType = 'Google_Service_YouTube_VideoLocalization';
+  protected $localizedDataType = '';
+  public $publishedAt;
+  public $tags;
+  protected $thumbnailsType = 'Google_Service_YouTube_ThumbnailDetails';
+  protected $thumbnailsDataType = '';
+  public $title;
+
+
+  public function setCategoryId($categoryId)
+  {
+    $this->categoryId = $categoryId;
+  }
+  public function getCategoryId()
+  {
+    return $this->categoryId;
+  }
+  public function setChannelId($channelId)
+  {
+    $this->channelId = $channelId;
+  }
+  public function getChannelId()
+  {
+    return $this->channelId;
+  }
+  public function setChannelTitle($channelTitle)
+  {
+    $this->channelTitle = $channelTitle;
+  }
+  public function getChannelTitle()
+  {
+    return $this->channelTitle;
+  }
+  public function setDefaultAudioLanguage($defaultAudioLanguage)
+  {
+    $this->defaultAudioLanguage = $defaultAudioLanguage;
+  }
+  public function getDefaultAudioLanguage()
+  {
+    return $this->defaultAudioLanguage;
+  }
+  public function setDefaultLanguage($defaultLanguage)
+  {
+    $this->defaultLanguage = $defaultLanguage;
+  }
+  public function getDefaultLanguage()
+  {
+    return $this->defaultLanguage;
+  }
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  public function setLiveBroadcastContent($liveBroadcastContent)
+  {
+    $this->liveBroadcastContent = $liveBroadcastContent;
+  }
+  public function getLiveBroadcastContent()
+  {
+    return $this->liveBroadcastContent;
+  }
+  public function setLocalized(Google_Service_YouTube_VideoLocalization $localized)
+  {
+    $this->localized = $localized;
+  }
+  public function getLocalized()
+  {
+    return $this->localized;
+  }
+  public function setPublishedAt($publishedAt)
+  {
+    $this->publishedAt = $publishedAt;
+  }
+  public function getPublishedAt()
+  {
+    return $this->publishedAt;
+  }
+  public function setTags($tags)
+  {
+    $this->tags = $tags;
+  }
+  public function getTags()
+  {
+    return $this->tags;
+  }
+  public function setThumbnails(Google_Service_YouTube_ThumbnailDetails $thumbnails)
+  {
+    $this->thumbnails = $thumbnails;
+  }
+  public function getThumbnails()
+  {
+    return $this->thumbnails;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_YouTube_VideoStatistics extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $commentCount;
+  public $dislikeCount;
+  public $favoriteCount;
+  public $likeCount;
+  public $viewCount;
+
+
+  public function setCommentCount($commentCount)
+  {
+    $this->commentCount = $commentCount;
+  }
+  public function getCommentCount()
+  {
+    return $this->commentCount;
+  }
+  public function setDislikeCount($dislikeCount)
+  {
+    $this->dislikeCount = $dislikeCount;
+  }
+  public function getDislikeCount()
+  {
+    return $this->dislikeCount;
+  }
+  public function setFavoriteCount($favoriteCount)
+  {
+    $this->favoriteCount = $favoriteCount;
+  }
+  public function getFavoriteCount()
+  {
+    return $this->favoriteCount;
+  }
+  public function setLikeCount($likeCount)
+  {
+    $this->likeCount = $likeCount;
+  }
+  public function getLikeCount()
+  {
+    return $this->likeCount;
+  }
+  public function setViewCount($viewCount)
+  {
+    $this->viewCount = $viewCount;
+  }
+  public function getViewCount()
+  {
+    return $this->viewCount;
+  }
+}
+
+class Google_Service_YouTube_VideoStatus extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $embeddable;
+  public $failureReason;
+  public $license;
+  public $privacyStatus;
+  public $publicStatsViewable;
+  public $publishAt;
+  public $rejectionReason;
+  public $uploadStatus;
+
+
+  public function setEmbeddable($embeddable)
+  {
+    $this->embeddable = $embeddable;
+  }
+  public function getEmbeddable()
+  {
+    return $this->embeddable;
+  }
+  public function setFailureReason($failureReason)
+  {
+    $this->failureReason = $failureReason;
+  }
+  public function getFailureReason()
+  {
+    return $this->failureReason;
+  }
+  public function setLicense($license)
+  {
+    $this->license = $license;
+  }
+  public function getLicense()
+  {
+    return $this->license;
+  }
+  public function setPrivacyStatus($privacyStatus)
+  {
+    $this->privacyStatus = $privacyStatus;
+  }
+  public function getPrivacyStatus()
+  {
+    return $this->privacyStatus;
+  }
+  public function setPublicStatsViewable($publicStatsViewable)
+  {
+    $this->publicStatsViewable = $publicStatsViewable;
+  }
+  public function getPublicStatsViewable()
+  {
+    return $this->publicStatsViewable;
+  }
+  public function setPublishAt($publishAt)
+  {
+    $this->publishAt = $publishAt;
+  }
+  public function getPublishAt()
+  {
+    return $this->publishAt;
+  }
+  public function setRejectionReason($rejectionReason)
+  {
+    $this->rejectionReason = $rejectionReason;
+  }
+  public function getRejectionReason()
+  {
+    return $this->rejectionReason;
+  }
+  public function setUploadStatus($uploadStatus)
+  {
+    $this->uploadStatus = $uploadStatus;
+  }
+  public function getUploadStatus()
+  {
+    return $this->uploadStatus;
+  }
+}
+
+class Google_Service_YouTube_VideoSuggestions extends Google_Collection
+{
+  protected $collection_key = 'tagSuggestions';
+  protected $internal_gapi_mappings = array(
+  );
+  public $editorSuggestions;
+  public $processingErrors;
+  public $processingHints;
+  public $processingWarnings;
+  protected $tagSuggestionsType = 'Google_Service_YouTube_VideoSuggestionsTagSuggestion';
+  protected $tagSuggestionsDataType = 'array';
+
+
+  public function setEditorSuggestions($editorSuggestions)
+  {
+    $this->editorSuggestions = $editorSuggestions;
+  }
+  public function getEditorSuggestions()
+  {
+    return $this->editorSuggestions;
+  }
+  public function setProcessingErrors($processingErrors)
+  {
+    $this->processingErrors = $processingErrors;
+  }
+  public function getProcessingErrors()
+  {
+    return $this->processingErrors;
+  }
+  public function setProcessingHints($processingHints)
+  {
+    $this->processingHints = $processingHints;
+  }
+  public function getProcessingHints()
+  {
+    return $this->processingHints;
+  }
+  public function setProcessingWarnings($processingWarnings)
+  {
+    $this->processingWarnings = $processingWarnings;
+  }
+  public function getProcessingWarnings()
+  {
+    return $this->processingWarnings;
+  }
+  public function setTagSuggestions($tagSuggestions)
+  {
+    $this->tagSuggestions = $tagSuggestions;
+  }
+  public function getTagSuggestions()
+  {
+    return $this->tagSuggestions;
+  }
+}
+
+class Google_Service_YouTube_VideoSuggestionsTagSuggestion extends Google_Collection
+{
+  protected $collection_key = 'categoryRestricts';
+  protected $internal_gapi_mappings = array(
+  );
+  public $categoryRestricts;
+  public $tag;
+
+
+  public function setCategoryRestricts($categoryRestricts)
+  {
+    $this->categoryRestricts = $categoryRestricts;
+  }
+  public function getCategoryRestricts()
+  {
+    return $this->categoryRestricts;
+  }
+  public function setTag($tag)
+  {
+    $this->tag = $tag;
+  }
+  public function getTag()
+  {
+    return $this->tag;
+  }
+}
+
+class Google_Service_YouTube_VideoTopicDetails extends Google_Collection
+{
+  protected $collection_key = 'topicIds';
+  protected $internal_gapi_mappings = array(
+  );
+  public $relevantTopicIds;
+  public $topicIds;
+
+
+  public function setRelevantTopicIds($relevantTopicIds)
+  {
+    $this->relevantTopicIds = $relevantTopicIds;
+  }
+  public function getRelevantTopicIds()
+  {
+    return $this->relevantTopicIds;
+  }
+  public function setTopicIds($topicIds)
+  {
+    $this->topicIds = $topicIds;
+  }
+  public function getTopicIds()
+  {
+    return $this->topicIds;
+  }
+}
+
+class Google_Service_YouTube_WatchSettings extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $backgroundColor;
+  public $featuredPlaylistId;
+  public $textColor;
+
+
+  public function setBackgroundColor($backgroundColor)
+  {
+    $this->backgroundColor = $backgroundColor;
+  }
+  public function getBackgroundColor()
+  {
+    return $this->backgroundColor;
+  }
+  public function setFeaturedPlaylistId($featuredPlaylistId)
+  {
+    $this->featuredPlaylistId = $featuredPlaylistId;
+  }
+  public function getFeaturedPlaylistId()
+  {
+    return $this->featuredPlaylistId;
+  }
+  public function setTextColor($textColor)
+  {
+    $this->textColor = $textColor;
+  }
+  public function getTextColor()
+  {
+    return $this->textColor;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/YouTubeAnalytics.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/YouTubeAnalytics.php
@@ -1,0 +1,1197 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for YouTubeAnalytics (v1).
+ *
+ * <p>
+ * Retrieve your YouTube Analytics reports.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="http://developers.google.com/youtube/analytics/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_YouTubeAnalytics extends Google_Service
+{
+  /** Manage your YouTube account. */
+  const YOUTUBE =
+      "https://www.googleapis.com/auth/youtube";
+  /** View your YouTube account. */
+  const YOUTUBE_READONLY =
+      "https://www.googleapis.com/auth/youtube.readonly";
+  /** View and manage your assets and associated content on YouTube. */
+  const YOUTUBEPARTNER =
+      "https://www.googleapis.com/auth/youtubepartner";
+  /** View monetary and non-monetary YouTube Analytics reports for your YouTube content. */
+  const YT_ANALYTICS_MONETARY_READONLY =
+      "https://www.googleapis.com/auth/yt-analytics-monetary.readonly";
+  /** View YouTube Analytics reports for your YouTube content. */
+  const YT_ANALYTICS_READONLY =
+      "https://www.googleapis.com/auth/yt-analytics.readonly";
+
+  public $batchReportDefinitions;
+  public $batchReports;
+  public $groupItems;
+  public $groups;
+  public $reports;
+  
+
+  /**
+   * Constructs the internal representation of the YouTubeAnalytics service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->servicePath = 'youtube/analytics/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'youtubeAnalytics';
+
+    $this->batchReportDefinitions = new Google_Service_YouTubeAnalytics_BatchReportDefinitions_Resource(
+        $this,
+        $this->serviceName,
+        'batchReportDefinitions',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'batchReportDefinitions',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->batchReports = new Google_Service_YouTubeAnalytics_BatchReports_Resource(
+        $this,
+        $this->serviceName,
+        'batchReports',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'batchReports',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'batchReportDefinitionId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->groupItems = new Google_Service_YouTubeAnalytics_GroupItems_Resource(
+        $this,
+        $this->serviceName,
+        'groupItems',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'groupItems',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'groupItems',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'groupItems',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'groupId' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->groups = new Google_Service_YouTubeAnalytics_Groups_Resource(
+        $this,
+        $this->serviceName,
+        'groups',
+        array(
+          'methods' => array(
+            'delete' => array(
+              'path' => 'groups',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'insert' => array(
+              'path' => 'groups',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'groups',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'id' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'mine' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
+              ),
+            ),'update' => array(
+              'path' => 'groups',
+              'httpMethod' => 'PUT',
+              'parameters' => array(
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->reports = new Google_Service_YouTubeAnalytics_Reports_Resource(
+        $this,
+        $this->serviceName,
+        'reports',
+        array(
+          'methods' => array(
+            'query' => array(
+              'path' => 'reports',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'ids' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'start-date' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'end-date' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'metrics' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'max-results' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'sort' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'dimensions' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'start-index' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'currency' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'filters' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "batchReportDefinitions" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeAnalyticsService = new Google_Service_YouTubeAnalytics(...);
+ *   $batchReportDefinitions = $youtubeAnalyticsService->batchReportDefinitions;
+ *  </code>
+ */
+class Google_Service_YouTubeAnalytics_BatchReportDefinitions_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a list of available batch report definitions.
+   * (batchReportDefinitions.listBatchReportDefinitions)
+   *
+   * @param string $onBehalfOfContentOwner The onBehalfOfContentOwner parameter
+   * identifies the content owner that the user is acting on behalf of.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_YouTubeAnalytics_BatchReportDefinitionList
+   */
+  public function listBatchReportDefinitions($onBehalfOfContentOwner, $optParams = array())
+  {
+    $params = array('onBehalfOfContentOwner' => $onBehalfOfContentOwner);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTubeAnalytics_BatchReportDefinitionList");
+  }
+}
+
+/**
+ * The "batchReports" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeAnalyticsService = new Google_Service_YouTubeAnalytics(...);
+ *   $batchReports = $youtubeAnalyticsService->batchReports;
+ *  </code>
+ */
+class Google_Service_YouTubeAnalytics_BatchReports_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieves a list of processed batch reports. (batchReports.listBatchReports)
+   *
+   * @param string $batchReportDefinitionId The batchReportDefinitionId parameter
+   * specifies the ID of the batch reportort definition for which you are
+   * retrieving reports.
+   * @param string $onBehalfOfContentOwner The onBehalfOfContentOwner parameter
+   * identifies the content owner that the user is acting on behalf of.
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_YouTubeAnalytics_BatchReportList
+   */
+  public function listBatchReports($batchReportDefinitionId, $onBehalfOfContentOwner, $optParams = array())
+  {
+    $params = array('batchReportDefinitionId' => $batchReportDefinitionId, 'onBehalfOfContentOwner' => $onBehalfOfContentOwner);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTubeAnalytics_BatchReportList");
+  }
+}
+
+/**
+ * The "groupItems" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeAnalyticsService = new Google_Service_YouTubeAnalytics(...);
+ *   $groupItems = $youtubeAnalyticsService->groupItems;
+ *  </code>
+ */
+class Google_Service_YouTubeAnalytics_GroupItems_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Removes an item from a group. (groupItems.delete)
+   *
+   * @param string $id The id parameter specifies the YouTube group item ID for
+   * the group that is being deleted.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Creates a group item. (groupItems.insert)
+   *
+   * @param Google_GroupItem $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @return Google_Service_YouTubeAnalytics_GroupItem
+   */
+  public function insert(Google_Service_YouTubeAnalytics_GroupItem $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_YouTubeAnalytics_GroupItem");
+  }
+
+  /**
+   * Returns a collection of group items that match the API request parameters.
+   * (groupItems.listGroupItems)
+   *
+   * @param string $groupId The id parameter specifies the unique ID of the group
+   * for which you want to retrieve group items.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @return Google_Service_YouTubeAnalytics_GroupItemListResponse
+   */
+  public function listGroupItems($groupId, $optParams = array())
+  {
+    $params = array('groupId' => $groupId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTubeAnalytics_GroupItemListResponse");
+  }
+}
+
+/**
+ * The "groups" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeAnalyticsService = new Google_Service_YouTubeAnalytics(...);
+ *   $groups = $youtubeAnalyticsService->groups;
+ *  </code>
+ */
+class Google_Service_YouTubeAnalytics_Groups_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Deletes a group. (groups.delete)
+   *
+   * @param string $id The id parameter specifies the YouTube group ID for the
+   * group that is being deleted.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   */
+  public function delete($id, $optParams = array())
+  {
+    $params = array('id' => $id);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params));
+  }
+
+  /**
+   * Creates a group. (groups.insert)
+   *
+   * @param Google_Group $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @return Google_Service_YouTubeAnalytics_Group
+   */
+  public function insert(Google_Service_YouTubeAnalytics_Group $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('insert', array($params), "Google_Service_YouTubeAnalytics_Group");
+  }
+
+  /**
+   * Returns a collection of groups that match the API request parameters. For
+   * example, you can retrieve all groups that the authenticated user owns, or you
+   * can retrieve one or more groups by their unique IDs. (groups.listGroups)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @opt_param string id The id parameter specifies a comma-separated list of the
+   * YouTube group ID(s) for the resource(s) that are being retrieved. In a group
+   * resource, the id property specifies the group's YouTube group ID.
+   * @opt_param bool mine Set this parameter's value to true to instruct the API
+   * to only return groups owned by the authenticated user.
+   * @return Google_Service_YouTubeAnalytics_GroupListResponse
+   */
+  public function listGroups($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTubeAnalytics_GroupListResponse");
+  }
+
+  /**
+   * Modifies a group. For example, you could change a group's title.
+   * (groups.update)
+   *
+   * @param Google_Group $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner Note: This parameter is intended
+   * exclusively for YouTube content partners.
+   *
+   * The onBehalfOfContentOwner parameter indicates that the request's
+   * authorization credentials identify a YouTube CMS user who is acting on behalf
+   * of the content owner specified in the parameter value. This parameter is
+   * intended for YouTube content partners that own and manage many different
+   * YouTube channels. It allows content owners to authenticate once and get
+   * access to all their video and channel data, without having to provide
+   * authentication credentials for each individual channel. The CMS account that
+   * the user authenticates with must be linked to the specified YouTube content
+   * owner.
+   * @return Google_Service_YouTubeAnalytics_Group
+   */
+  public function update(Google_Service_YouTubeAnalytics_Group $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('update', array($params), "Google_Service_YouTubeAnalytics_Group");
+  }
+}
+
+/**
+ * The "reports" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubeAnalyticsService = new Google_Service_YouTubeAnalytics(...);
+ *   $reports = $youtubeAnalyticsService->reports;
+ *  </code>
+ */
+class Google_Service_YouTubeAnalytics_Reports_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Retrieve your YouTube Analytics reports. (reports.query)
+   *
+   * @param string $ids Identifies the YouTube channel or content owner for which
+   * you are retrieving YouTube Analytics data. - To request data for a YouTube
+   * user, set the ids parameter value to channel==CHANNEL_ID, where CHANNEL_ID
+   * specifies the unique YouTube channel ID. - To request data for a YouTube CMS
+   * content owner, set the ids parameter value to contentOwner==OWNER_NAME, where
+   * OWNER_NAME is the CMS name of the content owner.
+   * @param string $startDate The start date for fetching YouTube Analytics data.
+   * The value should be in YYYY-MM-DD format.
+   * @param string $endDate The end date for fetching YouTube Analytics data. The
+   * value should be in YYYY-MM-DD format.
+   * @param string $metrics A comma-separated list of YouTube Analytics metrics,
+   * such as views or likes,dislikes. See the Available Reports document for a
+   * list of the reports that you can retrieve and the metrics available in each
+   * report, and see the Metrics document for definitions of those metrics.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int max-results The maximum number of rows to include in the
+   * response.
+   * @opt_param string sort A comma-separated list of dimensions or metrics that
+   * determine the sort order for YouTube Analytics data. By default the sort
+   * order is ascending. The '-' prefix causes descending sort order.
+   * @opt_param string dimensions A comma-separated list of YouTube Analytics
+   * dimensions, such as views or ageGroup,gender. See the Available Reports
+   * document for a list of the reports that you can retrieve and the dimensions
+   * used for those reports. Also see the Dimensions document for definitions of
+   * those dimensions.
+   * @opt_param int start-index An index of the first entity to retrieve. Use this
+   * parameter as a pagination mechanism along with the max-results parameter
+   * (one-based, inclusive).
+   * @opt_param string currency The currency to which financial metrics should be
+   * converted. The default is US Dollar (USD). If the result contains no
+   * financial metrics, this flag will be ignored. Responds with an error if the
+   * specified currency is not recognized.
+   * @opt_param string filters A list of filters that should be applied when
+   * retrieving YouTube Analytics data. The Available Reports document identifies
+   * the dimensions that can be used to filter each report, and the Dimensions
+   * document defines those dimensions. If a request uses multiple filters, join
+   * them together with a semicolon (;), and the returned result table will
+   * satisfy both filters. For example, a filters parameter value of
+   * video==dMH0bHeiRNg;country==IT restricts the result set to include data for
+   * the given video in Italy.
+   * @return Google_Service_YouTubeAnalytics_ResultTable
+   */
+  public function query($ids, $startDate, $endDate, $metrics, $optParams = array())
+  {
+    $params = array('ids' => $ids, 'start-date' => $startDate, 'end-date' => $endDate, 'metrics' => $metrics);
+    $params = array_merge($params, $optParams);
+    return $this->call('query', array($params), "Google_Service_YouTubeAnalytics_ResultTable");
+  }
+}
+
+
+
+
+class Google_Service_YouTubeAnalytics_BatchReport extends Google_Collection
+{
+  protected $collection_key = 'outputs';
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  protected $outputsType = 'Google_Service_YouTubeAnalytics_BatchReportOutputs';
+  protected $outputsDataType = 'array';
+  public $reportId;
+  protected $timeSpanType = 'Google_Service_YouTubeAnalytics_BatchReportTimeSpan';
+  protected $timeSpanDataType = '';
+  public $timeUpdated;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setOutputs($outputs)
+  {
+    $this->outputs = $outputs;
+  }
+  public function getOutputs()
+  {
+    return $this->outputs;
+  }
+  public function setReportId($reportId)
+  {
+    $this->reportId = $reportId;
+  }
+  public function getReportId()
+  {
+    return $this->reportId;
+  }
+  public function setTimeSpan(Google_Service_YouTubeAnalytics_BatchReportTimeSpan $timeSpan)
+  {
+    $this->timeSpan = $timeSpan;
+  }
+  public function getTimeSpan()
+  {
+    return $this->timeSpan;
+  }
+  public function setTimeUpdated($timeUpdated)
+  {
+    $this->timeUpdated = $timeUpdated;
+  }
+  public function getTimeUpdated()
+  {
+    return $this->timeUpdated;
+  }
+}
+
+class Google_Service_YouTubeAnalytics_BatchReportDefinition extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+  public $name;
+  public $status;
+  public $type;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_YouTubeAnalytics_BatchReportDefinitionList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_YouTubeAnalytics_BatchReportDefinition';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_YouTubeAnalytics_BatchReportList extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $itemsType = 'Google_Service_YouTubeAnalytics_BatchReport';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_YouTubeAnalytics_BatchReportOutputs extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $downloadUrl;
+  public $format;
+  public $type;
+
+
+  public function setDownloadUrl($downloadUrl)
+  {
+    $this->downloadUrl = $downloadUrl;
+  }
+  public function getDownloadUrl()
+  {
+    return $this->downloadUrl;
+  }
+  public function setFormat($format)
+  {
+    $this->format = $format;
+  }
+  public function getFormat()
+  {
+    return $this->format;
+  }
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+  public function getType()
+  {
+    return $this->type;
+  }
+}
+
+class Google_Service_YouTubeAnalytics_BatchReportTimeSpan extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $endTime;
+  public $startTime;
+
+
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+}
+
+class Google_Service_YouTubeAnalytics_Group extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  protected $contentDetailsType = 'Google_Service_YouTubeAnalytics_GroupContentDetails';
+  protected $contentDetailsDataType = '';
+  public $etag;
+  public $id;
+  public $kind;
+  protected $snippetType = 'Google_Service_YouTubeAnalytics_GroupSnippet';
+  protected $snippetDataType = '';
+
+
+  public function setContentDetails(Google_Service_YouTubeAnalytics_GroupContentDetails $contentDetails)
+  {
+    $this->contentDetails = $contentDetails;
+  }
+  public function getContentDetails()
+  {
+    return $this->contentDetails;
+  }
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSnippet(Google_Service_YouTubeAnalytics_GroupSnippet $snippet)
+  {
+    $this->snippet = $snippet;
+  }
+  public function getSnippet()
+  {
+    return $this->snippet;
+  }
+}
+
+class Google_Service_YouTubeAnalytics_GroupContentDetails extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $itemCount;
+  public $itemType;
+
+
+  public function setItemCount($itemCount)
+  {
+    $this->itemCount = $itemCount;
+  }
+  public function getItemCount()
+  {
+    return $this->itemCount;
+  }
+  public function setItemType($itemType)
+  {
+    $this->itemType = $itemType;
+  }
+  public function getItemType()
+  {
+    return $this->itemType;
+  }
+}
+
+class Google_Service_YouTubeAnalytics_GroupItem extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  public $groupId;
+  public $id;
+  public $kind;
+  protected $resourceType = 'Google_Service_YouTubeAnalytics_GroupItemResource';
+  protected $resourceDataType = '';
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setGroupId($groupId)
+  {
+    $this->groupId = $groupId;
+  }
+  public function getGroupId()
+  {
+    return $this->groupId;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setResource(Google_Service_YouTubeAnalytics_GroupItemResource $resource)
+  {
+    $this->resource = $resource;
+  }
+  public function getResource()
+  {
+    return $this->resource;
+  }
+}
+
+class Google_Service_YouTubeAnalytics_GroupItemListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_YouTubeAnalytics_GroupItem';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_YouTubeAnalytics_GroupItemResource extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $kind;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_YouTubeAnalytics_GroupListResponse extends Google_Collection
+{
+  protected $collection_key = 'items';
+  protected $internal_gapi_mappings = array(
+  );
+  public $etag;
+  protected $itemsType = 'Google_Service_YouTubeAnalytics_Group';
+  protected $itemsDataType = 'array';
+  public $kind;
+
+
+  public function setEtag($etag)
+  {
+    $this->etag = $etag;
+  }
+  public function getEtag()
+  {
+    return $this->etag;
+  }
+  public function setItems($items)
+  {
+    $this->items = $items;
+  }
+  public function getItems()
+  {
+    return $this->items;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+}
+
+class Google_Service_YouTubeAnalytics_GroupSnippet extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $publishedAt;
+  public $title;
+
+
+  public function setPublishedAt($publishedAt)
+  {
+    $this->publishedAt = $publishedAt;
+  }
+  public function getPublishedAt()
+  {
+    return $this->publishedAt;
+  }
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+class Google_Service_YouTubeAnalytics_ResultTable extends Google_Collection
+{
+  protected $collection_key = 'rows';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $columnHeadersType = 'Google_Service_YouTubeAnalytics_ResultTableColumnHeaders';
+  protected $columnHeadersDataType = 'array';
+  public $kind;
+  public $rows;
+
+
+  public function setColumnHeaders($columnHeaders)
+  {
+    $this->columnHeaders = $columnHeaders;
+  }
+  public function getColumnHeaders()
+  {
+    return $this->columnHeaders;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setRows($rows)
+  {
+    $this->rows = $rows;
+  }
+  public function getRows()
+  {
+    return $this->rows;
+  }
+}
+
+class Google_Service_YouTubeAnalytics_ResultTableColumnHeaders extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $columnType;
+  public $dataType;
+  public $name;
+
+
+  public function setColumnType($columnType)
+  {
+    $this->columnType = $columnType;
+  }
+  public function getColumnType()
+  {
+    return $this->columnType;
+  }
+  public function setDataType($dataType)
+  {
+    $this->dataType = $dataType;
+  }
+  public function getDataType()
+  {
+    return $this->dataType;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/YouTubeReporting.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/YouTubeReporting.php
@@ -1,0 +1,674 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Service definition for YouTubeReporting (v1).
+ *
+ * <p>
+ * An API to schedule reporting jobs and download the resulting bulk data
+ * reports about YouTube channels, videos etc. in the form of CSV files.</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/youtube/reporting/v1/reports/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Google_Service_YouTubeReporting extends Google_Service
+{
+  /** View monetary and non-monetary YouTube Analytics reports for your YouTube content. */
+  const YT_ANALYTICS_MONETARY_READONLY =
+      "https://www.googleapis.com/auth/yt-analytics-monetary.readonly";
+  /** View YouTube Analytics reports for your YouTube content. */
+  const YT_ANALYTICS_READONLY =
+      "https://www.googleapis.com/auth/yt-analytics.readonly";
+
+  public $jobs;
+  public $jobs_reports;
+  public $media;
+  public $reportTypes;
+  
+
+  /**
+   * Constructs the internal representation of the YouTubeReporting service.
+   *
+   * @param Google_Client $client
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+    $this->rootUrl = 'https://youtubereporting.googleapis.com/';
+    $this->servicePath = '';
+    $this->version = 'v1';
+    $this->serviceName = 'youtubereporting';
+
+    $this->jobs = new Google_Service_YouTubeReporting_Jobs_Resource(
+        $this,
+        $this->serviceName,
+        'jobs',
+        array(
+          'methods' => array(
+            'create' => array(
+              'path' => 'v1/jobs',
+              'httpMethod' => 'POST',
+              'parameters' => array(
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'delete' => array(
+              'path' => 'v1/jobs/{jobId}',
+              'httpMethod' => 'DELETE',
+              'parameters' => array(
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'get' => array(
+              'path' => 'v1/jobs/{jobId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1/jobs',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->jobs_reports = new Google_Service_YouTubeReporting_JobsReports_Resource(
+        $this,
+        $this->serviceName,
+        'reports',
+        array(
+          'methods' => array(
+            'get' => array(
+              'path' => 'v1/jobs/{jobId}/reports/{reportId}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'reportId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
+            ),'list' => array(
+              'path' => 'v1/jobs/{jobId}/reports',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'jobId' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->media = new Google_Service_YouTubeReporting_Media_Resource(
+        $this,
+        $this->serviceName,
+        'media',
+        array(
+          'methods' => array(
+            'download' => array(
+              'path' => 'v1/media/{+resourceName}',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'resourceName' => array(
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ),
+              ),
+            ),
+          )
+        )
+    );
+    $this->reportTypes = new Google_Service_YouTubeReporting_ReportTypes_Resource(
+        $this,
+        $this->serviceName,
+        'reportTypes',
+        array(
+          'methods' => array(
+            'list' => array(
+              'path' => 'v1/reportTypes',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'onBehalfOfContentOwner' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'pageSize' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+              ),
+            ),
+          )
+        )
+    );
+  }
+}
+
+
+/**
+ * The "jobs" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubereportingService = new Google_Service_YouTubeReporting(...);
+ *   $jobs = $youtubereportingService->jobs;
+ *  </code>
+ */
+class Google_Service_YouTubeReporting_Jobs_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Creates a job and returns it. (jobs.create)
+   *
+   * @param Google_Job $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner The content owner's external ID on
+   * which behalf the user is acting on. If not set, the user is acting for
+   * himself (his own channel).
+   * @return Google_Service_YouTubeReporting_Job
+   */
+  public function create(Google_Service_YouTubeReporting_Job $postBody, $optParams = array())
+  {
+    $params = array('postBody' => $postBody);
+    $params = array_merge($params, $optParams);
+    return $this->call('create', array($params), "Google_Service_YouTubeReporting_Job");
+  }
+
+  /**
+   * Deletes a job. (jobs.delete)
+   *
+   * @param string $jobId The ID of the job to delete.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner The content owner's external ID on
+   * which behalf the user is acting on. If not set, the user is acting for
+   * himself (his own channel).
+   * @return Google_Service_YouTubeReporting_Empty
+   */
+  public function delete($jobId, $optParams = array())
+  {
+    $params = array('jobId' => $jobId);
+    $params = array_merge($params, $optParams);
+    return $this->call('delete', array($params), "Google_Service_YouTubeReporting_Empty");
+  }
+
+  /**
+   * Gets a job. (jobs.get)
+   *
+   * @param string $jobId The ID of the job to retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner The content owner's external ID on
+   * which behalf the user is acting on. If not set, the user is acting for
+   * himself (his own channel).
+   * @return Google_Service_YouTubeReporting_Job
+   */
+  public function get($jobId, $optParams = array())
+  {
+    $params = array('jobId' => $jobId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_YouTubeReporting_Job");
+  }
+
+  /**
+   * Lists jobs. (jobs.listJobs)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A token identifying a page of results the server
+   * should return. Typically, this is the value of
+   * ListReportTypesResponse.next_page_token returned in response to the previous
+   * call to the `ListJobs` method.
+   * @opt_param string onBehalfOfContentOwner The content owner's external ID on
+   * which behalf the user is acting on. If not set, the user is acting for
+   * himself (his own channel).
+   * @opt_param int pageSize Requested page size. Server may return fewer jobs
+   * than requested. If unspecified, server will pick an appropriate default.
+   * @return Google_Service_YouTubeReporting_ListJobsResponse
+   */
+  public function listJobs($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTubeReporting_ListJobsResponse");
+  }
+}
+
+/**
+ * The "reports" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubereportingService = new Google_Service_YouTubeReporting(...);
+ *   $reports = $youtubereportingService->reports;
+ *  </code>
+ */
+class Google_Service_YouTubeReporting_JobsReports_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Gets the metadata of a specific report. (reports.get)
+   *
+   * @param string $jobId The ID of the job.
+   * @param string $reportId The ID of the report to retrieve.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string onBehalfOfContentOwner The content owner's external ID on
+   * which behalf the user is acting on. If not set, the user is acting for
+   * himself (his own channel).
+   * @return Google_Service_YouTubeReporting_Report
+   */
+  public function get($jobId, $reportId, $optParams = array())
+  {
+    $params = array('jobId' => $jobId, 'reportId' => $reportId);
+    $params = array_merge($params, $optParams);
+    return $this->call('get', array($params), "Google_Service_YouTubeReporting_Report");
+  }
+
+  /**
+   * Lists reports created by a specific job. Returns NOT_FOUND if the job does
+   * not exist. (reports.listJobsReports)
+   *
+   * @param string $jobId The ID of the job.
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A token identifying a page of results the server
+   * should return. Typically, this is the value of
+   * ListReportsResponse.next_page_token returned in response to the previous call
+   * to the `ListReports` method.
+   * @opt_param string onBehalfOfContentOwner The content owner's external ID on
+   * which behalf the user is acting on. If not set, the user is acting for
+   * himself (his own channel).
+   * @opt_param int pageSize Requested page size. Server may return fewer report
+   * types than requested. If unspecified, server will pick an appropriate
+   * default.
+   * @return Google_Service_YouTubeReporting_ListReportsResponse
+   */
+  public function listJobsReports($jobId, $optParams = array())
+  {
+    $params = array('jobId' => $jobId);
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTubeReporting_ListReportsResponse");
+  }
+}
+
+/**
+ * The "media" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubereportingService = new Google_Service_YouTubeReporting(...);
+ *   $media = $youtubereportingService->media;
+ *  </code>
+ */
+class Google_Service_YouTubeReporting_Media_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Method for media download. Download is supported on the URI
+   * `/v1/media/{+name}?alt=media`. (media.download)
+   *
+   * @param string $resourceName Name of the media that is being downloaded. See
+   * [][ByteStream.ReadRequest.resource_name].
+   * @param array $optParams Optional parameters.
+   * @return Google_Service_YouTubeReporting_Media
+   */
+  public function download($resourceName, $optParams = array())
+  {
+    $params = array('resourceName' => $resourceName);
+    $params = array_merge($params, $optParams);
+    return $this->call('download', array($params), "Google_Service_YouTubeReporting_Media");
+  }
+}
+
+/**
+ * The "reportTypes" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $youtubereportingService = new Google_Service_YouTubeReporting(...);
+ *   $reportTypes = $youtubereportingService->reportTypes;
+ *  </code>
+ */
+class Google_Service_YouTubeReporting_ReportTypes_Resource extends Google_Service_Resource
+{
+
+  /**
+   * Lists report types. (reportTypes.listReportTypes)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string pageToken A token identifying a page of results the server
+   * should return. Typically, this is the value of
+   * ListReportTypesResponse.next_page_token returned in response to the previous
+   * call to the `ListReportTypes` method.
+   * @opt_param string onBehalfOfContentOwner The content owner's external ID on
+   * which behalf the user is acting on. If not set, the user is acting for
+   * himself (his own channel).
+   * @opt_param int pageSize Requested page size. Server may return fewer report
+   * types than requested. If unspecified, server will pick an appropriate
+   * default.
+   * @return Google_Service_YouTubeReporting_ListReportTypesResponse
+   */
+  public function listReportTypes($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('list', array($params), "Google_Service_YouTubeReporting_ListReportTypesResponse");
+  }
+}
+
+
+
+
+class Google_Service_YouTubeReporting_Empty extends Google_Model
+{
+}
+
+class Google_Service_YouTubeReporting_Job extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $createTime;
+  public $id;
+  public $name;
+  public $reportTypeId;
+
+
+  public function setCreateTime($createTime)
+  {
+    $this->createTime = $createTime;
+  }
+  public function getCreateTime()
+  {
+    return $this->createTime;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+  public function setReportTypeId($reportTypeId)
+  {
+    $this->reportTypeId = $reportTypeId;
+  }
+  public function getReportTypeId()
+  {
+    return $this->reportTypeId;
+  }
+}
+
+class Google_Service_YouTubeReporting_ListJobsResponse extends Google_Collection
+{
+  protected $collection_key = 'jobs';
+  protected $internal_gapi_mappings = array(
+  );
+  protected $jobsType = 'Google_Service_YouTubeReporting_Job';
+  protected $jobsDataType = 'array';
+  public $nextPageToken;
+
+
+  public function setJobs($jobs)
+  {
+    $this->jobs = $jobs;
+  }
+  public function getJobs()
+  {
+    return $this->jobs;
+  }
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+class Google_Service_YouTubeReporting_ListReportTypesResponse extends Google_Collection
+{
+  protected $collection_key = 'reportTypes';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $reportTypesType = 'Google_Service_YouTubeReporting_ReportType';
+  protected $reportTypesDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setReportTypes($reportTypes)
+  {
+    $this->reportTypes = $reportTypes;
+  }
+  public function getReportTypes()
+  {
+    return $this->reportTypes;
+  }
+}
+
+class Google_Service_YouTubeReporting_ListReportsResponse extends Google_Collection
+{
+  protected $collection_key = 'reports';
+  protected $internal_gapi_mappings = array(
+  );
+  public $nextPageToken;
+  protected $reportsType = 'Google_Service_YouTubeReporting_Report';
+  protected $reportsDataType = 'array';
+
+
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  public function setReports($reports)
+  {
+    $this->reports = $reports;
+  }
+  public function getReports()
+  {
+    return $this->reports;
+  }
+}
+
+class Google_Service_YouTubeReporting_Media extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $resourceName;
+
+
+  public function setResourceName($resourceName)
+  {
+    $this->resourceName = $resourceName;
+  }
+  public function getResourceName()
+  {
+    return $this->resourceName;
+  }
+}
+
+class Google_Service_YouTubeReporting_Report extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $createTime;
+  public $downloadUrl;
+  public $endTime;
+  public $id;
+  public $jobId;
+  public $startTime;
+
+
+  public function setCreateTime($createTime)
+  {
+    $this->createTime = $createTime;
+  }
+  public function getCreateTime()
+  {
+    return $this->createTime;
+  }
+  public function setDownloadUrl($downloadUrl)
+  {
+    $this->downloadUrl = $downloadUrl;
+  }
+  public function getDownloadUrl()
+  {
+    return $this->downloadUrl;
+  }
+  public function setEndTime($endTime)
+  {
+    $this->endTime = $endTime;
+  }
+  public function getEndTime()
+  {
+    return $this->endTime;
+  }
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setJobId($jobId)
+  {
+    $this->jobId = $jobId;
+  }
+  public function getJobId()
+  {
+    return $this->jobId;
+  }
+  public function setStartTime($startTime)
+  {
+    $this->startTime = $startTime;
+  }
+  public function getStartTime()
+  {
+    return $this->startTime;
+  }
+}
+
+class Google_Service_YouTubeReporting_ReportType extends Google_Model
+{
+  protected $internal_gapi_mappings = array(
+  );
+  public $id;
+  public $name;
+
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  public function getId()
+  {
+    return $this->id;
+  }
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+  public function getName()
+  {
+    return $this->name;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Signer/P12.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Signer/P12.php
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-require_once 'Google/Auth/Exception.php';
-require_once 'Google/Signer/Abstract.php';
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
 
 /**
  * Signs data.
@@ -44,6 +45,8 @@ class Google_Signer_P12 extends Google_Signer_Abstract
     // and the key from google wasn't being accepted by the version available
     // at the time.
     if (!$password && strpos($p12, "-----BEGIN RSA PRIVATE KEY-----") !== false) {
+      $this->privateKey = openssl_pkey_get_private($p12);
+    } elseif ($password === 'notasecret' && strpos($p12, "-----BEGIN PRIVATE KEY-----") !== false) {
       $this->privateKey = openssl_pkey_get_private($p12);
     } else {
       // This throws on error

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Task/Exception.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Task/Exception.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
+
+class Google_Task_Exception extends Google_Exception
+{
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Task/Retryable.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Task/Retryable.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
+
+/**
+ * Interface for checking how many times a given task can be retried following
+ * a failure.
+ */
+interface Google_Task_Retryable
+{
+  /**
+   * Gets the number of times the associated task can be retried.
+   *
+   * NOTE: -1 is returned if the task can be retried indefinitely
+   *
+   * @return integer
+   */
+  public function allowedRetries();
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Task/Runner.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Task/Runner.php
@@ -1,0 +1,257 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
+
+/**
+ * A task runner with exponential backoff support.
+ *
+ * @see https://developers.google.com/drive/web/handle-errors#implementing_exponential_backoff
+ */
+class Google_Task_Runner
+{
+  /**
+   * @var integer $maxDelay The max time (in seconds) to wait before a retry.
+   */
+  private $maxDelay = 60;
+  /**
+   * @var integer $delay The previous delay from which the next is calculated.
+   */
+  private $delay = 1;
+
+  /**
+   * @var integer $factor The base number for the exponential back off.
+   */
+  private $factor = 2;
+  /**
+   * @var float $jitter A random number between -$jitter and $jitter will be
+   * added to $factor on each iteration to allow for a better distribution of
+   * retries.
+   */
+  private $jitter = 0.5;
+
+  /**
+   * @var integer $attempts The number of attempts that have been tried so far.
+   */
+  private $attempts = 0;
+  /**
+   * @var integer $maxAttempts The max number of attempts allowed.
+   */
+  private $maxAttempts = 1;
+
+  /**
+   * @var Google_Client $client The current API client.
+   */
+  private $client;
+
+  /**
+   * @var string $name The name of the current task (used for logging).
+   */
+  private $name;
+  /**
+   * @var callable $action The task to run and possibly retry.
+   */
+  private $action;
+  /**
+   * @var array $arguments The task arguments.
+   */
+  private $arguments;
+
+  /**
+   * Creates a new task runner with exponential backoff support.
+   *
+   * @param Google_Client $client The current API client
+   * @param string $name The name of the current task (used for logging)
+   * @param callable $action The task to run and possibly retry
+   * @param array $arguments The task arguments
+   * @throws Google_Task_Exception when misconfigured
+   */
+  public function __construct(
+      Google_Client $client,
+      $name,
+      $action,
+      array $arguments = array()
+  ) {
+    $config = (array) $client->getClassConfig('Google_Task_Runner');
+
+    if (isset($config['initial_delay'])) {
+      if ($config['initial_delay'] < 0) {
+        throw new Google_Task_Exception(
+            'Task configuration `initial_delay` must not be negative.'
+        );
+      }
+
+      $this->delay = $config['initial_delay'];
+    }
+
+    if (isset($config['max_delay'])) {
+      if ($config['max_delay'] <= 0) {
+        throw new Google_Task_Exception(
+            'Task configuration `max_delay` must be greater than 0.'
+        );
+      }
+
+      $this->maxDelay = $config['max_delay'];
+    }
+
+    if (isset($config['factor'])) {
+      if ($config['factor'] <= 0) {
+        throw new Google_Task_Exception(
+            'Task configuration `factor` must be greater than 0.'
+        );
+      }
+
+      $this->factor = $config['factor'];
+    }
+
+    if (isset($config['jitter'])) {
+      if ($config['jitter'] <= 0) {
+        throw new Google_Task_Exception(
+            'Task configuration `jitter` must be greater than 0.'
+        );
+      }
+
+      $this->jitter = $config['jitter'];
+    }
+
+    if (isset($config['retries'])) {
+      if ($config['retries'] < 0) {
+        throw new Google_Task_Exception(
+            'Task configuration `retries` must not be negative.'
+        );
+      }
+      $this->maxAttempts += $config['retries'];
+    }
+
+    if (!is_callable($action)) {
+        throw new Google_Task_Exception(
+            'Task argument `$action` must be a valid callable.'
+        );
+    }
+
+    $this->name = $name;
+    $this->client = $client;
+    $this->action = $action;
+    $this->arguments = $arguments;
+  }
+
+  /**
+   * Checks if a retry can be attempted.
+   *
+   * @return boolean
+   */
+  public function canAttmpt()
+  {
+    return $this->attempts < $this->maxAttempts;
+  }
+
+  /**
+   * Runs the task and (if applicable) automatically retries when errors occur.
+   *
+   * @return mixed
+   * @throws Google_Task_Retryable on failure when no retries are available.
+   */
+  public function run()
+  {
+    while ($this->attempt()) {
+      try {
+        return call_user_func_array($this->action, $this->arguments);
+      } catch (Google_Task_Retryable $exception) {
+        $allowedRetries = $exception->allowedRetries();
+
+        if (!$this->canAttmpt() || !$allowedRetries) {
+          throw $exception;
+        }
+
+        if ($allowedRetries > 0) {
+          $this->maxAttempts = min(
+              $this->maxAttempts,
+              $this->attempts + $allowedRetries
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Runs a task once, if possible. This is useful for bypassing the `run()`
+   * loop.
+   *
+   * NOTE: If this is not the first attempt, this function will sleep in
+   * accordance to the backoff configurations before running the task.
+   *
+   * @return boolean
+   */
+  public function attempt()
+  {
+    if (!$this->canAttmpt()) {
+      return false;
+    }
+
+    if ($this->attempts > 0) {
+      $this->backOff();
+    }
+
+    $this->attempts++;
+    return true;
+  }
+
+  /**
+   * Sleeps in accordance to the backoff configurations.
+   */
+  private function backOff()
+  {
+    $delay = $this->getDelay();
+
+    $this->client->getLogger()->debug(
+        'Retrying task with backoff',
+        array(
+            'request' => $this->name,
+            'retry' => $this->attempts,
+            'backoff_seconds' => $delay
+        )
+    );
+
+    usleep($delay * 1000000);
+  }
+
+  /**
+   * Gets the delay (in seconds) for the current backoff period.
+   *
+   * @return float
+   */
+  private function getDelay()
+  {
+    $jitter = $this->getJitter();
+    $factor = $this->attempts > 1 ? $this->factor + $jitter : 1 + abs($jitter);
+
+    return $this->delay = min($this->maxDelay, $this->delay * $factor);
+  }
+
+  /**
+   * Gets the current jitter (random number between -$this->jitter and
+   * $this->jitter).
+   *
+   * @return float
+   */
+  private function getJitter()
+  {
+    return $this->jitter * 2 * mt_rand() / mt_getrandmax() - $this->jitter;
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Utils.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Utils.php
@@ -18,8 +18,6 @@
 /**
  * Collection of static utility methods used for convenience across
  * the client library.
- *
- * @author Chirag Shah <chirags@google.com>
  */
 class Google_Utils
 {

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Utils/URITemplate.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Utils/URITemplate.php
@@ -16,7 +16,7 @@
  */
 
 /**
- * Implementation of levels 1-3 of the URI Template spec. 
+ * Implementation of levels 1-3 of the URI Template spec.
  * @see http://tools.ietf.org/html/rfc6570
  */
 class Google_Utils_URITemplate
@@ -26,7 +26,7 @@ class Google_Utils_URITemplate
   const TYPE_SCALAR = "4";
 
   /**
-   * @var $operators array 
+   * @var $operators array
    * These are valid at the start of a template block to
    * modify the way in which the variables inside are
    * processed.
@@ -64,7 +64,7 @@ class Google_Utils_URITemplate
   /**
    * This function finds the first matching {...} block and
    * executes the replacement. It then calls itself to find
-   * subsequent blocks, if any. 
+   * subsequent blocks, if any.
    */
   private function resolveNextSection($string, $parameters)
   {
@@ -213,7 +213,7 @@ class Google_Utils_URITemplate
     
     if (isset($parameters[$key])) {
       $data_type = $this->getDataType($parameters[$key]);
-      switch($data_type) {
+      switch ($data_type) {
         case self::TYPE_SCALAR:
           $value = $this->getValue($parameters[$key], $length);
           break;

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Verifier/Pem.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Verifier/Pem.php
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
  
-require_once 'Google/Auth/Exception.php';
-require_once 'Google/Verifier/Abstract.php';
+if (!class_exists('Google_Client')) {
+  require_once dirname(__FILE__) . '/../autoload.php';
+}
 
 /**
  * Verifies signatures using PEM encoded certificates.

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/autoload.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/autoload.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function google_api_php_client_autoload($className)
+{
+  $classPath = explode('_', $className);
+  if ($classPath[0] != 'Google') {
+    return;
+  }
+  // Drop 'Google', and maximum class file path depth in this project is 3.
+  $classPath = array_slice($classPath, 1, 2);
+  $filePath = dirname(__FILE__) . '/' . implode('/', $classPath) . '.php';
+  if (file_exists($filePath)) {
+    require_once($filePath);
+  }
+}
+spl_autoload_register('google_api_php_client_autoload');

--- a/apps/files_external/lib/storage/google.php
+++ b/apps/files_external/lib/storage/google.php
@@ -39,6 +39,7 @@ use Icewind\Streams\RetryWrapper;
 
 set_include_path(get_include_path().PATH_SEPARATOR.
 	\OC_App::getAppPath('files_external').'/3rdparty/google-api-php-client/src');
+require_once 'Google/autoload.php';
 require_once 'Google/Client.php';
 require_once 'Google/Service/Drive.php';
 


### PR DESCRIPTION
Experimental update of the google-api-php-client library to version 1.1.7, as discussed in #24431 .
The library is licensed under the Apache License, my own changes to owncloud code under MIT.
