### PR TITLE
Only recurse into incomplete folders during background scans

### DIFF
--- a/lib/public/Files/Cache/IScanner.php
+++ b/lib/public/Files/Cache/IScanner.php
@@ -27,6 +27,7 @@ namespace OCP\Files\Cache;
  * @since 9.0.0
  */
 interface IScanner {
+	const SCAN_RECURSIVE_INCOMPLETE = 2; // only recursive into not fully scanned folders
 	const SCAN_RECURSIVE = true;
 	const SCAN_SHALLOW = false;
 


### PR DESCRIPTION
Improves background scan performance on large folder structures

cc @PVince81 @rullzer 
