### PR TITLE
Delay getRootFolder from RemoveRootShares repair step

### DIFF
--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -137,7 +137,7 @@ class Repair implements IOutput{
 			new SharePropagation(\OC::$server->getConfig()),
 			new RemoveOldShares(\OC::$server->getDatabaseConnection()),
 			new AvatarPermissions(\OC::$server->getDatabaseConnection()),
-			new RemoveRootShares(\OC::$server->getDatabaseConnection(), \OC::$server->getUserManager(), \OC::$server->getRootFolder()),
+			new RemoveRootShares(\OC::$server->getDatabaseConnection(), \OC::$server->getUserManager(), \OC::$server->getLazyRootFolder()),
 		];
 	}
 


### PR DESCRIPTION
This prevents the command registration to setup the FS too early when
FS-related apps might need upgrading.

Fixes https://github.com/owncloud/core/issues/25156

Please review @owncloud/sharing @owncloud/filesystem @DeepDiver1975 @butonic
