### PR TITLE
Fix misleading MySQL DB creation error

### DIFF
--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -60,12 +60,20 @@ class MySQL extends AbstractDatabase {
 			//we can't use OC_BD functions here because we need to connect as the administrative user.
 			$query = "CREATE DATABASE IF NOT EXISTS `$name` CHARACTER SET utf8 COLLATE utf8_bin;";
 			$connection->executeUpdate($query);
+		} catch (\Exception $ex) {
+			$this->logger->error('Database creation failed: {error}', [
+				'app' => 'mysql.setup',
+				'error' => $ex->getMessage()
+			]);
+			return;
+		}
 
+		try {
 			//this query will fail if there aren't the right permissions, ignore the error
 			$query="GRANT ALL PRIVILEGES ON `$name` . * TO '$user'";
 			$connection->executeUpdate($query);
 		} catch (\Exception $ex) {
-			$this->logger->error('Database creation failed: {error}', [
+			$this->logger->debug('Could not automatically grant privileges, this can be ignored if database user already had privileges: {error}', [
 				'app' => 'mysql.setup',
 				'error' => $ex->getMessage()
 			]);


### PR DESCRIPTION
Whenever the GRANT ALL failed, it used to display "Database creation
failed" which is incorrect. It's only the privleges setting that failed.

This moves the privilege setting message to DEBUG and makes it more
precise.

Before:

```
{"reqId":"CcPWb6+Y3d3VmT7weVKR","remoteAddr":"","app":"mysql.setup","message":"Database creation failed: An exception occurred while executing 'GRANT ALL PRIVILEGES ON `owncloud` . * TO 'owncloud'':\n\nSQLSTATE[42000]: Syntax error or access violation: 1044 Access denied for user 'owncloud'@'localhost' to database 'owncloud'","level":3,"time":"2016-07-15T08:09:12+00:00","method":"--","url":"--","user":"--"}
```

After:

```
{"reqId":"6JpnenOiRfSe1\/Jl6jQy","remoteAddr":"","app":"mysql.setup","message":"Could not automatically grant privileges, this can be ignored if database user already had privileges: An exception occurred while executing 'GRANT ALL PRIVILEGES ON `owncloud` . * TO 'owncloud'':\n\nSQLSTATE[42000]: Syntax error or access violation: 1044 Access denied for user 'owncloud'@'localhost' to database 'owncloud'","level":0,"time":"2016-07-15T08:13:36+00:00","method":"--","url":"--","user":"--"}
```

@DeepDiver1975 @RealRancor @SergioBertolinSG @guruz 
