### PR TITLE
[stable9] Use capped cache for encryption's user access list

### DIFF
--- a/lib/private/encryption/file.php
+++ b/lib/private/encryption/file.php
@@ -22,6 +22,8 @@
 
 namespace OC\Encryption;
 
+use OC\Cache\CappedMemoryCache;
+
 class File implements \OCP\Encryption\IFile {
 
 	/** @var Util */
@@ -36,6 +38,7 @@ class File implements \OCP\Encryption\IFile {
 
 	public function __construct(Util $util) {
 		$this->util = $util;
+		$this->cache = new CappedMemoryCache();
 	}
 
 


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/25055 to stable9

Please review @nickvergessen @owncloud/filesystem @owncloud/encryption @butonic 
