### PR TITLE
Fixes undefined two-factor-providers

### DIFF
--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -108,15 +108,17 @@ class Manager {
 
 		foreach ($allApps as $appId) {
 			$info = $this->appManager->getAppInfo($appId);
-			$providerClasses = $info['two-factor-providers'];
-			foreach ($providerClasses as $class) {
-				try {
-					$this->loadTwoFactorApp($appId);
-					$provider = OC::$server->query($class);
-					$providers[$provider->getId()] = $provider;
-				} catch (QueryException $exc) {
-					// Provider class can not be resolved
-					throw new Exception("Could not load two-factor auth provider $class");
+			if (isset($info['two-factor-providers'])) {
+				$providerClasses = $info['two-factor-providers'];
+				foreach ($providerClasses as $class) {
+					try {
+						$this->loadTwoFactorApp($appId);
+						$provider = OC::$server->query($class);
+						$providers[$provider->getId()] = $provider;
+					} catch (QueryException $exc) {
+						// Provider class can not be resolved
+						throw new Exception("Could not load two-factor auth provider $class");
+					}
 				}
 			}
 		}


### PR DESCRIPTION
```
[Mon Jul 25 14:17:19 2016] Undefined index: two-factor-providers at /home/deepdiver/Development/ownCloud/master/lib/private/Authentication/TwoFactorAuth/Manager.php#111
[Mon Jul 25 14:17:19 2016] Invalid argument supplied for foreach() at /home/deepdiver/Development/ownCloud/master/lib/private/Authentication/TwoFactorAuth/Manager.php#112
```
