### PR TITLE
decrease initial users to load to 50

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -14,7 +14,7 @@ var UserList = {
 	availableGroups: [],
 	offset: 0,
 	usersToLoad: 10, //So many users will be loaded when user scrolls down
-	initialUsersToLoad: 250, //initial number of users to load
+	initialUsersToLoad: 50, //initial number of users to load
 	currentGid: '',
 	filter: '',
 


### PR DESCRIPTION
Prevents timeouts on the initial loading of users. proper fix will be in https://github.com/owncloud/core/pull/10994
Workaround for https://github.com/owncloud/core/issues/24734

@DeepDiver1975 @PVince81 Should be backported to 9.0.3
