### PR TITLE
[8.0] Add a warning when the transaction isolation level is not READ_COMMITED

### DIFF
--- a/settings/admin.php
+++ b/settings/admin.php
@@ -58,6 +58,19 @@ $excludedGroupsList = $appConfig->getValue('core', 'shareapi_exclude_groups_list
 $excludedGroupsList = explode(',', $excludedGroupsList); // FIXME: this should be JSON!
 $template->assign('shareExcludedGroupsList', implode('|', $excludedGroupsList));
 
+/** @var \Doctrine\DBAL\Connection $connection */
+$connection = \OC::$server->getDatabaseConnection();
+try {
+	if ($connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\SqlitePlatform) {
+		$template->assign('invalidTransactionIsolationLevel', false);
+	} else {
+		$template->assign('invalidTransactionIsolationLevel', $connection->getTransactionIsolation() !== \Doctrine\DBAL\Connection::TRANSACTION_READ_COMMITTED);
+	}
+} catch (\Doctrine\DBAL\DBALException $e) {
+	// ignore
+	$template->assign('invalidTransactionIsolationLevel', false);
+}
+
 // Check if connected using HTTPS
 $template->assign('isConnectedViaHTTPS', OC_Request::serverProtocol() === 'https');
 $template->assign('enforceHTTPSEnabled', $config->getSystemValue('forcessl', false));

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -132,6 +132,20 @@ if ($_['databaseOverload']) {
 <?php
 }
 
+// Is the Transaction isolation level READ_COMMITED?
+if ($_['invalidTransactionIsolationLevel']) {
+	?>
+	<div class="section">
+		<h2><?php p($l->t('Transaction isolation level'));?></h2>
+
+		<p class="securitywarning">
+			<?php p($l->t('Your database does not run with "READ COMMITED" transaction isolation level. This can cause problems when multiple actions are executed in parallel.')); ?>
+		</p>
+
+	</div>
+<?php
+}
+
 // Windows Warning
 if ($_['WindowsWarning']) {
 	?>


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/24889
Approval https://github.com/owncloud/core/pull/24889#issuecomment-222621118
