### PR TITLE
Log user out correctly if max session lifetime is reached

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -438,7 +438,7 @@ class OC {
 			if (isset($_COOKIE[session_name()])) {
 				setcookie(session_name(), null, -1, self::$WEBROOT ? : '/');
 			}
-			$session->clear();
+			\OC::$server->getUserSession()->logout();
 		}
 
 		$session->set('LAST_ACTIVITY', time());


### PR DESCRIPTION
fixes #24542

This logs the user out correctly, so also cookies, session tokens and other stuff is cleared instead of only clearing the session data.

cc @LukasReschke @rullzer 

Setting the session timeout to a small value makes it possible to test this easily

``` bash
php occ config:system:set session_lifetime --value=30 
```
