### PR TITLE
Only save federated share after remote server is notified

### DIFF
--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -240,6 +240,7 @@ class FederatedShareProvider implements IShareProvider {
 				throw new \Exception($message_t);
 			}
 		} catch (\Exception $e) {
+			$this->logger->error('Failed to notify remote server of federated share, removing share (' . $e->getMessage() . ')');
 			$this->removeShareFromTableById($shareId);
 			throw $e;
 		}

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -187,7 +187,7 @@
 			}).fail(function(xhr) {
 				var msg = t('core', 'Error');
 				var result = xhr.responseJSON;
-				if (result.ocs && result.ocs.meta) {
+				if (result && result.ocs && result.ocs.meta) {
 					msg = result.ocs.meta.message;
 				}
 


### PR DESCRIPTION
If we fail to notify the remote share the entry in the share table is useless but the sharee will still think the file is shared.

Also improves error handling a bit by showing an error message if a non-json result is returned from the share call.

cc @owncloud/sharing @PVince81 
