### PR TITLE
Add ability for TwoFactorController.php to display a custom CSP if provided by IProvider

### DIFF
--- a/core/Controller/TwoFactorChallengeController.php
+++ b/core/Controller/TwoFactorChallengeController.php
@@ -110,6 +110,8 @@ class TwoFactorChallengeController extends Controller {
 		} else {
 			$error = false;
 		}
+		//Attempt to get custom ContentSecurityPolicy(CSP) from 2FA provider
+                $csp  = $provider->getCSP();
 		$tmpl = $provider->getTemplate($user);
 		$tmpl->assign('redirect_url', $redirect_url);
 		$data = [
@@ -118,7 +120,12 @@ class TwoFactorChallengeController extends Controller {
 			'logout_attribute' => $this->getLogoutAttribute(),
 			'template' => $tmpl->fetchPage(),
 		];
-		return new TemplateResponse($this->appName, 'twofactorshowchallenge', $data, 'guest');
+		//Generate the response and add the custom CSP (if defined)
+                $response = new TemplateResponse($this->appName, 'twofactorshowchallenge', $data, 'guest');
+                if (!is_null($csp)) {
+                        $response->setContentSecurityPolicy($csp);
+                }
+                return $response;
 	}
 
 	/**


### PR DESCRIPTION
In order to display an external frame (required for Duo 2FA), the provided "OCP\Template" class does not contain the required ability to add a CSP policy (since it is not a "TemplateResponse" object). Therefore, I added a function that adds a custom CSP policy (from $provider->getCSP()), if it exists. So this means that the provider can implement a getCSP() function (which returns a OCP\AppFramework\Http\ContentSecurityPolicy() object) in order to add a custom CSP to the "twofactorshowchallenge" template.

Following this change, I have successfully implemented Duo 2FA as a 2FA provider in ownCloud (see: https://github.com/elie195/duo_provider)
