### PR TITLE
create a real federated share if a user add a public link to his ownCloud

### DIFF
--- a/apps/federatedfilesharing/appinfo/routes.php
+++ b/apps/federatedfilesharing/appinfo/routes.php
@@ -1,9 +1,8 @@
 <?php
 /**
- * @author Björn Schießle <bjoern@schiessle.org>
- * @author Joas Schilling <coding@schilljs.com>
+ * @author Björn Schießle <schiessle@owncloud.com>
  *
- * @copyright Copyright (c) 2016, ownCloud GmbH.
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify
@@ -20,22 +19,8 @@
  *
  */
 
-$app = new \OCA\FederatedFileSharing\AppInfo\Application();
-
-use OCA\FederatedFileSharing\Notifier;
-
-$l = \OC::$server->getL10N('files_sharing');
-
-$app->registerSettings();
-
-$manager = \OC::$server->getNotificationManager();
-$manager->registerNotifier(function() {
-	return new Notifier(
-		\OC::$server->getL10NFactory()
-	);
-}, function() use ($l) {
-	return [
-		'id' => 'files_sharing',
-		'name' => $l->t('Federated sharing'),
-	];
-});
+return [
+	'routes' => [
+		['name' => 'SaveToOwnCloud#saveToOwnCloud', 'url' => '/saveToOwnCloud', 'verb' => 'POST'],
+	]
+];

