### PR TITLE
Hash class+arguments in joblist for indexing

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -991,10 +991,27 @@
 				<notnull>false</notnull>
 			</field>
 
+			<field>
+				<!-- sha1 hash of the class+arguments to have more efficient checking -->
+				<name>hash</name>
+				<type>text</type>
+				<default></default>
+				<length>40</length>
+				<notnull>false</notnull>
+			</field>
+
 			<index>
 				<name>job_class_index</name>
 				<field>
 					<name>class</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+
+			<index>
+				<name>job_hash</name>
+				<field>
+					<name>hash</name>
 					<sorting>ascending</sorting>
 				</field>
 			</index>

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -34,6 +34,7 @@ use OC\Repair\AvatarPermissions;
 use OC\Repair\CleanTags;
 use OC\Repair\Collation;
 use OC\Repair\DropOldJobs;
+use OC\Repair\JobHash;
 use OC\Repair\OldGroupMembershipShares;
 use OC\Repair\RemoveGetETagEntries;
 use OC\Repair\RemoveOldShares;
@@ -156,6 +157,7 @@ class Repair implements IOutput{
 				\OC::$server->getUserManager(),
 				\OC::$server->getGroupManager()
 			),
+			new JobHash(\OC::$server->getDatabaseConnection()),
 		];
 	}
 

--- a/lib/private/Repair/JobHash.php
+++ b/lib/private/Repair/JobHash.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Repair;
+
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+/**
+ * Class JobHash
+ *
+ * @package OC\Repair
+ */
+class JobHash implements IRepairStep {
+
+	/** @var IDBConnection */
+	protected $connection;
+
+	/**
+	 * JobHash constructor.
+	 *
+	 * @param IDBConnection $connection
+	 */
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getName() {
+		return 'Add hash to job table to allow quick lookup';
+	}
+
+	/**
+	 * @param IOutput $output
+	 */
+	public function run(IOutput $output) {
+		while(true) {
+			$qb = $this->connection->getQueryBuilder();
+			$qb->select('id', 'class', 'argument')
+				->from('jobs')
+				->where($qb->expr()->isNull('hash'))
+				->setMaxResults(1000);
+
+			$cursor = $qb->execute();
+			$data = $cursor->fetchAll();
+			$cursor->closeCursor();
+
+			if (count($data) === 0) {
+				break;
+			}
+
+			$hashes = [];
+			foreach ($data as $d) {
+				if ($d['argument'] === null || $d['argument'] === '') {
+					$d['argument'] = json_encode(null);
+
+					$qb = $this->connection->getQueryBuilder();
+					$qb->update('jobs')
+						->set('argument', $qb->expr()->literal($d['argument']));
+					$qb->execute();
+				}
+
+				$hashes[$d['id']] = sha1($d['class'] . $d['argument']);
+			}
+
+			foreach ($hashes as $id => $hash) {
+				$qb = $this->connection->getQueryBuilder();
+				$qb->update('jobs')
+					->set('hash', $qb->createNamedParameter($hash))
+					->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
+				$qb->execute();
+			}
+		}
+	}
+}

--- a/tests/lib/Repair/JobHashTest.php
+++ b/tests/lib/Repair/JobHashTest.php
@@ -73,6 +73,13 @@ class JobHashTest extends \Test\TestCase {
 			['\OC\My\Class', json_encode('my arguments'), 'my arguments'],
 			['\OC\My\Class', json_encode(''), ''],
 			['\OC\My\Class', json_encode(null), null],
+			['\OC\My\Class', json_encode([]), []],
+			['\OC\My\Class', json_encode([[], []]), [[], []]],
+			['\OC\My\Class', json_encode([[true], [false], [1]]), [[true], [false], [1]]],
+			['\OC\My\Class', json_encode(['one' => 1, 'two' => 2, 'true' => true]), ['one' => 1, 'two' => 2, 'true' => true]],
+			['\OC\My\Class', json_encode(1), 1],
+			['\OC\My\Class', json_encode(new \stdclass()), new \stdclass()],
+			['\OC\My\Class', json_encode((array)(new \stdclass())), (array)(new \stdclass())],
 			['\OC\My\Class', null, null],
 		];
 	}

--- a/tests/lib/Repair/JobHashTest.php
+++ b/tests/lib/Repair/JobHashTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace Test\Repair;
+
+use OC\Repair\JobHash;
+use OCP\BackgroundJob\IJobList;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+
+/**
+ * @group DB
+ *
+ * @see \OC\Repair\JobHashTest
+ */
+class JobHashTest extends \Test\TestCase {
+
+	/** @var JobHash */
+	protected $repair;
+
+	/** @var IDBConnection */
+	protected $connection;
+
+	/** @var IJobList */
+	protected $jobList;
+
+	/** @var IOutput */
+	private $outputMock;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->repair = new JobHash($this->connection);
+		$this->jobList = \OC::$server->getJobList();
+		$this->cleanUpTables();
+	}
+
+	protected function tearDown() {
+		$this->cleanUpTables();
+
+		parent::tearDown();
+	}
+
+	protected function cleanUpTables() {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('jobs')->execute();
+	}
+
+	public function testData() {
+		return [
+			['\OC\My\Class', json_encode('my arguments'), 'my arguments'],
+			['\OC\My\Class', json_encode(''), ''],
+			['\OC\My\Class', json_encode(null), null],
+			['\OC\My\Class', null, null],
+		];
+	}
+
+	/**
+	 * @dataProvider testData
+	 */
+	public function testRun($class, $arguments, $argCall) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->insert('jobs')
+			->values([
+				'class' => $qb->expr()->literal($class),
+				'argument' => $qb->expr()->literal($arguments),
+			]);
+		$qb->execute();
+
+		$this->assertFalse($this->jobList->has($class, $argCall));
+
+		$this->repair->run($this->outputMock);
+
+		$this->assertTrue($this->jobList->has($class, $argCall));
+	}
+
+}

--- a/tests/lib/Repair/JobHashTest.php
+++ b/tests/lib/Repair/JobHashTest.php
@@ -80,7 +80,6 @@ class JobHashTest extends \Test\TestCase {
 			['\OC\My\Class', json_encode(1), 1],
 			['\OC\My\Class', json_encode(new \stdclass()), new \stdclass()],
 			['\OC\My\Class', json_encode((array)(new \stdclass())), (array)(new \stdclass())],
-			['\OC\My\Class', null, null],
 		];
 	}
 
@@ -91,8 +90,8 @@ class JobHashTest extends \Test\TestCase {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->insert('jobs')
 			->values([
-				'class' => $qb->expr()->literal($class),
-				'argument' => $qb->expr()->literal($arguments),
+				'class' => $qb->createNamedParameter($class),
+				'argument' => $qb->createNamedParameter($arguments),
 			]);
 		$qb->execute();
 


### PR DESCRIPTION
Fixes #23420

Since we can't index class + arguments this PR introduces a hash column. Here we calculate the sha1 of the `$class . $argument`. This we then in turn can index.

Assuming the database is smart enough to first lookup the index and only then compare class and arguments (to guard against the very unlikely hash collisions).

CC: @PVince81 @nickvergessen @DeepDiver1975
