### PR TITLE
Load external storage backends/auth mechanisms lazily

### DIFF
--- a/apps/files_external/lib/config/iauthmechanismprovider.php
+++ b/apps/files_external/lib/config/iauthmechanismprovider.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @author Robin McCorkell <robin@mccorkell.me.uk>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Lib\Config;
+
+use \OCA\Files_External\Lib\Auth\AuthMechanism;
+
+/**
+ * Provider of external storage auth mechanisms
+ * @since 9.1.0
+ */
+interface IAuthMechanismProvider {
+
+	/**
+	 * @since 9.1.0
+	 * @return AuthMechanism[]
+	 */
+	public function getAuthMechanisms();
+
+}

--- a/apps/files_external/lib/config/ibackendprovider.php
+++ b/apps/files_external/lib/config/ibackendprovider.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @author Robin McCorkell <robin@mccorkell.me.uk>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Lib\Config;
+
+use \OCA\Files_External\Lib\Backend\Backend;
+
+/**
+ * Provider of external storage backends
+ * @since 9.1.0
+ */
+interface IBackendProvider {
+
+	/**
+	 * @since 9.1.0
+	 * @return Backend[]
+	 */
+	public function getBackends();
+
+}

--- a/apps/files_external/service/backendservice.php
+++ b/apps/files_external/service/backendservice.php
@@ -26,6 +26,8 @@ use \OCP\IConfig;
 
 use \OCA\Files_External\Lib\Backend\Backend;
 use \OCA\Files_External\Lib\Auth\AuthMechanism;
+use \OCA\Files_External\Lib\Config\IBackendProvider;
+use \OCA\Files_External\Lib\Config\IAuthMechanismProvider;
 
 /**
  * Service class to manage backend definitions
@@ -55,8 +57,14 @@ class BackendService {
 	/** @var Backend[] */
 	private $backends = [];
 
+	/** @var IBackendProvider[] */
+	private $backendProviders = [];
+
 	/** @var AuthMechanism[] */
 	private $authMechanisms = [];
+
+	/** @var IAuthMechanismProvider[] */
+	private $authMechanismProviders = [];
 
 	/**
 	 * @param IConfig $config
@@ -81,8 +89,43 @@ class BackendService {
 	}
 
 	/**
+	 * Register a backend provider
+	 *
+	 * @since 9.1.0
+	 * @param IBackendProvider $provider
+	 */
+	public function registerBackendProvider(IBackendProvider $provider) {
+		$this->backendProviders[] = $provider;
+	}
+
+	private function loadBackendProviders() {
+		foreach ($this->backendProviders as $provider) {
+			$this->registerBackends($provider->getBackends());
+		}
+		$this->backendProviders = [];
+	}
+
+	/**
+	 * Register an auth mechanism provider
+	 *
+	 * @since 9.1.0
+	 * @param IAuthMechanismProvider $provider
+	 */
+	public function registerAuthMechanismProvider(IAuthMechanismProvider $provider) {
+		$this->authMechanismProviders[] = $provider;
+	}
+
+	private function loadAuthMechanismProviders() {
+		foreach ($this->authMechanismProviders as $provider) {
+			$this->registerAuthMechanisms($provider->getAuthMechanisms());
+		}
+		$this->authMechanismProviders = [];
+	}
+
+	/**
 	 * Register a backend
 	 *
+	 * @deprecated 9.1.0 use registerBackendProvider()
 	 * @param Backend $backend
 	 */
 	public function registerBackend(Backend $backend) {
@@ -95,6 +138,7 @@ class BackendService {
 	}
 
 	/**
+	 * @deprecated 9.1.0 use registerBackendProvider()
 	 * @param Backend[] $backends
 	 */
 	public function registerBackends(array $backends) {
@@ -105,6 +149,7 @@ class BackendService {
 	/**
 	 * Register an authentication mechanism
 	 *
+	 * @deprecated 9.1.0 use registerAuthMechanismProvider()
 	 * @param AuthMechanism $authMech
 	 */
 	public function registerAuthMechanism(AuthMechanism $authMech) {
@@ -117,6 +162,7 @@ class BackendService {
 	}
 
 	/**
+	 * @deprecated 9.1.0 use registerAuthMechanismProvider()
 	 * @param AuthMechanism[] $mechanisms
 	 */
 	public function registerAuthMechanisms(array $mechanisms) {
@@ -131,6 +177,7 @@ class BackendService {
 	 * @return Backend[]
 	 */
 	public function getBackends() {
+		$this->loadBackendProviders();
 		// only return real identifiers, no aliases
 		$backends = [];
 		foreach ($this->backends as $backend) {
@@ -155,6 +202,7 @@ class BackendService {
 	 * @return Backend|null
 	 */
 	public function getBackend($identifier) {
+		$this->loadBackendProviders();
 		if (isset($this->backends[$identifier])) {
 			return $this->backends[$identifier];
 		}
@@ -167,6 +215,7 @@ class BackendService {
 	 * @return AuthMechanism[]
 	 */
 	public function getAuthMechanisms() {
+		$this->loadAuthMechanismProviders();
 		// only return real identifiers, no aliases
 		$mechanisms = [];
 		foreach ($this->authMechanisms as $mechanism) {
@@ -192,6 +241,7 @@ class BackendService {
 	 * @return AuthMechanism|null
 	 */
 	public function getAuthMechanism($identifier) {
+		$this->loadAuthMechanismProviders();
 		if (isset($this->authMechanisms[$identifier])) {
 			return $this->authMechanisms[$identifier];
 		}


### PR DESCRIPTION
Lots of operations don't actually need external storage backends at all, so we don't need to load them. This introduces the Provider pattern to BackendService, allowing code to pass a provider instead of the fully-constructed backends/auth mechanisms, which is evaluated when actually needed.

Looking at a [Blackfire.io trace from my ODroid C1+](https://blackfire.io/profiles/bf708bc0-89e0-498b-b9c8-bf8823876b9a/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=OCA%5CFiles_External%5CAppInfo%5CApplication%3A%3AloadBackends&callname=main%28%29) which was without this PR, notice that loading backends takes 4% of the time, that should drop to 0% for most requests now.

cc @PVince81 @icewind1991 
