### PR TITLE
Prevent the advanced options toggle in the setup from acting as a link

### DIFF
--- a/core/js/setup.js
+++ b/core/js/setup.js
@@ -43,7 +43,8 @@ $(document).ready(function() {
 
 	$('input[checked]').trigger('click');
 
-	$('#showAdvanced').click(function() {
+	$('#showAdvanced').click(function(e) {
+		e.preventDefault();
 		$('#datadirContent').slideToggle(250);
 		$('#databaseBackend').slideToggle(250);
 		$('#databaseField').slideToggle(250);


### PR DESCRIPTION
Prevent it from reloading the page

No clue why this wasn't needed before or why things aren't burning down everywhere.

I tested it back till 8.1 and it seems broken to me for all versions I tested.

cc @PVince81 
