### PR TITLE
Fix GDrive upload file which name might match the one of a folder

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Google.php
+++ b/apps/files_external/lib/Lib/Storage/Google.php
@@ -97,6 +97,9 @@ class Google extends \OC\Files\Storage\Common {
 	private function getDriveFile($path) {
 		// Remove leading and trailing slashes
 		$path = trim($path, '/');
+		if ($path === '.') {
+			$path = '';
+		}
 		if (isset($this->driveFiles[$path])) {
 			return $this->driveFiles[$path];
 		} else if ($path === '') {
@@ -138,7 +141,7 @@ class Google extends \OC\Files\Storage\Common {
 						if ($pos !== false) {
 							$pathWithoutExt = substr($path, 0, $pos);
 							$file = $this->getDriveFile($pathWithoutExt);
-							if ($file) {
+							if ($file && $this->isGoogleDocFile($file)) {
 								// Switch cached Google_Service_Drive_DriveFile to the correct index
 								unset($this->driveFiles[$pathWithoutExt]);
 								$this->driveFiles[$path] = $file;
@@ -206,6 +209,17 @@ class Google extends \OC\Files\Storage\Common {
 		} else {
 			return '';
 		}
+	}
+
+	/**
+	 * Returns whether the given drive file is a Google Doc file
+	 *
+	 * @param \Google_Service_Drive_DriveFile
+	 *
+	 * @return true if the file is a Google Doc file, false otherwise
+	 */
+	private function isGoogleDocFile($file) {
+		return $this->getGoogleDocExtension($file->getMimeType()) !== '';
 	}
 
 	public function mkdir($path) {

--- a/apps/files_external/tests/Storage/GoogleTest.php
+++ b/apps/files_external/tests/Storage/GoogleTest.php
@@ -60,4 +60,13 @@ class GoogleTest extends \Test\Files\Storage\Storage {
 
 		parent::tearDown();
 	}
+
+	public function testSameNameAsFolderWithExtension() {
+		$this->assertTrue($this->instance->mkdir('testsamename'));
+		$this->assertEquals(13, $this->instance->file_put_contents('testsamename.txt', 'some contents'));
+		$this->assertEquals('some contents', $this->instance->file_get_contents('testsamename.txt'));
+		$this->assertTrue($this->instance->is_dir('testsamename'));
+		$this->assertTrue($this->instance->unlink('testsamename.txt'));
+		$this->assertTrue($this->instance->rmdir('testsamename'));
+	}
 }


### PR DESCRIPTION
Whenever a file is uploaded to GDrive, there is a check for that file
with and without extension, due to Google Docs files having no
extension. This logic now only kicks in whenever the detected
extensionless file is really a Google Doc file, not a folder.

This makes it possible again to upload a file "test.txt" in a folder
that also has a folder called "test"

Fixes https://github.com/owncloud/core/issues/24631
