### PR TITLE
In case of unit testing - just return the default services

### DIFF
--- a/apps/federatedfilesharing/lib/DiscoveryManager.php
+++ b/apps/federatedfilesharing/lib/DiscoveryManager.php
@@ -84,6 +84,9 @@ class DiscoveryManager {
 			'share' => '/ocs/v1.php/cloud/shares',
 		];
 
+		if (defined('PHPUNIT_RUN')) {
+			return $discoveredServices;
+		}
 		// Read the data from the response body
 		try {
 			$response = $this->client->get($remote . '/ocs-provider/', [


### PR DESCRIPTION
@PVince81 alternative approach compared to https://github.com/owncloud/core/pull/25706/commits/7153a28571e4547cc7e5749a058cc93f3a895d76

Basically the DiscoveryManager is the only victim why http stack is called based on the analysis of #25707 
