### PR TITLE
 	Make sure we evaluate installed everywhere as a boolean

### DIFF
--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -168,6 +168,7 @@ class Updater extends BasicEmitter {
 
 		$this->emit('\OC\Updater', 'resetLogLevel', [ $logLevel, $this->logLevelNames[$logLevel] ]);
 		$this->config->setSystemValue('loglevel', $logLevel);
+		$this->config->setSystemValue('installed', true);
 
 		return $success;
 	}

--- a/status.php
+++ b/status.php
@@ -31,8 +31,8 @@ try {
 
 	$systemConfig = \OC::$server->getSystemConfig();
 
-	$installed = $systemConfig->getValue('installed') == 1;
-	$maintenance = $systemConfig->getValue('maintenance', false);
+	$installed = (bool) $systemConfig->getValue('installed', false);
+	$maintenance = (bool) $systemConfig->getValue('maintenance', false);
 	$values=array(
 		'installed'=>$installed,
 		'maintenance' => $maintenance,


### PR DESCRIPTION
Regarding status.php:
`(bool) 'true'` === true
`'true' == 1` === false

Should backport @karlitschek @PVince81 

@tflidd please review

Fix #24714
