### PR TITLE
flat federated re-share

### DIFF
--- a/apps/federatedfilesharing/appinfo/app.php
+++ b/apps/federatedfilesharing/appinfo/app.php
@@ -20,4 +20,21 @@
  */
 
 $app = new \OCA\FederatedFileSharing\AppInfo\Application('federatedfilesharing');
+
+use OCA\FederatedFileSharing\Notifier;
+
+$l = \OC::$server->getL10N('files_sharing');
+
 $app->registerSettings();
+
+$manager = \OC::$server->getNotificationManager();
+$manager->registerNotifier(function() {
+	return new Notifier(
+		\OC::$server->getL10NFactory()
+	);
+}, function() use ($l) {
+	return [
+		'id' => 'files_sharing',
+		'name' => $l->t('Federated sharing'),
+	];
+});

--- a/apps/federatedfilesharing/appinfo/database.xml
+++ b/apps/federatedfilesharing/appinfo/database.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+
+<!--
+Keep a mapping of the share ID stored in the local oc_share table
+and the share ID stored in the remote servers oc_share table.
+This is needed in order to send updates in both directions between
+the servers (e.g. permissions change, unshare,...)
+-->
+
+<database>
+	<name>*dbname*</name>
+	<create>true</create>
+	<overwrite>false</overwrite>
+	<charset>utf8</charset>
+	<table>
+		<name>*dbprefix*federated_reshares</name>
+		<declaration>
+			<field>
+				<name>share_id</name>
+				<type>integer</type>
+				<notnull>true</notnull>
+				<length>4</length>
+			</field>
+			<field>
+				<name>remote_id</name>
+				<type>integer</type>
+				<notnull>true</notnull>
+				<length>4</length>
+				<comments>share ID at the remote server</comments>
+			</field>
+			<index>
+				<name>share_id_index</name>
+				<unique>true</unique>
+				<field>
+					<name>share_id</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+		</declaration>
+	</table>
+</database>

--- a/apps/federatedfilesharing/appinfo/info.xml
+++ b/apps/federatedfilesharing/appinfo/info.xml
@@ -5,7 +5,7 @@
     <description>Provide federated file sharing across ownCloud servers</description>
     <licence>AGPL</licence>
     <author>Bjoern Schiessle, Roeland Jago Douma</author>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
     <namespace>FederatedFileSharing</namespace>
     <category>other</category>
     <dependencies>

--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -81,7 +81,8 @@ class Application extends App {
 			\OC::$server->getL10N('federatedfilesharing'),
 			\OC::$server->getLogger(),
 			\OC::$server->getLazyRootFolder(),
-			\OC::$server->getConfig()
+			\OC::$server->getConfig(),
+			\OC::$server->getUserManager()
 		);
 	}
 

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -23,13 +23,12 @@
 
 namespace OCA\FederatedFileSharing;
 
-use OC\Files\View;
 use OC\Share20\Share;
 use OCP\Files\IRootFolder;
-use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\ILogger;
+use OCP\IUserManager;
 use OCP\Share\IShare;
 use OCP\Share\IShareProvider;
 use OC\Share20\Exception\InvalidShare;
