### PR TITLE
[stable9.1] 204 and 304 must not have a body, see https://tools.ietf.org/html/rfc7230#section-3.3

### DIFF
--- a/lib/public/AppFramework/Http/JSONResponse.php
+++ b/lib/public/AppFramework/Http/JSONResponse.php
@@ -60,15 +60,21 @@ class JSONResponse extends Response {
 
 	/**
 	 * Returns the rendered json
-	 * @return string the rendered json
+	 * @return string|null the rendered json
 	 * @since 6.0.0
 	 * @throws \Exception If data could not get encoded
 	 */
 	public function render() {
-		$response = json_encode($this->data, JSON_HEX_TAG);
-		if($response === false) {
-			throw new \Exception(sprintf('Could not json_encode due to invalid ' .
-				'non UTF-8 characters in the array: %s', var_export($this->data, true)));
+		if ($this->getStatus() === Http::STATUS_NO_CONTENT
+			|| $this->getStatus() === Http::STATUS_NOT_MODIFIED
+		) {
+			$response = null;
+		} else {
+			$response = json_encode($this->data, JSON_HEX_TAG);
+			if ($response === false) {
+				throw new \Exception(sprintf('Could not json_encode due to invalid ' .
+					'non UTF-8 characters in the array: %s', var_export($this->data, true)));
+			}
 		}
 
 		return $response;


### PR DESCRIPTION
backport of https://github.com/owncloud/core/pull/25835 to stable9.1

cc @felixboehm 
