### PR TITLE
Bring back sharedstorage hooks

### DIFF
--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -415,4 +415,22 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 		return $this->sourceStorage;
 	}
 
+	public function file_get_contents($path) {
+		$info = [
+			'target' => $this->getMountPoint() . '/' . $path,
+			'source' => $this->getSourcePath($path),
+		];
+		\OCP\Util::emitHook('\OC\Files\Storage\Shared', 'file_get_contents', $info);
+		return parent::file_get_contents($path);
+	}
+
+	public function file_put_contents($path, $data) {
+		$info = [
+			'target' => $this->getMountPoint() . '/' . $path,
+			'source' => $this->getSourcePath($path),
+		];
+		\OCP\Util::emitHook('\OC\Files\Storage\Shared', 'file_put_contents', $info);
+		return parent::file_put_contents($path, $data);
+	}
+
 }


### PR DESCRIPTION
Fixes #24937

This brings back the hooks on `file_get_contents` and `file_put_contents`. However. I have no idea how or when they are used so verifying is bit hard.

CC: @PVince81 @icewind1991 @oparoz 
