### PR TITLE
Fix "Other" value handling in quota dropdown in users page

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -138,10 +138,13 @@ var UserList = {
 				.find('option').attr('selected', null)
 				.first().attr('selected', 'selected');
 		} else {
-			if ($quotaSelect.find('option').filterAttr('value', user.quota).length > 0) {
-				$quotaSelect.find('option').filterAttr('value', user.quota).attr('selected', 'selected');
+			var $options = $quotaSelect.find('option');
+			var $foundOption = $options.filterAttr('value', user.quota);
+			if ($foundOption.length > 0) {
+				$foundOption.attr('selected', 'selected');
 			} else {
-				$quotaSelect.append('<option value="' + escapeHTML(user.quota) + '" selected="selected">' + escapeHTML(user.quota) + '</option>');
+				// append before "Other" entry
+				$options.last().before('<option value="' + escapeHTML(user.quota) + '" selected="selected">' + escapeHTML(user.quota) + '</option>');
 			}
 		}
 
@@ -576,6 +579,9 @@ var UserList = {
 		var $select = $(ev.target);
 		var uid = UserList.getUID($select);
 		var quota = $select.val();
+		if (quota === 'other') {
+			return;
+		}
 		UserList._updateQuota(uid, quota, function(returnedQuota){
 			if (quota !== returnedQuota) {
 				$select.find(':selected').text(returnedQuota);

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -582,6 +582,12 @@ var UserList = {
 		if (quota === 'other') {
 			return;
 		}
+		if (isNaN(parseInt(quota, 10)) || parseInt(quota, 10) < 0) {
+			// the select component has added the bogus value, delete it again
+			$select.find('option[selected]').remove();
+			OC.Notification.showTemporary(t('core', 'Invalid quota value "{val}"', {val: quota}));
+			return;
+		}
 		UserList._updateQuota(uid, quota, function(returnedQuota){
 			if (quota !== returnedQuota) {
 				$select.find(':selected').text(returnedQuota);


### PR DESCRIPTION
Prevents "other" value to be deleted.
When appending custom value, put it above the "other" entry.

Fixes https://github.com/owncloud/core/issues/24664

Please review @owncloud/javascript @icewind1991 @guruz @georgehrke @SergioBertolinSG  @humblemumble
- [x] TEST: select "Other", leave field without entering, reopen dropdown: dropdown looks sane
- [x] TEST: select "Other", enter value. Value properly selected in dropdown (before/after page refresh)
- [x] TEST: custom quota appears above "Other" in dropdown (before/after page refresh)
