### PR TITLE
Fix getting the certificate bundle for dav external storage

### DIFF
--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -328,7 +328,7 @@ class Manager {
 	public function removeShare($mountPoint) {
 
 		$mountPointObj = $this->mountManager->find($mountPoint);
-		$id = $mountPointObj->getStorage()->getCache()->getId();
+		$id = $mountPointObj->getStorage()->getCache()->getId('');
 
 		$mountPoint = $this->stripPath($mountPoint);
 		$hash = md5($mountPoint);

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -107,7 +107,11 @@ class DAV extends Common {
 			}
 			if ($this->secure === true) {
 				// inject mock for testing
-				$certPath = \OC_User::getHome(\OC_User::getUser()) . '/files_external/rootcerts.crt';
+				$certManager = \OC::$server->getCertificateManager();
+				if (is_null($certManager)) { //no user
+					$certManager = \OC::$server->getCertificateManager(null);
+				}
+				$certPath = $certManager->getAbsoluteBundlePath();
 				if (file_exists($certPath)) {
 					$this->certPath = $certPath;
 				}

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -816,6 +816,7 @@ class DAV extends Common {
 	 * which might be temporary
 	 */
 	private function convertException(Exception $e, $path = '') {
+		\OC::$server->getLogger()->logException($e);
 		Util::writeLog('files_external', $e->getMessage(), Util::ERROR);
 		if ($e instanceof ClientHttpException) {
 			if ($e->getHttpStatus() === 423) {


### PR DESCRIPTION
Required in (some?) cases to get fed. sharing working with self-signed certificates

cc @owncloud/filesystem 
