### PR TITLE
Show error message when posting an invalid comment

### DIFF
--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -337,10 +337,10 @@
 					$comment.data('commentEl').remove();
 					$comment.remove();
 				},
-				error: function(msg) {
+				error: function() {
 					$loading.addClass('hidden');
 					$comment.removeClass('disabled');
-					OC.Notification.showTemporary(msg);
+					OC.Notification.showTemporary(t('comments', 'Error occurred while retrieving comment with id {id}', {id: commentId}));
 				}
 			});
 
@@ -388,12 +388,12 @@
 							.html(self._formatMessage(model.get('message')));
 						$row.remove();
 					},
-					error: function(msg) {
+					error: function() {
 						$submit.removeClass('hidden');
 						$loading.addClass('hidden');
 						$textArea.prop('disabled', false);
 
-						OC.Notification.showTemporary(msg);
+						OC.Notification.showTemporary(t('comments', 'Error occurred while updating comment with id {id}', {id: commentId}));
 					}
 				});
 			} else {
@@ -413,12 +413,12 @@
 						$loading.addClass('hidden');
 						$textArea.val('').prop('disabled', false);
 					},
-					error: function(msg) {
+					error: function() {
 						$submit.removeClass('hidden');
 						$loading.addClass('hidden');
 						$textArea.prop('disabled', false);
 
-						OC.Notification.showTemporary(msg);
+						OC.Notification.showTemporary(t('comments', 'Error occurred while posting comment'));
 					}
 				});
 			}

--- a/apps/dav/lib/Comments/CommentNode.php
+++ b/apps/dav/lib/Comments/CommentNode.php
@@ -185,7 +185,7 @@ class CommentNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 				$msg = 'Message exceeds allowed character limit of ';
 				throw new BadRequest($msg . IComment::MAX_MESSAGE_LENGTH, 0, $e);
 			}
-			return false;
+			throw $e;
 		}
 	}
 

--- a/apps/dav/tests/unit/Comments/CommentsNodeTest.php
+++ b/apps/dav/tests/unit/Comments/CommentsNodeTest.php
@@ -166,6 +166,10 @@ class CommentsNodeTest extends \Test\TestCase {
 		$this->assertTrue($this->node->updateComment($msg));
 	}
 
+	/**
+	 * @expectedException Exception
+	 * @expectedExceptionMessage buh!
+	 */
 	public function testUpdateCommentLogException() {
 		$msg = null;
 
@@ -198,7 +202,7 @@ class CommentsNodeTest extends \Test\TestCase {
 		$this->logger->expects($this->once())
 			->method('logException');
 
-		$this->assertFalse($this->node->updateComment($msg));
+		$this->node->updateComment($msg);
 	}
 
 	/**


### PR DESCRIPTION
When an internal server error occurs while creating or updating a
comment, display a proper error notification in the UI.
- [x] TEST: create new comment with emoji char with MySQL
- [x] TEST: update existing comment with emoji char with MySQL

=> the UI shows a generic error message instead of "[Object]" or nothing at all

Please note that currently we have no good way to parse the sabre exception, so a generic error is the workaround until this becomes possible.

Fixes https://github.com/owncloud/core/issues/23871

Please review @owncloud/javascript @icewind1991 @georgehrke @DeepDiver1975 @dragotin @nickvergessen 
