### PR TITLE
Capped cache for cache info in UserMountCache

### DIFF
--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -36,6 +36,7 @@ use OCP\IDBConnection;
 use OCP\ILogger;
 use OCP\IUser;
 use OCP\IUserManager;
+use OC\Cache\CappedMemoryCache;
 
 /**
  * Cache mounts points per user in the cache so we can easilly look them up
@@ -51,15 +52,23 @@ class UserMountCache implements IUserMountCache {
 	 */
 	private $userManager;
 
-	/** @var ICachedMountInfo[][] [$userId => [$cachedMountInfo, ....], ...] */
-	private $mountsForUsers = [];
+	/**
+	 * Cached mount info.
+	 * Map of $userId to ICachedMountInfo.
+	 *
+	 * @var ICache
+	 **/
+	private $mountsForUsers;
 
 	/**
 	 * @var ILogger
 	 */
 	private $logger;
 
-	private $cacheInfoCache = [];
+	/**
+	 * @var ICache
+	 */
+	private $cacheInfoCache;
 
 	/**
 	 * UserMountCache constructor.
@@ -72,6 +81,8 @@ class UserMountCache implements IUserMountCache {
 		$this->connection = $connection;
 		$this->userManager = $userManager;
 		$this->logger = $logger;
+		$this->cacheInfoCache = new CappedMemoryCache();
+		$this->mountsForUsers = new CappedMemoryCache();
 	}
 
 	public function registerMounts(IUser $user, array $mounts) {


### PR DESCRIPTION
@owncloud/filesystem 

I don't think we can use the capped cache for `$mountsForUsers` because the logic doesn't allow so. If we did, it would limit the number of users to 512... possibly 512 received shares or so, which isn't good as it could cause unpredictable effects when exceeding that value.
Or the logic needs to be rewritten to be able to re-resolve the "cache miss" values.

@icewind1991 what do you think ?

CC @butonic 
