### PR TITLE
allow deleting "ghost files" trough the View and Node api

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/DeleteTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/DeleteTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ * @author Robin Appelman <icewind@owncloud.com>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\unit\Connector\Sabre\RequestTest;
+
+use OC\Connector\Sabre\Exception\FileLocked;
+use OCP\AppFramework\Http;
+use OCP\Lock\ILockingProvider;
+
+/**
+ * Class DeleteTest
+ *
+ * @group DB
+ *
+ * @package OCA\DAV\Tests\unit\Connector\Sabre\RequestTest
+ */
+class DeleteTest extends RequestTest {
+	public function testBasicUpload() {
+		$user = $this->getUniqueID();
+		$view = $this->setupUser($user, 'pass');
+
+		$view->file_put_contents('foo.txt', 'asd');
+		$mount = $view->getMount('foo.txt');
+		$internalPath = $view->getAbsolutePath();
+
+		// create a ghost file
+		$mount->getStorage()->unlink($mount->getInternalPath($internalPath));
+
+		// cache entry still exists
+		$this->assertInstanceOf('\OCP\Files\FileInfo', $view->getFileInfo('foo.txt'));
+
+		$response = $this->request($view, $user, 'pass', 'DELETE', '/foo.txt');
+
+		$this->assertEquals(Http::STATUS_NO_CONTENT, $response->getStatus());
+
+		// no longer in the cache
+		$this->assertFalse($view->getFileInfo('foo.txt'));
+	}
+}

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -157,7 +157,7 @@ class Local extends \OC\Files\Storage\Common {
 
 	public function filemtime($path) {
 		clearstatcache($this->getSourcePath($path));
-		return filemtime($this->getSourcePath($path));
+		return $this->file_exists($path) ? filemtime($this->getSourcePath($path)) : false;
 	}
 
 	public function touch($path, $mtime = null) {
@@ -188,7 +188,7 @@ class Local extends \OC\Files\Storage\Common {
 			return '';
 		}
 
-		$handle = fopen($fileName,'rb');
+		$handle = fopen($fileName, 'rb');
 		$content = fread($handle, $fileSize);
 		fclose($handle);
 		return $content;
@@ -377,7 +377,7 @@ class Local extends \OC\Files\Storage\Common {
 	 * @return bool
 	 */
 	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
-		if($sourceStorage->instanceOfStorage('\OC\Files\Storage\Local')){
+		if ($sourceStorage->instanceOfStorage('\OC\Files\Storage\Local')) {
 			/**
 			 * @var \OC\Files\Storage\Local $sourceStorage
 			 */

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -691,8 +691,10 @@ class View {
 			$storage = $mount->getStorage();
 			$internalPath = $mount->getInternalPath($absolutePath);
 			$storage->getUpdater()->remove($internalPath);
+			return true;
+		} else {
+			return $result;
 		}
-		return $result;
 	}
 
 	/**

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -337,10 +337,17 @@ class View {
 			return $this->removeMount($mount, $absolutePath);
 		}
 		if ($this->is_dir($path)) {
-			return $this->basicOperation('rmdir', $path, array('delete'));
+			$result = $this->basicOperation('rmdir', $path, array('delete'));
 		} else {
-			return false;
+			$result = false;
 		}
+
+		if (!$result && !$this->file_exists($path)) { //clear ghost files from the cache on delete
+			$storage = $mount->getStorage();
+			$internalPath = $mount->getInternalPath($absolutePath);
+			$storage->getUpdater()->remove($internalPath);
+		}
+		return $result;
 	}
 
 	/**
@@ -429,7 +436,7 @@ class View {
 
 	/**
 	 * @param string $path
-	 * @param int $from 
+	 * @param int $from
 	 * @param int $to
 	 * @return bool|mixed
 	 * @throws \OCP\Files\InvalidPathException
@@ -441,18 +448,18 @@ class View {
 		$handle = $this->fopen($path, 'rb');
 		if ($handle) {
 			if (fseek($handle, $from) === 0) {
-			    $chunkSize = 8192; // 8 kB chunks
-			    $end = $to + 1;
-			    while (!feof($handle) && ftell($handle) < $end) {
-				$len = $end-ftell($handle);
-				if ($len > $chunkSize) { 
-				    $len = $chunkSize; 
+				$chunkSize = 8192; // 8 kB chunks
+				$end = $to + 1;
+				while (!feof($handle) && ftell($handle) < $end) {
+					$len = $end - ftell($handle);
+					if ($len > $chunkSize) {
+						$len = $chunkSize;
+					}
+					echo fread($handle, $len);
+					flush();
 				}
-				echo fread($handle, $len);
-				flush();
-			    }
-			    $size = ftell($handle) - $from;
-			    return $size;
+				$size = ftell($handle) - $from;
+				return $size;
 			}
 
 			throw new \OCP\Files\UnseekableException('fseek error');
@@ -679,7 +686,13 @@ class View {
 		if ($mount and $mount->getInternalPath($absolutePath) === '') {
 			return $this->removeMount($mount, $absolutePath);
 		}
-		return $this->basicOperation('unlink', $path, array('delete'));
+		$result = $this->basicOperation('unlink', $path, array('delete'));
+		if (!$result && !$this->file_exists($path)) { //clear ghost files from the cache on delete
+			$storage = $mount->getStorage();
+			$internalPath = $mount->getInternalPath($absolutePath);
+			$storage->getUpdater()->remove($internalPath);
+		}
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
When deleting a file or folder fails because it doesn't exist, still try to remove it from the cache

This allows deleting of "ghost files" that exist in the cache but not on disk

cc @PVince81 @rullzer @VicDeo 
