### PR TITLE
[stable9] Capped cache for user config

### DIFF
--- a/lib/private/allconfig.php
+++ b/lib/private/allconfig.php
@@ -27,6 +27,7 @@
  */
 
 namespace OC;
+use OC\Cache\CappedMemoryCache;
 use OCP\IDBConnection;
 use OCP\PreConditionNotMetException;
 
@@ -58,14 +59,15 @@ class AllConfig implements \OCP\IConfig {
 	 *   - deleteAllUserValues
 	 *   - deleteAppFromAllUsers
 	 *
-	 * @var array $userCache
+	 * @var CappedMemoryCache $userCache
 	 */
-	private $userCache = array();
+	private $userCache;
 
 	/**
 	 * @param SystemConfig $systemConfig
 	 */
 	function __construct(SystemConfig $systemConfig) {
+		$this->userCache = new CappedMemoryCache();
 		$this->systemConfig = $systemConfig;
 	}
 


### PR DESCRIPTION
use a capped memory cache for user config. during migration we check if a user is enabled ... causing the code to accumulate user config for all users.

ref https://github.com/owncloud/core/issues/24403
