### PR TITLE
[stable9] Allow to set logout redirect url through config

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -222,6 +222,11 @@ $CONFIG = array(
 'lost_password_link' => 'https://example.org/link/to/password/reset',
 
 /**
+ * The URL to redirect to after the user has been logged out.
+ */
+'logout_url' => 'https://example.org/',
+
+/**
  * Mail Parameters
  *
  * These configure the email settings for ownCloud notifications and password

--- a/lib/base.php
+++ b/lib/base.php
@@ -929,8 +929,10 @@ class OC {
 					\OC::$server->getConfig()->deleteUserValue(OC_User::getUser(), 'login_token', $_COOKIE['oc_token']);
 				}
 				OC_User::logout();
-				// redirect to webroot and add slash if webroot is empty
-				header("Location: " . \OC::$server->getURLGenerator()->getAbsoluteURL('/'));
+				// Use system config or redirect to webroot and add slash if webroot is empty
+				$redirect_url = $systemConfig->getValue('logout_url',
+					\OC::$server->getURLGenerator()->getAbsoluteURL('/'));
+				header("Location: " . $redirect_url);
 			} else {
 				// Redirect to default application
 				OC_Util::redirectToDefaultPage();


### PR DESCRIPTION
This allows to specify the URL to redirect to after the user has been logged out from the config. It is especially useful when using an external authentication mechanism - e.g. SSO. We need it for example in [YunoHost](https://yunohost.org) to allow the user to log out from the integrated SSO when clicking on the Logout button from ownCloud. It is a common feature that we already find in other Web applications.

I didn't filled the contribution form so this really little contribution is MIT licensed. I purpose you this feature in the hope you will consider and integrate it - maybe in a better way and in the _master_ branch too. It will by the way allow us to not have to patch this very few lines! :) Thanks in advance!
