### PR TITLE
[WIP] Show the LDAP configuration status in the configuration chooser

### DIFF
--- a/apps/user_ldap/js/wizard/wizardTabElementary.js
+++ b/apps/user_ldap/js/wizard/wizardTabElementary.js
@@ -83,6 +83,7 @@ OCA = OCA || {};
 			this.configModel.on('newConfiguration', this.onNewConfiguration, this);
 			this.configModel.on('deleteConfiguration', this.onDeleteConfiguration, this);
 			this.configModel.on('receivedLdapFeature', this.onTestResultReceived, this);
+			this.configModel.on('setCompleted', this.onConfigurationActiveChange, this);
 			this._enableConfigChooser();
 			this._enableConfigButtons();
 		},
@@ -287,6 +288,24 @@ OCA = OCA || {};
 					}
 				}
 				OC.Notification.showTemporary(message);
+			}
+		},
+
+		onConfigurationActiveChange: function(view, result) {
+			if(result.isSuccess === true) {
+				if (result.key === 'ldap_configuration_active') {
+					var selectedOpt = view.$configChooser.find('option:selected');
+					var selectedOptText = selectedOpt.text();
+					if (parseInt(result.value) === 1) {
+						// configuration active -> remove the "(inactive)" text
+						selectedOpt.text(selectedOptText.replace(/ \(inactive\)$/, ''));
+					} else {
+						// configuration inactive -> add "(inactive)" text
+						selectedOpt.text(selectedOptText + ' (inactive)');
+					}
+				}
+			} else {
+				OC.Notification.showTemporary(result.errorMessage);
 			}
 		},
 

--- a/apps/user_ldap/settings.php
+++ b/apps/user_ldap/settings.php
@@ -34,6 +34,7 @@ $tmpl = new OCP\Template('user_ldap', 'settings');
 
 $helper = new \OCA\User_LDAP\Helper();
 $prefixes = $helper->getServerConfigurationPrefixes();
+$activePrefixes = $helper->getServerConfigurationPrefixes(true);
 $hosts = $helper->getServerConfigurationHosts();
 
 $wizardHtml = '';
@@ -56,6 +57,7 @@ for($i = 0; $i < $wizTabsCount; $i++) {
 	$tab = new OCP\Template('user_ldap', $wizTabs[$i]['tpl']);
 	if($i === 0) {
 		$tab->assign('serverConfigurationPrefixes', $prefixes);
+		$tab->assign('serverConfigurationActivePrefixes', $activePrefixes);
 		$tab->assign('serverConfigurationHosts', $hosts);
 	}
 	$tab->assign('wizardControls', $wControls);

--- a/apps/user_ldap/templates/part.wizard-server.php
+++ b/apps/user_ldap/templates/part.wizard-server.php
@@ -16,8 +16,9 @@
 			$i = 1;
 			$sel = ' selected';
 			foreach($_['serverConfigurationPrefixes'] as $prefix) {
+				$confActive = (in_array($prefix, $_['serverConfigurationActivePrefixes'], true)) ? '' : '(inactive)';
 				?>
-				<option value="<?php p($prefix); ?>"<?php p($sel); $sel = ''; ?>><?php p($l->t('%s. Server:', array($i++)));?> <?php p(' '.$_['serverConfigurationHosts'][$prefix]); ?></option>
+				<option value="<?php p($prefix); ?>"<?php p($sel); $sel = ''; ?>><?php p($l->t('%s. Server:', array($i++)));?> <?php p(' '.$_['serverConfigurationHosts'][$prefix]); ?> <?php p($confActive); ?></option>
 				<?php
 			}
 		}


### PR DESCRIPTION
PoC for https://github.com/owncloud/core/issues/16059

A couple of things to notice:
- The server chooser will have appended the "(inactive)" if that configuration is inactive. This should be an easy and quick way to know the inactive configurations. Other ideas are welcome as long as they're cross-browser compatible.
- The `$helper->getServerConfigurationPrefixes()` function needs some changes. I'm aware of that, but I'd rather have something working to check the UX before cleaning up.

So, what's the level of interest? Keep moving this forward or stop at this point? Any other change needed?
