### PR TITLE
Quickfix: do not lazy load auth mechanisms for ext storages

### DIFF
--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -52,6 +52,10 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 		$backendService->registerBackendProvider($this);
 		$backendService->registerAuthMechanismProvider($this);
 
+		// force-load auth mechanisms since some will register hooks
+		// TODO: obsolete these and use the TokenProvider to get the user's password from the session
+		$this->getAuthMechanisms();
+
 		// app developers: do NOT depend on this! it will disappear with oC 9.0!
 		\OC::$server->getEventDispatcher()->dispatch(
 			'OCA\\Files_External::loadAdditionalBackends'


### PR DESCRIPTION
Some auth mechanisms like SessionCredentials need to register hooks
early, so they cannot be lazy loaded.

Fixes https://github.com/owncloud/core/issues/25272

Note: this is a quick fix. A proper future solution could use @ChristophWurst's token provider and get the password from there instead of capturing it. (but it has no public API for this yet)

Please review @icewind1991 @Xenopathic @SergioBertolinSG 
