### PR TITLE
block DAV if 2FA challenge needs to be solved first

### DIFF
--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -34,6 +34,7 @@ $authBackend = new Auth(
 	\OC::$server->getSession(),
 	\OC::$server->getUserSession(),
 	\OC::$server->getRequest(),
+	\OC::$server->getTwoFactorAuthManager(),
 	'principals/'
 );
 $principalBackend = new Principal(

--- a/apps/dav/appinfo/v1/carddav.php
+++ b/apps/dav/appinfo/v1/carddav.php
@@ -35,6 +35,7 @@ $authBackend = new Auth(
 	\OC::$server->getSession(),
 	\OC::$server->getUserSession(),
 	\OC::$server->getRequest(),
+	\OC::$server->getTwoFactorAuthManager(),
 	'principals/'
 );
 $principalBackend = new Principal(

--- a/apps/dav/appinfo/v1/webdav.php
+++ b/apps/dav/appinfo/v1/webdav.php
@@ -42,6 +42,7 @@ $authBackend = new \OCA\DAV\Connector\Sabre\Auth(
 	\OC::$server->getSession(),
 	\OC::$server->getUserSession(),
 	\OC::$server->getRequest(),
+	\OC::$server->getTwoFactorAuthManager(),
 	'principals/'
 );
 $requestUri = \OC::$server->getRequest()->getRequestUri();

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -25,7 +25,6 @@
 namespace OCA\DAV;
 
 use OCA\DAV\CalDAV\Schedule\IMipPlugin;
-use OCA\DAV\Connector\FedAuth;
 use OCA\DAV\Connector\Sabre\Auth;
 use OCA\DAV\Connector\Sabre\BlockLegacyClientPlugin;
 use OCA\DAV\Connector\Sabre\DavAclPlugin;
@@ -57,7 +56,8 @@ class Server {
 		$authBackend = new Auth(
 			\OC::$server->getSession(),
 			\OC::$server->getUserSession(),
-			\OC::$server->getRequest()
+			\OC::$server->getRequest(),
+			\OC::$server->getTwoFactorAuthManager()
 		);
 
 		// Set URL explicitly due to reverse-proxy situations


### PR DESCRIPTION
fixes #24933 

How I tested this:
1. open the files app in two tabs
2. log out and in on the second tab without solving the 2FA challenge
3. Resend the PROPFIND request in the first tab (use browser's dev console network tab), the requesttoken of the second tab must be used
4. See 207 on master, 401 on this branch
