### PR TITLE
Allow chunk GC mtime tolerance for unfinished part chunks

### DIFF
--- a/lib/private/Cache/File.php
+++ b/lib/private/Cache/File.php
@@ -172,7 +172,9 @@ class File implements ICache {
 	public function gc() {
 		$storage = $this->getStorage();
 		if ($storage and $storage->is_dir('/')) {
-			$now = time();
+			// extra hour safety, in case of stray part chunks that take longer to write,
+			// because touch() is only called after the chunk was finished
+			$now = time() - 3600;
 			$dh = $storage->opendir('/');
 			if (!is_resource($dh)) {
 				return null;


### PR DESCRIPTION
Whenever part chunks are written, every fwrite in the write loop will
reset the mtime to the current mtime. Only at the end will the touch()
operation set the mtime to now + ttl, in the future.

However the GC code is expecting that every chunk with mtime < now are
old and must be deleted. This causes the GC to sometimes delete part
chunks in which the write loop is slow.

To fix this, a tolerance value is added in the GC code to allow for
more time before a part chunk gets deleted.

Fixes https://github.com/owncloud/core/issues/24653
Steps here: https://github.com/owncloud/core/issues/24653#issuecomment-219735296

Please review @icewind1991 @Marginal @MorrisJobke @nickvergessen @schiesbn @rullzer 
