### PR TITLE
Fix etag propegation test race condition

### DIFF
--- a/apps/files_sharing/tests/etagpropagation.php
+++ b/apps/files_sharing/tests/etagpropagation.php
@@ -192,7 +192,8 @@ class EtagPropagation extends PropagationTestCase {
 	public function testOwnerWritesToSingleFileShare() {
 		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER1);
 		Filesystem::file_put_contents('/foo.txt', 'longer_bar');
-		Filesystem::touch('/foo.txt', time() - 1);
+		$t = (int)Filesystem::filemtime('/foo.txt') - 1;
+		Filesystem::touch('/foo.txt', $t);
 		$this->assertEtagsNotChanged([self::TEST_FILES_SHARING_API_USER4, self::TEST_FILES_SHARING_API_USER3]);
 		$this->assertEtagsChanged([self::TEST_FILES_SHARING_API_USER1, self::TEST_FILES_SHARING_API_USER2]);
 


### PR DESCRIPTION
E-tag propagation replies on the mtime of the file. Order of events:
1. add file 'foo.txt' with content 'bar'
2. Set mtime to now() - 1
3. Check if etag changed.

Now this goes right often when 1 and 2 happen in the same second.
However imagine
1. add file 'foo.txt' with content 'bar' (at t=0.999)
2. Set mtime to now() - 1 (at t=1.001)

Now the mtime will be set to the same time. Thus not chaning the etag.

CC: @icewind1991 @PVince81 @DeepDiver1975 
