### PR TITLE
dont update search onResize

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -507,8 +507,6 @@
 			this.breadcrumb.setMaxWidth(containerWidth - actionsWidth - 10);
 
 			this.$table.find('>thead').width($('#app-content').width() - OC.Util.getScrollBarWidth());
-
-			this.updateSearch();
 		},
 
 		/**


### PR DESCRIPTION
Searchbox is broken at least on latest Android Chrome. this.updateSearch() sets the current file list instance and clears the box. This is unnecessary and makes the search box unsuable on some mobile devices where a keyboard fade-in triggers onResize, which would then clear and blur and finally hide the box.
