### PR TITLE
Cache l10n app results better to avoid unnecessary work

### DIFF
--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -95,12 +95,14 @@ class Factory implements IFactory {
 		if ($lang !== null) {
 			$lang = str_replace(array('\0', '/', '\\', '..'), '', (string) $lang);
 		}
-		if ($lang === null || !$this->languageExists($app, $lang)) {
-			$lang = $this->findLanguage($app);
-		}
 
 		if (!isset($this->instances[$lang][$app])) {
-			$this->instances[$lang][$app] = new L10N(
+			$langOrig = $lang;
+			if ($lang === null || !$this->languageExists($app, $lang)) {
+				$lang = $this->findLanguage($app);
+			}
+
+			$this->instances[$langOrig][$app] = $this->instances[$lang][$app] = new L10N(
 				$this, $app, $lang,
 				$this->getL10nFilesForApp($app, $lang)
 			);


### PR DESCRIPTION
This changes the order of some things in the L10N factory to avoid unnecessary work. To be honest, this only results in about 2% improvement when loading the main /apps/files page, which isn't a huge amount, but it was very low-hanging fruit, and every little helps.

Note: setting an array value with a `null` key actually sets an empty string key, so it works fine (but looks a bit odd I know).
