### PR TITLE
Move OC\Files\Storage\Shared to the right namespace

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -250,8 +250,8 @@ abstract class Node implements \Sabre\DAV\INode {
 
 		$path = $this->info->getInternalPath();
 
-		if ($storage->instanceOfStorage('\OC\Files\Storage\Shared')) {
-			/** @var \OC\Files\Storage\Shared $storage */
+		if ($storage->instanceOfStorage('\OCA\Files_Sharing\SharedStorage')) {
+			/** @var \OCA\Files_Sharing\SharedStorage $storage */
 			$permissions = (int)$storage->getShare()->getPermissions();
 		} else {
 			$permissions = $storage->getPermissions($path);

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -210,7 +210,7 @@ class DirectoryTest extends \Test\TestCase {
 		$storage->expects($this->any())
 			->method('instanceOfStorage')
 			->will($this->returnValueMap([
-				'\OC\Files\Storage\Shared' => false,
+				'\OCA\Files_Sharing\SharedStorage' => false,
 				'\OC\Files\Storage\Wrapper\Quota' => false,
 			]));
 
@@ -241,7 +241,7 @@ class DirectoryTest extends \Test\TestCase {
 		$storage->expects($this->any())
 			->method('instanceOfStorage')
 			->will($this->returnValueMap([
-				['\OC\Files\Storage\Shared', false],
+				['\OCA\Files_Sharing\SharedStorage', false],
 				['\OC\Files\Storage\Wrapper\Quota', true],
 			]));
 

--- a/apps/federatedfilesharing/tests/TestCase.php
+++ b/apps/federatedfilesharing/tests/TestCase.php
@@ -113,7 +113,7 @@ abstract class TestCase extends \Test\TestCase {
 	 * reset init status for the share storage
 	 */
 	protected static function resetStorage() {
-		$storage = new \ReflectionClass('\OC\Files\Storage\Shared');
+		$storage = new \ReflectionClass('\OCA\Files_Sharing\SharedStorage');
 		$isInitialized = $storage->getProperty('initialized');
 		$isInitialized->setAccessible(true);
 		$isInitialized->setValue($storage, false);

--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -28,8 +28,6 @@
 
 $l = \OC::$server->getL10N('files_sharing');
 
-\OC::$CLASSPATH['OC\Files\Storage\Shared'] = 'files_sharing/lib/sharedstorage.php';
-
 \OCA\Files_Sharing\Helper::registerHooks();
 
 \OCP\Share::registerBackend('file', 'OCA\Files_Sharing\ShareBackend\File');

--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -37,7 +37,7 @@ use OCP\Files\Storage\IStorage;
  */
 class Cache extends CacheJail {
 	/**
-	 * @var \OC\Files\Storage\Shared
+	 * @var \OCA\Files_Sharing\SharedStorage
 	 */
 	private $storage;
 
@@ -57,7 +57,7 @@ class Cache extends CacheJail {
 	private $sourceCache;
 
 	/**
-	 * @param \OC\Files\Storage\Shared $storage
+	 * @param \OCA\Files_Sharing\SharedStorage $storage
 	 * @param IStorage $sourceStorage
 	 * @param ICacheEntry $sourceRootInfo
 	 */

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -80,7 +80,7 @@ class MountProvider implements IMountProvider {
 		foreach ($superShares as $share) {
 			try {
 				$mounts[] = new SharedMount(
-					'\OC\Files\Storage\Shared',
+					'\OCA\Files_Sharing\SharedStorage',
 					$mounts,
 					[
 						'user' => $user->getUID(),

--- a/apps/files_sharing/lib/Scanner.php
+++ b/apps/files_sharing/lib/Scanner.php
@@ -54,7 +54,7 @@ class Scanner extends \OC\Files\Cache\Scanner {
 		if ($this->sourceScanner) {
 			return $this->sourceScanner;
 		}
-		if ($this->storage->instanceOfStorage('\OC\Files\Storage\Shared')) {
+		if ($this->storage->instanceOfStorage('\OCA\Files_Sharing\SharedStorage')) {
 			/** @var \OC\Files\Storage\Storage $storage */
 			list($storage) = $this->storage->resolvePath('');
 			$this->sourceScanner = $storage->getScanner();

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -36,7 +36,7 @@ use OC\Files\View;
  */
 class SharedMount extends MountPoint implements MoveableMount {
 	/**
-	 * @var \OC\Files\Storage\Shared $storage
+	 * @var \OCA\Files_Sharing\SharedStorage $storage
 	 */
 	protected $storage = null;
 
@@ -211,7 +211,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 	 */
 	public function removeMount() {
 		$mountManager = \OC\Files\Filesystem::getMountManager();
-		/** @var $storage \OC\Files\Storage\Shared */
+		/** @var $storage \OCA\Files_Sharing\SharedStorage */
 		$storage = $this->getStorage();
 		$result = $storage->unshareStorage();
 		$mountManager->removeMount($this->mountPoint);

--- a/apps/files_sharing/lib/SharedPropagator.php
+++ b/apps/files_sharing/lib/SharedPropagator.php
@@ -26,7 +26,7 @@ use OC\Files\Cache\Propagator;
 
 class SharedPropagator extends Propagator {
 	/**
-	 * @var \OC\Files\Storage\Shared
+	 * @var \OCA\Files_Sharing\SharedStorage
 	 */
 	protected $storage;
 

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -28,11 +28,10 @@
  *
  */
 
-namespace OC\Files\Storage;
+namespace OCA\Files_Sharing;
 
 use OC\Files\Filesystem;
 use OC\Files\Cache\FailedCache;
-use OCA\Files_Sharing\ISharedStorage;
 use OCP\Constants;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Storage\IStorage;
@@ -43,7 +42,8 @@ use OCP\Files\NotFoundException;
 /**
  * Convert target path to source path and pass the function call to the correct storage provider
  */
-class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
+class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
+
 	/** @var \OCP\Share\IShare */
 	private $superShare;
 

--- a/apps/files_sharing/tests/CacheTest.php
+++ b/apps/files_sharing/tests/CacheTest.php
@@ -487,7 +487,7 @@ class CacheTest extends TestCase {
 		$this->assertTrue(\OC\Files\Filesystem::file_exists('/test.txt'));
 		list($sharedStorage) = \OC\Files\Filesystem::resolvePath('/' . self::TEST_FILES_SHARING_API_USER2 . '/files/test.txt');
 		/**
-		 * @var \OC\Files\Storage\Shared $sharedStorage
+		 * @var \OCA\Files_Sharing\SharedStorage $sharedStorage
 		 */
 
 		$sharedCache = $sharedStorage->getCache();
@@ -517,7 +517,7 @@ class CacheTest extends TestCase {
 		$this->assertTrue(\OC\Files\Filesystem::file_exists('/foo'));
 		list($sharedStorage) = \OC\Files\Filesystem::resolvePath('/' . self::TEST_FILES_SHARING_API_USER2 . '/files/foo');
 		/**
-		 * @var \OC\Files\Storage\Shared $sharedStorage
+		 * @var \OCA\Files_Sharing\SharedStorage $sharedStorage
 		 */
 
 		$sharedCache = $sharedStorage->getCache();

--- a/apps/files_sharing/tests/SharedStorageTest.php
+++ b/apps/files_sharing/tests/SharedStorageTest.php
@@ -522,7 +522,7 @@ class SharedStorageTest extends TestCase {
 
 		$mount = $view2->getMount('/foo');
 		$this->assertInstanceOf('\OCA\Files_Sharing\SharedMount', $mount);
-		/** @var \OC\Files\Storage\Shared $storage */
+		/** @var \OCA\Files_Sharing\SharedStorage $storage */
 		$storage = $mount->getStorage();
 
 		$this->assertEquals(self::TEST_FILES_SHARING_API_USER1, $storage->getOwner(''));

--- a/apps/files_sharing/tests/TestCase.php
+++ b/apps/files_sharing/tests/TestCase.php
@@ -179,7 +179,7 @@ abstract class TestCase extends \Test\TestCase {
 	 * reset init status for the share storage
 	 */
 	protected static function resetStorage() {
-		$storage = new \ReflectionClass('\OC\Files\Storage\Shared');
+		$storage = new \ReflectionClass('\OCA\Files_Sharing\SharedStorage');
 		$isInitialized = $storage->getProperty('initialized');
 		$isInitialized->setAccessible(true);
 		$isInitialized->setValue($storage, false);

--- a/apps/files_versions/tests/VersioningTest.php
+++ b/apps/files_versions/tests/VersioningTest.php
@@ -879,7 +879,7 @@ class VersioningTest extends \Test\TestCase {
 			\OC::$server->getUserManager()->registerBackend($backend);
 		}
 
-		$storage = new \ReflectionClass('\OC\Files\Storage\Shared');
+		$storage = new \ReflectionClass('\OCA\Files_Sharing\SharedStorage');
 		$isInitialized = $storage->getProperty('initialized');
 		$isInitialized->setAccessible(true);
 		$isInitialized->setValue($storage, false);

--- a/lib/private/Encryption/DecryptAll.php
+++ b/lib/private/Encryption/DecryptAll.php
@@ -210,7 +210,7 @@ class DecryptAll {
 			$content = $this->rootView->getDirectoryContent($root);
 			foreach ($content as $file) {
 				// only decrypt files owned by the user
-				if($file->getStorage()->instanceOfStorage('OC\Files\Storage\Shared')) {
+				if($file->getStorage()->instanceOfStorage('OCA\Files_Sharing\SharedStorage')) {
 						continue;
 				}
 				$path = $root . '/' . $file['name'];

--- a/lib/private/Encryption/EncryptionWrapper.php
+++ b/lib/private/Encryption/EncryptionWrapper.php
@@ -80,7 +80,7 @@ class EncryptionWrapper {
 			'mount' => $mount
 		];
 
-		if (!$storage->instanceOfStorage('OC\Files\Storage\Shared')
+		if (!$storage->instanceOfStorage('OCA\Files_Sharing\SharedStorage')
 			&& !$storage->instanceOfStorage('OCA\Files_Sharing\External\Storage')
 			&& !$storage->instanceOfStorage('OC\Files\Storage\OwnCloud')) {
 

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -465,6 +465,10 @@ abstract class Common implements Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function instanceOfStorage($class) {
+		if (ltrim($class, '\\') === 'OC\Files\Storage\Shared') {
+			// FIXME Temporary fix to keep existing checks working
+			$class = '\OCA\Files_Sharing\SharedStorage';
+		}
 		return is_a($this, $class);
 	}
 

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -482,6 +482,10 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function instanceOfStorage($class) {
+		if (ltrim($class, '\\') === 'OC\Files\Storage\Shared') {
+			// FIXME Temporary fix to keep existing checks working
+			$class = '\OCA\Files_Sharing\SharedStorage';
+		}
 		return is_a($this, $class) or $this->getWrapperStorage()->instanceOfStorage($class);
 	}
 

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1355,7 +1355,7 @@ class View {
 						$subStorage = $mount->getStorage();
 						if ($subStorage) {
 							// exclude shared storage ?
-							if ($extOnly && $subStorage instanceof \OC\Files\Storage\Shared) {
+							if ($extOnly && $subStorage instanceof \OCA\Files_Sharing\SharedStorage) {
 								continue;
 							}
 							$subCache = $subStorage->getCache('');

--- a/lib/private/legacy/helper.php
+++ b/lib/private/legacy/helper.php
@@ -582,7 +582,7 @@ class OC_Helper {
 		$quota = \OCP\Files\FileInfo::SPACE_UNLIMITED;
 		$storage = $rootInfo->getStorage();
 		$sourceStorage = $storage;
-		if ($storage->instanceOfStorage('\OC\Files\Storage\Shared')) {
+		if ($storage->instanceOfStorage('\OCA\Files_Sharing\SharedStorage')) {
 			$includeExtStorage = false;
 			$sourceStorage = $storage->getSourceStorage();
 		}

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -164,15 +164,14 @@ class OC_Util {
 
 		// install storage availability wrapper, before most other wrappers
 		\OC\Files\Filesystem::addStorageWrapper('oc_availability', function ($mountPoint, $storage) {
-			/** @var \OCP\Files\Storage $storage */
-			if (!$storage->instanceOfStorage('\OC\Files\Storage\Shared') && !$storage->isLocal()) {
+			if (!$storage->instanceOfStorage('\OCA\Files_Sharing\SharedStorage') && !$storage->isLocal()) {
 				return new \OC\Files\Storage\Wrapper\Availability(['storage' => $storage]);
 			}
 			return $storage;
 		});
 
 		\OC\Files\Filesystem::addStorageWrapper('oc_encoding', function ($mountPoint, \OCP\Files\Storage $storage, \OCP\Files\Mount\IMountPoint $mount) {
-			if ($mount->getOption('encoding_compatibility', false) && !$storage->instanceOfStorage('\OC\Files\Storage\Shared') && !$storage->isLocal()) {
+			if ($mount->getOption('encoding_compatibility', false) && !$storage->instanceOfStorage('\OCA\Files_Sharing\SharedStorage') && !$storage->isLocal()) {
 				return new \OC\Files\Storage\Wrapper\Encoding(['storage' => $storage]);
 			}
 			return $storage;

--- a/tests/lib/Encryption/DecryptAllTest.php
+++ b/tests/lib/Encryption/DecryptAllTest.php
@@ -239,7 +239,7 @@ class DecryptAllTest extends TestCase {
 	}
 
 	public function testDecryptUsersFiles() {
-		$storage = $this->getMockBuilder('OC\Files\Storage\Shared')
+		$storage = $this->getMockBuilder('OCA\Files_Sharing\SharedStorage')
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/lib/Encryption/EncryptionWrapperTest.php
+++ b/tests/lib/Encryption/EncryptionWrapperTest.php
@@ -88,13 +88,13 @@ class EncryptionWrapperTest extends TestCase {
 			[true, ['OCA\Files_Trashbin\Storage']],
 
 			// Do not wrap shared storages
-			[false, ['OC\Files\Storage\Shared']],
+			[false, ['OCA\Files_Sharing\SharedStorage']],
 			[false, ['OCA\Files_Sharing\External\Storage']],
 			[false, ['OC\Files\Storage\OwnCloud']],
-			[false, ['OC\Files\Storage\Shared', 'OCA\Files_Sharing\External\Storage']],
-			[false, ['OC\Files\Storage\Shared', 'OC\Files\Storage\OwnCloud']],
+			[false, ['OCA\Files_Sharing\SharedStorage', 'OCA\Files_Sharing\External\Storage']],
+			[false, ['OCA\Files_Sharing\SharedStorage', 'OC\Files\Storage\OwnCloud']],
 			[false, ['OCA\Files_Sharing\External\Storage', 'OC\Files\Storage\OwnCloud']],
-			[false, ['OC\Files\Storage\Shared', 'OCA\Files_Sharing\External\Storage', 'OC\Files\Storage\OwnCloud']],
+			[false, ['OCA\Files_Sharing\SharedStorage', 'OCA\Files_Sharing\External\Storage', 'OC\Files\Storage\OwnCloud']],
 		];
 	}
 


### PR DESCRIPTION
I moved it with a bit of BC, the `IStorage::instanceOf()` check maps the old name to the new one, so we don't need to update all apps, other usages within the current universe are doc types only, so functionality is retained.

Ref https://github.com/owncloud/core/issues/12573#issuecomment-222691219

@PVince81 @rullzer 
