### PR TITLE
do not generate device token if 2FA is enable for user

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -120,7 +120,8 @@ class Application extends App {
 				$c->query('AppName'),
 				$c->query('Request'),
 				$c->query('UserManager'),
-				$c->query('OC\Authentication\Token\DefaultTokenProvider'),
+				$c->query('ServerContainer')->query('OC\Authentication\Token\IProvider'),
+				$c->query('TwoFactorAuthManager'),
 				$c->query('SecureRandom')
 			);
 		});

--- a/lib/private/Authentication/Token/DefaultTokenCleanupJob.php
+++ b/lib/private/Authentication/Token/DefaultTokenCleanupJob.php
@@ -28,6 +28,7 @@ class DefaultTokenCleanupJob extends Job {
 
 	protected function run($argument) {
 		/* @var $provider DefaultTokenProvider */
+		// TODO: add OC\Authentication\Token\IProvider::invalidateOldTokens and query interface
 		$provider = OC::$server->query('OC\Authentication\Token\DefaultTokenProvider');
 		$provider->invalidateOldTokens();
 	}


### PR DESCRIPTION
fixes #24976

Can be tested with `curl -v --request POST -d user=admin -d password=admin localhost:8080/index.php/token/generate`

@PVince81 @rullzer @nickvergessen review please
