### PR TITLE
allow browser-based logins for clients

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -29,6 +29,7 @@ namespace OC\Core;
 
 use OC\AppFramework\Utility\SimpleContainer;
 use OC\AppFramework\Utility\TimeFactory;
+use OC\Core\Controller\AuthController;
 use OC\Core\Controller\AvatarController;
 use OC\Core\Controller\LoginController;
 use OC\Core\Controller\LostController;
@@ -80,6 +81,15 @@ class Application extends App {
 				$c->query('Request'),
 				$c->query('UserManager'),
 				$c->query('Defaults')
+			);
+		});
+		$container->registerService('AuthController', function (SimpleContainer $c) {
+			return new AuthController(
+				$c->query('AppName'),
+				$c->query('Request'),
+				$c->query('ServerContainer')->query('OC\Authentication\ClientLogin\IClientLoginCoordinator'),
+				$c->query('URLGenerator'),
+				$c->query('UserSession')
 			);
 		});
 		$container->registerService('AvatarController', function(SimpleContainer $c) {

--- a/core/Application.php
+++ b/core/Application.php
@@ -89,7 +89,8 @@ class Application extends App {
 				$c->query('Request'),
 				$c->query('ServerContainer')->query('OC\Authentication\ClientLogin\IClientLoginCoordinator'),
 				$c->query('URLGenerator'),
-				$c->query('UserSession')
+				$c->query('UserSession'),
+				$c->query('L10N')
 			);
 		});
 		$container->registerService('AvatarController', function(SimpleContainer $c) {

--- a/core/Controller/AuthController.php
+++ b/core/Controller/AuthController.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Controller;
+
+use OC\Authentication\ClientLogin\AccessToken;
+use OC\Authentication\ClientLogin\IClientLoginCoordinator;
+use OC\Authentication\Exceptions\ClientLoginPendingException;
+use OC\Authentication\Exceptions\InvalidAccessTokenException;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IUserSession;
+
+class AuthController extends Controller {
+
+	/** @var IClientLoginCoordinator */
+	private $coordinator;
+
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
+	/** @var IUserSession */
+	private $userSession;
+
+	public function __construct($appName, IRequest $request, IClientLoginCoordinator $coordinator, IURLGenerator $urlGenerator, IUserSession $userSession) {
+		parent::__construct($appName, $request);
+		$this->coordinator = $coordinator;
+		$this->urlGenerator = $urlGenerator;
+		$this->userSession = $userSession;
+	}
+
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 *
+	 * @param string $name client name
+	 * @return JSONResponse
+	 */
+	public function start($name = 'unknown client') {
+		$token = $this->coordinator->startClientLogin($name);
+
+		$url = $this->urlGenerator->linkToRoute('core.auth.check', [
+			'accesstoken' => $token
+		]);
+		$fullUrl = $this->urlGenerator->getAbsoluteURL($url);
+		return [
+			'url' => $fullUrl,
+			'accessToken' => $token,
+		];
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * @param string $accesstoken
+	 * @return TemplateResponse
+	 */
+	public function check($accesstoken) {
+		try {
+			$user = $this->userSession->getUser();
+			$this->coordinator->finishClientLogin($accesstoken, $user);
+		} catch (InvalidAccessTokenException $ex) {
+			return new RedirectResponse($this->urlGenerator->linkToRoute('files.view.index'));
+		}
+		return new TemplateResponse('core', 'authsuccess', [], 'guest');
+	}
+
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 *
+	 * @param string $accesstoken
+	 * @return JSONResponse
+	 */
+	public function status($accesstoken) {
+		try {
+			$token = $this->coordinator->getClientToken($accesstoken);
+		} catch (ClientLoginPendingException $ex) {
+			return [
+				'status' => AccessToken::STATUS_PENDING,
+				'token' => null,
+			];
+		} catch (InvalidAccessTokenException $ex) {
+			$resp = new JSONResponse();
+			$resp->setStatus(Http::STATUS_BAD_REQUEST);
+			return $resp;
+		}
+
+		return [
+			'status' => AccessToken::STATUS_FINISHED,
+			'token' => $token,
+		];
+	}
+
+}

--- a/core/js/authsuccess.js
+++ b/core/js/authsuccess.js
@@ -1,0 +1,26 @@
+/**
+ * @author Christoph Wurst <christoph@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+(function() {
+	setTimeout(function() {
+		// TODO: doesn't work on all browsers
+		window.close();
+	}, 200);
+})();

--- a/core/routes.php
+++ b/core/routes.php
@@ -36,7 +36,9 @@ $application = new Application();
 $application->registerRoutes($this, [
 	'routes' => [
 		['name' => 'auth#start', 'url' => '/auth/start', 'verb' => 'POST'],
-		['name' => 'auth#check', 'url' => '/auth/check', 'verb' => 'GET'],
+		['name' => 'auth#askPermissions', 'url' => '/auth/authorize', 'verb' => 'GET'],
+		['name' => 'auth#grantPermissions', 'url' => '/auth/authorize', 'verb' => 'POST'],
+		['name' => 'auth#success', 'url' => '/auth/success', 'verb' => 'GET'],
 		['name' => 'auth#status', 'url' => '/auth/status', 'verb' => 'POST'],
 		['name' => 'lost#email', 'url' => '/lostpassword/email', 'verb' => 'POST'],
 		['name' => 'lost#resetform', 'url' => '/lostpassword/reset/form/{token}/{userId}', 'verb' => 'GET'],

--- a/core/routes.php
+++ b/core/routes.php
@@ -35,6 +35,9 @@ use OC\Core\Application;
 $application = new Application();
 $application->registerRoutes($this, [
 	'routes' => [
+		['name' => 'auth#start', 'url' => '/auth/start', 'verb' => 'POST'],
+		['name' => 'auth#check', 'url' => '/auth/check', 'verb' => 'GET'],
+		['name' => 'auth#status', 'url' => '/auth/status', 'verb' => 'POST'],
 		['name' => 'lost#email', 'url' => '/lostpassword/email', 'verb' => 'POST'],
 		['name' => 'lost#resetform', 'url' => '/lostpassword/reset/form/{token}/{userId}', 'verb' => 'GET'],
 		['name' => 'lost#setPassword', 'url' => '/lostpassword/set/{token}/{userId}', 'verb' => 'POST'],

--- a/core/templates/authsuccess.php
+++ b/core/templates/authsuccess.php
@@ -1,5 +1,0 @@
-<?php script('core', 'authsuccess'); ?>
-<fieldset class="warning">
-	<legend><strong><?php p($l->t('Login success')); ?></strong></legend>
-	<?php p($l->t('Login was successful. This window can be closed.')); ?>
-</fieldset>

--- a/core/templates/authsuccess.php
+++ b/core/templates/authsuccess.php
@@ -1,0 +1,5 @@
+<?php script('core', 'authsuccess'); ?>
+<fieldset class="warning">
+	<legend><strong><?php p($l->t('Login success')); ?></strong></legend>
+	<?php p($l->t('Login was successful. This window can be closed.')); ?>
+</fieldset>

--- a/core/templates/clientauthorize.php
+++ b/core/templates/clientauthorize.php
@@ -1,0 +1,12 @@
+<fieldset class="warning">
+	<legend><strong><?php p($l->t('Authorize application')); ?></strong></legend>
+	<?php p($l->t('"%s" would like permissions to access your %s account. If you grant permissions, "%s" gets full access to your data. You can revoke access via your personal settings at any time.', [
+		$_['clientName'],
+		$theme->getName(),
+		$_['clientName'],
+	])); ?>
+	<form method="POST">
+		<input type="hidden" value="<?php p($_['requesttoken']); ?>" name="requesttoken" />
+		<input type="submit" value="<?php p($l->t('Authorize application')); ?>">
+	</form>
+</fieldset>

--- a/core/templates/clientauthsuccess.php
+++ b/core/templates/clientauthsuccess.php
@@ -1,0 +1,5 @@
+<?php script('core', 'authsuccess'); ?>
+<fieldset class="warning">
+	<legend><strong><?php p($l->t('Application authorized successfully')); ?></strong></legend>
+	<?php p($l->t('This window can be closed.')); ?>
+</fieldset>

--- a/db_structure.xml
+++ b/db_structure.xml
@@ -1049,6 +1049,76 @@
 	</table>
 
 	<table>
+		<name>*dbprefix*client_access_tokens</name>
+
+		<declaration>
+
+			<field>
+				<name>id</name>
+				<type>integer</type>
+				<default>0</default>
+				<notnull>true</notnull>
+				<autoincrement>1</autoincrement>
+				<unsigned>true</unsigned>
+				<length>4</length>
+			</field>
+
+			<field>
+				<name>token</name>
+				<type>text</type>
+				<default></default>
+				<notnull>true</notnull>
+				<length>200</length>
+			</field>
+
+			<!-- Foreign Key users::uid -->
+			<field>
+				<name>uid</name>
+				<type>text</type>
+				<default></default>
+				<notnull>true</notnull>
+				<length>64</length>
+			</field>
+
+			<field>
+				<name>client_name</name>
+				<type>clob</type>
+				<default></default>
+				<notnull>true</notnull>
+			</field>
+
+			<field>
+				<name>status</name>
+				<type>integer</type>
+				<default>0</default>
+				<notnull>true</notnull>
+				<unsigned>true</unsigned>
+				<length>2</length>
+			</field>
+
+			<field>
+				<name>created_at</name>
+				<type>integer</type>
+				<default>0</default>
+				<notnull>true</notnull>
+				<unsigned>true</unsigned>
+				<length>4</length>
+			</field>
+
+			<index>
+				<name>client_access_tokens_index</name>
+				<unique>true</unique>
+				<field>
+					<name>token</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+
+		</declaration>
+
+	</table>
+
+	<table>
 		<name>*dbprefix*authtoken</name>
 
 		<declaration>

--- a/lib/private/Authentication/ClientLogin/AccessToken.php
+++ b/lib/private/Authentication/ClientLogin/AccessToken.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Authentication\ClientLogin;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * @method string getToken()
+ * @method void setToken(string $accessToken)
+ * @method string getUid()
+ * @method void setUid(string $uid)
+ * @method string getClientName()
+ * @method void setClientName(string $name)
+ * @method int getStatus()
+ * @method void setStatus(int $status)
+ * @method int getCreatedAt()
+ * @method void setCreatedAt(int $created)
+ */
+class AccessToken extends Entity {
+
+	const STATUS_PENDING = 0;
+	const STATUS_FINISHED = 1;
+
+	/** @var string hashed access token */
+	protected $token;
+
+	/** @var string user UID (only set on finished tokens) */
+	protected $uid;
+
+	/** @var string client name */
+	protected $clientName;
+
+	/** @var int login status */
+	protected $status;
+
+	/** @var timestamp */
+	protected $createdAt;
+
+}

--- a/lib/private/Authentication/ClientLogin/AccessTokenMapper.php
+++ b/lib/private/Authentication/ClientLogin/AccessTokenMapper.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Authentication\ClientLogin;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\Mapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+class AccessTokenMapper extends Mapper {
+
+	/**
+	 * @param IDBConnection $db
+	 */
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'client_access_tokens');
+	}
+
+	/**
+	 * @param string $accessToken hashed access token
+	 * @throws DoesNotExistException
+	 * @return AccessToken
+	 */
+	public function getToken($accessToken) {
+		/* @var $qb IQueryBuilder */
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('id', 'token', 'uid', 'client_name', 'status', 'created_at')
+			->from('client_access_tokens')
+			->where($qb->expr()->eq('token', $qb->createNamedParameter($accessToken)));
+		$result = $qb->execute();
+
+		$data = $result->fetch();
+		$result->closeCursor();
+
+		if ($data === false) {
+			throw new DoesNotExistException('access token does not exist');
+		}
+
+		return AccessToken::fromRow($data);
+	}
+
+}

--- a/lib/private/Authentication/ClientLogin/Coordinator.php
+++ b/lib/private/Authentication/ClientLogin/Coordinator.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Authentication\ClientLogin;
+
+use OC\Authentication\Exceptions\ClientLoginPendingException;
+use OC\Authentication\Exceptions\InvalidAccessTokenException;
+use OC\Authentication\Token\IProvider;
+use OC\Authentication\Token\IToken;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IConfig;
+use OCP\IUser;
+use OCP\Security\ISecureRandom;
+
+class Coordinator implements IClientLoginCoordinator {
+
+	/** @var AccessTokenMapper */
+	private $mapper;
+
+	/** @var IProvider */
+	private $tokenProvider;
+
+	/** @var ISecureRandom */
+	private $random;
+
+	/** @var IConfig */
+	private $config;
+
+	/** @var ITimeFactory */
+	private $timeFactory;
+
+	/**
+	 * @param AccessTokenMapper $mapper
+	 * @param IProvider $tokenProvider
+	 * @param ISecureRandom $random
+	 * @param IConfig $config
+	 * @param ITimeFactory $timeFactory
+	 */
+	public function __construct(AccessTokenMapper $mapper, IProvider $tokenProvider, ISecureRandom $random,
+		IConfig $config, ITimeFactory $timeFactory) {
+		$this->mapper = $mapper;
+		$this->tokenProvider = $tokenProvider;
+		$this->random = $random;
+		$this->config = $config;
+		$this->timeFactory = $timeFactory;
+	}
+
+	/**
+	 * @param string $name client name
+	 * @return string new access token to identify async login process
+	 */
+	public function startClientLogin($name) {
+		$token = $this->random->generate(128);
+		$hashedToken = $this->hashToken($token);
+
+		$accessToken = new AccessToken();
+		$accessToken->setToken($hashedToken);
+		$accessToken->setClientName($name);
+		$accessToken->setStatus(AccessToken::STATUS_PENDING);
+		$accessToken->setCreatedAt($this->timeFactory->getTime());
+
+		$this->mapper->insert($accessToken);
+
+		return $token;
+	}
+
+	/**
+	 * @param string $accessToken
+	 * @param IUser $user
+	 * @throws InvalidAccessTokenException
+	 */
+	public function finishClientLogin($accessToken, IUser $user) {
+		$hashedToken = $this->hashToken($accessToken);
+		try {
+			$dbToken = $this->mapper->getToken($hashedToken);
+		} catch (DoesNotExistException $ex) {
+			throw new InvalidAccessTokenException();
+		}
+
+		$dbToken->setStatus(AccessToken::STATUS_FINISHED);
+		$dbToken->setUid($user->getUID());
+		$this->mapper->update($dbToken);
+	}
+
+	/**
+	 * @param string $accessToken
+	 * @throws InvalidAccessTokenException
+	 * @throws ClientLoginPendingException
+	 * @return string
+	 */
+	public function getClientToken($accessToken) {
+		$hashedToken = $this->hashToken($accessToken);
+		try {
+			$dbToken = $this->mapper->getToken($hashedToken);
+		} catch (DoesNotExistException $ex) {
+			throw new InvalidAccessTokenException();
+		}
+
+		// TODO: limit token age and check it here
+
+		if (((int) $dbToken->getStatus()) === AccessToken::STATUS_PENDING) {
+			// Login process pending
+			throw new ClientLoginPendingException();
+		}
+
+		$this->mapper->delete($dbToken);
+		return $this->createDeviceToken($dbToken);
+	}
+
+	private function hashToken($token) {
+		$secret = $this->config->getSystemValue('secret');
+		return hash('sha512', $token . $secret);
+	}
+
+	/**
+	 * @param AccessToken $accessToken
+	 */
+	private function createDeviceToken(AccessToken $accessToken) {
+		$token = $this->random->generate(128);
+		// Password set to null, hence there will be no password check in OC\User\Session::validateSession
+		// Therefore we also do not need to loginname (we don't know it anyway)
+		$this->tokenProvider->generateToken($token, $accessToken->getUid(), '?', null, $accessToken->getClientName(), IToken::PERMANENT_TOKEN);
+		return $token;
+	}
+
+}

--- a/lib/private/Authentication/ClientLogin/Coordinator.php
+++ b/lib/private/Authentication/ClientLogin/Coordinator.php
@@ -127,6 +127,21 @@ class Coordinator implements IClientLoginCoordinator {
 		return $this->createDeviceToken($dbToken);
 	}
 
+	/**
+	 * @param string $accessToken
+	 * @throws InvalidAccessTokenException
+	 * @return string
+	 */
+	public function getClientName($accessToken) {
+		$hashedToken = $this->hashToken($accessToken);
+		try {
+			$dbToken = $this->mapper->getToken($hashedToken);
+		} catch (DoesNotExistException $ex) {
+			throw new InvalidAccessTokenException();
+		}
+		return $dbToken->getClientName();
+	}
+
 	private function hashToken($token) {
 		$secret = $this->config->getSystemValue('secret');
 		return hash('sha512', $token . $secret);

--- a/lib/private/Authentication/ClientLogin/IClientLoginCoordinator.php
+++ b/lib/private/Authentication/ClientLogin/IClientLoginCoordinator.php
@@ -47,4 +47,11 @@ interface IClientLoginCoordinator {
 	 * @return string
 	 */
 	public function getClientToken($accessToken);
+
+	/**
+	 * @param string $accessToken
+	 * @throws InvalidAccessTokenException
+	 * @return string
+	 */
+	public function getClientName($accessToken);
 }

--- a/lib/private/Authentication/ClientLogin/IClientLoginCoordinator.php
+++ b/lib/private/Authentication/ClientLogin/IClientLoginCoordinator.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Authentication\ClientLogin;
+
+use OC\Authentication\Exceptions\ClientLoginPendingException;
+use OC\Authentication\Exceptions\InvalidAccessTokenException;
+use OCP\IUser;
+
+interface IClientLoginCoordinator {
+
+	/**
+	 * @param string $name client name
+	 * @return string new access token to identify async login process
+	 */
+	public function startClientLogin($name);
+
+	/**
+	 * @param type $accessToken
+	 * @throws InvalidAccessTokenException
+	 */
+	public function finishClientLogin($accessToken, IUser $user);
+
+	/**
+	 * @param string $accessToken
+	 * @throws InvalidAccessTokenException
+	 * @throws ClientLoginPendingException
+	 * @return string
+	 */
+	public function getClientToken($accessToken);
+}

--- a/lib/private/Authentication/Exceptions/ClientLoginPendingException.php
+++ b/lib/private/Authentication/Exceptions/ClientLoginPendingException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Authentication\Exceptions;
+
+use Exception;
+
+class ClientLoginPendingException extends Exception {
+
+}

--- a/lib/private/Authentication/Exceptions/InvalidAccessTokenException.php
+++ b/lib/private/Authentication/Exceptions/InvalidAccessTokenException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Authentication\Exceptions;
+
+use Exception;
+
+class InvalidAccessTokenException extends Exception {
+
+}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -213,9 +213,23 @@ class Server extends ServerContainer implements IServerContainer {
 			});
 			return $groupManager;
 		});
