### PR TITLE
use client login method on CORS routes

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
@@ -26,13 +26,13 @@ namespace OC\AppFramework\Middleware\Security;
 
 use OC\AppFramework\Middleware\Security\Exceptions\SecurityException;
 use OC\AppFramework\Utility\ControllerMethodReflector;
+use OC\User\Session;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\IRequest;
-use OCP\IUserSession;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Middleware;
+use OCP\IRequest;
 
 /**
  * This middleware sets the correct CORS headers on a response if the
@@ -53,18 +53,18 @@ class CORSMiddleware extends Middleware {
 	private $reflector;
 
 	/**
-	 * @var IUserSession
+	 * @var Session
 	 */
 	private $session;
 
 	/**
 	 * @param IRequest $request
 	 * @param ControllerMethodReflector $reflector
-	 * @param IUserSession $session
+	 * @param Session $session
 	 */
 	public function __construct(IRequest $request,
 								ControllerMethodReflector $reflector,
-								IUserSession $session) {
+								Session $session) {
 		$this->request = $request;
 		$this->reflector = $reflector;
 		$this->session = $session;
@@ -89,7 +89,7 @@ class CORSMiddleware extends Middleware {
 			$pass = $this->request->server['PHP_AUTH_PW'];
 
 			$this->session->logout();
-			if(!$this->session->login($user, $pass)) {
+			if(!$this->session->logClientIn($user, $pass)) {
 				throw new SecurityException('CORS requires basic auth', Http::STATUS_UNAUTHORIZED);
 			}
 		}

--- a/tests/lib/AppFramework/Middleware/Security/CORSMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/CORSMiddlewareTest.php
@@ -16,7 +16,6 @@ use OC\AppFramework\Http\Request;
 use OC\AppFramework\Middleware\Security\CORSMiddleware;
 use OC\AppFramework\Utility\ControllerMethodReflector;
 use OC\AppFramework\Middleware\Security\Exceptions\SecurityException;
-use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
 
@@ -29,7 +28,9 @@ class CORSMiddlewareTest extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 		$this->reflector = new ControllerMethodReflector();
-		$this->session = $this->getMock('\OCP\IUserSession');
+		$this->session = $this->getMockBuilder('\OC\User\Session')
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	/**
@@ -127,7 +128,7 @@ class CORSMiddlewareTest extends \Test\TestCase {
 		$this->session->expects($this->never())
 			->method('logout');
 		$this->session->expects($this->never())
-			->method('login')
+			->method('logClientIn')
 			->with($this->equalTo('user'), $this->equalTo('pass'))
 			->will($this->returnValue(true));
 		$this->reflector->reflect($this, __FUNCTION__);
@@ -150,7 +151,7 @@ class CORSMiddlewareTest extends \Test\TestCase {
 		$this->session->expects($this->once())
 			->method('logout');
 		$this->session->expects($this->once())
-			->method('login')
+			->method('logClientIn')
 			->with($this->equalTo('user'), $this->equalTo('pass'))
 			->will($this->returnValue(true));
 		$this->reflector->reflect($this, __FUNCTION__);
@@ -175,7 +176,7 @@ class CORSMiddlewareTest extends \Test\TestCase {
 		$this->session->expects($this->once())
 			->method('logout');
 		$this->session->expects($this->once())
-			->method('login')
+			->method('logClientIn')
 			->with($this->equalTo('user'), $this->equalTo('pass'))
 			->will($this->returnValue(false));
 		$this->reflector->reflect($this, __FUNCTION__);


### PR DESCRIPTION
Found a code path were the simple login was used which is not blocking password logins if strict token auth is enforced (#24811): Controller methods having the `@CORS` annotation.

I triple checked now that `IUserSession::login` is only used in the LoginController and during setup. All other login routines should use the new `UserSession::logClientIn` method which additionally checks if the password is really a password and not a token.

TODO
- [x] test
