### PR TITLE
[stable9.1] [WIP] Usermountcache hell revertsharedstorage

### DIFF
--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -41,7 +41,7 @@ use OCP\Lock\ILockingProvider;
 /**
  * Convert target path to source path and pass the function call to the correct storage provider
  */
-class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
+class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 
 	private $share;   // the shared resource
 
@@ -77,16 +77,6 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 		$this->ownerView = $arguments['ownerView'];
 		$this->logger = \OC::$server->getLogger();
 		$this->newShare = $arguments['newShare'];
-		$this->user = $arguments['user'];
-
-		Filesystem::initMountPoints($this->newShare->getShareOwner());
-		$sourcePath = $this->ownerView->getPath($this->newShare->getNodeId());
-		list($storage, $internalPath) = $this->ownerView->resolvePath($sourcePath);
-
-		parent::__construct([
-			'storage' => $storage,
-			'root' => $internalPath,
-		]);
 	}
 
 	private function init() {
@@ -128,6 +118,58 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 	}
 
 	/**
+	 * Get the source file path, permissions, and owner for a shared file
+	 *
+	 * @param string $target Shared target file path
+	 * @return array Returns array with the keys path, permissions, and owner or false if not found
+	 */
+	public function getFile($target) {
+		$this->init();
+		if (!isset($this->files[$target])) {
+			// Check for partial files
+			if (pathinfo($target, PATHINFO_EXTENSION) === 'part') {
+				$source = \OC_Share_Backend_File::getSource(substr($target, 0, -5), $this->getShare());
+				if ($source) {
+					$source['path'] .= '.part';
+					// All partial files have delete permission
+					$source['permissions'] |= \OCP\Constants::PERMISSION_DELETE;
+				}
+			} else {
+				$source = \OC_Share_Backend_File::getSource($target, $this->getShare());
+			}
+			$this->files[$target] = $source;
+		}
+		return $this->files[$target];
+	}
+
+	/**
+	 * Get the source file path for a shared file
+	 *
+	 * @param string $target Shared target file path
+	 * @return string|false source file path or false if not found
+	 */
+	public function getSourcePath($target) {
+		if (!$this->isValid()){
+			return false;
+		}
+		$source = $this->getFile($target);
+		if ($source) {
+			if (!isset($source['fullPath'])) {
+				\OC\Files\Filesystem::initMountPoints($source['fileOwner']);
+				$mount = \OC\Files\Filesystem::getMountByNumericId($source['storage']);
+				if (is_array($mount) && !empty($mount)) {
+					$this->files[$target]['fullPath'] = $mount[key($mount)]->getMountPoint() . $source['path'];
+				} else {
+					$this->files[$target]['fullPath'] = false;
+					\OCP\Util::writeLog('files_sharing', "Unable to get mount for shared storage '" . $source['storage'] . "' user '" . $source['fileOwner'] . "'", \OCP\Util::ERROR);
+				}
+			}
+			return $this->files[$target]['fullPath'];
+		}
+		return false;
+	}
+
+	/**
 	 * Get the permissions granted for a shared file
 	 *
 	 * @param string $target Shared target file path
@@ -148,6 +190,84 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 		}
 
 		return $permissions;
+	}
+
+	public function mkdir($path) {
+		if ($path == '' || $path == '/' || !$this->isCreatable(dirname($path))) {
+			return false;
+		} else if ($source = $this->getSourcePath($path)) {
+			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+			return $storage->mkdir($internalPath);
+		}
+		return false;
+	}
+
+	/**
+	 * Delete the directory if DELETE permission is granted
+	 *
+	 * @param string $path
+	 * @return boolean
+	 */
+	public function rmdir($path) {
+
+		// never delete a share mount point
+		if (empty($path)) {
+			return false;
+		}
+
+		if (($source = $this->getSourcePath($path)) && $this->isDeletable($path)) {
+			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+			return $storage->rmdir($internalPath);
+		}
+		return false;
+	}
+
+	public function opendir($path) {
+		$source = $this->getSourcePath($path);
+		list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+		return $storage->opendir($internalPath);
+	}
+
+	public function is_dir($path) {
+		$source = $this->getSourcePath($path);
+		list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+		return $storage->is_dir($internalPath);
+	}
+
+	public function is_file($path) {
+		if ($source = $this->getSourcePath($path)) {
+			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+			return $storage->is_file($internalPath);
+		}
+		return false;
+	}
+
+	public function stat($path) {
+		if ($path == '' || $path == '/') {
+			$stat['size'] = $this->filesize($path);
+			$stat['mtime'] = $this->filemtime($path);
+			return $stat;
+		} else if ($source = $this->getSourcePath($path)) {
+			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+			return $storage->stat($internalPath);
+		}
+		return false;
+	}
+
+	public function filetype($path) {
+		if ($path == '' || $path == '/') {
+			return 'dir';
+		} else if ($source = $this->getSourcePath($path)) {
+			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+			return $storage->filetype($internalPath);
+		}
+		return false;
+	}
+
+	public function filesize($path) {
+		$source = $this->getSourcePath($path);
+		list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+		return $storage->filesize($internalPath);
 	}
 
 	public function isCreatable($path) {
@@ -178,6 +298,127 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 			return false;
 		}
 		return ($this->getPermissions($path) & \OCP\Constants::PERMISSION_SHARE);
