### PR TITLE
[9.2] Adding a button to the detailed view where the webdav url can be copi…

### DIFF
--- a/apps/files/css/detailsView.css
+++ b/apps/files/css/detailsView.css
@@ -18,6 +18,10 @@
 	display: inline-block;
 }
 
+#app-sidebar .mainFileInfoView .icon-external {
+	opacity: .5;
+}
+
 #app-sidebar .mainFileInfoView .permalink {
 	margin-left: 10px;
 	opacity: .5;

--- a/apps/files/css/detailsView.css
+++ b/apps/files/css/detailsView.css
@@ -18,8 +18,13 @@
 	display: inline-block;
 }
 
+#app-sidebar .mainFileInfoView .hidden {
+	display: none;
+}
+
 #app-sidebar .mainFileInfoView .icon-external {
 	opacity: .5;
+	padding-left: 8px;
 }
 
 #app-sidebar .mainFileInfoView .permalink {

--- a/apps/files/js/mainfileinfodetailview.js
+++ b/apps/files/js/mainfileinfodetailview.js
@@ -18,6 +18,7 @@
 				'<span class="icon icon-public"></span>' +
 				'<span class="hidden-visually">{{permalinkTitle}}</span>' +
 			'</a>' +
+			'<a class="{{#unless showWebDavCopyButton}}hidden-visually{{/unless}} clipboardButton icon icon-external" data-clipboard-text="{{webDavUrl}}"></a>' +
 		'</div>' +
 		'	<div class="file-details ellipsis">' +
 		'		<a href="#" ' +
@@ -81,6 +82,8 @@
 			if (!this._fileActions) {
 				throw 'Missing required parameter "fileActions"';
 			}
+
+			OC.Util.setupClipboard('.clipboardButton');
 		},
 
 		_onClickPermalink: function() {
@@ -117,6 +120,17 @@
 			return baseUrl + OC.generateUrl('/f/{fileId}', {fileId: fileId});
 		},
 
+		_makeWebDavUrl: function (fullPath) {
+			var pathSections = fullPath.split('/');
+			var encodedPath = '';
+			_.each(pathSections, function(section) {
+				if (section !== '') {
+					encodedPath += '/' + encodeURIComponent(section);
+				}
+			});
+			return OC.linkToRemote('webdav') + encodedPath;
+		},
+
 		setFileInfo: function(fileInfo) {
 			if (this.model) {
 				this.model.off('change', this._onModelChanged, this);
@@ -150,7 +164,9 @@
 					starAltText: isFavorite ? t('files', 'Favorited') : t('files', 'Favorite'),
 					starIcon: OC.imagePath('core', isFavorite ? 'actions/starred' : 'actions/star'),
 					permalink: this._makePermalink(this.model.get('id')),
-					permalinkTitle: t('files', 'Local link')
+					permalinkTitle: t('files', 'Local link'),
+					showWebDavCopyButton: this.model.isDirectory(),
+					webDavUrl: this._makeWebDavUrl(this.model.getFullPath())
 				}));
 
 				// TODO: we really need OC.Previews

--- a/apps/files/js/mainfileinfodetailview.js
+++ b/apps/files/js/mainfileinfodetailview.js
@@ -18,7 +18,7 @@
 				'<span class="icon icon-public"></span>' +
 				'<span class="hidden-visually">{{permalinkTitle}}</span>' +
 			'</a>' +
-			'<a class="{{#unless showWebDavCopyButton}}hidden-visually{{/unless}} clipboardButton icon icon-external" data-clipboard-text="{{webDavUrl}}"></a>' +
+			'<a class="{{#unless showWebDavCopyButton}}hidden{{/unless}} webDavUrlCopyButton icon icon-external" title="{{webDavUrlTitle}}" data-clipboard-text="{{webDavUrl}}"></a>' +
 		'</div>' +
 		'	<div class="file-details ellipsis">' +
 		'		<a href="#" ' +
@@ -83,7 +83,10 @@
 				throw 'Missing required parameter "fileActions"';
 			}
 
-			OC.Util.setupClipboard('.clipboardButton');
+			OC.Util.setupClipboard('.webDavUrlCopyButton', {
+				notificationMode: 'notification',
+				successMessage: t('files', 'WebDAV link copied!')
+			});
 		},
 
 		_onClickPermalink: function() {
@@ -166,7 +169,8 @@
 					permalink: this._makePermalink(this.model.get('id')),
 					permalinkTitle: t('files', 'Local link'),
 					showWebDavCopyButton: this.model.isDirectory(),
-					webDavUrl: this._makeWebDavUrl(this.model.getFullPath())
+					webDavUrl: this._makeWebDavUrl(this.model.getFullPath()),
+					webDavUrlTitle: t('files', 'Direct WebDAV link')
 				}));
 
 				// TODO: we really need OC.Previews

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1933,6 +1933,39 @@ OC.Util = {
 			}
 		}
 		return false;