+		$this->registerService('OC\Authentication\ClientLogin\AccessTokenMapper', function (Server $c) {
+			$dbConnection = $c->getDatabaseConnection();
+			return new \OC\Authentication\ClientLogin\AccessTokenMapper($dbConnection);
+		});
+		$this->registerService('OC\Authentication\ClientLogin\Coordinator', function (Server $c) {
+			return new \OC\Authentication\ClientLogin\Coordinator(
+				$c->query('OC\Authentication\ClientLogin\AccessTokenMapper'),
+				$c->query('OC\Authentication\Token\IProvider'),
+				$c->query('SecureRandom'),
+				$c->query('AllConfig'),
+				new TimeFactory()
+			);
+		});
+		$this->registerAlias('OC\Authentication\ClientLogin\IClientLoginCoordinator', 'OC\Authentication\ClientLogin\Coordinator');
 		$this->registerService('OC\Authentication\Token\DefaultTokenMapper', function (Server $c) {
 			$dbConnection = $c->getDatabaseConnection();
-			return new Authentication\Token\DefaultTokenMapper($dbConnection);
+			return new \OC\Authentication\Token\DefaultTokenMapper($dbConnection);
 		});
 		$this->registerService('OC\Authentication\Token\DefaultTokenProvider', function (Server $c) {
 			$mapper = $c->query('OC\Authentication\Token\DefaultTokenMapper');

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -282,7 +282,7 @@ class Session implements IUserSession, Emitter {
 	public function login($uid, $password) {
 		$this->session->regenerateId();
 
-		if ($this->validateToken($password, $uid)) {
+		if ($this->validateToken($password)) {
 			return $this->loginWithToken($password);
 		}
 		return $this->loginWithPassword($uid, $password);

--- a/tests/Core/Controller/AuthControllerTest.php
+++ b/tests/Core/Controller/AuthControllerTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Core\Controller;
+
+use OC\AppFramework\Http;
+use OC\Authentication\Exceptions\ClientLoginPendingException;
+use OC\Authentication\Exceptions\InvalidAccessTokenException;
+use OC\Core\Controller\AuthController;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\AppFramework\Http\TemplateResponse;
+use Test\TestCase;
+
+class AuthControllerTest extends TestCase {
+
+	private $appName;
+	private $request;
+	private $coordinator;
+	private $urlGenerator;
+	private $userSession;
+
+	/** @var AuthController */
+	private $controller;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->appName = 'core';
+		$this->request = $this->getMock('\OCP\IRequest');
+		$this->coordinator = $this->getMock('\OC\Authentication\ClientLogin\IClientLoginCoordinator');
+		$this->urlGenerator = $this->getMock('\OCP\IURLGenerator');
+		$this->userSession = $this->getMock('\OCP\IUserSession');
+
+		$this->controller = new AuthController($this->appName, $this->request, $this->coordinator, $this->urlGenerator, $this->userSession);
+	}
+
+	public function testStart() {
+		$name = 'my client';
+		$token = 'tokenxyz';
+		$this->coordinator->expects($this->once())
+			->method('startClientLogin')
+			->with($name)
+			->will($this->returnValue('tokenxyz'));
+		$this->urlGenerator->expects($this->once())
+			->method('linkToRoute')
+			->with('core.auth.check', [
+				'accesstoken' => $token,
+			])
+			->will($this->returnValue('token/url'));
+		$this->urlGenerator->expects($this->once())
+			->method('getAbsoluteURL')
+			->with('token/url')
+			->will($this->returnValue('absolute/token/url'));
+		$expected = [
+			'url' => 'absolute/token/url',
+			'accessToken' => $token,
+		];
+
+		$this->assertEquals($expected, $this->controller->start($name));
+	}
+
+	public function testCheck() {
+		$token = 'abcdefg';
+		$user = $this->getMock('\OCP\IUser');
+
+		$this->userSession->expects($this->once())
+			->method('getUser')
+			->will($this->returnValue($user));
+		$this->coordinator->expects($this->once())
+			->method('finishClientLogin')
+			->with($token, $user);
+		$expected = new TemplateResponse('core', 'authsuccess', [], 'guest');
+
+		$this->assertEquals($expected, $this->controller->check($token));
+	}
+
+	public function testCheckInvalidToken() {
+		$token = 'abcdefg';
+		$user = $this->getMock('\OCP\IUser');
+
+		$this->userSession->expects($this->once())
+			->method('getUser')
+			->will($this->returnValue($user));
+		$this->coordinator->expects($this->once())
+			->method('finishClientLogin')
+			->with($token, $user)
+			->will($this->throwException(new InvalidAccessTokenException()));
+		$this->urlGenerator->expects($this->once())
+			->method('linkToRoute')
+			->with('files.view.index')
+			->will($this->returnValue('files/url'));
+		$expected = new RedirectResponse('files/url');
+
+		$this->assertEquals($expected, $this->controller->check($token));
+	}
+
+	public function testStatus() {
+		$accessToken = 'accesstoken';
+		$token = 'anewclienttoken';
+
+		$this->coordinator->expects($this->once())
+			->method('getClientToken')
+			->with($accessToken)
+			->will($this->returnValue($token));
+		$expected = [
+			'status' => 1,
+			'token' => $token,
+		];
+
+		$this->assertEquals($expected, $this->controller->status($accessToken));
+	}
+
+	public function testStatusInvalidToken() {
+		$accessToken = 'accesstoken';
+
+		$this->coordinator->expects($this->once())
+			->method('getClientToken')
+			->with($accessToken)
+			->will($this->throwException(new InvalidAccessTokenException()));
+		$expected = new JSONResponse();
+		$expected->setStatus(Http::STATUS_BAD_REQUEST);
+
+		$this->assertEquals($expected, $this->controller->status($accessToken));
+	}
+
+	public function testStatusClientLoginPending() {
+		$accessToken = 'accesstoken';
+		$token = 'anewclienttoken';
+
+		$this->coordinator->expects($this->once())
+			->method('getClientToken')
+			->with($accessToken)
+			->will($this->throwException(new ClientLoginPendingException()));
+		$expected = [
+			'status' => 0,
+			'token' => null,
+		];
+
+		$this->assertEquals($expected, $this->controller->status($accessToken));
+	}
+
+}

--- a/tests/lib/Authentication/ClientLogin/AccessTokenMapperTest.php
+++ b/tests/lib/Authentication/ClientLogin/AccessTokenMapperTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Authentication\ClientLogin;
+
+use OC;
+use OC\Authentication\ClientLogin\AccessTokenMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use Test\TestCase;
+
+/**
+ * @group DB
+ */
+class AccessTokenMapperTest extends TestCase {
+
+	/** @var AccessTokenMapper */
+	private $mapper;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->db = OC::$server->getDatabaseConnection();
+		$this->resetDatabase();
+
+		$this->mapper = new AccessTokenMapper($this->db);
+	}
+
+	private function resetDatabase() {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete('client_access_tokens')->execute();
+		$qb->insert('client_access_tokens')->values([
+			'token' => $qb->createNamedParameter('9c5a2e661482b65597408a6bb6c4a3d1af36337381872ac56e445a06cdb7fea2b1039db707545c11027a4966919918b19d875a8b774840b18c6cbb7ae56fe206'),
+			'uid' => $qb->createNamedParameter('user1'),
+			'client_name' => $qb->createNamedParameter('ownCloud Android'),
+			'status' => $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT),
+			'created_at' => $qb->createNamedParameter(time(), IQueryBuilder::PARAM_INT),
+		])->execute();
+		$qb->insert('client_access_tokens')->values([
+			'token' => $qb->createNamedParameter('1504445f1524fc801035448a95681a9378ba2e83930c814546c56e5d6ebde221198792fd900c88ed5ead0555780dad1ebce3370d7e154941cd5de87eb419899b'),
+			'uid' => $qb->createNamedParameter('user2'),
+			'client_name' => $qb->createNamedParameter('ownCloud Sync Client'),
+			'status' => $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT),
+			'created_at' => $qb->createNamedParameter(time(), IQueryBuilder::PARAM_INT),
+		])->execute();
+	}
+
+	public function testGetToken() {
+		$accessToken = '9c5a2e661482b65597408a6bb6c4a3d1af36337381872ac56e445a06cdb7fea2b1039db707545c11027a4966919918b19d875a8b774840b18c6cbb7ae56fe206';
+
+		$this->assertNotNull($this->mapper->getToken($accessToken));
+	}
+
+	/**
+	 * @expectedException \OCP\AppFramework\Db\DoesNotExistException
+	 */
+	public function testGetTokenDoesNotExist() {
+		$accessToken = 'doesnotexist';
+
+		$this->mapper->getToken($accessToken);
+	}
+
+}

--- a/tests/lib/Authentication/ClientLogin/CoordinatorTest.php
+++ b/tests/lib/Authentication/ClientLogin/CoordinatorTest.php
@@ -194,7 +194,7 @@ class CoordinatorTest extends TestCase {
 	/**
 	 * @expectedException \OC\Authentication\Exceptions\ClientLoginPendingException
 	 */
-	public function testGetClientTOkenPendingState() {
+	public function testGetClientTokenPendingState() {
 		$accessToken = 'secrettoken';
 		$dbToken = $this->getMockBuilder('\OC\Authentication\ClientLogin\AccessToken')
 			->disableOriginalConstructor()
@@ -215,6 +215,43 @@ class CoordinatorTest extends TestCase {
 			->will($this->returnValue(AccessToken::STATUS_PENDING));
 
 		$this->coordinator->getClientToken($accessToken);
+	}
+
+	public function testGetClientName() {
+		$accessToken = 'secrettoken';
+		$dbToken = new AccessToken();
+		$dbToken->setClientName('My client');
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('secret')
+			->will($this->returnValue('abc'));
+		$this->mapper->expects($this->once())
+			->method('getToken')
+			->with(hash('sha512', 'secrettokenabc'))
+			->will($this->returnValue($dbToken));
+
+		$this->assertEquals('My client', $this->coordinator->getClientName($accessToken));
+	}
+
+	/**
+	 * @expectedException \OC\Authentication\Exceptions\InvalidAccessTokenException
+	 */
+	public function testGetClientNameInvalidToken() {
+		$accessToken = 'secrettoken';
+		$dbToken = new AccessToken();
+		$dbToken->setClientName('My client');
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('secret')
+			->will($this->returnValue('abc'));
+		$this->mapper->expects($this->once())
+			->method('getToken')
+			->with(hash('sha512', 'secrettokenabc'))
+			->will($this->throwException(new DoesNotExistException('')));
+
+		$this->coordinator->getClientName($accessToken);
 	}
 
 }

--- a/tests/lib/Authentication/ClientLogin/CoordinatorTest.php
+++ b/tests/lib/Authentication/ClientLogin/CoordinatorTest.php
@@ -24,7 +24,6 @@ namespace Test\Authentication\ClientLogin;
 
 use OC\Authentication\ClientLogin\AccessToken;
 use OC\Authentication\ClientLogin\Coordinator;
-use OC\Authentication\Exceptions\InvalidAccessTokenException;
 use OC\Authentication\Token\IToken;
 use OCP\AppFramework\Db\DoesNotExistException;
 use Test\TestCase;
@@ -168,7 +167,7 @@ class CoordinatorTest extends TestCase {
 			->will($this->returnValue('sync client'));
 		$this->tokenProvider->expects($this->once())
 			->method('generateToken')
-			->with('securerandom', 'user123', '?', '?', 'sync client', IToken::PERMANENT_TOKEN)
+			->with('securerandom', 'user123', '?', null, 'sync client', IToken::PERMANENT_TOKEN)
 			->will($this->returnValue($clientToken));
 
 		$this->assertEquals('securerandom', $this->coordinator->getClientToken($accessToken));

--- a/tests/lib/Authentication/ClientLogin/CoordinatorTest.php
+++ b/tests/lib/Authentication/ClientLogin/CoordinatorTest.php
@@ -1,0 +1,221 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Authentication\ClientLogin;
+
+use OC\Authentication\ClientLogin\AccessToken;
+use OC\Authentication\ClientLogin\Coordinator;
+use OC\Authentication\Exceptions\InvalidAccessTokenException;
+use OC\Authentication\Token\IToken;
+use OCP\AppFramework\Db\DoesNotExistException;
+use Test\TestCase;
+
+class CoordinatorTest extends TestCase {
+
+	private $mapper;
+	private $tokenProvider;
+	private $random;
+	private $config;
+	private $timeFactory;
+
+	/** @var Coordinator */
+	private $coordinator;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->mapper = $this->getMockBuilder('\OC\Authentication\ClientLogin\AccessTokenMapper')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->tokenProvider = $this->getMock('\OC\Authentication\Token\IProvider');
+		$this->random = $this->getMock('\OCP\Security\ISecureRandom');
+		$this->config = $this->getMock('\OCP\IConfig');
+		$this->timeFactory = $this->getMock('\OCP\AppFramework\Utility\ITimeFactory');
+
+		$this->coordinator = new Coordinator($this->mapper, $this->tokenProvider, $this->random, $this->config, $this->timeFactory);
+	}
+
+	public function testStartClientLogin() {
+		$this->random->expects($this->once())
+			->method('generate')
+			->with(128)
+			->will($this->returnValue('randomtoken'));
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('secret')
+			->will($this->returnValue('abc'));
+
+		$accessToken = new AccessToken();
+		$accessToken->setToken(hash('sha512', 'randomtokenabc'));
+		$accessToken->setClientName('sync client');
+		$accessToken->setStatus(AccessToken::STATUS_PENDING);
+		$this->timeFactory->expects($this->once())
+			->method('getTime')
+			->will($this->returnValue(1000));
+		$accessToken->setCreatedAt(1000);
+
+		$this->mapper->expects($this->once())
+			->method('insert')
+			->with($accessToken);
+
+		$this->assertEquals('randomtoken', $this->coordinator->startClientLogin('sync client'));
+	}
+
+	public function testFinishClientLogin() {
+		$accessToken = 'secrettoken';
+		$user = $this->getMock('\OCP\IUser');
+		$dbToken = $this->getMockBuilder('\OC\Authentication\ClientLogin\AccessToken')
+			->disableOriginalConstructor()
+			->setMethods(['setStatus', 'setUid'])
+			->getMock();
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('secret')
+			->will($this->returnValue('abc'));
+		$this->mapper->expects($this->once())
+			->method('getToken')
+			->with(hash('sha512', 'secrettokenabc'))
+			->will($this->returnValue($dbToken));
+
+		$dbToken->expects($this->once())
+			->method('setStatus')
+			->with(AccessToken::STATUS_FINISHED);
+		$user->expects($this->once())
+			->method('getUID')
+			->will($this->returnValue('user123'));
+		$dbToken->expects($this->once())
+			->method('setUid')
+			->with('user123');
+		$this->mapper->expects($this->once())
+			->method('update')
+			->with($dbToken);
+
+		$this->coordinator->finishClientLogin($accessToken, $user);
+	}
+
+	/**
+	 * @expectedException \OC\Authentication\Exceptions\InvalidAccessTokenException
+	 */
+	public function testFinishClientLoginInvalidToken() {
+		$accessToken = 'secrettoken';
+		$user = $this->getMock('\OCP\IUser');
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('secret')
+			->will($this->returnValue('abc'));
+		$this->mapper->expects($this->once())
+			->method('getToken')
+			->with(hash('sha512', 'secrettokenabc'))
+			->will($this->throwException(new DoesNotExistException('token does not exist')));
+
+		$this->coordinator->finishClientLogin($accessToken, $user);
+	}
+
+	public function testGetClientToken() {
+		$accessToken = 'secrettoken';
+		$dbToken = $this->getMockBuilder('\OC\Authentication\ClientLogin\AccessToken')
+			->disableOriginalConstructor()
+			->setMethods(['getStatus', 'getUid', 'getClientName'])
+			->getMock();
+		$clientToken = $this->getMock('\OC\Authentication\Token\IToken');
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('secret')
+			->will($this->returnValue('abc'));
+		$this->mapper->expects($this->once())
+			->method('getToken')
+			->with(hash('sha512', 'secrettokenabc'))
+			->will($this->returnValue($dbToken));
+
+		$dbToken->expects($this->once())
+			->method('getStatus')
+			->will($this->returnValue(AccessToken::STATUS_FINISHED));
+		$this->mapper->expects($this->once())
+			->method('delete')
+			->with($dbToken);
+
+		$this->random->expects($this->once())
+			->method('generate')
+			->with(128)
+			->will($this->returnValue('securerandom'));
+		$dbToken->expects($this->once())
+			->method('getUID')
+			->will($this->returnValue('user123'));
+		$dbToken->expects($this->once())
+			->method('getClientName')
+			->will($this->returnValue('sync client'));
+		$this->tokenProvider->expects($this->once())
+			->method('generateToken')
+			->with('securerandom', 'user123', '?', '?', 'sync client', IToken::PERMANENT_TOKEN)
+			->will($this->returnValue($clientToken));
+
+		$this->assertEquals('securerandom', $this->coordinator->getClientToken($accessToken));
+	}
+
+	/**
+	 * @expectedException OC\Authentication\Exceptions\InvalidAccessTokenException
+	 */
+	public function testGetClientTokenInvalidToken() {
+		$accessToken = 'secrettoken';
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('secret')
+			->will($this->returnValue('abc'));
+		$this->mapper->expects($this->once())
+			->method('getToken')
+			->with(hash('sha512', 'secrettokenabc'))
+			->will($this->throwException(new DoesNotExistException('')));
+
+		$this->coordinator->getClientToken($accessToken);
+	}
+
+	/**
+	 * @expectedException \OC\Authentication\Exceptions\ClientLoginPendingException
+	 */
+	public function testGetClientTOkenPendingState() {
+		$accessToken = 'secrettoken';
+		$dbToken = $this->getMockBuilder('\OC\Authentication\ClientLogin\AccessToken')
+			->disableOriginalConstructor()
+			->setMethods(['getStatus'])
+			->getMock();
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('secret')
+			->will($this->returnValue('abc'));
+		$this->mapper->expects($this->once())
+			->method('getToken')
+			->with(hash('sha512', 'secrettokenabc'))
+			->will($this->returnValue($dbToken));
+
+		$dbToken->expects($this->once())
+			->method('getStatus')
+			->will($this->returnValue(AccessToken::STATUS_PENDING));
+
+		$this->coordinator->getClientToken($accessToken);
+	}
+
+}


### PR DESCRIPTION
TODO
- [x] create DB table to store temporary access tokens
- [x] finish implementation
- [x] allow password-less login (we may need a new token type for that)
- [x] tests
- [ ] extract login name and password from session token and save it to access token. Save those credentials with the new device token then.

OPTIONAL
- [ ] create background job to kill old access tokens
- [ ] logging
- [ ] a temporary browser session is created that could be killed on successful login
- [x] requires https://github.com/owncloud/core/issues/24850 to work with 2FA too

fixes https://github.com/owncloud/core/issues/24794
