### PR TITLE
Pass on the error message from the user manager to the UI

### DIFF
--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -355,9 +355,13 @@ class UsersController extends Controller {
 		try {
 			$user = $this->userManager->createUser($username, $password);
 		} catch (\Exception $exception) {
+			$message = $exception->getMessage();
+			if (!$message) {
+				$message = $this->l10n->t('Unable to create user.');
+			}
 			return new DataResponse(
 				array(
-					'message' => (string)$this->l10n->t('Unable to create user.')
+					'message' => (string) $message,
 				),
 				Http::STATUS_FORBIDDEN
 			);

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -840,7 +840,7 @@ $(document).ready(function () {
 				}).fail(function(result) {
 					OC.Notification.showTemporary(t('settings', 'Error creating user: {message}', {
 						message: result.responseJSON.message
-					}));
+					}, undefined, {escape: false}));
 				}).success(function(){
 					$('#newuser').get(0).reset();
 				});


### PR DESCRIPTION
Currently the UI always shows `Unable to create user.` instead of:
- `Only the following characters are allowed in a username: "a-z", "A-Z", "0-9", and "_.@-\'"`
- `Username contains whitespace at the beginning or at the end`
- `The username is already being used`

I think we should also backport this to at least 9.0 @karlitschek 

Fix #24512

@LukasReschke @DeepDiver1975 
