### PR TITLE
[stable9] Simplify testPermissionMovedGroupShare (#25573)

### DIFF
--- a/apps/files_sharing/tests/sharedmount.php
+++ b/apps/files_sharing/tests/sharedmount.php
@@ -240,63 +240,27 @@ class Test_Files_Sharing_Mount extends OCA\Files_sharing\Tests\TestCase {
 	}
 
 	function dataPermissionMovedGroupShare() {
-		$data = [];
-
-		$powerset = function($permissions) {
-			$results = [\OCP\Constants::PERMISSION_READ];
-
-			foreach ($permissions as $permission) {
-				foreach ($results as $combination) {
-					$results[] = $permission | $combination;
-				}
-			}
-			return $results;
-		};
-
-		//Generate file permissions
-		$permissions = [
-			\OCP\Constants::PERMISSION_UPDATE,
-			\OCP\Constants::PERMISSION_CREATE,
-			\OCP\Constants::PERMISSION_SHARE,
+		return [
+			[
+				'file',
+				\OCP\Constants::PERMISSION_READ
+				| \OCP\Constants::PERMISSION_UPDATE
+				| \OCP\Constants::PERMISSION_SHARE,
+				\OCP\Constants::PERMISSION_READ
+				| \OCP\Constants::PERMISSION_SHARE,
+			],
+			[
+				'folder',
+				\OCP\Constants::PERMISSION_READ
+				| \OCP\Constants::PERMISSION_CREATE
+				| \OCP\Constants::PERMISSION_UPDATE
+				| \OCP\Constants::PERMISSION_DELETE
+				| \OCP\Constants::PERMISSION_SHARE,
+				\OCP\Constants::PERMISSION_READ
+				| \OCP\Constants::PERMISSION_CREATE
+				| \OCP\Constants::PERMISSION_UPDATE,
+			],
 		];
-
-		$allPermissions = $powerset($permissions);
-
-		foreach ($allPermissions as $before) {
-			foreach ($allPermissions as $after) {
-				if ($before === $after) { continue; }
-
-				$data[] = [
-					'file', 
-					$before,
-					$after,
-				];
-			}
-		}
-
-		//Generate folder permissions
-		$permissions = [
-			\OCP\Constants::PERMISSION_UPDATE,
-			\OCP\Constants::PERMISSION_CREATE,
-			\OCP\Constants::PERMISSION_SHARE,
-			\OCP\Constants::PERMISSION_DELETE,
-		];
-
-		$allPermissions = $powerset($permissions);
-
-		foreach ($allPermissions as $before) {
-			foreach ($allPermissions as $after) {
-				if ($before === $after) { continue; }
-
-				$data[] = [
-					'folder',
-					$before,
-					$after,
-				];
-			}
-		}
-
-		return $data;
 	}
 
 


### PR DESCRIPTION
Reduces significantly the testing time but still cover the permission change
