### PR TITLE
Prevent concurrent INSERT errors for file locks

### DIFF
--- a/lib/private/Lock/DBLockingProvider.php
+++ b/lib/private/Lock/DBLockingProvider.php
@@ -31,6 +31,7 @@ use OCP\IDBConnection;
 use OCP\ILogger;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 
 /**
  * Locking provider that stores the locks in the database
@@ -109,12 +110,17 @@ class DBLockingProvider extends AbstractLockingProvider {
 	 *
 	 * @param string $path
 	 * @param int $lock
-	 * @return int number of inserted rows
+	 * @return int number of inserted rows or -1 in case of constraint violation
 	 */
 
 	protected function initLockField($path, $lock = 0) {
 		$expire = $this->getExpireTime();
-		return $this->connection->insertIfNotExist('*PREFIX*file_locks', ['key' => $path, 'lock' => $lock, 'ttl' => $expire], ['key']);
+		try {
+			return $this->connection->insertIfNotExist('*PREFIX*file_locks', ['key' => $path, 'lock' => $lock, 'ttl' => $expire], ['key']);
+		} catch (UniqueConstraintViolationException $e) {
+			// field already exists
+			return -1;
+		}
 	}
 
 	/**

--- a/tests/lib/Lock/DBLockingProviderTest.php
+++ b/tests/lib/Lock/DBLockingProviderTest.php
@@ -22,6 +22,7 @@
 namespace Test\Lock;
 
 use OCP\Lock\ILockingProvider;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 
 /**
  * Class DBLockingProvider
@@ -62,7 +63,7 @@ class DBLockingProviderTest extends LockingProvider {
 	/**
 	 * @return \OCP\Lock\ILockingProvider
 	 */
