### PR TITLE
[stable9] DAV now returns file name with Content-Disposition header

### DIFF
--- a/apps/dav/lib/connector/sabre/filesplugin.php
+++ b/apps/dav/lib/connector/sabre/filesplugin.php
@@ -77,15 +77,25 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 	private $fileView;
 
 	/**
+	* @var IRequest
+	*/
+	private $request;
+
+	/**
 	 * @param \Sabre\DAV\Tree $tree
 	 * @param \OC\Files\View $view
+	 * @param \OCP\IRequest $request
 	 * @param bool $isPublic
 	 */
-	public function __construct(\Sabre\DAV\Tree $tree,
-	                            \OC\Files\View $view,
-	                            $isPublic = false) {
+	public function __construct(
+			\Sabre\DAV\Tree $tree,
+			\OC\Files\View $view,
+			\OCP\IRequest $request,
+			$isPublic = false
+	) {
 		$this->tree = $tree;
 		$this->fileView = $view;
+		$this->request = $request;
 		$this->isPublic = $isPublic;
 	}
 
@@ -193,7 +203,18 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 		if (!($node instanceof IFile)) return;
 
 		// adds a 'Content-Disposition: attachment' header
-		$response->addHeader('Content-Disposition', 'attachment');
+		$filename = $node->getName();
+		if ($this->request->isUserAgent(
+			[
+				\OC\AppFramework\Http\Request::USER_AGENT_IE,
+				\OC\AppFramework\Http\Request::USER_AGENT_ANDROID_MOBILE_CHROME,
+				\OC\AppFramework\Http\Request::USER_AGENT_FREEBOX,
+			])) {
+			$response->addHeader('Content-Disposition', 'attachment; filename="' . rawurlencode($filename) . '"');
+		} else {
+			$response->addHeader('Content-Disposition', 'attachment; filename*=UTF-8\'\'' . rawurlencode($filename)
+												 . '; filename="' . rawurlencode($filename) . '"');
+		}
 
 		if ($node instanceof \OCA\DAV\Connector\Sabre\File) {
 			//Add OC-Checksum header

--- a/apps/dav/lib/connector/sabre/serverfactory.php
+++ b/apps/dav/lib/connector/sabre/serverfactory.php
@@ -137,7 +137,11 @@ class ServerFactory {
 			}
 			$objectTree->init($root, $view, $this->mountManager);
 
-			$server->addPlugin(new \OCA\DAV\Connector\Sabre\FilesPlugin($objectTree, $view));
+			$server->addPlugin(new \OCA\DAV\Connector\Sabre\FilesPlugin(
+				$objectTree,
+				$view,
+				$this->request
+			));
 			$server->addPlugin(new \OCA\DAV\Connector\Sabre\QuotaPlugin($view));
 
 			if($this->userSession->isLoggedIn()) {

--- a/apps/dav/lib/server.php
+++ b/apps/dav/lib/server.php
@@ -125,7 +125,11 @@ class Server {
 			$user = \OC::$server->getUserSession()->getUser();
 			if (!is_null($user)) {
 				$view = \OC\Files\Filesystem::getView();
-				$this->server->addPlugin(new FilesPlugin($this->server->tree, $view));
+				$this->server->addPlugin(new FilesPlugin(
+					$this->server->tree,
+					$view,
+					$this->request
+				));
 
 				$this->server->addPlugin(
 					new \Sabre\DAV\PropertyStorage\Plugin(

--- a/apps/dav/tests/unit/connector/sabre/filesplugin.php
+++ b/apps/dav/tests/unit/connector/sabre/filesplugin.php
@@ -72,8 +72,13 @@ class FilesPlugin extends \Test\TestCase {
 		$this->view = $this->getMockBuilder('\OC\Files\View')
 			->disableOriginalConstructor()
 			->getMock();
+		$request = $this->getMock('\OCP\IRequest');
 
-		$this->plugin = new \OCA\DAV\Connector\Sabre\FilesPlugin($this->tree, $this->view);
+		$this->plugin = new \OCA\DAV\Connector\Sabre\FilesPlugin(
+			$this->tree,
+			$this->view,
+			$request
+		);
 		$this->plugin->initialize($this->server);
 	}
 
@@ -237,7 +242,11 @@ class FilesPlugin extends \Test\TestCase {
 	}
 
 	public function testGetPublicPermissions() {
-		$this->plugin = new \OCA\DAV\Connector\Sabre\FilesPlugin($this->tree, $this->view, true);
+		$this->plugin = new \OCA\DAV\Connector\Sabre\FilesPlugin(
+			$this->tree,
+			$this->view,
+			$this->getMock('\OCP\IRequest'),
+			true);
 		$this->plugin->initialize($this->server);
 
 		$propFind = new \Sabre\DAV\PropFind(

--- a/apps/dav/tests/unit/connector/sabre/filesreportplugin.php
+++ b/apps/dav/tests/unit/connector/sabre/filesreportplugin.php
@@ -336,7 +336,11 @@ class FilesReportPlugin extends \Test\TestCase {
 			->method('getSize')
 			->will($this->returnValue(1024));
 
-		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\FilesPlugin($this->tree, $this->view));
+		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\FilesPlugin(
+			$this->tree,
+			$this->view,
+			$this->getMock('\OCP\IRequest')
+		));
 		$this->plugin->initialize($this->server);
 		$responses = $this->plugin->prepareResponses($requestedProps, [$node1, $node2]);
 

--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -73,7 +73,7 @@ Feature: webdav-related
 		And As an "admin"
 		When Downloading file "/welcome.txt"
 		Then The following headers should be set
-			|Content-Disposition|attachment|
+			|Content-Disposition|attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt"|
 			|Content-Security-Policy|default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; frame-src *; img-src * data: blob:; font-src 'self' data:; media-src *; connect-src *|
 			|X-Content-Type-Options |nosniff|
 			|X-Download-Options|noopen|
@@ -88,7 +88,7 @@ Feature: webdav-related
 		And As an "admin"
 		When Downloading file "/welcome.txt"
 		Then The following headers should be set
-			|Content-Disposition|attachment|
+			|Content-Disposition|attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt"|
 			|Content-Security-Policy|default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; frame-src *; img-src * data: blob:; font-src 'self' data:; media-src *; connect-src *|
 			|X-Content-Type-Options |nosniff|
 			|X-Download-Options|noopen|


### PR DESCRIPTION
That was a tough backport of https://github.com/owncloud/core/pull/25043 to stable9 due to many conflicts.

Please review and test @owncloud/filesystem @DeepDiver1975 @nickvergessen @rullzer @guruz 

Sync client download, cadaver download and Chromium download worked properly.
