### PR TITLE
Add support to know where the storage test comes from

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -299,7 +299,8 @@ StorageConfig.prototype = {
 			mountPoint: this.mountPoint,
 			backend: this.backend,
 			authMechanism: this.authMechanism,
-			backendOptions: this.backendOptions
+			backendOptions: this.backendOptions,
+			origin: 'settings'
 		};
 		if (this.id) {
 			data.id = this.id;
@@ -326,6 +327,7 @@ StorageConfig.prototype = {
 		$.ajax({
 			type: 'GET',
 			url: OC.generateUrl(this._url + '/{id}', {id: this.id}),
+			data: {'origin': 'settings'},
 			success: options.success,
 			error: options.error
 		});
@@ -908,6 +910,7 @@ MountConfigListView.prototype = _.extend({
 			$.ajax({
 				type: 'GET',
 				url: OC.generateUrl('apps/files_external/userglobalstorages'),
+				data: {'origin' : 'settings'},
 				contentType: 'application/json',
 				success: function(result) {
 					var onCompletion = jQuery.Deferred();

--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -300,7 +300,7 @@ StorageConfig.prototype = {
 			backend: this.backend,
 			authMechanism: this.authMechanism,
 			backendOptions: this.backendOptions,
-			origin: 'settings'
+			testOnly: true
 		};
 		if (this.id) {
 			data.id = this.id;
@@ -327,7 +327,7 @@ StorageConfig.prototype = {
 		$.ajax({
 			type: 'GET',
 			url: OC.generateUrl(this._url + '/{id}', {id: this.id}),
-			data: {'origin': 'settings'},
+			data: {'testOnly': true},
 			success: options.success,
 			error: options.error
 		});
@@ -910,7 +910,7 @@ MountConfigListView.prototype = _.extend({
 			$.ajax({
 				type: 'GET',
 				url: OC.generateUrl('apps/files_external/userglobalstorages'),
-				data: {'origin' : 'settings'},
+				data: {'testOnly' : true},
 				contentType: 'application/json',
 				success: function(result) {
 					var onCompletion = jQuery.Deferred();

--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -78,7 +78,7 @@ OCA.External.StatusManager = {
 			defObj = $.ajax({
 				type: 'GET',
 				url: OC.webroot + '/index.php/apps/files_external/' + ((mountData.type === 'personal') ? 'userstorages' : 'userglobalstorages') + '/' + mountData.id,
-				data: {'origin' : 'statusmanager'},
+				data: {'testOnly' : false},
 				success: function (response) {
 					if (response && response.status === 0) {
 						self.mountStatus[mountData.mount_point] = response;

--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -78,6 +78,7 @@ OCA.External.StatusManager = {
 			defObj = $.ajax({
 				type: 'GET',
 				url: OC.webroot + '/index.php/apps/files_external/' + ((mountData.type === 'personal') ? 'userstorages' : 'userglobalstorages') + '/' + mountData.id,
+				data: {'origin' : 'statusmanager'},
 				success: function (response) {
 					if (response && response.status === 0) {
 						self.mountStatus[mountData.mount_point] = response;

--- a/apps/files_external/lib/Controller/GlobalStoragesController.php
+++ b/apps/files_external/lib/Controller/GlobalStoragesController.php
@@ -139,7 +139,8 @@ class GlobalStoragesController extends StoragesController {
 		$mountOptions,
 		$applicableUsers,
 		$applicableGroups,
-		$priority
+		$priority,
+		$origin = null
 	) {
 		$storage = $this->createStorage(
 			$mountPoint,
@@ -172,7 +173,7 @@ class GlobalStoragesController extends StoragesController {
 			);
 		}
 
-		$this->updateStorageStatus($storage);
+		$this->updateStorageStatus($storage, $origin);
 
 		return new DataResponse(
 			$storage,

--- a/apps/files_external/lib/Controller/GlobalStoragesController.php
+++ b/apps/files_external/lib/Controller/GlobalStoragesController.php
@@ -140,7 +140,7 @@ class GlobalStoragesController extends StoragesController {
 		$applicableUsers,
 		$applicableGroups,
 		$priority,
-		$testOnly = null
+		$testOnly = true
 	) {
 		$storage = $this->createStorage(
 			$mountPoint,

--- a/apps/files_external/lib/Controller/GlobalStoragesController.php
+++ b/apps/files_external/lib/Controller/GlobalStoragesController.php
@@ -140,7 +140,7 @@ class GlobalStoragesController extends StoragesController {
 		$applicableUsers,
 		$applicableGroups,
 		$priority,
-		$origin = null
+		$testOnly = null
 	) {
 		$storage = $this->createStorage(
 			$mountPoint,
@@ -173,7 +173,7 @@ class GlobalStoragesController extends StoragesController {
 			);
 		}
 
-		$this->updateStorageStatus($storage, $origin);
+		$this->updateStorageStatus($storage, $testOnly);
 
 		return new DataResponse(
 			$storage,

--- a/apps/files_external/lib/Controller/StoragesController.php
+++ b/apps/files_external/lib/Controller/StoragesController.php
@@ -238,7 +238,7 @@ abstract class StoragesController extends Controller {
 	 *
 	 * @param StorageConfig $storage storage configuration
 	 */
-	protected function updateStorageStatus(StorageConfig &$storage, $origin = null) {
+	protected function updateStorageStatus(StorageConfig &$storage, $testOnly = null) {
 		try {
 			$this->manipulateStorageConfig($storage);
 
@@ -250,7 +250,7 @@ abstract class StoragesController extends Controller {
 					$backend->getStorageClass(),
 					$storage->getBackendOptions(),
 					false,
-					$origin
+					$testOnly
 				)
 			);
 		} catch (InsufficientDataForMeaningfulAnswerException $e) {
@@ -294,11 +294,11 @@ abstract class StoragesController extends Controller {
 	 *
 	 * @return DataResponse
 	 */
-	public function show($id, $origin = null) {
+	public function show($id, $testOnly = null) {
 		try {
 			$storage = $this->service->getStorage($id);
 
-			$this->updateStorageStatus($storage, $origin);
+			$this->updateStorageStatus($storage, $testOnly);
 		} catch (NotFoundException $e) {
 			return new DataResponse(
 				[

--- a/apps/files_external/lib/Controller/StoragesController.php
+++ b/apps/files_external/lib/Controller/StoragesController.php
@@ -238,7 +238,7 @@ abstract class StoragesController extends Controller {
 	 *
 	 * @param StorageConfig $storage storage configuration
 	 */
-	protected function updateStorageStatus(StorageConfig &$storage) {
+	protected function updateStorageStatus(StorageConfig &$storage, $origin = null) {
 		try {
 			$this->manipulateStorageConfig($storage);
 
@@ -249,7 +249,8 @@ abstract class StoragesController extends Controller {
 				\OC_Mount_Config::getBackendStatus(
 					$backend->getStorageClass(),
 					$storage->getBackendOptions(),
-					false
+					false,
+					$origin
 				)
 			);
 		} catch (InsufficientDataForMeaningfulAnswerException $e) {
@@ -293,11 +294,11 @@ abstract class StoragesController extends Controller {
 	 *
 	 * @return DataResponse
 	 */
-	public function show($id) {
+	public function show($id, $origin = null) {
 		try {
 			$storage = $this->service->getStorage($id);
 
-			$this->updateStorageStatus($storage);
+			$this->updateStorageStatus($storage, $origin);
 		} catch (NotFoundException $e) {
 			return new DataResponse(
 				[

--- a/apps/files_external/lib/Controller/StoragesController.php
+++ b/apps/files_external/lib/Controller/StoragesController.php
@@ -238,7 +238,7 @@ abstract class StoragesController extends Controller {
 	 *
 	 * @param StorageConfig $storage storage configuration
 	 */
-	protected function updateStorageStatus(StorageConfig &$storage, $testOnly = null) {
+	protected function updateStorageStatus(StorageConfig &$storage, $testOnly = true) {
 		try {
 			$this->manipulateStorageConfig($storage);
 
@@ -294,7 +294,7 @@ abstract class StoragesController extends Controller {
 	 *
 	 * @return DataResponse
 	 */
-	public function show($id, $testOnly = null) {
+	public function show($id, $testOnly = true) {
 		try {
 			$storage = $this->service->getStorage($id);
 

--- a/apps/files_external/lib/Controller/UserGlobalStoragesController.php
+++ b/apps/files_external/lib/Controller/UserGlobalStoragesController.php
@@ -111,11 +111,11 @@ class UserGlobalStoragesController extends StoragesController {
 	 *
 	 * @NoAdminRequired
 	 */
-	public function show($id) {
+	public function show($id, $origin = null) {
 		try {
 			$storage = $this->service->getStorage($id);
 
-			$this->updateStorageStatus($storage);
+			$this->updateStorageStatus($storage, $origin);
 		} catch (NotFoundException $e) {
 			return new DataResponse(
 				[
@@ -146,7 +146,8 @@ class UserGlobalStoragesController extends StoragesController {
 	 */
 	public function update(
 		$id,
-		$backendOptions
+		$backendOptions,
+		$origin = null
 	) {
 		try {
 			$storage = $this->service->getStorage($id);

--- a/apps/files_external/lib/Controller/UserGlobalStoragesController.php
+++ b/apps/files_external/lib/Controller/UserGlobalStoragesController.php
@@ -111,11 +111,11 @@ class UserGlobalStoragesController extends StoragesController {
 	 *
 	 * @NoAdminRequired
 	 */
-	public function show($id, $origin = null) {
+	public function show($id, $testOnly = null) {
 		try {
 			$storage = $this->service->getStorage($id);
 
-			$this->updateStorageStatus($storage, $origin);
+			$this->updateStorageStatus($storage, $testOnly);
 		} catch (NotFoundException $e) {
 			return new DataResponse(
 				[
@@ -147,7 +147,7 @@ class UserGlobalStoragesController extends StoragesController {
 	public function update(
 		$id,
 		$backendOptions,
-		$origin = null
+		$testOnly = null
 	) {
 		try {
 			$storage = $this->service->getStorage($id);
@@ -172,7 +172,7 @@ class UserGlobalStoragesController extends StoragesController {
 			);
 		}
 
-		$this->updateStorageStatus($storage);
+		$this->updateStorageStatus($storage, $testOnly);
 		$this->sanitizeStorage($storage);
 
 		return new DataResponse(

--- a/apps/files_external/lib/Controller/UserGlobalStoragesController.php
+++ b/apps/files_external/lib/Controller/UserGlobalStoragesController.php
@@ -111,7 +111,7 @@ class UserGlobalStoragesController extends StoragesController {
 	 *
 	 * @NoAdminRequired
 	 */
-	public function show($id, $testOnly = null) {
+	public function show($id, $testOnly = true) {
 		try {
 			$storage = $this->service->getStorage($id);
 
@@ -147,7 +147,7 @@ class UserGlobalStoragesController extends StoragesController {
 	public function update(
 		$id,
 		$backendOptions,
-		$testOnly = null
+		$testOnly = true
 	) {
 		try {
 			$storage = $this->service->getStorage($id);

--- a/apps/files_external/lib/Controller/UserStoragesController.php
+++ b/apps/files_external/lib/Controller/UserStoragesController.php
@@ -101,8 +101,8 @@ class UserStoragesController extends StoragesController {
 	 *
 	 * {@inheritdoc}
 	 */
-	public function show($id) {
-		return parent::show($id);
+	public function show($id, $origin = null) {
+		return parent::show($id, $origin);
 	}
 
 	/**
@@ -170,7 +170,8 @@ class UserStoragesController extends StoragesController {
 		$backend,
 		$authMechanism,
 		$backendOptions,
-		$mountOptions
+		$mountOptions,
+		$origin = null
 	) {
 		$storage = $this->createStorage(
 			$mountPoint,
@@ -200,7 +201,7 @@ class UserStoragesController extends StoragesController {
 			);
 		}
 
-		$this->updateStorageStatus($storage);
+		$this->updateStorageStatus($storage, $origin);
 
 		return new DataResponse(
 			$storage,

--- a/apps/files_external/lib/Controller/UserStoragesController.php
+++ b/apps/files_external/lib/Controller/UserStoragesController.php
@@ -101,8 +101,8 @@ class UserStoragesController extends StoragesController {
 	 *
 	 * {@inheritdoc}
 	 */
-	public function show($id, $origin = null) {
-		return parent::show($id, $origin);
+	public function show($id, $testOnly = null) {
+		return parent::show($id, $testOnly);
 	}
 
 	/**
@@ -171,7 +171,7 @@ class UserStoragesController extends StoragesController {
 		$authMechanism,
 		$backendOptions,
 		$mountOptions,
-		$origin = null
+		$testOnly = null
 	) {
 		$storage = $this->createStorage(
 			$mountPoint,
@@ -201,7 +201,7 @@ class UserStoragesController extends StoragesController {
 			);
 		}
 
-		$this->updateStorageStatus($storage, $origin);
+		$this->updateStorageStatus($storage, $testOnly);
 
 		return new DataResponse(
 			$storage,

--- a/apps/files_external/lib/Controller/UserStoragesController.php
+++ b/apps/files_external/lib/Controller/UserStoragesController.php
@@ -101,7 +101,7 @@ class UserStoragesController extends StoragesController {
 	 *
 	 * {@inheritdoc}
 	 */
-	public function show($id, $testOnly = null) {
+	public function show($id, $testOnly = true) {
 		return parent::show($id, $testOnly);
 	}
 
@@ -171,7 +171,7 @@ class UserStoragesController extends StoragesController {
 		$authMechanism,
 		$backendOptions,
 		$mountOptions,
-		$testOnly = null
+		$testOnly = true
 	) {
 		$storage = $this->createStorage(
 			$mountPoint,

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -215,7 +215,7 @@ class OC_Mount_Config {
 	 * @return int see self::STATUS_*
 	 * @throws Exception
 	 */
-	public static function getBackendStatus($class, $options, $isPersonal) {
+	public static function getBackendStatus($class, $options, $isPersonal, $origin = null) {
 		if (self::$skipTest) {
 			return StorageNotAvailableException::STATUS_SUCCESS;
 		}
@@ -228,7 +228,7 @@ class OC_Mount_Config {
 				$storage = new $class($options);
 
 				try {
-					$result = $storage->test($isPersonal);
+					$result = $storage->test($isPersonal, $origin);
 					$storage->setAvailability($result);
 					if ($result) {
 						return StorageNotAvailableException::STATUS_SUCCESS;

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -215,7 +215,7 @@ class OC_Mount_Config {
 	 * @return int see self::STATUS_*
 	 * @throws Exception
 	 */
-	public static function getBackendStatus($class, $options, $isPersonal, $origin = null) {
+	public static function getBackendStatus($class, $options, $isPersonal, $testOnly = null) {
 		if (self::$skipTest) {
 			return StorageNotAvailableException::STATUS_SUCCESS;
 		}
@@ -228,7 +228,7 @@ class OC_Mount_Config {
 				$storage = new $class($options);
 
 				try {
-					$result = $storage->test($isPersonal, $origin);
+					$result = $storage->test($isPersonal, $testOnly);
 					$storage->setAvailability($result);
 					if ($result) {
 						return StorageNotAvailableException::STATUS_SUCCESS;

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -215,7 +215,7 @@ class OC_Mount_Config {
 	 * @return int see self::STATUS_*
 	 * @throws Exception
 	 */
-	public static function getBackendStatus($class, $options, $isPersonal, $testOnly = null) {
+	public static function getBackendStatus($class, $options, $isPersonal, $testOnly = true) {
 		if (self::$skipTest) {
 			return StorageNotAvailableException::STATUS_SUCCESS;
 		}

--- a/apps/files_external/tests/js/settingsSpec.js
+++ b/apps/files_external/tests/js/settingsSpec.js
@@ -223,7 +223,8 @@ describe('OCA.External.Settings tests', function() {
 					applicableGroups: [],
 					mountOptions: {
 						'previews': true
-					}
+					},
+					testOnly: true
 				});
 
 				// TODO: respond and check data-id


### PR DESCRIPTION
Required to move forward https://github.com/owncloud/windows_network_drive/pull/389#issuecomment-223297989

Different kind of tests can be provided depending on the origin, if we're trying to setup a mount point or we're trying to access to it. I think this is good enough on the short run, although I'm not sure if we'll need to provide more information.

@PVince81 @DeepDiver1975 
