### PR TITLE
Wrap publicwebdav in sharePermission mask

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -66,14 +66,11 @@ $server = $serverFactory->createServer($baseuri, $requestUri, $authBackend, func
 
 	$share = $authBackend->getShare();
 	$owner = $share->getShareOwner();
-	$isWritable = $share->getPermissions() & (\OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE);
 	$fileId = $share->getNodeId();
 
-	if (!$isWritable) {
-		\OC\Files\Filesystem::addStorageWrapper('readonly', function ($mountPoint, $storage) {
-			return new \OC\Files\Storage\Wrapper\PermissionsMask(array('storage' => $storage, 'mask' => \OCP\Constants::PERMISSION_READ + \OCP\Constants::PERMISSION_SHARE));
-		});
-	}
+	\OC\Files\Filesystem::addStorageWrapper('sharePermissions', function ($mountPoint, $storage) use ($share) {
+		return new \OC\Files\Storage\Wrapper\PermissionsMask(array('storage' => $storage, 'mask' => $share->getPermissions() | \OCP\Constants::PERMISSION_SHARE));
+	});
 
 	OC_Util::setupFS($owner);
 	$ownerView = \OC\Files\Filesystem::getView();


### PR DESCRIPTION
Fixes #24868

The writable mask was a bit misleading. We should wrap with the
sharepermissions (as they are used everywhere else). The
PERMISSIONS_SHARE are added since that is required for the public link
check plugin.

CC: @PVince81 @mcastroSG @nickvergessen @icewind1991 
