### PR TITLE
Add timeouts to make the UI usable again when a remote share is unrea…

### DIFF
--- a/apps/federatedfilesharing/lib/DiscoveryManager.php
+++ b/apps/federatedfilesharing/lib/DiscoveryManager.php
@@ -85,8 +85,8 @@ class DiscoveryManager {
 		// Read the data from the response body
 		try {
 			$response = $this->client->get($remote . '/ocs-provider/', [
-				'timeout' => 3,
-				'connect_timeout' => 3,
+				'timeout' => 10,
+				'connect_timeout' => 10,
 			]);
 			if($response->getStatusCode() === 200) {
 				$decodedService = json_decode($response->getBody(), true);

--- a/apps/federatedfilesharing/lib/DiscoveryManager.php
+++ b/apps/federatedfilesharing/lib/DiscoveryManager.php
@@ -84,7 +84,10 @@ class DiscoveryManager {
 
 		// Read the data from the response body
 		try {
-			$response = $this->client->get($remote . '/ocs-provider/');
+			$response = $this->client->get($remote . '/ocs-provider/', [
+				'timeout' => 3,
+				'connect_timeout' => 3,
+			]);
 			if($response->getStatusCode() === 200) {
 				$decodedService = json_decode($response->getBody(), true);
 				if(is_array($decodedService)) {

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -288,8 +288,8 @@ class Notifications {
 			try {
 				$response = $client->post($protocol . $remoteDomain . $endpoint . $urlSuffix . '?format=' . self::RESPONSE_FORMAT, [
 					'body' => $fields,
-					'timeout' => 3,
-					'connect_timeout' => 3,
+					'timeout' => 10,
+					'connect_timeout' => 10,
 				]);
 				$result['result'] = $response->getBody();
 				$result['success'] = true;

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -287,7 +287,9 @@ class Notifications {
 			$endpoint = $this->discoveryManager->getShareEndpoint($protocol . $remoteDomain);
 			try {
 				$response = $client->post($protocol . $remoteDomain . $endpoint . $urlSuffix . '?format=' . self::RESPONSE_FORMAT, [
-					'body' => $fields
+					'body' => $fields,
+					'timeout' => 3,
+					'connect_timeout' => 3,
 				]);
 				$result['result'] = $response->getBody();
 				$result['success'] = true;

--- a/apps/federatedfilesharing/tests/DiscoveryManagerTest.php
+++ b/apps/federatedfilesharing/tests/DiscoveryManagerTest.php
@@ -77,7 +77,10 @@ class DiscoveryManagerTest extends \Test\TestCase {
 		$this->client
 			->expects($this->once())
 			->method('get')
-			->with('https://myhost.com/ocs-provider/', [])
+			->with('https://myhost.com/ocs-provider/', [
+				'timeout' => 10,
+				'connect_timeout' => 10,
+			])
 			->willReturn($response);
 		$this->cache
 			->expects($this->at(0))
@@ -111,7 +114,10 @@ class DiscoveryManagerTest extends \Test\TestCase {
 		$this->client
 			->expects($this->once())
 			->method('get')
-			->with('https://myhost.com/ocs-provider/', [])
+			->with('https://myhost.com/ocs-provider/', [
+				'timeout' => 10,
+				'connect_timeout' => 10,
+			])
 			->willReturn($response);
 
 		$expectedResult = '/public.php/MyCustomEndpoint/';
@@ -131,7 +137,10 @@ class DiscoveryManagerTest extends \Test\TestCase {
 		$this->client
 			->expects($this->once())
 			->method('get')
-			->with('https://myhost.com/ocs-provider/', [])
+			->with('https://myhost.com/ocs-provider/', [
+				'timeout' => 10,
+				'connect_timeout' => 10,
+			])
 			->willReturn($response);
 
 		$expectedResult = '/public.php/webdav';
@@ -151,7 +160,10 @@ class DiscoveryManagerTest extends \Test\TestCase {
 		$this->client
 			->expects($this->once())
 			->method('get')
-			->with('https://myhost.com/ocs-provider/', [])
+			->with('https://myhost.com/ocs-provider/', [
+				'timeout' => 10,
+				'connect_timeout' => 10,
+			])
 			->willReturn($response);
 
 		$expectedResult = '/ocs/v2.php/cloud/MyCustomShareEndpoint';
@@ -171,7 +183,10 @@ class DiscoveryManagerTest extends \Test\TestCase {
 		$this->client
 			->expects($this->once())
 			->method('get')
-			->with('https://myhost.com/ocs-provider/', [])
+			->with('https://myhost.com/ocs-provider/', [
+				'timeout' => 10,
+				'connect_timeout' => 10,
+			])
 			->willReturn($response);
 		$this->cache
 			->expects($this->at(0))

--- a/apps/files_sharing/ajax/external.php
+++ b/apps/files_sharing/ajax/external.php
@@ -77,7 +77,10 @@ $externalManager = new \OCA\Files_Sharing\External\Manager(
 // check for ssl cert
 if (substr($remote, 0, 5) === 'https') {
 	try {
-		\OC::$server->getHTTPClientService()->newClient()->get($remote)->getBody();
+		\OC::$server->getHTTPClientService()->newClient()->get($remote, [
+			'timeout' => 3,
+			'connect_timeout' => 3,
+		])->getBody();
 	} catch (\Exception $e) {
 		\OCP\JSON::error(array('data' => array('message' => $l->t('Invalid or untrusted SSL certificate'))));
 		exit;

--- a/apps/files_sharing/ajax/external.php
+++ b/apps/files_sharing/ajax/external.php
@@ -78,8 +78,8 @@ $externalManager = new \OCA\Files_Sharing\External\Manager(
 if (substr($remote, 0, 5) === 'https') {
 	try {
 		\OC::$server->getHTTPClientService()->newClient()->get($remote, [
-			'timeout' => 3,
-			'connect_timeout' => 3,
+			'timeout' => 10,
+			'connect_timeout' => 10,
 		])->getBody();
 	} catch (\Exception $e) {
 		\OCP\JSON::error(array('data' => array('message' => $l->t('Invalid or untrusted SSL certificate'))));

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -254,7 +254,10 @@ class Storage extends DAV implements ISharedStorage {
 
 		$client = $this->httpClient->newClient();
 		try {
-			$result = $client->get($url)->getBody();
+			$result = $client->get($url, [
+				'timeout' => 3,
+				'connect_timeout' => 3,
+			])->getBody();
 			$data = json_decode($result);
 			$returnValue = (is_object($data) && !empty($data->version));
 		} catch (ConnectException $e) {
@@ -301,7 +304,11 @@ class Storage extends DAV implements ISharedStorage {
 		// TODO: DI
 		$client = \OC::$server->getHTTPClientService()->newClient();
 		try {
-			$response = $client->post($url, ['body' => ['password' => $password]]);
+			$response = $client->post($url, [
+				'body' => ['password' => $password],
+				'timeout' => 3,
+				'connect_timeout' => 3,
+			]);
 		} catch (\GuzzleHttp\Exception\RequestException $e) {
 			if ($e->getCode() === 401 || $e->getCode() === 403) {
 				throw new ForbiddenException();

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -255,8 +255,8 @@ class Storage extends DAV implements ISharedStorage {
 		$client = $this->httpClient->newClient();
 		try {
 			$result = $client->get($url, [
-				'timeout' => 3,
-				'connect_timeout' => 3,
+				'timeout' => 10,
+				'connect_timeout' => 10,
 			])->getBody();
 			$data = json_decode($result);
 			$returnValue = (is_object($data) && !empty($data->version));
@@ -306,8 +306,8 @@ class Storage extends DAV implements ISharedStorage {
 		try {
 			$response = $client->post($url, [
 				'body' => ['password' => $password],
-				'timeout' => 3,
-				'connect_timeout' => 3,
+				'timeout' => 10,
+				'connect_timeout' => 10,
 			]);
 		} catch (\GuzzleHttp\Exception\RequestException $e) {
 			if ($e->getCode() === 401 || $e->getCode() === 403) {


### PR DESCRIPTION
…chable
### Steps
1. Make a local remote share and accept
2. Change the URL in share_external to an URL that is invalid (not 404 or anything else) e.g. jobisch.no-ip.org
3. Change the md5 in storages to `md5(share_external.share_token . '@' . share_external.remote)`
4. Open the UI for the recipient
### Before

Not reachable
### After

Takes 3 seconds then it shows up.

Fix #23005

The UI is now usable (after the 3 sec timeout), but the share can still not be removed correctly.
Will have a look at that tomorrow.
