### PR TITLE
[WIP] use device password as session id

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -116,7 +116,6 @@ class Auth extends AbstractBasic {
 		} else {
 			\OC_Util::setupFS(); //login hooks may need early access to the filesystem
 			if($this->userSession->logClientIn($username, $password)) {
-				$this->userSession->createSessionToken($this->request, $this->userSession->getUser()->getUID(), $username, $password);
 				\OC_Util::setupFS($this->userSession->getUser()->getUID());
 				$this->session->set(self::DAV_AUTHENTICATED, $this->userSession->getUser()->getUID());
 				$this->session->close();

--- a/lib/private/Session/CryptoSessionData.php
+++ b/lib/private/Session/CryptoSessionData.php
@@ -155,6 +155,26 @@ class CryptoSessionData implements \ArrayAccess, ISession {
 	}
 
 	/**
+	 * Wrapper around session_id($id)
+	 *
+	 * @param string $id new session id
+	 * @param bool $copyData copy data into new session
+	 * @throws SessionNotAvailableException
+	 * @since 9.1.0
+	 */
+	public function setId($id, $copyData) {
+		// Flush data
+		if($this->isModified) {
+			$encryptedValue = $this->crypto->encrypt(json_encode($this->sessionValues), $this->passphrase);
+			$this->session->set(self::encryptedSessionName, $encryptedValue);
+		}
+		// Get new session
+		$this->session->setId($id, $copyData);
+		// Copy data back
+		$this->initializeSession();
+	}
+
+	/**
 	 * Close the session and release the lock, also writes all changed data in batch
 	 */
 	public function close() {

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -144,15 +144,14 @@ class Internal extends Session {
 				$oldData[$k] = $this->get($k);
 			}
 		}
+		session_write_close();
 
 		$newId = @session_id($id);
-		@session_start();
-		if ($newId === '') {
+		if ($newId === '' || session_start() === false) {
 			throw new SessionNotAvailableException();
 		}
 
 		if ($copyData) {
-			@session_start();
 			foreach ($oldData as $k => $v) {
 				$this->set($k, $v);
 			}

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -130,6 +130,36 @@ class Internal extends Session {
 	}
 
 	/**
+	 * Wrapper around session_id($id)
+	 *
+	 * @param string $id new session id
+	 * @param bool $copyData copy data into new session
+	 * @throws SessionNotAvailableException
+	 * @since 9.1.0
+	 */
+	public function setId($id, $copyData = true) {
+		if ($copyData) {
+			$oldData = [];
+			foreach ($_SESSION as $k => $v) {
+				$oldData[$k] = $this->get($k);
+			}
+		}
+
+		$newId = @session_id($id);
+		@session_start();
+		if ($newId === '') {
+			throw new SessionNotAvailableException();
+		}
+
+		if ($copyData) {
+			@session_start();
+			foreach ($oldData as $k => $v) {
+				$this->set($k, $v);
+			}
+		}
+	}
+
+	/**
 	 * @throws \Exception
 	 */
 	public function reopen() {

--- a/lib/private/Session/Memory.php
+++ b/lib/private/Session/Memory.php
@@ -103,6 +103,18 @@ class Memory extends Session {
 	}
 
 	/**
+	 * Wrapper around session_id($id)
+	 *
+	 * @param string $id new session id
+	 * @param bool $copyData copy data into new session
+	 * @throws SessionNotAvailableException
+	 * @since 9.1.0
+	 */
+	public function setId($id, $copyData) {
+		throw new SessionNotAvailableException('Memory session does not have an ID');
+	}
+
+	/**
 	 * Helper function for PHPUnit execution - don't use in non-test code
 	 */
 	public function reopen() {

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -296,7 +296,7 @@ class Session implements IUserSession, Emitter {
 	 * @throws LoginException
 	 */
 	public function login($uid, $password) {
-		$this->session->regenerateId();
+		$this->session->regenerateId(true);
 		if ($this->validateToken($password)) {
 			$user = $this->getUser();
 
@@ -367,6 +367,11 @@ class Session implements IUserSession, Emitter {
 				return $this->login($users[0]->getUID(), $password);
 			}
 			return false;
+		}
+		if ($isTokenPassword) {
+			// Let's use the device token as session token
+			$this->session->setId($password);
+			$y = $this->session->getId();
 		}
 		return true;
 	}

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -372,6 +372,10 @@ class Session implements IUserSession, Emitter {
 			// Let's use the device token as session token
 			$this->session->setId($password);
 			$y = $this->session->getId();
+		} else {
+			// Ideally only devices that support tokens should get a session token
+			// See https://github.com/owncloud/core/pull/24742
+			$this->createSessionToken(OC::$server->getRequest(), $this->getUser()->getUID(), $user, $password);
 		}
 		return true;
 	}

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -371,7 +371,6 @@ class Session implements IUserSession, Emitter {
 		if ($isTokenPassword) {
 			// Let's use the device token as session token
 			$this->session->setId($password);
-			$y = $this->session->getId();
 		} else {
 			// Ideally only devices that support tokens should get a session token
 			// See https://github.com/owncloud/core/pull/24742

--- a/lib/private/legacy/api.php
+++ b/lib/private/legacy/api.php
@@ -103,7 +103,6 @@ class OC_API {
 	 * api actions
 	 */
 	protected static $actions = array();
-	private static $logoutRequired = false;
 	private static $isLoggedIn = false;
 
 	/**
@@ -180,9 +179,6 @@ class OC_API {
 		}
 		$response = self::mergeResponses($responses);
 		$format = self::requestedFormat();
-		if (self::$logoutRequired) {
-			\OC::$server->getUserSession()->logout();
-		}
 
 		self::respond($response, $format);
 	}
@@ -369,10 +365,8 @@ class OC_API {
 		} catch (\OC\User\LoginException $e) {
 			return false;
 		}
-	
-		if ($loginSuccess === true) {
-			self::$logoutRequired = true;
 
+		if ($loginSuccess === true) {
 			// initialize the user's filesystem
 			\OC_Util::setupFS(\OC_User::getUser());
 			self::$isLoggedIn = true;

--- a/lib/public/ISession.php
+++ b/lib/public/ISession.php
@@ -105,4 +105,14 @@ interface ISession {
 	 * @since 9.1.0
 	 */
 	public function getId();
+
+	/**
+	 * Wrapper around session_id($id)
+	 *
+	 * @param string new session id
+	 * @param bool copy data into new session
+	 * @throws SessionNotAvailableException
+	 * @since 9.1.0
+	 */
+	public function setId($id, $copyData);
 }


### PR DESCRIPTION
WIP of using the device token as session id. That makes session tokens for devices obsolete, which are hacky anyway. This should be compatible with the current session validation mechanism, that uses the session id to load the token from the token provider.

~~Does not work yet for some reason :cry:~~ works as expected, `session_start()` was needed after setting the ID.

cc @guruz 
