### PR TITLE
Fix sessionless clients

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -115,8 +115,7 @@ class Auth extends AbstractBasic {
 			return true;
 		} else {
 			\OC_Util::setupFS(); //login hooks may need early access to the filesystem
-			if($this->userSession->logClientIn($username, $password)) {
-				$this->userSession->createSessionToken($this->request, $this->userSession->getUser()->getUID(), $username, $password);
+			if($this->userSession->logClientIn($username, $password, $this->request)) {
 				\OC_Util::setupFS($this->userSession->getUser()->getUID());
 				$this->session->set(self::DAV_AUTHENTICATED, $this->userSession->getUser()->getUID());
 				$this->session->close();

--- a/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
@@ -159,7 +159,7 @@ class AuthTest extends TestCase {
 		$user = $this->getMockBuilder('\OCP\IUser')
 			->disableOriginalConstructor()
 			->getMock();
-		$user->expects($this->exactly(4))
+		$user->expects($this->exactly(3))
 			->method('getUID')
 			->will($this->returnValue('MyTestUser'));
 		$this->userSession
@@ -167,7 +167,7 @@ class AuthTest extends TestCase {
 			->method('isLoggedIn')
 			->will($this->returnValue(true));
 		$this->userSession
-			->expects($this->exactly(4))
+			->expects($this->exactly(3))
 			->method('getUser')
 			->will($this->returnValue($user));
 		$this->session
@@ -178,12 +178,8 @@ class AuthTest extends TestCase {
 		$this->userSession
 			->expects($this->once())
 			->method('logClientIn')
-			->with('MyTestUser', 'MyTestPassword')
+			->with('MyTestUser', 'MyTestPassword', $this->request)
 			->will($this->returnValue(true));
-		$this->userSession
-			->expects($this->once())
-			->method('createSessionToken')
-			->with($this->request, 'MyTestUser', 'MyTestUser', 'MyTestPassword');
 		$this->session
 			->expects($this->once())
 			->method('set')
@@ -626,17 +622,14 @@ class AuthTest extends TestCase {
 			->method('logClientIn')
 			->with('username', 'password')
 			->will($this->returnValue(true));
-		$this->userSession
-			->expects($this->once())
-			->method('createSessionToken');
 		$user = $this->getMockBuilder('\OCP\IUser')
 			->disableOriginalConstructor()
 			->getMock();
-		$user->expects($this->exactly(4))
+		$user->expects($this->exactly(3))
 			->method('getUID')
 			->will($this->returnValue('MyTestUser'));
 		$this->userSession
-			->expects($this->exactly(4))
+			->expects($this->exactly(3))
 			->method('getUser')
 			->will($this->returnValue($user));
 		$response = $this->auth->check($server->httpRequest, $server->httpResponse);

--- a/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
@@ -89,7 +89,7 @@ class CORSMiddleware extends Middleware {
 			$pass = $this->request->server['PHP_AUTH_PW'];
 
 			$this->session->logout();
-			if(!$this->session->logClientIn($user, $pass)) {
+			if(!$this->session->logClientIn($user, $pass, $this->request)) {
 				throw new SecurityException('CORS requires basic auth', Http::STATUS_UNAUTHORIZED);
 			}
 		}

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -348,10 +348,11 @@ class Session implements IUserSession, Emitter {
 	 *
 	 * @param string $user
 	 * @param string $password
+	 * @param IRequest $request
 	 * @throws LoginException
 	 * @return boolean
 	 */
-	public function logClientIn($user, $password) {
+	public function logClientIn($user, $password, IRequest $request) {
 		$isTokenPassword = $this->isTokenPassword($password);
 		if (!$isTokenPassword && $this->isTokenAuthEnforced()) {
 			// TODO: throw LoginException instead (https://github.com/owncloud/core/pull/24616)
@@ -368,6 +369,9 @@ class Session implements IUserSession, Emitter {
 			}
 			return false;
 		}
+
+		$this->createSessionToken($request, $this->getUser()->getUID(), $user, $password);
+
 		return true;
 	}
 
@@ -428,7 +432,8 @@ class Session implements IUserSession, Emitter {
 	 */
 	public function tryBasicAuthLogin(IRequest $request) {
 		if (!empty($request->server['PHP_AUTH_USER']) && !empty($request->server['PHP_AUTH_PW'])) {
-			$result = $this->logClientIn($request->server['PHP_AUTH_USER'], $request->server['PHP_AUTH_PW']);
+			$request = \OC::$server->getRequest();
+			$result = $this->logClientIn($request->server['PHP_AUTH_USER'], $request->server['PHP_AUTH_PW'], $request);
 			if ($result === true) {
 				/**
 				 * Add DAV authenticated. This should in an ideal world not be

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -370,9 +370,19 @@ class Session implements IUserSession, Emitter {
 			return false;
 		}
 
-		$this->createSessionToken($request, $this->getUser()->getUID(), $user, $password);
+		if ($this->supportsCookies($request)) {
+			$this->createSessionToken($request, $this->getUser()->getUID(), $user, $password);
+		}
 
 		return true;
+	}
+
+	protected function supportsCookies(IRequest $request) {
+		if (!is_null($request->getCookie('cookie_test'))) {
+			return true;
+		}
+		setcookie('cookie_test', 'test', $this->timeFacory->getTime() + 3600);
+		return false;
 	}
 
 	private function isTokenAuthEnforced() {
@@ -432,7 +442,6 @@ class Session implements IUserSession, Emitter {
 	 */
 	public function tryBasicAuthLogin(IRequest $request) {
 		if (!empty($request->server['PHP_AUTH_USER']) && !empty($request->server['PHP_AUTH_PW'])) {
-			$request = \OC::$server->getRequest();
 			$result = $this->logClientIn($request->server['PHP_AUTH_USER'], $request->server['PHP_AUTH_PW'], $request);
 			if ($result === true) {
 				/**

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -311,11 +311,13 @@ class SessionTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$session = $this->getMock('\OCP\ISession');
+		$request = $this->getMock('\OCP\IRequest');
+		$user = $this->getMock('\OCP\IUser');
 
 		/** @var \OC\User\Session $userSession */
 		$userSession = $this->getMockBuilder('\OC\User\Session')
 			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config])
-			->setMethods(['login'])
+			->setMethods(['login', 'supportsCookies', 'createSessionToken', 'getUser'])
 			->getMock();
 
 		$this->tokenProvider->expects($this->once())
@@ -327,7 +329,46 @@ class SessionTest extends \Test\TestCase {
 			->with('token_auth_enforced', false)
 			->will($this->returnValue(true));
 
-		$this->assertFalse($userSession->logClientIn('john', 'doe'));
+		$this->assertFalse($userSession->logClientIn('john', 'doe', $request));
+	}
+
+	public function testLogClientInWithTokenPassword() {
+		$manager = $this->getMockBuilder('\OC\User\Manager')
+			->disableOriginalConstructor()
+			->getMock();
+		$session = $this->getMock('\OCP\ISession');
+		$request = $this->getMock('\OCP\IRequest');
+		$user = $this->getMock('\OCP\IUser');
+
+		/** @var \OC\User\Session $userSession */
+		$userSession = $this->getMockBuilder('\OC\User\Session')
+			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config])
+			->setMethods(['isTokenPassword', 'login', 'supportsCookies', 'createSessionToken', 'getUser'])
+			->getMock();
+
+		$userSession->expects($this->once())
+			->method('isTokenPassword')
+			->will($this->returnValue(true));
+		$userSession->expects($this->once())
+			->method('login')
+			->with('john', 'doe')
+			->will($this->returnValue(true));
+
+		$userSession->expects($this->once())
+			->method('supportsCookies')
+			->with($request)
+			->will($this->returnValue(true));
+		$userSession->expects($this->once())
+			->method('getUser')
+			->will($this->returnValue($user));
+		$user->expects($this->once())
+			->method('getUID')
+			->will($this->returnValue('user123'));
+		$userSession->expects($this->once())
+			->method('createSessionToken')
+			->with($request, 'user123', 'john', 'doe');
+		
+		$this->assertTrue($userSession->logClientIn('john', 'doe', $request));
 	}
 
 	public function testLogClientInNoTokenPasswordNo2fa() {
@@ -336,6 +377,7 @@ class SessionTest extends \Test\TestCase {
 			->getMock();
 		$session = $this->getMock('\OCP\ISession');
 		$user = $this->getMock('\OCP\IUser');
+		$request = $this->getMock('\OCP\IRequest');
 
 		/** @var \OC\User\Session $userSession */
 		$userSession = $this->getMockBuilder('\OC\User\Session')
@@ -357,7 +399,7 @@ class SessionTest extends \Test\TestCase {
 			->with('john')
 			->will($this->returnValue(true));
 
-		$this->assertFalse($userSession->logClientIn('john', 'doe'));
+		$this->assertFalse($userSession->logClientIn('john', 'doe', $request));
 	}
 
 	public function testRememberLoginValidToken() {


### PR DESCRIPTION
fixes #25059

TODO
- [x] fix/add tests

This way we do not create a session token for clients if they do not support cookies. Otherwise the list of connected browsers was spammed.

Can be tested with curl:

``` bash
$ for x in {1..50}; do curl --request PROPFIND -u admin:YDOAF-MFAGV-LXZEE-JTERS http://localhost:8080/remote.php/webdav; done
```

cc @LukasReschke @PVince81 @guruz
