### PR TITLE
Fix trashed file name corruption when rerendering trashbin list

### DIFF
--- a/apps/files_trashbin/js/filelist.js
+++ b/apps/files_trashbin/js/filelist.js
@@ -93,6 +93,8 @@
 
 		_renderRow: function(fileData, options) {
 			options = options || {};
+			// make a copy to avoid changing original object
+			fileData = _.extend({}, fileData);
 			var dir = this.getCurrentDirectory();
 			var dirListing = dir !== '' && dir !== '/';
 			// show deleted time as mtime

--- a/apps/files_trashbin/tests/js/filelistSpec.js
+++ b/apps/files_trashbin/tests/js/filelistSpec.js
@@ -163,6 +163,28 @@ describe('OCA.Trashbin.FileList tests', function() {
 
 			expect(fileList.findFileEl('One.txt.d11111')[0]).toEqual($tr[0]);
 		});
+		it('renders rows with the correct data when in root after calling setFiles with the same data set', function() {
+			// dir listing is false when in root
+			$('#dir').val('/');
+			fileList.setFiles(testFiles);
+			fileList.setFiles(fileList.files);
+			var $rows = fileList.$el.find('tbody tr');
+			var $tr = $rows.eq(0);
+			expect($rows.length).toEqual(4);
+			expect($tr.attr('data-id')).toEqual('1');
+			expect($tr.attr('data-type')).toEqual('file');
+			expect($tr.attr('data-file')).toEqual('One.txt.d11111');
+			expect($tr.attr('data-size')).not.toBeDefined();
+			expect($tr.attr('data-etag')).toEqual('abc');
+			expect($tr.attr('data-permissions')).toEqual('9'); // read and delete
+			expect($tr.attr('data-mime')).toEqual('text/plain');
+			expect($tr.attr('data-mtime')).toEqual('11111000');
+			expect($tr.find('a.name').attr('href')).toEqual('#');
+
+			expect($tr.find('.nametext').text().trim()).toEqual('One.txt');
+
+			expect(fileList.findFileEl('One.txt.d11111')[0]).toEqual($tr[0]);
+		});
 		it('renders rows with the correct data when in subdirectory', function() {
 			// dir listing is true when in a subdir
 			$('#dir').val('/subdir');


### PR DESCRIPTION
The trashbin code does some gymnastics with the file data at render
time. This fix makes sure that the modifications done on the file data
are only local to the rendering code and doesn't affect the actual file
data from the file list.

Fixes https://github.com/owncloud/core/issues/25032

Please review @owncloud/javascript @SergioBertolinSG @icewind1991 
