### PR TITLE
Ignore invalid paths in the JS file list

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1397,6 +1397,16 @@
 			return OC.linkTo('files', 'index.php')+"?dir="+ encodeURIComponent(dir).replace(/%2F/g, '/');
 		},
 
+		_isValidPath: function(path) {
+			var sections = path.split('/');
+			for (var i = 0; i < sections.length; i++) {
+				if (sections[i] === '..') {
+					return false;
+				}
+			}
+			return true;
+		},
+
 		/**
 		 * Sets the current directory name and updates the breadcrumb.
 		 * @param targetDir directory to display
@@ -1405,6 +1415,10 @@
 		 */
 		_setCurrentDir: function(targetDir, changeUrl, fileId) {
 			targetDir = targetDir.replace(/\\/g, '/');
+			if (!this._isValidPath(targetDir)) {
+				targetDir = '/';
+				changeUrl = true;
+			}
 			var previousDir = this.getCurrentDirectory(),
 				baseDir = OC.basename(targetDir);
 

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1334,6 +1334,31 @@ describe('OCA.Files.FileList tests', function() {
 			fileList.changeDirectory('/another\\subdir');
 			expect(fileList.getCurrentDirectory()).toEqual('/another/subdir');
 		});
+		it('switches to root dir when current directory is invalid', function() {
+			_.each([
+				'..',
+				'/..',
+				'../',
+				'/../',
+				'/../abc',
+				'/abc/..',
+				'/abc/../',
+				'/../abc/'
+			], function(path) {
+				fileList.changeDirectory(path);
+				expect(fileList.getCurrentDirectory()).toEqual('/');
+			});
+		});
+		it('allows paths with dotdot at the beginning or end', function() {
+			_.each([
+				'..abc',
+				'def..',
+				'...'
+			], function(path) {
+				fileList.changeDirectory(path);
+				expect(fileList.getCurrentDirectory()).toEqual(path);
+			});
+		});
 		it('switches to root dir when current directory does not exist', function() {
 			fileList.changeDirectory('/unexist');
 			deferredList.reject(404);


### PR DESCRIPTION
Please review @ChristophWurst @guruz @georgehrke @VicDeo @DeepDiver1975 

You can test this by adding ".." sections in the URL directly, for example:
http://localhost/owncloud/index.php/apps/files/?dir=/../../something

Note that on master you'll have to remove the fileid argument as it takes precedence over the path.

Should be backported to stable9.1 and stable9.
