### PR TITLE
[stable9] Hide the LDAP password in the client side

### DIFF
--- a/apps/user_ldap/ajax/getConfiguration.php
+++ b/apps/user_ldap/ajax/getConfiguration.php
@@ -30,4 +30,9 @@ OCP\JSON::callCheck();
 $prefix = (string)$_POST['ldap_serverconfig_chooser'];
 $ldapWrapper = new OCA\user_ldap\lib\LDAP();
 $connection = new \OCA\user_ldap\lib\Connection($ldapWrapper, $prefix);
-OCP\JSON::success(array('configuration' => $connection->getConfiguration()));
+$configuration = $connection->getConfiguration();
+if (isset($configuration['ldap_agent_password']) && $configuration['ldap_agent_password'] !== '') {
+	// hide password
+	$configuration['ldap_agent_password'] = '**PASSWORD SET**';
+}
+OCP\JSON::success(array('configuration' => $configuration));

--- a/apps/user_ldap/js/wizard/configModel.js
+++ b/apps/user_ldap/js/wizard/configModel.js
@@ -318,7 +318,7 @@ OCA = OCA || {};
 		 */
 		requestConfigurationTest: function() {
 			var url = OC.generateUrl('apps/user_ldap/ajax/testConfiguration.php');
-			var params = OC.buildQueryString(this.configuration);
+			var params = OC.buildQueryString({ldap_serverconfig_chooser: this.configID});
 			var model = this;
 			$.post(url, params, function(result) { model._processTestResult(model, result) });
 			//TODO: make sure only one test is running at a time

--- a/apps/user_ldap/js/wizard/view.js
+++ b/apps/user_ldap/js/wizard/view.js
@@ -268,7 +268,7 @@ OCA = OCA || {};
 		 * requests a configuration test
 		 */
 		onTestButtonClick: function() {
-			this.configModel.requestWizard('ldap_action_test_connection', this.configModel.configuration);
+			this.configModel.requestWizard('ldap_action_test_connection', {ldap_serverconfig_chooser: this.configModel.configID});
 		},
 
 		/**


### PR DESCRIPTION
Connection checks will be done by using the configuration id, with the
stored password. LDAP password won't be sent to the client.

Conflicts:
    apps/user_ldap/ajax/getConfiguration.php
    apps/user_ldap/ajax/testConfiguration.php

Backport of https://github.com/owncloud/core/pull/25702
