### PR TITLE
get only vcards which match both the address book id and the vcard uri

### DIFF
--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -848,7 +848,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		$query = $this->db->getQueryBuilder();
 		$query->select('*')->from($this->dbCardsTable)
 				->where($query->expr()->eq('uri', $query->createNamedParameter($uri)))
-				->where($query->expr()->eq('addressbookid', $query->createNamedParameter($addressBookId)));
+				->andWhere($query->expr()->eq('addressbookid', $query->createNamedParameter($addressBookId)));
 		$queryResult = $query->execute();
 		$contact = $queryResult->fetch();
 		$queryResult->closeCursor();

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -606,6 +606,10 @@ class CardDavBackendTest extends TestCase {
 		$this->assertSame(5489543, (int)$result['lastmodified']);
 		$this->assertSame('etag0', $result['etag']);
 		$this->assertSame(120, (int)$result['size']);
+
+		// this shouldn't return any result because 'uri1' is in address book 1
+		$result = $this->backend->getContact(0, 'uri1');
+		$this->assertEmpty($result);
 	}
 
 	public function testGetContactFail() {


### PR DESCRIPTION
getContact() should only return contacts which match both the address book id and the vcard uri

This is just a one-liner, so there shouldn't be any copyright issues. But if you prefer, I hereby grant you permission to use it under the MIT license.

cc @DeepDiver1975 @PVince81 
