### PR TITLE
Make permalinks work for trashed files

### DIFF
--- a/apps/files/appinfo/application.php
+++ b/apps/files/appinfo/application.php
@@ -59,7 +59,8 @@ class Application extends App {
 				$server->getConfig(),
 				$server->getEventDispatcher(),
 				$server->getUserSession(),
-				$server->getUserFolder()
+				$server->getAppManager(),
+				$server->getRootFolder()
 			);
 		});
 


### PR DESCRIPTION
Opening a permalink that points to a trashed file will now display the
file within the "Deleted Files" section in the files web UI.

Use case is whenever you had a permalink already for a file or folder, but that one got deleted. Opening that link will display it in your trashbin instead.

Also goal is to have activity app integration where some links lead to trashbin as well: https://github.com/owncloud/activity/pull/521

Please review @nickvergessen @LukasReschke @MorrisJobke @schiesbn @blizzz 
