### PR TITLE
redirect to new login route

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -962,11 +962,12 @@ class OC_Util {
 	public static function checkLoggedIn() {
 		// Check if we are a user
 		if (!OC_User::isLoggedIn()) {
-			header('Location: ' . \OCP\Util::linkToAbsolute('', 'index.php',
-					[
-						'redirect_url' => \OC::$server->getRequest()->getRequestUri()
-					]
-				)
+			header('Location: ' . \OC::$server->getURLGenerator()->linkToRoute(
+						'core.login.showLoginForm',
+						[
+							'redirect_url' => urlencode(\OC::$server->getRequest()->getRequestUri()),
+						]
+					)
 			);
 			exit();
 		}

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -368,6 +368,17 @@ $(document).ready(function () {
 		collection: collection
 	});
 	view.reload();
+
+	// 'redirect' to anchor sections
+	// anchors are lost on redirects (e.g. while solving the 2fa challenge) otherwise
+	// example: /settings/person?section=devices will result in /settings/person?#devices
+	if (!window.location.hash) {
+		var query = OC.parseQueryString(location.search);
+		if (query && query.section) {
+			OC.Util.History.replaceState({});
+			window.location.hash = query.section;
+		}
+	}
 });
 
 if (!OC.Encryption) {


### PR DESCRIPTION
fixes #25097

Apparently that piece of code redirected to the index page, which worked before we had the explicit /login route.

@ogoffart @PVince81 @rullzer review please
