### PR TITLE
Add repair step to reset stray locks

### DIFF
--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -50,6 +50,7 @@ use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use OC\Repair\ClearStrayFileLocks;
 
 class Repair implements IOutput{
 	/* @var IRepairStep[] */
@@ -127,6 +128,7 @@ class Repair implements IOutput{
 			new AssetCache(),
 			new FillETags(\OC::$server->getDatabaseConnection()),
 			new CleanTags(\OC::$server->getDatabaseConnection()),
+			new ClearStrayFileLocks(\OC::$server->getDatabaseConnection()),
 			new DropOldTables(\OC::$server->getDatabaseConnection()),
 			new DropOldJobs(\OC::$server->getJobList()),
 			new RemoveGetETagEntries(\OC::$server->getDatabaseConnection()),

--- a/lib/private/Repair/ClearStrayFileLocks.php
+++ b/lib/private/Repair/ClearStrayFileLocks.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Repair;
+
+use OCP\IDBConnection;
+use OCP\Migration\IRepairStep;
+use OCP\Migration\IOutput;
+
+/**
+ * Repair step that clears stray file locks
+ */
+class ClearStrayFileLocks implements IRepairStep {
+	/**
+	 * @var IDBConnection
+	 **/
+	protected $connection;
+
+	/**
+	 * @param \OCP\IDBConnection $connection
+	 */
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * Returns the step's name
+	 *
+	 * @return string
+	 */
+	public function getName() {
+		return 'Clear stray file locks';
+	}
+
+	/**
+	 * Run repair step.
+	 * Must throw exception on error.
+	 *
+	 * @throws \Exception in case of failure
+	 */
+	public function run(IOutput $output) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->update('file_locks')
+			->set('lock', $qb->expr()->literal(0))
+			->where($qb->expr()->neq('lock', $qb->expr()->literal(0)));
+
+		$result = $qb->execute();
+		$output->info('Cleared ' . $result . ' stray locks');
+	}
+}

--- a/tests/lib/Repair/ClearStrayFileLocksTest.php
+++ b/tests/lib/Repair/ClearStrayFileLocksTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Repair;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Migration\IOutput;
+
+/**
+ * Tests for the clearings stray file locks
+ *
+ * @group DB
+ *
+ * @see \OC\Repair\ClearStrayFileLocks
+ */
+class ClearStrayFileLocksTest extends \Test\TestCase {
+
+	/** @var \OC\Repair\ClearStrayFileLocks */
+	protected $repair;
+
+	/** @var \OCP\IDBConnection */
+	protected $connection;
+
+	/** @var IOutput */
+	private $outputMock;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->repair = new \OC\Repair\ClearStrayFileLocks($this->connection);
+		$this->cleanUpTables();
+	}
+
+	protected function tearDown() {
+		$this->cleanUpTables();
+
+		parent::tearDown();
+	}
+
+	protected function cleanUpTables() {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('file_locks')
+			->execute();
+	}
+
+	private function getLock($key) {
+		$qb = $this->connection->getQueryBuilder();
+		$result = $qb->select('lock')
+			->from('file_locks')
+			->where($qb->expr()->eq('key', $qb->createNamedParameter($key)))
+			->execute();
+
+		$row = $result->fetch();
+		if ($row) {
+			return $row['lock'];
+		}
+		$result->closeCursor();
+		return null;
+	}
+
+	private function addLock($key, $value) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->insert('file_locks')
+			->values([
+				'lock' => $qb->createNamedParameter($value),
+				'key' => $qb->createNamedParameter($key),
+				'ttl' => $qb->createNamedParameter(time() + 3600),
+			])
+			->execute();
+	}
+
+	public function testRun() {
+		$this->addLock('key0', 0);
+		$this->addLock('key-1', -1);
+		$this->addLock('key1', 1);
+		$this->addLock('key2', 2);
+
+		$this->outputMock->expects($this->once())
+			->method('info')
+			->with('Cleared 3 stray locks');
+
+		$this->repair->run($this->outputMock);
+
+		$this->assertEquals(0, $this->getLock('key0'));
+		$this->assertEquals(0, $this->getLock('key-1'));
+		$this->assertEquals(0, $this->getLock('key1'));
+		$this->assertEquals(0, $this->getLock('key2'));
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/24494

Note: I decided to just reset the "lock" value to 0 instead of deleting all entries to prevent bigger database operations (does a DBMS defragment or restructure the data when deleting entries ?).

@owncloud/filesystem @butonic @nickvergessen 