--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -31,6 +31,10 @@ class Application extends App {
 	/** @var FederatedShareProvider */
 	protected $federatedShareProvider;
 
+	public function __construct() {
+		parent::__construct('federatedfilesharing');
+	}
+
 	/**
 	 * register personal and admin settings page
 	 */

--- a/apps/federatedfilesharing/lib/Controller/SaveToOwnCloudController.php
+++ b/apps/federatedfilesharing/lib/Controller/SaveToOwnCloudController.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\FederatedFileSharing\Controller;
+
+use OC\HintException;
+use OCA\FederatedFileSharing\AddressHandler;
+use OCA\FederatedFileSharing\FederatedShareProvider;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\Share\IManager;
+
+class SaveToOwnCloudController extends Controller {
+
+	/** @var FederatedShareProvider */
+	private $federatedShareProvider;
+
+	/** @var AddressHandler */
+	private $addressHandler;
+
+	/** @var IManager  */
+	private $shareManager;
+
+	public function __construct($appName,
+								IRequest $request,
+								FederatedShareProvider $federatedShareProvider,
+								IManager $shareManager,
+								AddressHandler $addressHandler) {
+		parent::__construct($appName, $request);
+
+		$this->federatedShareProvider = $federatedShareProvider;
+		$this->shareManager = $shareManager;
+		$this->addressHandler = $addressHandler;
+	}
+
+	/**
+	 * save public link to my ownCloud by asking the owner to create a federated
+	 * share with me
+	 *
+	 * @NoCSRFRequired
+	 * @PublicPage
+	 *
+	 * @param string $shareWith
+	 * @param string $token
+	 * @return JSONResponse
+	 */
+	public function saveToOwnCloud($shareWith, $token) {
+
+		try {
+			list(, $server) = $this->addressHandler->splitUserRemote($shareWith);
+			$share = $this->shareManager->getShareByToken($token);
+		} catch (HintException $e) {
+			return new JSONResponse(['message' => $e->getHint()], Http::STATUS_BAD_REQUEST);
+		}
+
+		$share->setSharedWith($shareWith);
+
+		try {
+			$this->federatedShareProvider->create($share);
+		} catch (\Exception $e) {
+			return new JSONResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+		}
+		
+		return new JSONResponse(['remoteUrl' => $server]);
+	}
+	
+}

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -728,13 +728,13 @@ class FederatedShareProvider implements IShareProvider {
 		$data = $cursor->fetch();
 
 		if ($data === false) {
-			throw new ShareNotFound();
+			throw new ShareNotFound('Share not found', $this->l('Could not find share'));
 		}
 
 		try {
 			$share = $this->createShareObject($data);
 		} catch (InvalidShare $e) {
-			throw new ShareNotFound();
+			throw new ShareNotFound('Share not found', $this->l('Could not find share'));
 		}
 
 		return $share;

--- a/apps/federatedfilesharing/tests/Controller/SaveToOwnCloudControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/SaveToOwnCloudControllerTest.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\FederatedFileSharing\Tests\Controller;
+
+use OC\HintException;
+use OCA\FederatedFileSharing\AddressHandler;
+use OCA\FederatedFileSharing\Controller\SaveToOwnCloudController;
+use OCA\FederatedFileSharing\FederatedShareProvider;
+use OCP\AppFramework\Http;
+use OCP\Files\IRootFolder;
+use OCP\IUserManager;
+use OCP\Share;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+
+class SaveToOwnCloudControllerTest extends \Test\TestCase {
+
+	/** @var  SaveToOwnCloudController */
+	private $controller;
+
+	/** @var  \OCP\IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	private $request;
+
+	/** @var  FederatedShareProvider | \PHPUnit_Framework_MockObject_MockObject */
+	private $federatedShareProvider;
+
+	/** @var  IManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $shareManager;
+
+	/** @var  AddressHandler | \PHPUnit_Framework_MockObject_MockObject */
+	private $addressHandler;
+
+	/** @var  IRootFolder | \PHPUnit_Framework_MockObject_MockObject */
+	private $rootFolder;
+
+	/** @var  IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $userManager;
+
+	/** @var  IShare */
+	private $share;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->request = $this->getMock('OCP\IRequest');
+		$this->federatedShareProvider = $this->getMockBuilder('OCA\FederatedFileSharing\FederatedShareProvider')
+			->disableOriginalConstructor()->getMock();
+		$this->shareManager = $this->getMock('OCP\Share\IManager');
+		$this->addressHandler = $this->getMockBuilder('OCA\FederatedFileSharing\AddressHandler')
+			->disableOriginalConstructor()->getMock();
+		$this->rootFolder = $this->getMock('OCP\Files\IRootFolder');
+		$this->userManager = $this->getMock('OCP\IUserManager');
+		$this->share = new \OC\Share20\Share($this->rootFolder, $this->userManager);
+
+		$this->controller = new SaveToOwnCloudController(
+			'federatedfilesharing', $this->request,
+			$this->federatedShareProvider,
+			$this->shareManager,
+			$this->addressHandler
+		);
+	}
+
+	/**
+	 * @dataProvider dataTestSaveToOwnCloud
+	 *
+	 * @param string $shareWith
+	 * @param bool $validShareWith
+	 * @param string $token
+	 * @param bool $validToken
+	 * @param bool $createSuccessful
+	 * @param string $expectedReturnData
+	 */
+	public function testSaveToOwnCloud($shareWith, $validShareWith, $token, $validToken, $createSuccessful, $expectedReturnData) {
+		$this->addressHandler->expects($this->any())->method('splitUserRemote')
+			->with($shareWith)
+			->willReturnCallback(
+				function($shareWith) use ($validShareWith, $expectedReturnData) {
+					if ($validShareWith) {
+						return ['user', 'server'];
+					}
+					throw new HintException($expectedReturnData, $expectedReturnData);
+				}
+			);
+		
+		$share = $this->share;
+		
+		$this->shareManager->expects($this->any())->method('getShareByToken')
+			->with($token)
+			->willReturnCallback(
+				function ($token) use ($validToken, $share, $expectedReturnData) {
+					if ($validToken) {
+						return $share;
+					}
+					throw new HintException($expectedReturnData, $expectedReturnData);
+				}
+			);
+		
+		$this->federatedShareProvider->expects($this->any())->method('create')
+			->with($share)
+			->willReturnCallback(
+				function (IShare $share) use ($createSuccessful, $shareWith, $expectedReturnData) {
+					$this->assertEquals($shareWith, $share->getSharedWith());
+					if ($createSuccessful) {
+						return $share;
+					}
+					throw new HintException($expectedReturnData, $expectedReturnData);
+				}
+			);
+
+		$result = $this->controller->saveToOwnCloud($shareWith, $token);
+
+		$errorCase = !$validShareWith || !$validToken || !$createSuccessful;
+
+		if ($errorCase) {
+			$this->assertSame(Http::STATUS_BAD_REQUEST, $result->getStatus());
+			$this->assertTrue(isset($result->getData()['message']));
+			$this->assertSame($expectedReturnData, $result->getData()['message']);
+		} else {
+			$this->assertSame(Http::STATUS_OK, $result->getStatus());
+			$this->assertTrue(isset($result->getData()['remoteUrl']));
+			$this->assertSame($expectedReturnData, $result->getData()['remoteUrl']);
+
+		}
+		
+	}
+
+	public function dataTestSaveToOwnCloud() {
+		return [
+			//shareWith, validShareWith, token, validToken, createSuccessful, expectedReturnData
+			['user@server', true, 'token', true, true, 'server'],
+			['user@server', false, 'token', true, true, 'invalid federated cloud id'],
+			['user@server', false, 'token', false, true, 'invalid federated cloud id'],
+			['user@server', false, 'token', false, false, 'invalid federated cloud id'],
+			['user@server', false, 'token', true, false, 'invalid federated cloud id'],
+			['user@server', true, 'token', false, true, 'invalid token'],
+			['user@server', true, 'token', false, false, 'invalid token'],
+			['user@server', true, 'token', true, false, 'can not create share']
+		];
+	}
+
+}

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -261,10 +261,8 @@ OCA.Sharing.PublicApp = {
 			var remote = $(this).find('input[type="text"]').val();
 			var token = $('#sharingToken').val();
 			var owner = $('#save').data('owner');
-			var ownerDisplayName = $('#save').data('owner-display-name');
 			var name = $('#save').data('name');
-			var isProtected = $('#save').data('protected') ? 1 : 0;
-			OCA.Sharing.PublicApp._saveToOwnCloud(remote, token, owner, ownerDisplayName, name, isProtected);
+			OCA.Sharing.PublicApp._saveToOwnCloud(remote, token);
 		});
 
 		$('#remote_address').on("keyup paste", function() {
@@ -311,50 +309,42 @@ OCA.Sharing.PublicApp = {
 		this.fileList.changeDirectory(params.path || params.dir, false, true);
 	},
 
-	_saveToOwnCloud: function (remote, token, owner, ownerDisplayName, name, isProtected) {
-		var toggleLoading = function() {
-			var iconClass = $('#save-button-confirm').attr('class');
-			var loading = iconClass.indexOf('icon-loading-small') !== -1;
-			if(loading) {
-				$('#save-button-confirm')
-				.removeClass("icon-loading-small")
-				.addClass("icon-confirm");
-				
+	_saveToOwnCloud: function (remote, token) {
+
+		$.post(
+			OC.generateUrl('/apps/federatedfilesharing/saveToOwnCloud'),
+			{
+				'shareWith': remote,
+				'token': token
 			}
-			else {
-				$('#save-button-confirm')
-				.removeClass("icon-confirm")
-				.addClass("icon-loading-small");
+		).done(
+			function (data) {
+				var url = data.remoteUrl;
 
-			}
-		};
-
-		toggleLoading();
-		var location = window.location.protocol + '//' + window.location.host + OC.webroot;
-		
-		if(remote.substr(-1) !== '/') {
-			remote += '/'
-		};
-
-		var url = remote + 'index.php/apps/files#' + 'remote=' + encodeURIComponent(location) // our location is the remote for the other server
-			+ "&token=" + encodeURIComponent(token) + "&owner=" + encodeURIComponent(owner) +"&ownerDisplayName=" + encodeURIComponent(ownerDisplayName) + "&name=" + encodeURIComponent(name) + "&protected=" + isProtected;
-
-
-		if (remote.indexOf('://') > 0) {
-			OC.redirect(url);
-		} else {
-			// if no protocol is specified, we automatically detect it by testing https and http
-			// this check needs to happen on the server due to the Content Security Policy directive
-			$.get(OC.generateUrl('apps/files_sharing/testremote'), {remote: remote}).then(function (protocol) {
-				if (protocol !== 'http' && protocol !== 'https') {
-					toggleLoading();
-					OC.dialogs.alert(t('files_sharing', 'No ownCloud installation (7 or higher) found at {remote}', {remote: remote}),
-						t('files_sharing', 'Invalid ownCloud url'));
+				if (url.indexOf('://') > 0) {
+					OC.redirect(url);
 				} else {
-					OC.redirect(protocol + '://' + url);
+					// if no protocol is specified, we automatically detect it by testing https and http
+					// this check needs to happen on the server due to the Content Security Policy directive
+					$.get(OC.generateUrl('apps/files_sharing/testremote'), {remote: remote}).then(function (protocol) {
+						if (protocol !== 'http' && protocol !== 'https') {
+							toggleLoading();
+							OC.dialogs.alert(t('files_sharing', 'No ownCloud installation (7 or higher) found at {remote}', {remote: remote}),
+								t('files_sharing', 'Invalid ownCloud url'));
+						} else {
+							OC.redirect(protocol + '://' + url);
+						}
+					});
 				}
-			});
-		}
+			}
+		).fail(
+			function (jqXHR) {
+				console.log("ERROR!");
+				console.log(jqXHR);
+				OC.dialogs.alert(JSON.parse(jqXHR.responseText).message,
+					t('files_sharing', 'Failed to add the public link to your ownCloud'));
+			}
+		);
 	}
 };
 

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -81,7 +81,7 @@ OCP\Util::addHeader('meta', ['property' => "og:image", 'content' => $_['previewI
 						  data-owner-display-name="<?php p($_['displayName']) ?>" data-owner="<?php p($_['owner']) ?>" data-name="<?php p($_['filename']) ?>">
 					<button id="save-button"><?php p($l->t('Add to your ownCloud')) ?></button>
 					<form class="save-form hidden" action="#">
-						<input type="text" id="remote_address" placeholder="example.com/owncloud"/>
+						<input type="text" id="remote_address" placeholder="user@example.com/owncloud"/>
 						<button id="save-button-confirm" class="icon-confirm svg" disabled></button>
 					</form>
 				</span>


### PR DESCRIPTION
this way the owner sees all mounted public links and control them individually.

This changes the work flow:
- The user now adds his federated cloud ID instead of just the server URL to  the "Add to your ownCloud" input field
- The ownCloud will send a federated share to the user given in the input field
- The user will be re-directed to his ownCloud and will see a notification that he received a new federated share

cc @PVince81 
