### PR TITLE
Fix null pointer exception in user_ldap

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -732,7 +732,14 @@ class Access extends LDAPUtility implements IUserTools {
 				$user->unmark();
 				$user = $this->userManager->get($ocName);
 			}
-			$user->processAttributes($userRecord);
+			if ($user !== null) {
+				$user->processAttributes($userRecord);
+			} else {
+				\OC::$server->getLogger()->debug(
+					"The ldap user manager returned null for $ocName",
+					['app'=>'user_ldap']
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
This will prevent upgrade experiences like this:

```
I tried to prepare our next upgrade from 8.2.5 to 9.0.2. The occ-script 
is throwing an error: 

[root@owncloud owncloud_9.0.2]# php55 occ -vvv upgrade 
--skip-migration-test 
ownCloud or one of the apps require upgrade - only a limited number of 
commands are available 
You may use your browser or the occ upgrade command to do the upgrade 
2016-06-06T11:20:43+02:00 Set log level to debug 
2016-06-06T11:20:43+02:00 Turned on maintenance mode 
2016-06-06T11:20:43+02:00 Repair step: Repair MySQL database engine 
2016-06-06T11:20:43+02:00 Repair step: Repair MySQL collation 
2016-06-06T11:20:43+02:00 Repair step: Repair SQLite autoincrement 
2016-06-06T11:20:43+02:00 Repair step: Repair duplicate entries in 
oc_lucene_status 
2016-06-06T11:20:43+02:00 Repair info: lucene_status table does not 
exist -> nothing to do 
2016-06-06T11:20:43+02:00 Updating database schema 
2016-06-06T11:20:44+02:00 Updated database 
2016-06-06T11:20:44+02:00 Disabled 3rd-party app: files_videoviewer 
2016-06-06T11:20:44+02:00 Disabled 3rd-party app: updater 
2016-06-06T11:20:44+02:00 Updating <files_pdfviewer> ... 
2016-06-06T11:20:44+02:00 Updated <files_pdfviewer> to 0.8.1 
2016-06-06T11:20:44+02:00 Updating <files_texteditor> ... 
2016-06-06T11:20:44+02:00 Updated <files_texteditor> to 2.1 
2016-06-06T11:20:44+02:00 Updating <gallery> ... 
2016-06-06T11:20:44+02:00 Updated <gallery> to 14.5.0 
2016-06-06T11:20:44+02:00 Updating <user_ldap> ... 
2016-06-06T11:20:44+02:00 Updated <user_ldap> to 0.8.0 
2016-06-06T11:20:44+02:00 Updating <files> ... 
2016-06-06T11:20:44+02:00 Updated <files> to 1.4.4 
2016-06-06T11:20:44+02:00 Updating <activity> ... 
2016-06-06T11:20:44+02:00 Updated <activity> to 2.2.1 
2016-06-06T11:20:44+02:00 Updating <files_sharing> ... 
2016-06-06T11:20:44+02:00 Updated <files_sharing> to 0.9.1 
2016-06-06T11:20:44+02:00 Updating <files_trashbin> ... 
2016-06-06T11:20:44+02:00 Updated <files_trashbin> to 0.8.0 
2016-06-06T11:20:44+02:00 Updating <files_versions> ... 
2016-06-06T11:20:44+02:00 Updated <files_versions> to 1.2.0 
2016-06-06T11:20:44+02:00 Updating <firewall> ... 
2016-06-06T11:20:44+02:00 Updated <firewall> to 2.3.0 
2016-06-06T11:20:44+02:00 Updating <notifications> ... 
2016-06-06T11:20:44+02:00 Updated <notifications> to 0.2.3 
2016-06-06T11:20:44+02:00 Updating <provisioning_api> ... 
2016-06-06T11:20:44+02:00 Updated <provisioning_api> to 0.4.1 
2016-06-06T11:20:44+02:00 Updating <admin_audit> ... 
2016-06-06T11:20:44+02:00 Updated <admin_audit> to 0.7 
PHP Fatal error: Call to a member function processAttributes() on a 
non-object in 
/var/www/html/owncloud_9.0.2/apps/user_ldap/lib/access.php 
on line 733 
[root@owncloud owncloud_9.0.2]# 
```

Leaves the qestion why do we get null from the ldap user manager ...

00005599
