### PR TITLE
Fix core/vendor/gitignore for jquery

### DIFF
--- a/core/vendor/.gitignore
+++ b/core/vendor/.gitignore
@@ -2,6 +2,7 @@ test/
 src/
 bower.json
 .gitignore
+!/.gitignore
 .jshintrc
 .travis.yml
 CHANGELOG*
@@ -36,6 +37,8 @@ moment/templates
 # jquery
 jquery/**
 !jquery/.bower.json
+!jquery/dist/
+jquery/dist/*
 !jquery/dist/jquery.*
 !jquery/MIT-LICENSE.txt
 


### PR DESCRIPTION
While adding jquery #08dd81e we hit the same problem as it was fixed in #f4930cd for davclient.js and es6-promise.
In addition I think it makes sense not to exclude the .gitignore in core/vendor.
