### PR TITLE
Store the shared propagator instance

### DIFF
--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -328,10 +328,15 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 	}
 
 	public function getPropagator($storage = null) {
+		if (isset($this->propagator)) {
+			return $this->propagator;
+		}
+
 		if (!$storage) {
 			$storage = $this;
 		}
-		return new \OCA\Files_Sharing\SharedPropagator($storage, \OC::$server->getDatabaseConnection());
+		$this->propagator = new \OCA\Files_Sharing\SharedPropagator($storage, \OC::$server->getDatabaseConnection());
+		return $this->propagator;
 	}
 
 	public function getOwner($path) {

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -138,9 +138,10 @@ class Scanner extends PublicEmitter {
 				$this->triggerPropagator($storage, $path);
 			});
 
-			$storage->getPropagator()->beginBatch();
+			$propagator = $storage->getPropagator();
+			$propagator->beginBatch();
 			$scanner->backgroundScan();
-			$storage->getPropagator()->commitBatch();
+			$propagator->commitBatch();
 		}
 	}
 
@@ -189,14 +190,15 @@ class Scanner extends PublicEmitter {
 				$this->db->beginTransaction();
 			}
 			try {
-				$storage->getPropagator()->beginBatch();
+				$propagator = $storage->getPropagator();
+				$propagator->beginBatch();
 				$scanner->scan($relativePath, \OC\Files\Cache\Scanner::SCAN_RECURSIVE, \OC\Files\Cache\Scanner::REUSE_ETAG | \OC\Files\Cache\Scanner::REUSE_SIZE);
 				$cache = $storage->getCache();
 				if ($cache instanceof Cache) {
 					// only re-calculate for the root folder we scanned, anything below that is taken care of by the scanner
 					$cache->correctFolderSize($relativePath);
 				}
-				$storage->getPropagator()->commitBatch();
+				$propagator->commitBatch();
 			} catch (StorageNotAvailableException $e) {
 				$this->logger->error('Storage ' . $storage->getId() . ' not available');
 				$this->logger->logException($e);


### PR DESCRIPTION
This instead of recreating it for every call.

Fixes https://github.com/owncloud/core/issues/25506

Steps to reproduce are here https://github.com/owncloud/core/issues/25506#issuecomment-233285671

Note: no backport required, only happens on 9.1

@owncloud/filesystem please review
