### PR TITLE
[stable9.1] Fix OR operands in SharedMountTest

### DIFF
--- a/apps/files_sharing/tests/SharedMountTest.php
+++ b/apps/files_sharing/tests/SharedMountTest.php
@@ -246,21 +246,21 @@ class SharedMountTest extends TestCase {
 			[
 				'file',
 				\OCP\Constants::PERMISSION_READ
-				|| \OCP\Constants::PERMISSION_UPDATE
-				|| \OCP\Constants::PERMISSION_SHARE,
+				| \OCP\Constants::PERMISSION_UPDATE
+				| \OCP\Constants::PERMISSION_SHARE,
 				\OCP\Constants::PERMISSION_READ
-				|| \OCP\Constants::PERMISSION_SHARE,
+				| \OCP\Constants::PERMISSION_SHARE,
 			],
 			[
 				'folder',
 				\OCP\Constants::PERMISSION_READ
-				|| \OCP\Constants::PERMISSION_CREATE
-				|| \OCP\Constants::PERMISSION_UPDATE
-				|| \OCP\Constants::PERMISSION_DELETE
-				|| \OCP\Constants::PERMISSION_SHARE,
+				| \OCP\Constants::PERMISSION_CREATE
+				| \OCP\Constants::PERMISSION_UPDATE
+				| \OCP\Constants::PERMISSION_DELETE
+				| \OCP\Constants::PERMISSION_SHARE,
 				\OCP\Constants::PERMISSION_READ
-				|| \OCP\Constants::PERMISSION_CREATE
-				|| \OCP\Constants::PERMISSION_UPDATE,
+				| \OCP\Constants::PERMISSION_CREATE
+				| \OCP\Constants::PERMISSION_UPDATE,
 			],
 		];
 	}


### PR DESCRIPTION
@DeepDiver1975 please approve if Jenkins passes (test passed locally)
