### PR TITLE
Include "Product Name" in status.php printout

### DIFF
--- a/status.php
+++ b/status.php
@@ -36,7 +36,7 @@ try {
 	$maintenance = (bool) $systemConfig->getValue('maintenance', false);
 	# see core/lib/private/legacy/defaults.php and core/themes/example/defaults.php
 	# for description and defaults
-	$defaults = new \OC_Defaults();
+	$defaults = new \OCP\Defaults();
 	$values=array(
 		'installed'=>$installed,
 		'maintenance' => $maintenance,

--- a/status.php
+++ b/status.php
@@ -34,12 +34,16 @@ try {
 
 	$installed = (bool) $systemConfig->getValue('installed', false);
 	$maintenance = (bool) $systemConfig->getValue('maintenance', false);
+	# see core/lib/private/legacy/defaults.php and core/themes/example/defaults.php
+	# for description and defaults
+	$defaults = new \OC_Defaults();
 	$values=array(
 		'installed'=>$installed,
 		'maintenance' => $maintenance,
 		'version'=>implode('.', \OCP\Util::getVersion()),
 		'versionstring'=>OC_Util::getVersionString(),
-		'edition'=>OC_Util::getEditionString());
+		'edition'=>OC_Util::getEditionString(),
+		'productname'=>$defaults->getName());
 	if (OC::$CLI) {
 		print_r($values);
 	} else {


### PR DESCRIPTION
Refs: #25822 [Feature Request] status.php should also print out the source name

After discussing I am not using the vendor name but the product name due to branding possibilities.
The product name is either the default (ownCloud) or any defined one by the standard branding procedure.

**New output:**
`{"installed":true,"maintenance":false,"version":"9.2.0.1","versionstring":"9.2.0 pre alpha","edition":"","productname":"ownCloud"}`

@PVince81 
(in case of, support for backporting needed...)
