### PR TITLE
try token login first

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -287,12 +287,20 @@ class Session implements IUserSession, Emitter {
 	 */
 	public function login($uid, $password) {
 		$this->session->regenerateId();
-		$this->manager->emit('\OC\User', 'preLogin', array($uid, $password));
-		$user = $this->manager->checkPassword($uid, $password);
-		if ($user === false) {
-			if ($this->validateToken($password)) {
-				$user = $this->getUser();
+		if ($this->validateToken($password)) {
+			$user = $this->getUser();
+
+			// When logging in with token, the password must be decrypted first before passing to login hook
+			try {
+				$token = $this->tokenProvider->getToken($password);
+				$password = $this->tokenProvider->getPassword($token, $password);
+				$this->manager->emit('\OC\User', 'preLogin', array($uid, $password));
+			} catch (InvalidTokenException $ex) {
+				// Invalid token, nothing to do
 			}
+		} else {
+			$this->manager->emit('\OC\User', 'preLogin', array($uid, $password));
+			$user = $this->manager->checkPassword($uid, $password);
 		}
 		if ($user !== false) {
 			if (!is_null($user)) {


### PR DESCRIPTION
When checking password login first, the user manager logs a failed login attempt to owncloud.log. To prevent that the order is inverted and token auth is tried first.

partially fixes #24727

and fixes the unreported (found it while fixing) bug that the login hook was triggered with the token instead of the actual login password :boom: 

@rullzer @LukasReschke 
