### PR TITLE
Fix share indicator handling

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -188,13 +188,16 @@
 					// remove icon, if applicable
 					OC.Share.markFileAsShared($tr, false, false);
 				}
-				var newIcon = $tr.attr('data-icon');
-				// in case markFileAsShared decided to change the icon,
-				// we need to modify the model
-				// (FIXME: yes, this is hacky)
-				if (fileInfoModel.get('icon') !== newIcon) {
-					fileInfoModel.set('icon', newIcon);
-				}
+
+				// FIXME: this is too convoluted. We need to get rid of the above updates
+				// and only ever update the model and let the events take care of rerendering
+				fileInfoModel.set({
+					shareTypes: shareModel.getShareTypes(),
+					// in case markFileAsShared decided to change the icon,
+					// we need to modify the model
+					// (FIXME: yes, this is hacky)
+					icon: $tr.attr('data-icon')
+				});
 			});
 			fileList.registerTabView(shareTab);
 		},

--- a/apps/files_sharing/js/sharetabview.js
+++ b/apps/files_sharing/js/sharetabview.js
@@ -69,6 +69,9 @@
 				this._dialog.model.on('change', function() {
 					self.trigger('sharesChanged', shareModel);
 				});
+				this._dialog.model.getLinkSharesCollection().on('update', function() {
+					self.trigger('sharesChanged', shareModel);
+				});
 			} else {
 				this.$el.empty();
 				// TODO: render placeholder text?

--- a/apps/files_sharing/tests/js/shareSpec.js
+++ b/apps/files_sharing/tests/js/shareSpec.js
@@ -469,5 +469,84 @@ describe('OCA.Sharing.Util tests', function() {
 			expect($('[data-share-recipient]').length).toEqual(0);
 		});
 	});
+
+	describe('ShareTabView interaction', function() {
+		var shareTabSpy;
+		var fileInfoModel;
+		var configModel;
+		var shareModel;
+
+		beforeEach(function() {
+			shareTabSpy = sinon.spy(OCA.Sharing, 'ShareTabView');
+
+			var attributes = {
+				itemType: 'file',
+				itemSource: 123,
+				possiblePermissions: 31,
+				permissions: 31
+			};
+			fileInfoModel = new OCA.Files.FileInfoModel(testFiles[0]);
+			configModel = new OC.Share.ShareConfigModel({
+				enforcePasswordForPublicLink: false,
+				isResharingAllowed: true,
+				isDefaultExpireDateEnabled: false,
+				isDefaultExpireDateEnforced: false,
+				defaultExpireDate: 7
+			});
+			shareModel = new OC.Share.ShareItemModel(attributes, {
+				configModel: configModel,
+				fileInfoModel: fileInfoModel
+			});
+
+			/* jshint camelcase: false */
+			shareModel.set({
+				reshare: {},
+				shares: [{
+					id: 100,
+					item_source: 1,
+					permissions: 31,
+					share_type: OC.Share.SHARE_TYPE_USER,
+					share_with: 'user1',
+					share_with_displayname: 'User One'
+				}, {
+					id: 102,
+					item_source: 1,
+					permissions: 31,
+					share_type: OC.Share.SHARE_TYPE_REMOTE,
+					share_with: 'foo@bar.com/baz',
+					share_with_displayname: 'foo@bar.com/baz'
+
+				}]
+			}, {parse: true});
+
+			fileList.destroy();
+			fileList = new OCA.Files.FileList(
+				$('#listContainer'), {
+					id: 'files',
+					fileActions: new OCA.Files.FileActions()
+				}
+			);
+			OCA.Sharing.Util.attach(fileList);
+			fileList.setFiles(testFiles);
+		});
+		afterEach(function() { 
+			shareTabSpy.restore(); 
+		});
+
+		it('updates fileInfoModel when shares changed', function() {
+			var changeHandler = sinon.stub();
+			fileInfoModel.on('change', changeHandler);
+
+			shareTabSpy.getCall(0).thisValue.trigger('sharesChanged', shareModel);
+
+			expect(changeHandler.calledOnce).toEqual(true);
+			expect(changeHandler.getCall(0).args[0].changed).toEqual({
+				shareTypes: [
+					OC.Share.SHARE_TYPE_USER,
+					OC.Share.SHARE_TYPE_REMOTE,
+				]
+			});
+		});
+	});
 	
 });

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -725,6 +725,20 @@
 				}
 			}
 			return time;
+		},
+
+		/**
+		 * Returns a list of share types from the existing shares.
+		 *
+		 * @return {Array.<int>} array of share types
+		 */
+		getShareTypes: function() {
+			var result;
+			result = _.pluck(this.getSharesWithCurrentItem(), 'share_type');
+			if (this.hasLinkShare()) {
+				result.push(OC.Share.SHARE_TYPE_LINK);
+			}
+			return _.uniq(result);
 		}
 	});
 

--- a/core/js/tests/specs/shareitemmodelSpec.js
+++ b/core/js/tests/specs/shareitemmodelSpec.js
@@ -685,5 +685,66 @@ describe('OC.Share.ShareItemModel', function() {
 			expect(errorStub.lastCall.args[1]).toEqual('Some error message');
 		});
 	});
+
+	describe('getShareTypes', function() {
+
+		var dataProvider = [
+			[
+			],
+			[
+				OC.Share.SHARE_TYPE_USER,
+				OC.Share.SHARE_TYPE_USER,
+			],
+			[
+				OC.Share.SHARE_TYPE_USER,
+				OC.Share.SHARE_TYPE_GROUP,
+				OC.Share.SHARE_TYPE_LINK,
+				OC.Share.SHARE_TYPE_REMOTE
+			],
+			[
+				OC.Share.SHARE_TYPE_USER,
+				OC.Share.SHARE_TYPE_GROUP,
+				OC.Share.SHARE_TYPE_GROUP,
+				OC.Share.SHARE_TYPE_LINK,
+				OC.Share.SHARE_TYPE_LINK,
+				OC.Share.SHARE_TYPE_REMOTE,
+				OC.Share.SHARE_TYPE_REMOTE,
+				OC.Share.SHARE_TYPE_REMOTE
+			],
+			[
+				OC.Share.SHARE_TYPE_LINK,
+				OC.Share.SHARE_TYPE_LINK,
+				OC.Share.SHARE_TYPE_USER
+			]
+		];
+
+		_.each(dataProvider, function testCase(shareTypes, i) {
+			it('returns set of share types for case ' + i, function() {
+				/* jshint camelcase: false */
+				fetchReshareDeferred.resolve(makeOcsResponse([]));
+
+				var id = 100;
+				var shares = _.map(shareTypes, function(shareType) {
+					return {
+						id: id++,
+						item_source: 123,
+						permissions: 31,
+						share_type: shareType,
+						uid_owner: 'root'
+					};
+				});
+
+				var expectedResult = _.uniq(shareTypes).sort();
+
+				fetchSharesDeferred.resolve(makeOcsResponse(shares));
+
+				OC.currentUser = 'root';
+
+				model.fetch();
+
+				expect(model.getShareTypes().sort()).toEqual(expectedResult);
+			});
+		});
+	});
 });
 


### PR DESCRIPTION
Properly update the fileInfoModel with the updated share types, which
also updates the file list row indicator properly

Fixes https://github.com/owncloud/core/issues/25311
- [x] Need to check performance impact because this code is sometimes called even when there are no changes
- [x] JS unit tests
