### PR TITLE
Fix overwriting folders on rename with SFTP

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -426,7 +426,7 @@ class SFTP extends \OC\Files\Storage\Common {
 	 */
 	public function rename($source, $target) {
 		try {
-			if (!$this->is_dir($target) && $this->file_exists($target)) {
+			if ($this->file_exists($target)) {
 				$this->unlink($target);
 			}
 			return $this->getConnection()->rename(


### PR DESCRIPTION
This aligns the behavior with other storages and also fixes the failing
unit test testRenameOverWriteDirectory (see https://github.com/owncloud/core/issues/11692)

Tests can be run with: `./autotest-external.sh sqlite sftp-atmoz`.

They'll all pass except the testHashInFileName which is fixed separately.

Please review @Xenopathic @icewind1991 @DeepDiver1975 @guruz @georgehrke 
