### PR TITLE
[stable9] Backport of share id as string fix

### DIFF
--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -131,7 +131,7 @@ class Helper {
 				$newHash = '';
 				if(\OC::$server->getHasher()->verify($password, $linkItem['share_with'], $newHash)) {
 					// Save item id in session for future requests
-					\OC::$server->getSession()->set('public_link_authenticated', $linkItem['id']);
+					\OC::$server->getSession()->set('public_link_authenticated', (string) $linkItem['id']);
 
 					/**
 					 * FIXME: Migrate old hashes to new hash format
@@ -161,7 +161,7 @@ class Helper {
 		else {
 			// not authenticated ?
 			if ( ! \OC::$server->getSession()->exists('public_link_authenticated')
-				|| \OC::$server->getSession()->get('public_link_authenticated') !== $linkItem['id']) {
+				|| \OC::$server->getSession()->get('public_link_authenticated') !== (string)$linkItem['id']) {
 				return false;
 			}
 		}

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -2477,7 +2477,7 @@ class Share extends Constants {
 		}
 
 		if ( \OC::$server->getSession()->exists('public_link_authenticated')
-			&& \OC::$server->getSession()->get('public_link_authenticated') === $linkItem['id'] ) {
+			&& \OC::$server->getSession()->get('public_link_authenticated') === (string)$linkItem['id'] ) {
 			return true;
 		}
 

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -1144,7 +1144,7 @@ class Test_Share extends \Test\TestCase {
 	 * @param $item
 	 */
 	public function testCheckPasswordProtectedShare($expected, $item) {
-		\OC::$server->getSession()->set('public_link_authenticated', 100);
+		\OC::$server->getSession()->set('public_link_authenticated', '100');
 		$result = \OCP\Share::checkPasswordProtectedShare($item);
 		$this->assertEquals($expected, $result);
 	}
@@ -1156,8 +1156,12 @@ class Test_Share extends \Test\TestCase {
 			array(true, array('share_with' => '')),
 			array(true, array('share_with' => '1234567890', 'share_type' => '1')),
 			array(true, array('share_with' => '1234567890', 'share_type' => 1)),
+			array(true, array('share_with' => '1234567890', 'share_type' => '3', 'id' => '100')),
+			array(true, array('share_with' => '1234567890', 'share_type' => 3, 'id' => '100')),
 			array(true, array('share_with' => '1234567890', 'share_type' => '3', 'id' => 100)),
 			array(true, array('share_with' => '1234567890', 'share_type' => 3, 'id' => 100)),
+			array(false, array('share_with' => '1234567890', 'share_type' => '3', 'id' => '101')),
+			array(false, array('share_with' => '1234567890', 'share_type' => 3, 'id' => '101')),
 			array(false, array('share_with' => '1234567890', 'share_type' => '3', 'id' => 101)),
 			array(false, array('share_with' => '1234567890', 'share_type' => 3, 'id' => 101)),
 		);


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/23066

Backport of https://github.com/owncloud/core/pull/24689 to stable9

Please review @nickvergessen @icewind1991 @rullzer 

@TDannhauer I guess you already tested this on OC 9.0 ?
