### PR TITLE
Remove tooltip when disconnecting token

### DIFF
--- a/settings/js/authtoken_view.js
+++ b/settings/js/authtoken_view.js
@@ -220,6 +220,8 @@
 
 			var destroyingToken = token.destroy();
 
+			$row.find('.icon-delete').tooltip('hide');
+
 			var _this = this;
 			$.when(destroyingToken).fail(function() {
 				OC.Notification.showTemporary(t('core', 'Error while deleting the token'));


### PR DESCRIPTION
To reproduce: make the "Disconnect" tooltip appear, then click.

Before: tooltip would stay and never disappear
After: tooltip disappears

Please review @owncloud/javascript @ChristophWurst 
