### PR TITLE
Have displayname, or username if there is no displayname, appear in s…

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -688,7 +688,7 @@ class Share extends Constants {
 			}
 			if (!\OC_User::userExists($shareWith)) {
 				$message = 'Sharing %s failed, because the user %s does not exist';
-				$message_t = $l->t('Sharing %s failed, because the user %s does not exist', array($itemSourceName, $shareWith));
+				$message_t = $l->t('Sharing %s failed, because the user %s does not exist', array($itemSourceName, \OCP\User::getDisplayName($shareWith)));
 				\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName, $shareWith), \OCP\Util::DEBUG);
 				throw new \Exception($message_t);
 			}
@@ -697,7 +697,7 @@ class Share extends Constants {
 				if (empty($inGroup)) {
 					$message = 'Sharing %s failed, because the user '
 						.'%s is not a member of any groups that %s is a member of';
-					$message_t = $l->t('Sharing %s failed, because the user %s is not a member of any groups that %s is a member of', array($itemName, $shareWith, $uidOwner));
+					$message_t = $l->t('Sharing %s failed, because the user %s is not a member of any groups that %s is a member of', array($itemName, \OCP\User::getDisplayName($shareWith), \OCP\User::getDisplayName($uidOwner)));
 					\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemName, $shareWith, $uidOwner), \OCP\Util::DEBUG);
 					throw new \Exception($message_t);
 				}
@@ -710,7 +710,7 @@ class Share extends Constants {
 				// permissions for a specific user
 				if ($checkExists['uid_owner'] != $uidOwner || $checkExists['share_type'] == $shareType) {
 					$message = 'Sharing %s failed, because this item is already shared with %s';
-					$message_t = $l->t('Sharing %s failed, because this item is already shared with %s', array($itemSourceName, $shareWith));
+					$message_t = $l->t('Sharing %s failed, because this item is already shared with %s', array($itemSourceName, \OCP\User::getDisplayName($shareWith)));
 					\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName, $shareWith), \OCP\Util::DEBUG);
 					throw new \Exception($message_t);
 				}
@@ -722,7 +722,7 @@ class Share extends Constants {
 				// permissions for a specific user
 				if ($checkExists['uid_owner'] != $uidOwner || $checkExists['share_type'] == $shareType) {
 					$message = 'Sharing %s failed, because this item is already shared with user %s';
-					$message_t = $l->t('Sharing %s failed, because this item is already shared with user %s', array($itemSourceName, $shareWith));
+					$message_t = $l->t('Sharing %s failed, because this item is already shared with user %s', array($itemSourceName, \OCP\User::getDisplayName($shareWith)));
 					\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName, $shareWith), \OCP\Util::ERROR);
 					throw new \Exception($message_t);
 				}
@@ -737,7 +737,7 @@ class Share extends Constants {
 			if ($shareWithinGroupOnly && !\OC_Group::inGroup($uidOwner, $shareWith)) {
 				$message = 'Sharing %s failed, because '
 					.'%s is not a member of the group %s';
-				$message_t = $l->t('Sharing %s failed, because %s is not a member of the group %s', array($itemSourceName, $uidOwner, $shareWith));
+				$message_t = $l->t('Sharing %s failed, because %s is not a member of the group %s', array($itemSourceName, \OCP\User::getDisplayName($uidOwner), $shareWith));
 				\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName, $uidOwner, $shareWith), \OCP\Util::DEBUG);
 				throw new \Exception($message_t);
 			}


### PR DESCRIPTION
…haring error messages rather than just username only. Fixes guids appearing in user facing messages in ldap/ad based setups.
