### PR TITLE
[stable9] Use explode() instead of split() - fixes #25483 

### DIFF
--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -191,7 +191,7 @@ class OC_Files {
 	 * @return array $rangeArray ('from'=>int,'to'=>int), ...
 	 */
 	private static function parseHttpRangeHeader($rangeHeaderPos, $fileSize) {
-		$rArray=split(',', $rangeHeaderPos);
+		$rArray=explode(',', $rangeHeaderPos);
 		$minOffset = 0;
 		$ind = 0;
 


### PR DESCRIPTION
backport #25488
