### PR TITLE
don't allow token login for disabled users

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -362,6 +362,10 @@ class Session implements IUserSession, Emitter {
 			// user does not exist
 			return false;
 		}
+		if (!$user->isEnabled()) {
+			// disabled users can not log in
+			return false;
+		}
 
 		//login
 		$this->setUser($user);


### PR DESCRIPTION
Steps to reproduce the bug/test the fix:
1. generate a device specific token (POST localhost:8080/token/generate?user=yourusername&password=yourpassword)
2. use that token to access a OCS API (e.g. GET http://localhost:8080/ocs/v1.php/apps/files_sharing/api/v1/sharees?format=json&search=a&perPage=200&itemType=folder with header `Authorization: token xxxxxxxxxxxxxx`
3. get access or not depending on which branch is used
