### PR TITLE
Skip version and trash expiry for users that never logged in

### DIFF
--- a/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
+++ b/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
@@ -78,7 +78,7 @@ class ExpireTrash extends \OC\BackgroundJob\TimedJob {
 
 		$this->userManager->callForAllUsers(function(IUser $user) {
 			$uid = $user->getUID();
-			if (!$this->setupFS($uid)) {
+			if ($user->getLastLogin() === 0 || !$this->setupFS($uid)) {
 				return;
 			}
 			$dirContent = Helper::getTrashFiles('/', $uid, 'mtime');

--- a/apps/files_versions/lib/BackgroundJob/ExpireVersions.php
+++ b/apps/files_versions/lib/BackgroundJob/ExpireVersions.php
@@ -68,7 +68,7 @@ class ExpireVersions extends \OC\BackgroundJob\TimedJob {
 
 		$this->userManager->callForAllUsers(function(IUser $user) {
 			$uid = $user->getUID();
-			if (!$this->setupFS($uid)) {
+			if ($user->getLastLogin() === 0 || !$this->setupFS($uid)) {
 				return;
 			}
 			Storage::expireOlderThanMaxForUser($uid);


### PR DESCRIPTION
it saves us trying to set up the filesystem
