### PR TITLE
Use temporary htaccesstest.txt for data dir security check

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -197,7 +197,7 @@
 			}
 			var afterCall = function(xhr) {
 				var messages = [];
-				if (xhr.status !== 403 && xhr.status !== 307 && xhr.status !== 301 && xhr.responseText === '') {
+				if (xhr.status !== 403 && xhr.status !== 307 && xhr.status !== 301 && xhr.responseText !== '') {
 					messages.push({
 						msg: t('core', 'Your data directory and your files are probably accessible from the Internet. The .htaccess file is not working. We strongly suggest that you configure your web server in a way that the data directory is no longer accessible or you move the data directory outside the web server document root.'),
 						type: OC.SetupChecks.MESSAGE_TYPE_ERROR
@@ -208,7 +208,7 @@
 
 			$.ajax({
 				type: 'GET',
-				url: OC.linkTo('', oc_dataURL+'/.ocdata'),
+				url: OC.linkTo('', oc_dataURL+'/htaccesstest.txt?t=' + (new Date()).getTime()),
 				complete: afterCall
 			});
 			return deferred.promise();

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -103,7 +103,7 @@ describe('OC.SetupChecks tests', function() {
 		it('should return an error if data directory is not protected', function(done) {
 			var async = OC.SetupChecks.checkDataProtected();
 
-			suite.server.requests[0].respond(200);
+			suite.server.requests[0].respond(200, {'Content-Type': 'text/plain'}, 'file contents');
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1128,19 +1128,8 @@ class OC_Util {
 		return $encoded;
 	}
 
-	/**
-	 * Check if the .htaccess file is working
-	 * @param \OCP\IConfig $config
-	 * @return bool
-	 * @throws Exception
-	 * @throws \OC\HintException If the test file can't get written.
-	 */
-	public function isHtaccessWorking(\OCP\IConfig $config) {
 
-		if (\OC::$CLI || !$config->getSystemValue('check_for_working_htaccess', true)) {
-			return true;
-		}
-
+	public function createHtaccessTestFile(\OCP\IConfig $config) {
 		// php dev server does not support htaccess
 		if (php_sapi_name() === 'cli-server') {
 			return false;
@@ -1148,7 +1137,7 @@ class OC_Util {
 
 		// testdata
 		$fileName = '/htaccesstest.txt';
-		$testContent = 'testcontent';
+		$testContent = 'This is used for testing whether htaccess is properly enabled to disallow access from the outside. This file can be safely removed.';
 
 		// creating a test file
 		$testFile = $config->getSystemValue('datadirectory', OC::$SERVERROOT . '/data') . '/' . $fileName;
@@ -1164,6 +1153,28 @@ class OC_Util {
 		}
 		fwrite($fp, $testContent);
 		fclose($fp);
+	}
+
+	/**
+	 * Check if the .htaccess file is working
+	 * @param \OCP\IConfig $config
+	 * @return bool
+	 * @throws Exception
+	 * @throws \OC\HintException If the test file can't get written.
+	 */
+	public function isHtaccessWorking(\OCP\IConfig $config) {
+
+		if (\OC::$CLI || !$config->getSystemValue('check_for_working_htaccess', true)) {
+			return true;
+		}
+
+		$testContent = $this->createHtaccessTestFile($config);
+		if ($testContent === false) {
+			return false;
+		}
+
+		$fileName = '/htaccesstest.txt';
+		$testFile = $config->getSystemValue('datadirectory', OC::$SERVERROOT . '/data') . '/' . $fileName;
 
 		// accessing the file via http
 		$url = \OC::$server->getURLGenerator()->getAbsoluteURL(OC::$WEBROOT . '/data' . $fileName);

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -267,3 +267,7 @@ if ($updaterAppPanel) {
 $template->assign('forms', $formsAndMore);
 
 $template->printPage();
+
+$util = new \OC_Util();
+$util->createHtaccessTestFile(\OC::$server->getConfig());
+


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/24987

Brings back the htaccesstest.txt file and uses that instead of ".ocdata" for the ajax htaccess check.
Also added cache buster for that file to avoid getting 304 when accessing the file.

I'm not too happy about the approach but it seems to work.
The reason I'm not happy:
- stray file
- the PR touches the existing `isHtaccessWorking` function which is still used at setup time, but not touching it would result in duplicate code

Please review @nickvergessen @rullzer @RealRancor @icewind1991 @danimo 
