### PR TITLE
Filelist change dir auto-prepend slash

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -513,7 +513,7 @@
 		 * Event handler for when the URL changed
 		 */
 		_onUrlChanged: function(e) {
-			if (e && e.dir) {
+			if (e && _.isString(e.dir)) {
 				this.changeDirectory(e.dir, false, true);
 			}
 		},
@@ -1415,6 +1415,9 @@
 				this.setPageTitle();
 			}
 
+			if (targetDir.length > 0 && targetDir[0] !== '/') {
+				targetDir = '/' + targetDir;
+			}
 			this._currentDirectory = targetDir;
 
 			// legacy stuff

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1391,6 +1391,12 @@ describe('OCA.Files.FileList tests', function() {
 			setDirSpy.restore();
 			getFolderContentsStub.restore();
 		});
+		it('prepends a slash to directory if none was given', function() {
+			fileList.changeDirectory('');
+			expect(fileList.getCurrentDirectory()).toEqual('/');
+			fileList.changeDirectory('noslash');
+			expect(fileList.getCurrentDirectory()).toEqual('/noslash');
+		});
 	});
 	describe('breadcrumb events', function() {
 		var deferredList;


### PR DESCRIPTION
Prepend a slash to directories in case it was missing since many places
assume that it's there.

Fixes https://github.com/owncloud/core/issues/25200

Please review @owncloud/javascript @guruz @georgehrke 
