### PR TITLE
Fix scanner lock on shared storages resulting into locked files

### DIFF
--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -261,7 +261,7 @@ class Scanner extends BasicEmitter {
 			$reuse = ($recursive === self::SCAN_SHALLOW) ? self::REUSE_ETAG | self::REUSE_SIZE : self::REUSE_ETAG;
 		}
 		if ($lock) {
-			$this->storage->acquireLock('scanner::' . $path, ILockingProvider::LOCK_EXCLUSIVE, $this->lockingProvider);
+			$this->lockingProvider->acquireLock('scanner::' . $this->storageId . '::' . $path, ILockingProvider::LOCK_EXCLUSIVE);
 			$this->storage->acquireLock($path, ILockingProvider::LOCK_SHARED, $this->lockingProvider);
 		}
 		$data = $this->scanFile($path, $reuse, -1, null, $lock);
@@ -271,7 +271,7 @@ class Scanner extends BasicEmitter {
 		}
 		if ($lock) {
 			$this->storage->releaseLock($path, ILockingProvider::LOCK_SHARED, $this->lockingProvider);
-			$this->storage->releaseLock('scanner::' . $path, ILockingProvider::LOCK_EXCLUSIVE, $this->lockingProvider);
+			$this->lockingProvider->releaseLock('scanner::' . $this->storageId . '::' . $path, ILockingProvider::LOCK_EXCLUSIVE);
 		}
 		return $data;
 	}


### PR DESCRIPTION
The problem was caused by prepending the `scanner::` to the path passed to `SharedStorage::acquireLock`, in < 9.0 passing a non-existing path results it in acquiring the lock on the root of the shared storage, this causes a lock conflict with the lock acquired on the next line

By calling the locking provider directly we bypass this issue

cc @owncloud/filesystem @owncloud/sharing 
