### PR TITLE
Preview delete performance

### DIFF
--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -25,6 +25,8 @@
  */
 
 namespace OC\Files\Cache;
+
+use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Cache\IUpdater;
 use OCP\Files\Storage\IStorage;
 
@@ -150,12 +152,20 @@ class Updater implements IUpdater {
 			$parent = '';
 		}
 
+		$entry = $this->cache->get($path);
+
 		$this->cache->remove($path);
-		if ($this->cache instanceof Cache) {
-			$this->cache->correctFolderSize($parent);
-		}
+
 		$this->correctParentStorageMtime($path);
-		$this->propagator->propagateChange($path, time());
+		if ($entry instanceof ICacheEntry) {
+			$this->propagator->propagateChange($path, time(), -$entry->getSize());
+		} else {
+			$this->propagator->propagateChange($path, time());
+			if ($this->cache instanceof Cache) {
+				$this->cache->correctFolderSize($parent);
+			}
+		}
+
 	}
 
 	/**

--- a/lib/private/Preview.php
+++ b/lib/private/Preview.php
@@ -422,7 +422,6 @@ class Preview {
 				// .ocTransferId*.part file from chunked file upload.
 				if (!empty($fileId)) {
 					$previewPath = $this->getPreviewPath($fileId);
-					$this->userView->deleteAll($previewPath);
 					$this->userView->rmdir($previewPath);
 				}
 			}

--- a/lib/private/Preview.php
+++ b/lib/private/Preview.php
@@ -136,9 +136,9 @@ class Preview {
 
 		//check if there are preview backends
 		if (!\OC::$server->getPreviewManager()
-						 ->hasProviders()
+				->hasProviders()
 			&& \OC::$server->getConfig()
-						   ->getSystemValue('enable_previews', true)
+				->getSystemValue('enable_previews', true)
 		) {
 			\OCP\Util::writeLog('core', 'No preview providers exist', \OCP\Util::ERROR);
 			throw new \Exception('No preview providers');
@@ -410,6 +410,10 @@ class Preview {
 	 * Deletes all previews of a file
 	 */
 	public function deleteAllPreviews() {
+		$thumbnailMount = $this->userView->getMount($this->getThumbnailsFolder());
+		$propagator = $thumbnailMount->getStorage()->getPropagator();
+		$propagator->beginBatch();
+
 		$toDelete = $this->getChildren();
 		$toDelete[] = $this->getFileInfo();
 
@@ -426,6 +430,8 @@ class Preview {
 				}
 			}
 		}
+
+		$propagator->commitBatch();
 	}
 
 	/**
@@ -572,8 +578,8 @@ class Preview {
 	 * @return integer[]
 	 */
 	private function applyAspectRatio($askedWidth, $askedHeight, $originalWidth = 0, $originalHeight = 0) {
-		if(!$originalWidth){
-			$originalWidth= $this->maxPreviewWidth;
+		if (!$originalWidth) {
+			$originalWidth = $this->maxPreviewWidth;
 		}
 		if (!$originalHeight) {
 			$originalHeight = $this->maxPreviewHeight;
@@ -1112,7 +1118,7 @@ class Preview {
 		$preview = null;
 
 		$previewProviders = \OC::$server->getPreviewManager()
-										->getProviders();
+			->getProviders();
 		foreach ($previewProviders as $supportedMimeType => $providers) {
 			if (!preg_match($supportedMimeType, $this->mimeType)) {
 				continue;
@@ -1126,7 +1132,7 @@ class Preview {
 
 				\OCP\Util::writeLog(
 					'core', 'Generating preview for "' . $file . '" with "' . get_class($provider)
-							. '"', \OCP\Util::DEBUG
+					. '"', \OCP\Util::DEBUG
 				);
 
 				/** @var $provider Provider */
@@ -1260,7 +1266,7 @@ class Preview {
 
 		$absPath = Files\Filesystem::normalizePath($view->getAbsolutePath($path));
 		$fileInfo = $view->getFileInfo($path);
-		if($fileInfo === false) {
+		if ($fileInfo === false) {
 			return;
 		}
 		self::addPathToDeleteFileMapper($absPath, $fileInfo);


### PR DESCRIPTION
Improves performance of deleting multiple previews:
- remove the duplicate call to `rmdir`
- enable propagator batching
- enable optimized size propagation for deletes

Combine to about [50% less time](https://blackfire.io/profiles/compare/ac9533e3-da04-4528-887a-7b272c573dad/graph) spend deleting a folder with ~150 files

cc @owncloud/filesystem 
