### PR TITLE
[v9.1.0] Fix UserMountCache shared storage recursion hell

### DIFF
--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -223,4 +223,13 @@ class SharedMount extends MountPoint implements MoveableMount {
 	public function getStorageRootId() {
 		return $this->share->getNodeId();
 	}
+
+	public function getStorageNumericId() {
+		$query = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$query->select('storage')
+			->from('filecache')
+			->where($query->expr()->eq('fileid', $query->createNamedParameter($this->share->getNodeId())));
+
+		return $query->execute()->fetchColumn();
+	}
 }

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -37,6 +37,7 @@ use OCP\Constants;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Storage\IStorage;
 use OCP\Lock\ILockingProvider;
+use OC\Files\Storage\FailedStorage;
 
 /**
  * Convert target path to source path and pass the function call to the correct storage provider
@@ -96,11 +97,12 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 			list($this->sourceStorage, $sourceInternalPath) = $this->ownerView->resolvePath($sourcePath);
 			$this->sourceRootInfo = $this->sourceStorage->getCache()->get($sourceInternalPath);
 			// adjust jail
-			$this->storage = $this->sourceStorage;
 			$this->rootPath = $sourceInternalPath;
 		} catch (\Exception $e) {
+			$this->sourceStorage = new FailedStorage(['exception' => $e]);
 			$this->logger->logException($e);
 		}
+		$this->storage = $this->sourceStorage;
 	}
 
 	private function isValid() {
@@ -311,7 +313,7 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 
 	public function getCache($path = '', $storage = null) {
 		$this->init();
-		if (is_null($this->sourceStorage)) {
+		if (is_null($this->sourceStorage) || $this->sourceStorage instanceof FailedStorage) {
 			return new FailedCache(false);
 		}
 		if (!$storage) {
@@ -437,5 +439,4 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 
 		return $this->sourceStorage;
 	}
-
 }

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -90,13 +90,17 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 			return;
 		}
 		$this->initialized = true;
-		Filesystem::initMountPoints($this->newShare->getShareOwner());
-		$sourcePath = $this->ownerView->getPath($this->newShare->getNodeId());
-		list($this->sourceStorage, $sourceInternalPath) = $this->ownerView->resolvePath($sourcePath);
-		$this->sourceRootInfo = $this->sourceStorage->getCache()->get($sourceInternalPath);
-		// adjust jail
-		$this->storage = $this->sourceStorage;
-		$this->rootPath = $sourceInternalPath;
+		try {
+			Filesystem::initMountPoints($this->newShare->getShareOwner());
+			$sourcePath = $this->ownerView->getPath($this->newShare->getNodeId());
+			list($this->sourceStorage, $sourceInternalPath) = $this->ownerView->resolvePath($sourcePath);
+			$this->sourceRootInfo = $this->sourceStorage->getCache()->get($sourceInternalPath);
+			// adjust jail
+			$this->storage = $this->sourceStorage;
+			$this->rootPath = $sourceInternalPath;
+		} catch (\Exception $e) {
+			$this->logger->logException($e);
+		}
 	}
 
 	private function isValid() {

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -92,7 +92,7 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 		$this->initialized = true;
 		try {
 			Filesystem::initMountPoints($this->newShare->getShareOwner());
-			$sourcePath = $this->ownerView->getPath($this->newShare->getNodeId());
+			$sourcePath = $this->ownerView->getPath($this->newShare->getNodeId(), false);
 			list($this->sourceStorage, $sourceInternalPath) = $this->ownerView->resolvePath($sourcePath);
 			$this->sourceRootInfo = $this->sourceStorage->getCache()->get($sourceInternalPath);
 			// adjust jail

--- a/lib/private/Files/Config/LazyStorageMountInfo.php
+++ b/lib/private/Files/Config/LazyStorageMountInfo.php
@@ -47,11 +47,15 @@ class LazyStorageMountInfo extends CachedMountInfo {
 	 */
 	public function getStorageId() {
 		if (!$this->storageId) {
-			$storage = $this->mount->getStorage();
-			if (!$storage) {
-				return -1;
+			if (method_exists($this->mount, 'getStorageNumericId')) {
+				$this->storageId = $this->mount->getStorageNumericId();
+			} else {
+				$storage = $this->mount->getStorage();
+				if (!$storage) {
+					return -1;
+				}
+				$this->storageId = $storage->getStorageCache()->getNumericId();
 			}
-			$this->storageId = $storage->getStorageCache()->getNumericId();
 		}
 		return parent::getStorageId();
 	}

--- a/lib/private/Files/Storage/Wrapper/Jail.php
+++ b/lib/private/Files/Storage/Wrapper/Jail.php
@@ -45,10 +45,15 @@ class Jail extends Wrapper {
 	 */
 	public function __construct($arguments) {
 		parent::__construct($arguments);
+		// null value is allowed for lazy init, but it must set at earliest
+		// before the first file operation
 		$this->rootPath = $arguments['root'];
 	}
 
 	public function getSourcePath($path) {
+		if ($this->rootPath === null) {
+			throw new \InvalidArgumentException('Jail rootPath is null');
+		}
 		if ($path === '') {
 			return $this->rootPath;
 		} else {
@@ -67,7 +72,7 @@ class Jail extends Wrapper {
 	 * @return bool
 	 */
 	public function mkdir($path) {
-		return $this->storage->mkdir($this->getSourcePath($path));
+		return $this->getWrapperStorage()->mkdir($this->getSourcePath($path));
 	}
 
 	/**
@@ -77,7 +82,7 @@ class Jail extends Wrapper {
 	 * @return bool
 	 */
 	public function rmdir($path) {
-		return $this->storage->rmdir($this->getSourcePath($path));
+		return $this->getWrapperStorage()->rmdir($this->getSourcePath($path));
 	}
 
 	/**
@@ -87,7 +92,7 @@ class Jail extends Wrapper {
 	 * @return resource
 	 */
 	public function opendir($path) {
-		return $this->storage->opendir($this->getSourcePath($path));
+		return $this->getWrapperStorage()->opendir($this->getSourcePath($path));
 	}
 
 	/**
@@ -97,7 +102,7 @@ class Jail extends Wrapper {
 	 * @return bool
 	 */
 	public function is_dir($path) {
-		return $this->storage->is_dir($this->getSourcePath($path));
+		return $this->getWrapperStorage()->is_dir($this->getSourcePath($path));
 	}
 
 	/**
@@ -107,7 +112,7 @@ class Jail extends Wrapper {
 	 * @return bool
 	 */
 	public function is_file($path) {
-		return $this->storage->is_file($this->getSourcePath($path));
+		return $this->getWrapperStorage()->is_file($this->getSourcePath($path));
 	}
 
 	/**
@@ -118,7 +123,7 @@ class Jail extends Wrapper {
 	 * @return array
 	 */
 	public function stat($path) {
-		return $this->storage->stat($this->getSourcePath($path));
+		return $this->getWrapperStorage()->stat($this->getSourcePath($path));
 	}
 
 	/**
@@ -128,7 +133,7 @@ class Jail extends Wrapper {
 	 * @return bool
 	 */
 	public function filetype($path) {
-		return $this->storage->filetype($this->getSourcePath($path));
+		return $this->getWrapperStorage()->filetype($this->getSourcePath($path));
 	}
 
 	/**
@@ -139,7 +144,7 @@ class Jail extends Wrapper {
 	 * @return int
 	 */
 	public function filesize($path) {
-		return $this->storage->filesize($this->getSourcePath($path));
+		return $this->getWrapperStorage()->filesize($this->getSourcePath($path));
 	}
 
 	/**
@@ -149,7 +154,7 @@ class Jail extends Wrapper {
 	 * @return bool
 	 */
 	public function isCreatable($path) {
-		return $this->storage->isCreatable($this->getSourcePath($path));
+		return $this->getWrapperStorage()->isCreatable($this->getSourcePath($path));
 	}
 
 	/**
@@ -159,7 +164,7 @@ class Jail extends Wrapper {
 	 * @return bool
 	 */
 	public function isReadable($path) {
-		return $this->storage->isReadable($this->getSourcePath($path));
+		return $this->getWrapperStorage()->isReadable($this->getSourcePath($path));
 	}
 
 	/**
@@ -169,7 +174,7 @@ class Jail extends Wrapper {
 	 * @return bool
 	 */
 	public function isUpdatable($path) {
-		return $this->storage->isUpdatable($this->getSourcePath($path));
+		return $this->getWrapperStorage()->isUpdatable($this->getSourcePath($path));
 	}
 
 	/**
@@ -179,7 +184,7 @@ class Jail extends Wrapper {
 	 * @return bool
 	 */
 	public function isDeletable($path) {
-		return $this->storage->isDeletable($this->getSourcePath($path));
+		return $this->getWrapperStorage()->isDeletable($this->getSourcePath($path));
 	}
 
 	/**
@@ -189,7 +194,7 @@ class Jail extends Wrapper {
 	 * @return bool
 	 */
 	public function isSharable($path) {
-		return $this->storage->isSharable($this->getSourcePath($path));
+		return $this->getWrapperStorage()->isSharable($this->getSourcePath($path));
 	}
 
 	/**
@@ -200,7 +205,7 @@ class Jail extends Wrapper {
 	 * @return int
 	 */
 	public function getPermissions($path) {
-		return $this->storage->getPermissions($this->getSourcePath($path));
+		return $this->getWrapperStorage()->getPermissions($this->getSourcePath($path));
 	}
 
 	/**
@@ -210,7 +215,7 @@ class Jail extends Wrapper {
 	 * @return bool
 	 */
 	public function file_exists($path) {
-		return $this->storage->file_exists($this->getSourcePath($path));
+		return $this->getWrapperStorage()->file_exists($this->getSourcePath($path));
 	}
 
 	/**
@@ -220,7 +225,7 @@ class Jail extends Wrapper {
 	 * @return int
 	 */
 	public function filemtime($path) {
-		return $this->storage->filemtime($this->getSourcePath($path));
+		return $this->getWrapperStorage()->filemtime($this->getSourcePath($path));
 	}
 
 	/**
@@ -230,7 +235,7 @@ class Jail extends Wrapper {
 	 * @return string
 	 */
 	public function file_get_contents($path) {
-		return $this->storage->file_get_contents($this->getSourcePath($path));
+		return $this->getWrapperStorage()->file_get_contents($this->getSourcePath($path));
 	}
 
 	/**
@@ -241,7 +246,7 @@ class Jail extends Wrapper {
 	 * @return bool
 	 */
 	public function file_put_contents($path, $data) {
-		return $this->storage->file_put_contents($this->getSourcePath($path), $data);
+		return $this->getWrapperStorage()->file_put_contents($this->getSourcePath($path), $data);
 	}
 
 	/**
@@ -251,7 +256,7 @@ class Jail extends Wrapper {
 	 * @return bool
 	 */
 	public function unlink($path) {
-		return $this->storage->unlink($this->getSourcePath($path));
+		return $this->getWrapperStorage()->unlink($this->getSourcePath($path));
 	}
 
 	/**
@@ -262,7 +267,7 @@ class Jail extends Wrapper {
 	 * @return bool
 	 */
 	public function rename($path1, $path2) {
-		return $this->storage->rename($this->getSourcePath($path1), $this->getSourcePath($path2));
+		return $this->getWrapperStorage()->rename($this->getSourcePath($path1), $this->getSourcePath($path2));
 	}
 
 	/**
@@ -273,7 +278,7 @@ class Jail extends Wrapper {
 	 * @return bool
 	 */
 	public function copy($path1, $path2) {
-		return $this->storage->copy($this->getSourcePath($path1), $this->getSourcePath($path2));
+		return $this->getWrapperStorage()->copy($this->getSourcePath($path1), $this->getSourcePath($path2));
 	}
 
 	/**
@@ -284,7 +289,7 @@ class Jail extends Wrapper {
 	 * @return resource
 	 */
 	public function fopen($path, $mode) {
-		return $this->storage->fopen($this->getSourcePath($path), $mode);
+		return $this->getWrapperStorage()->fopen($this->getSourcePath($path), $mode);
 	}
 
 	/**
@@ -295,7 +300,7 @@ class Jail extends Wrapper {
 	 * @return string
 	 */
 	public function getMimeType($path) {
-		return $this->storage->getMimeType($this->getSourcePath($path));
+		return $this->getWrapperStorage()->getMimeType($this->getSourcePath($path));
 	}
 
 	/**
@@ -307,7 +312,7 @@ class Jail extends Wrapper {
 	 * @return string
 	 */
 	public function hash($type, $path, $raw = false) {
-		return $this->storage->hash($type, $this->getSourcePath($path), $raw);
+		return $this->getWrapperStorage()->hash($type, $this->getSourcePath($path), $raw);
 	}
 
 	/**
@@ -317,7 +322,7 @@ class Jail extends Wrapper {
 	 * @return int
 	 */
 	public function free_space($path) {
-		return $this->storage->free_space($this->getSourcePath($path));
+		return $this->getWrapperStorage()->free_space($this->getSourcePath($path));
 	}
 
 	/**
@@ -327,7 +332,7 @@ class Jail extends Wrapper {
 	 * @return array
 	 */
 	public function search($query) {
-		return $this->storage->search($query);
+		return $this->getWrapperStorage()->search($query);
 	}
 
 	/**
@@ -339,7 +344,7 @@ class Jail extends Wrapper {
 	 * @return bool
 	 */
 	public function touch($path, $mtime = null) {
-		return $this->storage->touch($this->getSourcePath($path), $mtime);
+		return $this->getWrapperStorage()->touch($this->getSourcePath($path), $mtime);
 	}
 
 	/**
@@ -350,7 +355,7 @@ class Jail extends Wrapper {
 	 * @return string
 	 */
 	public function getLocalFile($path) {
-		return $this->storage->getLocalFile($this->getSourcePath($path));
+		return $this->getWrapperStorage()->getLocalFile($this->getSourcePath($path));
 	}
 
 	/**
@@ -364,7 +369,7 @@ class Jail extends Wrapper {
 	 * returning true for other changes in the folder is optional
 	 */
 	public function hasUpdated($path, $time) {
-		return $this->storage->hasUpdated($this->getSourcePath($path), $time);
+		return $this->getWrapperStorage()->hasUpdated($this->getSourcePath($path), $time);
 	}
 
 	/**
@@ -375,10 +380,13 @@ class Jail extends Wrapper {
 	 * @return \OC\Files\Cache\Cache
 	 */
 	public function getCache($path = '', $storage = null) {
+		if ($this->rootPath === null) {
+			throw new \InvalidArgumentException('Jail rootPath is null');
+		}
 		if (!$storage) {
 			$storage = $this;
 		}
-		$sourceCache = $this->storage->getCache($this->getSourcePath($path), $storage);
+		$sourceCache = $this->getWrapperStorage()->getCache($this->getSourcePath($path), $storage);
 		return new CacheJail($sourceCache, $this->rootPath);
 	}
 
@@ -389,7 +397,7 @@ class Jail extends Wrapper {
 	 * @return string
 	 */
 	public function getOwner($path) {
-		return $this->storage->getOwner($this->getSourcePath($path));
+		return $this->getWrapperStorage()->getOwner($this->getSourcePath($path));
 	}
 
 	/**
@@ -403,7 +411,7 @@ class Jail extends Wrapper {
 		if (!$storage) {
 			$storage = $this;
 		}
-		return $this->storage->getWatcher($this->getSourcePath($path), $storage);
+		return $this->getWrapperStorage()->getWatcher($this->getSourcePath($path), $storage);
 	}
 
 	/**
@@ -413,7 +421,7 @@ class Jail extends Wrapper {
 	 * @return string
 	 */
 	public function getETag($path) {
-		return $this->storage->getETag($this->getSourcePath($path));
+		return $this->getWrapperStorage()->getETag($this->getSourcePath($path));
 	}
 
 	/**
@@ -421,7 +429,7 @@ class Jail extends Wrapper {
 	 * @return array
 	 */
 	public function getMetaData($path) {
-		return $this->storage->getMetaData($this->getSourcePath($path));
+		return $this->getWrapperStorage()->getMetaData($this->getSourcePath($path));
 	}
 
 	/**
@@ -431,7 +439,7 @@ class Jail extends Wrapper {
 	 * @throws \OCP\Lock\LockedException
 	 */
 	public function acquireLock($path, $type, ILockingProvider $provider) {
-		$this->storage->acquireLock($this->getSourcePath($path), $type, $provider);
+		$this->getWrapperStorage()->acquireLock($this->getSourcePath($path), $type, $provider);
 	}
 
 	/**
@@ -440,7 +448,7 @@ class Jail extends Wrapper {
 	 * @param \OCP\Lock\ILockingProvider $provider
 	 */
 	public function releaseLock($path, $type, ILockingProvider $provider) {
-		$this->storage->releaseLock($this->getSourcePath($path), $type, $provider);
+		$this->getWrapperStorage()->releaseLock($this->getSourcePath($path), $type, $provider);
 	}
 
 	/**
@@ -449,7 +457,7 @@ class Jail extends Wrapper {
 	 * @param \OCP\Lock\ILockingProvider $provider
 	 */
 	public function changeLock($path, $type, ILockingProvider $provider) {
-		$this->storage->changeLock($this->getSourcePath($path), $type, $provider);
+		$this->getWrapperStorage()->changeLock($this->getSourcePath($path), $type, $provider);
 	}
 
 	/**
@@ -459,7 +467,7 @@ class Jail extends Wrapper {
 	 * @return array
 	 */
 	public function resolvePath($path) {
-		return [$this->storage, $this->getSourcePath($path)];
+		return [$this->getWrapperStorage(), $this->getSourcePath($path)];
 	}
 
 	/**
@@ -472,7 +480,7 @@ class Jail extends Wrapper {
 		if ($sourceStorage === $this) {
 			return $this->copy($sourceInternalPath, $targetInternalPath);
 		}
-		return $this->storage->copyFromStorage($sourceStorage, $sourceInternalPath, $this->getSourcePath($targetInternalPath));
+		return $this->getWrapperStorage()->copyFromStorage($sourceStorage, $sourceInternalPath, $this->getSourcePath($targetInternalPath));
 	}
 
 	/**
@@ -485,6 +493,6 @@ class Jail extends Wrapper {
 		if ($sourceStorage === $this) {
 			return $this->rename($sourceInternalPath, $targetInternalPath);
 		}
-		return $this->storage->moveFromStorage($sourceStorage, $sourceInternalPath, $this->getSourcePath($targetInternalPath));
+		return $this->getWrapperStorage()->moveFromStorage($sourceStorage, $sourceInternalPath, $this->getSourcePath($targetInternalPath));
 	}
 }

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -83,7 +83,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function rmdir($path) {
-		return $this->storage->rmdir($path);
+		return $this->getWrapperStorage()->rmdir($path);
 	}
 
 	/**
@@ -93,7 +93,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return resource
 	 */
 	public function opendir($path) {
-		return $this->storage->opendir($path);
+		return $this->getWrapperStorage()->opendir($path);
 	}
 
 	/**
@@ -103,7 +103,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function is_dir($path) {
-		return $this->storage->is_dir($path);
+		return $this->getWrapperStorage()->is_dir($path);
 	}
 
 	/**
@@ -113,7 +113,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function is_file($path) {
-		return $this->storage->is_file($path);
+		return $this->getWrapperStorage()->is_file($path);
 	}
 
 	/**
@@ -124,7 +124,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return array
 	 */
 	public function stat($path) {
-		return $this->storage->stat($path);
+		return $this->getWrapperStorage()->stat($path);
 	}
 
 	/**
@@ -134,7 +134,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function filetype($path) {
-		return $this->storage->filetype($path);
+		return $this->getWrapperStorage()->filetype($path);
 	}
 
 	/**
@@ -145,7 +145,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return int
 	 */
 	public function filesize($path) {
-		return $this->storage->filesize($path);
+		return $this->getWrapperStorage()->filesize($path);
 	}
 
 	/**
@@ -155,7 +155,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function isCreatable($path) {
-		return $this->storage->isCreatable($path);
+		return $this->getWrapperStorage()->isCreatable($path);
 	}
 
 	/**
@@ -165,7 +165,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function isReadable($path) {
-		return $this->storage->isReadable($path);
+		return $this->getWrapperStorage()->isReadable($path);
 	}
 
 	/**
@@ -175,7 +175,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function isUpdatable($path) {
-		return $this->storage->isUpdatable($path);
+		return $this->getWrapperStorage()->isUpdatable($path);
 	}
 
 	/**
@@ -185,7 +185,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function isDeletable($path) {
-		return $this->storage->isDeletable($path);
+		return $this->getWrapperStorage()->isDeletable($path);
 	}
 
 	/**
@@ -195,7 +195,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function isSharable($path) {
-		return $this->storage->isSharable($path);
+		return $this->getWrapperStorage()->isSharable($path);
 	}
 
 	/**
@@ -206,7 +206,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return int
 	 */
 	public function getPermissions($path) {
-		return $this->storage->getPermissions($path);
+		return $this->getWrapperStorage()->getPermissions($path);
 	}
 
 	/**
@@ -216,7 +216,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function file_exists($path) {
-		return $this->storage->file_exists($path);
+		return $this->getWrapperStorage()->file_exists($path);
 	}
 
 	/**
@@ -226,7 +226,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return int
 	 */
 	public function filemtime($path) {
-		return $this->storage->filemtime($path);
+		return $this->getWrapperStorage()->filemtime($path);
 	}
 
 	/**
@@ -236,7 +236,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return string
 	 */
 	public function file_get_contents($path) {
-		return $this->storage->file_get_contents($path);
+		return $this->getWrapperStorage()->file_get_contents($path);
 	}
 
 	/**
@@ -247,7 +247,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function file_put_contents($path, $data) {
-		return $this->storage->file_put_contents($path, $data);
+		return $this->getWrapperStorage()->file_put_contents($path, $data);
 	}
 
 	/**
@@ -257,7 +257,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function unlink($path) {
-		return $this->storage->unlink($path);
+		return $this->getWrapperStorage()->unlink($path);
 	}
 
 	/**
@@ -268,7 +268,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function rename($path1, $path2) {
-		return $this->storage->rename($path1, $path2);
+		return $this->getWrapperStorage()->rename($path1, $path2);
 	}
 
 	/**
@@ -279,7 +279,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function copy($path1, $path2) {
-		return $this->storage->copy($path1, $path2);
+		return $this->getWrapperStorage()->copy($path1, $path2);
 	}
 
 	/**
@@ -290,7 +290,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return resource
 	 */
 	public function fopen($path, $mode) {
-		return $this->storage->fopen($path, $mode);
+		return $this->getWrapperStorage()->fopen($path, $mode);
 	}
 
 	/**
@@ -301,7 +301,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return string
 	 */
 	public function getMimeType($path) {
-		return $this->storage->getMimeType($path);
+		return $this->getWrapperStorage()->getMimeType($path);
 	}
 
 	/**
@@ -313,7 +313,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return string
 	 */
 	public function hash($type, $path, $raw = false) {
-		return $this->storage->hash($type, $path, $raw);
+		return $this->getWrapperStorage()->hash($type, $path, $raw);
 	}
 
 	/**
@@ -323,7 +323,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return int
 	 */
 	public function free_space($path) {
-		return $this->storage->free_space($path);
+		return $this->getWrapperStorage()->free_space($path);
 	}
 
 	/**
@@ -333,7 +333,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return array
 	 */
 	public function search($query) {
-		return $this->storage->search($query);
+		return $this->getWrapperStorage()->search($query);
 	}
 
 	/**
@@ -345,7 +345,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function touch($path, $mtime = null) {
-		return $this->storage->touch($path, $mtime);
+		return $this->getWrapperStorage()->touch($path, $mtime);
 	}
 
 	/**
@@ -356,7 +356,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return string
 	 */
 	public function getLocalFile($path) {
-		return $this->storage->getLocalFile($path);
+		return $this->getWrapperStorage()->getLocalFile($path);
 	}
 
 	/**
@@ -370,7 +370,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * returning true for other changes in the folder is optional
 	 */
 	public function hasUpdated($path, $time) {
-		return $this->storage->hasUpdated($path, $time);
+		return $this->getWrapperStorage()->hasUpdated($path, $time);
 	}
 
 	/**
@@ -384,7 +384,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 		if (!$storage) {
 			$storage = $this;
 		}
-		return $this->storage->getCache($path, $storage);
+		return $this->getWrapperStorage()->getCache($path, $storage);
 	}
 
 	/**
@@ -398,7 +398,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 		if (!$storage) {
 			$storage = $this;
 		}
-		return $this->storage->getScanner($path, $storage);
+		return $this->getWrapperStorage()->getScanner($path, $storage);
 	}
 
 
@@ -409,7 +409,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return string
 	 */
 	public function getOwner($path) {
-		return $this->storage->getOwner($path);
+		return $this->getWrapperStorage()->getOwner($path);
 	}
 
 	/**

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -63,7 +63,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return string
 	 */
 	public function getId() {
-		return $this->storage->getId();
+		return $this->getWrapperStorage()->getId();
 	}
 
 	/**
@@ -73,7 +73,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function mkdir($path) {
-		return $this->storage->mkdir($path);
+		return $this->getWrapperStorage()->mkdir($path);
 	}
 
 	/**
@@ -423,28 +423,28 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 		if (!$storage) {
 			$storage = $this;
 		}
-		return $this->storage->getWatcher($path, $storage);
+		return $this->getWrapperStorage()->getWatcher($path, $storage);
 	}
 
 	public function getPropagator($storage = null) {
 		if (!$storage) {
 			$storage = $this;
 		}
-		return $this->storage->getPropagator($storage);
+		return $this->getWrapperStorage()->getPropagator($storage);
 	}
 
 	public function getUpdater($storage = null) {
 		if (!$storage) {
 			$storage = $this;
 		}
-		return $this->storage->getUpdater($storage);
+		return $this->getWrapperStorage()->getUpdater($storage);
 	}
 
 	/**
 	 * @return \OC\Files\Cache\Storage
 	 */
 	public function getStorageCache() {
-		return $this->storage->getStorageCache();
+		return $this->getWrapperStorage()->getStorageCache();
 	}
 
 	/**
@@ -454,7 +454,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return string
 	 */
 	public function getETag($path) {
-		return $this->storage->getETag($path);
+		return $this->getWrapperStorage()->getETag($path);
 	}
 
 	/**
@@ -463,7 +463,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return true
 	 */
 	public function test() {
-		return $this->storage->test();
+		return $this->getWrapperStorage()->test();
 	}
 
 	/**
@@ -472,7 +472,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool wrapped storage's isLocal() value
 	 */
 	public function isLocal() {
-		return $this->storage->isLocal();
+		return $this->getWrapperStorage()->isLocal();
 	}
 
 	/**
@@ -482,7 +482,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function instanceOfStorage($class) {
-		return is_a($this, $class) or $this->storage->instanceOfStorage($class);
+		return is_a($this, $class) or $this->getWrapperStorage()->instanceOfStorage($class);
 	}
 
 	/**
@@ -493,7 +493,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return mixed
 	 */
 	public function __call($method, $args) {
-		return call_user_func_array(array($this->storage, $method), $args);
+		return call_user_func_array(array($this->getWrapperStorage(), $method), $args);
 	}
 
 	/**
@@ -505,7 +505,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return array
 	 */
 	public function getDirectDownload($path) {
-		return $this->storage->getDirectDownload($path);
+		return $this->getWrapperStorage()->getDirectDownload($path);
 	}
 
 	/**
@@ -514,7 +514,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return array [ available, last_checked ]
 	 */
 	public function getAvailability() {
-		return $this->storage->getAvailability();
+		return $this->getWrapperStorage()->getAvailability();
 	}
 
 	/**
@@ -523,7 +523,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @param bool $isAvailable
 	 */
 	public function setAvailability($isAvailable) {
-		$this->storage->setAvailability($isAvailable);
+		$this->getWrapperStorage()->setAvailability($isAvailable);
 	}
 
 	/**
@@ -533,7 +533,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @throws InvalidPathException
 	 */
 	public function verifyPath($path, $fileName) {
-		$this->storage->verifyPath($path, $fileName);
+		$this->getWrapperStorage()->verifyPath($path, $fileName);
 	}
 
 	/**
@@ -547,7 +547,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 			return $this->copy($sourceInternalPath, $targetInternalPath);
 		}
 
-		return $this->storage->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+		return $this->getWrapperStorage()->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}
 
 	/**
@@ -561,7 +561,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 			return $this->rename($sourceInternalPath, $targetInternalPath);
 		}
 
-		return $this->storage->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+		return $this->getWrapperStorage()->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}
 
 	/**
@@ -569,7 +569,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @return array
 	 */
 	public function getMetaData($path) {
-		return $this->storage->getMetaData($path);
+		return $this->getWrapperStorage()->getMetaData($path);
 	}
 
 	/**
@@ -579,8 +579,9 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @throws \OCP\Lock\LockedException
 	 */
 	public function acquireLock($path, $type, ILockingProvider $provider) {
-		if ($this->storage->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
-			$this->storage->acquireLock($path, $type, $provider);
+		$storage = $this->getWrapperStorage();
+		if ($storage->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
+			$storage->acquireLock($path, $type, $provider);
 		}
 	}
 
@@ -590,8 +591,9 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @param \OCP\Lock\ILockingProvider $provider
 	 */
 	public function releaseLock($path, $type, ILockingProvider $provider) {
-		if ($this->storage->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
-			$this->storage->releaseLock($path, $type, $provider);
+		$storage = $this->getWrapperStorage();
+		if ($storage->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
+			$storage->releaseLock($path, $type, $provider);
 		}
 	}
 
@@ -601,8 +603,9 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 	 * @param \OCP\Lock\ILockingProvider $provider
 	 */
 	public function changeLock($path, $type, ILockingProvider $provider) {
-		if ($this->storage->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
-			$this->storage->changeLock($path, $type, $provider);
+		$storage = $this->getWrapperStorage();
+		if ($storage->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
+			$storage->changeLock($path, $type, $provider);
 		}
 	}
 }


### PR DESCRIPTION
To prevent recursions in initMountPoints which requires the numeric id
to populate oc_mounts

Fixes https://github.com/owncloud/core/issues/25557

@owncloud/sharing @owncloud/filesystem 
