### PR TITLE
Use CLOB for auth token names to allow long user agent strings

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -1065,10 +1065,9 @@
 
 			<field>
 				<name>name</name>
-				<type>text</type>
+				<type>clob</type>
 				<default></default>
 				<notnull>true</notnull>
-				<length>100</length>
 			</field>
 
 			<field>

--- a/tests/lib/authentication/token/defaulttokenprovidertest.php
+++ b/tests/lib/authentication/token/defaulttokenprovidertest.php
@@ -62,7 +62,10 @@ class DefaultTokenProviderTest extends TestCase {
 		$token = 'token';
 		$uid = 'user';
 		$password = 'passme';
-		$name = 'Some browser';
+		$name = 'User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.2.12) Gecko/20101026 Firefox/3.6.12'
+			. 'User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.2.12) Gecko/20101026 Firefox/3.6.12'
+			. 'User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.2.12) Gecko/20101026 Firefox/3.6.12'
+			. 'User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.2.12) Gecko/20101026 Firefox/3.6.12';
 		$type = IToken::PERMANENT_TOKEN;
 
 		$toInsert = new DefaultToken();

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 1, 0, 1);
+$OC_Version = array(9, 1, 0, 2);
 
 // The human readable string
 $OC_VersionString = '9.1.0 pre alpha';


### PR DESCRIPTION
fixes #24593
