### PR TITLE
Fix GDrive test rename overwrite folder

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Google.php
+++ b/apps/files_external/lib/Lib/Storage/Google.php
@@ -168,11 +168,11 @@ class Google extends \OC\Files\Storage\Common {
 		$path = trim($path, '/');
 		$this->driveFiles[$path] = $file;
 		if ($file === false) {
-			// Set all child paths as false
+			// Remove all children
 			$len = strlen($path);
 			foreach ($this->driveFiles as $key => $file) {
 				if (substr($key, 0, $len) === $path) {
-					$this->driveFiles[$key] = false;
+					unset($this->driveFiles[$key]);
 				}
 			}
 		}


### PR DESCRIPTION
Partial fix for failing tests: https://github.com/owncloud/core/issues/22481

So far it fixes "testRenameOverWriteDirectory" but the others remain.

Strangely running the other ones individually don't fail.

Waiting for https://github.com/owncloud/core/issues/24631 to be merged to get less failures.
