### PR TITLE
Use a capped memory cache for the user/group cache

### DIFF
--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -36,6 +36,7 @@
 
 namespace OCA\User_LDAP;
 
+use OC\Cache\CappedMemoryCache;
 
 class Group_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	protected $enabled = false;
@@ -43,12 +44,12 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	/**
 	 * @var string[] $cachedGroupMembers array of users with gid as key
 	 */
-	protected $cachedGroupMembers = array();
+	protected $cachedGroupMembers;
 
 	/**
 	 * @var string[] $cachedGroupsByMember array of groups with uid as key
 	 */
-	protected $cachedGroupsByMember = array();
+	protected $cachedGroupsByMember;
 
 	public function __construct(Access $access) {
 		parent::__construct($access);
@@ -57,6 +58,9 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface {
 		if(!empty($filter) && !empty($gassoc)) {
 			$this->enabled = true;
 		}
+
+		$this->cachedGroupMembers = new CappedMemoryCache();
+		$this->cachedGroupsByMember = new CappedMemoryCache();
 	}
 
 	/**


### PR DESCRIPTION
For #24403
When upgrading huge installations this can lead to memory problems as
the cache will only grow and grow.

Capping this memory will make sure we don't run out while during normal
operation still basically cache everything.

CC: @blizzz @PVince81 @MorrisJobke
