### PR TITLE
[Stable9] fix unit test on new jenkins setup and adjust Jenkinsfile (…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,68 +1,137 @@
 #!groovy
+/*
+ * This Jenkinsfile is intended to run on https://ci.owncloud.org and may fail anywhere else.
+ * It makes assumptions about plugins being installed, labels mapping to nodes that can build what is needed, etc.
+ */
 
-node('SLAVE') {
+timestampedNode('SLAVE') {
     stage 'Checkout'
         checkout scm
         sh '''git submodule update --init'''
 
     stage 'JavaScript Testing'
-        sh '''./autotest-js.sh'''
-        step([$class: 'JUnitResultArchiver', testResults: 'tests/autotest-results-js.xml'])
+        executeAndReport('tests/autotest-results-js.xml') {
+            sh '''./autotest-js.sh'''
+        }
 
     stage 'PHPUnit'
-        sh '''
-        export NOCOVERAGE=1
-        unset USEDOCKER
-        phpenv local 7.0
-        ./autotest.sh sqlite
-        phpenv local 5.4
-        ./autotest.sh mysql
-        phpenv local 5.6
-        ./autotest.sh pgsql
-        phpenv local 5.5
-        ./autotest.sh oci
-        '''
-        step([$class: 'JUnitResultArchiver', testResults: 'tests/autotest-results-sqlite.xml'])
-        step([$class: 'JUnitResultArchiver', testResults: 'tests/autotest-results-mysql.xml'])
-        step([$class: 'JUnitResultArchiver', testResults: 'tests/autotest-results-oci.xml'])
-        step([$class: 'JUnitResultArchiver', testResults: 'tests/autotest-results-pgsql.xml'])
+        executeAndReport('tests/autotest-results-sqlite.xml') {
+            sh '''
+            export NOCOVERAGE=1
+            unset USEDOCKER
+            phpenv local 7.0
+            ./autotest.sh sqlite
+            '''
+        }
+        executeAndReport('tests/autotest-results-mysql.xml') {
+            sh '''
+            export NOCOVERAGE=1
+            unset USEDOCKER
+            phpenv local 5.4
+            ./autotest.sh mysql
+            '''
+        }
+        executeAndReport('tests/autotest-results-pgsql.xml') {
+            sh '''
+            export NOCOVERAGE=1
+            unset USEDOCKER
+            phpenv local 5.6
+            ./autotest.sh pgsql
+            '''
+        }
+        executeAndReport('tests/autotest-results-oci.xml') {
+            sh '''
+            export NOCOVERAGE=1
+            unset USEDOCKER
+            phpenv local 5.5
+            ./autotest.sh oci
+            '''
+        }
 
     stage 'Files External Testing'
-        sh '''phpenv local 7.0
-        export NOCOVERAGE=1
-        unset USEDOCKER
-        ./autotest-external.sh sqlite webdav-ownCloud
-        ./autotest-external.sh sqlite smb-silvershell
-        ./autotest-external.sh sqlite swift-ceph
-        '''
+        executeAndReport('tests/autotest-external-results-sqlite-webdav-ownCloud.xml') {
+            sh '''phpenv local 7.0
+            export NOCOVERAGE=1
+            unset USEDOCKER
+            ./autotest-external.sh sqlite webdav-ownCloud
+            '''
+        }
+        executeAndReport('tests/autotest-external-results-sqlite-smb-silvershell.xml') {
+            sh '''phpenv local 7.0
+            export NOCOVERAGE=1
+            unset USEDOCKER
+            ./autotest-external.sh sqlite smb-silvershell
+            '''
+        }
+        executeAndReport('tests/autotest-external-results-sqlite-swift-ceph.xml') {
+            sh '''phpenv local 7.0
+            export NOCOVERAGE=1
+            unset USEDOCKER
+            ./autotest-external.sh sqlite swift-ceph
+            '''
+        }
+        executeAndReport('tests/autotest-external-results-sqlite-smb-windows.xml') {
+            sh '''phpenv local 7.0
+            export NOCOVERAGE=1
+            unset USEDOCKER
+            ./autotest-external.sh sqlite smb-windows
+            '''
+        }
+
         step([$class: 'JUnitResultArchiver', testResults: 'tests/autotest-external-results-sqlite.xml'])
-        step([$class: 'JUnitResultArchiver', testResults: 'tests/autotest-external-results-sqlite-webdav-ownCloud.xml'])
-        step([$class: 'JUnitResultArchiver', testResults: 'tests/autotest-external-results-sqlite-smb-silvershell.xml'])
-        step([$class: 'JUnitResultArchiver', testResults: 'tests/autotest-external-results-sqlite-swift-ceph.xml'])
 
     stage 'Primary Objectstore Test - Swift'
-        sh '''phpenv local 7.0
+        executeAndReport('tests/autotest-results-mysql.xml') {
+            sh '''phpenv local 7.0
 
-        export NOCOVERAGE=1
-        export RUN_OBJECTSTORE_TESTS=1
-        export PRIMARY_STORAGE_CONFIG="swift"
-        unset USEDOCKER
+            export NOCOVERAGE=1
+            export RUN_OBJECTSTORE_TESTS=1
+            export PRIMARY_STORAGE_CONFIG="swift"
+            unset USEDOCKER
 
-        rm tests/autotest-results-*.xml
-        ./autotest.sh mysql
-        '''
-        step([$class: 'JUnitResultArchiver', testResults: 'tests/autotest-results-mysql.xml'])
+            rm tests/autotest-results-*.xml
+            ./autotest.sh mysql
+            '''
+        }
 
     stage 'Integration Testing'
-        sh '''phpenv local 7.0
-        rm -rf config/config.php
-        ./occ maintenance:install --admin-pass=admin
-        rm -rf build/integration/output
-        rm -rf build/integration/vendor
-        rm -rf build/integration/composer.lock
-        cd build/integration
-        ./run.sh
-       '''
-        step([$class: 'JUnitResultArchiver', testResults: 'build/integration/output/*.xml'])
+        executeAndReport('build/integration/output/*.xml') {
+            sh '''phpenv local 7.0
+            rm -rf config/config.php
+            ./occ maintenance:install --admin-pass=admin
+            rm -rf build/integration/output
+            rm -rf build/integration/vendor
+            rm -rf build/integration/composer.lock
+            cd build/integration
+            ./run.sh
+           '''
+        }
 }
 
+void executeAndReport(String testResultLocation, def body) {
+    def failed = false
+    // We're wrapping this in a timeout - if it takes longer, kill it.
+    try {
+        timeout(time: 120, unit: 'MINUTES') {
+            body.call()
+        }
+    } catch (Exception e) {
+        failed = true
+        echo "Test execution failed: ${e}"
+    } finally {
+        step([$class: 'JUnitResultArchiver', testResults: testResultLocation])
+    }
+
+    if (failed) {
+        error "Test execution failed. Terminating the build"
+    }
+}
+
+// Runs the given body within a Timestamper wrapper on the given label.
+def timestampedNode(String label, Closure body) {
+    node(label) {
+        wrap([$class: 'TimestamperBuildWrapper']) {
+            body.call()
+        }
+    }
+}

--- a/apps/federatedfilesharing/lib/discoverymanager.php
+++ b/apps/federatedfilesharing/lib/discoverymanager.php
@@ -39,6 +39,8 @@ class DiscoveryManager {
 	private $cache;
 	/** @var IClient */
 	private $client;
+	/** @var bool */
+	public $underTest = false;
 
 	/**
 	 * @param ICacheFactory $cacheFactory
@@ -81,6 +83,10 @@ class DiscoveryManager {
 			'webdav' => '/public.php/webdav',
 			'share' => '/ocs/v1.php/cloud/shares',
 		];
+
+		if (defined('PHPUNIT_RUN') && !$this->underTest) {
+			return $discoveredServices;
+		}
 
 		// Read the data from the response body
 		try {

--- a/apps/federatedfilesharing/tests/DiscoveryManagerTest.php
+++ b/apps/federatedfilesharing/tests/DiscoveryManagerTest.php
@@ -62,6 +62,7 @@ class DiscoveryManagerTest extends TestCase {
 			$cacheFactory,
 			$clientService
 		);
+		$this->discoveryManager->underTest = true;
 	}
 
 	public function testWithMalformedFormattedEndpointCached() {

--- a/tests/lib/systemtag/systemtagobjectmappertest.php
+++ b/tests/lib/systemtag/systemtagobjectmappertest.php
@@ -142,7 +142,7 @@ class SystemTagObjectMapperTest extends TestCase {
 		$this->assertEquals([
 			'1',
 			'2',
-		], $objectIds);
+		], $objectIds, '', 0.0, 10, true);
 	}
 
 	public function testGetObjectsForTagsLimit() {


### PR DESCRIPTION
…#25772)
- Next step jenkinsfile (#25622)
- Adding timestamper and evaluation of test results even in case of failure
- Adding build timeout
- use fixed value 120 minutes as timeout for each test executing for now
- Terminate the build as soon as test execution fails
- Adjust external testing as well
- Finalize use of executeAndReport
- Fix discoverymanager tests (#25769)
- Allow testing of the DiscoveryManager
- Array sort order is of no relevance
