### PR TITLE
Cast share id to string in public auth

### DIFF
--- a/apps/dav/lib/Connector/PublicAuth.php
+++ b/apps/dav/lib/Connector/PublicAuth.php
@@ -98,7 +98,7 @@ class PublicAuth extends AbstractBasic {
 				if ($this->shareManager->checkPassword($share, $password)) {
 					return true;
 				} else if ($this->session->exists('public_link_authenticated')
-					&& $this->session->get('public_link_authenticated') === $share->getId()) {
+					&& $this->session->get('public_link_authenticated') === (string)$share->getId()) {
 					return true;
 				} else {
 					if (in_array('XMLHttpRequest', explode(',', $this->request->getHeader('X-Requested-With')))) {


### PR DESCRIPTION
Additional fix for https://github.com/owncloud/core/issues/23066

@butonic @DeepDiver1975 @owncloud/sharing 

Backports needed to:
- stable9.1
- stable9
