### PR TITLE
Workaround to check htaccess in case of redirects

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -198,7 +198,7 @@
 			}
 			var afterCall = function(xhr) {
 				var messages = [];
-				if (xhr.status !== 403 && xhr.status !== 307 && xhr.status !== 301 && xhr.responseText !== '') {
+				if (xhr.status !== 403 && xhr.status !== 307 && xhr.status !== 301 && xhr.responseText.indexOf('HTACCESSFAIL') >= 0) {
 					messages.push({
 						msg: t('core', 'Your data directory and your files are probably accessible from the Internet. The .htaccess file is not working. We strongly suggest that you configure your web server in a way that the data directory is no longer accessible or you move the data directory outside the web server document root.'),
 						type: OC.SetupChecks.MESSAGE_TYPE_ERROR

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1143,7 +1143,8 @@ class OC_Util {
 
 		// testdata
 		$fileName = '/htaccesstest.txt';
-		$testContent = 'This is used for testing whether htaccess is properly enabled to disallow access from the outside. This file can be safely removed.';
+		// test content containing the string "HTACCESSFAIL"
+		$testContent = 'HTACCESSFAIL: This is used for testing whether htaccess is properly enabled to disallow access from the outside. This file can be safely removed.';
 
 		// creating a test file
 		$testFile = $config->getSystemValue('datadirectory', OC::$SERVERROOT . '/data') . '/' . $fileName;


### PR DESCRIPTION
In some setups, the web server will redirect any call to "data/" to the
main page. This causes the XHR to return the 200 HTTP status code and
the body contains the HTML page of the main page / files app.

This fix improves the htaccess failure detection by adding a known
string inside the test file "htaccesstest.txt". If we are able to find
this string, it means that the web server didn't block access to that
file.

Reported by greysun on IRC.

Please review @RealRancor @LukasReschke @danimo @DeepDiver1975 @guruz @georgehrke 

Would be good to backport this to 9.1 and 9.0 to avoid annoying false positives.
