### PR TITLE
DAV now returns file name with Content-Disposition header

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -144,6 +144,7 @@ class ServerFactory {
 					$objectTree,
 					$view,
 					$this->config,
+					$this->request,
 					false,
 					!$this->config->getSystemValue('debug', false)
 				)

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -141,6 +141,7 @@ class Server {
 						$this->server->tree,
 						$view,
 						\OC::$server->getConfig(),
+						$this->request,
 						false,
 						!\OC::$server->getConfig()->getSystemValue('debug', false)
 					)

--- a/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
@@ -343,7 +343,8 @@ class FilesReportPluginTest extends \Test\TestCase {
 			new \OCA\DAV\Connector\Sabre\FilesPlugin(
 				$this->tree,
 				$this->view,
-				$config
+				$config,
+				$this->getMock('\OCP\IRequest')
 			)
 		);
 		$this->plugin->initialize($this->server);

--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -82,7 +82,7 @@ Feature: webdav-related
 		And As an "admin"
 		When Downloading file "/welcome.txt"
 		Then The following headers should be set
-			|Content-Disposition|attachment|
+			|Content-Disposition|attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt"|
 			|Content-Security-Policy|default-src 'none';|
 			|X-Content-Type-Options |nosniff|
 			|X-Download-Options|noopen|
@@ -97,7 +97,7 @@ Feature: webdav-related
 		And As an "admin"
 		When Downloading file "/welcome.txt"
 		Then The following headers should be set
-			|Content-Disposition|attachment|
+			|Content-Disposition|attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt"|
 			|Content-Security-Policy|default-src 'none';|
 			|X-Content-Type-Options |nosniff|
 			|X-Download-Options|noopen|


### PR DESCRIPTION
Fixes issue where Chrome would append ".txt" to XML files when downloaded in the web UI

Fixes https://github.com/owncloud/core/issues/23176

Please review @owncloud/filesystem @DeepDiver1975 @nickvergessen @rullzer 

Would be best to backport this to 9.0 because that's where the issue first appeared, at the time where we switched the web UI to use the Webdav endpoint for downloads.

CC @DeepDiver1975 @dragotin 
