### PR TITLE
Do not try to load avatar for users that never logged in

### DIFF
--- a/lib/private/avatarmanager.php
+++ b/lib/private/avatarmanager.php
@@ -81,6 +81,8 @@ class AvatarManager implements IAvatarManager {
 		$user = $this->userManager->get($userId);
 		if (is_null($user)) {
 			throw new \Exception('user does not exist');
+		} else if ($user->getLastLogin() === 0) {
+			throw new \Exception('user never logged in, yet');
 		}
 
 		/*


### PR DESCRIPTION
alternative approach to not initialize the fs for every user, see https://github.com/owncloud/core/pull/25286#issue-162637879

supersedes https://github.com/owncloud/core/pull/25286

ref https://github.com/owncloud/core/pull/25790

cc @PVince81 @DeepDiver1975 My mind keeps telling me that the user backend should provide the avatar. In case of ldap that means some jpg from the ldap server. Which is theoretically possible even if the user never logged in before. 
