### PR TITLE
[stable9] Use a capped memory cache for the user/group cache

### DIFF
--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -36,6 +36,7 @@ namespace OCA\user_ldap;
 
 use OCA\user_ldap\lib\Access;
 use OCA\user_ldap\lib\BackendUtility;
+use OC\Cache\CappedMemoryCache;
 
 class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	protected $enabled = false;
@@ -43,12 +44,12 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	/**
 	 * @var string[] $cachedGroupMembers array of users with gid as key
 	 */
-	protected $cachedGroupMembers = array();
+	protected $cachedGroupMembers;
 
 	/**
 	 * @var string[] $cachedGroupsByMember array of groups with uid as key
 	 */
-	protected $cachedGroupsByMember = array();
+	protected $cachedGroupsByMember;
 
 	public function __construct(Access $access) {
 		parent::__construct($access);
@@ -57,6 +58,9 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 		if(!empty($filter) && !empty($gassoc)) {
 			$this->enabled = true;
 		}
+
+		$this->cachedGroupMembers = new CappedMemoryCache();
+		$this->cachedGroupsByMember = new CappedMemoryCache();
 	}
 
 	/**


### PR DESCRIPTION
Backport of #24869

For #24403 
When upgrading huge installations this can lead to memory problems as
the cache will only grow and grow.

Capping this memory will make sure we don't run out while during normal
operation still basically cache everything.

CC: @PVince81 @nickvergessen 
@karlitschek for approval
