### PR TITLE
[stable9.1] Use explode() instead of split() - fixes #25483 

### DIFF
--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -192,7 +192,7 @@ class OC_Files {
 	 * @return array $rangeArray ('from'=>int,'to'=>int), ...
 	 */
 	private static function parseHttpRangeHeader($rangeHeaderPos, $fileSize) {
-		$rArray=split(',', $rangeHeaderPos);
+		$rArray=explode(',', $rangeHeaderPos);
 		$minOffset = 0;
 		$ind = 0;
 


### PR DESCRIPTION
backport of #25488
