### PR TITLE
Delay files_sharing's registerMountProviders

### DIFF
--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -32,13 +32,13 @@ $l = \OC::$server->getL10N('files_sharing');
 \OC::$CLASSPATH['OC_Share_Backend_Folder'] = 'files_sharing/lib/share/folder.php';
 \OC::$CLASSPATH['OC\Files\Storage\Shared'] = 'files_sharing/lib/sharedstorage.php';
 
-$application = new \OCA\Files_Sharing\AppInfo\Application();
-$application->registerMountProviders();
-
 \OCA\Files_Sharing\Helper::registerHooks();
 
 \OCP\Share::registerBackend('file', 'OC_Share_Backend_File');
 \OCP\Share::registerBackend('folder', 'OC_Share_Backend_Folder', 'file');
+
+$application = new \OCA\Files_Sharing\AppInfo\Application();
+$application->registerMountProviders();
 
 $eventDispatcher = \OC::$server->getEventDispatcher();
 $eventDispatcher->addListener(


### PR DESCRIPTION
This moves registerMountProviders until after the sharing backends were
registered. In some situations registerMountProviders will trigger
listeners which might require filesystem access which itself would
mount shares, which itself requires the sharing backends to be
initialized.

Fixes https://github.com/owncloud/core/issues/23497

Please review @owncloud/sharing @owncloud/filesystem 

We should backport this to 9.0 to avoid update issues with shares in some envs. @DeepDiver1975 @dragotin 
