### PR TITLE
[stable9] Skip version and trash expiry for users that never logged in

### DIFF
--- a/apps/files_trashbin/lib/backgroundjob/expiretrash.php
+++ b/apps/files_trashbin/lib/backgroundjob/expiretrash.php
@@ -77,7 +77,7 @@ class ExpireTrash extends \OC\BackgroundJob\TimedJob {
 
 		$this->userManager->callForAllUsers(function(IUser $user) {
 			$uid = $user->getUID();
-			if (!$this->setupFS($uid)) {
+			if ($user->getLastLogin() === 0 || !$this->setupFS($uid)) {
 				return;
 			}
 			$dirContent = Helper::getTrashFiles('/', $uid, 'mtime');

--- a/apps/files_versions/lib/backgroundjob/expireversions.php
+++ b/apps/files_versions/lib/backgroundjob/expireversions.php
@@ -67,7 +67,7 @@ class ExpireVersions extends \OC\BackgroundJob\TimedJob {
 
 		$this->userManager->callForAllUsers(function(IUser $user) {
 			$uid = $user->getUID();
-			if (!$this->setupFS($uid)) {
+			if ($user->getLastLogin() === 0 || !$this->setupFS($uid)) {
 				return;
 			}
 			Storage::expireOlderThanMaxForUser($uid);


### PR DESCRIPTION
backport of https://github.com/owncloud/core/pull/25741 to stable9
