### PR TITLE
[stable9] getJailedPath expects $path to have a trailing /  (#25703)

### DIFF
--- a/lib/private/files/cache/wrapper/cachejail.php
+++ b/lib/private/files/cache/wrapper/cachejail.php
@@ -56,6 +56,9 @@ class CacheJail extends CacheWrapper {
 	 * @return null|string the jailed path or null if the path is outside the jail
 	 */
 	protected function getJailedPath($path) {
+		if ($this->root === '') {
+			return $path;
+		}
 		$rootLength = strlen($this->root) + 1;
 		if ($path === $this->root) {
 			return '';

--- a/tests/lib/files/cache/wrapper/cachejail.php
+++ b/tests/lib/files/cache/wrapper/cachejail.php
@@ -63,8 +63,17 @@ class CacheJail extends Cache {
 	}
 
 	function testGetById() {
-		//not supported
-		$this->assertTrue(true);
+		$data1 = array('size' => 100, 'mtime' => 50, 'mimetype' => 'httpd/unix-directory');
+		$id = $this->sourceCache->put('foo/bar', $data1);
+
+		// path from jailed foo of foo/bar is bar
+		$path = $this->cache->getPathById($id);
+		$this->assertEquals('bar', $path);
+
+		// path from jailed '' of foo/bar is foo/bar
+		$this->cache = new \OC\Files\Cache\Wrapper\CacheJail($this->sourceCache, '');
+		$path = $this->cache->getPathById($id);
+		$this->assertEquals('foo/bar', $path);
 	}
 
 	function testGetIncomplete() {


### PR DESCRIPTION
- getJailedPath expects $path to have a trailing / - fixes #25464
- Adding test case for getPathById including a jailed cache where root is just empty
