### PR TITLE
[stable9] Add support to know where the storage test comes from

### DIFF
--- a/apps/files_external/controller/globalstoragescontroller.php
+++ b/apps/files_external/controller/globalstoragescontroller.php
@@ -131,6 +131,7 @@ class GlobalStoragesController extends StoragesController {
 	 * @param array $applicableUsers users for which to mount the storage
 	 * @param array $applicableGroups groups for which to mount the storage
 	 * @param int $priority priority
+	 * @param bool $testOnly whether to storage should only test the connection or do more things
 	 *
 	 * @return DataResponse
 	 */
@@ -143,7 +144,8 @@ class GlobalStoragesController extends StoragesController {
 		$mountOptions,
 		$applicableUsers,
 		$applicableGroups,
-		$priority
+		$priority,
+		$testOnly = true
 	) {
 		$storage = $this->createStorage(
 			$mountPoint,
@@ -176,7 +178,7 @@ class GlobalStoragesController extends StoragesController {
 			);
 		}
 
-		$this->updateStorageStatus($storage);
+		$this->updateStorageStatus($storage, $testOnly);
 
 		return new DataResponse(
 			$storage,

--- a/apps/files_external/controller/storagescontroller.php
+++ b/apps/files_external/controller/storagescontroller.php
@@ -240,8 +240,9 @@ abstract class StoragesController extends Controller {
 	 * on whether the remote storage is available or not.
 	 *
 	 * @param StorageConfig $storage storage configuration
+	 * @param bool $testOnly whether to storage should only test the connection or do more things
 	 */
-	protected function updateStorageStatus(StorageConfig &$storage) {
+	protected function updateStorageStatus(StorageConfig &$storage, $testOnly = true) {
 		try {
 			$this->manipulateStorageConfig($storage);
 
@@ -252,7 +253,8 @@ abstract class StoragesController extends Controller {
 				\OC_Mount_Config::getBackendStatus(
 					$backend->getStorageClass(),
 					$storage->getBackendOptions(),
-					false
+					false,
+					$testOnly
 				)
 			);
 		} catch (InsufficientDataForMeaningfulAnswerException $e) {
@@ -293,14 +295,15 @@ abstract class StoragesController extends Controller {
 	 * Get an external storage entry.
 	 *
 	 * @param int $id storage id
+	 * @param bool $testOnly whether to storage should only test the connection or do more things
 	 *
 	 * @return DataResponse
 	 */
-	public function show($id) {
+	public function show($id, $testOnly = true) {
 		try {
 			$storage = $this->service->getStorage($id);
 
-			$this->updateStorageStatus($storage);
+			$this->updateStorageStatus($storage, $testOnly);
 		} catch (NotFoundException $e) {
 			return new DataResponse(
 				[

--- a/apps/files_external/controller/userglobalstoragescontroller.php
+++ b/apps/files_external/controller/userglobalstoragescontroller.php
@@ -106,15 +106,16 @@ class UserGlobalStoragesController extends StoragesController {
 	 * Get an external storage entry.
 	 *
 	 * @param int $id storage id
+	 * @param bool $testOnly whether to storage should only test the connection or do more things
 	 * @return DataResponse
 	 *
 	 * @NoAdminRequired
 	 */
-	public function show($id) {
+	public function show($id, $testOnly = true) {
 		try {
 			$storage = $this->service->getStorage($id);
 
-			$this->updateStorageStatus($storage);
+			$this->updateStorageStatus($storage, $testOnly);
 		} catch (NotFoundException $e) {
 			return new DataResponse(
 				[
@@ -138,6 +139,7 @@ class UserGlobalStoragesController extends StoragesController {
 	 *
 	 * @param int $id storage id
 	 * @param array $backendOptions backend-specific options
+	 * @param bool $testOnly whether to storage should only test the connection or do more things
 	 *
 	 * @return DataResponse
 	 *
@@ -145,7 +147,8 @@ class UserGlobalStoragesController extends StoragesController {
 	 */
 	public function update(
 		$id,
-		$backendOptions
+		$backendOptions,
+		$testOnly = true
 	) {
 		try {
 			$storage = $this->service->getStorage($id);
@@ -170,7 +173,7 @@ class UserGlobalStoragesController extends StoragesController {
 			);
 		}
 
-		$this->updateStorageStatus($storage);
+		$this->updateStorageStatus($storage, $testOnly);
 		$this->sanitizeStorage($storage);
 
 		return new DataResponse(

--- a/apps/files_external/controller/userstoragescontroller.php
+++ b/apps/files_external/controller/userstoragescontroller.php
@@ -104,8 +104,8 @@ class UserStoragesController extends StoragesController {
 	 *
 	 * {@inheritdoc}
 	 */
-	public function show($id) {
-		return parent::show($id);
+	public function show($id, $testOnly = true) {
+		return parent::show($id, $testOnly);
 	}
 
 	/**
@@ -162,6 +162,7 @@ class UserStoragesController extends StoragesController {
 	 * @param string $authMechanism authentication mechanism identifier
 	 * @param array $backendOptions backend-specific options
 	 * @param array $mountOptions backend-specific mount options
+	 * @param bool $testOnly whether to storage should only test the connection or do more things
 	 *
 	 * @return DataResponse
 	 *
@@ -173,7 +174,8 @@ class UserStoragesController extends StoragesController {
 		$backend,
 		$authMechanism,
 		$backendOptions,
-		$mountOptions
+		$mountOptions,
+		$testOnly = true
 	) {
 		$storage = $this->createStorage(
 			$mountPoint,
@@ -203,7 +205,7 @@ class UserStoragesController extends StoragesController {
 			);
 		}
 
-		$this->updateStorageStatus($storage);
+		$this->updateStorageStatus($storage, $testOnly);
 
 		return new DataResponse(
 			$storage,

--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -305,7 +305,8 @@ StorageConfig.prototype = {
 			mountPoint: this.mountPoint,
 			backend: this.backend,
 			authMechanism: this.authMechanism,
-			backendOptions: this.backendOptions
+			backendOptions: this.backendOptions,
+			testOnly: true
 		};
 		if (this.id) {
 			data.id = this.id;
@@ -332,6 +333,7 @@ StorageConfig.prototype = {
 		$.ajax({
 			type: 'GET',
 			url: OC.generateUrl(this._url + '/{id}', {id: this.id}),
+			data: {'testOnly': true},
 			success: options.success,
 			error: options.error
 		});
@@ -911,6 +913,7 @@ MountConfigListView.prototype = _.extend({
 			$.ajax({
 				type: 'GET',
 				url: OC.generateUrl('apps/files_external/userglobalstorages'),
+				data: {'testOnly': true},
 				contentType: 'application/json',
 				success: function(result) {
 					var onCompletion = jQuery.Deferred();

--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -78,6 +78,7 @@ OCA.External.StatusManager = {
 			defObj = $.ajax({
 				type: 'GET',
 				url: OC.webroot + '/index.php/apps/files_external/' + ((mountData.type === 'personal') ? 'userstorages' : 'userglobalstorages') + '/' + mountData.id,
+				data: {'testOnly': false},
 				success: function (response) {
 					if (response && response.status === 0) {
 						self.mountStatus[mountData.mount_point] = response;

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -215,7 +215,7 @@ class OC_Mount_Config {
 	 * @return int see self::STATUS_*
 	 * @throws Exception
 	 */
-	public static function getBackendStatus($class, $options, $isPersonal) {
+	public static function getBackendStatus($class, $options, $isPersonal, $testOnly = true) {
 		if (self::$skipTest) {
 			return StorageNotAvailableException::STATUS_SUCCESS;
 		}
@@ -228,7 +228,7 @@ class OC_Mount_Config {
 				$storage = new $class($options);
 
 				try {
-					$result = $storage->test($isPersonal);
+					$result = $storage->test($isPersonal, $testOnly);
 					$storage->setAvailability($result);
 					if ($result) {
 						return StorageNotAvailableException::STATUS_SUCCESS;

--- a/apps/files_external/tests/js/settingsSpec.js
+++ b/apps/files_external/tests/js/settingsSpec.js
@@ -223,7 +223,8 @@ describe('OCA.External.Settings tests', function() {
 					applicableGroups: [],
 					mountOptions: {
 						'previews': true
-					}
+					},
+					testOnly: true
 				});
 
 				// TODO: respond and check data-id


### PR DESCRIPTION
(manual) backport of https://github.com/owncloud/core/pull/25008 to stable9 . Minor changes have been added (mainly boolean conversions that weren't required for master)

Required for https://github.com/owncloud/windows_network_drive/pull/408
