### PR TITLE
Use less CLASSPATH hacks in sharing app

### DIFF
--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -28,14 +28,12 @@
 
 $l = \OC::$server->getL10N('files_sharing');
 
-\OC::$CLASSPATH['OC_Share_Backend_File'] = 'files_sharing/lib/share/file.php';
-\OC::$CLASSPATH['OC_Share_Backend_Folder'] = 'files_sharing/lib/share/folder.php';
 \OC::$CLASSPATH['OC\Files\Storage\Shared'] = 'files_sharing/lib/sharedstorage.php';
 
 \OCA\Files_Sharing\Helper::registerHooks();
 
-\OCP\Share::registerBackend('file', 'OC_Share_Backend_File');
-\OCP\Share::registerBackend('folder', 'OC_Share_Backend_Folder', 'file');
+\OCP\Share::registerBackend('file', 'OCA\Files_Sharing\ShareBackend\File');
+\OCP\Share::registerBackend('folder', 'OCA\Files_Sharing\ShareBackend\Folder', 'file');
 
 $application = new \OCA\Files_Sharing\AppInfo\Application();
 $application->registerMountProviders();

--- a/apps/files_sharing/lib/ShareBackend/File.php
+++ b/apps/files_sharing/lib/ShareBackend/File.php
@@ -27,38 +27,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+namespace OCA\Files_Sharing\ShareBackend;
+
 use OCA\FederatedFileSharing\FederatedShareProvider;
 
-/**
- * @author Andreas Fischer <bantu@owncloud.com>
- * @author Bart Visscher <bartv@thisnet.nl>
- * @author Björn Schießle <schiessle@owncloud.com>
- * @author Lukas Reschke <lukas@owncloud.com>
- * @author Michael Gapczynski <GapczynskiM@gmail.com>
- * @author Morris Jobke <hey@morrisjobke.de>
- * @author Robin Appelman <icewind@owncloud.com>
- * @author Roeland Jago Douma <rullzer@owncloud.com>
- * @author Thomas Müller <thomas.mueller@tmit.eu>
- * @author Vincent Petry <pvince81@owncloud.com>
- *
- * @copyright Copyright (c) 2016, ownCloud, Inc.
- * @license AGPL-3.0
- *
- * This code is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License, version 3,
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License, version 3,
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *
- */
-
-class OC_Share_Backend_File implements OCP\Share_Backend_File_Dependent {
+class File implements \OCP\Share_Backend_File_Dependent {
 
 	const FORMAT_SHARED_STORAGE = 0;
 	const FORMAT_GET_FOLDER_CONTENTS = 1;

--- a/apps/files_sharing/lib/ShareBackend/Folder.php
+++ b/apps/files_sharing/lib/ShareBackend/Folder.php
@@ -24,7 +24,9 @@
  *
  */
 
-class OC_Share_Backend_Folder extends OC_Share_Backend_File implements OCP\Share_Backend_Collection {
+namespace OCA\Files_Sharing\ShareBackend;
+
+class Folder extends File implements \OCP\Share_Backend_Collection {
 
 	/**
 	 * get shared parents

--- a/apps/files_sharing/tests/BackendTest.php
+++ b/apps/files_sharing/tests/BackendTest.php
@@ -78,7 +78,7 @@ class BackendTest extends TestCase {
 		$this->assertTrue(\OCP\Share::shareItem('folder', $fileinfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
 				self::TEST_FILES_SHARING_API_USER3, 31));
 
-		$backend = new \OC_Share_Backend_Folder();
+		$backend = new \OCA\Files_Sharing\ShareBackend\Folder();
 
 		$result = $backend->getParents($fileinfo3['fileid']);
 		$this->assertSame(2, count($result));

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -2532,7 +2532,7 @@ class Share extends Constants {
 				}
 			} else {
 				if ($fileDependent) {
-					if ($format == \OC_Share_Backend_File::FORMAT_GET_FOLDER_CONTENTS || $format == \OC_Share_Backend_File::FORMAT_FILE_APP_ROOT) {
+					if ($format == \OCA\Files_Sharing\ShareBackend\File::FORMAT_GET_FOLDER_CONTENTS || $format == \OCA\Files_Sharing\ShareBackend\File::FORMAT_FILE_APP_ROOT) {
 						$select = '`*PREFIX*share`.`id`, `item_type`, `item_source`, `*PREFIX*share`.`parent`, `uid_owner`, '
 							. '`share_type`, `share_with`, `file_source`, `path`, `file_target`, `stime`, '
 							. '`*PREFIX*share`.`permissions`, `expiration`, `storage`, `*PREFIX*filecache`.`parent` as `file_parent`, '

--- a/tests/lib/Files/EtagTest.php
+++ b/tests/lib/Files/EtagTest.php
@@ -34,8 +34,8 @@ class EtagTest extends \Test\TestCase {
 		\OC_Hook::clear('OC_Filesystem', 'setup');
 		$application = new \OCA\Files_Sharing\AppInfo\Application();
 		$application->registerMountProviders();
-		\OCP\Share::registerBackend('file', 'OC_Share_Backend_File');
-		\OCP\Share::registerBackend('folder', 'OC_Share_Backend_Folder', 'file');
+		\OCP\Share::registerBackend('file', 'OCA\Files_Sharing\ShareBackend\File');
+		\OCP\Share::registerBackend('folder', 'OCA\Files_Sharing\ShareBackend\Folder', 'file');
 
 		$config = \OC::$server->getConfig();
 		$this->datadir = $config->getSystemValue('datadirectory');


### PR DESCRIPTION
Just make sure that federated sharing still works, and it does for me.
Ref https://github.com/owncloud/core/issues/12573#issuecomment-222691219

@PVince81 @rullzer 

Btw do I see that correctly, that these two files should basically be in the ffs app?
