### PR TITLE
load 2FA provider apps before querying classes

### DIFF
--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -24,6 +24,7 @@ namespace OC\Authentication\TwoFactorAuth;
 use Exception;
 use OC;
 use OC\App\AppManager;
+use OC_App;
 use OCP\AppFramework\QueryException;
 use OCP\Authentication\TwoFactorAuth\IProvider;
 use OCP\IConfig;
@@ -110,6 +111,7 @@ class Manager {
 			$providerClasses = $info['two-factor-providers'];
 			foreach ($providerClasses as $class) {
 				try {
+					$this->loadTwoFactorApp($appId);
 					$provider = OC::$server->query($class);
 					$providers[$provider->getId()] = $provider;
 				} catch (QueryException $exc) {
@@ -123,6 +125,17 @@ class Manager {
 			/* @var $provider IProvider */
 			return $provider->isTwoFactorAuthEnabledForUser($user);
 		});
+	}
+
+	/**
+	 * Load an app by ID if it has not been loaded yet
+	 *
+	 * @param string $appId
+	 */
+	protected function loadTwoFactorApp($appId) {
+		if (!OC_App::isAppLoaded($appId)) {
+			OC_App::loadApp($appId);
+		}
 	}
 
 	/**

--- a/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
@@ -86,6 +86,10 @@ class ManagerTest extends TestCase {
 						'\OCA\MyCustom2faApp\FakeProvider',
 					],
 		]));
+
+		$this->manager->expects($this->once())
+			->method('loadTwoFactorApp')
+			->with('mycustom2faapp');
 	}
 
 	/**
@@ -97,6 +101,9 @@ class ManagerTest extends TestCase {
 			->method('getEnabledAppsForUser')
 			->with($this->user)
 			->will($this->returnValue(['faulty2faapp']));
+		$this->manager->expects($this->once())
+			->method('loadTwoFactorApp')
+			->with('faulty2faapp');
 
 		$this->appManager->expects($this->once())
 			->method('getAppInfo')

--- a/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
@@ -55,7 +55,10 @@ class ManagerTest extends TestCase {
 		$this->session = $this->getMock('\OCP\ISession');
 		$this->config = $this->getMock('\OCP\IConfig');
 
-		$this->manager = new Manager($this->appManager, $this->session, $this->config);
+		$this->manager = $this->getMockBuilder('\OC\Authentication\TwoFactorAuth\Manager')
+			->setConstructorArgs([$this->appManager, $this->session, $this->config])
+			->setMethods(['loadTwoFactorApp']) // Do not actually load the apps
+			->getMock();
 
 		$this->fakeProvider = $this->getMock('\OCP\Authentication\TwoFactorAuth\IProvider');
 		$this->fakeProvider->expects($this->any())


### PR DESCRIPTION
fixes https://github.com/ChristophWurst/twofactor_totp/issues/17

This makes sure that apps are actually loaded before we query their classes as some apps rely on running `app.php` before they are used.

Before

```
curl --request PROPFIND -u admin:admin http://localhost:8080/remote.php/webdav                                                                                                    
<?xml version="1.0" encoding="utf-8"?>                                                                                                                                                                                  
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">                                                                                                                                                               
  <s:exception>Sabre\DAV\Exception\ServiceUnavailable</s:exception>                                                                                                                                                     
  <s:message>Exception: Could not load two-factor auth provider OCA\TwoFactor_Totp\Provider\TotpProvider</s:message>                                                                                                    
</d:error> 
```

After

```
curl --request PROPFIND -u admin:admin http://localhost:8080/remote.php/webdav                                                                                                          
<?xml version="1.0" encoding="utf-8"?>                                                                                                                                                                                  
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">                                                                                                                                                               
  <s:exception>Sabre\DAV\Exception\NotAuthenticated</s:exception>                                                                                                                                                       
  <s:message>Username or password was incorrect</s:message>                                                                                                                                                             
</d:error> 
```

(401 is expected as 2fa forbids password logins)
