### PR TITLE
[stable9] Prevent setting email and triggering events at login time

### DIFF
--- a/apps/user_ldap/lib/user/user.php
+++ b/apps/user_ldap/lib/user/user.php
@@ -433,7 +433,10 @@ class User {
 		}
 		if(!is_null($email)) {
 			$user = $this->userManager->get($this->uid);
-			$user->setEMailAddress($email);
+			$currentEmail = $user->getEMailAddress();
+			if ($currentEmail !== $email) {
+				$user->setEMailAddress($email);
+			}
 		}
 	}
 


### PR DESCRIPTION
Whenever an LDAP user also has an email address defined in LDAP, the
LDAP code will try and update the email address of the locally known
user. This happens at login time or every time the user's LDAP
attributes are processed.

There is code listening to the email setting hook which updates the
system address book, which also will trigger FS setup due to avatars
and other things.

This fix only sets the email address when really necessary.

Note that there were similar issues before that were fixed on a different level, like https://github.com/owncloud/core/issues/24423#issuecomment-226532465

Please review @butonic @owncloud/ldap @DeepDiver1975 
- [x] TODO: forward ports to 9.1 and master
