### PR TITLE
Provide support for user defined thumbnails for .mp4 movies

### DIFF
--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -85,13 +85,13 @@ class Movie extends Provider {
 	 * @return bool|string
 	 */
 	private function extractMp4CoverArtwork($absPath) {
-		if(isset($this->noArtworkIndex[$absPath]))
+		if (isset($this->noArtworkIndex[$absPath])) {
 			return false;
+		}
 
-
-		if(self::$atomicParsleyBinary) {
+		if (self::$atomicParsleyBinary) {
 			$suffix = substr($absPath, -4);
-			if('.mp4' === $suffix || '.MP4' === $suffix) {
+			if ('.mp4' === strtolower($suffix)) {
 				$tmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
 				$tmpBase = $tmpFolder.'/Cover';
 				$cmd = self::$atomicParsleyBinary . ' ' .
@@ -103,9 +103,9 @@ class Movie extends Provider {
 
 				if ($returnCode === 0) {
 					$endings = array('.jpg', '.png');
-					foreach($endings as $ending) {
+					foreach ($endings as $ending) {
 						$extractedFile = $tmpBase.'_artwork_1'.$ending;
-						if(is_file($extractedFile) &&
+						if (is_file($extractedFile) &&
 							filesize($extractedFile) > 0) {
 							return $extractedFile;
 						}
@@ -157,14 +157,13 @@ class Movie extends Provider {
 	private function generateThumbNail($maxX, $maxY, $absPath, $second) {
 
 		$extractedCover = $this->extractMp4CoverArtwork($absPath);
-		if(false !== $extractedCover) {
+		if (false !== $extractedCover) {
 			$tmpPath = $extractedCover;
-		}
-		else {
+		} else {
 			$tmpPath = $this->generateFromMovie($absPath, $second);
 		}
 
-		if(is_string($tmpPath) and is_file($tmpPath)) {
+		if (is_string($tmpPath) && is_file($tmpPath)) {
 			$image = new \OC_Image();
 			$image->loadFromFile($tmpPath);
 			unlink($tmpPath);

--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -157,7 +157,7 @@ class Movie extends Provider {
 	private function generateThumbNail($maxX, $maxY, $absPath, $second) {
 
 		$extractedCover = $this->extractMp4CoverArtwork($absPath);
-		if($extractedCover) {
+		if(false !== $extractedCover) {
 			$tmpPath = $extractedCover;
 		}
 		else {

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -348,7 +348,7 @@ class PreviewManager implements IPreview {
 				\OC\Preview\Movie::$atomicParsleyBinary = $atomicParsleyBinary;
 				$registerProvider = true;
 			}
-			if(true === $registerProvider) {
+			if (true === $registerProvider) {
 				$this->registerCoreProvider('\OC\Preview\Movie', '/video\/.*/');
 			}
 		}

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -334,12 +334,21 @@ class PreviewManager implements IPreview {
 			$ffmpegBinary = ($avconvBinary) ? null : \OC_Helper::findBinaryPath('ffmpeg');
 			$atomicParsleyBinary = \OC_Helper::findBinaryPath('AtomicParsley');
 
-			if ($avconvBinary || $ffmpegBinary || $atomicParsleyBinary) {
-				// FIXME // a bit hacky but didn't want to use subclasses
+			// FIXME // a bit hacky but didn't want to use subclasses
+			$registerProvider = false;
+			if (null !== $avconvBinary) {
 				\OC\Preview\Movie::$avconvBinary = $avconvBinary;
+				$registerProvider = true;
+			}
+			if (null !== $ffmpegBinary) {
 				\OC\Preview\Movie::$ffmpegBinary = $ffmpegBinary;
+				$registerProvider = true;
+			}
+			if (null !== $atomicParsleyBinary) {
 				\OC\Preview\Movie::$atomicParsleyBinary = $atomicParsleyBinary;
-
+				$registerProvider = true;
+			}
+			if(true === $registerProvider) {
 				$this->registerCoreProvider('\OC\Preview\Movie', '/video\/.*/');
 			}
 		}

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -6,6 +6,7 @@
  * @author Robin Appelman <icewind@owncloud.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Vincent Petry <pvince81@owncloud.com>
+ * @author Lorenzo Perone <lorenzo.perone@yellowspace.net>
  *
  * @copyright Copyright (c) 2017, ownCloud GmbH
  * @license AGPL-3.0
@@ -328,13 +329,16 @@ class PreviewManager implements IPreview {
 		// Video requires avconv or ffmpeg and is therefor
 		// currently not supported on Windows.
 		if (in_array('OC\Preview\Movie', $this->getEnabledDefaultProvider())) {
+		// AtomicParsley would actually work under Windows.
 			$avconvBinary = \OC_Helper::findBinaryPath('avconv');
 			$ffmpegBinary = ($avconvBinary) ? null : \OC_Helper::findBinaryPath('ffmpeg');
+			$atomicParsleyBinary = \OC_Helper::findBinaryPath('AtomicParsley');
 
-			if ($avconvBinary || $ffmpegBinary) {
+			if ($avconvBinary || $ffmpegBinary || $atomicParsleyBinary) {
 				// FIXME // a bit hacky but didn't want to use subclasses
 				\OC\Preview\Movie::$avconvBinary = $avconvBinary;
 				\OC\Preview\Movie::$ffmpegBinary = $ffmpegBinary;
+				\OC\Preview\Movie::$atomicParsleyBinary = $atomicParsleyBinary;
 
 				$this->registerCoreProvider('\OC\Preview\Movie', '/video\/.*/');
 			}


### PR DESCRIPTION
This change provides support for cover art embedded into .mp4 moov atoms (a standard used by some authoring software and tools), to be used as the thumbnail art for the videos

The implementation requires AtomicParsley (available on all major platforms, including Windows) to read them out. Appropriate checks are made to ensure that if AtomicParsley is not installed, the code falls back gracefully to the current implementation.

References:
- AtomicParsley: http://atomicparsley.sourceforge.net/
- Article about the MPEG-4 movie atom:
  https://www.adobe.com/devnet/video/articles/mp4_movie_atom.html
- Implementation of a script to set the cover artwork with ffmpeg and AtomicParsley:
  https://gist.github.com/lopezio/6b7ef121c15ab69f494fb024bf0dd58f

This change has been contributed by a customer request. We hope you find it useful, complying with your guidelines and QA, and can integrate into upstream code, so that updates will be easier.
