### PR TITLE
fail hard if 2fa provider can not be loaded

### DIFF
--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -21,6 +21,7 @@
 
 namespace OC\Authentication\TwoFactorAuth;
 
+use Exception;
 use OC;
 use OC\App\AppManager;
 use OCP\AppFramework\QueryException;
@@ -112,7 +113,8 @@ class Manager {
 					$provider = OC::$server->query($class);
 					$providers[$provider->getId()] = $provider;
 				} catch (QueryException $exc) {
-					// Provider class can not be resolved, ignore it
+					// Provider class can not be resolved
+					throw new Exception("Could not load two-factor auth provider $class");
 				}
 			}
 		}


### PR DESCRIPTION
Simple solution to my question on IRC

```
[15:13:49] <ChristophWurst> What should we do (security-wise) if a 2FA provider can not be loaded? I discovered that my twofactor_totp app does work for the login screen, but resolving the class in an early state of the request fails as the app.php of the app was not loaded yet and the alias registration on the app container is not executed yet. Currently we ignore that https://github.com/owncloud/core/blob/master/lib/private/Authentication/TwoFactorAuth/Manager.php#L103-L124
[15:14:25] <ChristophWurst> However, that leads to the problem where the "is 2FA enabled for this user, so we block password login"-mechanism fails and allows password logins on APIs altough 2FA is enabled
[15:14:29] <ChristophWurst> which is bad, really bad
```

Security-wise it's better to fail than to let someone access the user account although 2FA is enabled.

A [bug in the TOTP provider](https://github.com/ChristophWurst/twofactor_totp/issues/17) revealed this problem. I was able to access webdav via password although the provider was enabled for the user :boom: 
