### PR TITLE
files_external: Keep checkbox and its label on one line

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -854,7 +854,7 @@ MountConfigListView.prototype = _.extend({
 		this.configureAuthMechanism($tr, storageConfig.authMechanism, onCompletion);
 
 		if (storageConfig.backendOptions) {
-			$td.children().each(function() {
+			$td.find('input, select').each(function() {
 				var input = $(this);
 				var val = storageConfig.backendOptions[input.data('parameter')];
 				if (val !== undefined) {
@@ -1001,7 +1001,7 @@ MountConfigListView.prototype = _.extend({
 			newElement = $('<input type="password" class="'+classes.join(' ')+'" data-parameter="'+parameter+'" placeholder="'+ trimmedPlaceholder+'" />');
 		} else if (placeholder.type === MountConfigListView.ParameterTypes.BOOLEAN) {
 			var checkboxId = _.uniqueId('checkbox_');
-			newElement = $('<input type="checkbox" id="'+checkboxId+'" class="'+classes.join(' ')+'" data-parameter="'+parameter+'" /><label for="'+checkboxId+'">'+ trimmedPlaceholder+'</label>');
+			newElement = $('<div><label><input type="checkbox" id="'+checkboxId+'" class="'+classes.join(' ')+'" data-parameter="'+parameter+'" />'+ trimmedPlaceholder+'</label></div>');
 		} else if (placeholder.type === MountConfigListView.ParameterTypes.HIDDEN) {
 			newElement = $('<input type="hidden" class="'+classes.join(' ')+'" data-parameter="'+parameter+'" />');
 		} else {

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -51,13 +51,17 @@
 			break;
 		case DefinitionParameter::VALUE_BOOLEAN: ?>
 			<?php $checkboxId = uniqid("checkbox_"); ?>
+			<div>
+			<label>
 			<input type="checkbox"
 				id="<?php p($checkboxId); ?>"
 				<?php if (!empty($classes)): ?> class="checkbox <?php p(implode(' ', $classes)); ?>"<?php endif; ?>
 				data-parameter="<?php p($parameter->getName()); ?>"
 				<?php if ($value === true): ?> checked="checked"<?php endif; ?>
 			/>
-			<label for="<?php p($checkboxId); ?>"><?php p($placeholder); ?></label>
+			<?php p($placeholder); ?>
+			</label>
+			</div>
 			<?php
 			break;
 		case DefinitionParameter::VALUE_HIDDEN: ?>


### PR DESCRIPTION
Else the checkbox and the decription end up on different lines in my Chrome on OS X

I only saw the settings.js executed, not the PHP. Can anyone tell me where/how the PHP part is used?
