### PR TITLE
don't spam the log file with failed token validation entries

### DIFF
--- a/lib/private/Authentication/Token/DefaultTokenProvider.php
+++ b/lib/private/Authentication/Token/DefaultTokenProvider.php
@@ -148,13 +148,11 @@ class DefaultTokenProvider implements IProvider {
 	 * @return DefaultToken user UID
 	 */
 	public function validateToken($token) {
-		$this->logger->debug('validating default token <' . $token . '>');
 		try {
 			$dbToken = $this->mapper->getToken($this->hashToken($token));
-			$this->logger->debug('valid token for ' . $dbToken->getUID());
+			$this->logger->debug('valid default token for ' . $dbToken->getUID());
 			return $dbToken;
 		} catch (DoesNotExistException $ex) {
-			$this->logger->warning('invalid token');
 			throw new InvalidTokenException();
 		}
 	}


### PR DESCRIPTION
Since token login is one of three possible auth mechanisms on APIs (we have basic auth, basic auth with token as password and pure token auth), token validation may fail regularily. However, this does **not** mean that the login fails, it could just mean that one of the auth mechanisms tried did not succeed.
As those log entries may be confusing, I'd like to remove those again.

@LukasReschke @rullzer
