### PR TITLE
Add ability for TwoFactorController.php to display a custom CSP if provided by IProvider

### DIFF
--- a/core/Controller/TwoFactorChallengeController.php
+++ b/core/Controller/TwoFactorChallengeController.php
@@ -110,6 +110,8 @@ class TwoFactorChallengeController extends Controller {
 		} else {
 			$error = false;
 		}
+		//Attempt to get custom ContentSecurityPolicy(CSP) from 2FA provider
+                $csp  = $provider->getCSP();
 		$tmpl = $provider->getTemplate($user);
 		$tmpl->assign('redirect_url', $redirect_url);
 		$data = [
@@ -118,7 +120,12 @@ class TwoFactorChallengeController extends Controller {
 			'logout_attribute' => $this->getLogoutAttribute(),
 			'template' => $tmpl->fetchPage(),
 		];
-		return new TemplateResponse($this->appName, 'twofactorshowchallenge', $data, 'guest');
+		//Generate the response and add the custom CSP (if defined)
+                $response = new TemplateResponse($this->appName, 'twofactorshowchallenge', $data, 'guest');
+                if (!is_null($csp)) {
+                        $response->setContentSecurityPolicy($csp);
+                }
+                return $response;
 	}
 
 	/**

--- a/core/Controller/TwoFactorChallengeController.php
+++ b/core/Controller/TwoFactorChallengeController.php
@@ -111,7 +111,7 @@ class TwoFactorChallengeController extends Controller {
 			$error = false;
 		}
 		//Attempt to get custom ContentSecurityPolicy(CSP) from 2FA provider
-                $csp  = $provider->getCSP();
+		$csp  = $provider->getCSP();
 		$tmpl = $provider->getTemplate($user);
 		$tmpl->assign('redirect_url', $redirect_url);
 		$data = [
@@ -121,12 +121,12 @@ class TwoFactorChallengeController extends Controller {
 			'template' => $tmpl->fetchPage(),
 		];
 		//Generate the response and add the custom CSP (if defined)
-                $response = new TemplateResponse($this->appName, 'twofactorshowchallenge', $data, 'guest');
-                if (!is_null($csp)) {
-                        $response->setContentSecurityPolicy($csp);
-                }
-                return $response;
-	}
+		$response = new TemplateResponse($this->appName, 'twofactorshowchallenge', $data, 'guest');
+		if (!is_null($csp)) {
+			$response->setContentSecurityPolicy($csp);
+		}
+		return $response;
+	}	
 
 	/**
 	 * @NoAdminRequired

--- a/core/Controller/TwoFactorChallengeController.php
+++ b/core/Controller/TwoFactorChallengeController.php
@@ -111,7 +111,9 @@ class TwoFactorChallengeController extends Controller {
 			$error = false;
 		}
 		//Attempt to get custom ContentSecurityPolicy(CSP) from 2FA provider
-		$csp  = $provider->getCSP();
+		if ($provider instanceof \OCP\Authentication\TwoFactorAuth\IProvider2) {
+			$csp  = $provider->getCSP();
+		}
 		$tmpl = $provider->getTemplate($user);
 		$tmpl->assign('redirect_url', $redirect_url);
 		$data = [

--- a/lib/public/Authentication/TwoFactorAuth/IProvider.php
+++ b/lib/public/Authentication/TwoFactorAuth/IProvider.php
@@ -89,15 +89,4 @@ interface IProvider {
 	 * @return boolean
 	 */
 	public function isTwoFactorAuthEnabledForUser(IUser $user);
-
-
-	/**
-	 * Get the Content Security Policy for the template (required for showing external content, otherwise optional)
-	 *
-	 * @since 9.2.0
-	 *
-	 * @return \OCP\AppFramework\Http\ContentSecurityPolicy
-	 */
-
-	public function getCSP();
 }

--- a/lib/public/Authentication/TwoFactorAuth/IProvider.php
+++ b/lib/public/Authentication/TwoFactorAuth/IProvider.php
@@ -89,4 +89,15 @@ interface IProvider {
 	 * @return boolean
 	 */
 	public function isTwoFactorAuthEnabledForUser(IUser $user);
+
+
+	/**
+	 * Get the Content Security Policy for the template (required for showing external content, otherwise optional)
+	 *
+	 * @since 9.2.0
+	 *
+	 * @return \OCP\AppFramework\Http\ContentSecurityPolicy
+	 */
+
+	public function getCSP();
 }

--- a/lib/public/Authentication/TwoFactorAuth/IProvider2.php
+++ b/lib/public/Authentication/TwoFactorAuth/IProvider2.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @author El-ad Blech <elie@theinfamousblix.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Authentication\TwoFactorAuth;
+
+/**
+ * @since 9.2.0
+ */
+interface IProvider2 extends IProvider {
+
+	 /**
+	 * Get the Content Security Policy for the template (required for showing external content, otherwise optional)
+	 *
+	 * @since 9.2.0
+	 *
+	 * @return \OCP\AppFramework\Http\ContentSecurityPolicy
+	 */
+
+        public function getCSP();
+}


### PR DESCRIPTION
In order to display an external frame (required for Duo 2FA), the provided "OCP\Template" class does not contain the required ability to add a CSP policy (since it is not a "TemplateResponse" object). Therefore, I added a function that adds a custom CSP policy (from $provider->getCSP()), if it exists. So this means that the provider can implement a getCSP() function (which returns a OCP\AppFramework\Http\ContentSecurityPolicy() object) in order to add a custom CSP to the "twofactorshowchallenge" template.

Following this change, I have successfully implemented Duo 2FA as a 2FA provider in ownCloud (see: https://github.com/elie195/duo_provider)
