### PR TITLE
the path of a mount config may be an empty string, which requires a nullable column on oracle

### DIFF
--- a/apps/files_external/appinfo/database.xml
+++ b/apps/files_external/appinfo/database.xml
@@ -142,9 +142,9 @@
 				<length>64</length>
 			</field>
 			<field>
+				<!-- null / emptystring possible -->
 				<name>value</name>
 				<type>text</type>
-				<notnull>true</notnull>
 				<length>4096</length>
 			</field>
 

--- a/apps/files_external/appinfo/info.xml
+++ b/apps/files_external/appinfo/info.xml
@@ -13,7 +13,7 @@
 		<admin>admin-external-storage</admin>
 	</documentation>
 	<rememberlogin>false</rememberlogin>
-	<version>0.6.0</version>
+	<version>0.6.1</version>
 	<types>
 		<filesystem/>
 	</types>


### PR DESCRIPTION
without this files_external is broken on oracle
