### PR TITLE
block OCS if 2FA challenge needs to be solved first

### DIFF
--- a/lib/private/legacy/api.php
+++ b/lib/private/legacy/api.php
@@ -341,6 +341,10 @@ class OC_API {
 		// reuse existing login
 		$loggedIn = \OC::$server->getUserSession()->isLoggedIn();
 		if ($loggedIn === true) {
+			if (\OC::$server->getTwoFactorAuthManager()->needsSecondFactor()) {
+				// Do not allow access to OCS until the 2FA challenge was solved successfully
+				return false;
+			}
 			$ocsApiRequest = isset($_SERVER['HTTP_OCS_APIREQUEST']) ? $_SERVER['HTTP_OCS_APIREQUEST'] === 'true' : false;
 			if ($ocsApiRequest) {
 


### PR DESCRIPTION
fixes #24932 

How I tested this:
1. open the files app in two tabs
2. in the first tab, click on a file to open the sidebar and switch to the sharing tab
3. log out and in on the second tab without solving the 2FA challenge
4. Resend the OCS sharing request in the first tab (use browser's dev console network tab)
5. See 200 on master, 401 on this branch
