### PR TITLE
don't update storage mtime if we can't get the modified date

### DIFF
--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -231,7 +231,10 @@ class Updater implements IUpdater {
 		$parentId = $this->cache->getParentId($internalPath);
 		$parent = dirname($internalPath);
 		if ($parentId != -1) {
-			$this->cache->update($parentId, array('storage_mtime' => $this->storage->filemtime($parent)));
+			$mtime = $this->storage->filemtime($parent);
+			if ($mtime !== false) {
+				$this->cache->update($parentId, array('storage_mtime' => $mtime));
+			}
 		}
 	}
 }

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -643,6 +643,9 @@ abstract class Common implements Storage, ILockingStorage {
 		$data = [];
 		$data['mimetype'] = $this->getMimeType($path);
 		$data['mtime'] = $this->filemtime($path);
+		if ($data['mtime'] === false) {
+			$data['mtime'] = time();
+		}
 		if ($data['mimetype'] == 'httpd/unix-directory') {
 			$data['size'] = -1; //unknown
 		} else {


### PR DESCRIPTION
if a file doesn't exist, `filemtime` will return false

Error is caused by trying to delete a ghost file since https://github.com/owncloud/core/pull/24813

Fixes https://github.com/owncloud/core/issues/25002
