### PR TITLE
remove AS to play nice with oracle

### DIFF
--- a/lib/private/Repair/SearchLuceneTables.php
+++ b/lib/private/Repair/SearchLuceneTables.php
@@ -67,7 +67,7 @@ class SearchLuceneTables implements IRepairStep {
 						FROM `*PREFIX*lucene_status`
 						GROUP BY `fileid`
 						HAVING count(`fileid`) > 1
-					) AS `mysqlerr1093hack`
+					) `mysqlerr1093hack`
 				)');
 			$query->execute();
 		} else {


### PR DESCRIPTION
running the current query on oracle chokes:

```
Fehler bei Befehlszeile : 20 Spalte : 7
Fehlerbericht -
SQL-Fehler: ORA-00907: Rechte Klammer fehlt
00907. 00000 -  "missing right parenthesis"
```

the as is optional and also works on mysql.
To test:
- [ ] postgres compatability
- [ ] sqlite compatability
