### PR TITLE
[stable9] fix swift primary object store test 

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1959,7 +1959,7 @@ class View {
 		$mount = $this->getMountForLock($absolutePath, $lockMountPoint);
 		if ($mount) {
 			$storage = $mount->getStorage();
-			if ($storage->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
+			if ($storage && $storage->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
 				$storage->releaseLock(
 					$mount->getInternalPath($absolutePath),
 					$type,

--- a/tests/objectstore/wait-for-connection
+++ b/tests/objectstore/wait-for-connection
@@ -1,0 +1,45 @@
+#!/usr/bin/php
+<?php
+
+$timeout = 60;
+
+switch ($argc) {
+case 4:
+	$timeout = (float)$argv[3];
+case 3:
+	$host = $argv[1];
+	$port = (int)$argv[2];
+	break;
+default:
+	fwrite(STDERR, 'Usage: '.$argv[0].' host port [timeout]'."\n");
+	exit(2);
+}
+
+if ($timeout < 0) {
+	fwrite(STDERR, 'Timeout must be greater than zero'."\n");
+	exit(2);
+}
+if ($port < 1) {
+	fwrite(STDERR, 'Port must be an integer greater than zero'."\n");
+	exit(2);
+}
+
+$socketTimeout = (float)ini_get('default_socket_timeout');
+if ($socketTimeout > $timeout) {
+	$socketTimeout = $timeout;
+}
+
+$stopTime = time() + $timeout;
+do {
+	$sock = @fsockopen($host, $port, $errno, $errstr, $socketTimeout);
+	if ($sock !== false) {
+		fclose($sock);
+		fwrite(STDOUT, "\n");
+		exit(0);
+	}
+	sleep(1);
+	fwrite(STDOUT, '.');
+} while (time() < $stopTime);
+
+fwrite(STDOUT, "\n");
+exit(1);


### PR DESCRIPTION
backport #25281
- Wait for socket to be open
- Fix call on null
- Allow DB access for MountProviderTest

Makes unit tests pass when using object store, since their FS access is
actually oc_filecache DB access. It is currently not possible to mock
or bypass the logic from "SharedMount::verifyMountPoint()" triggered by
this test.
