### PR TITLE
translate default calendar & default address book displaynames & add …

### DIFF
--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -60,7 +60,8 @@ class Application extends App {
 				$c->getServer()->getUserManager(),
 				$c->query('SyncService'),
 				$c->query('CalDavBackend'),
-				$c->query('CardDavBackend')
+				$c->query('CardDavBackend'),
+				$c->getServer()->getL10N('dav')
 			);
 		});
 

--- a/apps/dav/lib/HookManager.php
+++ b/apps/dav/lib/HookManager.php
@@ -20,6 +20,7 @@
  */
 namespace OCA\DAV;
 
+use OC\L10N\L10N;
 use OCA\DAV\CalDAV\BirthdayService;
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CardDAV\CardDavBackend;
@@ -45,14 +46,19 @@ class HookManager {
 	/** @var CardDavBackend */
 	private $cardDav;
 
+	/** @var L10N */
+	private $l10n;
+
 	public function __construct(IUserManager $userManager,
 								SyncService $syncService,
 								CalDavBackend $calDav,
-								CardDavBackend $cardDav) {
+								CardDavBackend $cardDav,
+								L10N $l10n) {
 		$this->userManager = $userManager;
 		$this->syncService = $syncService;
 		$this->calDav = $calDav;
 		$this->cardDav = $cardDav;
+		$this->l10n = $l10n;
 	}
 
 	public function setup() {
@@ -107,7 +113,8 @@ class HookManager {
 			if (empty($calendars) || (count($calendars) === 1 && $calendars[0]['uri'] === BirthdayService::BIRTHDAY_CALENDAR_URI)) {
 				try {
 					$this->calDav->createCalendar($principal, 'personal', [
-						'{DAV:}displayname' => 'Personal']);
+						'{DAV:}displayname' => $this->l10n->t('Personal'),
+						'{http://apple.com/ns/ical/}calendar-color' => '#1d2d44']);
 				} catch (\Exception $ex) {
 					\OC::$server->getLogger()->logException($ex);
 				}
@@ -116,7 +123,7 @@ class HookManager {
 			if (empty($books)) {
 				try {
 					$this->cardDav->createAddressBook($principal, 'contacts', [
-						'{DAV:}displayname' => 'Contacts']);
+						'{DAV:}displayname' => $this->l10n->t('Contacts')]);
 				} catch (\Exception $ex) {
 					\OC::$server->getLogger()->logException($ex);
 				}

--- a/apps/dav/tests/unit/DAV/HookManagerTest.php
+++ b/apps/dav/tests/unit/DAV/HookManagerTest.php
@@ -22,6 +22,7 @@
 
 namespace OCA\DAV\Tests\unit\DAV;
 
+use OC\L10N\L10N;
 use OCA\DAV\CalDAV\BirthdayService;
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CardDAV\CardDavBackend;
@@ -31,6 +32,23 @@ use OCP\IUserManager;
 use Test\TestCase;
 
 class HookManagerTest extends TestCase {
+
+	/** @var L10N */
+	private $l10n;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->l10n = $this->getMockBuilder('OC\L10N\L10N')
+			->disableOriginalConstructor()->getMock();
+		$this->l10n
+			->expects($this->any())
+			->method('t')
+			->will($this->returnCallback(function ($text, $parameters = array()) {
+				return vsprintf($text, $parameters);
+			}));
+	}
+
 	public function test() {
 		$user = $this->getMockBuilder('\OCP\IUser')
 			->disableOriginalConstructor()
@@ -55,7 +73,11 @@ class HookManagerTest extends TestCase {
 		$cal->expects($this->once())->method('getCalendarsForUser')->willReturn([]);
 		$cal->expects($this->once())->method('createCalendar')->with(
 			'principals/users/newUser',
-			'personal', ['{DAV:}displayname' => 'Personal']);
+			'personal',
+			[
+				'{DAV:}displayname' => $this->l10n->t('Personal'),
+				'{http://apple.com/ns/ical/}calendar-color' => '#1d2d44'
+			]);
 
 		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $card */
 		$card = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')
@@ -64,9 +86,9 @@ class HookManagerTest extends TestCase {
 		$card->expects($this->once())->method('getAddressBooksForUser')->willReturn([]);
 		$card->expects($this->once())->method('createAddressBook')->with(
 			'principals/users/newUser',
-			'contacts', ['{DAV:}displayname' => 'Contacts']);
+			'contacts', ['{DAV:}displayname' => $this->l10n->t('Contacts')]);
 
-		$hm = new HookManager($userManager, $syncService, $cal, $card);
+		$hm = new HookManager($userManager, $syncService, $cal, $card, $this->l10n);
 		$hm->postLogin(['uid' => 'newUser']);
 	}
 
@@ -105,7 +127,7 @@ class HookManagerTest extends TestCase {
 		]);
 		$card->expects($this->never())->method('createAddressBook');
 
-		$hm = new HookManager($userManager, $syncService, $cal, $card);
+		$hm = new HookManager($userManager, $syncService, $cal, $card, $this->l10n);
 		$hm->postLogin(['uid' => 'newUser']);
 	}
 
@@ -135,7 +157,11 @@ class HookManagerTest extends TestCase {
 		]);
 		$cal->expects($this->once())->method('createCalendar')->with(
 			'principals/users/newUser',
-			'personal', ['{DAV:}displayname' => 'Personal']);
+			'personal',
+			[
+				'{DAV:}displayname' => $this->l10n->t('Personal'),
+				'{http://apple.com/ns/ical/}calendar-color' => '#1d2d44',
+			]);
 
 		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $card */
 		$card = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')
@@ -144,9 +170,9 @@ class HookManagerTest extends TestCase {
 		$card->expects($this->once())->method('getAddressBooksForUser')->willReturn([]);
 		$card->expects($this->once())->method('createAddressBook')->with(
 			'principals/users/newUser',
-			'contacts', ['{DAV:}displayname' => 'Contacts']);
+			'contacts', ['{DAV:}displayname' => $this->l10n->t('Contacts')]);
 
-		$hm = new HookManager($userManager, $syncService, $cal, $card);
+		$hm = new HookManager($userManager, $syncService, $cal, $card, $this->l10n);
 		$hm->postLogin(['uid' => 'newUser']);
 	}
 }

--- a/l10n/.tx/config
+++ b/l10n/.tx/config
@@ -92,3 +92,9 @@ source_file = templates/updatenotification.pot
 source_lang = en
 type = PO
 
+[owncloud.dav]
+file_filter = <lang>/dav.po
+source_file = templates/dav.pot
+source_lang = en
+type = PO
+


### PR DESCRIPTION
…color for calendar

Translation doesn't seem to work for now but there must be an issue somewhere since the Contact birthdays displayname isn't translated as well.

Also, please tell me if translation service is needed in tests.

Fixes https://github.com/owncloud/core/issues/25880
