### PR TITLE
Settings sections id should not change with i18n

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -732,7 +732,11 @@ class OC_App {
 				return array();
 		}
 		foreach ($source as $form) {
-			$forms[] = include $form;
+			$page = include $form['page'];
+			$forms[] = [
+				'appId' => $form['appId'],
+				'page' => $page,
+			];
 		}
 		return $forms;
 	}
@@ -744,7 +748,10 @@ class OC_App {
 	 * @param string $page
 	 */
 	public static function registerAdmin($app, $page) {
-		self::$adminForms[] = $app . '/' . $page . '.php';
+		self::$adminForms[] = [
+			'appId' => $app,
+			'page' => $app . '/' . $page . '.php',
+		];
 	}
 
 	/**
@@ -753,7 +760,10 @@ class OC_App {
 	 * @param string $page
 	 */
 	public static function registerPersonal($app, $page) {
-		self::$personalForms[] = $app . '/' . $page . '.php';
+		self::$personalForms[] = [
+			'appId' => $app,
+			'page' => $app . '/' . $page . '.php',
+		];
 	}
 
 	/**

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -236,10 +236,11 @@ if ($lockingProvider instanceof NoopLockingProvider) {
 }
 
 $formsMap = array_map(function ($form) {
-	if (preg_match('%(<h2(?P<class>[^>]*)>.*?</h2>)%i', $form, $regs)) {
+	if (preg_match('%(<h2(?P<class>[^>]*)>.*?</h2>)%i', $form['page'], $regs)) {
 		$sectionName = str_replace('<h2'.$regs['class'].'>', '', $regs[0]);
 		$sectionName = str_replace('</h2>', '', $sectionName);
-		$anchor = strtolower($sectionName);
+
+		$anchor = strtolower($form['appId']);
 		$anchor = str_replace(' ', '-', $anchor);
 
 		return array(

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -194,10 +194,11 @@ if ($enableCertImport) {
 }
 
 $formsMap = array_map(function($form){
-	if (preg_match('%(<h2(?P<class>[^>]*)>.*?</h2>)%i', $form, $regs)) {
+	if (preg_match('%(<h2(?P<class>[^>]*)>.*?</h2>)%i', $form['page'], $regs)) {
 		$sectionName = str_replace('<h2'.$regs['class'].'>', '', $regs[0]);
 		$sectionName = str_replace('</h2>', '', $sectionName);
-		$anchor = strtolower($sectionName);
+
+		$anchor = strtolower($form['appId']);
 		$anchor = str_replace(' ', '-', $anchor);
 
 		return array(

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -285,8 +285,8 @@ if ($_['cronErrors']) {
 <?php print_unescaped($_['filesExternal']); ?>
 
 <?php foreach($_['forms'] as $form) {
-	if (isset($form['form'])) {?>
-		<div id="<?php isset($form['anchor']) ? p($form['anchor']) : p('');?>"><?php print_unescaped($form['form']);?></div>
+	if (isset($form['form']) and isset($form['form']['page'])) {?>
+		<div id="<?php isset($form['anchor']) ? p($form['anchor']) : p('');?>"><?php print_unescaped($form['form']['page']);?></div>
 	<?php }
 };?>
 

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -248,8 +248,8 @@ if($_['passwordChangeSupported']) {
 </div>
 
 <?php foreach($_['forms'] as $form) {
-	if (isset($form['form'])) {?>
-	<div id="<?php isset($form['anchor']) ? p($form['anchor']) : p('');?>"><?php print_unescaped($form['form']);?></div>
+	if (isset($form['form']) and isset($form['form']['page'])) {?>
+	<div id="<?php isset($form['anchor']) ? p($form['anchor']) : p('');?>"><?php print_unescaped($form['form']['page']);?></div>
 	<?php }
 };?>
 


### PR DESCRIPTION
This PR fix #25527

This split the sectionName and id string process, keeping translation active for sectionName in title but not for id.
