### PR TITLE
skip scanning for a user when the user is not setup yet

### DIFF
--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -160,7 +160,12 @@ class Scanner extends PublicEmitter {
 			if ($storage->instanceOfStorage('\OC\Files\Storage\Home') and
 				(!$storage->isCreatable('') or !$storage->isCreatable('files'))
 			) {
-				throw new ForbiddenException();
+				if ($storage->file_exists('') or $storage->getCache()->inCache('')) {
+					throw new ForbiddenException();
+				} else {// if the root exists in neither the cache nor the storage the user isn't setup yet
+					break;
+				}
+
 			}
 			$relativePath = $mount->getInternalPath($dir);
 			$scanner = $storage->getScanner();


### PR DESCRIPTION
Otherwise an invalid 'home storage not writable' error is thrown

cc @owncloud/filesystem 
