### PR TITLE
Prevent infinite loop in search auto-nextpage

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2352,13 +2352,16 @@
 		 */
 		setFilter:function(filter) {
 			var total = 0;
+			if (this._filter === filter) {
+				return;
+			}
 			this._filter = filter;
 			this.fileSummary.setFilter(filter, this.files);
 			total = this.fileSummary.getTotal();
 			if (!this.$el.find('.mask').exists()) {
 				this.hideIrrelevantUIWhenNoFilesMatch();
 			}
-			var that = this;
+
 			var visibleCount = 0;
 			filter = filter.toLowerCase();
 
@@ -2378,7 +2381,7 @@
 				if (visibleCount < total) {
 					$trs = this._nextPage(false);
 				}
-			} while (visibleCount < total);
+			} while (visibleCount < total && $trs.length > 0);
 
 			this.$container.trigger('scroll');
 		},


### PR DESCRIPTION
When loading the next page of search results, make sure that the loop
can end if there are no more elements in case the total doesn't match.

Also added a check to avoid recomputing the search results whenever the
setFilter() is called with the same value. This happens when navigating
away to another folder, the search field gets cleared automatically and
it calls FileList.setFilter('').

Fixes https://github.com/owncloud/core/issues/25308

Please review @jvillafanez @SergioBertolinSG @georgehrke @butonic @VicDeo @DeepDiver1975 @icewind1991 
