### PR TITLE
Correctly load server2server sharing configs

### DIFF
--- a/lib/private/appconfig.php
+++ b/lib/private/appconfig.php
@@ -284,7 +284,13 @@ class AppConfig implements IAppConfig {
 				$sql->expr()->in('configkey', $sql->createParameter('legit_configs'))
 			))
 			->setParameter('appid', 'files_sharing', \PDO::PARAM_STR)
-			->setParameter('legit_configs', ['enabled', 'installed_version', 'types'], Connection::PARAM_STR_ARRAY);
+			->setParameter('legit_configs', [
+				'enabled',
+				'installed_version',
+				'types',
+				'incoming_server2server_share_enabled',
+				'outgoing_server2server_share_enabled',
+			], Connection::PARAM_STR_ARRAY);
 		$result = $sql->execute();
 
 		while ($row = $result->fetch()) {


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/pull/23505#issuecomment-219096382

To test:
1. Disable the two options in the admin settings:
   
   > - Allow users on this server to send shares to other servers
   > - Allow users on this server to receive shares from other servers 
2. Refresh the page

@rullzer @schiesbn 

@karlitschek for the backport
