### PR TITLE
[stable8.2] Fix paths returned by \OC\Files\Storage\Shared hooks

### DIFF
--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -295,7 +295,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		$source = $this->getSourcePath($path);
 		if ($source) {
 			$info = array(
-				'target' => $this->getMountPoint() . $path,
+				'target' => $this->getMountPoint() . '/' . $path,
 				'source' => $source,
 			);
 			\OCP\Util::emitHook('\OC\Files\Storage\Shared', 'file_get_contents', $info);
@@ -434,7 +434,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 					}
 			}
 			$info = array(
-				'target' => $this->getMountPoint() . $path,
+				'target' => $this->getMountPoint() . '/' . $path,
 				'source' => $source,
 				'mode' => $mode,
 			);


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/23620

Resend of https://github.com/owncloud/core/pull/23648 from @oparoz for stable8.2
