### PR TITLE
204 and 304 must not have a body, see https://tools.ietf.org/html/rfc7230#section-3.3

### DIFF
--- a/lib/public/AppFramework/Http/JSONResponse.php
+++ b/lib/public/AppFramework/Http/JSONResponse.php
@@ -60,15 +60,21 @@ class JSONResponse extends Response {
 
 	/**
 	 * Returns the rendered json
-	 * @return string the rendered json
+	 * @return string|null the rendered json
 	 * @since 6.0.0
 	 * @throws \Exception If data could not get encoded
 	 */
 	public function render() {
-		$response = json_encode($this->data, JSON_HEX_TAG);
-		if($response === false) {
-			throw new \Exception(sprintf('Could not json_encode due to invalid ' .
-				'non UTF-8 characters in the array: %s', var_export($this->data, true)));
+		if ($this->getStatus() === Http::STATUS_NO_CONTENT
+			|| $this->getStatus() === Http::STATUS_NOT_MODIFIED
+		) {
+			$response = null;
+		} else {
+			$response = json_encode($this->data, JSON_HEX_TAG);
+			if ($response === false) {
+				throw new \Exception(sprintf('Could not json_encode due to invalid ' .
+					'non UTF-8 characters in the array: %s', var_export($this->data, true)));
+			}
 		}
 
 		return $response;


### PR DESCRIPTION
The activity app [always sets content](https://github.com/owncloud/activity/blob/stable9/controller/endpoint.php#L77), even for a for a 304 response, which makes firewalls cry:

```
http_process_state_prepend - Invalid action:0x109010 Server sends too much data.
```

Instead of fixing the app I chose to make the appframework do a sanity check in case another app misbehaves.

backport to oc9 requested.

cc @felixboehm 
