### PR TITLE
Prerender file list pages to include search results

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2351,22 +2351,36 @@
 		 * @param filter
 		 */
 		setFilter:function(filter) {
+			var total = 0;
 			this._filter = filter;
 			this.fileSummary.setFilter(filter, this.files);
+			total = this.fileSummary.getTotal();
 			if (!this.$el.find('.mask').exists()) {
 				this.hideIrrelevantUIWhenNoFilesMatch();
 			}
 			var that = this;
+			var visibleCount = 0;
 			filter = filter.toLowerCase();
-			this.$fileList.find('tr').each(function(i,e) {
-				var $e = $(e);
+
+			function filterRows(tr) {
+				var $e = $(tr);
 				if ($e.data('file').toString().toLowerCase().indexOf(filter) === -1) {
 					$e.addClass('hidden');
 				} else {
+					visibleCount++;
 					$e.removeClass('hidden');
 				}
-			});
-			that.$container.trigger('scroll');
+			}
+
+			var $trs = this.$fileList.find('tr');
+			do {
+				_.each($trs, filterRows);
+				if (visibleCount < total) {
+					$trs = this._nextPage(false);
+				}
+			} while (visibleCount < total);
+
+			this.$container.trigger('scroll');
 		},
 		hideIrrelevantUIWhenNoFilesMatch:function() {
 			if (this._filter && this.fileSummary.summary.totalDirs + this.fileSummary.summary.totalFiles === 0) {

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -989,6 +989,17 @@ describe('OCA.Files.FileList tests', function() {
 			expect($summary.find('.info').text()).toEqual("1 folder and 3 files");
 			expect($nofilterresults.hasClass('hidden')).toEqual(true);
 		});
+		it('filters the list of non-rendered rows using filter()', function() {
+			var $summary = $('#filestable .summary');
+			var $nofilterresults = fileList.$el.find(".nofilterresults");
+			fileList.setFiles(generateFiles(0, 64));
+
+			fileList.setFilter('63');
+			expect($('#fileList tr:not(.hidden)').length).toEqual(1);
+			expect($summary.hasClass('hidden')).toEqual(false);
+			expect($summary.find('.info').text()).toEqual("0 folders and 1 file matches '63'");
+			expect($nofilterresults.hasClass('hidden')).toEqual(true);
+		});
 		it('hides the emptyfiles notice when using filter()', function() {
 			expect(fileList.files.length).toEqual(0);
 			expect(fileList.files).toEqual([]);


### PR DESCRIPTION
When filtering the file list, if a result is on an unrendered page,
make sure to call _nextPage() to prerender the pages in order to
display all matching results.

Fixes https://github.com/owncloud/core/issues/25205

Please review @owncloud/javascript @butonic @georgehrke 
