### PR TITLE
Use capped cache for encryption's user access list

### DIFF
--- a/lib/private/Encryption/File.php
+++ b/lib/private/Encryption/File.php
@@ -22,6 +22,8 @@
 
 namespace OC\Encryption;
 
+use OC\Cache\CappedMemoryCache;
+
 class File implements \OCP\Encryption\IFile {
 
 	/** @var Util */
@@ -36,6 +38,7 @@ class File implements \OCP\Encryption\IFile {
 
 	public function __construct(Util $util) {
 		$this->util = $util;
+		$this->cache = new CappedMemoryCache();
 	}
 
 


### PR DESCRIPTION
For https://github.com/owncloud/core/issues/24403#issuecomment-217817883

@owncloud/filesystem @owncloud/encryption @butonic @mmattel @nickvergessen @rullzer 
