### PR TITLE
Add the background jobs after the table was updated

### DIFF
--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -216,8 +216,6 @@ class Updater extends BasicEmitter {
 		try {
 			Setup::updateHtaccess();
 			Setup::protectDataDirectory();
-			// TODO: replace with the new repair step mechanism https://github.com/owncloud/core/pull/24378
-			Setup::installBackgroundJobs();
 		} catch (\Exception $e) {
 			throw new \Exception($e->getMessage());
 		}
@@ -242,6 +240,13 @@ class Updater extends BasicEmitter {
 
 		if ($this->updateStepEnabled) {
 			$this->doCoreUpgrade();
+
+			try {
+				// TODO: replace with the new repair step mechanism https://github.com/owncloud/core/pull/24378
+				Setup::installBackgroundJobs();
+			} catch (\Exception $e) {
+				throw new \Exception($e->getMessage());
+			}
 
 			// update all shipped apps
 			$disabledApps = $this->checkAppsRequirements();


### PR DESCRIPTION
Fixes an exception when updating
### Steps
1. `git checkout master@{2016-05-01}`
2. Install
3. `git checkout master`
4. `occ upgrade`
### Before

```
Exception: An exception occurred while executing 'INSERT INTO `oc_jobs` (`class`, `argument`, `last_run`, `last_checked`) VALUES(?, ?, ?, ?)' with params ["\\OC\\Authentication\\Token\\DefaultTokenCleanupJob", "null", 0, 1464018638]:

SQLSTATE[42S22]: Column not found: 1054 Unknown column 'last_checked' in 'field list'
Update failed
```
### After

```
Update successful
```

@PVince81 @MorrisJobke 
