### PR TITLE
[stable9] Change order of share creation validation

### DIFF
--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -26,6 +26,21 @@ Feature: sharing
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
 
+  Scenario: Creating a new share with user who already received a share through their group
+    Given As an "admin"
+    And user "user0" exists
+    And user "user1" exists
+    And group "sharing-group" exists
+    And user "user1" belongs to group "sharing-group"
+    And file "welcome.txt" of user "user0" is shared with group "sharing-group"
+    And As an "user0"
+    Then sending "POST" to "/apps/files_sharing/api/v1/shares" with
+      | path | welcome.txt |
+      | shareWith | user1 |
+      | shareType | 0 |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+
   Scenario: Creating a new public share
     Given user "user0" exists
     And As an "user0"

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -505,6 +505,24 @@ class Manager implements IManager {
 
 		$this->generalCreateChecks($share);
 
+		// Verify if there are any issues with the path
+		$this->pathCreateChecks($share->getNode());
+
+		/*
+		 * On creation of a share the owner is always the owner of the path
+		 * Except for mounted federated shares.
+		 */
+		$storage = $share->getNode()->getStorage();
+		if ($storage->instanceOfStorage('OCA\Files_Sharing\External\Storage')) {
+			$parent = $share->getNode()->getParent();
+			while($parent->getStorage()->instanceOfStorage('OCA\Files_Sharing\External\Storage')) {
+				$parent = $parent->getParent();
+			}
+			$share->setShareOwner($parent->getOwner()->getUID());
+		} else {
+			$share->setShareOwner($share->getNode()->getOwner()->getUID());
+		}
+
 		//Verify share type
 		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER) {
 			$this->userCreateChecks($share);
@@ -536,24 +554,6 @@ class Manager implements IManager {
 			if ($share->getPassword() !== null) {
 				$share->setPassword($this->hasher->hash($share->getPassword()));
 			}
-		}
-
-		// Verify if there are any issues with the path
-		$this->pathCreateChecks($share->getNode());
-
-		/*
-		 * On creation of a share the owner is always the owner of the path
-		 * Except for mounted federated shares.
-		 */
-		$storage = $share->getNode()->getStorage();
-		if ($storage->instanceOfStorage('OCA\Files_Sharing\External\Storage')) {
-			$parent = $share->getNode()->getParent();
-			while($parent->getStorage()->instanceOfStorage('OCA\Files_Sharing\External\Storage')) {
-				$parent = $parent->getParent();
-			}
-			$share->setShareOwner($parent->getOwner()->getUID());
-		} else {
-			$share->setShareOwner($share->getNode()->getOwner()->getUID());
 		}
 
 		// Cannot share with the owner


### PR DESCRIPTION
Makes sure that the share owner is set before entering the checks that
need it.

Partial backport of afa37d3 from

Fixes https://github.com/owncloud/core/issues/25359 which is a regression from OC 8.2.

I will add an integration test for this to avoid future regressions.
