### PR TITLE
Show login error message correctly

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -178,7 +178,6 @@ class LoginController extends Controller {
 		}
 		if ($loginResult === false) {
 			$this->session->set('loginMessages', [
-				[],
 				['invalidpassword']
 			]);
 			// Read current user and append if possible


### PR DESCRIPTION
Another bug caused by my pluggable auth PR :see_no_evil: 

cc @LukasReschke @PVince81 @nickvergessen 
# Before

![bildschirmfoto von 2016-05-12 12-13-31](https://cloud.githubusercontent.com/assets/1374172/15211540/0355d0a4-183c-11e6-83d2-246109adff89.png)
# After

![bildschirmfoto von 2016-05-12 12-13-51](https://cloud.githubusercontent.com/assets/1374172/15211541/037b36a0-183c-11e6-82bd-e5381daed96d.png)
