### PR TITLE
Fix hidden files handling

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -329,6 +329,21 @@ table td.filename .nametext {
 	margin-right: 50px;
 }
 
+.hide-hidden-files #fileList tr.hidden-file,
+.hide-hidden-files #fileList tr.hidden-file.dragging {
+	display: none;
+}
+
+#fileList tr.animate-opacity {
+	-webkit-transition:opacity 250ms;
+	-moz-transition:opacity 250ms;
+	-o-transition:opacity 250ms;
+	transition:opacity 250ms;
+}
+#fileList tr.dragging {
+	opacity: 0.2;
+}
+
 table td.filename .nametext .innernametext {
 	text-overflow: ellipsis;
 	overflow: hidden;

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -391,14 +391,18 @@ var dragOptions={
 		if (!$selectedFiles.length) {
 			$selectedFiles = $(this);
 		}
-		$selectedFiles.closest('tr').fadeTo(250, 0.2).addClass('dragging');
+		$selectedFiles.closest('tr').addClass('animate-opacity dragging');
 	},
 	stop: function(event, ui) {
 		var $selectedFiles = $('td.filename input:checkbox:checked');
 		if (!$selectedFiles.length) {
 			$selectedFiles = $(this);
 		}
-		$selectedFiles.closest('tr').fadeTo(250, 1).removeClass('dragging');
+		var $tr = $selectedFiles.closest('tr');
+		$tr.removeClass('dragging');
+		setTimeout(function() {
+			$tr.removeClass('animate-opacity');
+		}, 300);
 	},
 	drag: function(event, ui) {
 		var scrollingArea = FileList.$container;

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -24,6 +24,7 @@ describe('OCA.Files.FileList tests', function() {
 	var testFiles, testRoot, notificationStub, fileList, pageSizeStub;
 	var bcResizeStub;
 	var filesClient;
+	var filesConfig;
 	var redirectStub;
 
 	/**
@@ -54,6 +55,10 @@ describe('OCA.Files.FileList tests', function() {
 	}
 
 	beforeEach(function() {
+		filesConfig = new OC.Backbone.Model({
+			showhidden: true
+		});
+
 		filesClient = new OC.Files.Client({
 			host: 'localhost',
 			port: 80,
@@ -153,7 +158,8 @@ describe('OCA.Files.FileList tests', function() {
 		})];
 		pageSizeStub = sinon.stub(OCA.Files.FileList.prototype, 'pageSize').returns(20);
 		fileList = new OCA.Files.FileList($('#app-content-files'), {
-			filesClient: filesClient
+			filesClient: filesClient,
+			config: filesConfig
 		});
 	});
 	afterEach(function() {
@@ -405,6 +411,35 @@ describe('OCA.Files.FileList tests', function() {
 				$tr = fileList.add(fileData);
 				expect($tr.find('.nametext .extension').text()).toEqual(testSet['extension']);
 			}
+		});
+	});
+	describe('Hidden files', function() {
+		it('sets the class hidden-file for hidden files', function() {
+			var fileData = {
+				type: 'dir',
+				name: '.testFolder'
+			};
+			var $tr = fileList.add(fileData);
+
+			expect($tr).toBeDefined();
+			expect($tr.hasClass('hidden-file')).toEqual(true);
+		});
+		it('does not set the class hidden-file for visible files', function() {
+			var fileData = {
+				type: 'dir',
+				name: 'testFolder'
+			};
+			var $tr = fileList.add(fileData);
+
+			expect($tr).toBeDefined();
+			expect($tr.hasClass('hidden-file')).toEqual(false);
+		});
+		it('toggles the list\'s class when toggling hidden files', function() {
+			expect(fileList.$el.hasClass('hide-hidden-files')).toEqual(false);
+			filesConfig.set('showhidden', false);
+			expect(fileList.$el.hasClass('hide-hidden-files')).toEqual(true);
+			filesConfig.set('showhidden', true);
+			expect(fileList.$el.hasClass('hide-hidden-files')).toEqual(false);
 		});
 	});
 	describe('Removing files from the list', function() {


### PR DESCRIPTION
Hidden files (dot files) are now always rendered in the DOM to make
sure that all file operations and selection still work as expected.

Their visibility is now toggled on CSS level.

Fixes #25309
Fixes #25680

@SergioBertolinSG will need some thorough testing to see if all functionality still works.
Note that if you select all files with the special checkbox, the hidden files are selected too and also affected by "delete all".

The only part I'm not too happy about is the summary, raised here https://github.com/owncloud/core/issues/25855
