### PR TITLE
Fix dropbox autoload

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Dropbox.php
+++ b/apps/files_external/lib/Lib/Storage/Dropbox.php
@@ -33,7 +33,9 @@ use GuzzleHttp\Exception\RequestException;
 use Icewind\Streams\IteratorDirectory;
 use Icewind\Streams\RetryWrapper;
 
-require_once __DIR__ . '/../../3rdparty/Dropbox/autoload.php';
+set_include_path(get_include_path().PATH_SEPARATOR.
+	\OC_App::getAppPath('files_external').'/3rdparty');
+require_once 'Dropbox/autoload.php';
 
 class Dropbox extends \OC\Files\Storage\Common {
 


### PR DESCRIPTION
Please review @rullzer @Xenopathic @icewind1991 @nickvergessen 

Pretty sure it must be wrong. Not sure why we don't include "3rdparty" directly in the first place.

I tried to do it in a similar way like this https://github.com/owncloud/core/pull/24799/commits/6b62379562075aa5f96c304b05f5a502481ae36d (from Google SDK update PR https://github.com/owncloud/core/pull/24799)

Please hijack and fix properly, thanks.
