### PR TITLE
factor out redis configuration into it's own factory

### DIFF
--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -37,33 +37,7 @@ class Redis extends Cache implements IMemcacheTTL {
 	public function __construct($prefix = '') {
 		parent::__construct($prefix);
 		if (is_null(self::$cache)) {
-			// TODO allow configuring a RedisArray, see https://github.com/nicolasff/phpredis/blob/master/arrays.markdown#redis-arrays
-			self::$cache = new \Redis();
-			$config = \OC::$server->getSystemConfig()->getValue('redis', array());
-			if (isset($config['host'])) {
-				$host = $config['host'];
-			} else {
-				$host = '127.0.0.1';
-			}
-			if (isset($config['port'])) {
-				$port = $config['port'];
-			} else {
-				$port = 6379;
-			}
-			if (isset($config['timeout'])) {
-				$timeout = $config['timeout'];
-			} else {
-				$timeout = 0.0; // unlimited
-			}
-
-			self::$cache->connect($host, $port, $timeout);
-			if(isset($config['password']) && $config['password'] !== '') {
-				self::$cache->auth($config['password']);
-			}
-
-			if (isset($config['dbindex'])) {
-				self::$cache->select($config['dbindex']);
-			}
+			self::$cache = \OC::$server->getGetRedisFactory()->getInstance();
 		}
 	}
 
@@ -201,8 +175,7 @@ class Redis extends Cache implements IMemcacheTTL {
 	}
 
 	static public function isAvailable() {
-		return extension_loaded('redis')
-		&& version_compare(phpversion('redis'), '2.2.5', '>=');
+		return \OC::$server->getGetRedisFactory()->isAvailable();
 	}
 }
 

--- a/lib/private/RedisFactory.php
+++ b/lib/private/RedisFactory.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC;
+
+class RedisFactory {
+	/** @var  \Redis */
+	private $instance;
+
+	/** @var  SystemConfig */
+	private $config;
+
+	/**
+	 * RedisFactory constructor.
+	 *
+	 * @param SystemConfig $config
+	 */
+	public function __construct(SystemConfig $config) {
+		$this->config = $config;
+	}
+
+	private function create() {
+		$this->instance = new \Redis();
+		// TODO allow configuring a RedisArray, see https://github.com/nicolasff/phpredis/blob/master/arrays.markdown#redis-arrays
+		$config = $this->config->getValue('redis', array());
+		if (isset($config['host'])) {
+			$host = $config['host'];
+		} else {
+			$host = '127.0.0.1';
+		}
+		if (isset($config['port'])) {
+			$port = $config['port'];
+		} else {
+			$port = 6379;
+		}
+		if (isset($config['timeout'])) {
+			$timeout = $config['timeout'];
+		} else {
+			$timeout = 0.0; // unlimited
+		}
+
+		$this->instance->connect($host, $port, $timeout);
+		if (isset($config['password']) && $config['password'] !== '') {
+			$this->instance->auth($config['password']);
+		}
+
+		if (isset($config['dbindex'])) {
+			$this->instance->select($config['dbindex']);
+		}
+	}
+
+	public function getInstance() {
+		if (!$this->isAvailable()) {
+			throw new \Exception('Redis support is not available');
+		}
+		if (!$this->instance instanceof \Redis) {
+			$this->create();
+		}
+
+		return $this->instance;
+	}
+
+	public function isAvailable() {
+		return extension_loaded('redis')
+		&& version_compare(phpversion('redis'), '2.2.5', '>=');
+	}
+}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -312,6 +312,10 @@ class Server extends ServerContainer implements IServerContainer {
 				'\\OC\\Memcache\\ArrayCache'
 			);
 		});
+		$this->registerService('RedisFactory', function (Server $c) {
+			$systemConfig = $c->getSystemConfig();
+			return new RedisFactory($systemConfig);
+		});
 		$this->registerService('ActivityManager', function (Server $c) {
 			return new \OC\Activity\Manager(
 				$c->getRequest(),
@@ -904,6 +908,16 @@ class Server extends ServerContainer implements IServerContainer {
 	public function getMemCacheFactory() {
 		return $this->query('MemCacheFactory');
 	}
+
+	/**
+	 * Returns an \OC\RedisFactory instance
+	 *
+	 * @return \OC\RedisFactory
+	 */
+	public function getGetRedisFactory() {
+		return $this->query('RedisFactory');
+	}
+
 
 	/**
 	 * Returns the current session


### PR DESCRIPTION
Re-opening #23999 since #24033 has been put on the backburner (github didn't let me just re-open the original pr)

I still feel it's useful to have an easy way for different apps/core parts to get the configured redis instance since some use cases require more direct redis access than the memcache implementation we provide (my [teamweek project](https://github.com/icewind1991/xray) uses it for pub/sub)

cc @rullzer @DeepDiver1975 @PVince81 
