### PR TITLE
Increase version to 9.2

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,12 +25,12 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 1, 0, 11);
+$OC_Version = array(9, 2, 0, 0);
 
 // The human readable string
-$OC_VersionString = '9.1.0 RC1';
+$OC_VersionString = '9.2.0 pre alpha';
 
-$OC_VersionCanBeUpgradedFrom = array(9, 0);
+$OC_VersionCanBeUpgradedFrom = array(9, 1);
 
 // The ownCloud channel
 $OC_Channel = 'git';


### PR DESCRIPTION
Without this you'll get errors when trying to upgrade from 9.1.0RC2 to master...

Master needs to have a higher version.

@DeepDiver1975 @danimo 
