### PR TITLE
[stable8.1] Bitmap preview unit test requires Imagick

### DIFF
--- a/tests/lib/preview/bitmap.php
+++ b/tests/lib/preview/bitmap.php
@@ -21,6 +21,9 @@
 
 namespace Test\Preview;
 
+/**
+ * @requires function Imagick::__construct
+ */
 class Bitmap extends Provider {
 
 	public function setUp() {


### PR DESCRIPTION
phpunit falls apart if imagck is not available:

```
Fatal error:  Class 'Imagick' not found in /ssd/jenkins/workspace/server-stable8.1/database/sqlite/label/SLAVE/lib/private/preview/bitmap.php on line 77
00:18:30.330 PHP Stack trace:
00:18:30.330 PHP   1. {main}() /usr/local/bin/phpunit:0
00:18:30.330 PHP   2. PHPUnit_TextUI_Command::main() /usr/local/bin/phpunit:548
00:18:30.330 PHP   3. PHPUnit_TextUI_Command->run() phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:100
00:18:30.330 PHP   4. PHPUnit_TextUI_TestRunner->doRun() phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:149
00:18:30.330 PHP   5. PHPUnit_Framework_TestSuite->run() phar:///usr/local/bin/phpunit/phpunit/TextUI/TestRunner.php:440
00:18:30.330 PHP   6. PHPUnit_Framework_TestSuite->run() phar:///usr/local/bin/phpunit/phpunit/Framework/TestSuite.php:747
00:18:30.330 PHP   7. PHPUnit_Framework_TestSuite->run() phar:///usr/local/bin/phpunit/phpunit/Framework/TestSuite.php:747
00:18:30.330 PHP   8. PHPUnit_Framework_TestCase->run() phar:///usr/local/bin/phpunit/phpunit/Framework/TestSuite.php:747
00:18:30.330 PHP   9. PHPUnit_Framework_TestResult->run() phar:///usr/local/bin/phpunit/phpunit/Framework/TestCase.php:724
00:18:30.330 PHP  10. PHPUnit_Framework_TestCase->runBare() phar:///usr/local/bin/phpunit/phpunit/Framework/TestResult.php:612
00:18:30.330 PHP  11. PHPUnit_Framework_TestCase->runTest() phar:///usr/local/bin/phpunit/phpunit/Framework/TestCase.php:768
00:18:30.330 PHP  12. ReflectionMethod->invokeArgs() phar:///usr/local/bin/phpunit/phpunit/Framework/TestCase.php:909
00:18:30.330 PHP  13. Test\Preview\Provider->testGetThumbnail() phar:///usr/local/bin/phpunit/phpunit/Framework/TestCase.php:909
00:18:30.330 PHP  14. Test\Preview\Provider->getPreview() /ssd/jenkins/workspace/server-stable8.1/database/sqlite/label/SLAVE/tests/lib/preview/provider.php:102
00:18:30.330 PHP  15. OC\Preview\Bitmap->getThumbnail() /ssd/jenkins/workspace/server-stable8.1/database/sqlite/label/SLAVE/tests/lib/preview/provider.php:138
00:18:30.330 PHP  16. OC\Preview\Bitmap->getResizedPreview() /ssd/jenkins/workspace/server-stable8.1/database/sqlite/label/SLAVE/lib/private/preview/bitmap.php:47
```
