### PR TITLE
Update start-swift-ceph.sh

### DIFF
--- a/apps/files_external/tests/env/start-swift-ceph.sh
+++ b/apps/files_external/tests/env/start-swift-ceph.sh
@@ -24,6 +24,9 @@ docker_image=xenopathic/ceph-keystone
 echo "Fetch recent ${docker_image} docker image"
 docker pull ${docker_image}
 
+# debian 8 default comes without loaded loop module. please run "sudo modprobe loop" if you get an error here:
+lsmod | grep '^loop' || { echo "Error: kernel module loop not loaded. Needed by docker image ${docker_image}"; exit 1; }
+
 # retrieve current folder to place the config in the parent folder
 thisFolder=`echo $0 | sed 's#env/start-swift-ceph\.sh##'`
 


### PR DESCRIPTION
Verbose diagnostics with failing https://ci.owncloud.org/job/server-master-linux-externals/database=sqlite,external=swift-ceph,label=SLAVE/

@DeepDiver1975 we need a 'modprobe loop' somewhere in the ansible scripts. Please advise.
