### PR TITLE
Fix GDrive file size when mime type doesn't match contents

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Google.php
+++ b/apps/files_external/lib/Lib/Storage/Google.php
@@ -326,7 +326,7 @@ class Google extends \OC\Files\Storage\Common {
 				$stat['size'] = 0;
 			} else {
 				// Check if this is a Google Doc
-				if ($this->getMimeType($path) !== $file->getMimeType()) {
+				if ($this->isGoogleDocFile($file)) {
 					// Return unknown file size
 					$stat['size'] = \OCP\Files\FileInfo::SPACE_UNKNOWN;
 				} else {


### PR DESCRIPTION
Uploading a txt file with XML contents makes GDrive return the XML mime
type.

This fix makes sure the logic that returns "SPACE_UNKNOWN" for the size
properly rely on the Google Docs mime types.

Fixes https://github.com/owncloud/core/issues/25006

Please review @icewind1991 @Xenopathic @guruz @rullzer 

After merging https://github.com/owncloud/core/pull/25007 I'll rebase and rerun the GDrive tests manually locally (they are slow...)
