### PR TITLE
[stable9] skip scanning for a user when the user is not setup yet

### DIFF
--- a/lib/private/files/utils/scanner.php
+++ b/lib/private/files/utils/scanner.php
@@ -148,7 +148,12 @@ class Scanner extends PublicEmitter {
 			if ($storage->instanceOfStorage('\OC\Files\Storage\Home') and
 				(!$storage->isCreatable('') or !$storage->isCreatable('files'))
 			) {
-				throw new ForbiddenException();
+				if ($storage->file_exists('') or $storage->getCache()->inCache('')) {
+					throw new ForbiddenException();
+				} else {// if the root exists in neither the cache nor the storage the user isn't setup yet
+					break;
+				}
+
 			}
 			$relativePath = $mount->getInternalPath($dir);
 			$scanner = $storage->getScanner();


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/25028 to stable9

Please review and test @mmattel @icewind1991 @owncloud/filesystem 
