### PR TITLE
Allow opening the password reset link in a new window when its a URL

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -135,7 +135,8 @@ class LoginController extends Controller {
 		}
 
 		$parameters['canResetPassword'] = true;
-		if (!$this->config->getSystemValue('lost_password_link')) {
+		$parameters['resetPasswordLink'] = $this->config->getSystemValue('lost_password_link', '');
+		if (!$parameters['resetPasswordLink']) {
 			if (!is_null($user) && $user !== '') {
 				$userObj = $this->userManager->get($user);
 				if ($userObj instanceof IUser) {

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -57,7 +57,7 @@ script('core', [
 		</p>
 
 		<?php if (!empty($_['invalidpassword']) && !empty($_['canResetPassword'])) { ?>
-		<a id="lost-password" class="warning" href="">
+		<a id="lost-password" class="warning" href="<?php p($_['resetPasswordLink']); ?>">
 			<?php p($l->t('Wrong password. Reset it?')); ?>
 		</a>
 		<?php } else if (!empty($_['invalidpassword'])) { ?>


### PR DESCRIPTION
1. Add config `'lost_password_link' => 'https://example.org/link/to/password/reset',`
2. Login with wrong password
3. Open `Wrong password. Reset it?` in a new tab.
### Expected

https://example.org/link/to/password/reset
### Actual

http://localhost/index.php/login?user=admin

Fix #24789

@PVince81 @LukasReschke @ChristophWurst 
