### PR TITLE
Additional settings for admin, to forbit users deleting (unshare) …

### DIFF
--- a/lib/private/Files/FileInfo.php
+++ b/lib/private/Files/FileInfo.php
@@ -210,6 +210,11 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 		if (\OCP\Util::isSharingDisabledForUser() || ($this->isShared() && !\OC\Share\Share::isResharingAllowed())) {
 			$perms = $perms & ~\OCP\Constants::PERMISSION_SHARE;
 		}
+		if ($this->isShared() && ($this->internalPath == "")) {
+			if (\OC::$server->getConfig()->getAppValue('core', 'shareapi_allow_delete_root_share', 'yes') !== 'yes') {
+				$perms = $perms & ~\OCP\Constants::PERMISSION_DELETE;
+			}
+		}
 		return $perms;
 	}
 

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -769,9 +769,8 @@ class View {
 				if ($internalPath1 === '' and $mount1 instanceof MoveableMount) {
 					if (\OC::$server->getConfig()->getAppValue('core', 'shareapi_allow_rename_root_share', 'yes') !== 'yes') {
 						$result = false;
-						return false;
 					}
-					if ($this->isTargetAllowed($absolutePath2)) {
+					elseif ($this->isTargetAllowed($absolutePath2)) {
 						/**
 						 * @var \OC\Files\Mount\MountPoint | \OC\Files\Mount\MoveableMount $mount1
 						 */

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -767,6 +767,10 @@ class View {
 				$this->changeLock($path2, ILockingProvider::LOCK_EXCLUSIVE, true);
 
 				if ($internalPath1 === '' and $mount1 instanceof MoveableMount) {
+					if (\OC::$server->getConfig()->getAppValue('core', 'shareapi_allow_rename_root_share', 'yes') !== 'yes') {
+						$result = false;
+						return false;
+					}
 					if ($this->isTargetAllowed($absolutePath2)) {
 						/**
 						 * @var \OC\Files\Mount\MountPoint | \OC\Files\Mount\MoveableMount $mount1

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -144,6 +144,8 @@ $template->assign('allowResharing', $appConfig->getValue('core', 'shareapi_allow
 $template->assign('allowPublicMailNotification', $appConfig->getValue('core', 'shareapi_allow_public_notification', 'no'));
 $template->assign('allowMailNotification', $appConfig->getValue('core', 'shareapi_allow_mail_notification', 'no'));
 $template->assign('allowShareDialogUserEnumeration', $appConfig->getValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes'));
+$template->assign('allowDeleteRootShare', $appConfig->getValue('core', 'shareapi_allow_delete_root_share', 'yes'));
+$template->assign('allowRenameRootShare', $appConfig->getValue('core', 'shareapi_allow_rename_root_share', 'yes'));
 $template->assign('onlyShareWithGroupMembers', \OC\Share\Share::shareWithGroupMembersOnly());
 $template->assign('allowGroupSharing', $appConfig->getValue('core', 'shareapi_allow_group_sharing', 'yes'));
 $databaseOverload = (strpos(\OCP\Config::getSystemValue('dbtype'), 'sqlite') !== false);

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -278,6 +278,16 @@ if ($_['cronErrors']) {
 				<?php if ($_['allowShareDialogUserEnumeration'] === 'yes') print_unescaped('checked="checked"'); ?> />
 			<label for="shareapi_allow_share_dialog_user_enumeration"><?php p($l->t('Allow username autocompletion in share dialog. If this is disabled the full username needs to be entered.'));?></label><br />
 		</p>
+		<p class="<?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
+			<input type="checkbox" name="shareapi_allow_delete_root_share" value="1" id="shareapi_allow_delete_root_share" class="checkbox"
+				<?php if ($_['allowDeleteRootShare'] === 'yes') print_unescaped('checked="checked"'); ?> />
+			<label for="shareapi_allow_delete_root_share"><?php p($l->t('Allow user to delete a root share folder or file.'));?></label><br />
+		</p>
+		<p class="<?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
+			<input type="checkbox" name="shareapi_allow_rename_root_share" value="1" id="shareapi_allow_rename_root_share" class="checkbox"
+				<?php if ($_['allowRenameRootShare'] === 'yes') print_unescaped('checked="checked"'); ?> />
+			<label for="shareapi_allow_rename_root_share"><?php p($l->t('Allow user to rename a root share folder or file.'));?></label><br />
+		</p>
 
 		<?php print_unescaped($_['fileSharingSettings']); ?>
 	</div>


### PR DESCRIPTION
…or renaming their shared root folders or files.

So two new checkboxes are added to admin settings
- allowDeleteRootShare --> Uncheck to forbid deleting the root share
- allowRenameRootShare --> Uncheck to forbid renaming the root share

This is sometimes helpful, to ensure, that all users can see what you have shared with them.
Then you can also be sure, that the folder name is the same.

I have not yet translated the text for booth checkboxes.
