### PR TITLE
Properly deliver content-disposition when downloading in DAV from browser

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -233,8 +233,10 @@ class FilesPlugin extends ServerPlugin {
 		$node = $this->tree->getNodeForPath($request->getPath());
 		if (!($node instanceof IFile)) return;
 
+		$queryParams = $request->getQueryParameters();
+
 		// adds a 'Content-Disposition: attachment' header
-		if ($this->downloadAttachment) {
+		if ($this->downloadAttachment || isset($queryParams['downloadStartSecret'])) {
 			$filename = $node->getName();
 			if ($this->request->isUserAgent(
 				[


### PR DESCRIPTION
Steps to reproduce:
1. Upload a text file
2. For the text file, click on the "Download" link in the file row

Before: text file opened directly inline in browser
After: text file properly downloaded

Not sure why we have that `$this->downloadAttachment` property that is false sometimes so I left it and relied on the "downloadSecret" parameter.

Please review @owncloud/filesystem @rullzer @icewind1991 
