### PR TITLE
[stable9] Use named parameter instead of direct value for system tags…

### DIFF
--- a/lib/private/systemtag/systemtagmanager.php
+++ b/lib/private/systemtag/systemtagmanager.php
@@ -126,7 +126,7 @@ class SystemTagManager implements ISystemTagManager {
 			$query->andWhere(
 				$query->expr()->like(
 					'name',
-					$query->expr()->literal('%' . $this->connection->escapeLikeParameter($nameSearchPattern). '%')
+					$query->createNamedParameter('%' . $this->connection->escapeLikeParameter($nameSearchPattern). '%')
 				)
 			);
 		}


### PR DESCRIPTION
… search param

backport of #25380
