### PR TITLE
Handle "storage not available" to show an error message

### DIFF
--- a/apps/files/ajax/delete.php
+++ b/apps/files/ajax/delete.php
@@ -72,6 +72,9 @@ try {
 } catch(\OCP\Files\NotFoundException $e) {
 	OCP\JSON::error(['data' => ['message' => 'File not found']]);
 	return;
+} catch(\OCP\Files\StorageNotAvailableException $e) {$
+	OCP\JSON::error(['data' => ['message' => 'Storage not available']]);
+	return;
 }
 
 if ($success) {

--- a/apps/files/ajax/delete.php
+++ b/apps/files/ajax/delete.php
@@ -72,7 +72,7 @@ try {
 } catch(\OCP\Files\NotFoundException $e) {
 	OCP\JSON::error(['data' => ['message' => 'File not found']]);
 	return;
-} catch(\OCP\Files\StorageNotAvailableException $e) {$
+} catch(\OCP\Files\StorageNotAvailableException $e) {
 	OCP\JSON::error(['data' => ['message' => 'Storage not available']]);
 	return;
 }


### PR DESCRIPTION
OC 9 and 9.1 don't use the modifed file, so this is the latest OC version in which this patch can work.

Fix https://github.com/owncloud/windows_network_drive/issues/376

For OC 9 and 9.1, it shows an error message "error deleting file", which is good enough (although the reason seems to be a bit different, but I guess it's ok)
