### PR TITLE
[WIP] Throw exception on invalid limit offset combo when running on oracle

### DIFF
--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -23,7 +23,9 @@
 
 namespace OC\DB\QueryBuilder;
 
+use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use OC\DB\OracleConnection;
 use OC\DB\QueryBuilder\ExpressionBuilder\ExpressionBuilder;
@@ -138,6 +140,10 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return \Doctrine\DBAL\Driver\Statement|int
 	 */
 	public function execute() {
+		if ($this->getFirstResult() > 0 && $this->getMaxResults() <= 0
+		&& $this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+			throw new InvalidArgumentException("Oracle requires limit to be > 0 when an offset is used. But it is ".$this->getMaxResults());
+		}
 		return $this->queryBuilder->execute();
 	}
 


### PR DESCRIPTION
On oracle Doctrine silently ignores an offset when no limit has been given. This can lead to weird problems. This PR throws an exception instead of ignoring the problem to prevent endless loops, see https://github.com/owncloud/core/pull/25094

Do NOT merge this pr as it would break listing shares. It is intended to check our CI for other problematic calls.
