### PR TITLE
Hide the LDAP password in the client side

### DIFF
--- a/apps/user_ldap/ajax/getConfiguration.php
+++ b/apps/user_ldap/ajax/getConfiguration.php
@@ -31,4 +31,9 @@ OCP\JSON::callCheck();
 $prefix = (string)$_POST['ldap_serverconfig_chooser'];
 $ldapWrapper = new OCA\User_LDAP\LDAP();
 $connection = new \OCA\User_LDAP\Connection($ldapWrapper, $prefix);
-OCP\JSON::success(array('configuration' => $connection->getConfiguration()));
+$configuration = $connection->getConfiguration();
+if (isset($configuration['ldap_agent_password']) && $configuration['ldap_agent_password'] !== '') {
+	// hide password
+	$configuration['ldap_agent_password'] = '**PASSWORD SET**';
+}
+OCP\JSON::success(array('configuration' => $configuration));

--- a/apps/user_ldap/ajax/testConfiguration.php
+++ b/apps/user_ldap/ajax/testConfiguration.php
@@ -32,12 +32,19 @@ OCP\JSON::callCheck();
 $l = \OC::$server->getL10N('user_ldap');
 
 $ldapWrapper = new OCA\User_LDAP\LDAP();
-$connection = new \OCA\User_LDAP\Connection($ldapWrapper, '', null);
-//needs to be true, otherwise it will also fail with an irritating message
-$_POST['ldap_configuration_active'] = 1;
+$connection = new \OCA\User_LDAP\Connection($ldapWrapper, $_POST['ldap_serverconfig_chooser']);
+
 
 try {
-	if ($connection->setConfiguration($_POST)) {
+	$configurationOk = true;
+	$conf = $connection->getConfiguration();
+	if ($conf['ldap_configuration_active'] === '0') {
+		//needs to be true, otherwise it will also fail with an irritating message
+		$conf['ldap_configuration_active'] = '1';
+		$configurationOk = $connection->setConfiguration($conf);
+	}
+	if ($configurationOk) {
+		//Configuration is okay
 		/*
 		 * Clossing the session since it won't be used from this point on. There might be a potential
 		 * race condition if a second request is made: either this request or the other might not
@@ -45,7 +52,6 @@ try {
 		 * problem with that other than the extra connection.
 		 */
 		\OC::$server->getSession()->close();
-		//Configuration is okay
 		if ($connection->bind()) {
 			/*
 			 * This shiny if block is an ugly hack to find out whether anonymous

--- a/apps/user_ldap/js/wizard/configModel.js
+++ b/apps/user_ldap/js/wizard/configModel.js
@@ -318,7 +318,7 @@ OCA = OCA || {};
 		 */
 		requestConfigurationTest: function() {
 			var url = OC.generateUrl('apps/user_ldap/ajax/testConfiguration.php');
-			var params = OC.buildQueryString(this.configuration);
+			var params = OC.buildQueryString({ldap_serverconfig_chooser: this.configID});
 			var model = this;
 			$.post(url, params, function(result) { model._processTestResult(model, result) });
 			//TODO: make sure only one test is running at a time

--- a/apps/user_ldap/js/wizard/view.js
+++ b/apps/user_ldap/js/wizard/view.js
@@ -271,7 +271,7 @@ OCA = OCA || {};
 		 * requests a configuration test
 		 */
 		onTestButtonClick: function() {
-			this.configModel.requestWizard('ldap_action_test_connection', this.configModel.configuration);
+			this.configModel.requestWizard('ldap_action_test_connection', {ldap_serverconfig_chooser: this.configModel.configID});
 		},
 
 		/**


### PR DESCRIPTION
Connection checks will be done by using the configuration id, with the
stored password. LDAP password won't be sent to the client.

Fix https://github.com/owncloud/enterprise/issues/1489

@DeepDiver1975 backports are required
