### PR TITLE
don't fail on "bad signature" during login

### DIFF
--- a/apps/encryption/lib/KeyManager.php
+++ b/apps/encryption/lib/KeyManager.php
@@ -360,6 +360,13 @@ class KeyManager {
 			return false;
 		} catch (DecryptionFailedException $e) {
 			return false;
+		} catch (\Exception $e) {
+			$this->log->warning(
+				'Could not decrypt the private key from user "' . $uid . '"" during login. ' .
+				'Assume password change on the user back-end. Error message: '
+				. $e->getMessage()
+			);
+			return false;
 		}
 
 		if ($privateKey) {


### PR DESCRIPTION
Most likely this happens because the login password changed at the user back-end (e.g ldap). Such failures will be handled after login correctly by allowing the user to adjust the passwords.

fix https://github.com/owncloud/core/issues/24832

Probably needs a backport to 9.0 because we introduced the signature with 9.0. @SergioBertolinSG can you confirm it?
