### PR TITLE
Convert Dropbox Forbidden exception to StorageNotAvailableException

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Dropbox.php
+++ b/apps/files_external/lib/Lib/Storage/Dropbox.php
@@ -32,6 +32,7 @@ namespace OCA\Files_External\Lib\Storage;
 use GuzzleHttp\Exception\RequestException;
 use Icewind\Streams\IteratorDirectory;
 use Icewind\Streams\RetryWrapper;
+use OCP\Files\StorageNotAvailableException;
 
 require_once __DIR__ . '/../../../3rdparty/Dropbox/autoload.php';
 
@@ -94,6 +95,8 @@ class Dropbox extends \OC\Files\Storage\Common {
 			if ($list) {
 				try {
 					$response = $this->dropbox->getMetaData($path);
+				} catch (\Dropbox_Exception_Forbidden $e) {
+					throw new StorageNotAvailableException('Dropbox API rate limit exceeded', StorageNotAvailableException::STATUS_ERROR, $e);
 				} catch (\Exception $exception) {
 					\OCP\Util::writeLog('files_external', $exception->getMessage(), \OCP\Util::ERROR);
 					return false;
@@ -127,6 +130,8 @@ class Dropbox extends \OC\Files\Storage\Common {
 						return $response;
 					}
 					return null;
+				} catch (\Dropbox_Exception_Forbidden $e) {
+					throw new StorageNotAvailableException('Dropbox API rate limit exceeded', StorageNotAvailableException::STATUS_ERROR, $e);
 				} catch (\Exception $exception) {
 					if ($exception instanceof \Dropbox_Exception_NotFound) {
 						// don't log, might be a file_exist check


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/24739

Basically Dropbox's Forbidden exception is almost always about an error in the request, server error or rate limit error, never something about the files directly. So we can assume that it's about the server not being available temporarily and convert it to StorageNotAvailableException.

This prevents the bad code path that returns `false` and makes the caller think that the file/folder does not exist any more (false positive).

Please review @owncloud/filesystem @faulix

Would be good to backport this to 9.0 and maybe 8.2 too @DeepDiver1975 @dragotin 
