### PR TITLE
lastInsertId requires the prefix

### DIFF
--- a/apps/files_external/lib/Service/DBConfigService.php
+++ b/apps/files_external/lib/Service/DBConfigService.php
@@ -207,7 +207,7 @@ class DBConfigService {
 				'type' => $builder->createNamedParameter($type, IQueryBuilder::PARAM_INT)
 			]);
 		$query->execute();
-		return (int)$this->connection->lastInsertId('external_mounts');
+		return (int)$this->connection->lastInsertId('*PREFIX*external_mounts');
 	}
 
 	/**


### PR DESCRIPTION
otherwise we get a "sequence does not exist error" on oracle. just check all other occurences of lastInsertId.
without this files_external is broken on oracle
