### PR TITLE
Make getShareFolder use given view instead of static FS

### DIFF
--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -277,19 +277,23 @@ class Helper {
 	/**
 	 * get default share folder
 	 *
+	 * @param \OC\Files\View
 	 * @return string
 	 */
-	public static function getShareFolder() {
+	public static function getShareFolder($view = null) {
+		if ($view === null) {
+			$view = Filesystem::getView();
+		}
 		$shareFolder = \OC::$server->getConfig()->getSystemValue('share_folder', '/');
 		$shareFolder = Filesystem::normalizePath($shareFolder);
 
-		if (!Filesystem::file_exists($shareFolder)) {
+		if (!$view->file_exists($shareFolder)) {
 			$dir = '';
 			$subdirs = explode('/', $shareFolder);
 			foreach ($subdirs as $subdir) {
 				$dir = $dir . '/' . $subdir;
-				if (!Filesystem::is_dir($dir)) {
-					Filesystem::mkdir($dir);
+				if (!$view->is_dir($dir)) {
+					$view->mkdir($dir);
 				}
 			}
 		}

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -81,7 +81,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 		$parent = dirname($share->getTarget());
 
 		if (!$this->recipientView->is_dir($parent)) {
-			$parent = Helper::getShareFolder();
+			$parent = Helper::getShareFolder($this->recipientView);
 		}
 
 		$newMountPoint = $this->generateUniqueTarget(


### PR DESCRIPTION
Workaround that makes #24423 work again.

However in that specific scenario the skeleton files won't be copied.

The code change itself should be fine as it makes use of a real view instance.

(forward port of https://github.com/owncloud/core/pull/25150 to 9.1/master)

Please review @owncloud/sharing @owncloud/filesystem 
