### PR TITLE
Make code integrity check work when OC is not installed yet

### DIFF
--- a/lib/private/IntegrityCheck/Checker.php
+++ b/lib/private/IntegrityCheck/Checker.php
@@ -108,7 +108,11 @@ class Checker {
 		 * applicable for very specific scenarios and we should not advertise it
 		 * too prominent. So please do not add it to config.sample.php.
 		 */
-		$isIntegrityCheckDisabled = $this->config->getSystemValue('integrity.check.disabled', false);
+		if ($this->config !== null) {
+			$isIntegrityCheckDisabled = $this->config->getSystemValue('integrity.check.disabled', false);
+		} else {
+			$isIntegrityCheckDisabled = false;
+		}
 		if($isIntegrityCheckDisabled === true) {
 			return false;
 		}
@@ -401,7 +405,10 @@ class Checker {
 			return json_decode($cachedResults, true);
 		}
 
-		return json_decode($this->config->getAppValue('core', self::CACHE_KEY, '{}'), true);
+		if ($this->config !== null) {
+			return json_decode($this->config->getAppValue('core', self::CACHE_KEY, '{}'), true);
+		}
+		return [];
 	}
 
 	/**
@@ -416,7 +423,9 @@ class Checker {
 		if(!empty($result)) {
 			$resultArray[$scope] = $result;
 		}
-		$this->config->setAppValue('core', self::CACHE_KEY, json_encode($resultArray));
+		if ($this->config !== null) {
+			$this->config->setAppValue('core', self::CACHE_KEY, json_encode($resultArray));
+		}
 		$this->cache->set(self::CACHE_KEY, json_encode($resultArray));
 	}
 


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/23869

To test:
1. Create a patch from this PR
2. Install OC 9.1.0beta2
3. Patch it with this PR
4. Run `sudo -u wwwrun php occ integrity:check-core`

The check will run and it will tell you that the check failed for the patched file, which is the correct behavior.

Please review @butonic @georgehrke @VicDeo @icewind1991 
