### PR TITLE
[Stable9.1] Respect theme for external folder icon

### DIFF
--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -537,7 +537,7 @@ OCA.External.StatusManager.Utils = {
 	 * of the tr matching the folder name
 	 */
 	getIconRoute: function (tr) {
-		var icon = OC.imagePath('core', 'filetypes/folder-external');
+		var icon = OC.MimeType.getIconUrl('dir-external');
 		var backend = null;
 
 		if (tr instanceof $) {


### PR DESCRIPTION
Forward-port of https://github.com/owncloud/core/pull/25487

See issue #25461. 
When using a theme with alternative filetype icons `OCA.External.StatusManager.Utils.getIconRoute` should respect that, rather than hard coding the default icon.

Note this change does not affect windows_network_drive and sharepoint icons, which appear not to be easily themeable.
