### PR TITLE
Added fix for issue #25332

### DIFF
--- a/settings/ChangePassword/Controller.php
+++ b/settings/ChangePassword/Controller.php
@@ -45,11 +45,11 @@ class Controller {
 			\OC_JSON::error(array("data" => array("message" => $l->t("Wrong password")) ));
 			exit();
 		}
-        if ($oldPassword == $password) {
-            $l = new \OC_L10n('settings');
-			\OC_JSON::error(array("data" => array("message" => $l->t("The new password can not be the same as the previous one")) ));
-			exit();
-        }
+	        if ($oldPassword === $password) {
+	            $l = new \OC_L10n('settings');
+				\OC_JSON::error(array("data" => array("message" => $l->t("The new password can not be the same as the previous one")) ));
+				exit();
+	        }
 		if (!is_null($password) && \OC_User::setPassword($username, $password)) {
 			\OC::$server->getUserSession()->updateSessionTokenPassword($password);
 			\OC_JSON::success();

--- a/settings/ChangePassword/Controller.php
+++ b/settings/ChangePassword/Controller.php
@@ -45,11 +45,6 @@ class Controller {
 			\OC_JSON::error(array("data" => array("message" => $l->t("Wrong password")) ));
 			exit();
 		}
-        if ($oldPassword == $password) {
-            $l = new \OC_L10n('settings');
-			\OC_JSON::error(array("data" => array("message" => $l->t("The new password can not be the same as the previous one")) ));
-			exit();
-        }
 		if (!is_null($password) && \OC_User::setPassword($username, $password)) {
 			\OC::$server->getUserSession()->updateSessionTokenPassword($password);
 			\OC_JSON::success();

--- a/settings/ChangePassword/Controller.php
+++ b/settings/ChangePassword/Controller.php
@@ -45,11 +45,11 @@ class Controller {
 			\OC_JSON::error(array("data" => array("message" => $l->t("Wrong password")) ));
 			exit();
 		}
-        if ($oldPassword === $password) {
-            $l = new \OC_L10n('settings');
-			\OC_JSON::error(array("data" => array("message" => $l->t("The new password can not be the same as the previous one")) ));
-			exit();
-        }
+	        if ($oldPassword === $password) {
+	            $l = new \OC_L10n('settings');
+				\OC_JSON::error(array("data" => array("message" => $l->t("The new password can not be the same as the previous one")) ));
+				exit();
+	        }
 		if (!is_null($password) && \OC_User::setPassword($username, $password)) {
 			\OC::$server->getUserSession()->updateSessionTokenPassword($password);
 			\OC_JSON::success();

--- a/settings/ChangePassword/Controller.php
+++ b/settings/ChangePassword/Controller.php
@@ -45,7 +45,7 @@ class Controller {
 			\OC_JSON::error(array("data" => array("message" => $l->t("Wrong password")) ));
 			exit();
 		}
-        if ($oldPassword == $password) {
+        if ($oldPassword === $password) {
             $l = new \OC_L10n('settings');
 			\OC_JSON::error(array("data" => array("message" => $l->t("The new password can not be the same as the previous one")) ));
 			exit();

--- a/settings/ChangePassword/Controller.php
+++ b/settings/ChangePassword/Controller.php
@@ -45,6 +45,11 @@ class Controller {
 			\OC_JSON::error(array("data" => array("message" => $l->t("Wrong password")) ));
 			exit();
 		}
+        if ($oldPassword == $password) {
+            $l = new \OC_L10n('settings');
+			\OC_JSON::error(array("data" => array("message" => $l->t("The new password can not be the same as the previous one")) ));
+			exit();
+        }
 		if (!is_null($password) && \OC_User::setPassword($username, $password)) {
 			\OC::$server->getUserSession()->updateSessionTokenPassword($password);
 			\OC_JSON::success();

--- a/settings/ChangePassword/Controller.php
+++ b/settings/ChangePassword/Controller.php
@@ -46,9 +46,9 @@ class Controller {
 			exit();
 		}
 	        if ($oldPassword === $password) {
-	            $l = new \OC_L10n('settings');
-				\OC_JSON::error(array("data" => array("message" => $l->t("The new password can not be the same as the previous one")) ));
-				exit();
+			$l = new \OC_L10n('settings');
+			\OC_JSON::error(array("data" => array("message" => $l->t("The new password can not be the same as the previous one")) ));
+			exit();
 	        }
 		if (!is_null($password) && \OC_User::setPassword($username, $password)) {
 			\OC::$server->getUserSession()->updateSessionTokenPassword($password);


### PR DESCRIPTION
Made sure that the newly entered password is not the same as the
existing password. This is done using a simple if statement comparing
already defined variables for the newly entered and the old password. If
the variables are the same a fitting error will be passed.

(used my girlfriend's account on accident, that explains the reverts)
