### PR TITLE
Do not log token or challenge with exception stacktrace

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -60,6 +60,13 @@ class Log implements ILogger {
 	/** @var Normalizer */
 	private $normalizer;
 
+	protected $methodsWithSensitiveParameters = [
+		'login',
+		'checkPassword',
+		'updatePrivateKeyPassword',
+		'validateUserPass',
+	];
+
 	/**
 	 * @param string $logger The logger that should be used
 	 * @param SystemConfig $config the system config object
@@ -286,7 +293,7 @@ class Log implements ILogger {
 			'File' => $exception->getFile(),
 			'Line' => $exception->getLine(),
 		);
-		$exception['Trace'] = preg_replace('!(login|checkPassword|updatePrivateKeyPassword|validateUserPass)\(.*\)!', '$1(*** username and password replaced ***)', $exception['Trace']);
+		$exception['Trace'] = preg_replace('!(' . implode('|', $this->methodsWithSensitiveParameters) . ')\(.*\)!', '$1(*** sensitive parameters replaced ***)', $exception['Trace']);
 		$msg = isset($context['message']) ? $context['message'] : 'Exception';
 		$msg .= ': ' . json_encode($exception);
 		$this->error($msg, $context);

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -61,10 +61,29 @@ class Log implements ILogger {
 	private $normalizer;
 
 	protected $methodsWithSensitiveParameters = [
+		// Session/User
 		'login',
 		'checkPassword',
 		'updatePrivateKeyPassword',
 		'validateUserPass',
+
+		// TokenProvider
+		'getToken',
+		'isTokenPassword',
+		'getPassword',
+		'decryptPassword',
+		'logClientIn',
+		'generateToken',
+		'validateToken',
+
+		// TwoFactorAuth
+		'solveChallenge',
+		'verifyChallenge',
+
+		//ICrypto
+		'calculateHMAC',
+		'encrypt',
+		'decrypt',
 	];
 
 	/**

--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -89,7 +89,7 @@ class LoggerTest extends TestCase {
 		foreach($logLines as $logLine) {
 			$this->assertNotContains($user, $logLine);
 			$this->assertNotContains($password, $logLine);
-			$this->assertContains('login(*** username and password replaced ***)', $logLine);
+			$this->assertContains('login(*** sensitive parameters replaced ***)', $logLine);
 		}
 	}
 
@@ -104,7 +104,7 @@ class LoggerTest extends TestCase {
 		foreach($logLines as $logLine) {
 			$this->assertNotContains($user, $logLine);
 			$this->assertNotContains($password, $logLine);
-			$this->assertContains('checkPassword(*** username and password replaced ***)', $logLine);
+			$this->assertContains('checkPassword(*** sensitive parameters replaced ***)', $logLine);
 		}
 	}
 
@@ -119,7 +119,7 @@ class LoggerTest extends TestCase {
 		foreach($logLines as $logLine) {
 			$this->assertNotContains($user, $logLine);
 			$this->assertNotContains($password, $logLine);
-			$this->assertContains('validateUserPass(*** username and password replaced ***)', $logLine);
+			$this->assertContains('validateUserPass(*** sensitive parameters replaced ***)', $logLine);
 		}
 	}
 }


### PR DESCRIPTION
Fix #24781 

To test, open all Token/TwoFactorAuth files,
find all `throws` and in those methods add (at the beginning):

``` php
\OC::$server->getLogger()->logException(new \Exception());
```

Afterwards generate a token, make a request using the token and make sure that your log file does not have the token (completly or partly).

cc @PVince81 @ChristophWurst 