@@ -74,6 +73,9 @@ class FederatedShareProvider implements IShareProvider {
 	/** @var string */
 	private $externalShareTable = 'share_external';
 
+	/** @var IUserManager */
+	private $userManager;
+
 	/**
 	 * DefaultShareProvider constructor.
 	 *
@@ -85,6 +87,7 @@ class FederatedShareProvider implements IShareProvider {
 	 * @param ILogger $logger
 	 * @param IRootFolder $rootFolder
 	 * @param IConfig $config
+	 * @param IUserManager $userManager
 	 */
 	public function __construct(
 			IDBConnection $connection,
@@ -94,7 +97,8 @@ class FederatedShareProvider implements IShareProvider {
 			IL10N $l10n,
 			ILogger $logger,
 			IRootFolder $rootFolder,
-			IConfig $config
+			IConfig $config,
+			IUserManager $userManager
 	) {
 		$this->dbConnection = $connection;
 		$this->addressHandler = $addressHandler;
@@ -104,6 +108,7 @@ class FederatedShareProvider implements IShareProvider {
 		$this->logger = $logger;
 		$this->rootFolder = $rootFolder;
 		$this->config = $config;
+		$this->userManager = $userManager;
 	}
 
 	/**
@@ -699,7 +704,7 @@ class FederatedShareProvider implements IShareProvider {
 	 */
 	private function createShare($data) {
 
-		$share = new Share($this->rootFolder);
+		$share = new Share($this->rootFolder, $this->userManager);
 		$share->setId((int)$data['id'])
 			->setShareType((int)$data['share_type'])
 			->setPermissions((int)$data['permissions'])

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -179,7 +179,7 @@ class FederatedShareProvider implements IShareProvider {
 				// fall back to old re-share behavior if the remote server
 				// doesn't support flat re-shares (was introduced with ownCloud 9.1)
 				$this->removeShareFromTable($share);
-				$this->createFederatedShare($share);
+				$shareId = $this->createFederatedShare($share);
 			}
 			if ($send) {
 				$this->updateSuccessfulReshare($shareId, $token);
@@ -191,7 +191,7 @@ class FederatedShareProvider implements IShareProvider {
 			}
 
 		} else {
-			$this->createFederatedShare($share);
+			$shareId = $this->createFederatedShare($share);
 		}
 
 		$data = $this->getRawShare($shareId);
@@ -202,7 +202,7 @@ class FederatedShareProvider implements IShareProvider {
 	 * create federated share and inform the recipient
 	 *
 	 * @param IShare $share
-	 * @return array
+	 * @return int
 	 * @throws ShareNotFound
 	 * @throws \Exception
 	 */
@@ -241,6 +241,7 @@ class FederatedShareProvider implements IShareProvider {
 			throw new \Exception($message_t);
 		}
 
+		return $shareId;
 	}
 
 	/**

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -183,7 +183,7 @@ class Notifications {
 	 * @return bool
 	 */
 	public function sendPermissionChange($remote, $remoteId, $token, $permissions) {
-		$this->sendUpdateToRemote($remote, $remoteId, $token, ['permissions' => $permissions]);
+		$this->sendUpdateToRemote($remote, $remoteId, $token, 'permissions', ['permissions' => $permissions]);
 	}
 
 	/**
@@ -222,6 +222,10 @@ class Notifications {
 	public function sendUpdateToRemote($remote, $remoteId, $token, $action, $data = [], $try = 0) {
 
 		$fields = array('token' => $token);
+		foreach ($data as $key => $value) {
+			$fields[$key] = $value;
+		}
+
 		$url = $this->addressHandler->removeProtocolFromUrl($remote);
 		$result = $this->tryHttpPostToShareEndpoint(rtrim($url, '/'), '/' . $remoteId . '/' . $action, $fields);
 		$status = json_decode($result['result'], true);

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -23,6 +23,7 @@
 
 namespace OCA\FederatedFileSharing;
 
+use OCP\AppFramework\Http;
 use OCP\BackgroundJob\IJobList;
 use OCP\Http\Client\IClientService;
 
@@ -291,6 +292,12 @@ class Notifications {
 				$result['success'] = true;
 				break;
 			} catch (\Exception $e) {
+				// if flat re-sharing is not supported by the remote server
+				// we re-throw the exception and fall back to the old behaviour.
+				// (flat re-shares has been introduced in ownCloud 9.1)
+				if ($e->getCode() === Http::STATUS_INTERNAL_SERVER_ERROR) {
+					throw $e;
+				}
 				$try++;
 				$protocol = 'http://';
 			}

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -272,6 +272,7 @@ class Notifications {
 	 * @param string $urlSuffix
 	 * @param array $fields post parameters
 	 * @return array
+	 * @throws \Exception
 	 */
 	protected function tryHttpPostToShareEndpoint($remoteDomain, $urlSuffix, array $fields) {
 		$client = $this->httpClientService->newClient();

--- a/apps/federatedfilesharing/lib/RequestHandler.php
+++ b/apps/federatedfilesharing/lib/RequestHandler.php
@@ -251,7 +251,7 @@ class RequestHandler {
 					$this->federatedShareProvider->storeRemoteId((int)$result->getId(), $remoteId);
 					return new \OC_OCS_Result(['token' => $result->getToken(), 'remoteId' => $result->getId()]);
 				} catch (\Exception $e) {
-					return new \OC_OCS_Result(null, Http::STATUS_INTERNAL_SERVER_ERROR);
+					return new \OC_OCS_Result(null, Http::STATUS_BAD_REQUEST);
 				}
 			} else {
 				return new \OC_OCS_Result(null, Http::STATUS_FORBIDDEN);

--- a/apps/federatedfilesharing/lib/RequestHandler.php
+++ b/apps/federatedfilesharing/lib/RequestHandler.php
@@ -23,14 +23,21 @@
  *
  */
 
-namespace OCA\Files_Sharing\API;
+namespace OCA\FederatedFileSharing;
 
 use OCA\FederatedFileSharing\DiscoveryManager;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\Files_Sharing\Activity;
 use OCP\Files\NotFoundException;
 
-class Server2Server {
+/**
+ * Class RequestHandler
+ * 
+ * handles OCS Request to the federated share API
+ *
+ * @package OCA\FederatedFileSharing\API
+ */
+class RequestHandler {
 
 	/** @var FederatedShareProvider */
 	private $federatedShareProvider;

--- a/apps/federatedfilesharing/lib/notifier.php
+++ b/apps/federatedfilesharing/lib/notifier.php
@@ -19,7 +19,7 @@
  *
  */
 
-namespace OCA\Files_Sharing;
+namespace OCA\FederatedFileSharing;
 
 
 use OCP\Notification\INotification;

--- a/apps/federatedfilesharing/tests/AddressHandlerTest.php
+++ b/apps/federatedfilesharing/tests/AddressHandlerTest.php
@@ -27,9 +27,8 @@ namespace OCA\FederatedFileSharing\Tests;
 use OCA\FederatedFileSharing\AddressHandler;
 use OCP\IL10N;
 use OCP\IURLGenerator;
-use Test\TestCase;
 
-class AddressHandlerTest extends TestCase {
+class AddressHandlerTest extends \Test\TestCase {
 
 	/** @var  AddressHandler */
 	private $addressHandler;

--- a/apps/federatedfilesharing/tests/DiscoveryManagerTest.php
+++ b/apps/federatedfilesharing/tests/DiscoveryManagerTest.php
@@ -26,9 +26,8 @@ use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\ICache;
 use OCP\ICacheFactory;
-use Test\TestCase;
 
-class DiscoveryManagerTest extends TestCase {
+class DiscoveryManagerTest extends \Test\TestCase {
 	/** @var ICache */
 	private $cache;
 	/** @var IClient */

--- a/apps/federatedfilesharing/tests/RequestHandlerTest.php
+++ b/apps/federatedfilesharing/tests/RequestHandlerTest.php
@@ -23,14 +23,19 @@
  *
  */
 
-use OCA\Files_Sharing\Tests\TestCase;
+namespace OCA\FederatedFileSharing\Tests;
+
+use OC\Files\Filesystem;
+use OCA\FederatedFileSharing\DiscoveryManager;
+use OCA\FederatedFileSharing\RequestHandler;
 
 /**
- * Class Test_Files_Sharing_Api
+ * Class RequestHandlerTest
  *
+ * @package OCA\FederatedFileSharing\Tests
  * @group DB
  */
-class Test_Files_Sharing_S2S_OCS_API extends TestCase {
+class RequestHandlerTest extends TestCase {
 
 	const TEST_FOLDER_NAME = '/folder_share_api_test';
 
@@ -69,7 +74,7 @@ class Test_Files_Sharing_S2S_OCS_API extends TestCase {
 
 		$this->registerHttpHelper($httpHelperMock);
 
-		$this->s2s = new \OCA\Files_Sharing\API\Server2Server($this->federatedShareProvider);
+		$this->s2s = new RequestHandler($this->federatedShareProvider);
 
 		$this->connection = \OC::$server->getDatabaseConnection();
 	}
@@ -194,14 +199,14 @@ class Test_Files_Sharing_S2S_OCS_API extends TestCase {
 	function testDeleteUser($toDelete, $expected, $remainingUsers) {
 		$this->createDummyS2SShares();
 
-		$discoveryManager = new \OCA\FederatedFileSharing\DiscoveryManager(
+		$discoveryManager = new DiscoveryManager(
 			\OC::$server->getMemCacheFactory(),
 			\OC::$server->getHTTPClientService()
 		);
-		$manager = new OCA\Files_Sharing\External\Manager(
+		$manager = new \OCA\Files_Sharing\External\Manager(
 			\OC::$server->getDatabaseConnection(),
-			\OC\Files\Filesystem::getMountManager(),
-			\OC\Files\Filesystem::getLoader(),
+			Filesystem::getMountManager(),
+			Filesystem::getLoader(),
 			\OC::$server->getHTTPHelper(),
 			\OC::$server->getNotificationManager(),
 			$discoveryManager,

--- a/apps/federatedfilesharing/tests/TestCase.php
+++ b/apps/federatedfilesharing/tests/TestCase.php
@@ -32,7 +32,6 @@ namespace OCA\FederatedFileSharing\Tests;
 
 use OC\Files\Filesystem;
 use OCA\Files\Share;
-use OCA\Files_Sharing\Appinfo\Application;
 
 /**
  * Class Test_Files_Sharing_Base

--- a/apps/federatedfilesharing/tests/TestCase.php
+++ b/apps/federatedfilesharing/tests/TestCase.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ * @author Lukas Reschke <lukas@owncloud.com>
+ * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Robin Appelman <icewind@owncloud.com>
+ * @author Robin McCorkell <robin@mccorkell.me.uk>
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedFileSharing\Tests;
+
+use OC\Files\Filesystem;
+use OCA\Files\Share;
+use OCA\Files_Sharing\Appinfo\Application;
+
+/**
+ * Class Test_Files_Sharing_Base
+ *
+ * @group DB
+ *
+ * Base class for sharing tests.
+ */
+abstract class TestCase extends \Test\TestCase {
+
+	const TEST_FILES_SHARING_API_USER1 = "test-share-user1";
+	const TEST_FILES_SHARING_API_USER2 = "test-share-user2";
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		// reset backend
+		\OC_User::clearBackends();
+		\OC_Group::clearBackends();
+
+		// create users
+		$backend = new \Test\Util\User\Dummy();
+		\OC_User::useBackend($backend);
+		$backend->createUser(self::TEST_FILES_SHARING_API_USER1, self::TEST_FILES_SHARING_API_USER1);
+		$backend->createUser(self::TEST_FILES_SHARING_API_USER2, self::TEST_FILES_SHARING_API_USER2);
+	}
+
+	protected function setUp() {
+		parent::setUp();
+
+		//login as user1
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+	}
+
+	public static function tearDownAfterClass() {
+		// cleanup users
+		$user = \OC::$server->getUserManager()->get(self::TEST_FILES_SHARING_API_USER1);
+		if ($user !== null) {
+			$user->delete();
+		}
+		$user = \OC::$server->getUserManager()->get(self::TEST_FILES_SHARING_API_USER2);
+		if ($user !== null) {
+			$user->delete();
+		}
+
+		\OC_Util::tearDownFS();
+		\OC_User::setUserId('');
+		Filesystem::tearDown();
+
+		// reset backend
+		\OC_User::clearBackends();
+		\OC_User::useBackend('database');
+		\OC_Group::clearBackends();
+		\OC_Group::useBackend(new \OC_Group_Database());
+
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * @param string $user
+	 * @param bool $create
+	 * @param bool $password
+	 */
+	protected static function loginHelper($user, $create = false, $password = false) {
+
+		if ($password === false) {
+			$password = $user;
+		}
+
+		if ($create) {
+			\OC::$server->getUserManager()->createUser($user, $password);
+			\OC_Group::createGroup('group');
+			\OC_Group::addToGroup($user, 'group');
+		}
+
+		self::resetStorage();
+
+		\OC_Util::tearDownFS();
+		\OC::$server->getUserSession()->setUser(null);
+		\OC\Files\Filesystem::tearDown();
+		\OC::$server->getUserSession()->login($user, $password);
+		\OC::$server->getUserFolder($user);
+
+		\OC_Util::setupFS($user);
+	}
+
+	/**
+	 * reset init status for the share storage
+	 */
+	protected static function resetStorage() {
+		$storage = new \ReflectionClass('\OC\Files\Storage\Shared');
+		$isInitialized = $storage->getProperty('initialized');
+		$isInitialized->setAccessible(true);
+		$isInitialized->setValue($storage, false);
+		$isInitialized->setAccessible(false);
+	}
+
+}

--- a/apps/federatedfilesharing/tests/TokenHandlerTest.php
+++ b/apps/federatedfilesharing/tests/TokenHandlerTest.php
@@ -26,9 +26,8 @@ namespace OCA\FederatedFileSharing\Tests;
 
 use OCA\FederatedFileSharing\TokenHandler;
 use OCP\Security\ISecureRandom;
-use Test\TestCase;
 
-class TokenHandlerTest extends TestCase {
+class TokenHandlerTest extends \Test\TestCase {
 
 	/** @var  TokenHandler */
 	private $tokenHandler;

--- a/apps/files_sharing/api/share20ocs.php
+++ b/apps/files_sharing/api/share20ocs.php
@@ -99,7 +99,15 @@ class Share20OCS {
 	 */
 	protected function formatShare(\OCP\Share\IShare $share) {
 		$sharedBy = $this->userManager->get($share->getSharedBy());
-		$shareOwner = $this->userManager->get($share->getShareOwner());
+		// for federated shares the owner can be a remote user, in this
+		// case we use the initiator
+		if ($this->userManager->userExists($share->getShareOwner())) {
+			$shareOwner = $this->userManager->get($share->getShareOwner());
+			$localUser = $share->getShareOwner();
+		} else {
+			$shareOwner = $this->userManager->get($share->getSharedBy());
+			$localUser = $share->getSharedBy();
+		}
 		$result = [
 			'id' => $share->getId(),
 			'share_type' => $share->getShareType(),
@@ -115,7 +123,7 @@ class Share20OCS {
 		];
 
 		$node = $share->getNode();
-		$result['path'] = $this->rootFolder->getUserFolder($share->getShareOwner())->getRelativePath($node->getPath());
+		$result['path'] = $this->rootFolder->getUserFolder($localUser)->getRelativePath($node->getPath());
 		if ($node instanceOf \OCP\Files\Folder) {
 			$result['item_type'] = 'folder';
 		} else {

--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -103,15 +103,3 @@ if ($config->getAppValue('core', 'shareapi_enabled', 'yes') === 'yes') {
 		}
 	}
 }
-
-$manager = \OC::$server->getNotificationManager();
-$manager->registerNotifier(function() {
-	return new \OCA\Files_Sharing\Notifier(
-		\OC::$server->getL10NFactory()
-	);
-}, function() use ($l) {
-	return [
-		'id' => 'files_sharing',
-		'name' => $l->t('Federated sharing'),
-	];
-});

--- a/apps/files_sharing/lib/external/manager.php
+++ b/apps/files_sharing/lib/external/manager.php
@@ -338,6 +338,7 @@ class Manager {
 			$share = $getShare->fetch();
 			$this->sendFeedbackToRemote($share['remote'], $share['share_token'], $share['remote_id'], 'decline');
 		}
+		$getShare->closeCursor();
 
 		$query = $this->connection->prepare('
 			DELETE FROM `*PREFIX*share_external`

--- a/apps/files_sharing/lib/external/manager.php
+++ b/apps/files_sharing/lib/external/manager.php
@@ -325,6 +325,10 @@ class Manager {
 	}
 
 	public function removeShare($mountPoint) {
+
+		$mountPointObj = $this->mountManager->find($mountPoint);
+		$id = $mountPointObj->getStorage()->getCache()->getId();
+
 		$mountPoint = $this->stripPath($mountPoint);
 		$hash = md5($mountPoint);
 
@@ -345,7 +349,36 @@ class Manager {
 			WHERE `mountpoint_hash` = ?
 			AND `user` = ?
 		');
-		return (bool)$query->execute(array($hash, $this->uid));
+		$result = (bool)$query->execute(array($hash, $this->uid));
+
+		if($result) {
+			$this->removeReShares($id);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * remove re-shares from share table and mapping in the federated_reshares table
+	 * 
+	 * @param $mountPointId
+	 */
+	protected function removeReShares($mountPointId) {
+		$selectQuery = $this->connection->getQueryBuilder();
+		$query = $this->connection->getQueryBuilder();
+		$selectQuery->select('id')->from('share')
+			->where($selectQuery->expr()->eq('file_source', $query->createNamedParameter($mountPointId)));
+		$select = $selectQuery->getSQL();
+
+
+		$query->delete('federated_reshares')
+			->where($query->expr()->in('share_id', $query->createFunction('(' . $select . ')')));
+		$query->execute();
+
+		$deleteReShares = $this->connection->getQueryBuilder();
+		$deleteReShares->delete('share')
+			->where($deleteReShares->expr()->eq('file_source', $deleteReShares->createNamedParameter($mountPointId)));
+		$deleteReShares->execute();
 	}
 
 	/**

--- a/apps/files_sharing/lib/notifier.php
+++ b/apps/files_sharing/lib/notifier.php
@@ -54,9 +54,15 @@ class Notifier implements INotifier {
 			// Deal with known subjects
 			case 'remote_share':
 				$params = $notification->getSubjectParameters();
-				$notification->setParsedSubject(
-					(string) $l->t('You received "/%2$s" as a remote share from %1$s', $params)
-				);
+				if ($params[0] !== $params[1] && $params[1] !== null) {
+					$notification->setParsedSubject(
+						(string) $l->t('You received "/%3$s" as a remote share from %1$s (on behalf of %2$s)', $params)
+					);
+				} else {
+					$notification->setParsedSubject(
+						(string)$l->t('You received "/%3$s" as a remote share from %1$s', $params)
+					);
+				}
 
 				// Deal with the actions for a known subject
 				foreach ($notification->getActions() as $action) {

--- a/apps/files_sharing/tests/api/share20ocstest.php
+++ b/apps/files_sharing/tests/api/share20ocstest.php
@@ -82,6 +82,8 @@ class Share20OCSTest extends \Test\TestCase {
 		$this->currentUser = $this->getMock('OCP\IUser');
 		$this->currentUser->method('getUID')->willReturn('currentUser');
 
+		$this->userManager->expects($this->any())->method('userExists')->willReturn(true);
+
 		$this->l = $this->getMock('\OCP\IL10N');
 		$this->l->method('t')
 			->will($this->returnCallback(function($text, $parameters = []) {

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -733,7 +733,7 @@ class DefaultShareProvider implements IShareProvider {
 	 * @throws InvalidShare
 	 */
 	private function createShare($data) {
-		$share = new Share($this->rootFolder);
+		$share = new Share($this->rootFolder, $this->userManager);
 		$share->setId((int)$data['id'])
 			->setShareType((int)$data['share_type'])
 			->setPermissions((int)$data['permissions'])

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -115,7 +115,8 @@ class ProviderFactory implements IProviderFactory {
 				$l,
 				$this->serverContainer->getLogger(),
 				$this->serverContainer->getLazyRootFolder(),
-				$this->serverContainer->getConfig()
+				$this->serverContainer->getConfig(),
+				$this->serverContainer->getUserManager()
 			);
 		}
 

--- a/ocs/routes.php
+++ b/ocs/routes.php
@@ -100,13 +100,46 @@ API::register(
 // Server-to-Server Sharing
 if (\OC::$server->getAppManager()->isEnabledForUser('files_sharing')) {
 	$federatedSharingApp = new \OCA\FederatedFileSharing\AppInfo\Application('federatedfilesharing');
-	$s2s = new OCA\FederatedFileSharing\RequestHandler($federatedSharingApp->getFederatedShareProvider(), \OC::$server->getDatabaseConnection());
+	$addressHandler = new \OCA\FederatedFileSharing\AddressHandler(
+		\OC::$server->getURLGenerator(),
+		\OC::$server->getL10N('federatedfilesharing')
+	);
+	$notification = new \OCA\FederatedFileSharing\Notifications(
+		$addressHandler,
+		\OC::$server->getHTTPClientService(),
+		new \OCA\FederatedFileSharing\DiscoveryManager(\OC::$server->getMemCacheFactory(), \OC::$server->getHTTPClientService()),
+		\OC::$server->getJobList()
+	);
+	$s2s = new OCA\FederatedFileSharing\RequestHandler(
+		$federatedSharingApp->getFederatedShareProvider(),
+		\OC::$server->getDatabaseConnection(),
+		\OC::$server->getShareManager(),
+		\OC::$server->getRequest(),
+		$notification,
+		$addressHandler,
+		\OC::$server->getUserManager()
+	);
 	API::register('post',
 		'/cloud/shares',
 		array($s2s, 'createShare'),
 		'files_sharing',
 		API::GUEST_AUTH
 	);
+
+	API::register('post',
+		'/cloud/shares/{id}/reshare',
+		array($s2s, 'reShare'),
+		'files_sharing',
+		API::GUEST_AUTH
+	);
+
+	API::register('post',
+		'/cloud/shares/{id}/permissions',
+		array($s2s, 'update'),
+		'files_sharing',
+		API::GUEST_AUTH
+	);
+
 
 	API::register('post',
 		'/cloud/shares/{id}/accept',
@@ -125,6 +158,13 @@ if (\OC::$server->getAppManager()->isEnabledForUser('files_sharing')) {
 	API::register('post',
 		'/cloud/shares/{id}/unshare',
 		array($s2s, 'unshare'),
+		'files_sharing',
+		API::GUEST_AUTH
+	);
+
+	API::register('post',
+		'/cloud/shares/{id}/revoke',
+		array($s2s, 'revoke'),
 		'files_sharing',
 		API::GUEST_AUTH
 	);

--- a/ocs/routes.php
+++ b/ocs/routes.php
@@ -100,7 +100,7 @@ API::register(
 // Server-to-Server Sharing
 if (\OC::$server->getAppManager()->isEnabledForUser('files_sharing')) {
 	$federatedSharingApp = new \OCA\FederatedFileSharing\AppInfo\Application('federatedfilesharing');
-	$s2s = new \OCA\Files_Sharing\API\Server2Server($federatedSharingApp->getFederatedShareProvider());
+	$s2s = new OCA\FederatedFileSharing\RequestHandler($federatedSharingApp->getFederatedShareProvider());
 	API::register('post',
 		'/cloud/shares',
 		array($s2s, 'createShare'),

--- a/ocs/routes.php
+++ b/ocs/routes.php
@@ -100,7 +100,7 @@ API::register(
 // Server-to-Server Sharing
 if (\OC::$server->getAppManager()->isEnabledForUser('files_sharing')) {
 	$federatedSharingApp = new \OCA\FederatedFileSharing\AppInfo\Application('federatedfilesharing');
-	$s2s = new OCA\FederatedFileSharing\RequestHandler($federatedSharingApp->getFederatedShareProvider());
+	$s2s = new OCA\FederatedFileSharing\RequestHandler($federatedSharingApp->getFederatedShareProvider(), \OC::$server->getDatabaseConnection());
 	API::register('post',
 		'/cloud/shares',
 		array($s2s, 'createShare'),

--- a/ocs/routes.php
+++ b/ocs/routes.php
@@ -135,7 +135,7 @@ if (\OC::$server->getAppManager()->isEnabledForUser('files_sharing')) {
 
 	API::register('post',
 		'/cloud/shares/{id}/permissions',
-		array($s2s, 'update'),
+		array($s2s, 'updatePermissions'),
 		'files_sharing',
 		API::GUEST_AUTH
 	);

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -57,6 +57,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->groupManager = $this->getMock('OCP\IGroupManager');
 		$this->rootFolder = $this->getMock('OCP\Files\IRootFolder');
 
+		$this->userManager->expects($this->any())->method('userExists')->willReturn(true);
+
 		//Empty share table
 		$this->dbConn->getQueryBuilder()->delete('share')->execute();
 
@@ -587,7 +589,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testCreateUserShare() {
-		$share = new \OC\Share20\Share($this->rootFolder);
+		$share = new \OC\Share20\Share($this->rootFolder, $this->userManager);
 
 		$shareOwner = $this->getMock('OCP\IUser');
 		$shareOwner->method('getUID')->WillReturn('shareOwner');
@@ -635,7 +637,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testCreateGroupShare() {
-		$share = new \OC\Share20\Share($this->rootFolder);
+		$share = new \OC\Share20\Share($this->rootFolder, $this->userManager);
 
 		$shareOwner = $this->getMock('\OCP\IUser');
 		$shareOwner->method('getUID')->willReturn('shareOwner');
@@ -683,7 +685,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testCreateLinkShare() {
-		$share = new \OC\Share20\Share($this->rootFolder);
+		$share = new \OC\Share20\Share($this->rootFolder, $this->userManager);
 
 		$shareOwner = $this->getMock('\OCP\IUser');
 		$shareOwner->method('getUID')->willReturn('shareOwner');

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -2283,6 +2283,9 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	public function testUpdateShareUser() {
+
+		$this->userManager->expects($this->any())->method('userExists')->willReturn(true);
+
 		$manager = $this->createManagerMock()
 			->setMethods([
 				'canShare',

--- a/tests/lib/Share20/ShareTest.php
+++ b/tests/lib/Share20/ShareTest.php
@@ -36,7 +36,8 @@ class ShareTest extends \Test\TestCase {
 
 	public function setUp() {
 		$this->rootFolder = $this->getMock('\OCP\Files\IRootFolder');
-		$this->share = new \OC\Share20\Share($this->rootFolder);
+		$this->userManager = $this->getMock('OCP\IUserManager');
+		$this->share = new \OC\Share20\Share($this->rootFolder, $this->userManager);
 	}
 
 	/**


### PR DESCRIPTION
This PR introduces flat federated re-shares. This means that if userA@serverA share a file with userB@serverB and userB decided to reshare the file with userC@serverC the share will be created directly between userA and userC. Still both userA and userB will see the share and will be able to manipulate it, unshare it etc.

This should be a nice performance boost for federated re-shares. Because now everyone is directly connected to the source of the file instead of going through multiple ownClouds.

Further this brings the same behavior we already have for internal shares to federated shares.
- [x] reshare gets created directly by the owner
- [x] unshare from self gets propagated to both the owner and the initiator of the share
- [x] unshare form the owner/initiator gets propagated to the recipient and the initiator/owner
- [x] notification says "you received fileX from userA@serverA on behalf of userB@serverB" so that you know who shared the file with you
- [x] propagate permission changes
- [x] fall-back for federated re-shares with older ownClouds
- [x] adjust unit tests
