### PR TITLE
Login hooks

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -414,6 +414,14 @@ class Session implements IUserSession, Emitter {
 		return false;
 	}
 
+	/**
+	 * Log an user in via login name and password
+	 *
+	 * @param string $uid
+	 * @param string $password
+	 * @return boolean
+	 * @throws LoginException if an app canceld the login process or the user is not enabled
+	 */
 	private function loginWithPassword($uid, $password) {
 		$this->manager->emit('\OC\User', 'preLogin', array($uid, $password));
 		$user = $this->manager->checkPassword($uid, $password);
@@ -442,6 +450,13 @@ class Session implements IUserSession, Emitter {
 		return false;
 	}
 
+	/**
+	 * Log an user in with a given token (id)
+	 *
+	 * @param string $token
+	 * @return boolean
+	 * @throws LoginException if an app canceld the login process or the user is not enabled
+	 */
 	private function loginWithToken($token) {
 		try {
 			$dbToken = $this->tokenProvider->getToken($token);
@@ -475,6 +490,7 @@ class Session implements IUserSession, Emitter {
 		//login
 		$this->setUser($user);
 		$this->setLoginName($dbToken->getLoginName());
+		$this->manager->emit('\OC\User', 'postLogin', array($user, $password));
 
 		if ($this->isLoggedIn()) {
 			$this->prepareUserLogin();
@@ -484,7 +500,6 @@ class Session implements IUserSession, Emitter {
 			throw new LoginException($message);
 		}
 
-		$this->manager->emit('\OC\User', 'postLogin', array($user, $password));
 		return true;
 	}
 

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -282,7 +282,7 @@ class Session implements IUserSession, Emitter {
 		$this->session->regenerateId();
 
 		if ($this->validateToken($password, $uid)) {
-			$this->loginWithToken($password);
+			return $this->loginWithToken($password);
 		} else {
 			$this->manager->emit('\OC\User', 'preLogin', array($uid, $password));
 			$user = $this->manager->checkPassword($uid, $password);

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -729,6 +729,9 @@ class SessionTest extends \Test\TestCase {
 		$this->assertFalse($userSession->createSessionToken($request, $uid, $loginName, $password));
 	}
 
+	/**
+	 * @expectedException \OC\User\LoginException
+	 */
 	public function testTryTokenLoginWithDisabledUser() {
 		$manager = $this->getMockBuilder('\OC\User\Manager')
 			->disableOriginalConstructor()
@@ -761,7 +764,7 @@ class SessionTest extends \Test\TestCase {
 			->method('isEnabled')
 			->will($this->returnValue(false));
 
-		$this->assertFalse($userSession->tryTokenLogin($request));
+		$userSession->tryTokenLogin($request);
 	}
 
 	public function testValidateSessionDisabledUser() {


### PR DESCRIPTION
I found an inconsistency of login hooks while working on https://github.com/owncloud/core/pull/25154.
1. hooks were triggered twice (once in `login` and then in `loginWithToken`)
2. the post login hook in `login` was called without tranlating a possible token password to the login password
3. when logging in a disabled user via token no `LoginException` was thrown (the login was still blocked, but resulted in a 401 instead)
4. when logging in via token there was no check whether an app aborted the login process via the post login hook

~~Needs rebase once https://github.com/owncloud/core/pull/25154 was merged.~~ done
