### PR TITLE
[stable9] Make getShareFolder use given view instead of static FS

### DIFF
--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -302,19 +302,23 @@ class Helper {
 	/**
 	 * get default share folder
 	 *
+	 * @param \OC\Files\View
 	 * @return string
 	 */
-	public static function getShareFolder() {
+	public static function getShareFolder($view = null) {
+		if ($view === null) {
+			$view = Filesystem::getView();
+		}
 		$shareFolder = \OC::$server->getConfig()->getSystemValue('share_folder', '/');
 		$shareFolder = Filesystem::normalizePath($shareFolder);
 
-		if (!Filesystem::file_exists($shareFolder)) {
+		if (!$view->file_exists($shareFolder)) {
 			$dir = '';
 			$subdirs = explode('/', $shareFolder);
 			foreach ($subdirs as $subdir) {
 				$dir = $dir . '/' . $subdir;
-				if (!Filesystem::is_dir($dir)) {
-					Filesystem::mkdir($dir);
+				if (!$view->is_dir($dir)) {
+					$view->mkdir($dir);
 				}
 			}
 		}

--- a/apps/files_sharing/lib/sharedmount.php
+++ b/apps/files_sharing/lib/sharedmount.php
@@ -75,7 +75,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 		$parent = dirname($share['file_target']);
 
 		if (!$this->recipientView->is_dir($parent)) {
-			$parent = Helper::getShareFolder();
+			$parent = Helper::getShareFolder($this->recipientView);
 		}
 
 		$newMountPoint = \OCA\Files_Sharing\Helper::generateUniqueTarget(


### PR DESCRIPTION
Workaround that makes https://github.com/owncloud/core/issues/24423 work again.

However in that specific scenario the skeleton files won't be copied.

The code change itself should be fine as it makes use of a real view instance.

@icewind1991 @rullzer @butonic 