+	}
+
+	public function file_exists($path) {
+		if ($path == '' || $path == '/') {
+			return true;
+		} else if ($source = $this->getSourcePath($path)) {
+			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+			return $storage->file_exists($internalPath);
+		}
+		return false;
+	}
+
+	public function filemtime($path) {
+		$source = $this->getSourcePath($path);
+		list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+		return $storage->filemtime($internalPath);
+	}
+
+	public function file_get_contents($path) {
+		$source = $this->getSourcePath($path);
+		if ($source) {
+			$info = array(
+				'target' => $this->getMountPoint() . $path,
+				'source' => $source,
+			);
+			\OCP\Util::emitHook('\OC\Files\Storage\Shared', 'file_get_contents', $info);
+			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+			return $storage->file_get_contents($internalPath);
+		}
+	}
+
+	public function file_put_contents($path, $data) {
+		if ($source = $this->getSourcePath($path)) {
+			// Check if permission is granted
+			if (($this->file_exists($path) && !$this->isUpdatable($path))
+				|| ($this->is_dir($path) && !$this->isCreatable($path))
+			) {
+				return false;
+			}
+			$info = array(
+				'target' => $this->getMountPoint() . '/' . $path,
+				'source' => $source,
+			);
+			\OCP\Util::emitHook('\OC\Files\Storage\Shared', 'file_put_contents', $info);
+			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+			$result = $storage->file_put_contents($internalPath, $data);
+			return $result;
+		}
+		return false;
+	}
+
+	/**
+	 * Delete the file if DELETE permission is granted
+	 *
+	 * @param string $path
+	 * @return boolean
+	 */
+	public function unlink($path) {
+
+		// never delete a share mount point
+		if (empty($path)) {
+			return false;
+		}
+		if ($source = $this->getSourcePath($path)) {
+			if ($this->isDeletable($path)) {
+				list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+				return $storage->unlink($internalPath);
+			}
+		}
+		return false;
+	}
+
+	public function rename($path1, $path2) {
+		$this->init();
+		// we need the paths relative to data/user/files
+		$relPath1 = $this->getMountPoint() . '/' . $path1;
+		$relPath2 = $this->getMountPoint() . '/' . $path2;
+		$pathinfo = pathinfo($relPath1);
+
+		$isPartFile = (isset($pathinfo['extension']) && $pathinfo['extension'] === 'part');
+		$targetExists = $this->file_exists($path2);
+		$sameFolder = (dirname($relPath1) === dirname($relPath2));
+		if ($targetExists || ($sameFolder && !$isPartFile)) {
+			// note that renaming a share mount point is always allowed
+			if (!$this->isUpdatable('')) {
+				return false;
+			}
+		} else {
+			if (!$this->isCreatable('')) {
+				return false;
+			}
+		}
+
+
+		/**
+		 * @var \OC\Files\Storage\Storage $sourceStorage
+		 */
+		list($sourceStorage, $sourceInternalPath) = $this->resolvePath($path1);
+		/**
+		 * @var \OC\Files\Storage\Storage $targetStorage
+		 */
+		list($targetStorage, $targetInternalPath) = $this->resolvePath($path2);
+
+		return $targetStorage->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+	}
+
+	public function copy($path1, $path2) {
+		// Copy the file if CREATE permission is granted
+		if ($this->isCreatable(dirname($path2))) {
+			/**
+			 * @var \OC\Files\Storage\Storage $sourceStorage
+			 */
+			list($sourceStorage, $sourceInternalPath) = $this->resolvePath($path1);
+			/**
+			 * @var \OC\Files\Storage\Storage $targetStorage
+			 */
+			list($targetStorage, $targetInternalPath) = $this->resolvePath($path2);
+
+			return $targetStorage->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+		}
+		return false;
 	}
 
 	public function fopen($path, $mode) {
@@ -223,34 +464,43 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 				'mode' => $mode,
 			);
 			\OCP\Util::emitHook('\OC\Files\Storage\Shared', 'fopen', $info);
-			return parent::fopen($path, $mode);
+			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+			return $storage->fopen($internalPath, $mode);
 		}
 		return false;
 	}
 
