### PR TITLE
add frame-ancestor to CSP to allow iframe embedding via app

### DIFF
--- a/lib/private/Security/CSP/ContentSecurityPolicy.php
+++ b/lib/private/Security/CSP/ContentSecurityPolicy.php
@@ -66,7 +66,7 @@ class ContentSecurityPolicy extends \OCP\AppFramework\Http\ContentSecurityPolicy
 	/**
 	 * @param array $allowedScriptDomains
 	 */
-	public function setAllowedScriptDomains($allowedScriptDomains) {
+	public function setAllowedScriptDomains(array $allowedScriptDomains) {
 		$this->allowedScriptDomains = $allowedScriptDomains;
 	}
 
@@ -94,7 +94,7 @@ class ContentSecurityPolicy extends \OCP\AppFramework\Http\ContentSecurityPolicy
 	/**
 	 * @param array $allowedStyleDomains
 	 */
-	public function setAllowedStyleDomains($allowedStyleDomains) {
+	public function setAllowedStyleDomains(array $allowedStyleDomains) {
 		$this->allowedStyleDomains = $allowedStyleDomains;
 	}
 
@@ -108,7 +108,7 @@ class ContentSecurityPolicy extends \OCP\AppFramework\Http\ContentSecurityPolicy
 	/**
 	 * @param array $allowedImageDomains
 	 */
-	public function setAllowedImageDomains($allowedImageDomains) {
+	public function setAllowedImageDomains(array $allowedImageDomains) {
 		$this->allowedImageDomains = $allowedImageDomains;
 	}
 
@@ -122,7 +122,7 @@ class ContentSecurityPolicy extends \OCP\AppFramework\Http\ContentSecurityPolicy
 	/**
 	 * @param array $allowedConnectDomains
 	 */
-	public function setAllowedConnectDomains($allowedConnectDomains) {
+	public function setAllowedConnectDomains(array $allowedConnectDomains) {
 		$this->allowedConnectDomains = $allowedConnectDomains;
 	}
 
@@ -136,7 +136,7 @@ class ContentSecurityPolicy extends \OCP\AppFramework\Http\ContentSecurityPolicy
 	/**
 	 * @param array $allowedMediaDomains
 	 */
-	public function setAllowedMediaDomains($allowedMediaDomains) {
+	public function setAllowedMediaDomains(array $allowedMediaDomains) {
 		$this->allowedMediaDomains = $allowedMediaDomains;
 	}
 
@@ -150,7 +150,7 @@ class ContentSecurityPolicy extends \OCP\AppFramework\Http\ContentSecurityPolicy
 	/**
 	 * @param array $allowedObjectDomains
 	 */
-	public function setAllowedObjectDomains($allowedObjectDomains) {
+	public function setAllowedObjectDomains(array $allowedObjectDomains) {
 		$this->allowedObjectDomains = $allowedObjectDomains;
 	}
 
@@ -164,7 +164,7 @@ class ContentSecurityPolicy extends \OCP\AppFramework\Http\ContentSecurityPolicy
 	/**
 	 * @param array $allowedFrameDomains
 	 */
-	public function setAllowedFrameDomains($allowedFrameDomains) {
+	public function setAllowedFrameDomains(array $allowedFrameDomains) {
 		$this->allowedFrameDomains = $allowedFrameDomains;
 	}
 
@@ -178,7 +178,7 @@ class ContentSecurityPolicy extends \OCP\AppFramework\Http\ContentSecurityPolicy
 	/**
 	 * @param array $allowedFontDomains
 	 */
-	public function setAllowedFontDomains($allowedFontDomains) {
+	public function setAllowedFontDomains(array $allowedFontDomains) {
 		$this->allowedFontDomains = $allowedFontDomains;
 	}
 
@@ -192,8 +192,22 @@ class ContentSecurityPolicy extends \OCP\AppFramework\Http\ContentSecurityPolicy
 	/**
 	 * @param array $allowedChildSrcDomains
 	 */
-	public function setAllowedChildSrcDomains($allowedChildSrcDomains) {
+	public function setAllowedChildSrcDomains(array $allowedChildSrcDomains) {
 		$this->allowedChildSrcDomains = $allowedChildSrcDomains;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getAllowedFrameAncestorDomains() {
+		return $this->allowedFrameAncestorDomains;
+	}
+
+	/**
+	 * @param array $allowedFrameAncestorDomains
+	 */
+	public function setAllowedFrameAncestorDomains(array $allowedFrameAncestorDomains) {
+		$this->allowedFrameAncestorDomains = $allowedFrameAncestorDomains;
 	}
 
 }

--- a/lib/public/AppFramework/Http/ContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/ContentSecurityPolicy.php
@@ -23,8 +23,6 @@
 
 namespace OCP\AppFramework\Http;
 
-use OCP\AppFramework\Http;
-
 /**
  * Class ContentSecurityPolicy is a simple helper which allows applications to
  * modify the Content-Security-Policy sent by ownCloud. Per default only JavaScript,
@@ -85,4 +83,6 @@ class ContentSecurityPolicy extends EmptyContentSecurityPolicy {
 	];
 	/** @var array Domains from which web-workers and nested browsing content can load elements */
 	protected $allowedChildSrcDomains = [];
+	/** @var array Domains from which the element can be embedded */
+	protected $allowedFrameAncestorDomains = [];
 }

--- a/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
@@ -67,6 +67,8 @@ class EmptyContentSecurityPolicy {
 	protected $allowedFontDomains = null;
 	/** @var array Domains from which web-workers and nested browsing content can load elements */
 	protected $allowedChildSrcDomains = null;
+	/** @var array Domains from which the element can be embedded */
+	protected $allowedFrameAncestorDomains = null;
 
 	/**
 	 * Whether inline JavaScript snippets are allowed or forbidden
@@ -313,6 +315,29 @@ class EmptyContentSecurityPolicy {
 	}
 
 	/**
+	 * Domains from which the element can be embedded
+	 * @param string $domain Domain to whitelist. Any passed value needs to be properly sanitized.
+	 * @return $this
+	 * @since 10.0.3
+	 */
+	public function addAllowedFrameAncestorDomain($domain) {
+		$this->allowedFrameAncestorDomains[] = $domain;
+		return $this;
+	}
+
+	/**
+	 * Remove the specified allowed frame ancestor domain from the allowed domains.
+	 *
+	 * @param string $domain
+	 * @return $this
+	 * @since 10.0.3
+	 */
+	public function disallowFrameAncestorDomain($domain) {
+		$this->allowedFrameAncestorDomains = array_diff($this->allowedFrameAncestorDomains, [$domain]);
+		return $this;
+	}
+
+	/**
 	 * Get the generated Content-Security-Policy as a string
 	 * @return string
 	 * @since 8.1.0
@@ -377,6 +402,11 @@ class EmptyContentSecurityPolicy {
 
 		if(!empty($this->allowedChildSrcDomains)) {
 			$policy .= 'child-src ' . implode(' ', $this->allowedChildSrcDomains);
+			$policy .= ';';
+		}
+
+		if(!empty($this->allowedFrameAncestorDomains)) {
+			$policy .= 'frame-ancestors ' . implode(' ', $this->allowedFrameAncestorDomains);
 			$policy .= ';';
 		}
 

--- a/tests/lib/AppFramework/Http/ContentSecurityPolicyTest.php
+++ b/tests/lib/AppFramework/Http/ContentSecurityPolicyTest.php
@@ -426,4 +426,43 @@ class ContentSecurityPolicyTest extends TestCase {
 		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org')->disallowChildSrcDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
+
+	public function testGetAllowedFrameAncestorDomain() {
+		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self';frame-ancestors owncloud.com";
+
+		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('owncloud.com');
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
+
+	public function testGetPolicyFrameAncestorValidMultiple() {
+		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self';frame-ancestors owncloud.com owncloud.org";
+
+		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('owncloud.com');
+		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('owncloud.org');
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
+
+	public function testGetPolicyDisallowFrameAncestorDomain() {
+		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
+
+		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('owncloud.com');
+		$this->contentSecurityPolicy->disallowFrameAncestorDomain('owncloud.com');
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
+
+	public function testGetPolicyDisallowChildFrameAncestorMultiple() {
+		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self';frame-ancestors owncloud.com";
+
+		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('owncloud.com');
+		$this->contentSecurityPolicy->disallowFrameAncestorDomain('owncloud.org');
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
+
+	public function testGetPolicyDisallowFrameAncestorDomainMultipleStakes() {
+		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
+
+		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('owncloud.com');
+		$this->contentSecurityPolicy->disallowFrameAncestorDomain('owncloud.org')->disallowFrameAncestorDomain('owncloud.com');
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
 }

--- a/tests/lib/AppFramework/Http/EmptyContentSecurityPolicyTest.php
+++ b/tests/lib/AppFramework/Http/EmptyContentSecurityPolicyTest.php
@@ -427,4 +427,43 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org')->disallowChildSrcDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
+
+	public function testGetAllowedFrameAncestorDomain() {
+		$expectedPolicy = "default-src 'none';manifest-src 'self';frame-ancestors owncloud.com";
+
+		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('owncloud.com');
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
+
+	public function testGetPolicyFrameAncestorValidMultiple() {
+		$expectedPolicy = "default-src 'none';manifest-src 'self';frame-ancestors owncloud.com owncloud.org";
+
+		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('owncloud.com');
+		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('owncloud.org');
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
+
+	public function testGetPolicyDisallowFrameAncestorDomain() {
+		$expectedPolicy = "default-src 'none';manifest-src 'self'";
+
+		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('owncloud.com');
+		$this->contentSecurityPolicy->disallowFrameAncestorDomain('owncloud.com');
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
+
+	public function testGetPolicyDisallowChildFrameAncestorMultiple() {
+		$expectedPolicy = "default-src 'none';manifest-src 'self';frame-ancestors owncloud.com";
+
+		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('owncloud.com');
+		$this->contentSecurityPolicy->disallowFrameAncestorDomain('owncloud.org');
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
+
+	public function testGetPolicyDisallowFrameAncestorDomainMultipleStakes() {
+		$expectedPolicy = "default-src 'none';manifest-src 'self'";
+
+		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('owncloud.com');
+		$this->contentSecurityPolicy->disallowFrameAncestorDomain('owncloud.org')->disallowFrameAncestorDomain('owncloud.com');
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
 }

--- a/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
+++ b/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
@@ -53,6 +53,7 @@ class ContentSecurityPolicyManagerTest extends TestCase {
 		$policy = new EmptyContentSecurityPolicy();
 		$policy->addAllowedChildSrcDomain('childdomain');
 		$policy->addAllowedFontDomain('anotherFontDomain');
+		$policy->addAllowedFrameAncestorDomain('ancestordomain.tld');
 		$this->contentSecurityPolicyManager->addDefaultPolicy($policy);
 
 		$expected = new ContentSecurityPolicy();
@@ -63,7 +64,8 @@ class ContentSecurityPolicyManagerTest extends TestCase {
 		$expected->addAllowedImageDomain('anotherdomain.de');
 		$expected->addAllowedImageDomain('example.org');
 		$expected->addAllowedChildSrcDomain('childdomain');
-		$expectedStringPolicy = 'default-src \'none\';manifest-src \'self\';script-src \'self\' \'unsafe-inline\' \'unsafe-eval\';style-src \'self\' \'unsafe-inline\';img-src \'self\' data: blob: anotherdomain.de example.org;font-src \'self\' mydomain.com example.com anotherFontDomain;connect-src \'self\';media-src \'self\';child-src childdomain';
+		$expected->addAllowedFrameAncestorDomain('ancestordomain.tld');
+		$expectedStringPolicy = 'default-src \'none\';manifest-src \'self\';script-src \'self\' \'unsafe-inline\' \'unsafe-eval\';style-src \'self\' \'unsafe-inline\';img-src \'self\' data: blob: anotherdomain.de example.org;font-src \'self\' mydomain.com example.com anotherFontDomain;connect-src \'self\';media-src \'self\';child-src childdomain;frame-ancestors ancestordomain.tld';
 
 		$this->assertEquals($expected, $this->contentSecurityPolicyManager->getDefaultPolicy());
 		$this->assertSame($expectedStringPolicy, $this->contentSecurityPolicyManager->getDefaultPolicy()->buildPolicy());


### PR DESCRIPTION
I am writing an app that should allow embetting OC in an IFrame. Unfortunately, I cannot change the frame ancestor CSP. This PR adds support for that.

See https://github.com/owncloud/core/pull/21989 which introduced the api and https://www.owasp.org/index.php/Content_Security_Policy_Cheat_Sheet for `frame-ancestor` examples.

cc @LukasReschke
