### PR TITLE
[stable9.1] Repair oc_mounts' shared:: storages that must not be

### DIFF
--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -53,6 +53,7 @@ use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use OC\Repair\RepairShareMountEntries;
 
 class Repair implements IOutput{
 	/* @var IRepairStep[] */
@@ -144,6 +145,10 @@ class Repair implements IOutput{
 				\OC::$server->getDatabaseConnection(),
 				\OC::$server->getUserManager(),
 				\OC::$server->getGroupManager()
+			),
+			new RepairShareMountEntries(
+				\OC::$server->getConfig(),
+				\OC::$server->getDatabaseConnection()
 			),
 		];
 	}

--- a/lib/private/Repair/RepairShareMountEntries.php
+++ b/lib/private/Repair/RepairShareMountEntries.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Repair;
+
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use OC\Share\Constants;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IUserManager;
+use OCP\IUser;
+use OCP\IGroupManager;
+use OC\Share20\DefaultShareProvider;
+
+/**
+ * The UserMountCache used to store the shared::/ storages in the "oc_mounts" table which
+ * is wrong. The "oc_mounts" cache must contain a direct reference to the target storage
+ * of the sharer. This repair step fixes this by checking whether the stored root id matches
+ * the referred storage id. When it doesn't, it will adjust it to the correct target storage.
+ */
+class RepairShareMountEntries implements IRepairStep {
+
+	const CHUNK_SIZE = 100;
+
+	/** @var \OCP\IConfig */
+	protected $config;
+
+	/** @var \OCP\IDBConnection */
+	protected $connection;
+
+	/**
+	 * @param \OCP\IConfig $config
+	 * @param \OCP\IDBConnection $connection
+	 */
+	public function __construct(
+		IConfig $config,
+		IDBConnection $connection
+	) {
+		$this->connection = $connection;
+		$this->config = $config;
+	}
+
+	public function getName() {
+		return 'Repair share entries in user mount cache';
+	}
+
+	private function countBrokenEntries() {
+		$query = $this->connection->getQueryBuilder();
+		$query->select($query->createFunction('count(*)'))
+			->from('mounts', 'm')
+			->innerJoin('m', 'filecache', 'f', $query->expr()->eq('m.root_id', 'f.fileid'))
+			->where($query->expr()->neq('m.storage_id', 'f.storage'));
+		return $query->execute()->fetchColumn();
+	}
+
+	private function repairMountEntries(IOutput $output) {
+		$pageSize = self::CHUNK_SIZE;
+		$query = $this->connection->getQueryBuilder();
+		$query = $query->select('id')
+			->from('mounts', 'm')
+			->innerJoin('m', 'filecache', 'f', $query->expr()->eq('m.root_id', 'f.fileid'))
+			->where($query->expr()->neq('m.storage_id', 'f.storage'))
+			->setMaxResults($pageSize);
+
+		$deleteQuery = $this->connection->getQueryBuilder();
+		$deleteQuery->delete('mounts')
+			->where($query->expr()->in('id', $query->createParameter('ids')));
+
+		do {
+			$results = $query->execute();
+
+			$idsToDelete = [];
+			while ($result = $results->fetch()) {
+				$idsToDelete[] = $result['id'];
+			}
+
+			$resultsCount = count($idsToDelete);
+			if ($resultsCount) {
+				$deleteQuery->setParameter('ids', $idsToDelete, IQueryBuilder::PARAM_INT_ARRAY);
+				$deleteQuery->execute();
+			}
+
+			$output->advance($resultsCount);
+
+		} while ($resultsCount > 0);
+	}
+
+	public function run(IOutput $output) {
+		$ocVersionFromBeforeUpdate = $this->config->getSystemValue('version', '0.0.0');
+		if (version_compare($ocVersionFromBeforeUpdate, '9.1.0.17', '<')) {
+			// this situation was only possible after 9.0.0
+
+			$count = $this->countBrokenEntries();
+			$output->startProgress($count);
+
+			$this->repairMountEntries($output);
+
+			$output->finishProgress();
+		}
+	}
+}

