### PR TITLE
[stable8] Hide revert button when no permission to revert

### DIFF
--- a/apps/files_versions/lib/storage.php
+++ b/apps/files_versions/lib/storage.php
@@ -274,8 +274,16 @@ class Storage {
 			// add expected leading slash
 			$file = '/' . ltrim($file, '/');
 			list($uid, $filename) = self::getUidAndFilename($file);
+			if ($uid === null || trim($filename, '/') === '') {
+				return false;
+			}
 			$users_view = new \OC\Files\View('/'.$uid);
 			$files_view = new \OC\Files\View('/'.\OCP\User::getUser().'/files');
+
+			if (!$files_view->isUpdatable($filename)) {
+				return false;
+			}
+
 			$versionCreated = false;
 
 			//first create a new version


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/25288 to stable8.1

Please review  @georgehrke @VicDeo @DeepDiver1975 @owncloud/filesystem 

Note that this commit did not change anything in the JS side because in this version the "Versions" dropdown is not available at all.

Also: bonus unit tests that came with the backport !

I tested this and it worked fine.

:warning: don't merge before 8.0.14 is out!
