### PR TITLE
fix admin link share settings sorting, use same order as in sidebar

### DIFF
--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -208,21 +208,21 @@ if ($_['cronErrors']) {
 		</p>
 
 		<p id="publicLinkSettings" class="indent <?php if ($_['allowLinks'] !== 'yes' || $_['shareAPIEnabled'] === 'no') p('hidden'); ?>">
-			<input type="checkbox" name="shareapi_enforce_links_password" id="enforceLinkPassword" class="checkbox"
-				   value="1" <?php if ($_['enforceLinkPassword']) print_unescaped('checked="checked"'); ?> />
-			<label for="enforceLinkPassword"><?php p($l->t('Enforce password protection'));?></label><br/>
-
 			<input type="checkbox" name="shareapi_allow_public_upload" id="allowPublicUpload" class="checkbox"
 				   value="1" <?php if ($_['allowPublicUpload'] == 'yes') print_unescaped('checked="checked"'); ?> />
 			<label for="allowPublicUpload"><?php p($l->t('Allow public uploads'));?></label><br/>
 
-			<input type="checkbox" name="shareapi_allow_public_notification" id="allowPublicMailNotification" class="checkbox"
-				   value="1" <?php if ($_['allowPublicMailNotification'] == 'yes') print_unescaped('checked="checked"'); ?> />
-			<label for="allowPublicMailNotification"><?php p($l->t('Allow users to send mail notification for shared files'));?></label><br/>
+			<input type="checkbox" name="shareapi_enforce_links_password" id="enforceLinkPassword" class="checkbox"
+				   value="1" <?php if ($_['enforceLinkPassword']) print_unescaped('checked="checked"'); ?> />
+			<label for="enforceLinkPassword"><?php p($l->t('Enforce password protection'));?></label><br/>
 
 			<input type="checkbox" name="shareapi_default_expire_date" id="shareapiDefaultExpireDate" class="checkbox"
 				   value="1" <?php if ($_['shareDefaultExpireDateSet'] === 'yes') print_unescaped('checked="checked"'); ?> />
 			<label for="shareapiDefaultExpireDate"><?php p($l->t('Set default expiration date'));?></label><br/>
+
+			<input type="checkbox" name="shareapi_allow_public_notification" id="allowPublicMailNotification" class="checkbox"
+				   value="1" <?php if ($_['allowPublicMailNotification'] == 'yes') print_unescaped('checked="checked"'); ?> />
+			<label for="allowPublicMailNotification"><?php p($l->t('Allow users to send mail notification for shared files'));?></label><br/>
 
 		</p>
 		<p id="setDefaultExpireDate" class="double-indent <?php if ($_['allowLinks'] !== 'yes' || $_['shareDefaultExpireDateSet'] === 'no' || $_['shareAPIEnabled'] === 'no') p('hidden');?>">


### PR DESCRIPTION
Before it was:
- require password
- allow public upload (on by default)
- allow share email notifications
- specify default expiration date

Now:
- allow public upload (on by default)
- require password
- specify default expiration date
- allow share email notifications

Makes a lot more sense since the default ticked option is the first now, and the expiration date is below password.

Please review @owncloud/designers @owncloud/sharing