--- a/tests/lib/Repair/RepairShareMountEntries.php
+++ b/tests/lib/Repair/RepairShareMountEntries.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Repair;
+
+
+use OC\Repair\RepairShareMountEntries;
+use OC\Share\Constants;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Test\TestCase;
+
+/**
+ * Tests for repairing share mount entries in the "oc_mounts" table.
+ *
+ * @group DB
+ *
+ * @see \OC\Repair\RepairShareMountEntries
+ */
+class RepairShareMountEntriesTest extends TestCase {
+
+	/** @var IRepairStep */
+	private $repair;
+
+	/** @var \OCP\IDBConnection */
+	private $connection;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$config = $this->getMockBuilder('OCP\IConfig')
+			->disableOriginalConstructor()
+			->getMock();
+		$config->expects($this->any())
+			->method('getSystemValue')
+			->with('version')
+			->will($this->returnValue('9.0.3.0'));
+
+		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->deleteAll();
+
+		/** @var \OCP\IConfig $config */
+		$this->repair = new RepairShareMountEntries($config, $this->connection);
+	}
+
+	protected function tearDown() {
+		$this->deleteAll();
+
+		parent::tearDown();
+	}
+
+	protected function deleteAll() {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('mounts')->execute();
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('filecache')->execute();
+	}
+
+	/**
+	 * Creates a root entry in oc_filecache for the given storage id
+	 *
+	 * @param int $storageId storage id for the root
+	 */
+	private function createRoot($storageId) {
+		$qb = $this->connection->getQueryBuilder();
+		$values = [
+			'path' => $qb->expr()->literal(''),
+			'path_hash' => $qb->expr()->literal('d41d8cd98f00b204e9800998ecf8427e'),
+			'name' => $qb->expr()->literal(''),
+			'storage' => $qb->expr()->literal($storageId),
+		];
+
+		$qb->insert('filecache')
+			->values($values)
+			->execute();
+		return $this->connection->lastInsertId('*PREFIX*filecache');
+	}
+
+	/**
+	 * Creates a mount entry with a matching root entry in oc_filecache
+	 *
+	 * @param int $storageId storage id
+	 * @param int $rootId root id
+	 * @param string $mountPoint mount point name
+	 */
+	private function createMount($storageId, $rootId, $mountPoint) {
+		$qb = $this->connection->getQueryBuilder();
+		$values = [
+			'storage_id' => $qb->expr()->literal($storageId),
+			'root_id' => $qb->expr()->literal($rootId),
+			'user_id' => $qb->expr()->literal('user1'),
+			'mount_point' => $qb->expr()->literal($mountPoint),
+		];
+		$qb->insert('mounts')
+			->values($values)
+			->execute();
+
+		return $this->connection->lastInsertId('*PREFIX*mount');
+	}
+
+	private function getAllMountIds() {
+		$query = $this->connection->getQueryBuilder();
+		$results = $query
+			->select('id')
+			->from('mounts')
+			->orderBy('id')
+			->execute()
+			->fetchAll();
+
+		$ids = [];
+		foreach ($results as $result) {
+			$ids[] = $result['id'];
+		}
+		return $ids;
+	}
+
+	/**
+	 * Test repair mount entries
+	 */
+	public function testRepairMountEntries() {
+		$pageSize = RepairShareMountEntries::CHUNK_SIZE;
+
+		$brokenIds = [];
+		$remainingIds = [];
+
+		$storageId = 10;
+		for ($i = 0; $i < $pageSize + 60; $i++) {
+			$rootId1 = $this->createRoot($storageId);
+			$remainingIds[] = $this->createMount($storageId, $rootId1, '/user1/files/test_matching' . $i);
+			$rootId2 = $this->createRoot($storageId + 1);
+			$brokenIds[] = $this->createMount($storageId, $rootId2, '/user1/files/test_non_matching' . $i);
+			$storageId += 10;
+		}
+
+		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$outputMock->expects($this->once())
+			->method('startProgress')
+			->with($pageSize + 60);
+
+		// test pagination
+		$outputMock->expects($this->at(1))
+			->method('advance')
+			->with($pageSize);
+		$outputMock->expects($this->at(2))
+			->method('advance')
+			->with(60);
+
+		$this->repair->run($outputMock);
+
+		$this->assertEquals($remainingIds, $this->getAllMountIds());
+	}
+}
+

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 1, 1, 3);
+$OC_Version = array(9, 1, 1, 4);
 
 // The human readable string
 $OC_VersionString = '9.1.1';


### PR DESCRIPTION
For https://github.com/owncloud/core/issues/24106

Delete oc_mounts' shared:: storages entries because they refer to a bogus storage entries. These entries will be recreated with the correct format the next time the user logs in.

This situation is only created in OC 9.0. New entries are created properly since 9.1 so this repair step is only to make the entries properly consistent.

Please review @owncloud/filesystem @owncloud/sharing @VicDeo @jvillafanez @butonic 
- [ ] forward port to master
