### PR TITLE
Allow other apps to register objectTypes for SystemTags

### DIFF
--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -70,8 +70,7 @@ class RootCollection extends SimpleCollection {
 			\OC::$server->getSystemTagManager(),
 			\OC::$server->getSystemTagObjectMapper(),
 			\OC::$server->getUserSession(),
-			\OC::$server->getGroupManager(),
-			\OC::$server->getRootFolder()
+			\OC::$server->getGroupManager()
 		);
 		$commentsCollection = new Comments\RootCollection(
 			\OC::$server->getCommentsManager(),

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -70,7 +70,8 @@ class RootCollection extends SimpleCollection {
 			\OC::$server->getSystemTagManager(),
 			\OC::$server->getSystemTagObjectMapper(),
 			\OC::$server->getUserSession(),
-			\OC::$server->getGroupManager()
+			\OC::$server->getGroupManager(),
+			\OC::$server->getEventDispatcher()
 		);
 		$commentsCollection = new Comments\RootCollection(
 			\OC::$server->getCommentsManager(),

--- a/apps/dav/lib/SystemTag/SystemTagsObjectTypeCollection.php
+++ b/apps/dav/lib/SystemTag/SystemTagsObjectTypeCollection.php
@@ -31,7 +31,6 @@ use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\ISystemTagObjectMapper;
 use OCP\IUserSession;
 use OCP\IGroupManager;
-use OCP\Files\IRootFolder;
 
 /**
  * Collection containing object ids by object type
@@ -64,9 +63,9 @@ class SystemTagsObjectTypeCollection implements ICollection {
 	private $userSession;
 
 	/**
-	 * @var IRootFolder
+	 * @var \Closure
 	 **/
-	protected $fileRoot;
+	protected $childExistsFunction;
 
 	/**
 	 * Constructor
@@ -76,7 +75,7 @@ class SystemTagsObjectTypeCollection implements ICollection {
 	 * @param ISystemTagObjectMapper $tagMapper
 	 * @param IUserSession $userSession
 	 * @param IGroupManager $groupManager
-	 * @param IRootFolder $fileRoot
+	 * @param \Closure $childExistsFunction
 	 */
 	public function __construct(
 		$objectType, 
@@ -84,14 +83,14 @@ class SystemTagsObjectTypeCollection implements ICollection {
 		ISystemTagObjectMapper $tagMapper,
 		IUserSession $userSession,
 		IGroupManager $groupManager,
-		IRootFolder $fileRoot
+		\Closure $childExistsFunction
 	) {
 		$this->tagManager = $tagManager;
 		$this->tagMapper = $tagMapper;
 		$this->objectType = $objectType;
 		$this->userSession = $userSession;
 		$this->groupManager = $groupManager;
-		$this->fileRoot = $fileRoot;
+		$this->childExistsFunction = $childExistsFunction;
 	}
 
 	/**
@@ -133,17 +132,13 @@ class SystemTagsObjectTypeCollection implements ICollection {
 	}
 
 	/**
+	 * Checks if a child-node with the specified name exists
+	 *
 	 * @param string $name
+	 * @return bool
 	 */
 	function childExists($name) {
-		// TODO: make this more abstract
-		if ($this->objectType === 'files') {
-			// make sure the object is reachable for the current user
-			$userId = $this->userSession->getUser()->getUID();
-			$nodes = $this->fileRoot->getUserFolder($userId)->getById(intval($name));
-			return !empty($nodes);
-		}
-		return true;
+		return call_user_func($this->childExistsFunction, $name);
 	}
 
 	function delete() {

--- a/apps/dav/lib/SystemTag/SystemTagsObjectTypeCollection.php
+++ b/apps/dav/lib/SystemTag/SystemTagsObjectTypeCollection.php
@@ -96,6 +96,7 @@ class SystemTagsObjectTypeCollection implements ICollection {
 	/**
 	 * @param string $name
 	 * @param resource|string $data Initial payload
+	 * @return null|string
 	 * @throws Forbidden
 	 */
 	function createFile($name, $data = null) {
@@ -104,6 +105,7 @@ class SystemTagsObjectTypeCollection implements ICollection {
 
 	/**
 	 * @param string $name
+	 * @throws Forbidden
 	 */
 	function createDirectory($name) {
 		throw new Forbidden('Permission denied to create collections');
@@ -111,6 +113,8 @@ class SystemTagsObjectTypeCollection implements ICollection {
 
 	/**
 	 * @param string $objectId
+	 * @return SystemTagsObjectMappingCollection
+	 * @throws NotFound
 	 */
 	function getChild($objectId) {
 		// make sure the object exists and is reachable
@@ -151,6 +155,7 @@ class SystemTagsObjectTypeCollection implements ICollection {
 
 	/**
 	 * @param string $name
+	 * @throws Forbidden
 	 */
 	function setName($name) {
 		throw new Forbidden('Permission denied to rename this collection');

--- a/apps/dav/lib/SystemTag/SystemTagsRelationsCollection.php
+++ b/apps/dav/lib/SystemTag/SystemTagsRelationsCollection.php
@@ -29,7 +29,6 @@ use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\SimpleCollection;
 use OCP\IUserSession;
 use OCP\IGroupManager;
-use OCP\Files\IRootFolder;
 
 class SystemTagsRelationsCollection extends SimpleCollection {
 
@@ -40,14 +39,12 @@ class SystemTagsRelationsCollection extends SimpleCollection {
 	 * @param ISystemTagObjectMapper $tagMapper
 	 * @param IUserSession $userSession
 	 * @param IGroupManager $groupManager
-	 * @param IRootFolder $fileRoot
 	 */
 	public function __construct(
 		ISystemTagManager $tagManager,
 		ISystemTagObjectMapper $tagMapper,
 		IUserSession $userSession,
-		IGroupManager $groupManager,
-		IRootFolder $fileRoot
+		IGroupManager $groupManager
 	) {
 		$children = [
 			new SystemTagsObjectTypeCollection(
@@ -56,7 +53,10 @@ class SystemTagsRelationsCollection extends SimpleCollection {
 				$tagMapper,
 				$userSession,
 				$groupManager,
-				$fileRoot
+				function($name) {
+					$nodes = \OC::$server->getUserFolder()->getById(intval($name));
+					return !empty($nodes);
+				}
 			),
 		];
 

--- a/apps/dav/tests/unit/systemtag/systemtagmappingnode.php
+++ b/apps/dav/tests/unit/systemtag/systemtagmappingnode.php
@@ -136,7 +136,7 @@ class SystemTagMappingNode extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\NotFound
+	 * @expectedException \Sabre\DAV\Exception\NotFound
 	 */
 	public function testDeleteTagNotFound() {
 		// assuming the tag existed at the time the node was created,

--- a/apps/dav/tests/unit/systemtag/systemtagnode.php
+++ b/apps/dav/tests/unit/systemtag/systemtagnode.php
@@ -76,7 +76,7 @@ class SystemTagNode extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\MethodNotAllowed
+	 * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
 	 */
 	public function testSetName() {
 		$this->getTagNode()->setName('2');
@@ -193,7 +193,7 @@ class SystemTagNode extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\Conflict
+	 * @expectedException \Sabre\DAV\Exception\Conflict
 	 */
 	public function testUpdateTagAlreadyExists() {
 		$tag = new SystemTag(1, 'tag1', true, true);
@@ -213,7 +213,7 @@ class SystemTagNode extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\NotFound
+	 * @expectedException \Sabre\DAV\Exception\NotFound
 	 */
 	public function testUpdateTagNotFound() {
 		$tag = new SystemTag(1, 'tag1', true, true);
@@ -291,7 +291,7 @@ class SystemTagNode extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\NotFound
+	 * @expectedException \Sabre\DAV\Exception\NotFound
 	 */
 	public function testDeleteTagNotFound() {
 		$tag = new SystemTag(1, 'tag1', true, true);

--- a/apps/dav/tests/unit/systemtag/systemtagsbyidcollection.php
+++ b/apps/dav/tests/unit/systemtag/systemtagsbyidcollection.php
@@ -69,14 +69,14 @@ class SystemTagsByIdCollection extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\Forbidden
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
 	 */
 	public function testForbiddenCreateFile() {
 		$this->getNode()->createFile('555');
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\Forbidden
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
 	 */
 	public function testForbiddenCreateDirectory() {
 		$this->getNode()->createDirectory('789');
@@ -102,7 +102,7 @@ class SystemTagsByIdCollection extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\BadRequest
+	 * @expectedException \Sabre\DAV\Exception\BadRequest
 	 */
 	public function testGetChildInvalidName() {
 		$this->tagManager->expects($this->once())
@@ -114,7 +114,7 @@ class SystemTagsByIdCollection extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\NotFound
+	 * @expectedException \Sabre\DAV\Exception\NotFound
 	 */
 	public function testGetChildNotFound() {
 		$this->tagManager->expects($this->once())
@@ -126,7 +126,7 @@ class SystemTagsByIdCollection extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\NotFound
+	 * @expectedException \Sabre\DAV\Exception\NotFound
 	 */
 	public function testGetChildUserNotVisible() {
 		$tag = new SystemTag(123, 'Test', false, false);
@@ -220,7 +220,7 @@ class SystemTagsByIdCollection extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\BadRequest
+	 * @expectedException \Sabre\DAV\Exception\BadRequest
 	 */
 	public function testChildExistsBadRequest() {
 		$this->tagManager->expects($this->once())

--- a/apps/dav/tests/unit/systemtag/systemtagsobjectmappingcollection.php
+++ b/apps/dav/tests/unit/systemtag/systemtagsobjectmappingcollection.php
@@ -124,7 +124,7 @@ class SystemTagsObjectMappingCollection extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\PreconditionFailed
+	 * @expectedException \Sabre\DAV\Exception\PreconditionFailed
 	 */
 	public function testAssignTagNotFound() {
 		$this->tagManager->expects($this->once())
@@ -136,7 +136,7 @@ class SystemTagsObjectMappingCollection extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\Forbidden
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
 	 */
 	public function testForbiddenCreateDirectory() {
 		$this->getNode()->createDirectory('789');
@@ -189,7 +189,7 @@ class SystemTagsObjectMappingCollection extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\NotFound
+	 * @expectedException \Sabre\DAV\Exception\NotFound
 	 */
 	public function testGetChildRelationNotFound() {
 		$this->tagMapper->expects($this->once())
@@ -201,7 +201,7 @@ class SystemTagsObjectMappingCollection extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\BadRequest
+	 * @expectedException \Sabre\DAV\Exception\BadRequest
 	 */
 	public function testGetChildInvalidId() {
 		$this->tagMapper->expects($this->once())
@@ -213,7 +213,7 @@ class SystemTagsObjectMappingCollection extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\NotFound
+	 * @expectedException \Sabre\DAV\Exception\NotFound
 	 */
 	public function testGetChildTagDoesNotExist() {
 		$this->tagMapper->expects($this->once())
@@ -317,7 +317,7 @@ class SystemTagsObjectMappingCollection extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\BadRequest
+	 * @expectedException \Sabre\DAV\Exception\BadRequest
 	 */
 	public function testChildExistsInvalidId() {
 		$this->tagMapper->expects($this->once())
@@ -329,14 +329,14 @@ class SystemTagsObjectMappingCollection extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\Forbidden
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
 	 */
 	public function testDelete() {
 		$this->getNode()->delete();
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\Forbidden
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
 	 */
 	public function testSetName() {
 		$this->getNode()->setName('somethingelse');

--- a/apps/dav/tests/unit/systemtag/systemtagsobjecttypecollection.php
+++ b/apps/dav/tests/unit/systemtag/systemtagsobjecttypecollection.php
@@ -82,14 +82,14 @@ class SystemTagsObjectTypeCollection extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\Forbidden
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
 	 */
 	public function testForbiddenCreateFile() {
 		$this->node->createFile('555');
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\Forbidden
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
 	 */
 	public function testForbiddenCreateDirectory() {
 		$this->node->createDirectory('789');
@@ -107,7 +107,7 @@ class SystemTagsObjectTypeCollection extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\NotFound
+	 * @expectedException \Sabre\DAV\Exception\NotFound
 	 */
 	public function testGetChildWithoutAccess() {
 		$this->userFolder->expects($this->once())
@@ -118,7 +118,7 @@ class SystemTagsObjectTypeCollection extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\MethodNotAllowed
+	 * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
 	 */
 	public function testGetChildren() {
 		$this->node->getChildren();
@@ -141,14 +141,14 @@ class SystemTagsObjectTypeCollection extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\Forbidden
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
 	 */
 	public function testDelete() {
 		$this->node->delete();
 	}
 
 	/**
-	 * @expectedException Sabre\DAV\Exception\Forbidden
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
 	 */
 	public function testSetName() {
 		$this->node->setName('somethingelse');

--- a/apps/dav/tests/unit/systemtag/systemtagsobjecttypecollection.php
+++ b/apps/dav/tests/unit/systemtag/systemtagsobjecttypecollection.php
@@ -34,7 +34,7 @@ class SystemTagsObjectTypeCollection extends \Test\TestCase {
 	private $tagManager;
 
 	/**
-	 * @var \OCP\SystemTag\ISystemTagMapper
+	 * @var \OCP\SystemTag\ISystemTagObjectMapper
 	 */
 	private $tagMapper;
 
@@ -64,12 +64,12 @@ class SystemTagsObjectTypeCollection extends \Test\TestCase {
 			->will($this->returnValue(true));
 
 		$this->userFolder = $this->getMock('\OCP\Files\Folder');
+		$userFolder = $this->userFolder;
 
-		$fileRoot = $this->getMock('\OCP\Files\IRootFolder');
-		$fileRoot->expects($this->any())
-			->method('getUserfolder')
-			->with('testuser')
-			->will($this->returnValue($this->userFolder));
+		$closure = function($name) use ($userFolder) {
+			$nodes = $userFolder->getById(intval($name));
+			return !empty($nodes);
+		};
 
 		$this->node = new \OCA\DAV\SystemTag\SystemTagsObjectTypeCollection(
 			'files',
@@ -77,7 +77,7 @@ class SystemTagsObjectTypeCollection extends \Test\TestCase {
 			$this->tagMapper,
 			$userSession,
 			$groupManager,
-			$fileRoot
+			$closure
 		);
 	}
 

--- a/lib/public/SystemTag/SystemTagsEntityEvent.php
+++ b/lib/public/SystemTag/SystemTagsEntityEvent.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\SystemTag;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class SystemTagsEntityEvent
+ *
+ * @package OCP\SystemTag
+ * @since 9.2.0
+ */
+class SystemTagsEntityEvent extends Event {
+
+	const EVENT_ENTITY = 'OCP\SystemTag\ISystemTagManager::registerEntity';
+
+	/** @var string */
+	protected $event;
+	/** @var \Closure[] */
+	protected $collections;
+
+	/**
+	 * SystemTagsEntityEvent constructor.
+	 *
+	 * @param string $event
+	 * @since 9.2.0
+	 */
+	public function __construct($event) {
+		$this->event = $event;
+		$this->collections = [];
+	}
+
+	/**
+	 * @param string $name
+	 * @param \Closure $entityExistsFunction The closure should take one
+	 *                 argument, which is the id of the entity, that tags
+	 *                 should be handled for. The return should then be bool,
+	 *                 depending on whether tags are allowed (true) or not.
+	 * @throws \OutOfBoundsException when the entity name is already taken
+	 * @since 9.2.0
+	 */
+	public function addEntityCollection($name, \Closure $entityExistsFunction) {
+		if (isset($this->collections[$name])) {
+			throw new \OutOfBoundsException('Duplicate entity name "' . $name . '"');
+		}
+
+		$this->collections[$name] = $entityExistsFunction;
+	}
+
+	/**
+	 * @return \Closure[]
+	 * @since 9.2.0
+	 */
+	public function getEntityCollections() {
+		return $this->collections;
+	}
+}


### PR DESCRIPTION
Copied the logic from the Comments DAV Plugin
- [ ] Decide if "systemtags for files" should be owned by the SystemTags plugin. I guess it makes sense to not be able to tag files via webdav, when there is no UI for it.
