### PR TITLE
[stable9.1] Workaround to check htaccess in case of redirects

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -198,7 +198,7 @@
 			}
 			var afterCall = function(xhr) {
 				var messages = [];
-				if (xhr.status !== 403 && xhr.status !== 307 && xhr.status !== 301 && xhr.responseText !== '') {
+				if (xhr.status !== 403 && xhr.status !== 307 && xhr.status !== 301 && xhr.responseText.indexOf('HTACCESSFAIL') >= 0) {
 					messages.push({
 						msg: t('core', 'Your data directory and your files are probably accessible from the Internet. The .htaccess file is not working. We strongly suggest that you configure your web server in a way that the data directory is no longer accessible or you move the data directory outside the web server document root.'),
 						type: OC.SetupChecks.MESSAGE_TYPE_ERROR

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -103,7 +103,7 @@ describe('OC.SetupChecks tests', function() {
 		it('should return an error if data directory is not protected', function(done) {
 			var async = OC.SetupChecks.checkDataProtected();
 
-			suite.server.requests[0].respond(200, {'Content-Type': 'text/plain'}, 'file contents');
+			suite.server.requests[0].respond(200, {'Content-Type': 'text/plain'}, '*cough*HTACCESSFAIL*cough*');
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([
@@ -125,6 +125,18 @@ describe('OC.SetupChecks tests', function() {
 				done();
 			});
 		});
+
+		it('should not return an error if data directory is protected and redirects to main page', function(done) {
+			var async = OC.SetupChecks.checkDataProtected();
+
+			suite.server.requests[0].respond(200, {'Content-Type': 'text/plain'}, '<html><body>blah</body></html>');
+
+			async.done(function( data, s, x ){
+				expect(data).toEqual([]);
+				done();
+			});
+		});
+
 
 		it('should return an error if data directory is a boolean', function(done) {
 

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1143,7 +1143,8 @@ class OC_Util {
 
 		// testdata
 		$fileName = '/htaccesstest.txt';
-		$testContent = 'This is used for testing whether htaccess is properly enabled to disallow access from the outside. This file can be safely removed.';
+		// test content containing the string "HTACCESSFAIL"
+		$testContent = 'HTACCESSFAIL: This is used for testing whether htaccess is properly enabled to disallow access from the outside. This file can be safely removed.';
 
 		// creating a test file
 		$testFile = $config->getSystemValue('datadirectory', OC::$SERVERROOT . '/data') . '/' . $fileName;


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/25331 to stable9.1

Please review @RealRancor @owncloud/javascript @guruz @DeepDiver1975 @georgehrke @VicDeo 

Setting to 9.1 as this might lead to false positives
