### PR TITLE
[stable8.2] Rollback version must also adjust cached size

### DIFF
--- a/apps/files_versions/lib/storage.php
+++ b/apps/files_versions/lib/storage.php
@@ -306,6 +306,17 @@ class Storage {
 				$versionCreated = true;
 			}
 
+			$fileToRestore =  'files_versions' . $filename . '.v' . $revision;
+
+			$oldFileInfo = $users_view->getFileInfo($fileToRestore);
+			$newFileInfo = $files_view->getFileInfo($filename);
+			$cache = $newFileInfo->getStorage()->getCache();
+			$cache->update(
+				$newFileInfo->getId(), [
+					'size' => $oldFileInfo->getSize()
+				]
+			);
+
 			// rollback
 			if (self::copyFileContents($users_view, 'files_versions' . $filename . '.v' . $revision, 'files' . $filename)) {
 				$files_view->touch($file, $revision);


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/25225 to stable8.2

Please review @owncloud/encryption @icewind1991 

Please note that this patch is slightly different because there was no "encryption version number" back in 8.2.

I retested this and it works fine.
