### PR TITLE
OCS routes to appframework

### DIFF
--- a/apps/federation/appinfo/routes.php
+++ b/apps/federation/appinfo/routes.php
@@ -40,8 +40,18 @@ $application->registerRoutes(
 				'url' => '/auto-add-servers',
 				'verb' => 'POST'
 			],
+		],
+		'ocs' => [
+			[
+				'name' => 'OCSAuthAPI#getSharedSecret',
+				'url' => '/api/v1/shared-secret',
+				'verb' => 'GET'
+			],
+			[
+				'name' => 'OCSAuthAPI#requestSharedSecret',
+				'url' => '/api/v1/request-shared-secret',
+				'verb' => 'POST'
+			]
 		]
 	]
 );
-
-$application->registerOCSApi();

--- a/apps/federation/lib/AppInfo/Application.php
+++ b/apps/federation/lib/AppInfo/Application.php
@@ -102,41 +102,7 @@ class Application extends \OCP\AppFramework\App {
 
 	private function registerMiddleware() {
 		$container = $this->getContainer();
-		$container->registerMiddleware('addServerMiddleware');
-	}
-
-	/**
-	 * register OCS API Calls
-	 */
-	public function registerOCSApi() {
-
-		$container = $this->getContainer();
-		$server = $container->getServer();
-
-		$auth = new OCSAuthAPI(
-			$server->getRequest(),
-			$server->getSecureRandom(),
-			$server->getJobList(),
-			$container->query('TrustedServers'),
-			$container->query('DbHandler'),
-			$server->getLogger()
-
-		);
-
-		API::register('get',
-			'/apps/federation/api/v1/shared-secret',
-			[$auth, 'getSharedSecret'],
-			'federation',
-			API::GUEST_AUTH
-		);
-
-		API::register('post',
-			'/apps/federation/api/v1/request-shared-secret',
-			[$auth, 'requestSharedSecret'],
-			'federation',
-			API::GUEST_AUTH
-		);
-
+		$container->registerMiddleWare('addServerMiddleware');
 	}
 
 	/**

--- a/apps/federation/lib/Controller/OCSAuthAPIController.php
+++ b/apps/federation/lib/Controller/OCSAuthAPIController.php
@@ -97,7 +97,7 @@ class OCSAuthAPIController extends OCSController  {
 
 		if ($this->trustedServers->isTrustedServer($url) === false) {
 			$this->logger->error('remote server not trusted (' . $url . ') while requesting shared secret', ['app' => 'federation']);
-			return ['statuscode' => HTTP::STATUS_FORBIDDEN];
+			return ['statuscode' => Http::STATUS_FORBIDDEN];
 		}
 
 		// if both server initiated the exchange of the shared secret the greater
@@ -108,7 +108,7 @@ class OCSAuthAPIController extends OCSController  {
 				'remote server (' . $url . ') presented lower token. We will initiate the exchange of the shared secret.',
 				['app' => 'federation']
 			);
-			return ['statuscode' => HTTP::STATUS_FORBIDDEN];
+			return ['statuscode' => Http::STATUS_FORBIDDEN];
 		}
 
 		// we ask for the shared secret so we no longer have to ask the other server
@@ -142,7 +142,7 @@ class OCSAuthAPIController extends OCSController  {
 
 		if ($this->trustedServers->isTrustedServer($url) === false) {
 			$this->logger->error('remote server not trusted (' . $url . ') while getting shared secret', ['app' => 'federation']);
-			return ['statuscode' => HTTP::STATUS_FORBIDDEN];
+			return ['statuscode' => Http::STATUS_FORBIDDEN];
 		}
 
 		if ($this->isValidToken($url, $token) === false) {
@@ -151,7 +151,7 @@ class OCSAuthAPIController extends OCSController  {
 				'remote server (' . $url . ') didn\'t send a valid token (got "' . $token . '" but expected "'. $expectedToken . '") while getting shared secret',
 				['app' => 'federation']
 			);
-			return ['statuscode' => HTTP::STATUS_FORBIDDEN];
+			return ['statuscode' => Http::STATUS_FORBIDDEN];
 		}
 
 		$sharedSecret = $this->secureRandom->generate(32);
@@ -160,7 +160,7 @@ class OCSAuthAPIController extends OCSController  {
 		// reset token after the exchange of the shared secret was successful
 		$this->dbHandler->addToken($url, '');
 
-		return ['statuscode' => HTTP::STATUS_OK,
+		return ['statuscode' => Http::STATUS_OK,
 			'data' => ['sharedSecret' => $sharedSecret]];
 	}
 

--- a/apps/federation/lib/Controller/OCSAuthAPIController.php
+++ b/apps/federation/lib/Controller/OCSAuthAPIController.php
@@ -61,6 +61,7 @@ class OCSAuthAPIController extends OCSController  {
 	/**
 	 * OCSAuthAPI constructor.
 	 *
+	 * @param string $appName
 	 * @param IRequest $request
 	 * @param ISecureRandom $secureRandom
 	 * @param IJobList $jobList
@@ -87,6 +88,9 @@ class OCSAuthAPIController extends OCSController  {
 	}
 
 	/**
+	 * @NoCSRFRequired
+	 * @PublicPage
+	 *
 	 * request received to ask remote server for a shared secret
 	 *
 	 * @param string $url
@@ -132,6 +136,9 @@ class OCSAuthAPIController extends OCSController  {
 	}
 
 	/**
+	 * @NoCSRFRequired
+	 * @PublicPage
+	 *
 	 * create shared secret and return it
 	 *
 	 * @param string $url

--- a/apps/federation/tests/API/OCSAuthAPITest.php
+++ b/apps/federation/tests/API/OCSAuthAPITest.php
@@ -25,7 +25,7 @@ namespace OCA\Federation\Tests\API;
 
 
 use OC\BackgroundJob\JobList;
-use OCA\Federation\API\OCSAuthAPI;
+use OCA\Federation\Controller\OCSAuthAPIController;
 use OCA\Federation\DbHandler;
 use OCA\Federation\TrustedServers;
 use OCP\AppFramework\Http;
@@ -54,24 +54,25 @@ class OCSAuthAPITest extends TestCase {
 	/** @var \PHPUnit_Framework_MockObject_MockObject | ILogger */
 	private $logger;
 
-	/** @var  OCSAuthApi */
+	/** @var  OCSAuthAPIController */
 	private $ocsAuthApi;
 
 	public function setUp() {
 		parent::setUp();
 
-		$this->request = $this->createMock('OCP\IRequest');
-		$this->secureRandom = $this->createMock('OCP\Security\ISecureRandom');
-		$this->trustedServers = $this->getMockBuilder('OCA\Federation\TrustedServers')
+		$this->request = $this->createMock(IRequest::class);
+		$this->secureRandom = $this->createMock(ISecureRandom::class);
+		$this->trustedServers = $this->getMockBuilder(TrustedServers::class)
 			->disableOriginalConstructor()->getMock();
-		$this->dbHandler = $this->getMockBuilder('OCA\Federation\DbHandler')
+		$this->dbHandler = $this->getMockBuilder(DbHandler::class)
 			->disableOriginalConstructor()->getMock();
-		$this->jobList = $this->getMockBuilder('OC\BackgroundJob\JobList')
+		$this->jobList = $this->getMockBuilder(JobList::class)
 			->disableOriginalConstructor()->getMock();
-		$this->logger = $this->getMockBuilder('OCP\ILogger')
+		$this->logger = $this->getMockBuilder(ILogger::class)
 			->disableOriginalConstructor()->getMock();
 
-		$this->ocsAuthApi = new OCSAuthAPI(
+		$this->ocsAuthApi = new OCSAuthAPIController(
+			'federation',
 			$this->request,
 			$this->secureRandom,
 			$this->jobList,
@@ -94,8 +95,6 @@ class OCSAuthAPITest extends TestCase {
 
 		$url = 'url';
 
-		$this->request->expects($this->at(0))->method('getParam')->with('url')->willReturn($url);
-		$this->request->expects($this->at(1))->method('getParam')->with('token')->willReturn($token);
 		$this->trustedServers
 			->expects($this->once())
 			->method('isTrustedServer')->with($url)->willReturn($isTrustedServer);
@@ -112,8 +111,8 @@ class OCSAuthAPITest extends TestCase {
 			$this->jobList->expects($this->never())->method('remove');
 		}
 
-		$result = $this->ocsAuthApi->requestSharedSecret();
-		$this->assertSame($expected, $result->getStatusCode());
+		$result = $this->ocsAuthApi->requestSharedSecret($url, $token);
+		$this->assertSame($expected, $result['statuscode']);
 	}
 
 	public function dataTestRequestSharedSecret() {
@@ -136,13 +135,11 @@ class OCSAuthAPITest extends TestCase {
 		$url = 'url';
 		$token = 'token';
 
-		$this->request->expects($this->at(0))->method('getParam')->with('url')->willReturn($url);
-		$this->request->expects($this->at(1))->method('getParam')->with('token')->willReturn($token);
-
-		/** @var OCSAuthAPI | \PHPUnit_Framework_MockObject_MockObject $ocsAuthApi */
-		$ocsAuthApi = $this->getMockBuilder('OCA\Federation\API\OCSAuthAPI')
+		/** @var OCSAuthAPIController | \PHPUnit_Framework_MockObject_MockObject $ocsAuthApi */
+		$ocsAuthApi = $this->getMockBuilder(OCSAuthAPIController::class)
 			->setConstructorArgs(
 				[
+					'federation',
 					$this->request,
 					$this->secureRandom,
 					$this->jobList,
@@ -172,12 +169,12 @@ class OCSAuthAPITest extends TestCase {
 			$this->dbHandler->expects($this->never())->method('addToken');
 		}
 
-		$result = $ocsAuthApi->getSharedSecret();
+		$result = $ocsAuthApi->getSharedSecret($url, $token);
 
-		$this->assertSame($expected, $result->getStatusCode());
+		$this->assertSame($expected, $result['statuscode']);
 
 		if ($expected === Http::STATUS_OK) {
-			$data =  $result->getData();
+			$data =  $result['data'];
 			$this->assertSame('secret', $data['sharedSecret']);
 		}
 	}

--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -39,6 +39,13 @@ $application->registerRoutes($this, [
 			'verb' => 'GET'
 		],
 	],
+	'ocs' => [
+		[
+			'name' => 'sharees#search',
+			'url' => '/api/v1/sharees',
+			'verb' => 'GET',
+		]
+	]
 ]);
 
 /** @var $this \OCP\Route\IRouter */
@@ -116,20 +123,3 @@ API::register('delete',
 		'/apps/files_sharing/api/v1/remote_shares/{id}',
 		['\OCA\Files_Sharing\API\Remote', 'unshare'],
 		'files_sharing');
-
-
-$sharees = new \OCA\Files_Sharing\API\Sharees(\OC::$server->getGroupManager(),
-                                              \OC::$server->getUserManager(),
-                                              \OC::$server->getContactsManager(),
-                                              \OC::$server->getConfig(),
-                                              \OC::$server->getUserSession(),
-                                              \OC::$server->getURLGenerator(),
-                                              \OC::$server->getRequest(),
-                                              \OC::$server->getLogger(),
-                                              \OC::$server->getShareManager());
-
-API::register('get',
-		'/apps/files_sharing/api/v1/sharees',
-		[$sharees, 'search'],
-		'files_sharing', API::USER_AUTH);
-

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -413,7 +413,7 @@ class ShareesController extends OCSController  {
 	 * @param string $itemType
 	 * @param int $page
 	 * @param int $perPage
-	 * @return DataResponse
+	 * @return array|DataResponse
 	 */
 	public function search($search = '', $itemType = null, $page = 1, $perPage = 200) {
 
@@ -481,7 +481,7 @@ class ShareesController extends OCSController  {
 	 * @param array $shareTypes
 	 * @param int $page
 	 * @param int $perPage
-	 * @return DataResponse
+	 * @return DataResponse|array
 	 */
 	protected function searchSharees($search, $itemType, array $shareTypes, $page, $perPage) {
 		// Verify arguments

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -27,6 +27,10 @@
  */
 
 namespace OCA\Files_Sharing\Tests;
+use OCP\Constants;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\Share;
 
 /**
  * Class ApiTest
@@ -41,6 +45,9 @@ class ApiTest extends TestCase {
 
 	/** @var \OCP\Files\Folder */
 	private $userFolder;
+
+	/** @var string */
+	private $subsubfolder;
 
 	protected function setUp() {
 		parent::setUp();
@@ -81,7 +88,7 @@ class ApiTest extends TestCase {
 	 * @return \OCP\IRequest
 	 */
 	private function createRequest(array $data) {
-		$request = $this->createMock('\OCP\IRequest');
+		$request = $this->createMock(IRequest::class);
 		$request->method('getParam')
 			->will($this->returnCallback(function($param, $default = null) use ($data) {
 				if (isset($data[$param])) {
@@ -100,7 +107,7 @@ class ApiTest extends TestCase {
 	private function createOCS($request, $userId) {
 		$currentUser = \OC::$server->getUserManager()->get($userId);
 
-		$l = $this->createMock('\OCP\IL10N');
+		$l = $this->createMock(IL10N::class);
 		$l->method('t')
 			->will($this->returnCallback(function($text, $parameters = []) {
 				return vsprintf($text, $parameters);
@@ -125,7 +132,7 @@ class ApiTest extends TestCase {
 		// simulate a post request
 		$data['path'] = $this->filename;
 		$data['shareWith'] = self::TEST_FILES_SHARING_API_USER2;
-		$data['shareType'] = \OCP\Share::SHARE_TYPE_USER;
+		$data['shareType'] = Share::SHARE_TYPE_USER;
 
 		$request = $this->createRequest($data);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
@@ -148,7 +155,7 @@ class ApiTest extends TestCase {
 		// simulate a post request
 		$data['path'] = $this->folder;
 		$data['shareWith'] = self::TEST_FILES_SHARING_API_USER2;
-		$data['shareType'] = \OCP\Share::SHARE_TYPE_USER;
+		$data['shareType'] = Share::SHARE_TYPE_USER;
 
 		$request = $this->createRequest($data);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
@@ -172,7 +179,7 @@ class ApiTest extends TestCase {
 		// simulate a post request
 		$data['path'] = $this->filename;
 		$data['shareWith'] = self::TEST_FILES_SHARING_API_GROUP1;
-		$data['shareType'] = \OCP\Share::SHARE_TYPE_GROUP;
+		$data['shareType'] = Share::SHARE_TYPE_GROUP;
 
 		$request = $this->createRequest($data);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
@@ -195,7 +202,7 @@ class ApiTest extends TestCase {
 		// simulate a post request
 		$data['path'] = $this->folder;
 		$data['shareWith'] = self::TEST_FILES_SHARING_API_GROUP1;
-		$data['shareType'] = \OCP\Share::SHARE_TYPE_GROUP;
+		$data['shareType'] = Share::SHARE_TYPE_GROUP;
 
 		$request = $this->createRequest($data);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
@@ -217,7 +224,7 @@ class ApiTest extends TestCase {
 	public function testCreateShareLink() {
 		// simulate a post request
 		$data['path'] = $this->folder;
-		$data['shareType'] = \OCP\Share::SHARE_TYPE_LINK;
+		$data['shareType'] = Share::SHARE_TYPE_LINK;
 
 		$request = $this->createRequest($data);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
@@ -246,7 +253,7 @@ class ApiTest extends TestCase {
 	public function testCreateShareLinkPublicUpload() {
 		// simulate a post request
 		$data['path'] = $this->folder;
-		$data['shareType'] = \OCP\Share::SHARE_TYPE_LINK;
+		$data['shareType'] = Share::SHARE_TYPE_LINK;
 		$data['publicUpload'] = 'true';
 
 		$request = $this->createRequest($data);
@@ -258,10 +265,10 @@ class ApiTest extends TestCase {
 
 		$data = $result->getData();
 		$this->assertEquals(
-			\OCP\Constants::PERMISSION_READ |
-			\OCP\Constants::PERMISSION_CREATE |
-			\OCP\Constants::PERMISSION_UPDATE |
-			\OCP\Constants::PERMISSION_DELETE,
+			Constants::PERMISSION_READ |
+			Constants::PERMISSION_CREATE |
+			Constants::PERMISSION_UPDATE |
+			Constants::PERMISSION_DELETE,
 			$data['permissions']
 		);
 		$this->assertEmpty($data['expiration']);
@@ -286,7 +293,7 @@ class ApiTest extends TestCase {
 
 		// don't allow to share link without a password
 		$data['path'] = $this->folder;
-		$data['shareType'] = \OCP\Share::SHARE_TYPE_LINK;
+		$data['shareType'] = Share::SHARE_TYPE_LINK;
 
 		$request = $this->createRequest($data);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
@@ -296,7 +303,7 @@ class ApiTest extends TestCase {
 		// don't allow to share link without a empty password
 		$data = [];
 		$data['path'] = $this->folder;
-		$data['shareType'] = \OCP\Share::SHARE_TYPE_LINK;
+		$data['shareType'] = Share::SHARE_TYPE_LINK;
 		$data['password'] = '';
 
 		$request = $this->createRequest($data);
@@ -307,7 +314,7 @@ class ApiTest extends TestCase {
 		// share with password should succeed
 		$data = [];
 		$data['path'] = $this->folder;
-		$data['shareType'] = \OCP\Share::SHARE_TYPE_LINK;
+		$data['shareType'] = Share::SHARE_TYPE_LINK;
 		$data['password'] = 'foo';
 
 		$request = $this->createRequest($data);
@@ -353,7 +360,7 @@ class ApiTest extends TestCase {
 		\OC::$server->getAppConfig()->setValue('core', 'shareapi_exclude_groups', 'no');
 		$post['path'] = $this->filename;
 		$post['shareWith'] = self::TEST_FILES_SHARING_API_USER2;
-		$post['shareType'] = \OCP\Share::SHARE_TYPE_USER;
+		$post['shareType'] = Share::SHARE_TYPE_USER;
 
 		$request = $this->createRequest($post);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
@@ -376,7 +383,7 @@ class ApiTest extends TestCase {
 		$post = [];
 		$post['path'] = $this->filename;
 		$post['shareWith'] = self::TEST_FILES_SHARING_API_USER2;
-		$post['shareType'] = \OCP\Share::SHARE_TYPE_USER;
+		$post['shareType'] = Share::SHARE_TYPE_USER;
 
 		$request = $this->createRequest($post);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
@@ -398,7 +405,7 @@ class ApiTest extends TestCase {
 		$post = [];
 		$post['path'] = $this->filename;
 		$post['shareWith'] = self::TEST_FILES_SHARING_API_USER2;
-		$post['shareType'] = \OCP\Share::SHARE_TYPE_USER;
+		$post['shareType'] = Share::SHARE_TYPE_USER;
 
 		$request = $this->createRequest($post);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
@@ -420,7 +427,7 @@ class ApiTest extends TestCase {
 		$share->setNode($node)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(19);
 
 		$share = $this->shareManager->createShare($share);
@@ -441,7 +448,7 @@ class ApiTest extends TestCase {
 		$share1->setNode($node1)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(19);
 		$share1 = $this->shareManager->createShare($share1);
 
@@ -450,7 +457,7 @@ class ApiTest extends TestCase {
 		$share2->setNode($node2)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(31);
 		$share2 = $this->shareManager->createShare($share2);
 
@@ -471,7 +478,7 @@ class ApiTest extends TestCase {
 	function testPublicLinkUrl() {
 		// simulate a post request
 		$post['path'] = $this->folder;
-		$post['shareType'] = \OCP\Share::SHARE_TYPE_LINK;
+		$post['shareType'] = Share::SHARE_TYPE_LINK;
 
 		$request = $this->createRequest($post);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
@@ -532,14 +539,14 @@ class ApiTest extends TestCase {
 		$share->setNode($node)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(19);
 		$share1 = $this->shareManager->createShare($share);
 
 		$share = $this->shareManager->newShare();
 		$share->setNode($node)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
-			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setShareType(Share::SHARE_TYPE_LINK)
 			->setPermissions(1);
 		$share2 = $this->shareManager->createShare($share);
 
@@ -566,7 +573,7 @@ class ApiTest extends TestCase {
 		$share1->setNode($node)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(19);
 		$share1 = $this->shareManager->createShare($share1);
 
@@ -574,7 +581,7 @@ class ApiTest extends TestCase {
 		$share2->setNode($node)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER2)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER3)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(19);
 		$share2 = $this->shareManager->createShare($share2);
 
@@ -611,7 +618,7 @@ class ApiTest extends TestCase {
 		$share1->setNode($node)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(19);
 		$share1 = $this->shareManager->createShare($share1);
 
@@ -636,7 +643,7 @@ class ApiTest extends TestCase {
 		$share1->setNode($node1)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(19);
 		$share1 = $this->shareManager->createShare($share1);
 
@@ -644,7 +651,7 @@ class ApiTest extends TestCase {
 		$share2 = $this->shareManager->newShare();
 		$share2->setNode($node2)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
-			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setShareType(Share::SHARE_TYPE_LINK)
 			->setPermissions(1);
 		$share2 = $this->shareManager->createShare($share2);
 
@@ -667,7 +674,7 @@ class ApiTest extends TestCase {
 		$share1->setNode($node1)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(19);
 		$share1 = $this->shareManager->createShare($share1);
 
@@ -692,7 +699,7 @@ class ApiTest extends TestCase {
 		$share1->setNode($node1)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(31);
 		$share1 = $this->shareManager->createShare($share1);
 
@@ -700,7 +707,7 @@ class ApiTest extends TestCase {
 		$share2 = $this->shareManager->newShare();
 		$share2->setNode($node2)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setShareType(Share::SHARE_TYPE_LINK)
 			->setPermissions(1);
 		$share2 = $this->shareManager->createShare($share2);
 
@@ -708,7 +715,7 @@ class ApiTest extends TestCase {
 		$share3 = $this->shareManager->newShare();
 		$share3->setNode($node3)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setShareType(Share::SHARE_TYPE_LINK)
 			->setPermissions(1);
 		$share3 = $this->shareManager->createShare($share3);
 
@@ -747,7 +754,7 @@ class ApiTest extends TestCase {
 		$share1->setNode($node1)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(31);
 		$share1 = $this->shareManager->createShare($share1);
 
@@ -755,7 +762,7 @@ class ApiTest extends TestCase {
 		$share2 = $this->shareManager->newShare();
 		$share2->setNode($node2)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setShareType(Share::SHARE_TYPE_LINK)
 			->setPermissions(1);
 		$share2 = $this->shareManager->createShare($share2);
 
@@ -786,7 +793,7 @@ class ApiTest extends TestCase {
 		$share1->setNode($node1)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(31);
 		$share1 = $this->shareManager->createShare($share1);
 
@@ -795,14 +802,14 @@ class ApiTest extends TestCase {
 		$share2->setNode($node2)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER2)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER3)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(31);
 		$share2 = $this->shareManager->createShare($share2);
 
 		$share3 = $this->shareManager->newShare();
 		$share3->setNode($node2)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER3)
-			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setShareType(Share::SHARE_TYPE_LINK)
 			->setPermissions(1);
 		$share3 = $this->shareManager->createShare($share3);
 
@@ -866,7 +873,7 @@ class ApiTest extends TestCase {
 		$share1->setNode($node1)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(31);
 		$share1 = $this->shareManager->createShare($share1);
 
@@ -875,14 +882,14 @@ class ApiTest extends TestCase {
 		$share2->setNode($node2)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(31);
 		$share2 = $this->shareManager->createShare($share2);
 
 		$share3 = $this->shareManager->newShare();
 		$share3->setNode($node1)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setShareType(Share::SHARE_TYPE_LINK)
 			->setPermissions(1);
 		$share3 = $this->shareManager->createShare($share3);
 
@@ -924,7 +931,7 @@ class ApiTest extends TestCase {
 		$share1->setNode($node1)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(31);
 		$share1 = $this->shareManager->createShare($share1);
 
@@ -934,7 +941,7 @@ class ApiTest extends TestCase {
 		$share2->setNode($node2)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER2)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER3)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(19);
 		$share2 = $this->shareManager->createShare($share2);
 
@@ -943,7 +950,7 @@ class ApiTest extends TestCase {
 		$share3 = $this->shareManager->newShare();
 		$share3->setNode($node3)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER3)
-			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setShareType(Share::SHARE_TYPE_LINK)
 			->setPermissions(1);
 		$share3 = $this->shareManager->createShare($share3);
 
@@ -990,14 +997,14 @@ class ApiTest extends TestCase {
 		$share1->setNode($node1)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(19);
 		$share1 = $this->shareManager->createShare($share1);
 
 		$share2 = $this->shareManager->newShare();
 		$share2->setNode($node1)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
-			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setShareType(Share::SHARE_TYPE_LINK)
 			->setPermissions(1);
 		$share2 = $this->shareManager->createShare($share2);
 
@@ -1049,11 +1056,11 @@ class ApiTest extends TestCase {
 		$share1->setNode($node1)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(19);
 		$share1 = $this->shareManager->createShare($share1);
 
-		$request = $this->createRequest(['permissions' => \OCP\Constants::PERMISSION_ALL]);
+		$request = $this->createRequest(['permissions' => Constants::PERMISSION_ALL]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->updateShare($share1->getId());
 
@@ -1076,7 +1083,7 @@ class ApiTest extends TestCase {
 		$share1 = $this->shareManager->newShare();
 		$share1->setNode($node1)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
-			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setShareType(Share::SHARE_TYPE_LINK)
 			->setPermissions(1);
 		$share1 = $this->shareManager->createShare($share1);
 
@@ -1088,10 +1095,10 @@ class ApiTest extends TestCase {
 
 		$share1 = $this->shareManager->getShareById($share1->getFullId());
 		$this->assertEquals(
-			\OCP\Constants::PERMISSION_READ |
-			\OCP\Constants::PERMISSION_CREATE |
-			\OCP\Constants::PERMISSION_UPDATE |
-			\OCP\Constants::PERMISSION_DELETE,
+			Constants::PERMISSION_READ |
+			Constants::PERMISSION_CREATE |
+			Constants::PERMISSION_UPDATE |
+			Constants::PERMISSION_DELETE,
 			$share1->getPermissions()
 		);
 
@@ -1107,7 +1114,7 @@ class ApiTest extends TestCase {
 		$share1 = $this->shareManager->newShare();
 		$share1->setNode($node1)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
-			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setShareType(Share::SHARE_TYPE_LINK)
 			->setPermissions(1);
 		$share1 = $this->shareManager->createShare($share1);
 
@@ -1173,14 +1180,14 @@ class ApiTest extends TestCase {
 		$share1->setNode($node1)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(19);
 		$share1 = $this->shareManager->createShare($share1);
 
 		$share2 = $this->shareManager->newShare();
 		$share2->setNode($node1)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
-			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setShareType(Share::SHARE_TYPE_LINK)
 			->setPermissions(1);
 		$share2 = $this->shareManager->createShare($share1);
 
@@ -1194,8 +1201,8 @@ class ApiTest extends TestCase {
 		$result = $ocs->deleteShare($share2->getId());
 		$this->assertTrue($result->succeeded());
 
-		$this->assertEmpty($this->shareManager->getSharesBy(self::TEST_FILES_SHARING_API_USER2, \OCP\Share::SHARE_TYPE_USER));
-		$this->assertEmpty($this->shareManager->getSharesBy(self::TEST_FILES_SHARING_API_USER2, \OCP\Share::SHARE_TYPE_LINK));
+		$this->assertEmpty($this->shareManager->getSharesBy(self::TEST_FILES_SHARING_API_USER2, Share::SHARE_TYPE_USER));
+		$this->assertEmpty($this->shareManager->getSharesBy(self::TEST_FILES_SHARING_API_USER2, Share::SHARE_TYPE_LINK));
 	}
 
 	/**
@@ -1207,7 +1214,7 @@ class ApiTest extends TestCase {
 		$share1->setNode($node1)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(31);
 		$share1 = $this->shareManager->createShare($share1);
 
@@ -1216,7 +1223,7 @@ class ApiTest extends TestCase {
 		$share2 = $this->shareManager->newShare();
 		$share2->setNode($node2)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER2)
-			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setShareType(Share::SHARE_TYPE_LINK)
 			->setPermissions(1);
 		$share2 = $this->shareManager->createShare($share2);
 
@@ -1239,11 +1246,11 @@ class ApiTest extends TestCase {
 		$fileInfo = $this->view->getFileInfo($this->folder);
 
 		$share = $this->share(
-			\OCP\Share::SHARE_TYPE_USER,
+			Share::SHARE_TYPE_USER,
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 
 		// user2 shares a file from the folder as link
@@ -1264,11 +1271,11 @@ class ApiTest extends TestCase {
 		$pass = true;
 		try {
 			$this->share(
-				\OCP\Share::SHARE_TYPE_USER,
+				Share::SHARE_TYPE_USER,
 				'localDir',
 				self::TEST_FILES_SHARING_API_USER2,
 				self::TEST_FILES_SHARING_API_USER3,
-				\OCP\Constants::PERMISSION_ALL
+				Constants::PERMISSION_ALL
 			);
 		} catch (\Exception $e) {
 			$pass = false;
@@ -1316,11 +1323,11 @@ class ApiTest extends TestCase {
 
 		// user 1 shares the mount point folder with user2
 		$share = $this->share(
-			\OCP\Share::SHARE_TYPE_USER,
+			Share::SHARE_TYPE_USER,
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 
 		// user2: check that mount point name appears correctly
@@ -1344,7 +1351,7 @@ class ApiTest extends TestCase {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
 		$id = PHP_INT_MAX - 1;
-		\OCP\Share::shareItem('file', $id, \OCP\Share::SHARE_TYPE_LINK, self::TEST_FILES_SHARING_API_USER2, 31);
+		Share::shareItem('file', $id, Share::SHARE_TYPE_LINK, self::TEST_FILES_SHARING_API_USER2, 31);
 	}
 
 	/**
@@ -1357,7 +1364,7 @@ class ApiTest extends TestCase {
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
-		\OCP\Share::shareItem('file', $info->getId(), \OCP\Share::SHARE_TYPE_LINK, self::TEST_FILES_SHARING_API_USER2, 31);
+		Share::shareItem('file', $info->getId(), Share::SHARE_TYPE_LINK, self::TEST_FILES_SHARING_API_USER2, 31);
 	}
 
 	public function testDefaultExpireDate() {
@@ -1389,34 +1396,34 @@ class ApiTest extends TestCase {
 		$info = \OC\Files\Filesystem::getFileInfo($this->filename);
 		$this->assertTrue($info instanceof \OC\Files\FileInfo);
 
-		$result = \OCP\Share::shareItem('file', $info->getId(), \OCP\Share::SHARE_TYPE_LINK, null, \OCP\Constants::PERMISSION_READ);
+		$result = Share::shareItem('file', $info->getId(), Share::SHARE_TYPE_LINK, null, Constants::PERMISSION_READ);
 		$this->assertTrue(is_string($result));
 
-		$result = \OCP\Share::shareItem('file', $info->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, 31);
+		$result = Share::shareItem('file', $info->getId(), Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, 31);
 		$this->assertTrue($result);
 
-		$result = \OCP\Share::setExpirationDate('file', $info->getId() , $expireDate, $now);
+		$result = Share::setExpirationDate('file', $info->getId() , $expireDate, $now);
 		$this->assertTrue($result);
 
 		//manipulate stime so that both shares are older then the default expire date
 		$statement = "UPDATE `*PREFIX*share` SET `stime` = ? WHERE `share_type` = ?";
 		$query = \OCP\DB::prepare($statement);
-		$result = $query->execute([$shareCreated, \OCP\Share::SHARE_TYPE_LINK]);
+		$result = $query->execute([$shareCreated, Share::SHARE_TYPE_LINK]);
 		$this->assertSame(1, $result);
 		$query = \OCP\DB::prepare($statement);
-		$result = $query->execute([$shareCreated, \OCP\Share::SHARE_TYPE_USER]);
+		$result = $query->execute([$shareCreated, Share::SHARE_TYPE_USER]);
 		$this->assertSame(1, $result);
 
 		// now the link share should expire because of enforced default expire date
 		// the user share should still exist
-		$result = \OCP\Share::getItemShared('file', $info->getId());
+		$result = Share::getItemShared('file', $info->getId());
 		$this->assertTrue(is_array($result));
 		$this->assertSame(1, count($result));
 		$share = reset($result);
-		$this->assertSame(\OCP\Share::SHARE_TYPE_USER, $share['share_type']);
+		$this->assertSame(Share::SHARE_TYPE_USER, $share['share_type']);
 
 		//cleanup
-		$result = \OCP\Share::unshare('file', $info->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
+		$result = Share::unshare('file', $info->getId(), Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$this->assertTrue($result);
 		$config->setAppValue('core', 'shareapi_default_expire_date', 'no');
 		$config->setAppValue('core', 'shareapi_enforce_expire_date', 'no');
@@ -1442,7 +1449,7 @@ class ApiTest extends TestCase {
 	public function testPublicLinkExpireDate($date, $valid) {
 		$request = $this->createRequest([
 			'path' => $this->folder,
-			'shareType' => \OCP\Share::SHARE_TYPE_LINK,
+			'shareType' => Share::SHARE_TYPE_LINK,
 			'expireDate' => $date,
 		]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
@@ -1484,7 +1491,7 @@ class ApiTest extends TestCase {
 
 		$request = $this->createRequest([
 			'path' => $this->folder,
-			'shareType' => \OCP\Share::SHARE_TYPE_LINK,
+			'shareType' => Share::SHARE_TYPE_LINK,
 			'expireDate' => $date->format('Y-m-d'),
 		]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
@@ -1521,7 +1528,7 @@ class ApiTest extends TestCase {
 
 		$request = $this->createRequest([
 			'path' => $this->folder,
-			'shareType' => \OCP\Share::SHARE_TYPE_LINK,
+			'shareType' => Share::SHARE_TYPE_LINK,
 			'expireDate' => $date->format('Y-m-d'),
 		]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
@@ -1542,7 +1549,7 @@ class ApiTest extends TestCase {
 
 		$request = $this->createRequest([
 			'path' => $this->folder,
-			'shareType' => \OCP\Share::SHARE_TYPE_LINK,
+			'shareType' => Share::SHARE_TYPE_LINK,
 			'expireDate' => $date->format('Y-m-d'),
 		]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
@@ -1564,7 +1571,7 @@ class ApiTest extends TestCase {
 		$request = $this->createRequest([
 			'path' => $this->folder,
 			'shareWith' => self::TEST_FILES_SHARING_API_USER2,
-			'shareType' => \OCP\Share::SHARE_TYPE_USER
+			'shareType' => Share::SHARE_TYPE_USER
 		]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare();
@@ -1575,7 +1582,7 @@ class ApiTest extends TestCase {
 
 		$request = $this->createRequest([
 			'path' => $this->folder . $this->subfolder,
-			'shareType' => \OCP\Share::SHARE_TYPE_LINK,
+			'shareType' => Share::SHARE_TYPE_LINK,
 		]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER2);
 		$result = $ocs->createShare();
@@ -1605,7 +1612,7 @@ class ApiTest extends TestCase {
 		$request = $this->createRequest([
 			'path' => $this->folder,
 			'shareWith' => self::TEST_FILES_SHARING_API_GROUP1,
-			'shareType' => \OCP\Share::SHARE_TYPE_GROUP
+			'shareType' => Share::SHARE_TYPE_GROUP
 		]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare();
@@ -1616,7 +1623,7 @@ class ApiTest extends TestCase {
 
 		$request = $this->createRequest([
 			'path' => $this->folder . $this->subfolder,
-			'shareType' => \OCP\Share::SHARE_TYPE_LINK,
+			'shareType' => Share::SHARE_TYPE_LINK,
 		]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER2);
 		$result = $ocs->createShare();

--- a/apps/files_sharing/tests/TestCase.php
+++ b/apps/files_sharing/tests/TestCase.php
@@ -32,6 +32,7 @@ namespace OCA\Files_Sharing\Tests;
 
 use OC\Files\Filesystem;
 use OCA\Files_Sharing\AppInfo\Application;
+use OCA\Files_Sharing\SharedStorage;
 
 /**
  * Class TestCase
@@ -179,7 +180,7 @@ abstract class TestCase extends \Test\TestCase {
 	 * reset init status for the share storage
 	 */
 	protected static function resetStorage() {
-		$storage = new \ReflectionClass('\OCA\Files_Sharing\SharedStorage');
+		$storage = new \ReflectionClass(SharedStorage::class);
 		$isInitialized = $storage->getProperty('initialized');
 		$isInitialized->setAccessible(true);
 		$isInitialized->setValue($storage, false);

--- a/build/integration/features/bootstrap/BasicStructure.php
+++ b/build/integration/features/bootstrap/BasicStructure.php
@@ -128,10 +128,12 @@ trait BasicStructure {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php" . $url;
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
-		} else {
-			$options['auth'] = [$this->currentUser, $this->regularUser];
+		if ($this->currentUser !== 'UNAUTHORIZED_USER') {
+			if ($this->currentUser === 'admin') {
+				$options['auth'] = $this->adminUser;
+			} else {
+				$options['auth'] = [$this->currentUser, $this->regularUser];
+			}
 		}
 		if ($body instanceof \Behat\Gherkin\Node\TableNode) {
 			$fd = $body->getRowsHash();

--- a/build/integration/federation_features/federated.feature
+++ b/build/integration/federation_features/federated.feature
@@ -182,7 +182,12 @@ Feature: federated
 		When Downloading file "/PARENT (2)/textfile0.txt" with range "bytes=3-13"
 		Then Downloaded content should be "AABBBBBCCCC"
 
-
+	Scenario: Trusted server handshake does not require authenticated requests - we force 403 by sending an empty body
+		Given Using server "LOCAL"
+		And using api version "2"
+		And As an "UNAUTHORIZED_USER"
+		When sending "POST" to "/apps/federation/api/v1/request-shared-secret"
+		Then the HTTP status code should be "403"
 
 
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -939,7 +939,7 @@ class OC {
 	 * @param OCP\IRequest $request
 	 * @return boolean
 	 */
-	private static function handleLogin(OCP\IRequest $request) {
+	static function handleLogin(OCP\IRequest $request) {
 		$userSession = self::$server->getUserSession();
 		if (OC_User::handleApacheAuth()) {
 			return true;

--- a/lib/private/AppFramework/Middleware/SessionMiddleware.php
+++ b/lib/private/AppFramework/Middleware/SessionMiddleware.php
@@ -30,15 +30,14 @@ use OCP\ISession;
 
 class SessionMiddleware extends Middleware {
 
-	/**
-	 * @var IRequest
-	 */
+	/** @var IRequest */
 	private $request;
 
-	/**
-	 * @var ControllerMethodReflector
-	 */
+	/** @var ControllerMethodReflector */
 	private $reflector;
+
+	/** @var ISession */
+	private $session;
 
 	/**
 	 * @param IRequest $request

--- a/lib/private/AppFramework/Routing/RouteConfig.php
+++ b/lib/private/AppFramework/Routing/RouteConfig.php
@@ -62,6 +62,61 @@ class RouteConfig {
 
 		// parse resources
 		$this->processResources($this->routes);
+
+		/*
+		 * OCS routes go into a different collection
+		 */
+		$oldCollection = $this->router->getCurrentCollection();
+		$this->router->useCollection($oldCollection.'.ocs');
+
+		// parse ocs simple routes
+		$this->processOCS($this->routes);
+
+		$this->router->useCollection($oldCollection);
+	}
+
+	private function processOCS(array $routes) {
+		$ocsRoutes = isset($routes['ocs']) ? $routes['ocs'] : [];
+		foreach ($ocsRoutes as $ocsRoute) {
+			$name = $ocsRoute['name'];
+			$postFix = '';
+
+			if (isset($ocsRoute['postfix'])) {
+				$postfix = $ocsRoute['postfix'];
+			}
+
+			$url = $ocsRoute['url'];
+			$verb = isset($ocsRoute['verb']) ? strtoupper($ocsRoute['verb']) : 'GET';
+
+			$split = explode('#', $name, 2);
+			if (count($split) != 2) {
+				throw new \UnexpectedValueException('Invalid route name');
+			}
+			$controller = $split[0];
+			$action = $split[1];
+
+			$controllerName = $this->buildControllerName($controller);
+			$actionName = $this->buildActionName($action);
+
+			// register the route
+			$handler = new RouteActionHandler($this->container, $controllerName, $actionName);
+
+			$router = $this->router->create('ocs.'.$this->appName.'.'.$controller.'.'.$action . $postfix, $url)
+				->method($verb)
+				->action($handler);
+
+			// optionally register requirements for route. This is used to
+			// tell the route parser how url parameters should be matched
+			if(array_key_exists('requirements', $ocsRoute)) {
+				$router->requirements($ocsRoute['requirements']);
+			}
+
+			// optionally register defaults for route. This is used to
+			// tell the route parser how url parameters should be default valued
+			if(array_key_exists('defaults', $ocsRoute)) {
+				$router->defaults($ocsRoute['defaults']);
+			}
+		}
 	}
 
 	/**

--- a/lib/private/AppFramework/Routing/RouteConfig.php
+++ b/lib/private/AppFramework/Routing/RouteConfig.php
@@ -35,14 +35,19 @@ use OCP\Route\IRouter;
  * @package OC\AppFramework\routing
  */
 class RouteConfig {
+	/** @var DIContainer */
 	private $container;
+	/** @var IRouter */
 	private $router;
+	/** @var array */
 	private $routes;
+	/** @var string */
 	private $appName;
 
 	/**
 	 * @param \OC\AppFramework\DependencyInjection\DIContainer $container
 	 * @param \OCP\Route\IRouter $router
+	 * @param $routes
 	 * @internal param $appName
 	 */
 	public function __construct(DIContainer $container, IRouter $router, $routes) {
@@ -82,7 +87,7 @@ class RouteConfig {
 			$postFix = '';
 
 			if (isset($ocsRoute['postfix'])) {
-				$postfix = $ocsRoute['postfix'];
+				$postFix = $ocsRoute['postfix'];
 			}
 
 			$url = $ocsRoute['url'];
@@ -101,7 +106,7 @@ class RouteConfig {
 			// register the route
 			$handler = new RouteActionHandler($this->container, $controllerName, $actionName);
 
-			$router = $this->router->create('ocs.'.$this->appName.'.'.$controller.'.'.$action . $postfix, $url)
+			$router = $this->router->create('ocs.'.$this->appName.'.'.$controller.'.'.$action . $postFix, $url)
 				->method($verb)
 				->action($handler);
 

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -150,6 +150,11 @@ class Router implements IRouter {
 				$collection = $this->getCollection($app);
 				$collection->addPrefix('/apps/' . $app);
 				$this->root->addCollection($collection);
+
+				// Also add the OCS collection
+				$collection = $this->getCollection($app.'.ocs');
+				$collection->addPrefix('/ocsapp/apps/' . $app);
+				$this->root->addCollection($collection);
 			}
 		}
 		if (!isset($this->loadedApps['core'])) {
@@ -237,6 +242,13 @@ class Router implements IRouter {
 		if (substr($url, 0, 6) === '/apps/') {
 			// empty string / 'apps' / $app / rest of the route
 			list(, , $app,) = explode('/', $url, 4);
+
+			$app = \OC_App::cleanAppId($app);
+			\OC::$REQUESTEDAPP = $app;
+			$this->loadRoutes($app);
+		} else if (substr($url, 0, 13) === '/ocsapp/apps/') {
+			// empty string / 'ocsapp' / 'apps' / $app / rest of the route
+			list(, , , $app,) = explode('/', $url, 5);
 
 			$app = \OC_App::cleanAppId($app);
 			\OC::$REQUESTEDAPP = $app;

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -71,7 +71,7 @@ class Router implements IRouter {
 		$this->logger = $logger;
 		$baseUrl = \OC::$WEBROOT;
 		if(!(getenv('front_controller_active') === 'true')) {
-			$baseUrl = \OC::$server->getURLGenerator()->linkTo('', 'index.php');
+			$baseUrl .= 'index.php';
 		}
 		if (!\OC::$CLI) {
 			$method = $_SERVER['REQUEST_METHOD'];
@@ -94,7 +94,7 @@ class Router implements IRouter {
 	public function getRoutingFiles() {
 		if (!isset($this->routingFiles)) {
 			$this->routingFiles = [];
-			foreach (\OC_APP::getEnabledApps() as $app) {
+			foreach (\OC_App::getEnabledApps() as $app) {
 				$appPath = \OC_App::getAppPath($app);
 				if($appPath !== false) {
 					$file = $appPath . '/appinfo/routes.php';

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -67,11 +67,13 @@ class Router implements IRouter {
 	/**
 	 * @param ILogger $logger
 	 */
-	public function __construct(ILogger $logger) {
+	public function __construct(ILogger $logger, $baseUrl = null) {
 		$this->logger = $logger;
-		$baseUrl = \OC::$WEBROOT;
+		if (is_null($baseUrl)) {
+			$baseUrl = \OC::$WEBROOT;
+		}
 		if(!(getenv('front_controller_active') === 'true')) {
-			$baseUrl .= 'index.php';
+			$baseUrl = rtrim($baseUrl, '/') . '/index.php';
 		}
 		if (!\OC::$CLI) {
 			$method = $_SERVER['REQUEST_METHOD'];

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -78,6 +78,7 @@ use OC\Security\SecureRandom;
 use OC\Security\TrustedDomainHelper;
 use OC\Session\CryptoWrapper;
 use OC\Tagging\TagMapper;
+use OC\URLGenerator;
 use OCP\IDateTimeFormatter;
 use OCP\IL10N;
 use OCP\IServerContainer;
@@ -307,9 +308,11 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('URLGenerator', function (Server $c) {
 			$config = $c->getConfig();
 			$cacheFactory = $c->getMemCacheFactory();
-			return new \OC\URLGenerator(
+			$router = $c->getRouter();
+			return new URLGenerator(
 				$config,
-				$cacheFactory
+				$cacheFactory,
+				$router
 			);
 		});
 		$this->registerService('AppHelper', function ($c) {

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -33,6 +33,7 @@ use OC_Defaults;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IURLGenerator;
+use OCP\Route\IRouter;
 use RuntimeException;
 
 /**
@@ -43,15 +44,20 @@ class URLGenerator implements IURLGenerator {
 	private $config;
 	/** @var ICacheFactory */
 	private $cacheFactory;
+	/** @var IRouter */
+	private $router;
 
 	/**
 	 * @param IConfig $config
 	 * @param ICacheFactory $cacheFactory
+	 * @param IRouter $router
 	 */
 	public function __construct(IConfig $config,
-								ICacheFactory $cacheFactory) {
+								ICacheFactory $cacheFactory,
+								IRouter $router) {
 		$this->config = $config;
 		$this->cacheFactory = $cacheFactory;
+		$this->router = $router;
 	}
 
 	/**
@@ -63,8 +69,7 @@ class URLGenerator implements IURLGenerator {
 	 * Returns a url to the given route.
 	 */
 	public function linkToRoute($route, $parameters = []) {
-		// TODO: mock router
-		$urlLinkTo = \OC::$server->getRouter()->generate($route, $parameters);
+		$urlLinkTo = $this->router->generate($route, $parameters);
 		return $urlLinkTo;
 	}
 

--- a/lib/private/legacy/api.php
+++ b/lib/private/legacy/api.php
@@ -385,7 +385,7 @@ class OC_API {
 
 	/**
 	 * respond to a call
-	 * @param OC_OCS_Result $result
+	 * @param OC_OCS_Result | \OC\OCS\Result $result
 	 * @param string $format the format xml|json
 	 */
 	public static function respond($result, $format='xml') {

--- a/lib/public/AppFramework/Http/OCSResponse.php
+++ b/lib/public/AppFramework/Http/OCSResponse.php
@@ -87,5 +87,20 @@ class OCSResponse extends Response {
 		return \OC_API::renderResult($this->format, $r->getMeta(), $r->getData());
 	}
 
+	/**
+	 * @return int
+	 * @since 9.2.0
+	 */
+	public function getStatusCode() {
+		return $this->statuscode;
+	}
+
+	/**
+	 * @param int $statuscode
+	 * @since 9.2.0
+	 */
+	public function setStatusCode($statuscode) {
+		$this->statuscode = $statuscode;
+	}
 
 }

--- a/lib/public/AppFramework/OCSController.php
+++ b/lib/public/AppFramework/OCSController.php
@@ -31,6 +31,7 @@ namespace OCP\AppFramework;
 
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\OCSResponse;
+use OCP\AppFramework\Http\Response;
 use OCP\IRequest;
 
 
@@ -100,4 +101,20 @@ abstract class OCSController extends ApiController {
 		);
 	}
 
+	/**
+	 * Serializes and formats a response
+	 * @param mixed $response the value that was returned from a controller and
+	 * is not a Response instance
+	 * @param string $format the format for which a formatter has been registered
+	 * @throws \DomainException if format does not match a registered formatter
+	 * @return Response
+	 * @since 7.0.0
+	 */
+	function buildResponse($response, $format = 'json') {
+		$format = $this->request->getParam('format');
+		if (is_null($format)) {
+			$format = 'xml';
+		}
+		return parent::buildResponse($response, $format);
+	}
 }

--- a/lib/public/AppFramework/OCSController.php
+++ b/lib/public/AppFramework/OCSController.php
@@ -115,6 +115,17 @@ abstract class OCSController extends ApiController {
 		if (is_null($format)) {
 			$format = 'xml';
 		}
-		return parent::buildResponse($response, $format);
+		/** @var OCSResponse $resp */
+		$resp = parent::buildResponse($response, $format);
+		$script = $this->request->getScriptName();
+
+		if (substr($script, -11) === '/ocs/v2.php') {
+			$statusCode = \OC_API::mapStatusCodes($resp->getStatusCode());
+			if (!is_null($statusCode)) {
+				$resp->setStatus($statusCode);
+			}
+		}
+
+		return $resp;
 	}
 }

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -43,6 +43,9 @@ if (\OCP\Util::needUpgrade()
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 
+/*
+ * First we try the routes of the appframework
+ */
 try {
 	OC_App::loadApps(['session']);
 	OC_App::loadApps(['authentication']);
@@ -53,6 +56,22 @@ try {
 	\OC::$server->getL10NFactory()->setLanguageFromRequest();
 
 	OC::$server->getRouter()->match('/ocs'.\OC::$server->getRequest()->getRawPathInfo());
+	return;
+} catch (ResourceNotFoundException $e) {
+	// Fall true the not found
+} catch (MethodNotAllowedException $e) {
+	OC_API::setContentType();
+	OC_Response::setStatus(405);
+} catch (\OC\OCS\Exception $ex) {
+	OC_API::respond($ex->getResult(), OC_API::requestedFormat());
+}
+
+/*
+ * Then we try the old OCS routes
+ */
+try {
+	OC::handleLogin(\OC::$server->getRequest());
+	OC::$server->getRouter()->match('/ocsapp'.\OC::$server->getRequest()->getRawPathInfo());
 } catch (ResourceNotFoundException $e) {
 	OC_API::setContentType();
 	OC_OCS::notFound();

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -27,6 +27,12 @@
  *
  */
 
+use OC\OCS\Exception;
+use OC\OCS\Result;
+use OC\User\LoginException;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
+
 require_once __DIR__ . '/../lib/base.php';
 
 if (\OCP\Util::needUpgrade()
@@ -35,13 +41,10 @@ if (\OCP\Util::needUpgrade()
 	// since the behavior of apps or remotes are unpredictable during
 	// an upgrade, return a 503 directly
 	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
-	$response = new OC_OCS_Result(null, OC_Response::STATUS_SERVICE_UNAVAILABLE, 'Service unavailable');
+	$response = new Result(null, OC_Response::STATUS_SERVICE_UNAVAILABLE, 'Service unavailable');
 	OC_API::respond($response, OC_API::requestedFormat());
 	exit;
 }
-
-use Symfony\Component\Routing\Exception\ResourceNotFoundException;
-use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 
 /*
  * First we try the routes of the appframework
@@ -62,7 +65,7 @@ try {
 } catch (MethodNotAllowedException $e) {
 	OC_API::setContentType();
 	OC_Response::setStatus(405);
-} catch (\OC\OCS\Exception $ex) {
+} catch (Exception $ex) {
 	OC_API::respond($ex->getResult(), OC_API::requestedFormat());
 }
 
@@ -70,15 +73,19 @@ try {
  * Then we try the old OCS routes
  */
 try {
-	OC::handleLogin(\OC::$server->getRequest());
+	if(!\OC::$server->getUserSession()->isLoggedIn()) {
+		OC::handleLogin(\OC::$server->getRequest());
+	}
 	OC::$server->getRouter()->match('/ocsapp'.\OC::$server->getRequest()->getRawPathInfo());
+} catch (LoginException $e) {
+	OC_API::respond(new Result(null, \OCP\API::RESPOND_UNAUTHORISED, 'Unauthorised'), OC_API::requestedFormat());
 } catch (ResourceNotFoundException $e) {
 	OC_API::setContentType();
 	OC_OCS::notFound();
 } catch (MethodNotAllowedException $e) {
 	OC_API::setContentType();
 	OC_Response::setStatus(405);
-} catch (\OC\OCS\Exception $ex) {
+} catch (Exception $ex) {
 	OC_API::respond($ex->getResult(), OC_API::requestedFormat());
 }
 

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -61,7 +61,7 @@ try {
 	OC::$server->getRouter()->match('/ocs'.\OC::$server->getRequest()->getRawPathInfo());
 	return;
 } catch (ResourceNotFoundException $e) {
-	// Fall true the not found
+	// Fall through the not found
 } catch (MethodNotAllowedException $e) {
 	OC_API::setContentType();
 	OC_Response::setStatus(405);

--- a/tests/lib/AppFramework/Controller/OCSControllerTest.php
+++ b/tests/lib/AppFramework/Controller/OCSControllerTest.php
@@ -27,14 +27,15 @@ namespace Test\AppFramework\Controller;
 use OC\AppFramework\Http\Request;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
+use OCP\IConfig;
+use OCP\Security\ISecureRandom;
+use Test\TestCase;
 
 
 class ChildOCSController extends OCSController {}
 
 
-class OCSControllerTest extends \Test\TestCase {
-
-	private $controller;
+class OCSControllerTest extends TestCase {
 
 	public function testCors() {
 		$request = new Request(
@@ -43,8 +44,8 @@ class OCSControllerTest extends \Test\TestCase {
 					'HTTP_ORIGIN' => 'test',
 				],
 			],
-			$this->createMock('\OCP\Security\ISecureRandom'),
-			$this->createMock('\OCP\IConfig')
+			$this->createMock(ISecureRandom::class),
+			$this->createMock(IConfig::class)
 		);
 		$controller = new ChildOCSController('app', $request, 'verbs',
 			'headers', 100);
@@ -64,8 +65,8 @@ class OCSControllerTest extends \Test\TestCase {
 	public function testXML() {
 		$controller = new ChildOCSController('app', new Request(
 			[],
-			$this->createMock('\OCP\Security\ISecureRandom'),
-			$this->createMock('\OCP\IConfig')
+			$this->createMock(ISecureRandom::class),
+			$this->createMock(IConfig::class)
 		));
 		$expected = "<?xml version=\"1.0\"?>\n" .
 		"<ocs>\n" .
@@ -96,8 +97,8 @@ class OCSControllerTest extends \Test\TestCase {
 	public function testXMLDataResponse() {
 		$controller = new ChildOCSController('app', new Request(
 			[],
-			$this->createMock('\OCP\Security\ISecureRandom'),
-			$this->createMock('\OCP\IConfig')
+			$this->createMock(ISecureRandom::class),
+			$this->createMock(IConfig::class)
 		));
 		$expected = "<?xml version=\"1.0\"?>\n" .
 		"<ocs>\n" .
@@ -127,9 +128,13 @@ class OCSControllerTest extends \Test\TestCase {
 
 	public function testJSON() {
 		$controller = new ChildOCSController('app', new Request(
-			[],
-			$this->createMock('\OCP\Security\ISecureRandom'),
-			$this->createMock('\OCP\IConfig')
+			[
+				'urlParams' => [
+					'format' => 'json'
+				]
+			],
+			$this->createMock(ISecureRandom::class),
+			$this->createMock(IConfig::class)
 		));
 		$expected = '{"ocs":{"meta":{"status":"failure","statuscode":400,"message":"OK",' .
 		            '"totalitems":"","itemsperpage":""},"data":{"test":"hi"}}}';

--- a/tests/lib/AppFramework/Controller/OCSControllerTest.php
+++ b/tests/lib/AppFramework/Controller/OCSControllerTest.php
@@ -64,7 +64,12 @@ class OCSControllerTest extends TestCase {
 
 	public function testXML() {
 		$controller = new ChildOCSController('app', new Request(
-			[],
+			[
+				'server' => [
+					'SCRIPT_NAME' => '',
+					'SCRIPT_FILENAME' => '',
+				],
+			],
 			$this->createMock(ISecureRandom::class),
 			$this->createMock(IConfig::class)
 		));
@@ -96,7 +101,12 @@ class OCSControllerTest extends TestCase {
 
 	public function testXMLDataResponse() {
 		$controller = new ChildOCSController('app', new Request(
-			[],
+			[
+				'server' => [
+					'SCRIPT_NAME' => '',
+					'SCRIPT_FILENAME' => '',
+				],
+			],
 			$this->createMock(ISecureRandom::class),
 			$this->createMock(IConfig::class)
 		));
@@ -130,8 +140,12 @@ class OCSControllerTest extends TestCase {
 		$controller = new ChildOCSController('app', new Request(
 			[
 				'urlParams' => [
-					'format' => 'json'
-				]
+					'format' => 'json',
+				],
+				'server' => [
+					'SCRIPT_NAME' => '',
+					'SCRIPT_FILENAME' => '',
+				],
 			],
 			$this->createMock(ISecureRandom::class),
 			$this->createMock(IConfig::class)

--- a/tests/lib/Route/RouterTest.php
+++ b/tests/lib/Route/RouterTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Route;
+
+
+use OC\Route\Router;
+use OCP\ILogger;
+
+class RouterTest extends \Test\TestCase {
+
+	/**
+	 * @dataProvider providesWebRoot
+	 * @param $expectedBase
+	 * @param $webRoot
+	 */
+	public function testWebRootSetup($expectedBase, $webRoot) {
+		$l = $this->createMock(ILogger::class);
+		$router = new Router($l, $webRoot);
+
+		$this->assertEquals($expectedBase, $router->getGenerator()->getContext()->getBaseUrl());
+	}
+
+	public function providesWebRoot() {
+		return [
+			['/index.php', ''],
+			['/index.php', '/'],
+			['/oc/index.php', '/oc'],
+			['/oc/index.php', '/oc/'],
+		];
+	}
+}


### PR DESCRIPTION
Finally add AppFramework capabilities to our OCS endpoints

Basic overview:
- added `ocs` part in route array
- add new route collection for apps. `<APP>.ocs`
- route is resolved at `/ocsapp/...` (To keep the old OCS routes working... all fine since we do this internally)

TODO:
- [x] Fix tests
- [x] More polishing
- [x] Tests!

@DeepDiver1975 FYI