-	/**
-	 * see http://php.net/manual/en/function.rename.php
-	 *
-	 * @param string $path1
-	 * @param string $path2
-	 * @return bool
-	 */
-	public function rename($path1, $path2) {
-		$isPartFile = pathinfo($path1, PATHINFO_EXTENSION) === 'part';
-		$targetExists = $this->file_exists($path2);
-		$sameFodler = dirname($path1) === dirname($path2);
-
-		if ($targetExists || ($sameFodler && !$isPartFile)) {
-			if (!$this->isUpdatable('')) {
-				return false;
-			}
-		} else {
-			if (!$this->isCreatable('')) {
-				return false;
-			}
+	public function getMimeType($path) {
+		if ($source = $this->getSourcePath($path)) {
+			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+			return $storage->getMimeType($internalPath);
 		}
+		return false;
+	}
 
-		return parent::rename($path1, $path2);
+	public function free_space($path) {
+		$source = $this->getSourcePath($path);
+		if ($source) {
+			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+			return $storage->free_space($internalPath);
+		}
+		return \OCP\Files\FileInfo::SPACE_UNKNOWN;
+	}
+
+	public function getLocalFile($path) {
+		if ($source = $this->getSourcePath($path)) {
+			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+			return $storage->getLocalFile($internalPath);
+		}
+		return false;
+	}
+
+	public function touch($path, $mtime = null) {
+		if ($source = $this->getSourcePath($path)) {
+			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+			return $storage->touch($internalPath, $mtime);
+		}
+		return false;
 	}
 
 	/**
@@ -339,6 +589,14 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 		return $this->newShare->getShareOwner();
 	}
 
+	public function getETag($path) {
+		if ($source = $this->getSourcePath($path)) {
+			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+			return $storage->getETag($internalPath);
+		}
+		return null;
+	}
+
 	/**
 	 * unshare complete storage, also the grouped shares
 	 *
@@ -347,6 +605,41 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 	public function unshareStorage() {
 		\OC::$server->getShareManager()->deleteFromSelf($this->newShare, $this->user);
 		return true;
+	}
+
+	/**
+	 * Resolve the path for the source of the share
+	 *
+	 * @param string $path
+	 * @return array
+	 */
+	public function resolvePath($path) {
+		$source = $this->getSourcePath($path);
+		return \OC\Files\Filesystem::resolvePath($source);
+	}
+
+	/**
+	 * @param \OCP\Files\Storage $sourceStorage
+	 * @param string $sourceInternalPath
+	 * @param string $targetInternalPath
+	 * @return bool
+	 */
+	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+		/** @var \OCP\Files\Storage $targetStorage */
+		list($targetStorage, $targetInternalPath) = $this->resolvePath($targetInternalPath);
+		return $targetStorage->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+	}
+
+	/**
+	 * @param \OCP\Files\Storage $sourceStorage
+	 * @param string $sourceInternalPath
+	 * @param string $targetInternalPath
+	 * @return bool
+	 */
+	public function moveFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+		/** @var \OCP\Files\Storage $targetStorage */
+		list($targetStorage, $targetInternalPath) = $this->resolvePath($targetInternalPath);
+		return $targetStorage->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}
 
 	/**
@@ -411,26 +704,12 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 		// shares do not participate in availability logic
 	}
 
+	public function isLocal() {
+		$this->init();
+		return $this->sourceStorage->isLocal();
+	}
+
 	public function getSourceStorage() {
 		return $this->sourceStorage;
 	}
-
-	public function file_get_contents($path) {
-		$info = [
-			'target' => $this->getMountPoint() . '/' . $path,
-			'source' => $this->getSourcePath($path),
-		];
-		\OCP\Util::emitHook('\OC\Files\Storage\Shared', 'file_get_contents', $info);
-		return parent::file_get_contents($path);
-	}
-
-	public function file_put_contents($path, $data) {
-		$info = [
-			'target' => $this->getMountPoint() . '/' . $path,
-			'source' => $this->getSourcePath($path),
-		];
-		\OCP\Util::emitHook('\OC\Files\Storage\Shared', 'file_put_contents', $info);
-		return parent::file_put_contents($path, $data);
-	}
-
 }

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -92,8 +92,15 @@ class UserMountCache implements IUserMountCache {
 		});
 		/** @var ICachedMountInfo[] $newMounts */
 		$newMounts = array_map(function (IMountPoint $mount) use ($user) {
+			$storage = $mount->getStorage();
+			if ($storage->instanceOfStorage('\OC\Files\Storage\Shared')) {
+				$rootId = (int)$storage->getShare()->getNodeId();
+			} else {
+				$rootId = (int)$storage->getCache()->getId('');
+			}
+			//$storageId = (int)$storage->getStorageCache()->getNumericId();
 			// filter out any storages which aren't scanned yet since we aren't interested in files from those storages (yet)
-			if ($mount->getStorageRootId() === -1) {
+			if ($rootId === -1) {
 				return null;
 			} else {
 				return new LazyStorageMountInfo($user, $mount);


### PR DESCRIPTION
Reverts the SharedStorage to be a real storage extending Common instead of being a wrapper.

Doesn't solve the issue from https://github.com/owncloud/core/issues/25557 fully and might need more fixes like https://github.com/owncloud/core/pull/25754 (getPath, etc).

But at least the laziness here looks less hacky then the jail one from https://github.com/owncloud/core/pull/25754
