### PR TITLE
Do not use the language name, when it's not the one from the language…

### DIFF
--- a/settings/personal.php
+++ b/settings/personal.php
@@ -81,8 +81,9 @@ $commonLanguages = array();
 foreach($languageCodes as $lang) {
 	$l = \OC::$server->getL10N('settings', $lang);
 	// TRANSLATORS this is the language name for the language switcher in the personal settings and should be the localized version
-	if(substr($l->t('__language_name__'), 0, 1) !== '_') {//first check if the language name is in the translation file
-		$ln=array('code'=>$lang, 'name'=> (string)$l->t('__language_name__'));
+	$potentialName = (string) $l->t('__language_name__');
+	if($l->getLanguageCode() === $lang && substr($potentialName, 0, 1) !== '_') {//first check if the language name is in the translation file
+		$ln=array('code'=>$lang, 'name'=> $potentialName);
 	}elseif(isset($languageNames[$lang])) {
 		$ln=array('code'=>$lang, 'name'=>$languageNames[$lang]);
 	}else{//fallback to language code


### PR DESCRIPTION
… we want

Fix #24536 

@PVince81 @ChristophWurst 

PS: one needs to select a different language then english to observe the error.

Should backport to 9.0
