### PR TITLE
[stable9] Properly check for mbstring extension

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -731,7 +731,7 @@ class OC_Util {
 			),
 			'functions' => [
 				'xml_parser_create' => 'libxml',
-				'mb_detect_encoding' => 'mb multibyte',
+				'mb_strcut' => 'mb multibyte',
 				'ctype_digit' => 'ctype',
 				'json_encode' => 'JSON',
 				'gd_info' => 'GD',


### PR DESCRIPTION
mb_detect_encoding is in the fallback we ship in the polyfill library, mb_strcut is not. Thus this lead to a false positive and ownCloud would just break.

Backport of https://github.com/owncloud/core/pull/24907

@karlitschek Please approve.
