### PR TITLE
Lock jobs while executing them, to allow multiple executors to run in…

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -615,17 +615,6 @@ $CONFIG = array(
 'cron_log' => true,
 
 /**
- * Location of the lock file for cron executions can be specified here.
- * Default is within the tmp directory. The file is named in the following way:
- * owncloud-server-$INSTANCEID-cron.lock
- * where $INSTANCEID is the string specified in the ``instanceid`` field.
- * Because the cron lock file is accessed at regular intervals, it may prevent
- * enabled disk drives from spinning down. A different location for this file
- * can solve such issues.
- */
-'cron.lockfile.location' => '',
-
-/**
  * Enables log rotation and limits the total size of logfiles. The default is 0,
  * or no rotation. Specify a size in bytes, for example 104857600 (100 megabytes
  * = 100 * 1024 * 1024 bytes). A new logfile is created with a new name when the

--- a/cron.php
+++ b/cron.php
@@ -100,32 +100,9 @@ try {
 			}
 		}
 
-		$instanceId = $config->getSystemValue('instanceid');
-		$lockFileName = 'owncloud-server-' . $instanceId . '-cron.lock';
-		$lockDirectory = $config->getSystemValue('cron.lockfile.location', sys_get_temp_dir());
-		$lockDirectory = rtrim($lockDirectory, '\\/');
-		$lockFile = $lockDirectory . '/' . $lockFileName;
-
-		if (!file_exists($lockFile)) {
-			touch($lockFile);
-		}
-
 		// We call ownCloud from the CLI (aka cron)
 		if ($appMode != 'cron') {
 			\OCP\BackgroundJob::setExecutionType('cron');
-		}
-
-		// open the file and try to lock it. If it is not locked, the background
-		// job can be executed, otherwise another instance is already running
-		$fp = fopen($lockFile, 'w');
-		$isLocked = flock($fp, LOCK_EX|LOCK_NB, $wouldBlock);
-
-		// check if backgroundjobs is still running. The wouldBlock check is
-		// needed on systems with advisory locking, see
-		// http://php.net/manual/en/function.flock.php#45464
-		if (!$isLocked || $wouldBlock) {
-			echo "Another instance of cron.php is still running!" . PHP_EOL;
-			exit(1);
 		}
 
 		// Work
@@ -154,10 +131,6 @@ try {
 				break;
 			}
 		}
-
-		// unlock the file
-		flock($fp, LOCK_UN);
-		fclose($fp);
 
 	} else {
 		// We call cron.php from some website

--- a/cron.php
+++ b/cron.php
@@ -138,6 +138,7 @@ try {
 		$executedJobs = [];
 		while ($job = $jobList->getNext()) {
 			if (isset($executedJobs[$job->getId()])) {
+				$jobList->unlockJob($job);
 				break;
 			}
 

--- a/db_structure.xml
+++ b/db_structure.xml
@@ -968,7 +968,24 @@
 			</field>
 
 			<field>
+				<!-- timestamp when the job was executed the last time -->
 				<name>last_run</name>
+				<type>integer</type>
+				<default></default>
+				<notnull>false</notnull>
+			</field>
+
+			<field>
+				<!-- timestamp when the job was checked if it needs execution the last time -->
+				<name>last_checked</name>
+				<type>integer</type>
+				<default></default>
+				<notnull>false</notnull>
+			</field>
+
+			<field>
+				<!-- timestamp when the job was reserved the last time, 1 day timeout -->
+				<name>reserved_at</name>
 				<type>integer</type>
 				<default></default>
 				<notnull>false</notnull>

--- a/lib/private/AppFramework/Db/Db.php
+++ b/lib/private/AppFramework/Db/Db.php
@@ -29,6 +29,7 @@ namespace OC\AppFramework\Db;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDb;
 use OCP\IDBConnection;
+use OCP\PreConditionNotMetException;
 
 /**
  * @deprecated use IDBConnection directly, will be removed in ownCloud 10
@@ -157,10 +158,24 @@ class Db implements IDb {
 	 * @param array $updatePreconditionValues ensure values match preconditions (column name => value)
 	 * @return int number of new rows
 	 * @throws \Doctrine\DBAL\DBALException
-	 * @throws PreconditionNotMetException
+	 * @throws PreConditionNotMetException
 	 */
 	public function setValues($table, array $keys, array $values, array $updatePreconditionValues = []) {
 		return $this->connection->setValues($table, $keys, $values, $updatePreconditionValues);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function lockTable($tableName) {
+		$this->connection->lockTable($tableName);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function unlockTable() {
+		$this->connection->unlockTable();
 	}
 
 	/**

--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -58,6 +58,26 @@ class Adapter {
 	}
 
 	/**
+	 * Create an exclusive read+write lock on a table
+	 *
+	 * @param string $tableName
+	 * @since 9.1.0
+	 */
+	public function lockTable($tableName) {
+		$this->conn->beginTransaction();
+		$this->conn->executeUpdate('LOCK TABLE `' .$tableName . '` IN EXCLUSIVE MODE');
+	}
+
+	/**
+	 * Release a previous acquired lock again
+	 *
+	 * @since 9.1.0
+	 */
+	public function unlockTable() {
+		$this->conn->commit();
+	}
+
+	/**
 	 * Insert a row if the matching row does not exists.
 	 *
 	 * @param string $table The table name (will replace *PREFIX* with the actual prefix)

--- a/lib/private/DB/AdapterMySQL.php
+++ b/lib/private/DB/AdapterMySQL.php
@@ -24,6 +24,18 @@
 namespace OC\DB;
 
 class AdapterMySQL extends Adapter {
+
+	/**
+	 * @param string $tableName
+	 */
+	public function lockTable($tableName) {
+		$this->conn->executeUpdate('LOCK TABLES `' .$tableName . '` WRITE');
+	}
+
+	public function unlockTable() {
+		$this->conn->executeUpdate('UNLOCK TABLES');
+	}
+
 	public function fixupStatement($statement) {
 		$statement = str_replace(' ILIKE ', ' COLLATE utf8_general_ci LIKE ', $statement);
 		return $statement;

--- a/lib/private/DB/AdapterSqlite.php
+++ b/lib/private/DB/AdapterSqlite.php
@@ -27,6 +27,18 @@
 namespace OC\DB;
 
 class AdapterSqlite extends Adapter {
+
+	/**
+	 * @param string $tableName
+	 */
+	public function lockTable($tableName) {
+		$this->conn->executeUpdate('BEGIN EXCLUSIVE TRANSACTION');
+	}
+
+	public function unlockTable() {
+		$this->conn->executeUpdate('COMMIT TRANSACTION');
+	}
+
 	public function fixupStatement($statement) {
 		$statement = preg_replace('( I?LIKE \?)', '$0 ESCAPE \'\\\'', $statement);
 		$statement = preg_replace('/`(\w+)` ILIKE \?/', 'LOWER($1) LIKE LOWER(?)', $statement);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -362,7 +362,11 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 		$this->registerService('JobList', function (Server $c) {
 			$config = $c->getConfig();
-			return new \OC\BackgroundJob\JobList($c->getDatabaseConnection(), $config);
+			return new \OC\BackgroundJob\JobList(
+				$c->getDatabaseConnection(),
+				$config,
+				new TimeFactory()
+			);
 		});
 		$this->registerService('Router', function (Server $c) {
 			$cacheFactory = $c->getMemCacheFactory();

--- a/lib/public/BackgroundJob/IJobList.php
+++ b/lib/public/BackgroundJob/IJobList.php
@@ -93,10 +93,21 @@ interface IJobList {
 	public function setLastJob($job);
 
 	/**
+	 * Remove the reservation for a job
+	 *
+	 * @param IJob $job
+	 * @since 9.1.0
+	 */
+	public function unlockJob($job);
+
+	/**
 	 * get the id of the last ran job
 	 *
 	 * @return int
 	 * @since 7.0.0
+	 * @deprecated 9.1.0 - The functionality behind the value is deprecated, it
+	 *    only tells you which job finished last, but since we now allow multiple
+	 *    executors to run in parallel, it's not used to calculate the next job.
 	 */
 	public function getLastJob();
 

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -125,6 +125,25 @@ interface IDBConnection {
 	public function setValues($table, array $keys, array $values, array $updatePreconditionValues = []);
 
 	/**
+	 * Create an exclusive read+write lock on a table
+	 *
+	 * Important Note: Due to the nature how locks work on different DBs, it is
+	 * only possible to lock one table at a time. You should also NOT start a
+	 * transaction while holding a lock.
+	 *
+	 * @param string $tableName
+	 * @since 9.1.0
+	 */
+	public function lockTable($tableName);
+
+	/**
+	 * Release a previous acquired lock again
+	 *
+	 * @since 9.1.0
+	 */
+	public function unlockTable();
+
+	/**
 	 * Start a transaction
 	 * @since 6.0.0
 	 */

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 1, 0, 2);
+$OC_Version = array(9, 1, 0, 3);
 
 // The human readable string
 $OC_VersionString = '9.1.0 pre alpha';


### PR DESCRIPTION
… parallel

Contributes towards https://github.com/owncloud/core/pull/24551
- [x] Clarify API
- [x] Fix tests

I implemented the `UPDATE with lock and then SELECT` because `SELECT ... FOR UPDATE` does not exist for all ours DBs, so it feels wrong adding that to the `IQueryBuilder`