+	},
+
+	setupClipboard: function(element) {
+		var clipboard = new Clipboard(element);
+		clipboard.on('success', function(e) {
+			$input = $(e.trigger);
+			$input.tooltip({placement: 'bottom', trigger: 'manual', title: t('core', 'Copied!')});
+			$input.tooltip('show');
+			_.delay(function() {
+				$input.tooltip('hide');
+			}, 3000);
+		});
+		clipboard.on('error', function (e) {
+			$input = $(e.trigger);
+			var actionMsg = '';
+			if (/iPhone|iPad/i.test(navigator.userAgent)) {
+				actionMsg = t('core', 'Not supported!');
+			} else if (/Mac/i.test(navigator.userAgent)) {
+				actionMsg = t('core', 'Press ⌘-C to copy.');
+			} else {
+				actionMsg = t('core', 'Press Ctrl-C to copy.');
+			}
+
+			$input.tooltip({
+				placement: 'bottom',
+				trigger: 'manual',
+				title: actionMsg
+			});
+			$input.tooltip('show');
+			_.delay(function () {
+				$input.tooltip('hide');
+			}, 3000);
+		});
 	}
 };
 
@@ -2234,4 +2267,4 @@ jQuery.fn.tipsy = function(argument) {
 		jQuery.fn.tooltip.call(this, argument);
 	}
 	return this;
-}
+};

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1935,15 +1935,22 @@ OC.Util = {
 		return false;
 	},
 
-	setupClipboard: function(element) {
+	setupClipboard: function(element, options) {
+		options = options || {};
+		options.notificationMode = options.notificationMode || 'tooltip';
+		options.successMessage = options.successMessage ||  t('core', 'Copied!');
 		var clipboard = new Clipboard(element);
 		clipboard.on('success', function(e) {
-			$input = $(e.trigger);
-			$input.tooltip({placement: 'bottom', trigger: 'manual', title: t('core', 'Copied!')});
-			$input.tooltip('show');
-			_.delay(function() {
-				$input.tooltip('hide');
-			}, 3000);
+			if (options.notificationMode === 'tooltip') {
+				$input = $(e.trigger);
+				$input.tooltip({placement: 'bottom', trigger: 'manual', title: options.successMessage});
+				$input.tooltip('show');
+				_.delay(function() {
+					$input.tooltip('hide');
+				}, 3000);
+			} else {
+				OC.Notification.showTemporary(options.successMessage);
+			}
 		});
 		clipboard.on('error', function (e) {
 			$input = $(e.trigger);
@@ -1956,15 +1963,19 @@ OC.Util = {
 				actionMsg = t('core', 'Press Ctrl-C to copy.');
 			}
 
-			$input.tooltip({
-				placement: 'bottom',
-				trigger: 'manual',
-				title: actionMsg
-			});
-			$input.tooltip('show');
-			_.delay(function () {
-				$input.tooltip('hide');
-			}, 3000);
+			if (options.notificationMode === 'tooltip') {
+				$input.tooltip({
+					placement: 'bottom',
+					trigger: 'manual',
+					title: actionMsg
+				});
+				$input.tooltip('show');
+				_.delay(function () {
+					$input.tooltip('hide');
+				}, 3000);
+			} else {
+				OC.Notification.showTemporary(options.successMessage);
+			}
 		});
 	}
 };

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -116,37 +116,7 @@
 				'onAllowPublicUploadChange'
 			);
 
-			var clipboard = new Clipboard('.clipboardButton');
-			clipboard.on('success', function(e) {
-				$input = $(e.trigger);
-				$input.tooltip({placement: 'bottom', trigger: 'manual', title: t('core', 'Copied!')});
-				$input.tooltip('show');
-				_.delay(function() {
-					$input.tooltip('hide');
-				}, 3000);
-			});
-			clipboard.on('error', function (e) {
-				$input = $(e.trigger);
-				var actionMsg = '';
-				if (/iPhone|iPad/i.test(navigator.userAgent)) {
-					actionMsg = t('core', 'Not supported!');
-				} else if (/Mac/i.test(navigator.userAgent)) {
-					actionMsg = t('core', 'Press ⌘-C to copy.');
-				} else {
-					actionMsg = t('core', 'Press Ctrl-C to copy.');
-				}
-
-				$input.tooltip({
-					placement: 'bottom',
-					trigger: 'manual',
-					title: actionMsg
-				});
-				$input.tooltip('show');
-				_.delay(function () {
-					$input.tooltip('hide');
-				}, 3000);
-			});
-
+			OC.Util.setupClipboard('.clipboardButton');
 		},
 
 		onLinkCheckBoxChange: function() {


### PR DESCRIPTION
…ed to the clipboard

![bildschirmfoto von 2016-08-10 14-59-34](https://cloud.githubusercontent.com/assets/1005065/17554477/48d1a034-5f0b-11e6-95a5-f9a8f8b5ab3b.png)

The webdav url to a folder can now easily be copied to the clipboard using this new button on the detailed view.

This is valuable for users who want to mount a specific folder in e.g. their windows explorer, nautilus file manager and so on ....
