### PR TITLE
Properly check for mbstring extension

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -738,7 +738,7 @@ class OC_Util {
 			),
 			'functions' => [
 				'xml_parser_create' => 'libxml',
-				'mb_detect_encoding' => 'mb multibyte',
+				'mb_strcut' => 'mb multibyte',
 				'ctype_digit' => 'ctype',
 				'json_encode' => 'JSON',
 				'gd_info' => 'GD',


### PR DESCRIPTION
mb_detect_encoding is in the fallback we ship in the polyfill library, mb_strcut is not. Thus this lead to a false positive and ownCloud would just break.

Fixes https://github.com/owncloud/core/issues/24906

@karlitschek We should backport this to stable9. Objections?
