### PR TITLE
Close session fast when doing a test to prevent blocking the next

### DIFF
--- a/apps/user_ldap/ajax/testConfiguration.php
+++ b/apps/user_ldap/ajax/testConfiguration.php
@@ -38,6 +38,13 @@ $_POST['ldap_configuration_active'] = 1;
 
 try {
 	if ($connection->setConfiguration($_POST)) {
+		/*
+		 * Clossing the session since it won't be used from this point on. There might be a potential
+		 * race condition if a second request is made: either this request or the other might not
+		 * contact the LDAP backup server the first time when it should, but there shouldn't be any
+		 * problem with that other than the extra connection.
+		 */
+		\OC::$server->getSession()->close();
 		//Configuration is okay
 		if ($connection->bind()) {
 			/*


### PR DESCRIPTION
requests

Fix https://github.com/owncloud/core/issues/15930 (or at least it's mitigated, there might be more cases to be checked)

Followed similar steps as described in the issue:
1. Setup two LDAP servers. I've setup one external server simulating a "blazing fast" connection with a 110bps of bandwith and 5000ms of latency, and another one inside a local network (no changes with the connection)
2. External LDAP server is disabled and the internal LDAP server enabled.
3. Test the connection of the external LDAP server (clicking the "test configuration" button in the advanced tab), and go to the users page immediately after.

**Without the patch**: the users page doesn't load (I've given up waiting)
**With the patch**: the users page loads normally the information of the internal LDAP server.
