### PR TITLE
[stable9.1] Change load order of auth backends so that we can throw an exception …

### DIFF
--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -66,12 +66,15 @@ class Server {
 		$this->server->setBaseUri($this->baseUri);
 
 		$this->server->addPlugin(new BlockLegacyClientPlugin(\OC::$server->getConfig()));
-		$authPlugin = new Plugin($authBackend, 'ownCloud');
+		$authPlugin = new Plugin();
 		$this->server->addPlugin($authPlugin);
 
 		// allow setup of additional auth backends
 		$event = new SabrePluginEvent($this->server);
 		$dispatcher->dispatch('OCA\DAV\Connector\Sabre::authInit', $event);
+
+		// because we are throwing exceptions this plugin has to be the last one
+		$authPlugin->addBackend($authBackend);
 
 		// debugging
 		if(\OC::$server->getConfig()->getSystemValue('debug', false)) {


### PR DESCRIPTION
…in OCA\DAV\Connector\Sabre\Auth

Backport of https://github.com/owncloud/core/pull/25476 to stable9.1

@DeepDiver1975 @davitol @ChristophWurst 
