### PR TITLE
Keep encryption enabled if decrypting for single user

### DIFF
--- a/core/Command/Encryption/DecryptAll.php
+++ b/core/Command/Encryption/DecryptAll.php
@@ -150,6 +150,9 @@ class DecryptAll extends Command {
 					$output->writeln(' aborted.');
 					$output->writeln('Server side encryption remains enabled');
 					$this->config->setAppValue('core', 'encryption_enabled', 'yes');
+				} else if ($uid !== '') {
+					$output->writeln('Server side encryption remains enabled');
+					$this->config->setAppValue('core', 'encryption_enabled', 'yes');
 				}
 				$this->resetSingleUserAndTrashbin();
 			} else {


### PR DESCRIPTION
When decrypting all files of a single user, the admin usually does not
intend encryption to be suddenly disabled for everyone. This fix
reenables encryption after decrypting for a single user.

Decrypting for all users will still disable encryption globally.

Fixes https://github.com/owncloud/core/issues/22167

@owncloud/encryption @icewind1991 
