### PR TITLE
25532_issue_password_update_notification

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -669,6 +669,7 @@ $(document).ready(function () {
 							{username: uid, password: $(this).val(), recoveryPassword: recoveryPasswordVal},
 							function (result) {
 								if(result.status == 'success') {
+									OC.Notification.showTemporary(t('admin', result.status));
 								} else {
 									OC.Notification.showTemporary(t('admin', result.data.message));
 								}

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -668,7 +668,9 @@ $(document).ready(function () {
 							OC.generateUrl('/settings/users/changepassword'),
 							{username: uid, password: $(this).val(), recoveryPassword: recoveryPasswordVal},
 							function (result) {
-								if (result.status != 'success') {
+								if(result.status == 'success') {
+									OC.Notification.showTemporary(t('admin', 'User password updated'));
+								} else {
 									OC.Notification.showTemporary(t('admin', result.data.message));
 								}
 							}

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -669,7 +669,6 @@ $(document).ready(function () {
 							{username: uid, password: $(this).val(), recoveryPassword: recoveryPasswordVal},
 							function (result) {
 								if(result.status == 'success') {
-									OC.Notification.showTemporary(t('admin', 'User password updated'));
 								} else {
 									OC.Notification.showTemporary(t('admin', result.data.message));
 								}


### PR DESCRIPTION
Applying a fix for issue #25532

This adds a temporary notification on updating a user password so the user knows it has gone through successfully. Previously, there was no feedback provided to the user unless it failed.
