### PR TITLE
[stable9] Allow empty host when installing on oracle via CLI (#25034)

### DIFF
--- a/core/command/maintenance/install.php
+++ b/core/command/maintenance/install.php
@@ -106,7 +106,12 @@ class Install extends Command {
 		$dbUser = $input->getOption('database-user');
 		$dbPass = $input->getOption('database-pass');
 		$dbName = $input->getOption('database-name');
-		$dbHost = $input->getOption('database-host');
+		if ($db === 'oci') {
+			// an empty hostname needs to be read from the raw parameters
+			$dbHost = $input->getParameterOption('--database-host', '');
+		} else {
+			$dbHost = $input->getOption('database-host');
+		}
 		$dbTablePrefix = 'oc_';
 		if ($input->hasParameterOption('--database-table-prefix')) {
 			$dbTablePrefix = (string) $input->getOption('database-table-prefix');


### PR DESCRIPTION
backport of https://github.com/owncloud/core/pull/25034 to stable9
