### PR TITLE
Add integration test for sharing with group, then user in group

### DIFF
--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -26,6 +26,21 @@ Feature: sharing
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
 
+  Scenario: Creating a new share with user who already received a share through their group
+    Given As an "admin"
+    And user "user0" exists
+    And user "user1" exists
+    And group "sharing-group" exists
+    And user "user1" belongs to group "sharing-group"
+    And file "welcome.txt" of user "user0" is shared with group "sharing-group"
+    And As an "user0"
+    Then sending "POST" to "/apps/files_sharing/api/v1/shares" with
+      | path | welcome.txt |
+      | shareWith | user1 |
+      | shareType | 0 |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+
   Scenario: Creating a new public share
     Given user "user0" exists
     And As an "user0"


### PR DESCRIPTION
Add integration test for the use case where a group share exists and
then the same owner creates a direct share to a user in that group.

Forward port of the integration test from https://github.com/owncloud/core/pull/25360

Please review @DeepDiver1975 @SergioBertolinSG @owncloud/sharing 
