### PR TITLE
Token login validation

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -1120,6 +1120,15 @@
 				<length>4</length>
 			</field>
 
+			<field>
+				<name>last_check</name>
+				<type>integer</type>
+				<default>0</default>
+				<notnull>true</notnull>
+				<unsigned>true</unsigned>
+				<length>4</length>
+			</field>
+
 			<index>
 				<name>authtoken_token_index</name>
 				<unique>true</unique>

--- a/lib/private/Authentication/Token/DefaultToken.php
+++ b/lib/private/Authentication/Token/DefaultToken.php
@@ -74,6 +74,11 @@ class DefaultToken extends Entity implements IToken {
 	 */
 	protected $lastActivity;
 
+	/**
+	 * @var int
+	 */
+	protected $lastCheck;
+
 	public function getId() {
 		return $this->id;
 	}
@@ -107,6 +112,24 @@ class DefaultToken extends Entity implements IToken {
 			'lastActivity' => $this->lastActivity,
 			'type' => $this->type,
 		];
+	}
+
+	/**
+	 * Get the timestamp of the last password check
+	 *
+	 * @return int
+	 */
+	public function getLastCheck() {
+		return parent::getLastCheck();
+	}
+
+	/**
+	 * Get the timestamp of the last password check
+	 *
+	 * @param int $time
+	 */
+	public function setLastCheck($time) {
+		return parent::setLastCheck($time);
 	}
 
 }

