### PR TITLE
Catch the ForbiddenException to make sure it gets handled

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -30,6 +30,7 @@ namespace OCA\DAV\Connector\Sabre;
 
 use OC\Files\View;
 use OCA\DAV\Upload\FutureFile;
+use OCP\Files\ForbiddenException;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\IFile;
@@ -310,6 +311,8 @@ class FilesPlugin extends ServerPlugin {
 						return $directDownloadUrl['url'];
 					}
 				} catch (StorageNotAvailableException $e) {
+					return false;
+				} catch (ForbiddenException $e) {
 					return false;
 				}
 				return false;


### PR DESCRIPTION
### Steps
1. Write a Storage Wrapper that throws `ForbiddenException` (e.g. for firewall reasons)
2. Set up a sync client
3. Try to sync
### Expected

403 - Forbidden
### Actual

500 - Internal Server Error

Fix owncloud/enterprise#1325

I guess we should backport to 9.0 where we started to use a storage wrapper @PVince81 
