### PR TITLE
Don't reload page in case of auth errors during setup checks

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -76,7 +76,8 @@
 			$.ajax({
 				type: 'PROPFIND',
 				url: url,
-				complete: afterCall
+				complete: afterCall,
+				allowAuthErrors: true
 			});
 			return deferred.promise();
 		},
@@ -209,7 +210,8 @@
 			$.ajax({
 				type: 'GET',
 				url: OC.linkTo('', oc_dataURL+'/htaccesstest.txt?t=' + (new Date()).getTime()),
-				complete: afterCall
+				complete: afterCall,
+				allowAuthErrors: true
 			});
 			return deferred.promise();
 		},


### PR DESCRIPTION
If an error occurs during setup checks, do not let the global ajax
error handler reload the page.

Fixes https://github.com/owncloud/core/issues/24309

Please review @owncloud/javascript @icewind1991 

If it works, also backport to 9.0 because the reload is annoying.

CC @dragotin @DeepDiver1975 
