### PR TITLE
Disable NFD encoding wrapper by default

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -172,7 +172,7 @@ class OC_Util {
 		});
 
 		\OC\Files\Filesystem::addStorageWrapper('oc_encoding', function ($mountPoint, \OCP\Files\Storage $storage, \OCP\Files\Mount\IMountPoint $mount) {
-			if ($mount->getOption('encoding_compatibility', true) && !$storage->instanceOfStorage('\OC\Files\Storage\Shared') && !$storage->isLocal()) {
+			if ($mount->getOption('encoding_compatibility', false) && !$storage->instanceOfStorage('\OC\Files\Storage\Shared') && !$storage->isLocal()) {
 				return new \OC\Files\Storage\Wrapper\Encoding(['storage' => $storage]);
 			}
 			return $storage;


### PR DESCRIPTION
Seems I forgot to set it back to false after testing.
Will give a performance boost for all storages.

Reminder: this encoding wrapper is opt-in and can be enabled in the ext storage extended options. It needs to be disabled by default for performance reasons.

Please review @owncloud/filesystem @DeepDiver1975 
