### PR TITLE
Catch exceptions while creating shared mounts

### DIFF
--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -115,7 +115,8 @@ class Application extends App {
 			$server = $c->query('ServerContainer');
 			return new MountProvider(
 				$server->getConfig(),
-				$server->getShareManager()
+				$server->getShareManager(),
+				$server->getLogger()
 			);
 		});
 


### PR DESCRIPTION
Instead of dying, we leave out the failing mount and log

cc @owncloud/sharing @owncloud/filesystem 
