### PR TITLE
Create session tokens for apache auth users

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -1084,8 +1084,7 @@
 				<name>password</name>
 				<type>clob</type>
 				<default></default>
-				<notnull>true</notnull>
-				<length>4000</length>
+				<notnull>false</notnull>
 			</field>
 
 			<field>

--- a/lib/private/Authentication/Exceptions/PasswordlessTokenException.php
+++ b/lib/private/Authentication/Exceptions/PasswordlessTokenException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Authentication\Exceptions;
+
+use Exception;
+
+class PasswordlessTokenException extends Exception {
+
+}

--- a/lib/private/Authentication/Token/DefaultToken.php
+++ b/lib/private/Authentication/Token/DefaultToken.php
@@ -27,7 +27,6 @@ use OCP\AppFramework\Db\Entity;
  * @method void setId(int $id)
  * @method void setUid(string $uid);
  * @method void setLoginName(string $loginName)
- * @method string getLoginName()
  * @method void setPassword(string $password)
  * @method void setName(string $name)
  * @method string getName()

--- a/lib/private/Authentication/Token/IProvider.php
+++ b/lib/private/Authentication/Token/IProvider.php
@@ -22,6 +22,7 @@
 namespace OC\Authentication\Token;
 
 use OC\Authentication\Exceptions\InvalidTokenException;
+use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OCP\IUser;
 
 interface IProvider {
@@ -32,7 +33,7 @@ interface IProvider {
 	 * @param string $token
 	 * @param string $uid
 	 * @param string $loginName
-	 * @param string $password
+	 * @param string|null $password
 	 * @param string $name
 	 * @param int $type token type
 	 * @return IToken
@@ -94,6 +95,7 @@ interface IProvider {
 	 * @param IToken $token
 	 * @param string $tokenId
 	 * @throws InvalidTokenException
+	 * @throws PasswordlessTokenException
 	 * @return string
 	 */
 	public function getPassword(IToken $token, $tokenId);

--- a/lib/private/legacy/user.php
+++ b/lib/private/legacy/user.php
@@ -180,6 +180,8 @@ class OC_User {
 				self::setUserId($uid);
 				self::setDisplayName($uid);
 				self::getUserSession()->setLoginName($uid);
+				$request = OC::$server->getRequest();
+				self::getUserSession()->createSessionToken($request, $uid, $uid);
 				// setup the filesystem
 				OC_Util::setupFS($uid);
 				// first call the post_login hooks, the login-process needs to be

--- a/settings/Controller/AuthSettingsController.php
+++ b/settings/Controller/AuthSettingsController.php
@@ -23,6 +23,7 @@ namespace OC\Settings\Controller;
 
 use OC\AppFramework\Http;
 use OC\Authentication\Exceptions\InvalidTokenException;
+use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
 use OCP\AppFramework\Controller;
@@ -101,7 +102,11 @@ class AuthSettingsController extends Controller {
 		try {
 			$sessionToken = $this->tokenProvider->getToken($sessionId);
 			$loginName = $sessionToken->getLoginName();
-			$password = $this->tokenProvider->getPassword($sessionToken, $sessionId);
+			try {
+				$password = $this->tokenProvider->getPassword($sessionToken, $sessionId);
+			} catch (PasswordlessTokenException $ex) {
+				$password = null;
+			}
 		} catch (InvalidTokenException $ex) {
 			$resp = new JSONResponse();
 			$resp->setStatus(Http::STATUS_SERVICE_UNAVAILABLE);

--- a/tests/lib/Authentication/Token/DefaultTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/DefaultTokenProviderTest.php
@@ -135,6 +135,17 @@ class DefaultTokenProviderTest extends TestCase {
 	}
 
 	/**
+	 * @expectedException \OC\Authentication\Exceptions\PasswordlessTokenException
+	 */
+	public function testGetPasswordPasswordLessToken() {
+		$token = 'token1234';
+		$tk = new DefaultToken();
+		$tk->setPassword(null);
+
+		$this->tokenProvider->getPassword($tk, $token);
+	}
+
+	/**
 	 * @expectedException \OC\Authentication\Exceptions\InvalidTokenException
 	 */
 	public function testGetPasswordDeletesInvalidToken() {

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 1, 0, 6);
+$OC_Version = array(9, 1, 0, 7);
 
 // The human readable string
 $OC_VersionString = '9.1.0 beta 1';


### PR DESCRIPTION
`OC\User\Session` checks the availability of a session tokens and it's password  once per five minutes. Hence we  should generate a session token for apache auth users too.

This will also show the browser sessions in the personal settings. Note that it is however impossible to log out apache auth users as those will be logged in again automatically. Nothing I can fix in that regard.

TODO
- [x] write/fix unit tests

cc @DeepDiver1975 @butonic @PVince81 @davitol