--- a/lib/private/Authentication/Token/DefaultTokenMapper.php
+++ b/lib/private/Authentication/Token/DefaultTokenMapper.php
@@ -70,7 +70,7 @@ class DefaultTokenMapper extends Mapper {
 	public function getToken($token) {
 		/* @var $qb IQueryBuilder */
 		$qb = $this->db->getQueryBuilder();
-		$result = $qb->select('id', 'uid', 'login_name', 'password', 'name', 'type', 'token', 'last_activity')
+		$result = $qb->select('id', 'uid', 'login_name', 'password', 'name', 'type', 'token', 'last_activity', 'last_check')
 			->from('authtoken')
 			->where($qb->expr()->eq('token', $qb->createParameter('token')))
 			->setParameter('token', $token)
@@ -95,7 +95,7 @@ class DefaultTokenMapper extends Mapper {
 	public function getTokenByUser(IUser $user) {
 		/* @var $qb IQueryBuilder */
 		$qb = $this->db->getQueryBuilder();
-		$qb->select('id', 'uid', 'login_name', 'password', 'name', 'type', 'token', 'last_activity')
+		$qb->select('id', 'uid', 'login_name', 'password', 'name', 'type', 'token', 'last_activity', 'last_check')
 			->from('authtoken')
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
 			->setMaxResults(1000);

--- a/lib/private/Authentication/Token/DefaultTokenProvider.php
+++ b/lib/private/Authentication/Token/DefaultTokenProvider.php
@@ -92,6 +92,18 @@ class DefaultTokenProvider implements IProvider {
 	}
 
 	/**
+	 * Save the updated token
+	 *
+	 * @param IToken $token
+	 */
+	public function updateToken(IToken $token) {
+		if (!($token instanceof DefaultToken)) {
+			throw new InvalidTokenException();
+		}
+		$this->mapper->update($token);
+	}
+
+	/**
 	 * Update token activity timestamp
 	 *
 	 * @throws InvalidTokenException
@@ -179,21 +191,6 @@ class DefaultTokenProvider implements IProvider {
 		$olderThan = $this->time->getTime() - (int) $this->config->getSystemValue('session_lifetime', 60 * 60 * 24);
 		$this->logger->info('Invalidating tokens older than ' . date('c', $olderThan));
 		$this->mapper->invalidateOld($olderThan);
-	}
-
-	/**
-	 * @param string $token
-	 * @throws InvalidTokenException
-	 * @return DefaultToken user UID
-	 */
-	public function validateToken($token) {
-		try {
-			$dbToken = $this->mapper->getToken($this->hashToken($token));
-			$this->logger->debug('valid default token for ' . $dbToken->getUID());
-			return $dbToken;
-		} catch (DoesNotExistException $ex) {
-			throw new InvalidTokenException();
-		}
 	}
 
 	/**

--- a/lib/private/Authentication/Token/DefaultTokenProvider.php
+++ b/lib/private/Authentication/Token/DefaultTokenProvider.php
@@ -97,14 +97,17 @@ class DefaultTokenProvider implements IProvider {
 	 * @throws InvalidTokenException
 	 * @param IToken $token
 	 */
-	public function updateToken(IToken $token) {
+	public function updateTokenActivity(IToken $token) {
 		if (!($token instanceof DefaultToken)) {
 			throw new InvalidTokenException();
 		}
 		/** @var DefaultToken $token */
-		$token->setLastActivity($this->time->getTime());
-
-		$this->mapper->update($token);
+		$now = $this->time->getTime();
+		if ($token->getLastActivity() < ($now - 60)) {
+			// Update token only once per minute
+			$token->setLastActivity($now);
+			$this->mapper->update($token);
+		}
 	}
 
 	/**

--- a/lib/private/Authentication/Token/IProvider.php
+++ b/lib/private/Authentication/Token/IProvider.php
@@ -76,7 +76,7 @@ interface IProvider {
 	 *
 	 * @param IToken $token
 	 */
-	public function updateToken(IToken $token);
+	public function updateTokenActivity(IToken $token);
 
 	/**
 	 * Get all token of a user

--- a/lib/private/Authentication/Token/IProvider.php
+++ b/lib/private/Authentication/Token/IProvider.php
@@ -50,13 +50,6 @@ interface IProvider {
 	public function getToken($tokenId) ;
 
 	/**
-	 * @param string $token
-	 * @throws InvalidTokenException
-	 * @return IToken
-	 */
-	public function validateToken($token);
-
-	/**
 	 * Invalidate (delete) the given session token
 	 *
 	 * @param string $token
@@ -70,6 +63,13 @@ interface IProvider {
 	 * @param int $id
 	 */
 	public function invalidateTokenById(IUser $user, $id);
+
+	/**
+	 * Save the updated token
+	 *
+	 * @param IToken $token
+	 */
+	public function updateToken(IToken $token);
 
 	/**
 	 * Update token activity timestamp

--- a/lib/private/Authentication/Token/IToken.php
+++ b/lib/private/Authentication/Token/IToken.php
@@ -55,4 +55,18 @@ interface IToken extends JsonSerializable {
 	 * @return string
 	 */
 	public function getPassword();
+
+	/**
+	 * Get the timestamp of the last password check
+	 *
+	 * @return int
+	 */
+	public function getLastCheck();
+
+	/**
+	 * Get the timestamp of the last password check
+	 *
+	 * @param int $time
+	 */
+	public function setLastCheck($time);
 }

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -454,12 +454,13 @@ class Session implements IUserSession, Emitter {
 		}
 		$uid = $dbToken->getUID();
 
+		$password = '';
 		try {
 			$password = $this->tokenProvider->getPassword($dbToken, $token);
-			$this->manager->emit('\OC\User', 'preLogin', array($uid, $password));
 		} catch (PasswordlessTokenException $ex) {
-			$this->manager->emit('\OC\User', 'preLogin', array($uid, ''));
+			// Ignore and use empty string instead
 		}
+		$this->manager->emit('\OC\User', 'preLogin', array($uid, $password));
 
 		$user = $this->manager->get($uid);
 		if (is_null($user)) {

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -237,8 +237,7 @@ class Session implements IUserSession, Emitter {
 			$this->session->set('last_login_check', $now);
 		}
 
-		// Session is valid, so the token can be refreshed
-		$this->updateToken($token);
+		$this->tokenProvider->updateTokenActivity($token);
 	}
 
 	/**
@@ -541,7 +540,7 @@ class Session implements IUserSession, Emitter {
 				$result = $this->loginWithToken($token->getUID());
 				if ($result) {
 					// Login success
-					$this->updateToken($token);
+					$this->tokenProvider->updateTokenActivity($token);
 					return true;
 				}
 			}
@@ -549,19 +548,6 @@ class Session implements IUserSession, Emitter {
 
 		}
 		return false;
-	}
-
-	/**
-	 * @param IToken $token
-	 */
-	private function updateToken(IToken $token) {
-		// To save unnecessary DB queries, this is only done once a minute
-		$lastTokenUpdate = $this->session->get('last_token_update') ? : 0;
-		$now = $this->timeFacory->getTime();
-		if ($lastTokenUpdate < ($now - 60)) {
-			$this->tokenProvider->updateToken($token);
-			$this->session->set('last_token_update', $now);
-		}
 	}
 
 	/**

--- a/tests/lib/Authentication/Token/DefaultTokenMapperTest.php
+++ b/tests/lib/Authentication/Token/DefaultTokenMapperTest.php
@@ -63,6 +63,7 @@ class DefaultTokenMapperTest extends TestCase {
 			'token' => $qb->createNamedParameter('9c5a2e661482b65597408a6bb6c4a3d1af36337381872ac56e445a06cdb7fea2b1039db707545c11027a4966919918b19d875a8b774840b18c6cbb7ae56fe206'),
 			'type' => $qb->createNamedParameter(IToken::TEMPORARY_TOKEN),
 			'last_activity' => $qb->createNamedParameter($this->time - 120, IQueryBuilder::PARAM_INT), // Two minutes ago
+			'last_check' => $this->time - 60 * 10, // 10mins ago
 		])->execute();
 		$qb->insert('authtoken')->values([
 			'uid' => $qb->createNamedParameter('user2'),
@@ -72,6 +73,7 @@ class DefaultTokenMapperTest extends TestCase {
 			'token' => $qb->createNamedParameter('1504445f1524fc801035448a95681a9378ba2e83930c814546c56e5d6ebde221198792fd900c88ed5ead0555780dad1ebce3370d7e154941cd5de87eb419899b'),
 			'type' => $qb->createNamedParameter(IToken::TEMPORARY_TOKEN),
 			'last_activity' => $qb->createNamedParameter($this->time - 60 * 60 * 24 * 3, IQueryBuilder::PARAM_INT), // Three days ago
+			'last_check' => $this->time -  10, // 10secs ago
 		])->execute();
 		$qb->insert('authtoken')->values([
 			'uid' => $qb->createNamedParameter('user1'),
@@ -81,6 +83,7 @@ class DefaultTokenMapperTest extends TestCase {
 			'token' => $qb->createNamedParameter('47af8697ba590fb82579b5f1b3b6e8066773a62100abbe0db09a289a62f5d980dc300fa3d98b01d7228468d1ab05c1aa14c8d14bd5b6eee9cdf1ac14864680c3'),
 			'type' => $qb->createNamedParameter(IToken::TEMPORARY_TOKEN),
 			'last_activity' => $qb->createNamedParameter($this->time - 120, IQueryBuilder::PARAM_INT), // Two minutes ago
+			'last_check' => $this->time - 60 * 10, // 10mins ago
 		])->execute();
 	}
 
@@ -127,6 +130,7 @@ class DefaultTokenMapperTest extends TestCase {
 		$token->setToken('1504445f1524fc801035448a95681a9378ba2e83930c814546c56e5d6ebde221198792fd900c88ed5ead0555780dad1ebce3370d7e154941cd5de87eb419899b');
 		$token->setType(IToken::TEMPORARY_TOKEN);
 		$token->setLastActivity($this->time - 60 * 60 * 24 * 3);
+		$token->setLastCheck($this->time - 10);
 
 		$dbToken = $this->mapper->getToken($token->getToken());
 

--- a/tests/lib/Authentication/Token/DefaultTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/DefaultTokenProviderTest.php
@@ -97,13 +97,24 @@ class DefaultTokenProviderTest extends TestCase {
 
 	public function testUpdateToken() {
 		$tk = new DefaultToken();
+		$tk->setLastActivity($this->time - 200);
 		$this->mapper->expects($this->once())
 			->method('update')
 			->with($tk);
 
-		$this->tokenProvider->updateToken($tk);
+		$this->tokenProvider->updateTokenActivity($tk);
 
 		$this->assertEquals($this->time, $tk->getLastActivity());
+	}
+
+	public function testUpdateTokenDebounce() {
+		$tk = new DefaultToken();
+		$tk->setLastActivity($this->time - 30);
+		$this->mapper->expects($this->never())
+			->method('update')
+			->with($tk);
+
+		$this->tokenProvider->updateTokenActivity($tk);
 	}
 	
 	public function testGetTokenByUser() {

--- a/tests/lib/Authentication/Token/DefaultTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/DefaultTokenProviderTest.php
@@ -218,30 +218,4 @@ class DefaultTokenProviderTest extends TestCase {
 		$this->tokenProvider->invalidateOldTokens();
 	}
 
-	public function testValidateToken() {
-		$token = 'sometoken';
-		$dbToken = new DefaultToken();
-		$this->mapper->expects($this->once())
-			->method('getToken')
-			->with(hash('sha512', $token))
-			->will($this->returnValue($dbToken));
-
-		$actual = $this->tokenProvider->validateToken($token);
-
-		$this->assertEquals($dbToken, $actual);
-	}
-
-	/**
-	 * @expectedException \OC\Authentication\Exceptions\InvalidTokenException
-	 */
-	public function testValidateInvalidToken() {
-		$token = 'sometoken';
-		$this->mapper->expects($this->once())
-			->method('getToken')
-			->with(hash('sha512', $token))
-			->will($this->throwException(new DoesNotExistException('')));
-
-		$this->tokenProvider->validateToken($token);
-	}
-
 }

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -41,6 +41,7 @@ class SessionTest extends \Test\TestCase {
 	public function testGetUser() {
 		$token = new \OC\Authentication\Token\DefaultToken();
 		$token->setLoginName('User123');
+		$token->setLastCheck(200);
 
 		$expectedUser = $this->getMock('\OCP\IUser');
 		$expectedUser->expects($this->any())
@@ -56,41 +57,32 @@ class SessionTest extends \Test\TestCase {
 		$manager = $this->getMockBuilder('\OC\User\Manager')
 			->disableOriginalConstructor()
 			->getMock();
+		$session->expects($this->at(1))
+			->method('get')
+			->with('app_password')
+			->will($this->returnValue(null)); // No password set -> browser session
 		$session->expects($this->once())
 			->method('getId')
 			->will($this->returnValue($sessionId));
 		$this->tokenProvider->expects($this->once())
 			->method('getToken')
+			->with($sessionId)
 			->will($this->returnValue($token));
-		$session->expects($this->at(2))
-			->method('get')
-			->with('last_login_check')
-			->will($this->returnValue(null)); // No check has been run yet
 		$this->tokenProvider->expects($this->once())
 			->method('getPassword')
 			->with($token, $sessionId)
-			->will($this->returnValue('password123'));
+			->will($this->returnValue('passme'));
 		$manager->expects($this->once())
 			->method('checkPassword')
-			->with('User123', 'password123')
+			->with('User123', 'passme')
 			->will($this->returnValue(true));
 		$expectedUser->expects($this->once())
 			->method('isEnabled')
 			->will($this->returnValue(true));
-		$session->expects($this->at(3))
-			->method('set')
-			->with('last_login_check', 10000);
 
-		$session->expects($this->at(4))
-			->method('get')
-			->with('last_token_update')
-			->will($this->returnValue(null)); // No check run so far
 		$this->tokenProvider->expects($this->once())
-			->method('updateToken')
+			->method('updateTokenActivity')
 			->with($token);
-		$session->expects($this->at(5))
-			->method('set')
-			->with('last_token_update', $this->equalTo(10000));
 
 		$manager->expects($this->any())
 			->method('get')
@@ -100,6 +92,7 @@ class SessionTest extends \Test\TestCase {
 		$userSession = new \OC\User\Session($manager, $session, $this->timeFactory, $this->tokenProvider, $this->config);
 		$user = $userSession->getUser();
 		$this->assertSame($expectedUser, $user);
+		$this->assertSame(10000, $token->getLastCheck());
 	}
 
 	public function isLoggedInData() {
@@ -155,6 +148,10 @@ class SessionTest extends \Test\TestCase {
 		$session = $this->getMock('\OC\Session\Memory', array(), array(''));
 		$session->expects($this->once())
 			->method('regenerateId');
+		$this->tokenProvider->expects($this->once())
+			->method('getToken')
+			->with('bar')
+			->will($this->throwException('\OC\Authentication\Exceptions\InvalidTokenException'));
 		$session->expects($this->exactly(2))
 			->method('set')
 			->with($this->callback(function ($key) {
@@ -219,6 +216,10 @@ class SessionTest extends \Test\TestCase {
 			->method('set');
 		$session->expects($this->once())
 			->method('regenerateId');
+		$this->tokenProvider->expects($this->once())
+			->method('getToken')
+			->with('bar')
+			->will($this->throwException(new \OC\Authentication\Exceptions\InvalidTokenException()));
 
 		$managerMethods = get_class_methods('\OC\User\Manager');
 		//keep following methods intact in order to ensure hooks are
@@ -252,11 +253,6 @@ class SessionTest extends \Test\TestCase {
 
 	public function testLoginInvalidPassword() {
 		$session = $this->getMock('\OC\Session\Memory', array(), array(''));
-		$session->expects($this->never())
-			->method('set');
-		$session->expects($this->once())
-			->method('regenerateId');
-
 		$managerMethods = get_class_methods('\OC\User\Manager');
 		//keep following methods intact in order to ensure hooks are
 		//working
@@ -268,10 +264,20 @@ class SessionTest extends \Test\TestCase {
 			}
 		}
 		$manager = $this->getMock('\OC\User\Manager', $managerMethods, array());
-
 		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$userSession = new \OC\User\Session($manager, $session, $this->timeFactory, $this->tokenProvider, $this->config);
 
 		$user = $this->getMock('\OC\User\User', array(), array('foo', $backend));
+
+		$session->expects($this->never())
+			->method('set');
+		$session->expects($this->once())
+			->method('regenerateId');
+		$this->tokenProvider->expects($this->once())
+			->method('getToken')
+			->with('bar')
+			->will($this->throwException(new \OC\Authentication\Exceptions\InvalidTokenException()));
+
 		$user->expects($this->never())
 			->method('isEnabled');
 		$user->expects($this->never())
@@ -282,27 +288,29 @@ class SessionTest extends \Test\TestCase {
 			->with('foo', 'bar')
 			->will($this->returnValue(false));
 
-		$userSession = new \OC\User\Session($manager, $session, $this->timeFactory, $this->tokenProvider, $this->config);
 		$userSession->login('foo', 'bar');
 	}
 
 	public function testLoginNonExisting() {
 		$session = $this->getMock('\OC\Session\Memory', array(), array(''));
+		$manager = $this->getMock('\OC\User\Manager');
+		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$userSession = new \OC\User\Session($manager, $session, $this->timeFactory, $this->tokenProvider, $this->config);
+
 		$session->expects($this->never())
 			->method('set');
 		$session->expects($this->once())
 			->method('regenerateId');
-
-		$manager = $this->getMock('\OC\User\Manager');
-
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$this->tokenProvider->expects($this->once())
+			->method('getToken')
+			->with('bar')
+			->will($this->throwException(new \OC\Authentication\Exceptions\InvalidTokenException()));
 
 		$manager->expects($this->once())
 			->method('checkPassword')
 			->with('foo', 'bar')
 			->will($this->returnValue(false));
 
-		$userSession = new \OC\User\Session($manager, $session, $this->timeFactory, $this->tokenProvider, $this->config);
 		$userSession->login('foo', 'bar');
 	}
 
@@ -351,24 +359,14 @@ class SessionTest extends \Test\TestCase {
 			->will($this->returnValue(true));
 		$userSession->expects($this->once())
 			->method('login')
-			->with('john', 'doe')
+			->with('john', 'I-AM-AN-APP-PASSWORD')
 			->will($this->returnValue(true));
 
-		$userSession->expects($this->once())
-			->method('supportsCookies')
-			->with($request)
-			->will($this->returnValue(true));
-		$userSession->expects($this->once())
-			->method('getUser')
-			->will($this->returnValue($user));
-		$user->expects($this->once())
-			->method('getUID')
-			->will($this->returnValue('user123'));
-		$userSession->expects($this->once())
-			->method('createSessionToken')
-			->with($request, 'user123', 'john', 'doe');
-		
-		$this->assertTrue($userSession->logClientIn('john', 'doe', $request));
+		$session->expects($this->once())
+			->method('set')
+			->with('app_password', 'I-AM-AN-APP-PASSWORD');
+
+		$this->assertTrue($userSession->logClientIn('john', 'I-AM-AN-APP-PASSWORD', $request));
 	}
 
 	public function testLogClientInNoTokenPasswordNo2fa() {
@@ -738,38 +736,40 @@ class SessionTest extends \Test\TestCase {
 			->getMock();
 
 		$user = $this->getMock('\OCP\IUser');
-		$token = $this->getMock('\OC\Authentication\Token\IToken');
+		$token = new \OC\Authentication\Token\DefaultToken();
+		$token->setLoginName('susan');
+		$token->setLastCheck(20);
 
 		$session->expects($this->once())
-			->method('getId')
-			->will($this->returnValue('sessionid'));
+			->method('get')
+			->with('app_password')
+			->will($this->returnValue('APP-PASSWORD'));
 		$tokenProvider->expects($this->once())
 			->method('getToken')
-			->with('sessionid')
+			->with('APP-PASSWORD')
 			->will($this->returnValue($token));
-		$session->expects($this->once())
-			->method('get')
-			->with('last_login_check')
-			->will($this->returnValue(1000));
 		$timeFactory->expects($this->once())
 			->method('getTime')
-			->will($this->returnValue(5000));
+			->will($this->returnValue(1000)); // more than 5min since last check
 		$tokenProvider->expects($this->once())
 			->method('getPassword')
-			->with($token, 'sessionid')
+			->with($token, 'APP-PASSWORD')
 			->will($this->returnValue('123456'));
-		$token->expects($this->once())
-			->method('getLoginName')
-			->will($this->returnValue('User5'));
 		$userManager->expects($this->once())
 			->method('checkPassword')
-			->with('User5', '123456')
+			->with('susan', '123456')
 			->will($this->returnValue(true));
 		$user->expects($this->once())
 			->method('isEnabled')
 			->will($this->returnValue(false));
-		$userSession->expects($this->once())
+		$this->tokenProvider->expects($this->once())
+			->method('invalidateToken')
+			->with($token);
+		$session->expects($this->once())
 			->method('logout');
+		$tokenProvider->expects($this->once())
+			->method('updateToken')
+			->with($token);
 
 		$this->invokePrivate($userSession, 'validateSession', [$user]);
 	}
@@ -785,31 +785,31 @@ class SessionTest extends \Test\TestCase {
 			->getMock();
 
 		$user = $this->getMock('\OCP\IUser');
-		$token = $this->getMock('\OC\Authentication\Token\IToken');
+		$token = new \OC\Authentication\Token\DefaultToken();
+		$token->setLastCheck(20);
 
-		$session->expects($this->once())
-			->method('getId')
-			->will($this->returnValue('sessionid'));
-		$tokenProvider->expects($this->once())
-			->method('getToken')
-			->with('sessionid')
-			->will($this->returnValue($token));
 		$session->expects($this->once())
 			->method('get')
-			->with('last_login_check')
-			->will($this->returnValue(1000));
+			->with('app_password')
+			->will($this->returnValue('APP-PASSWORD'));
+		$tokenProvider->expects($this->once())
+			->method('getToken')
+			->with('APP-PASSWORD')
+			->will($this->returnValue($token));
 		$timeFactory->expects($this->once())
 			->method('getTime')
-			->will($this->returnValue(5000));
+			->will($this->returnValue(1000)); // more than 5min since last check
 		$tokenProvider->expects($this->once())
 			->method('getPassword')
-			->with($token, 'sessionid')
+			->with($token, 'APP-PASSWORD')
 			->will($this->throwException(new \OC\Authentication\Exceptions\PasswordlessTokenException()));
-		$session->expects($this->once())
-			->method('set')
-			->with('last_login_check', 5000);
+		$tokenProvider->expects($this->once())
+			->method('updateToken')
+			->with($token);
 
 		$this->invokePrivate($userSession, 'validateSession', [$user]);
+
+		$this->assertEquals(1000, $token->getLastCheck());
 	}
 
 }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 1, 0, 8);
+$OC_Version = array(9, 1, 0, 9);
 
 // The human readable string
 $OC_VersionString = '9.1.0 beta 2';


### PR DESCRIPTION
The current token auth implementation does not validate the login password for requests that use an app password. Hence only session tokens were checked and invalidated in case the login password changes. Additionally, the login hook was not triggered for pure token auth.

To debounce password checks against the user backend for session-less clients, the time of the last check is now stored in the token itself instead of a session value.

TODO:
- [x] thorough manual testing
- [x] fix/adjust/extend user session unit tests

TESTED
- [x] password-authenticated clients with cookie support
- [x] token-authenticated clients with cookie support
- [x] password-authenticated clients without cookie support
- [x] token-authenticated clients without cookie support
- [x] browser sessions
- [x] password change invalidates browser sessions
- [x] disabling a user invalidates the session token
- [x] password checks are performed only once per five minutes
- [x] oc desktop client with token
- [x] oc desktop client with password
- [x] password auth is blocked when 2fa is enabled
- [x] OCS 'logout required' :hankey: 
- [x] 'pure' token auth with http token header
