### PR TITLE
our autoloader should not load classes in \OC

### DIFF
--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -102,7 +102,6 @@ class Autoloader {
 			}
 		} elseif (strpos($class, 'OC_') === 0) {
 			$paths[] = \OC::$SERVERROOT . '/lib/private/legacy/' . strtolower(str_replace('_', '/', substr($class, 3)) . '.php');
-			$paths[] = \OC::$SERVERROOT . '/lib/private/' . strtolower(str_replace('_', '/', substr($class, 3)) . '.php');
 		} elseif (strpos($class, 'OC\\') === 0) {
 			$split = explode('\\', $class, 3);
 

--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -102,23 +102,6 @@ class Autoloader {
 			}
 		} elseif (strpos($class, 'OC_') === 0) {
 			$paths[] = \OC::$SERVERROOT . '/lib/private/legacy/' . strtolower(str_replace('_', '/', substr($class, 3)) . '.php');
-		} elseif (strpos($class, 'OC\\') === 0) {
-			$split = explode('\\', $class, 3);
-
-			if (count($split) === 3) {
-				$split[1] = strtolower($split[1]);
-
-				if ($split[1] === 'core') {
-					// Covered by PSR-4 autoloader
-				} else if ($split[1] === 'settings') {
-					// Covered by PSR-4 autoloader
-				} else {
-					$paths[] = \OC::$SERVERROOT . '/lib/private/' . $split[1] . '/' . strtolower(str_replace('\\', '/', $split[2])) . '.php';
-				}
-
-			} else {
-				$paths[] = \OC::$SERVERROOT . '/lib/private/' . strtolower(str_replace('\\', '/', $split[1])) . '.php';
-			}
 		} elseif (strpos($class, 'OCP\\') === 0) {
 			$paths[] = \OC::$SERVERROOT . '/lib/public/' . strtolower(str_replace('\\', '/', substr($class, 4)) . '.php');
 		} elseif (strpos($class, 'OCA\\') === 0) {

--- a/tests/lib/autoloader.php
+++ b/tests/lib/autoloader.php
@@ -21,20 +21,19 @@ class AutoLoader extends TestCase {
 
 	public function testLeadingSlashOnClassName() {
 		$this->assertEquals([
-			\OC::$SERVERROOT . '/lib/private/files/storage/local.php',
-		], $this->loader->findClass('\OC\Files\Storage\Local'));
+			\OC::$SERVERROOT . '/lib/public/files/storage/local.php',
+		], $this->loader->findClass('\OCP\Files\Storage\Local'));
 	}
 
 	public function testNoLeadingSlashOnClassName() {
 		$this->assertEquals([
-			\OC::$SERVERROOT . '/lib/private/files/storage/local.php', 
-		], $this->loader->findClass('OC\Files\Storage\Local'));
+			\OC::$SERVERROOT . '/lib/public/files/storage/local.php',
+		], $this->loader->findClass('OCP\Files\Storage\Local'));
 	}
 
 	public function testLegacyPath() {
 		$this->assertEquals([
 			\OC::$SERVERROOT . '/lib/private/legacy/files.php', 
-			\OC::$SERVERROOT . '/lib/private/files.php',
 		], $this->loader->findClass('OC_Files'));
 	}
 
@@ -50,16 +49,9 @@ class AutoLoader extends TestCase {
 		], $this->loader->findClass('Test_Foo_Bar'));
 	}
 
-	public function testLoadCoreNamespace() {
-		$this->assertEquals([
-			\OC::$SERVERROOT . '/lib/private/foo/bar.php', 
-		], $this->loader->findClass('OC\Foo\Bar'));
-	}
-
 	public function testLoadCore() {
 		$this->assertEquals([
 			\OC::$SERVERROOT . '/lib/private/legacy/foo/bar.php', 
-			\OC::$SERVERROOT . '/lib/private/foo/bar.php',
 		], $this->loader->findClass('OC_Foo_Bar'));
 	}
 
@@ -82,11 +74,5 @@ class AutoLoader extends TestCase {
 
 	public function testLoadCoreNamespaceSettings() {
 		$this->assertEquals([], $this->loader->findClass('OC\Settings\Foo\Bar'));
-	}
-
-	public function testLoadCoreNamespaceRepair() {
-		$this->assertEquals([
-			\OC::$SERVERROOT . '/lib/private/repair/foo/bar.php',
-		], $this->loader->findClass('OC\Repair\Foo\Bar'));
 	}
 }


### PR DESCRIPTION
Now that all classes in \OC are moved to PSR-4 the ownCloud autoloader should not longer load them!
- All OC_xx stuff lives in the legacy folder (so only load from there)
- No longer load \OC classes with the ownCloud autoloader
- Fix unit tests related to changes

CC: @nickvergessen @MorrisJobke @LukasReschke @DeepDiver1975 
