### PR TITLE
show which login name to use for the new app password

### DIFF
--- a/settings/Controller/AuthSettingsController.php
+++ b/settings/Controller/AuthSettingsController.php
@@ -118,6 +118,7 @@ class AuthSettingsController extends Controller {
 
 		return [
 			'token' => $token,
+			'loginName' => $loginName,
 			'deviceToken' => $deviceToken
 		];
 	}

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -131,10 +131,18 @@ table.nostyle td { padding: 0.2em 0; }
 	opacity: 0.6;
 }
 
+#new-app-login-name,
 #new-app-password {
 	width: 186px;
 	font-family: monospace;
 	background-color: lightyellow;
+}
+.app-password-row {
+	display: table-row;
+}
+.app-password-label {
+	display: table-cell;
+	padding-right: 1em;
 }
 
 /* USERS */

--- a/settings/js/authtoken_view.js
+++ b/settings/js/authtoken_view.js
@@ -139,6 +139,7 @@
 
 			this._result = $('#app-password-result');
 			this._newAppLoginName = $('#new-app-login-name');
+			this._newAppLoginName.on('focus', _.bind(this._onNewTokenLoginNameFocus, this));
 			this._newAppPassword = $('#new-app-password');
 			this._newAppPassword.on('focus', _.bind(this._onNewTokenFocus, this));
 			this._hideAppPasswordBtn = $('#app-password-hide');
@@ -184,9 +185,7 @@
 			$.when(creatingToken).done(function(resp) {
 				_this.collection.add(resp.deviceToken);
 				_this.render();
-				_this._newAppLoginName.text(t('core', 'You may now configure your client with username "{loginName}" and the following password:', {
-					loginName: resp.loginName
-				}));
+				_this._newAppLoginName.val(resp.loginName);
 				_this._newAppPassword.val(resp.token);
 				_this._toggleFormResult(false);
 				_this._newAppPassword.select();
@@ -198,6 +197,10 @@
 			$.when(creatingToken).always(function() {
 				_this._toggleAddingToken(false);
 			});
+		},
+
+		_onNewTokenLoginNameFocus: function() {
+			this._newAppLoginName.select();
 		},
 
 		_onNewTokenFocus: function() {

--- a/settings/js/authtoken_view.js
+++ b/settings/js/authtoken_view.js
@@ -107,6 +107,8 @@
 
 		_result: undefined,
 
+		_newAppLoginName: undefined,
+
 		_newAppPassword: undefined,
 
 		_hideAppPasswordBtn: undefined,
@@ -136,6 +138,7 @@
 			this._addAppPasswordBtn.click(_.bind(this._addAppPassword, this));
 
 			this._result = $('#app-password-result');
+			this._newAppLoginName = $('#new-app-login-name');
 			this._newAppPassword = $('#new-app-password');
 			this._newAppPassword.on('focus', _.bind(this._onNewTokenFocus, this));
 			this._hideAppPasswordBtn = $('#app-password-hide');
@@ -181,6 +184,9 @@
 			$.when(creatingToken).done(function(resp) {
 				_this.collection.add(resp.deviceToken);
 				_this.render();
+				_this._newAppLoginName.text(t('core', 'You may now configure your client with username "{loginName}" and the following password:', {
+					loginName: resp.loginName
+				}));
 				_this._newAppPassword.val(resp.token);
 				_this._toggleFormResult(false);
 				_this._newAppPassword.select();

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -203,6 +203,7 @@ if($_['passwordChangeSupported']) {
 		<button id="add-app-password" class="button"><?php p($l->t('Create new app password')); ?></button>
 	</div>
 	<div id="app-password-result" class="hidden">
+		<span id="new-app-login-name"></span>
 		<input id="new-app-password" type="text" readonly="readonly"/>
 		<button id="app-password-hide" class="button"><?php p($l->t('Done')); ?></button>
 	</div>

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -203,9 +203,16 @@ if($_['passwordChangeSupported']) {
 		<button id="add-app-password" class="button"><?php p($l->t('Create new app password')); ?></button>
 	</div>
 	<div id="app-password-result" class="hidden">
-		<span id="new-app-login-name"></span>
-		<input id="new-app-password" type="text" readonly="readonly"/>
-		<button id="app-password-hide" class="button"><?php p($l->t('Done')); ?></button>
+		<span><?php p($l->t('Use the credentials below to configure your app or device.')); ?></span>
+		<div class="app-password-row">
+			<span class="app-password-label"><?php p($l->t('Username')); ?></span>
+			<input id="new-app-login-name" type="text" readonly="readonly"/>
+		</div>
+		<div class="app-password-row">
+			<span class="app-password-label"><?php p($l->t('Password')); ?></span>
+			<input id="new-app-password" type="text" readonly="readonly"/>
+			<button id="app-password-hide" class="button"><?php p($l->t('Done')); ?></button>
+		</div>
 	</div>
 </div>
 


### PR DESCRIPTION
Currently our user back-ends only allow to check user passwords with login name and password instead of UID and password. Hence, we need to store the login name with the browser/device token to be able to re-validate credentials periodically.

Since https://github.com/owncloud/core/pull/25154 we're checking whether the login name used when authenticating with a device token matches the one stored with the token. To make it clear that users have to use the same login name that they used when logging in via the browser we should show a hint which login name should be used on the client.

@PVince81 as discussed
