### PR TITLE
Allow downgrades of maintenance accross vendors

### DIFF
--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -183,6 +183,18 @@ class Updater extends BasicEmitter {
 	}
 
 	/**
+	 * Return vendor from which this version was published
+	 *
+	 * @return string Get the vendor
+	 */
+	private function getVendor() {
+		// this should really be a JSON file
+		require \OC::$SERVERROOT . '/version.php';
+		/** @var string $vendor */
+		return (string) $vendor;
+	}
+
+	/**
 	 * Whether an upgrade to a specified version is possible
 	 * @param string $oldVersion
 	 * @param string $newVersion
@@ -190,8 +202,22 @@ class Updater extends BasicEmitter {
 	 * @return bool
 	 */
 	public function isUpgradePossible($oldVersion, $newVersion, $allowedPreviousVersion) {
-		return (version_compare($allowedPreviousVersion, $oldVersion, '<=')
+		$allowedUpgrade =  (version_compare($allowedPreviousVersion, $oldVersion, '<=')
 			&& (version_compare($oldVersion, $newVersion, '<=') || $this->config->getSystemValue('debug', false)));
+
+		if ($allowedUpgrade) {
+			return $allowedUpgrade;
+		}
+
+		// Upgrade not allowed, someone switching vendor?
+		if ($this->getVendor() !== $this->config->getAppValue('core', 'vendor', '')) {
+			$oldVersion = explode('.', $oldVersion);
+			$newVersion = explode('.', $newVersion);
+
+			return $oldVersion[0] === $newVersion[0] && $oldVersion[1] === $newVersion[1];
+		}
+
+		return false;
 	}
 
 	/**
@@ -278,6 +304,7 @@ class Updater extends BasicEmitter {
 
 			// only set the final version if everything went well
 			$this->config->setSystemValue('version', implode('.', \OCP\Util::getVersion()));
+			$this->config->setAppValue('core', 'vendor', $this->getVendor());
 		}
 	}
 

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -988,7 +988,7 @@ class OC_App {
 		$currentVersion = OC_App::getAppVersion($app);
 		if ($currentVersion && isset($versions[$app])) {
 			$installedVersion = $versions[$app];
-			if (version_compare($currentVersion, $installedVersion, '>')) {
+			if (!version_compare($currentVersion, $installedVersion, '=')) {
 				return true;
 			}
 		}

--- a/tests/lib/UpdaterTest.php
+++ b/tests/lib/UpdaterTest.php
@@ -137,6 +137,12 @@ class UpdaterTest extends \Test\TestCase {
 			['8.1.0.0', '8.2.0.0', '8.1', true, true],
 			['8.2.0.1', '8.2.0.1', '8.1', true, true],
 			['8.3.0.0', '8.2.0.0', '8.1', true, true],
+
+			// Downgrade of maintenance
+			['9.0.53.0', '9.0.4.0', '8.1', false, false, 'owncloud'],
+			// with vendor switch
+			['9.0.53.0', '9.0.4.0', '8.1', true, false, ''],
+			['9.0.53.0', '9.0.4.0', '8.1', true, false, 'nextcloud'],
 		];
 	}
 
@@ -148,12 +154,17 @@ class UpdaterTest extends \Test\TestCase {
 	 * @param string $allowedVersion
 	 * @param bool $result
 	 * @param bool $debug
+	 * @param string $vendor
 	 */
-	public function testIsUpgradePossible($oldVersion, $newVersion, $allowedVersion, $result, $debug = false) {
+	public function testIsUpgradePossible($oldVersion, $newVersion, $allowedVersion, $result, $debug = false, $vendor = 'owncloud') {
 		$this->config->expects($this->any())
 			->method('getSystemValue')
 			->with('debug', false)
 			->willReturn($debug);
+		$this->config->expects($this->any())
+			->method('getAppValue')
+			->with('core', 'vendor', '')
+			->willReturn($vendor);
 
 		$this->assertSame($result, $this->updater->isUpgradePossible($oldVersion, $newVersion, $allowedVersion));
 	}

--- a/version.php
+++ b/version.php
@@ -36,3 +36,5 @@ $OC_Channel = 'git';
 // The build number
 $OC_Build = '';
 
+// Vendor of this package
+$vendor = 'owncloud';


### PR DESCRIPTION
Similar to https://github.com/nextcloud/server/pull/529 just replaced the vendor and default.

The idea is to allow people to migrate back and forth between both vendors.
