### PR TITLE
Convert the group limit to match the same behaviour as the user search

### DIFF
--- a/apps/user_ldap/lib/Command/Search.php
+++ b/apps/user_ldap/lib/Command/Search.php
@@ -113,6 +113,11 @@ class Search extends Command {
 			$proxy = new Group_Proxy($configPrefixes, $ldapWrapper);
 			$getMethod = 'getGroups';
 			$printID = false;
+			// convert the limit of groups to null. This will show all the groups available instead of
+			// nothing, and will match the same behaviour the search for users has.
+			if ($limit === 0) {
+				$limit = null;
+			}
 		} else {
 			$proxy = new User_Proxy($configPrefixes, $ldapWrapper, $this->ocConfig);
 			$getMethod = 'getDisplayNames';


### PR DESCRIPTION
Fix https://github.com/owncloud/core/issues/14248

This should be backported to all previous versions (it never worked before with those conditions).
