### PR TITLE
do not allow client password logins if token auth is enforced or 2FA …

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -103,8 +103,7 @@ class Auth extends AbstractBasic {
 			return true;
 		} else {
 			\OC_Util::setUpFS(); //login hooks may need early access to the filesystem
-			// TODO: do not allow basic auth if the user is 2FA enforced
-			if($this->userSession->login($username, $password)) {
+			if($this->userSession->logClientIn($username, $password)) {
 				$this->userSession->createSessionToken($this->request, $this->userSession->getUser()->getUID(), $username, $password);
 				\OC_Util::setUpFS($this->userSession->getUser()->getUID());
 				$this->session->set(self::DAV_AUTHENTICATED, $this->userSession->getUser()->getUID());

--- a/apps/dav/tests/unit/connector/sabre/auth.php
+++ b/apps/dav/tests/unit/connector/sabre/auth.php
@@ -167,7 +167,7 @@ class Auth extends TestCase {
 			->will($this->returnValue('AnotherUser'));
 		$this->userSession
 			->expects($this->once())
-			->method('login')
+			->method('logClientIn')
 			->with('MyTestUser', 'MyTestPassword')
 			->will($this->returnValue(true));
 		$this->userSession
@@ -192,7 +192,7 @@ class Auth extends TestCase {
 			->will($this->returnValue(false));
 		$this->userSession
 			->expects($this->once())
-			->method('login')
+			->method('logClientIn')
 			->with('MyTestUser', 'MyTestPassword')
 			->will($this->returnValue(false));
 		$this->session
@@ -560,7 +560,7 @@ class Auth extends TestCase {
 			->getMock();
 		$this->userSession
 			->expects($this->once())
-			->method('login')
+			->method('logClientIn')
 			->with('username', 'password')
 			->will($this->returnValue(true));
 		$this->userSession
@@ -602,7 +602,7 @@ class Auth extends TestCase {
 			->getMock();
 		$this->userSession
 			->expects($this->once())
-			->method('login')
+			->method('logClientIn')
 			->with('username', 'password')
 			->will($this->returnValue(false));
 		$response = $this->auth->check($server->httpRequest, $server->httpResponse);

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -195,6 +195,13 @@ $CONFIG = array(
 'session_keepalive' => true,
 
 /**
+ * Enforce token authentication for clients, which blocks requests using the user
+ * password for enhanced security. Users need to generate tokens in personal settings
+ * which can be used as passwords on their clients.
+ */
+'token_auth_enforced' => false,
+
+/**
  * The directory where the skeleton files are located. These files will be
  * copied to the data directory of new users. Leave empty to not copy any
  * skeleton files.

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -236,7 +236,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$defaultTokenProvider = null;
 			}
 			
-			$userSession = new \OC\User\Session($manager, $session, $timeFactory, $defaultTokenProvider);
+			$userSession = new \OC\User\Session($manager, $session, $timeFactory, $defaultTokenProvider, $c->getConfig());
 			$userSession->listen('\OC\User', 'preCreateUser', function ($uid, $password) {
 				\OC_Hook::emit('OC_User', 'pre_createUser', array('run' => true, 'uid' => $uid, 'password' => $password));
 			});

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -368,6 +368,9 @@ class Session implements IUserSession, Emitter {
 			array('uid' => &$username)
 		);
 		$user = $this->manager->get($username);
+		if (is_null($user)) {
+			return true;
+		}
 		// DI not possible due to cyclic dependencies :'-/
 		return OC::$server->getTwoFactorAuthManager()->isTwoFactorAuthenticated($user);
 	}

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -42,6 +42,7 @@ use OC_User;
 use OC_Util;
 use OCA\DAV\Connector\Sabre\Auth;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IConfig;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUser;
@@ -68,8 +69,8 @@ use OCP\Session\Exceptions\SessionNotAvailableException;
  * @package OC\User
  */
 class Session implements IUserSession, Emitter {
-	
-	/** @var Manager $manager */
+
+	/** @var IUserManager $manager */
 	private $manager;
 
 	/** @var ISession $session */
@@ -81,6 +82,9 @@ class Session implements IUserSession, Emitter {
 	/** @var IProvider */
 	private $tokenProvider;
 
+	/** @var IConfig */
+	private $config;
+
 	/** @var User $activeUser */
 	protected $activeUser;
 
@@ -89,12 +93,14 @@ class Session implements IUserSession, Emitter {
 	 * @param ISession $session
 	 * @param ITimeFactory $timeFacory
 	 * @param IProvider $tokenProvider
+	 * @param IConfig $config
 	 */
-	public function __construct(IUserManager $manager, ISession $session, ITimeFactory $timeFacory, $tokenProvider) {
+	public function __construct(IUserManager $manager, ISession $session, ITimeFactory $timeFacory, $tokenProvider, IConfig $config) {
 		$this->manager = $manager;
 		$this->session = $session;
 		$this->timeFacory = $timeFacory;
 		$this->tokenProvider = $tokenProvider;
+		$this->config = $config;
 	}
 
 	/**
@@ -279,7 +285,7 @@ class Session implements IUserSession, Emitter {
 	}
 
 	/**
-	 * try to login with the provided credentials
+	 * try to log in with the provided credentials
 	 *
 	 * @param string $uid
 	 * @param string $password
@@ -327,6 +333,60 @@ class Session implements IUserSession, Emitter {
 		return false;
 	}
 
+	/**
+	 * Tries to log in a client
+	 *
+	 * Checks token auth enforced
+	 * Checks 2FA enabled
+	 *
+	 * @param string $user
+	 * @param string $password
+	 * @throws LoginException
+	 * @return boolean
+	 */
+	public function logClientIn($user, $password) {
+		$isTokenPassword = $this->isTokenPassword($password);
+		if (!$isTokenPassword && $this->isTokenAuthEnforced()) {
+			// TODO: throw LoginException instead (https://github.com/owncloud/core/pull/24616)
+			return false;
+		}
+		if (!$isTokenPassword && $this->isTwoFactorEnforced($user)) {
+			// TODO: throw LoginException instead (https://github.com/owncloud/core/pull/24616)
+			return false;
+		}
+		return $this->login($user, $password);
+	}
+
+	private function isTokenAuthEnforced() {
+		return $this->config->getSystemValue('token_auth_enforced', false);
+	}
+
+	protected function isTwoFactorEnforced($username) {
+		\OCP\Util::emitHook(
+			'\OCA\Files_Sharing\API\Server2Server',
+			'preLoginNameUsedAsUserName',
+			array('uid' => &$username)
+		);
+		$user = $this->manager->get($username);
+		// DI not possible due to cyclic dependencies :'-/
+		return OC::$server->getTwoFactorAuthManager()->isTwoFactorAuthenticated($user);
+	}
+
+	/**
+	 * Check if the given 'password' is actually a device token
+	 *
+	 * @param type $password
+	 * @return boolean
+	 */
+	public function isTokenPassword($password) {
+		try {
+			$this->tokenProvider->getToken($password);
+			return true;
+		} catch (InvalidTokenException $ex) {
+			return false;
+		}
+	}
+
 	protected function prepareUserLogin() {
 		// TODO: mock/inject/use non-static
 		// Refresh the token
@@ -347,7 +407,7 @@ class Session implements IUserSession, Emitter {
 	 */
 	public function tryBasicAuthLogin(IRequest $request) {
 		if (!empty($request->server['PHP_AUTH_USER']) && !empty($request->server['PHP_AUTH_PW'])) {
-			$result = $this->login($request->server['PHP_AUTH_USER'], $request->server['PHP_AUTH_PW']);
+			$result = $this->logClientIn($request->server['PHP_AUTH_USER'], $request->server['PHP_AUTH_PW']);
 			if ($result === true) {
 				/**
 				 * Add DAV authenticated. This should in an ideal world not be


### PR DESCRIPTION
…is enabled

fixes #24779
fixes #24768

TODO
- [x] Check if instance enforces token auth (default for new installations)
- [x] Check if 2FA is enforced for the user
- [x] Add config to config.sample.php

Tested with DAV and OCS, works as expected.
