### PR TITLE
.htaccess update making two rules non-capturing

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -56,9 +56,9 @@
   RewriteRule ^\.well-known/carddav /remote.php/dav/ [R=301,L]
   RewriteRule ^\.well-known/caldav /remote.php/dav/ [R=301,L]
   RewriteRule ^remote/(.*) remote.php [QSA,L]
-  RewriteRule ^(build|tests|config|lib|3rdparty|templates)/.* - [R=404,L]
+  RewriteRule ^(?:build|tests|config|lib|3rdparty|templates)/.* - [R=404,L]
   RewriteCond %{REQUEST_URI} !^/.well-known/acme-challenge/.*
-  RewriteRule ^(\.|autotest|occ|issue|indie|db_|console).* - [R=404,L]
+  RewriteRule ^(?:\.|autotest|occ|issue|indie|db_|console).* - [R=404,L]
 </IfModule>
 <IfModule mod_mime.c>
   AddType image/svg+xml svg svgz


### PR DESCRIPTION
This is a small update to the .htaccess file making two RewriteRules non-capturing because the results are anyways never referenced. Having that, the Apache and the nginx rules are for those two statements now identical.

Here is the referenced issue: https://github.com/owncloud/core/issues/24968#issuecomment-223381539
@josh4trunks FYI
