### PR TITLE
Ldap empty hardening resubmission

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -174,14 +174,14 @@ class Access extends LDAPUtility implements IUserTools {
 		$dn = $this->DNasBaseParameter($dn);
 		$rr = @$this->ldap->read($cr, $dn, $filter, array($attr));
 		if(!$this->ldap->isResource($rr)) {
-			if(!empty($attr)) {
+			if($attr !== '') {
 				//do not throw this message on userExists check, irritates
 				\OCP\Util::writeLog('user_ldap', 'readAttribute failed for DN '.$dn, \OCP\Util::DEBUG);
 			}
 			//in case an error occurs , e.g. object does not exist
 			return false;
 		}
-		if (empty($attr) && ($filter === 'objectclass=*' || $this->ldap->countEntries($cr, $rr) === 1)) {
+		if (($attr !== '') && ($filter === 'objectclass=*' || $this->ldap->countEntries($cr, $rr) === 1)) {
 			\OCP\Util::writeLog('user_ldap', 'readAttribute: '.$dn.' found', \OCP\Util::DEBUG);
 			return array();
 		}
@@ -457,7 +457,7 @@ class Access extends LDAPUtility implements IUserTools {
 
 		if($isUser) {
 			$usernameAttribute = $this->connection->ldapExpertUsernameAttr;
-			if(!empty($usernameAttribute)) {
+			if($usernameAttribute !== '') {
 				$username = $this->readAttribute($fdn, $usernameAttribute);
 				$username = $username[0];
 			} else {
@@ -1162,7 +1162,7 @@ class Access extends LDAPUtility implements IUserTools {
 	private function combineFilter($filters, $operator) {
 		$combinedFilter = '('.$operator;
 		foreach($filters as $filter) {
-			if(!empty($filter) && $filter[0] !== '(') {
+			if((is_string($filter)) && ($filter !== '') && $filter[0] !== '(') {
 				$filter = '('.$filter.')';
 			}
 			$combinedFilter.=$filter;
@@ -1245,7 +1245,7 @@ class Access extends LDAPUtility implements IUserTools {
 
 		$search = $this->prepareSearchTerm($search);
 		if(!is_array($searchAttributes) || count($searchAttributes) === 0) {
-			if(empty($fallbackAttribute)) {
+			if((!is_string($fallbackAttribute)) || ($fallbackAttribute === '')) {
 				return '';
 			}
 			$filter[] = $fallbackAttribute . '=' . $search;
@@ -1271,8 +1271,12 @@ class Access extends LDAPUtility implements IUserTools {
 
 		$allowEnum = $config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes');
 
-		$result = empty($term) ? '*' :
-			$allowEnum !== 'no' ? $term . '*' : $term;
+		$result = $term;
+		if((!is_string($term)) || ($term === '')) {
+			$result = '*';
+		} else if ($allowEnum !== 'no') {
+			$result = $term . '*';
+		}
 		return $result;
 	}
 
@@ -1319,7 +1323,7 @@ class Access extends LDAPUtility implements IUserTools {
 		$filter       = $this->connection->ldapUserFilter;
 		$base         = $this->connection->ldapBaseUsers;
 
-		if($this->connection->ldapUuidUserAttribute === 'auto' && empty($uuidOverride)) {
+		if($this->connection->ldapUuidUserAttribute === 'auto' && ((!is_string($uuidOverride)) || ($uuidOverride === ''))) {
 			// Sacrebleu! The UUID attribute is unknown :( We need first an
 			// existing DN to be able to reliably detect it.
 			$result = $this->search($filter, $base, ['dn'], 1);
@@ -1375,7 +1379,7 @@ class Access extends LDAPUtility implements IUserTools {
 			return true;
 		}
 
-		if(!empty($uuidOverride) && !$force) {
+		if((is_string($uuidOverride)) && ($uuidOverride !== '') && !$force) {
 			$this->connection->$uuidAttr = $uuidOverride;
 			return true;
 		}
@@ -1418,7 +1422,8 @@ class Access extends LDAPUtility implements IUserTools {
 		if($this->detectUuidAttribute($dn, $isUser)) {
 			$uuid = $this->readAttribute($dn, $this->connection->$uuidAttr);
 			if( !is_array($uuid)
-				&& !empty($uuidOverride)
+				&& (is_string($uuidOverride))
+				&& ($uuidOverride !== '')
 				&& $this->detectUuidAttribute($dn, $isUser, true)) {
 					$uuid = $this->readAttribute($dn,
 												 $this->connection->$uuidAttr);

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -174,14 +174,14 @@ class Access extends LDAPUtility implements IUserTools {
 		$dn = $this->DNasBaseParameter($dn);
 		$rr = @$this->ldap->read($cr, $dn, $filter, array($attr));
 		if(!$this->ldap->isResource($rr)) {
-			if($attr !== '') {
+			if(is_string($attr) && ($attr !== '')) {
 				//do not throw this message on userExists check, irritates
 				\OCP\Util::writeLog('user_ldap', 'readAttribute failed for DN '.$dn, \OCP\Util::DEBUG);
 			}
 			//in case an error occurs , e.g. object does not exist
 			return false;
 		}
-		if (($attr !== '') && ($filter === 'objectclass=*' || $this->ldap->countEntries($cr, $rr) === 1)) {
+		if (((!is_string($attr)) || ($attr === '')) && ($filter === 'objectclass=*' || $this->ldap->countEntries($cr, $rr) === 1)) {
 			\OCP\Util::writeLog('user_ldap', 'readAttribute: '.$dn.' found', \OCP\Util::DEBUG);
 			return array();
 		}
@@ -457,7 +457,7 @@ class Access extends LDAPUtility implements IUserTools {
 
 		if($isUser) {
 			$usernameAttribute = $this->connection->ldapExpertUsernameAttr;
-			if($usernameAttribute !== '') {
+			if((is_string($usernameAttribute)) && ($usernameAttribute !== '')) {
 				$username = $this->readAttribute($fdn, $usernameAttribute);
 				$username = $username[0];
 			} else {

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -181,7 +181,7 @@ class Access extends LDAPUtility implements IUserTools {
 			//in case an error occurs , e.g. object does not exist
 			return false;
 		}
-		if (((!is_string($attr)) || ($attr === '')) && ($filter === 'objectclass=*' || $this->ldap->countEntries($cr, $rr) === 1)) {
+		if ($attr === '' && ($filter === 'objectclass=*' || $this->ldap->countEntries($cr, $rr) === 1)) {
 			\OCP\Util::writeLog('user_ldap', 'readAttribute: '.$dn.' found', \OCP\Util::DEBUG);
 			return array();
 		}
@@ -456,8 +456,8 @@ class Access extends LDAPUtility implements IUserTools {
 		}
 
 		if($isUser) {
-			$usernameAttribute = $this->connection->ldapExpertUsernameAttr;
-			if((is_string($usernameAttribute)) && ($usernameAttribute !== '')) {
+			$usernameAttribute = strval($this->connection->ldapExpertUsernameAttr);
+			if($usernameAttribute !== '') {
 				$username = $this->readAttribute($fdn, $usernameAttribute);
 				$username = $username[0];
 			} else {
@@ -1162,7 +1162,7 @@ class Access extends LDAPUtility implements IUserTools {
 	private function combineFilter($filters, $operator) {
 		$combinedFilter = '('.$operator;
 		foreach($filters as $filter) {
-			if((is_string($filter)) && ($filter !== '') && $filter[0] !== '(') {
+			if($filter !== '' && $filter[0] !== '(') {
 				$filter = '('.$filter.')';
 			}
 			$combinedFilter.=$filter;
@@ -1245,7 +1245,7 @@ class Access extends LDAPUtility implements IUserTools {
 
 		$search = $this->prepareSearchTerm($search);
 		if(!is_array($searchAttributes) || count($searchAttributes) === 0) {
-			if((!is_string($fallbackAttribute)) || ($fallbackAttribute === '')) {
+			if($fallbackAttribute === '') {
 				return '';
 			}
 			$filter[] = $fallbackAttribute . '=' . $search;
@@ -1272,7 +1272,7 @@ class Access extends LDAPUtility implements IUserTools {
 		$allowEnum = $config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes');
 
 		$result = $term;
-		if(!is_string($term) || $term === '') {
+		if($term === '') {
 			$result = '*';
 		} else if ($allowEnum !== 'no') {
 			$result = $term . '*';
@@ -1323,7 +1323,7 @@ class Access extends LDAPUtility implements IUserTools {
 		$filter       = $this->connection->ldapUserFilter;
 		$base         = $this->connection->ldapBaseUsers;
 
-		if($this->connection->ldapUuidUserAttribute === 'auto' && ((!is_string($uuidOverride)) || ($uuidOverride === ''))) {
+		if($this->connection->ldapUuidUserAttribute === 'auto' && $uuidOverride === '') {
 			// Sacrebleu! The UUID attribute is unknown :( We need first an
 			// existing DN to be able to reliably detect it.
 			$result = $this->search($filter, $base, ['dn'], 1);
@@ -1379,7 +1379,7 @@ class Access extends LDAPUtility implements IUserTools {
 			return true;
 		}
 
-		if((is_string($uuidOverride)) && ($uuidOverride !== '') && !$force) {
+		if($uuidOverride !== '' && !$force) {
 			$this->connection->$uuidAttr = $uuidOverride;
 			return true;
 		}
@@ -1422,8 +1422,7 @@ class Access extends LDAPUtility implements IUserTools {
 		if($this->detectUuidAttribute($dn, $isUser)) {
 			$uuid = $this->readAttribute($dn, $this->connection->$uuidAttr);
 			if( !is_array($uuid)
-				&& (is_string($uuidOverride))
-				&& ($uuidOverride !== '')
+				&& $uuidOverride !== ''
 				&& $this->detectUuidAttribute($dn, $isUser, true)) {
 					$uuid = $this->readAttribute($dn,
 												 $this->connection->$uuidAttr);

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -174,7 +174,7 @@ class Access extends LDAPUtility implements IUserTools {
 		$dn = $this->DNasBaseParameter($dn);
 		$rr = @$this->ldap->read($cr, $dn, $filter, array($attr));
 		if(!$this->ldap->isResource($rr)) {
-			if(is_string($attr) && ($attr !== '')) {
+			if($attr !== '') {
 				//do not throw this message on userExists check, irritates
 				\OCP\Util::writeLog('user_ldap', 'readAttribute failed for DN '.$dn, \OCP\Util::DEBUG);
 			}
@@ -1272,7 +1272,7 @@ class Access extends LDAPUtility implements IUserTools {
 		$allowEnum = $config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes');
 
 		$result = $term;
-		if((!is_string($term)) || ($term === '')) {
+		if(!is_string($term) || $term === '') {
 			$result = '*';
 		} else if ($allowEnum !== 'no') {
 			$result = $term . '*';

--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -308,7 +308,7 @@ class Configuration {
 			foreach($value as $key => $val) {
 				if(is_string($val)) {
 					$val = trim($val);
-					if((is_string($val)) && ($val !== '')) {
+					if($val !== '') {
 						//accidental line breaks are not wanted and can cause
 						// odd behaviour. Thus, away with them.
 						$finalValue[] = $val;

--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -160,7 +160,7 @@ class Configuration {
 					break;
 				case 'homeFolderNamingRule':
 					$trimmedVal = trim($val);
-					if(is_string($trimmedVal) && ($trimmedVal !== '') && strpos($val, 'attr:') === false) {
+					if($trimmedVal !== '' && strpos($val, 'attr:') === false) {
 						$val = 'attr:'.$trimmedVal;
 					}
 					break;

--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -160,7 +160,7 @@ class Configuration {
 					break;
 				case 'homeFolderNamingRule':
 					$trimmedVal = trim($val);
-					if(!empty($trimmedVal) && strpos($val, 'attr:') === false) {
+					if(is_string($trimmedVal) && ($trimmedVal !== '') && strpos($val, 'attr:') === false) {
 						$val = 'attr:'.$trimmedVal;
 					}
 					break;
@@ -308,7 +308,7 @@ class Configuration {
 			foreach($value as $key => $val) {
 				if(is_string($val)) {
 					$val = trim($val);
-					if(!empty($val)) {
+					if((is_string($val)) && ($val !== '')) {
 						//accidental line breaks are not wanted and can cause
 						// odd behaviour. Thus, away with them.
 						$finalValue[] = $val;

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -132,7 +132,7 @@ class Connection extends LDAPUtility {
 		$this->configuration->$name = $value;
 		$after = $this->configuration->$name;
 		if($before !== $after) {
-			if(!empty($this->configID)) {
+			if((is_string($this->configID)) && ($this->configID !== '')) {
 				$this->configuration->saveConfiguration();
 			}
 			$this->validateConfiguration();
@@ -353,8 +353,8 @@ class Connection extends LDAPUtility {
 			}
 		}
 
-		$backupPort = $this->configuration->ldapBackupPort;
-		if(empty($backupPort)) {
+		$backupPort = intval($this->configuration->ldapBackupPort);
+		if($backupPort <= 0) {
 			$this->configuration->backupPort = $this->configuration->ldapPort;
 		}
 
@@ -422,7 +422,8 @@ class Connection extends LDAPUtility {
 		//combinations
 		$agent = $this->configuration->ldapAgentName;
 		$pwd = $this->configuration->ldapAgentPassword;
-		if((empty($agent) && !empty($pwd)) || (!empty($agent) && empty($pwd))) {
+		if((((!is_string($agent)) || ($agent === ''))  && ((is_string($pwd)) && ($pwd !== '')))
+			|| (((is_string($agent)) && ($agent !== '')) && ((!is_string($pwd)) || ($pwd === '')))) {
 			\OCP\Util::writeLog('user_ldap',
 								$errorStr.'either no password is given for the'.
 								'user agent or a password is given, but not an'.
@@ -563,7 +564,7 @@ class Connection extends LDAPUtility {
 	 * @throws \OC\ServerNotAvailableException
 	 */
 	private function doConnect($host, $port) {
-		if(empty($host)) {
+		if((!is_string($host) || ($host === ''))) {
 			return false;
 		}
 		$this->ldapConnectionRes = $this->ldap->connect($host, $port);

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -132,7 +132,7 @@ class Connection extends LDAPUtility {
 		$this->configuration->$name = $value;
 		$after = $this->configuration->$name;
 		if($before !== $after) {
-			if((is_string($this->configID)) && ($this->configID !== '')) {
+			if($this->configID !== '') {
 				$this->configuration->saveConfiguration();
 			}
 			$this->validateConfiguration();
@@ -422,8 +422,10 @@ class Connection extends LDAPUtility {
 		//combinations
 		$agent = $this->configuration->ldapAgentName;
 		$pwd = $this->configuration->ldapAgentPassword;
-		if((((!is_string($agent)) || ($agent === ''))  && ((is_string($pwd)) && ($pwd !== '')))
-			|| (((is_string($agent)) && ($agent !== '')) && ((!is_string($pwd)) || ($pwd === '')))) {
+		if(
+			($agent === ''  && $pwd !== '')
+			|| ($agent !== '' && $pwd === '')
+		) {
 			\OCP\Util::writeLog('user_ldap',
 								$errorStr.'either no password is given for the'.
 								'user agent or a password is given, but not an'.
@@ -564,7 +566,7 @@ class Connection extends LDAPUtility {
 	 * @throws \OC\ServerNotAvailableException
 	 */
 	private function doConnect($host, $port) {
-		if((!is_string($host) || ($host === ''))) {
+		if($host === '') {
 			return false;
 		}
 		$this->ldapConnectionRes = $this->ldap->connect($host, $port);

--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -356,9 +356,6 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface {
 		if($groupID === false) {
 			throw new \Exception('Not a valid group');
 		}
-		if(!is_string($search)) {
-			throw new \InvalidArgumentException('String expected as search parameter');
-		}
 
 		$filterParts = [];
 		$filterParts[] = $this->access->getFilterForUserCount();
@@ -716,7 +713,7 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface {
 			return false;
 		}
 
-		if(is_string($search) && $search === '') {
+		if($search === '') {
 			$groupUsers = count($members) + $primaryUserCount;
 			$this->access->connection->writeToCache($cacheKey, $groupUsers);
 			return $groupUsers;

--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -356,10 +356,13 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface {
 		if($groupID === false) {
 			throw new \Exception('Not a valid group');
 		}
+		if(!is_string($search)) {
+			throw new \InvalidArgumentException('String expected as search parameter');
+		}
 
 		$filterParts = [];
 		$filterParts[] = $this->access->getFilterForUserCount();
-		if(!empty($search)) {
+		if($search !== '') {
 			$filterParts[] = $this->access->getFilterPartForUserSearch($search);
 		}
 		$filterParts[] = 'primaryGroupID=' . $groupID;
@@ -657,7 +660,7 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface {
 				$groupUsers[] = $this->access->dn2username($ldap_users[0]['dn'][0]);
 			} else {
 				//we got DNs, check if we need to filter by search or we can give back all of them
-				if(!empty($search)) {
+				if($search !== '') {
 					if(!$this->access->readAttribute($member,
 						$this->access->connection->ldapUserDisplayName,
 						$this->access->getFilterPartForUserSearch($search))) {
@@ -713,7 +716,7 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface {
 			return false;
 		}
 
-		if(empty($search)) {
+		if(is_string($search) && $search === '') {
 			$groupUsers = count($members) + $primaryUserCount;
 			$this->access->connection->writeToCache($cacheKey, $groupUsers);
 			return $groupUsers;
@@ -825,9 +828,8 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface {
 			return array();
 		}
 		$search = $this->access->escapeFilterPart($search, true);
-		$pagingSize = $this->access->connection->ldapPagingSize;
-		if ((! $this->access->connection->hasPagedResultSupport)
-		   	|| empty($pagingSize)) {
+		$pagingSize = intval($this->access->connection->ldapPagingSize);
+		if (!$this->access->connection->hasPagedResultSupport || $pagingSize <= 0) {
 			return $this->getGroupsChunk($search, $limit, $offset);
 		}
 		$maxGroups = 100000; // limit max results (just for safety reasons)

--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -178,7 +178,7 @@ class User {
 		if(isset($ldapEntry[$attr])) {
 			$displayName2 = $ldapEntry[$attr][0];
 		}
-		if(!empty($displayName)) {
+		if((is_string($displayName)) && ($displayName !== '')) {
 			$this->composeAndStoreDisplayName($displayName);
 			$this->access->cacheUserDisplayName(
 				$this->getUsername(),
@@ -265,7 +265,7 @@ class User {
 			}
 		}
 
-		if(!empty($path)) {
+		if((is_string($path)) && ($path !== '')) {
 			//if attribute's value is an absolute path take this, otherwise append it to data dir
 			//check for / at the beginning or pattern c:\ resp. c:/
 			if(   '/' !== $path[0]
@@ -382,7 +382,7 @@ class User {
 	 * @returns string the effective display name
 	 */
 	public function composeAndStoreDisplayName($displayName, $displayName2 = '') {
-		if(!empty($displayName2)) {
+		if((is_string($displayName2)) && ($displayName2 !== '')) {
 			$displayName .= ' (' . $displayName2 . ')';
 		}
 		$this->store('displayName', $displayName);
@@ -424,7 +424,7 @@ class User {
 		$email = $valueFromLDAP;
 		if(is_null($valueFromLDAP)) {
 			$emailAttribute = $this->connection->ldapEmailAttribute;
-			if(!empty($emailAttribute)) {
+			if((is_string($emailAttribute)) && ($emailAttribute !== '')) {
 				$aEmail = $this->access->readAttribute($this->dn, $emailAttribute);
 				if(is_array($aEmail) && (count($aEmail) > 0)) {
 					$email = $aEmail[0];
@@ -459,7 +459,7 @@ class User {
 
 		if(is_null($valueFromLDAP)) {
 			$quotaAttribute = $this->connection->ldapQuotaAttribute;
-			if(!empty($quotaAttribute)) {
+			if((is_string($quotaAttribute)) && ($quotaAttribute !== '')) {
 				$aQuota = $this->access->readAttribute($this->dn, $quotaAttribute);
 				if($aQuota && (count($aQuota) > 0)) {
 					$quota = $aQuota[0];

--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -172,13 +172,13 @@ class User {
 		$displayName = $displayName2 = '';
 		$attr = strtolower($this->connection->ldapUserDisplayName);
 		if(isset($ldapEntry[$attr])) {
-			$displayName = $ldapEntry[$attr][0];
+			$displayName = strval($ldapEntry[$attr][0]);
 		}
 		$attr = strtolower($this->connection->ldapUserDisplayName2);
 		if(isset($ldapEntry[$attr])) {
-			$displayName2 = $ldapEntry[$attr][0];
+			$displayName2 = strval($ldapEntry[$attr][0]);
 		}
-		if((is_string($displayName)) && ($displayName !== '')) {
+		if($displayName !== '') {
 			$this->composeAndStoreDisplayName($displayName);
 			$this->access->cacheUserDisplayName(
 				$this->getUsername(),
@@ -250,10 +250,10 @@ class User {
 	 * @throws \Exception
 	 */
 	public function getHomePath($valueFromLDAP = null) {
-		$path = $valueFromLDAP;
+		$path = strval($valueFromLDAP);
 		$attr = null;
 
-		if(   is_null($path)
+		if(   is_null($valueFromLDAP)
 		   && strpos($this->access->connection->homeFolderNamingRule, 'attr:') === 0
 		   && $this->access->connection->homeFolderNamingRule !== 'attr:')
 		{
@@ -265,7 +265,7 @@ class User {
 			}
 		}
 
-		if((is_string($path)) && ($path !== '')) {
+		if($path !== '') {
 			//if attribute's value is an absolute path take this, otherwise append it to data dir
 			//check for / at the beginning or pattern c:\ resp. c:/
 			if(   '/' !== $path[0]
@@ -382,7 +382,8 @@ class User {
 	 * @returns string the effective display name
 	 */
 	public function composeAndStoreDisplayName($displayName, $displayName2 = '') {
-		if((is_string($displayName2)) && ($displayName2 !== '')) {
+		$displayName2 = strval($displayName2);
+		if($displayName2 !== '') {
 			$displayName .= ' (' . $displayName2 . ')';
 		}
 		$this->store('displayName', $displayName);
@@ -421,20 +422,20 @@ class User {
 		if($this->wasRefreshed('email')) {
 			return;
 		}
-		$email = $valueFromLDAP;
+		$email = strval($valueFromLDAP);
 		if(is_null($valueFromLDAP)) {
 			$emailAttribute = $this->connection->ldapEmailAttribute;
-			if((is_string($emailAttribute)) && ($emailAttribute !== '')) {
+			if($emailAttribute !== '') {
 				$aEmail = $this->access->readAttribute($this->dn, $emailAttribute);
 				if(is_array($aEmail) && (count($aEmail) > 0)) {
-					$email = $aEmail[0];
+					$email = strval($aEmail[0]);
 				}
 			}
 		}
-		if(!is_null($email)) {
+		if($email !== '') {
 			$user = $this->userManager->get($this->uid);
 			if (!is_null($user)) {
-				$currentEmail = $user->getEMailAddress();
+				$currentEmail = strval($user->getEMailAddress());
 				if ($currentEmail !== $email) {
 					$user->setEMailAddress($email);
 				}
@@ -459,7 +460,7 @@ class User {
 
 		if(is_null($valueFromLDAP)) {
 			$quotaAttribute = $this->connection->ldapQuotaAttribute;
-			if((is_string($quotaAttribute)) && ($quotaAttribute !== '')) {
+			if($quotaAttribute !== '') {
 				$aQuota = $this->access->readAttribute($this->dn, $quotaAttribute);
 				if($aQuota && (count($aQuota) > 0)) {
 					$quota = $aQuota[0];

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -360,7 +360,7 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 		//Check whether the display name is configured to have a 2nd feature
 		$additionalAttribute = $this->access->connection->ldapUserDisplayName2;
 		$displayName2 = '';
-		if(!empty($additionalAttribute)) {
+		if((is_string($additionalAttribute)) && ($additionalAttribute !== '')) {
 			$displayName2 = $this->access->readAttribute(
 				$this->access->username2dn($uid),
 				$additionalAttribute);

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -360,7 +360,7 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 		//Check whether the display name is configured to have a 2nd feature
 		$additionalAttribute = $this->access->connection->ldapUserDisplayName2;
 		$displayName2 = '';
-		if((is_string($additionalAttribute)) && ($additionalAttribute !== '')) {
+		if($additionalAttribute !== '') {
 			$displayName2 = $this->access->readAttribute(
 				$this->access->username2dn($uid),
 				$additionalAttribute);
@@ -372,9 +372,8 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 
 		if($displayName && (count($displayName) > 0)) {
 			$displayName = $displayName[0];
-
-			if(is_array($displayName2) && (count($displayName2) > 0)) {
-				$displayName2 = $displayName2[0];
+			if(is_array($displayName2)){
+				$displayName2 = count($displayName2) > 0 ? $displayName2[0] : '';
 			}
 
 			$user = $this->access->userManager->get($uid);

--- a/apps/user_ldap/lib/Wizard.php
+++ b/apps/user_ldap/lib/Wizard.php
@@ -219,7 +219,7 @@ class Wizard extends LDAPUtility {
 		}
 
 		$attr = $this->configuration->ldapUserDisplayName;
-		if((is_string($attr)) && ($attr !== '') && ($attr !== 'displayName')) {
+		if($attr !== '' && $attr !== 'displayName') {
 			// most likely not the default value with upper case N,
 			// verify it still produces a result
 			$count = intval($this->countUsersWithAttribute($attr, true));
@@ -261,7 +261,7 @@ class Wizard extends LDAPUtility {
 		}
 
 		$attr = $this->configuration->ldapEmailAttribute;
-		if((is_string($attr)) && ($attr !== '')) {
+		if($attr !== '') {
 			$count = intval($this->countUsersWithAttribute($attr, true));
 			if($count > 0) {
 				return false;
@@ -551,7 +551,7 @@ class Wizard extends LDAPUtility {
 		}
 		//make sure the use display name is set
 		$displayName = $this->configuration->ldapGroupDisplayName;
-		if((!is_string($displayName)) || ($displayName === '')) {
+		if($displayName === '') {
 			$d = $this->configuration->getDefaults();
 			$this->applyFind('ldap_group_display_name',
 							 $d['ldap_group_display_name']);
@@ -575,7 +575,7 @@ class Wizard extends LDAPUtility {
 		}
 		//make sure the use display name is set
 		$displayName = $this->configuration->ldapUserDisplayName;
-		if((!is_string($displayName)) || ($displayName === '')) {
+		if($displayName === '') {
 			$d = $this->configuration->getDefaults();
 			$this->applyFind('ldap_display_name', $d['ldap_display_name']);
 		}
@@ -903,7 +903,7 @@ class Wizard extends LDAPUtility {
 							$er = $this->ldap->firstEntry($cr, $rr);
 							$attrs = $this->ldap->getAttributes($cr, $er);
 							$dn = $this->ldap->getDN($cr, $er);
-							if((!is_string($dn)) || ($dn === '')) {
+							if($dn==false || $dn === '') {
 								continue;
 							}
 							$filterPart = '(memberof=' . $dn . ')';
@@ -922,7 +922,7 @@ class Wizard extends LDAPUtility {
 				if($parts > 1) {
 					$filter = '(&' . $filter . ')';
 				}
-				if((!is_string($filter)) || ($filter === '')) {
+				if($filter === '') {
 					$filter = '(objectclass=*)';
 				}
 				break;
@@ -972,7 +972,7 @@ class Wizard extends LDAPUtility {
 						//fallback
 						$attr = 'cn';
 					}
-					if((is_string($attr)) && ($attr !== '')) {
+					if($attr !== '') {
 						$filterUsername = '(' . $attr . $loginpart . ')';
 						$parts++;
 					}
@@ -1097,8 +1097,10 @@ class Wizard extends LDAPUtility {
 		$agent = $this->configuration->ldapAgentName;
 		$pwd = $this->configuration->ldapAgentPassword;
 
-		return ( (is_string($agent) && ($agent !== '') && is_string($pwd) && ($pwd !== ''))
-		       ||  ((!is_string($agent) || ($agent === ''))  &&  ((!is_string($pwd)) || ($pwd === ''))));
+		return
+			($agent !== '' && $pwd !== '')
+			||  ($agent === '' && $pwd === '')
+		;
 	}
 
 	/**
@@ -1235,7 +1237,7 @@ class Wizard extends LDAPUtility {
 		if(is_array($setFeatures) && !empty($setFeatures)) {
 			//something is already configured? pre-select it.
 			$this->result->addChange($dbkey, $setFeatures);
-		} else if($po && (is_string($maxEntryObjC)) && ($maxEntryObjC !== '')) {
+		} else if($po && $maxEntryObjC !== '') {
 			//pre-select objectclass with most result entries
 			$maxEntryObjC = str_replace($p, '', $maxEntryObjC);
 			$this->applyFind($dbkey, $maxEntryObjC);

--- a/apps/user_ldap/lib/Wizard.php
+++ b/apps/user_ldap/lib/Wizard.php
@@ -1109,7 +1109,7 @@ class Wizard extends LDAPUtility {
 		$this->checkAgentRequirements();
 		foreach($reqs as $option) {
 			$value = $this->configuration->$option;
-			if((!is_string($value)) || ($value === '')) {
+			if(empty($value)) {
 				return false;
 			}
 		}

--- a/apps/user_ldap/lib/Wizard.php
+++ b/apps/user_ldap/lib/Wizard.php
@@ -219,7 +219,7 @@ class Wizard extends LDAPUtility {
 		}
 
 		$attr = $this->configuration->ldapUserDisplayName;
-		if($attr !== 'displayName' && !empty($attr)) {
+		if((is_string($attr)) && ($attr !== '') && ($attr !== 'displayName')) {
 			// most likely not the default value with upper case N,
 			// verify it still produces a result
 			$count = intval($this->countUsersWithAttribute($attr, true));
@@ -261,7 +261,7 @@ class Wizard extends LDAPUtility {
 		}
 
 		$attr = $this->configuration->ldapEmailAttribute;
-		if(!empty($attr)) {
+		if((is_string($attr)) && ($attr !== '')) {
 			$count = intval($this->countUsersWithAttribute($attr, true));
 			if($count > 0) {
 				return false;
@@ -551,7 +551,7 @@ class Wizard extends LDAPUtility {
 		}
 		//make sure the use display name is set
 		$displayName = $this->configuration->ldapGroupDisplayName;
-		if(empty($displayName)) {
+		if((!is_string($displayName)) || ($displayName === '')) {
 			$d = $this->configuration->getDefaults();
 			$this->applyFind('ldap_group_display_name',
 							 $d['ldap_group_display_name']);
@@ -575,7 +575,7 @@ class Wizard extends LDAPUtility {
 		}
 		//make sure the use display name is set
 		$displayName = $this->configuration->ldapUserDisplayName;
-		if(empty($displayName)) {
+		if((!is_string($displayName)) || ($displayName === '')) {
 			$d = $this->configuration->getDefaults();
 			$this->applyFind('ldap_display_name', $d['ldap_display_name']);
 		}
@@ -903,7 +903,7 @@ class Wizard extends LDAPUtility {
 							$er = $this->ldap->firstEntry($cr, $rr);
 							$attrs = $this->ldap->getAttributes($cr, $er);
 							$dn = $this->ldap->getDN($cr, $er);
-							if(empty($dn)) {
+							if((!is_string($dn)) || ($dn === '')) {
 								continue;
 							}
 							$filterPart = '(memberof=' . $dn . ')';
@@ -922,7 +922,7 @@ class Wizard extends LDAPUtility {
 				if($parts > 1) {
 					$filter = '(&' . $filter . ')';
 				}
-				if(empty($filter)) {
+				if((!is_string($filter)) || ($filter === '')) {
 					$filter = '(objectclass=*)';
 				}
 				break;
@@ -972,7 +972,7 @@ class Wizard extends LDAPUtility {
 						//fallback
 						$attr = 'cn';
 					}
-					if(!empty($attr)) {
+					if((is_string($attr)) && ($attr !== '')) {
 						$filterUsername = '(' . $attr . $loginpart . ')';
 						$parts++;
 					}
@@ -1097,8 +1097,8 @@ class Wizard extends LDAPUtility {
 		$agent = $this->configuration->ldapAgentName;
 		$pwd = $this->configuration->ldapAgentPassword;
 
-		return ( (!empty($agent) && !empty($pwd))
-		       || (empty($agent) &&  empty($pwd)));
+		return ( (is_string($agent) && ($agent !== '') && is_string($pwd) && ($pwd !== ''))
+		       ||  ((!is_string($agent) || ($agent === ''))  &&  ((!is_string($pwd)) || ($pwd === ''))));
 	}
 
 	/**
@@ -1109,7 +1109,7 @@ class Wizard extends LDAPUtility {
 		$this->checkAgentRequirements();
 		foreach($reqs as $option) {
 			$value = $this->configuration->$option;
-			if(empty($value)) {
+			if((!is_string($value)) || ($value === '')) {
 				return false;
 			}
 		}
@@ -1235,7 +1235,7 @@ class Wizard extends LDAPUtility {
 		if(is_array($setFeatures) && !empty($setFeatures)) {
 			//something is already configured? pre-select it.
 			$this->result->addChange($dbkey, $setFeatures);
-		} else if($po && !empty($maxEntryObjC)) {
+		} else if($po && (is_string($maxEntryObjC)) && ($maxEntryObjC !== '')) {
 			//pre-select objectclass with most result entries
 			$maxEntryObjC = str_replace($p, '', $maxEntryObjC);
 			$this->applyFind($dbkey, $maxEntryObjC);

--- a/apps/user_ldap/tests/Group_LDAPTest.php
+++ b/apps/user_ldap/tests/Group_LDAPTest.php
@@ -39,34 +39,48 @@ use OCA\User_LDAP\Connection;
  * @package OCA\User_LDAP\Tests
  */
 class Group_LDAPTest extends \Test\TestCase {
-	private function getAccessMock() {
+
+	protected $ldapWrapperMock;
+	protected $connectionMock;
+	protected $ldapUserManagerMock;
+	protected $accessMock;
+
+	public function setUp() {
+		parent::setUp();
+
 		static $conMethods;
 		static $accMethods;
+		static $umMethods;
 
 		if(is_null($conMethods) || is_null($accMethods)) {
 			$conMethods = get_class_methods('\OCA\User_LDAP\Connection');
 			$accMethods = get_class_methods('\OCA\User_LDAP\Access');
+			$umMethods  = get_class_methods('\OCA\User_LDAP\User\Manager');
 		}
-		$lw  = $this->getMock('\OCA\User_LDAP\ILDAPWrapper');
-		$connector = $this->getMock('\OCA\User_LDAP\Connection',
-									$conMethods,
-									array($lw, null, null));
-		$um = $this->getMockBuilder('\OCA\User_LDAP\User\Manager')
-			->disableOriginalConstructor()
-			->getMock();
-		$access = $this->getMock('\OCA\User_LDAP\Access',
-								 $accMethods,
-								 array($connector, $lw, $um));
 
-		$access->expects($this->any())
-			->method('getConnection')
-			->will($this->returnValue($connector));
+		$this->ldapWrapperMock = $this->getMock('\OCA\User_LDAP\ILDAPWrapper');
 
-		return $access;
+		$this->connectionMock = $this->getMock('OCA\User_LDAP\Connection',
+				$conMethods,
+				array($this->ldapWrapperMock, null, null));
+
+ 		$this->ldapUserManagerMock = $this->getMock('\OCA\User_LDAP\User\Manager',
+			$umMethods, array(
+				$this->getMock('\OCP\IConfig'),
+				$this->getMock('\OCA\User_LDAP\FilesystemHelper'),
+				$this->getMock('\OCA\User_LDAP\LogWrapper'),
+				$this->getMock('\OCP\IAvatarManager'),
+				$this->getMock('\OCP\Image'),
+				$this->getMock('\OCP\IDBConnection'),
+				$this->getMock('\OCP\IUserManager')));
+
+		$this->accessMock = $this->getMock('\OCA\User_LDAP\Access',
+			$accMethods,
+			array($this->connectionMock, $this->ldapWrapperMock, $this->ldapUserManagerMock));
 	}
 
-	private function enableGroups($access) {
-		$access->connection->expects($this->any())
+	private function enableGroups() {
+		$this->accessMock->connection->expects($this->any())
 			->method('__get')
 			->will($this->returnCallback(function($name) {
 				if($name === 'ldapDynamicGroupMemberURL') {
@@ -77,43 +91,39 @@ class Group_LDAPTest extends \Test\TestCase {
 	}
 
 	public function testCountEmptySearchString() {
-		$access = $this->getAccessMock();
+		$this->enableGroups();
 
-		$this->enableGroups($access);
-
-		$access->expects($this->any())
+		$this->accessMock->expects($this->any())
 			->method('groupname2dn')
 			->will($this->returnValue('cn=group,dc=foo,dc=bar'));
 
-		$access->expects($this->any())
+		$this->accessMock->expects($this->any())
 			->method('readAttribute')
 			->will($this->returnValue(array('u11', 'u22', 'u33', 'u34')));
 
 		// for primary groups
-		$access->expects($this->once())
+		$this->accessMock->expects($this->once())
 			->method('countUsers')
 			->will($this->returnValue(2));
 
-		$groupBackend = new GroupLDAP($access);
+		$groupBackend = new GroupLDAP($this->accessMock);
 		$users = $groupBackend->countUsersInGroup('group');
 
 		$this->assertSame(6, $users);
 	}
 
 	public function testCountWithSearchString() {
-		$access = $this->getAccessMock();
+		$this->enableGroups();
 
-		$this->enableGroups($access);
-
-		$access->expects($this->any())
+		$this->accessMock->expects($this->any())
 			->method('groupname2dn')
 			->will($this->returnValue('cn=group,dc=foo,dc=bar'));
 
-		$access->expects($this->any())
+		$this->accessMock->expects($this->any())
 			->method('fetchListOfUsers')
 			->will($this->returnValue(array()));
 
-		$access->expects($this->any())
+		$this->accessMock->expects($this->any())
 			->method('readAttribute')
 			->will($this->returnCallback(function($name) {
 				//the search operation will call readAttribute, thus we need
@@ -127,157 +137,149 @@ class Group_LDAPTest extends \Test\TestCase {
 				return array('u11', 'u22', 'u33', 'u34');
 			}));
 
-		$access->expects($this->any())
+		$this->accessMock->expects($this->any())
 			->method('dn2username')
 			->will($this->returnCallback(function() {
 				return 'foobar' . \OCP\Util::generateRandomBytes(7);
 			}));
 
-		$groupBackend = new GroupLDAP($access);
+		$groupBackend = new GroupLDAP($this->accessMock);
 		$users = $groupBackend->countUsersInGroup('group', '3');
 
 		$this->assertSame(2, $users);
 	}
 
 	public function testPrimaryGroupID2NameSuccess() {
-		$access = $this->getAccessMock();
-		$this->enableGroups($access);
+		$this->enableGroups();
 
 		$userDN = 'cn=alice,cn=foo,dc=barfoo,dc=bar';
 
-		$access->expects($this->once())
+		$this->accessMock->expects($this->once())
 			->method('getSID')
 			->with($userDN)
 			->will($this->returnValue('S-1-5-21-249921958-728525901-1594176202'));
 
-		$access->expects($this->once())
+		$this->accessMock->expects($this->once())
 			->method('searchGroups')
 			->will($this->returnValue([['dn' => ['cn=foo,dc=barfoo,dc=bar']]]));
 
-		$access->expects($this->once())
+		$this->accessMock->expects($this->once())
 			->method('dn2groupname')
 			->with('cn=foo,dc=barfoo,dc=bar')
 			->will($this->returnValue('MyGroup'));
 
-		$groupBackend = new GroupLDAP($access);
-
+		$groupBackend = new GroupLDAP($this->accessMock);
 		$group = $groupBackend->primaryGroupID2Name('3117', $userDN);
 
 		$this->assertSame('MyGroup', $group);
 	}
 
 	public function testPrimaryGroupID2NameNoSID() {
-		$access = $this->getAccessMock();
-		$this->enableGroups($access);
+		$this->enableGroups();
 
 		$userDN = 'cn=alice,cn=foo,dc=barfoo,dc=bar';
 
-		$access->expects($this->once())
+		$this->accessMock->expects($this->once())
 			->method('getSID')
 			->with($userDN)
 			->will($this->returnValue(false));
 
-		$access->expects($this->never())
+		$this->accessMock->expects($this->never())
 			->method('searchGroups');
 
-		$access->expects($this->never())
+		$this->accessMock->expects($this->never())
 			->method('dn2groupname');
 
-		$groupBackend = new GroupLDAP($access);
-
+		$groupBackend = new GroupLDAP($this->accessMock);
 		$group = $groupBackend->primaryGroupID2Name('3117', $userDN);
 
 		$this->assertSame(false, $group);
 	}
 
 	public function testPrimaryGroupID2NameNoGroup() {
-		$access = $this->getAccessMock();
-		$this->enableGroups($access);
+		$this->enableGroups();
 
 		$userDN = 'cn=alice,cn=foo,dc=barfoo,dc=bar';
 
-		$access->expects($this->once())
+		$this->accessMock->expects($this->once())
 			->method('getSID')
 			->with($userDN)
 			->will($this->returnValue('S-1-5-21-249921958-728525901-1594176202'));
 
-		$access->expects($this->once())
+		$this->accessMock->expects($this->once())
 			->method('searchGroups')
 			->will($this->returnValue(array()));
 
-		$access->expects($this->never())
+		$this->accessMock->expects($this->never())
 			->method('dn2groupname');
 
-		$groupBackend = new GroupLDAP($access);
-
+		$groupBackend = new GroupLDAP($this->accessMock);
 		$group = $groupBackend->primaryGroupID2Name('3117', $userDN);
 
 		$this->assertSame(false, $group);
 	}
 
 	public function testPrimaryGroupID2NameNoName() {
-		$access = $this->getAccessMock();
-		$this->enableGroups($access);
+		$this->enableGroups();
 
 		$userDN = 'cn=alice,cn=foo,dc=barfoo,dc=bar';
 
-		$access->expects($this->once())
+		$this->accessMock->expects($this->once())
 			->method('getSID')
 			->with($userDN)
 			->will($this->returnValue('S-1-5-21-249921958-728525901-1594176202'));
 
-		$access->expects($this->once())
+		$this->accessMock->expects($this->once())
 			->method('searchGroups')
 			->will($this->returnValue([['dn' => ['cn=foo,dc=barfoo,dc=bar']]]));
 
-		$access->expects($this->once())
+		$this->accessMock->expects($this->once())
 			->method('dn2groupname')
 			->will($this->returnValue(false));
 
-		$groupBackend = new GroupLDAP($access);
-
+		$groupBackend = new GroupLDAP($this->accessMock);
 		$group = $groupBackend->primaryGroupID2Name('3117', $userDN);
 
 		$this->assertSame(false, $group);
 	}
 
+	/**
+	 * tests getEntryGroupID via getGroupPrimaryGroupID
+	 * which is basically identical to getUserPrimaryGroupIDs
+	 */
 	public function testGetEntryGroupIDValue() {
-		//tests getEntryGroupID via getGroupPrimaryGroupID
-		//which is basically identical to getUserPrimaryGroupIDs
-		$access = $this->getAccessMock();
-		$this->enableGroups($access);
+		$this->enableGroups();
 
 		$dn = 'cn=foobar,cn=foo,dc=barfoo,dc=bar';
 		$attr = 'primaryGroupToken';
 
-		$access->expects($this->once())
+		$this->accessMock->expects($this->once())
 			->method('readAttribute')
 			->with($dn, $attr)
 			->will($this->returnValue(array('3117')));
 
-		$groupBackend = new GroupLDAP($access);
-
+		$groupBackend = new GroupLDAP($this->accessMock);
 		$gid = $groupBackend->getGroupPrimaryGroupID($dn);
 
 		$this->assertSame('3117', $gid);
 	}
 
+	/**
+	 * tests getEntryGroupID via getGroupPrimaryGroupID
+	 * which is basically identical to getUserPrimaryGroupIDs
+	 */
 	public function testGetEntryGroupIDNoValue() {
-		//tests getEntryGroupID via getGroupPrimaryGroupID
-		//which is basically identical to getUserPrimaryGroupIDs
-		$access = $this->getAccessMock();
-		$this->enableGroups($access);
+		$this->enableGroups();
 
 		$dn = 'cn=foobar,cn=foo,dc=barfoo,dc=bar';
 		$attr = 'primaryGroupToken';
 
-		$access->expects($this->once())
+		$this->accessMock->expects($this->once())
 			->method('readAttribute')
 			->with($dn, $attr)
 			->will($this->returnValue(false));
 
-		$groupBackend = new GroupLDAP($access);
-
+		$groupBackend = new GroupLDAP($this->accessMock);
 		$gid = $groupBackend->getGroupPrimaryGroupID($dn);
 
 		$this->assertSame(false, $gid);
@@ -288,34 +290,29 @@ class Group_LDAPTest extends \Test\TestCase {
 	 * is hit
 	 */
 	public function testInGroupHitsUidGidCache() {
-		$access = $this->getAccessMock();
-		$this->enableGroups($access);
+		$this->enableGroups();
 
 		$uid = 'someUser';
 		$gid = 'someGroup';
 		$cacheKey = 'inGroup'.$uid.':'.$gid;
-
-		$access->connection->expects($this->once())
+		$this->accessMock->connection->expects($this->once())
 			->method('getFromCache')
 			->with($cacheKey)
 			->will($this->returnValue(true));
-
-		$access->expects($this->never())
+		$this->accessMock->expects($this->never())
 			->method('username2dn');
-
-		$groupBackend = new GroupLDAP($access);
+		$groupBackend = new GroupLDAP($this->accessMock);
 		$groupBackend->inGroup($uid, $gid);
 	}
 
 	public function testGetGroupsWithOffset() {
-		$access = $this->getAccessMock();
-		$this->enableGroups($access);
+		$this->enableGroups();
 
-		$access->expects($this->once())
+		$this->accessMock->expects($this->once())
 			->method('ownCloudGroupNames')
 			->will($this->returnValue(array('group1', 'group2')));
 
-		$groupBackend = new GroupLDAP($access);
+		$groupBackend = new GroupLDAP($this->accessMock);
 		$groups = $groupBackend->getGroups('', 2, 2);
 
 		$this->assertSame(2, count($groups));
@@ -325,15 +322,19 @@ class Group_LDAPTest extends \Test\TestCase {
 	 * tests that a user listing is complete, if all it's members have the group
 	 * as their primary.
 	 */
-	public function testUsersInGroupPrimaryMembersOnly() {
-		$access = $this->getAccessMock();
-		$this->enableGroups($access);
+	public function  testUsersInGroupPrimaryMembersOnly() {
+		$this->enableGroups();
 
-		$access->connection->expects($this->any())
+		$this->accessMock->connection->expects($this->any())
 			->method('getFromCache')
 			->will($this->returnValue(null));
 
-		$access->expects($this->any())
+		$this->accessMock->expects($this->any())
+			->method('escapeFilterPart')
+			->with('', true)
+			->will($this->returnValue(''));
+
+		$this->accessMock->expects($this->any())
 			->method('readAttribute')
 			->will($this->returnCallback(function($dn, $attr) {
 				if($attr === 'primaryGroupToken') {
@@ -342,15 +343,15 @@ class Group_LDAPTest extends \Test\TestCase {
 				return array();
 			}));
 
-		$access->expects($this->any())
+		$this->accessMock->expects($this->any())
 			->method('groupname2dn')
 			->will($this->returnValue('cn=foobar,dc=foo,dc=bar'));
 
-		$access->expects($this->once())
+		$this->accessMock->expects($this->once())
 			->method('ownCloudUserNames')
 			->will($this->returnValue(array('lisa', 'bart', 'kira', 'brad')));
 
-		$groupBackend = new GroupLDAP($access);
+		$groupBackend = new GroupLDAP($this->accessMock);
 		$users = $groupBackend->usersInGroup('foobar');
 
 		$this->assertSame(4, count($users));
@@ -360,15 +361,14 @@ class Group_LDAPTest extends \Test\TestCase {
 	 * tests that a user counting is complete, if all it's members have the group
 	 * as their primary.
 	 */
-	public function testCountUsersInGroupPrimaryMembersOnly() {
-		$access = $this->getAccessMock();
-		$this->enableGroups($access);
+	public function  testCountUsersInGroupPrimaryMembersOnly() {
+		$this->enableGroups();
 
-		$access->connection->expects($this->any())
+		$this->accessMock->connection->expects($this->any())
 			->method('getFromCache')
 			->will($this->returnValue(null));
 
-		$access->expects($this->any())
+		$this->accessMock->expects($this->any())
 			->method('readAttribute')
 			->will($this->returnCallback(function($dn, $attr) {
 				if($attr === 'primaryGroupToken') {
@@ -377,54 +377,51 @@ class Group_LDAPTest extends \Test\TestCase {
 				return array();
 			}));
 
-		$access->expects($this->any())
+		$this->accessMock->expects($this->any())
 			->method('groupname2dn')
 			->will($this->returnValue('cn=foobar,dc=foo,dc=bar'));
 
-		$access->expects($this->once())
+		$this->accessMock->expects($this->once())
 			->method('countUsers')
 			->will($this->returnValue(4));
 
-		$groupBackend = new GroupLDAP($access);
+		$groupBackend = new GroupLDAP($this->accessMock);
 		$users = $groupBackend->countUsersInGroup('foobar');
 
 		$this->assertSame(4, $users);
 	}
 
 	public function testGetUserGroupsMemberOf() {
-		$access = $this->getAccessMock();
-		$this->enableGroups($access);
+		$this->enableGroups();
 
 		$dn = 'cn=userX,dc=foobar';
 
-		$access->connection->hasPrimaryGroups = false;
+		$this->accessMock->connection->hasPrimaryGroups = false;
 
-		$access->expects($this->any())
+		$this->accessMock->expects($this->any())
 			->method('username2dn')
 			->will($this->returnValue($dn));
 
-		$access->expects($this->exactly(3))
+		$this->accessMock->expects($this->exactly(3))
 			->method('readAttribute')
 			->will($this->onConsecutiveCalls(['cn=groupA,dc=foobar', 'cn=groupB,dc=foobar'], [], []));
 
-		$access->expects($this->exactly(2))
+		$this->accessMock->expects($this->exactly(2))
 			->method('dn2groupname')
 			->will($this->returnArgument(0));
 
-		$access->expects($this->exactly(3))
+		$this->accessMock->expects($this->exactly(3))
 			->method('groupsMatchFilter')
 			->will($this->returnArgument(0));
 
-		$groupBackend = new GroupLDAP($access);
+		$groupBackend = new GroupLDAP($this->accessMock);
 		$groups = $groupBackend->getUserGroups('userX');
 
 		$this->assertSame(2, count($groups));
 	}
 
 	public function testGetUserGroupsMemberOfDisabled() {
-		$access = $this->getAccessMock();
-
-		$access->connection->expects($this->any())
+		$this->accessMock->connection->expects($this->any())
 			->method('__get')
 			->will($this->returnCallback(function($name) {
 				if($name === 'useMemberOfToDetectMembership') {
@@ -437,21 +434,21 @@ class Group_LDAPTest extends \Test\TestCase {
 
 		$dn = 'cn=userX,dc=foobar';
 
-		$access->connection->hasPrimaryGroups = false;
+		$this->accessMock->connection->hasPrimaryGroups = false;
 
-		$access->expects($this->once())
+		$this->accessMock->expects($this->once())
 			->method('username2dn')
 			->will($this->returnValue($dn));
 
-		$access->expects($this->never())
+		$this->accessMock->expects($this->never())
 			->method('readAttribute')
 			->with($dn, 'memberOf');
 
-		$access->expects($this->once())
+		$this->accessMock->expects($this->once())
 			->method('ownCloudGroupNames')
 			->will($this->returnValue([]));
 
-		$groupBackend = new GroupLDAP($access);
+		$groupBackend = new GroupLDAP($this->accessMock);
 		$groupBackend->getUserGroups('userX');
 	}
 
@@ -508,4 +505,45 @@ class Group_LDAPTest extends \Test\TestCase {
 		$groupsAgain = $groupBackend->getUserGroups('userX');
 		$this->assertEquals(['group1', 'group2'], $groupsAgain);
 	}
+
+	public function testCountUsersInPrimaryGroupIllegalSearch() {
+		$groupDN = 'cn=foobar';
+
+		$groupBackend = new GroupLDAP($this->accessMock);
+		$count = $groupBackend->countUsersInPrimaryGroup($groupDN, null);
+
+		$this->assertSame(0, $count);
+
+		$groupBackend = new GroupLDAP($this->accessMock);
+		$count = $groupBackend->countUsersInPrimaryGroup($groupDN, 0);
+
+		$this->assertSame(0, $count);
+	}
+
+	public function testCountUsersInPrimaryGroup() {
+		$groupDN = 'cn=foobar';
+		$expected = 7;
+
+		$this->accessMock->expects($this->any())
+			->method('readAttribute')
+			->will($this->returnValue(['3117']));
+
+		$this->accessMock->expects($this->any())
+			->method('countUsers')
+			->with('properFilter')
+			->will($this->returnValue($expected));
+
+		$this->accessMock->expects($this->exactly(2))
+			->method('combineFilterWithAnd')
+			->will($this->returnValue('properFilter'));
+
+		$groupBackend = new GroupLDAP($this->accessMock);
+
+		$count = $groupBackend->countUsersInPrimaryGroup($groupDN);
+		$this->assertSame($expected, $count);
+
+		$count = $groupBackend->countUsersInPrimaryGroup($groupDN, 'barfoo');
+		$this->assertSame($expected, $count);
+	}
+
 }


### PR DESCRIPTION
Basically a cherry-pick from https://github.com/owncloud/core/pull/23535 with 
- more clear commit history 
- the conflicts resolved 
- changes according to the recent review comments

so the description below is shamelessly copied from the origin 

Contributes to #22522

List of uses: https://github.com/owncloud/core/issues/22522#issuecomment-200359298

Files to check:
- [X] apps/user_ldap/group_ldap.php – hardened for hypothetical cases, no real issues
- [x] apps/user_ldap/lib/user/user.php
- [x] apps/user_ldap/lib/connection.php
- [x] apps/user_ldap/lib/jobs.php
- [x] apps/user_ldap/lib/helper.php
- [x] apps/user_ldap/lib/access.php
- [x] apps/user_ldap/lib/wizard.php
- [x] apps/user_ldap/lib/configuration.php
- [x] apps/user_ldap/user_ldap.php
