### PR TITLE
[stable9] don't fail on "bad signature" during login

### DIFF
--- a/apps/encryption/lib/keymanager.php
+++ b/apps/encryption/lib/keymanager.php
@@ -356,6 +356,13 @@ class KeyManager {
 			return false;
 		} catch (DecryptionFailedException $e) {
 			return false;
+		} catch (\Exception $e) {
+			$this->log->warning(
+				'Could not decrypt the private key from user "' . $uid . '"" during login. ' .
+				'Assume password change on the user back-end. Error message: '
+				. $e->getMessage()
+			);
+			return false;
 		}
 
 		if ($privateKey) {


### PR DESCRIPTION
Most likely this happens because the login password changed at the user back-end (e.g ldap). Such failures will be handled after login correctly by allowing the user to adjust the passwords.

fix https://github.com/owncloud/core/issues/24832

Backport of https://github.com/owncloud/core/pull/24833