-	protected function getInstance() {
+	protected function createInstance() {
 		$this->connection = \OC::$server->getDatabaseConnection();
 		return new \OC\Lock\DBLockingProvider($this->connection, \OC::$server->getLogger(), $this->timeFactory, 3600);
 	}
@@ -95,4 +96,36 @@ class DBLockingProviderTest extends LockingProvider {
 		$query->execute();
 		return $query->fetchColumn();
 	}
+
+	public function testConcurrentSharedLockConstraintViolation() {
+		$connection1 = $this->getMock('\OCP\IDBConnection');
+		$connection2 = $this->getMock('\OCP\IDBConnection');
+		$instance1 = new \OC\Lock\DBLockingProvider($connection1, \OC::$server->getLogger(), $this->timeFactory, 3600);
+		$instance2 = new \OC\Lock\DBLockingProvider($connection2, \OC::$server->getLogger(), $this->timeFactory, 3600);
+
+		// first instance inserts entry
+		$connection1->expects($this->once())
+			->method('insertIfNotExist')
+			->with('*PREFIX*file_locks', ['key' => 'foo', 'lock' => 1, 'ttl' => $this->currentTime + 3600], ['key'])
+			->will($this->returnValue(1));
+		$connection1->expects($this->never())
+			->method('executeUpdate');
+
+		// second instance fails to insert due to constraint violation
+		$connection2->expects($this->once())
+			->method('insertIfNotExist')
+			->with('*PREFIX*file_locks', ['key' => 'foo', 'lock' => 1, 'ttl' => $this->currentTime + 3600], ['key'])
+			->will($this->throwException(new UniqueConstraintViolationException('dummy', $this->getMock('\Doctrine\DBAL\Driver\DriverException'))));
+		$connection2->expects($this->once())
+			->method('executeUpdate')
+			->with('UPDATE `*PREFIX*file_locks` SET `lock` = `lock` + 1, `ttl` = ? WHERE `key` = ? AND `lock` >= 0', [$this->currentTime + 3600, 'foo'])
+			->will($this->returnValue(1));
+
+		$instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$instance2->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+
+		$this->assertTrue($instance1->isLocked('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertTrue($instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
+	}
+
 }

--- a/tests/lib/Lock/MemcacheLockingProviderTest.php
+++ b/tests/lib/Lock/MemcacheLockingProviderTest.php
@@ -33,7 +33,7 @@ class MemcacheLockingProviderTest extends LockingProvider {
 	/**
 	 * @return \OCP\Lock\ILockingProvider
 	 */
-	protected function getInstance() {
+	protected function createInstance() {
 		$this->memcache = new ArrayCache();
 		return new \OC\Lock\MemcacheLockingProvider($this->memcache);
 	}


### PR DESCRIPTION
Whenever a lock entry doesn't exist yet, it will be inserted into the
database. This can happen concurrently so one of the INSERT calls will
fail with a duplicate entry violation.

This fix catches that error and lets the DBLockingProvider carry on
with an UPDATE operation instead.

Note: this is almost impossible to reproduce manually, but happened on my own server once.

Steps to get close to reproducing this issue:
1. Create a folder "test/sub"
2. Upload at least two files into "test/sub"
3. Clear the "oc_file_locks" table to make sure the entries do not exist and an "INSERT" will be attempted
4. Download ALL files from "test/sub" in **parallel** (like the sync client)

Expected: no errors
Actual: in some rare cases, one of the file will throw a 500 with this:

```
{"reqId":"Tzj\/eiq7+UugDs7pNvgU","remoteAddr":"85.180.4.42","app":"webdav","message":"Exception: {\"Message\":\"An exception occurred while executing 'INSERT INTO `oc_file_locks` (`key`,`lock`,`ttl`) SELECT ?,?,? FROM `oc_file_locks` WHERE `key` = ? HAVING COUNT(*) = 0' with params [\\\"files\\\\\\\/8fc0900ba504c48c8c428f538658a536\\\", 1, 1468829923, \\\"files\\\\\\\/8fc0900ba504c48c8c428f538658a536\\\"]:\\n\\nSQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'files\\\/8fc0900ba504c48c8c428f538658a536' for key 'lock_key_index'\",\"Exception\":\"Doctrine\\\\DBAL\\\\Exception\\\\UniqueConstraintViolationException\",\"Code\":0,\"Trace\":\"
#0 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/3rdparty\\\/doctrine\\\/dbal\\\/lib\\\/Doctrine\\\/DBAL\\\/DBALException.php(116): Doctrine\\\\DBAL\\\\Driver\\\\AbstractMySQLDriver->convertException('An exception oc...', Object(Doctrine\\\\DBAL\\\\Driver\\\\PDOException))\\n
#1 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/3rdparty\\\/doctrine\\\/dbal\\\/lib\\\/Doctrine\\\/DBAL\\\/Connection.php(996): Doctrine\\\\DBAL\\\\DBALException::driverExceptionDuringQuery(Object(Doctrine\\\\DBAL\\\\Driver\\\\PDOMySql\\\\Driver), Object(Doctrine\\\\DBAL\\\\Driver\\\\PDOException), 'INSERT INTO `oc...', Array)\\n
#2 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/DB\\\/Connection.php(209): Doctrine\\\\DBAL\\\\Connection->executeUpdate('INSERT INTO `oc...', Array, Array)\\n
#3 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/DB\\\/Adapter.php(113): OC\\\\DB\\\\Connection->executeUpdate('INSERT INTO `*P...', Array)\\n
#4 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/DB\\\/Connection.php(247): OC\\\\DB\\\\Adapter->insertIfNotExist('*PREFIX*file_lo...', Array, Array)\\n
#5 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Lock\\\/DBLockingProvider.php(117): OC\\\\DB\\\\Connection->insertIfNotExist('*PREFIX*file_lo...', Array, Array)\\n
#6 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Lock\\\/DBLockingProvider.php(162): OC\\\\Lock\\\\DBLockingProvider->initLockField('files\\\/8fc0900ba...', 1)\\n
#7 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Files\\\/Storage\\\/Common.php(668): OC\\\\Lock\\\\DBLockingProvider->acquireLock('files\\\/8fc0900ba...', 1)\\n
#8 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Files\\\/Storage\\\/Wrapper\\\/Wrapper.php(583): OC\\\\Files\\\\Storage\\\\Common->acquireLock('files\\\/clientsyn...', 1, Object(OC\\\\Lock\\\\DBLockingProvider))\\n
#9 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Files\\\/Storage\\\/Wrapper\\\/Wrapper.php(583): OC\\\\Files\\\\Storage\\\\Wrapper\\\\Wrapper->acquireLock('files\\\/clientsyn...', 1, Object(OC\\\\Lock\\\\DBLockingProvider))\\n
#10 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Files\\\/Storage\\\/Wrapper\\\/Wrapper.php(583): OC\\\\Files\\\\Storage\\\\Wrapper\\\\Wrapper->acquireLock('files\\\/clientsyn...', 1, Object(OC\\\\Lock\\\\DBLockingProvider))\\n
#11 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Files\\\/View.php(1909): OC\\\\Files\\\\Storage\\\\Wrapper\\\\Wrapper->acquireLock('files\\\/clientsyn...', 1, Object(OC\\\\Lock\\\\DBLockingProvider))\\n
#12 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Files\\\/View.php(2015): OC\\\\Files\\\\View->lockPath('\\\/clientsync\\\/wor...', 1)\\n
#13 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Files\\\/View.php(1104): OC\\\\Files\\\\View->lockFile('\\\/clientsync\\\/wor...', 1)\\n
#14 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Files\\\/View.php(961): OC\\\\Files\\\\View->basicOperation('fopen', 'clientsync\\\/work...', Array, 'rb')\\n
#15 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/apps\\\/dav\\\/lib\\\/Connector\\\/Sabre\\\/File.php(304): OC\\\\Files\\\\View->fopen('clientsync\\\/work...', 'rb')\\n
#16 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/3rdparty\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/CorePlugin.php(83): OCA\\\\DAV\\\\Connector\\\\Sabre\\\\File->get()\\n
#17 [internal function]: Sabre\\\\DAV\\\\CorePlugin->httpGet(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response))\\n
#18 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/3rdparty\\\/sabre\\\/event\\\/lib\\\/EventEmitterTrait.php(105): call_user_func_array(Array, Array)\\n
#19 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/3rdparty\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(459): Sabre\\\\Event\\\\EventEmitter->emit('method:GET', Array)\\n
#20 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/3rdparty\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(248): Sabre\\\\DAV\\\\Server->invokeMethod(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response))\\n
#21 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/apps\\\/dav\\\/appinfo\\\/v1\\\/webdav.php(56): Sabre\\\\DAV\\\\Server->exec()\\n
#22 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/remote.php(164): require_once('\\\/srv\\\/www\\\/htdocs...')\\n
#23 {main}\",\"File\":\"\\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/3rdparty\\\/doctrine\\\/dbal\\\/lib\\\/Doctrine\\\/DBAL\\\/Driver\\\/AbstractMySQLDriver.php\",\"Line\":66,\"User\":\"vincent\"}","level":4,"time":"2016-07-18T07:18:43+00:00","method":"GET","url":"\/remote.php\/webdav\/clientsync\/work\/pomodoro.txt","user":"vincent"}
```

While this is a legitimate error due to a race condition, it is not useful to throw it to the outside.
It's annoying mostly to uses who will get "Internal server error" and think something bad happened, but next sync will work fine.

The fix makes sure the flow continues and the locking provider continues to work.

Please review @DeepDiver1975 @jvillafanez 
