### PR TITLE
Use named parameter instead of direct value for system tags search param

### DIFF
--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -142,7 +142,7 @@ class SystemTagManager implements ISystemTagManager {
 			$query->andWhere(
 				$query->expr()->like(
 					'name',
-					$query->expr()->literal('%' . $this->connection->escapeLikeParameter($nameSearchPattern). '%')
+					$query->createNamedParameter('%' . $this->connection->escapeLikeParameter($nameSearchPattern). '%')
 				)
 			);
 		}


### PR DESCRIPTION
Please review @DeepDiver1975 @VicDeo @georgehrke @danimo @guruz 

To be backported to 9.1 and 9.0.
