### PR TITLE
Fire hooks for mkdir for folder upload

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -998,7 +998,10 @@ class View {
 
 			// Create the directories if any
 			if (!$this->file_exists($filePath)) {
-				$this->mkdir($filePath);
+				$result = $this->createParentDirectories($filePath);
+				if($result === false) {
+					return false;
+				}
 			}
 
 			$source = fopen($tmpFile, 'r');
@@ -2106,5 +2109,23 @@ class View {
 			}
 		}
 		return [$uid, $filename];
+	}
+
+	/**
+	 * Creates parent non-existing folders
+	 *
+	 * @param string $filePath
+	 * @return bool
+	 */
+	private function createParentDirectories($filePath) {
+		$parentDirectory = dirname($filePath);
+		while(!$this->file_exists($parentDirectory)) {
+			$result = $this->createParentDirectories($parentDirectory);
+			if($result === false) {
+				return false;
+			}
+		}
+		$this->mkdir($filePath);
+		return true;
 	}
 }


### PR DESCRIPTION
fromTmpFile function, usual mkdir call is only working for file's parent
directory. Does not care upper parent folders. I added a recursive
function that creates parent non-existing folders with usual mkdir.

Resend of rebased version of https://github.com/owncloud/core/pull/23491 from @karakayasemi
Fixes https://github.com/owncloud/core/issues/23360

Please review @owncloud/filesystem 
