### PR TITLE
Add explicit delete permission to link shares

### DIFF
--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -354,7 +354,8 @@ class Share20OCS {
 				$share->setPermissions(
 					\OCP\Constants::PERMISSION_READ |
 					\OCP\Constants::PERMISSION_CREATE |
-					\OCP\Constants::PERMISSION_UPDATE
+					\OCP\Constants::PERMISSION_UPDATE |
+					\OCP\Constants::PERMISSION_DELETE
 				);
 			} else {
 				$share->setPermissions(\OCP\Constants::PERMISSION_READ);
@@ -591,7 +592,7 @@ class Share20OCS {
 
 			$newPermissions = null;
 			if ($publicUpload === 'true') {
-				$newPermissions = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE;
+				$newPermissions = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE;
 			} else if ($publicUpload === 'false') {
 				$newPermissions = \OCP\Constants::PERMISSION_READ;
 			}
@@ -602,12 +603,21 @@ class Share20OCS {
 
 			if ($newPermissions !== null &&
 				$newPermissions !== \OCP\Constants::PERMISSION_READ &&
-				$newPermissions !== (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE)) {
+				// legacy
+				$newPermissions !== (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE) &&
+				// correct
+				$newPermissions !== (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE)
+			) {
 				$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
 				return new \OC_OCS_Result(null, 400, $this->l->t('Can\'t change permissions for public share links'));
 			}
 
-			if ($newPermissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE)) {
+			if (
+				// legacy
+				$newPermissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE) ||
+				// correct
+				$newPermissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE)
+			) {
 				if (!$this->shareManager->shareApiLinkAllowPublicUpload()) {
 					$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
 					return new \OC_OCS_Result(null, 403, $this->l->t('Public upload disabled by the administrator'));
@@ -617,6 +627,9 @@ class Share20OCS {
 					$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
 					return new \OC_OCS_Result(null, 400, $this->l->t('Public upload is only possible for publicly shared folders'));
 				}
+
+				// normalize to correct public upload permissions
+				$newPermissions = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE;
 			}
 
 			if ($newPermissions !== null) {

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -257,7 +257,13 @@ class ApiTest extends TestCase {
 		$this->assertTrue($result->succeeded());
 
 		$data = $result->getData();
-		$this->assertEquals(7, $data['permissions']);
+		$this->assertEquals(
+			\OCP\Constants::PERMISSION_READ |
+			\OCP\Constants::PERMISSION_CREATE |
+			\OCP\Constants::PERMISSION_UPDATE |
+			\OCP\Constants::PERMISSION_DELETE,
+			$data['permissions']
+		);
 		$this->assertEmpty($data['expiration']);
 		$this->assertTrue(is_string($data['token']));
 
@@ -1081,7 +1087,13 @@ class ApiTest extends TestCase {
 		$this->assertTrue($result->succeeded());
 
 		$share1 = $this->shareManager->getShareById($share1->getFullId());
-		$this->assertEquals(7, $share1->getPermissions());
+		$this->assertEquals(
+			\OCP\Constants::PERMISSION_READ |
+			\OCP\Constants::PERMISSION_CREATE |
+			\OCP\Constants::PERMISSION_UPDATE |
+			\OCP\Constants::PERMISSION_DELETE,
+			$share1->getPermissions()
+		);
 
 		// cleanup
 		$this->shareManager->deleteShare($share1);

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -61,7 +61,7 @@ Feature: sharing
     And the HTTP status code should be "200"
     And Share fields of last share match with
       | id | A_NUMBER |
-      | permissions | 7 |
+      | permissions | 15 |
       | expiration | +3 days |
       | url | AN_URL |
       | token | A_TOKEN |
@@ -159,7 +159,7 @@ Feature: sharing
       | share_type | 3 |
       | file_source | A_NUMBER |
       | file_target | /FOLDER |
-      | permissions | 7 |
+      | permissions | 15 |
       | stime | A_NUMBER |
       | token | A_TOKEN |
       | storage | A_NUMBER |
@@ -189,7 +189,7 @@ Feature: sharing
       | share_type | 3 |
       | file_source | A_NUMBER |
       | file_target | /FOLDER |
-      | permissions | 7 |
+      | permissions | 15 |
       | stime | A_NUMBER |
       | token | A_TOKEN |
       | storage | A_NUMBER |

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -202,7 +202,7 @@
 
 			var permissions = OC.PERMISSION_READ;
 			if($checkbox.is(':checked')) {
-				permissions = OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_READ;
+				permissions = OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_READ | OC.PERMISSION_DELETE;
 			}
 
 			this.model.saveLinkShare({

--- a/lib/private/Repair/RepairInvalidShares.php
+++ b/lib/private/Repair/RepairInvalidShares.php
@@ -72,6 +72,25 @@ class RepairInvalidShares implements IRepairStep {
 	}
 
 	/**
+	 * In the past link shares with public upload enabled were missing the delete permission.
+	 */
+	private function addShareLinkDeletePermission(IOutput $out) {
+		$oldPerms = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE;
+		$newPerms = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE;
+		$builder = $this->connection->getQueryBuilder();
+		$builder
+			->update('share')
+			->set('permissions', $builder->expr()->literal($newPerms))
+			->where($builder->expr()->eq('share_type', $builder->expr()->literal(\OC\Share\Constants::SHARE_TYPE_LINK)))
+			->andWhere($builder->expr()->eq('permissions', $builder->expr()->literal($oldPerms)));
+
+		$updatedEntries = $builder->execute();
+		if ($updatedEntries > 0) {
+			$out->info('Fixed link share permissions for ' . $updatedEntries . ' shares');
+		}
+	}
+
+	/**
 	 * Remove shares where the parent share does not exist anymore
 	 */
 	private function removeSharesNonExistingParent(IOutput $out) {
@@ -112,6 +131,10 @@ class RepairInvalidShares implements IRepairStep {
 		if (version_compare($ocVersionFromBeforeUpdate, '8.2.0.7', '<')) {
 			// this situation was only possible before 8.2
 			$this->removeExpirationDateFromNonLinkShares($out);
+		}
+		if (version_compare($ocVersionFromBeforeUpdate, '9.1.0.9', '<')) {
+			// this situation was only possible before 9.1
+			$this->addShareLinkDeletePermission($out);
 		}
 
 		$this->removeSharesNonExistingParent($out);

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -446,14 +446,9 @@ class Manager implements IManager {
 			throw new \InvalidArgumentException('Link shares can\'t have reshare permissions');
 		}
 
-		// We don't allow deletion on link shares
-		if ($share->getPermissions() & \OCP\Constants::PERMISSION_DELETE) {
-			throw new \InvalidArgumentException('Link shares can\'t have delete permissions');
-		}
-
 		// Check if public upload is allowed
 		if (!$this->shareApiLinkAllowPublicUpload() &&
-			($share->getPermissions() & (\OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE))) {
+			($share->getPermissions() & (\OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE))) {
 			throw new \InvalidArgumentException('Public upload not allowed');
 		}
 	}

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1320,24 +1320,6 @@ class ManagerTest extends \Test\TestCase {
 
 	/**
 	 * @expectedException Exception
-	 * @expectedExceptionMessage Link shares can't have delete permissions
-	 */
-	public function testLinkCreateChecksDeletePermissions() {
-		$share = $this->manager->newShare();
-
-		$share->setPermissions(\OCP\Constants::PERMISSION_DELETE);
-
-		$this->config
-			->method('getAppValue')
-			->will($this->returnValueMap([
-				['core', 'shareapi_allow_links', 'yes', 'yes'],
-			]));
-
-		$this->invokePrivate($this->manager, 'linkCreateChecks', [$share]);
-	}
-
-	/**
-	 * @expectedException Exception
 	 * @expectedExceptionMessage Public upload not allowed
 	 */
 	public function testLinkCreateChecksNoPublicUpload() {

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 1, 0, 9);
+$OC_Version = array(9, 1, 0, 10);
 
 // The human readable string
 $OC_VersionString = '9.1.0 beta 2';


### PR DESCRIPTION
Link shares always allowed deletion, however internally the permissions
were stored as 7 which lacked delete permissions. This created an
inconsistency in the Webdav permissions.

This fix makes sure we include delete permissions in the share
permissions, which now become 15.

In case a client is still passing 7 for legacy reasons, it gets
converted automatically to 15.

Fixes https://github.com/owncloud/core/issues/24868

TODOs:
- [x] JS code sends 15 instead of 7
- [x] OCS API adjusted to accept both 7 and 15 but normalizes to 15
- [x] Repair step to convert 7 to 15 for all link shares in DB

@rullzer I settled on normalizing to make sure we don't break existing clients that might be using the "permissions" attribute when updating link shares. I do hope they use "publicUpload" instead.
