### PR TITLE
Check 2FA state for raw php files too

### DIFF
--- a/lib/private/legacy/json.php
+++ b/lib/private/legacy/json.php
@@ -64,7 +64,9 @@ class OC_JSON{
 	 * @deprecated Use annotation based ACLs from the AppFramework instead
 	 */
 	public static function checkLoggedIn() {
-		if( !OC_User::isLoggedIn()) {
+		$twoFactorAuthManger = \OC::$server->getTwoFactorAuthManager();
+		if( !OC_User::isLoggedIn()
+			|| $twoFactorAuthManger->needsSecondFactor()) {
 			$l = \OC::$server->getL10N('lib');
 			http_response_code(\OCP\AppFramework\Http::STATUS_UNAUTHORIZED);
 			self::error(array( 'data' => array( 'message' => $l->t('Authentication error'), 'error' => 'authentication_error' )));

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -970,6 +970,11 @@ class OC_Util {
 			);
 			exit();
 		}
+		// Redirect to index page if 2FA challenge was not solved yet
+		if (\OC::$server->getTwoFactorAuthManager()->needsSecondFactor()) {
+			header('Location: ' . \OCP\Util::linkToAbsolute('', 'index.php'));
+			exit();
+		}
 	}
 
 	/**


### PR DESCRIPTION
I forgot to block raw php files before the 2FA challenge was solved.

Steps to reproduce
1. enable a 2fa provider
2. (log out)
3. log in, but do not solve the 2fa challenge
4. open raw PHP URL like `http://localhost:8080/index.php/apps/files/ajax/list.php`

On master, you will have access to user data, this patch blocks it.

thanks @LukasReschke
