### PR TITLE
Tear down FS to free memory for old storage wrappers

### DIFF
--- a/lib/private/avatarmanager.php
+++ b/lib/private/avatarmanager.php
@@ -87,6 +87,7 @@ class AvatarManager implements IAvatarManager {
 		 * Fix for #22119
 		 * Basically we do not want to copy the skeleton folder
 		 */
+		\OC\Files\Filesystem::tearDown();
 		\OC\Files\Filesystem::initMountPoints($userId);
 		$dir = '/' . $userId;
 		/** @var Folder $folder */

--- a/lib/private/avatarmanager.php
+++ b/lib/private/avatarmanager.php
@@ -84,10 +84,14 @@ class AvatarManager implements IAvatarManager {
 		}
 
 		/*
+		 * Resetup FS to free memory of old storage wrappers
+		 */
+		\OC_Util::tearDownFS();
+		\OC_Util::setupFS($userId);
+		/*
 		 * Fix for #22119
 		 * Basically we do not want to copy the skeleton folder
 		 */
-		\OC\Files\Filesystem::tearDown();
 		\OC\Files\Filesystem::initMountPoints($userId);
 		$dir = '/' . $userId;
 		/** @var Folder $folder */


### PR DESCRIPTION
With a lot of users the carddav SyncJob will run out of memory because it fetches an avatar, causing the filesystem for every user to be initialized.

The [workaround introduced to not create the skeleton when fetching an avatar](https://github.com/owncloud/core/pull/22410/files#diff-03f1a3008809a2ed478b57aafa65d0d1R82) can be further uglified by tearing down the filesystem so that all old storage wrappers are cleaned up.  I did not want to tear down the filesystem in a different place to minimize the impact on other code paths. 

@PVince81 @DeepDiver1975 @icewind1991 can you comment if the approach makes sense until we find a better solution as tracked in https://github.com/owncloud/core/issues/22414?

This is how memory developed before this PR:
1. at 2800 users
   ![1-2800users](https://cloud.githubusercontent.com/assets/956847/16409144/68670224-3d1c-11e6-8bfc-dc19e816c115.PNG)
2. at 3900 users
   ![2-3900users](https://cloud.githubusercontent.com/assets/956847/16409156/71b239ca-3d1c-11e6-95d5-18e71012b022.PNG)

This is after the patch:
1. 4600 users
   ![3-4600users-patched](https://cloud.githubusercontent.com/assets/956847/16409164/7c5dc10a-3d1c-11e6-903b-7bf1b2fd7461.PNG)
2. 6200 users
   ![4-6200users-patched](https://cloud.githubusercontent.com/assets/956847/16409177/89b4acce-3d1c-11e6-8e50-cf8f89140558.PNG)

While there is still a memory increase the whole encryption wrapper and filesystem mounts stuff is now freed. There are three classes still growing:
- [ ] \OC\User\Manager,
- [ ] \OC\AllConfig::getUserValues() and 
- [ ] \OC\Group\Manager::getUserIdGroups()

When these three use a capped cache the biggest loosers are removed.
- [ ] Additional memory profiling should be resceduled before the next release?
