### PR TITLE
Use OC.Backbone instead of Backbone directly in authtoken JS code

### DIFF
--- a/settings/js/authtoken.js
+++ b/settings/js/authtoken.js
@@ -20,14 +20,14 @@
  *
  */
 
-(function(OC, Backbone) {
+(function(OC) {
 	'use strict';
 
 	OC.Settings = OC.Settings || {};
 
-	var AuthToken = Backbone.Model.extend({
+	var AuthToken = OC.Backbone.Model.extend({
 	});
 
 	OC.Settings.AuthToken = AuthToken;
 
-})(OC, Backbone);
+})(OC);

--- a/settings/js/authtoken_collection.js
+++ b/settings/js/authtoken_collection.js
@@ -20,12 +20,12 @@
  *
  */
 
-(function(OC, Backbone) {
+(function(OC) {
 	'use strict';
 
 	OC.Settings = OC.Settings || {};
 
-	var AuthTokenCollection = Backbone.Collection.extend({
+	var AuthTokenCollection = OC.Backbone.Collection.extend({
 
 		model: OC.Settings.AuthToken,
 
@@ -49,4 +49,4 @@
 
 	OC.Settings.AuthTokenCollection = AuthTokenCollection;
 
-})(OC, Backbone);
+})(OC);

--- a/settings/js/authtoken_view.js
+++ b/settings/js/authtoken_view.js
@@ -1,4 +1,4 @@
-/* global Backbone, Handlebars, moment */
+/* global Handlebars, moment */
 
 /**
  * @author Christoph Wurst <christoph@owncloud.com>
@@ -20,7 +20,7 @@
  *
  */
 
-(function(OC, _, Backbone, $, Handlebars, moment) {
+(function(OC, _, $, Handlebars, moment) {
 	'use strict';
 
 	OC.Settings = OC.Settings || {};
@@ -32,7 +32,7 @@
 		+ '<td><a class="icon-delete has-tooltip" title="' + t('core', 'Disconnect') + '"></a></td>'
 		+ '<tr>';
 
-	var SubView = Backbone.View.extend({
+	var SubView = OC.Backbone.View.extend({
 		collection: null,
 
 		/**
@@ -94,7 +94,7 @@
 		}
 	});
 
-	var AuthTokenView = Backbone.View.extend({
+	var AuthTokenView = OC.Backbone.View.extend({
 		collection: null,
 
 		_views: [],
@@ -237,4 +237,4 @@
 
 	OC.Settings.AuthTokenView = AuthTokenView;
 
-})(OC, _, Backbone, $, Handlebars, moment);
+})(OC, _, $, Handlebars, moment);


### PR DESCRIPTION
Fixes asset pipeline issue with the auth token in personal page

Fixes https://github.com/owncloud/core/issues/25241

Note: might require deleting the contents of the "assets" folder if coming from a "broken" install.

Please review @DeepDiver1975 @ChristophWurst @owncloud/javascript @icewind1991 
