### PR TITLE
Fix OCS Share API path response

### DIFF
--- a/apps/files_sharing/tests/API/Share20OCSTest.php
+++ b/apps/files_sharing/tests/API/Share20OCSTest.php
@@ -433,8 +433,12 @@ class Share20OCSTest extends \Test\TestCase {
 			->method('getRelativePath')
 			->will($this->returnArgument(0));
 
+		$userFolder->method('getById')
+			->with($share->getNodeId())
+			->willReturn([$share->getNode()]);
+
 		$this->rootFolder->method('getUserFolder')
-			->with($share->getShareOwner())
+			->with($this->currentUser->getUID())
 			->willReturn($userFolder);
 
 		$this->urlGenerator
@@ -2006,8 +2010,19 @@ class Share20OCSTest extends \Test\TestCase {
 			->willReturn('myLink');
 
 
-		$this->rootFolder->method('getUserFolder')->with($share->getShareOwner())->will($this->returnSelf());
-		$this->rootFolder->method('getRelativePath')->will($this->returnArgument(0));
+		$this->rootFolder->method('getUserFolder')
+			->with($this->currentUser->getUID())
+			->will($this->returnSelf());
+
+		if (!$exception) {
+			$this->rootFolder->method('getById')
+				->with($share->getNodeId())
+				->willReturn([$share->getNode()]);
+
+			$this->rootFolder->method('getRelativePath')
+				->with($share->getNode()->getPath())
+				->will($this->returnArgument(0));
+		}
 
 		try {
 			$result = $this->invokePrivate($this->ocs, 'formatShare', [$share]);

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -800,6 +800,9 @@ class ApiTest extends TestCase {
 			->setPermissions(1);
 		$share3 = $this->shareManager->createShare($share3);
 
+		/*
+		 * Test as recipient
+		 */
 		$request = $this->createRequest(['path' => '/', 'subfiles' => 'true']);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER3);
 		$result = $ocs->getShares();
@@ -810,8 +813,37 @@ class ApiTest extends TestCase {
 
 		// we should get exactly one result
 		$this->assertCount(1, $data);
-
 		$this->assertEquals($this->subsubfolder, $data[0]['path']);
+
+		/*
+		 * Test for first owner/initiator
+		 */
+		$request = $this->createRequest([]);
+		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$result = $ocs->getShares();
+		$this->assertTrue($result->succeeded());
+
+		// test should return one share within $this->folder
+		$data = $result->getData();
+
+		// we should get exactly one result
+		$this->assertCount(1, $data);
+		$this->assertEquals($this->folder . $this->subfolder, $data[0]['path']);
+
+		/*
+		 * Test for second initiator
+		 */
+		$request = $this->createRequest([]);
+		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER2);
+		$result = $ocs->getShares();
+		$this->assertTrue($result->succeeded());
+
+		// test should return one share within $this->folder
+		$data = $result->getData();
+
+		// we should get exactly one result
+		$this->assertCount(1, $data);
+		$this->assertEquals($this->subfolder . $this->subsubfolder, $data[0]['path']);
 
 		$this->shareManager->deleteShare($share1);
 		$this->shareManager->deleteShare($share2);

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -764,8 +764,7 @@ class ApiTest extends TestCase {
 		// we should get exactly one result
 		$this->assertCount(1, $data);
 
-		$expectedPath = $this->folder . $this->subfolder;
-		$this->assertEquals($expectedPath, $data[0]['path']);
+		$this->assertEquals($this->subfolder, $data[0]['path']);
 
 		$this->shareManager->deleteShare($share2);
 		$this->shareManager->deleteShare($share1);
@@ -812,8 +811,7 @@ class ApiTest extends TestCase {
 		// we should get exactly one result
 		$this->assertCount(1, $data);
 
-		$expectedPath = $this->folder . $this->subfolder . $this->subsubfolder;
-		$this->assertEquals($expectedPath, $data[0]['path']);
+		$this->assertEquals($this->subsubfolder, $data[0]['path']);
 
 		$this->shareManager->deleteShare($share1);
 		$this->shareManager->deleteShare($share2);
@@ -922,8 +920,7 @@ class ApiTest extends TestCase {
 		// we should get exactly one result
 		$this->assertCount(1, $data);
 
-		$expectedPath = $this->folder.$this->subfolder.$this->filename;
-		$this->assertEquals($expectedPath, $data[0]['path']);
+		$this->assertEquals($this->filename, $data[0]['path']);
 
 		$this->shareManager->deleteShare($share1);
 		$this->shareManager->deleteShare($share2);


### PR DESCRIPTION
Fixes #24997

There are only 3 possible types of users that can request a share via the OCS Share API:
- owner
- inituator
- recipient

Else they won't find the share.
This makes sure we get the share for the current user. So that the path is always something meaningfull for that user.

CC: @nickvergessen @PVince81 @icewind1991 @scriptPilot
