### PR TITLE
[stable8.1] Rollback version must also adjust cached size

### DIFF
--- a/apps/files_versions/lib/storage.php
+++ b/apps/files_versions/lib/storage.php
@@ -300,6 +300,17 @@ class Storage {
 				$versionCreated = true;
 			}
 
+			$fileToRestore =  'files_versions' . $filename . '.v' . $revision;
+
+			$oldFileInfo = $users_view->getFileInfo($fileToRestore);
+			$newFileInfo = $files_view->getFileInfo($filename);
+			$cache = $newFileInfo->getStorage()->getCache();
+			$cache->update(
+				$newFileInfo->getId(), [
+					'size' => $oldFileInfo->getSize()
+				]
+			);
+
 			// rollback
 			if (self::copyFileContents($users_view, 'files_versions' . $filename . '.v' . $revision, 'files' . $filename)) {
 				$files_view->touch($file, $revision);


### PR DESCRIPTION
Backport of #25225 to stable8.1

Please review @owncloud/encryption @icewind1991

Please note that this patch is slightly different because there was no "encryption version number" back in 8.1.

I retested this and it works fine.
