### PR TITLE
Revert "Remove repair steps for broken updater repair"

### DIFF
--- a/lib/private/repair.php
+++ b/lib/private/repair.php
@@ -32,6 +32,7 @@ use OC\Hooks\BasicEmitter;
 use OC\Hooks\Emitter;
 use OC\Repair\AssetCache;
 use OC\Repair\AvatarPermissions;
+use OC\Repair\BrokenUpdaterRepair;
 use OC\Repair\CleanTags;
 use OC\Repair\Collation;
 use OC\Repair\CopyRewriteBaseToConfig;
@@ -118,6 +119,7 @@ class Repair extends BasicEmitter {
 			new UpdateOutdatedOcsIds(\OC::$server->getConfig()),
 			new RepairInvalidShares(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection()),
 			new AvatarPermissions(\OC::$server->getDatabaseConnection()),
+			new BrokenUpdaterRepair(),
 		];
 	}
 

--- a/lib/private/repair/brokenupdaterrepair.php
+++ b/lib/private/repair/brokenupdaterrepair.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * @author Lukas Reschke <lukas@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Repair;
+
+use OC\Hooks\BasicEmitter;
+
+/**
+ * Class BrokenUpdaterRepair fixes some issues caused by bugs in the ownCloud
+ * updater below version 9.0.2.
+ *
+ * FIXME: This file should be removed after the 9.0.2 release. The update server
+ * is instructed to deliver 9.0.2 for 9.0.0 and 9.0.1.
+ *
+ * @package OC\Repair
+ */
+class BrokenUpdaterRepair extends BasicEmitter implements \OC\RepairStep {
+
+	public function getName() {
+		return 'Manually copies the third-party folder changes since 9.0.0 due ' .
+		'to a bug in the updater.';
+	}
+
+	/**
+	 * Manually copy the third-party files that have changed since 9.0.0 because
+	 * the old updater does not copy over third-party changes.
+	 *
+	 * @return bool True if action performed, false otherwise
+	 */
+	private function manuallyCopyThirdPartyFiles() {
+		$resourceDir = __DIR__ . '/../../../resources/updater-fixes/';
+		$thirdPartyDir = __DIR__ . '/../../../3rdparty/';
+
+		$filesToCopy = [
+			// Composer updates
+			'composer.json',
+			'composer.lock',
+			'composer/autoload_classmap.php',
+			'composer/installed.json',
+			'composer/LICENSE',
+			// Icewind stream library
+			'icewind/streams/src/DirectoryFilter.php',
+			'icewind/streams/src/DirectoryWrapper.php',
+			'icewind/streams/src/RetryWrapper.php',
+			'icewind/streams/src/SeekableWrapper.php',
+			// Sabre update
+			'sabre/dav/CHANGELOG.md',
+			'sabre/dav/composer.json',
+			'sabre/dav/lib/CalDAV/Plugin.php',
+			'sabre/dav/lib/CardDAV/Backend/PDO.php',
+			'sabre/dav/lib/DAV/CorePlugin.php',
+			'sabre/dav/lib/DAV/Version.php',
+		];
+
+		// Check the hash for the autoload_classmap.php file, if the hash does match
+		// the expected value then the third-party folder has already been copied
+		// properly.
+		if(hash_file('sha512', $thirdPartyDir . '/composer/autoload_classmap.php') === 'abe09be19b6d427283cbfa7c4156d2c342cd9368d7d0564828a00ae02c435b642e7092cef444f94635f370dbe507eb6b2aa05109b32d8fb5d8a65c3a5a1c658f') {
+			$this->emit('\OC\Repair', 'info', ['Third-party files seem already to have been copied. No repair necessary.']);
+			return false;
+		}
+
+		foreach($filesToCopy as $file) {
+			$state = copy($resourceDir . '/' . $file, $thirdPartyDir . '/' . $file);
+			if($state === true) {
+				$this->emit('\OC\Repair', 'info', ['Successfully replaced '.$file.' with new version.']);
+			} else {
+				$this->emit('\OC\Repair', 'warning', ['Could not replace '.$file.' with new version.']);
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Rerun the integrity check after the update since the repair step has
+	 * repaired some invalid copied files.
+	 */
+	private function recheckIntegrity() {
+		\OC::$server->getIntegrityCodeChecker()->runInstanceVerification();
+	}
+
+	public function run() {
+		if($this->manuallyCopyThirdPartyFiles()) {
+			$this->emit('\OC\Repair', 'info', ['Start integrity recheck.']);
+			$this->recheckIntegrity();
+			$this->emit('\OC\Repair', 'info', ['Finished integrity recheck.']);
+		} else {
+			$this->emit('\OC\Repair', 'info', ['Rechecking code integrity not necessary.']);
+		}
+	}
+}
+


### PR DESCRIPTION
This reverts commit 58ed5b9328e9e12dd4319c0730202f385ca0dc5d.

Reverts https://github.com/owncloud/core/pull/24438

Fixes https://github.com/owncloud/updater/issues/358

The problem is as follows: whenever that PR was merged, it was assumed that the updater will provide the update path 9.0.x->9.0.2->9.0.3 in which case the repair would happen in 9.0.2.

However, due to another bug that was found later on related to encryption, we can't provide a smooth update path through 9.0.2 for people with encryption.

So this PR reverts the fix to make sure that updates like 9.0.0->9.0.4, 9.0.1->9.0.4 will be possible, skipping 9.0.2.

Now... need to double check whether we should even allow skipping 9.0.2 in the first place.
- [ ] double check whether skipping 9.0.2 could cause other troubles
- ~add a version check in the repair step (when coming from OC <= 9.0.1) to avoid unneeded operations~~

@VicDeo @DeepDiver1975 
