### PR TITLE
[FIX] owncloud/core#11893: disable the download link on empty public page

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -158,3 +158,16 @@ thead {
 	opacity: 1;
 	cursor: pointer;
 }
+
+#download.disabled,
+#download.disabled:hover,
+#download.disabled:focus {
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=40)";
+	filter: alpha(opacity=40);
+	opacity: 0.4;
+	cursor: default;
+}
+
+#download.disabled * {
+	cursor: default;
+}

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -193,10 +193,18 @@ OCA.Sharing.PublicApp = {
 			};
 
 			this.fileList.updateEmptyContent = function() {
+				var list = this;
 				this.$el.find('#emptycontent .uploadmessage').text(
 					t('files_sharing', 'You can upload into this folder')
 				);
-				$('#download').toggleClass('hidden', this.isEmpty);
+
+				$('#download').click(function(event) {
+					event.preventDefault();
+					if(!list.isEmpty) {
+						OC.redirect(FileList.getDownloadUrl());
+					}
+				});
+				$('#download').toggleClass('disabled', list.isEmpty);
 				OCA.Files.FileList.prototype.updateEmptyContent.apply(this, arguments);
 			};
 
@@ -224,11 +232,6 @@ OCA.Sharing.PublicApp = {
 			// URL history handling
 			this.fileList.$el.on('changeDirectory', _.bind(this._onDirectoryChanged, this));
 			OC.Util.History.addOnPopStateHandler(_.bind(this._onUrlChanged, this));
-
-			$('#download').click(function (e) {
-				e.preventDefault();
-				OC.redirect(FileList.getDownloadUrl());
-			});
 		}
 
 		$(document).on('click', '#directLink', function () {

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -196,6 +196,7 @@ OCA.Sharing.PublicApp = {
 				this.$el.find('#emptycontent .uploadmessage').text(
 					t('files_sharing', 'You can upload into this folder')
 				);
+				$('#download').toggleClass('hidden', this.isEmpty);
 				OCA.Files.FileList.prototype.updateEmptyContent.apply(this, arguments);
 			};
 

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -79,7 +79,7 @@ $thumbSize = 1024;
 					</form>
 				</span>
 				<?php } ?>
-				<a href="<?php p($_['downloadURL']); ?>" id="download" class="button hidden">
+				<a href="<?php p($_['downloadURL']); ?>" id="download" class="button disabled">
 					<img class="svg" alt="" src="<?php print_unescaped(image_path("core", "actions/download.svg")); ?>"/>
 					<span id="download-text"><?php p($l->t('Download'))?></span>
 				</a>

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -79,7 +79,7 @@ $thumbSize = 1024;
 					</form>
 				</span>
 				<?php } ?>
-				<a href="<?php p($_['downloadURL']); ?>" id="download" class="button">
+				<a href="<?php p($_['downloadURL']); ?>" id="download" class="button hidden">
 					<img class="svg" alt="" src="<?php print_unescaped(image_path("core", "actions/download.svg")); ?>"/>
 					<span id="download-text"><?php p($l->t('Download'))?></span>
 				</a>


### PR DESCRIPTION
Disable the download link by calling preventDefault() and do no futher action. The buttons default state is disabled as long the filelist is empty. Set opacity to .4 for the disabled button.

Fixes #11893
