### PR TITLE
Handling files which require Swift large object storage

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Swift.php
+++ b/apps/files_external/lib/Lib/Storage/Swift.php
@@ -370,12 +370,17 @@ class Swift extends \OC\Files\Storage\Common {
 		}
 
 		try {
-			$containerName = $this->getContainer()->getName();
-			$pathsToDelete = array(sprintf('/%s/%s', $containerName, $path));
-			foreach ($this->getFileSegments($path) as $segmentPath) {
-				$pathsToDelete[] = sprintf('/%s/%s', $containerName, $segmentPath);
+			$fileSegments = $this->getFileSegments($path);
+			if (count($fileSegments) == 0) {
+				$this->getContainer()->dataObject()->setName($path)->delete();
+			} else {
+				$containerName = $this->getContainer()->getName();
+				$pathsToDelete = array(sprintf('/%s/%s', $containerName, $path));
+				foreach ($fileSegments as $segmentPath) {
+					$pathsToDelete[] = sprintf('/%s/%s', $containerName, $segmentPath);
+				}
+				$this->getConnection()->bulkDelete($pathsToDelete);
 			}
-			$this->getConnection()->bulkDelete($pathsToDelete);
 			$this->objectCache->remove($path);
 			$this->objectCache->remove($path . '/');
 		} catch (ClientErrorResponseException $e) {


### PR DESCRIPTION
Thanks @tjdett for this commit, from https://github.com/owncloud/core/pull/19004

At a particular threshold, php-opencloud DLO support is used to upload
the object in segments.

Large object files are detected when copying, renaming and deleting.
Deletions remove any segments that follow the naming convention used by
php-opencloud.

For now, copy/rename simply fails for large files. The best solution for
implementing it involves upgrading php-opencloud.
