### PR TITLE
[9.0] Add a warning when the transaction isolation level is not READ_COMMITED

### DIFF
--- a/settings/admin.php
+++ b/settings/admin.php
@@ -100,6 +100,19 @@ $externalBackends = (count($backends) > 1) ? true : false;
 $template->assign('encryptionReady', \OC::$server->getEncryptionManager()->isReady());
 $template->assign('externalBackendsEnabled', $externalBackends);
 
+/** @var \Doctrine\DBAL\Connection $connection */
+$connection = \OC::$server->getDatabaseConnection();
+try {
+	if ($connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\SqlitePlatform) {
+		$template->assign('invalidTransactionIsolationLevel', false);
+	} else {
+		$template->assign('invalidTransactionIsolationLevel', $connection->getTransactionIsolation() !== \Doctrine\DBAL\Connection::TRANSACTION_READ_COMMITTED);
+	}
+} catch (\Doctrine\DBAL\DBALException $e) {
+	// ignore
+	$template->assign('invalidTransactionIsolationLevel', false);
+}
+
 $encryptionModules = \OC::$server->getEncryptionManager()->getEncryptionModules();
 $defaultEncryptionModuleId = \OC::$server->getEncryptionManager()->getDefaultEncryptionModuleId();
 

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -97,6 +97,15 @@ if (!$_['isAnnotationsWorking']) {
 <?php
 }
 
+// Is the Transaction isolation level READ_COMMITED?
+if ($_['invalidTransactionIsolationLevel']) {
+	?>
+	<li>
+		<?php p($l->t('Your database does not run with "READ COMMITED" transaction isolation level. This can cause problems when multiple actions are executed in parallel.')); ?>
+	</li>
+<?php
+}
+
 // Windows Warning
 if ($_['WindowsWarning']) {
 	?>


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/24889
Approval https://github.com/owncloud/core/pull/24889#issuecomment-222621118
