### PR TITLE
[stable9] Fix file permissions for SMB (read-only folders will be writeable)

### DIFF
--- a/apps/files_external/lib/smb.php
+++ b/apps/files_external/lib/smb.php
@@ -363,6 +363,19 @@ class SMB extends Common {
 	public function isUpdatable($path) {
 		try {
 			$info = $this->getFileInfo($path);
+			// following windows behaviour for read-only folders: they can be written into
+			// (https://support.microsoft.com/en-us/kb/326549 - "cause" section)
+			return !$info->isHidden() && (!$info->isReadOnly() || $this->is_dir($path));
+		} catch (NotFoundException $e) {
+			return false;
+		} catch (ForbiddenException $e) {
+			return false;
+		}
+	}
+
+	public function isDeletable($path) {
+		try {
+			$info = $this->getFileInfo($path);
 			return !$info->isHidden() && !$info->isReadOnly();
 		} catch (NotFoundException $e) {
 			return false;


### PR DESCRIPTION
Read-only folders won't be deletable

Backport of https://github.com/owncloud/core/pull/25301

Fix https://github.com/owncloud/core/issues/24608
