### PR TITLE
Fix redirection taking care of protocol and port

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -267,7 +267,7 @@ class OC {
 			if (OC::$CLI) {
 				throw new Exception('Not installed');
 			} else {
-				$url = 'http://' . $_SERVER['SERVER_NAME'] . OC::$WEBROOT . '/index.php';
+				$url = OC::$WEBROOT . '/index.php';
 				header('Location: ' . $url);
 			}
 			exit();


### PR DESCRIPTION
Tested scenario:
1. Try to install ownCloud 8.1.7 in ubuntu 16.04 with php 7. This will lead to a situation where ownCloud is left uninstalled (php 7 isn't support until ownCloud 8.2.0)
2. That ownCloud is accesible through a non-standard port, for example the 10080 one.
3. Try to access to the status page -> `curl -v http://server:10080/status.php`

The problem is that you're redirected to http://server/index.php , which is wrong becase ownCloud is in port 10080. The correct redirection (if we opt to redirect) should be http://server:10080/index.php.

In addition, a request to https://server/status.php will get redirected to **http**://server/index.php , which is also wrong

Without the patch:

```
curl -v http://10.0.2.6:10080/status.php
* Hostname was NOT found in DNS cache
*   Trying 10.0.2.6...
* Connected to 10.0.2.6 (10.0.2.6) port 10080 (#0)
> GET /status.php HTTP/1.1
> User-Agent: curl/7.35.0
> Host: 10.0.2.6:10080
> Accept: */*
> 
< HTTP/1.1 302 Found
< Date: Thu, 25 Aug 2016 12:17:58 GMT
* Server Apache/2.4.18 (Ubuntu) is not blacklisted
< Server: Apache/2.4.18 (Ubuntu)
< Set-Cookie: occav8p6l8af=bkpq0355iuq97el1gao4egoor2; path=/; HttpOnly
< Expires: Thu, 19 Nov 1981 08:52:00 GMT
< Cache-Control: no-store, no-cache, must-revalidate
< Pragma: no-cache
< Location: http://10.0.2.6/index.php
< Content-Length: 0
< Content-Type: text/html; charset=UTF-8
< 
* Connection #0 to host 10.0.2.6 left intact
```

With the patch:

```
curl -v http://10.0.2.6:10080/status.php
* Hostname was NOT found in DNS cache
*   Trying 10.0.2.6...
* Connected to 10.0.2.6 (10.0.2.6) port 10080 (#0)
> GET /status.php HTTP/1.1
> User-Agent: curl/7.35.0
> Host: 10.0.2.6:10080
> Accept: */*
> 
< HTTP/1.1 302 Found
< Date: Thu, 25 Aug 2016 12:20:57 GMT
* Server Apache/2.4.18 (Ubuntu) is not blacklisted
< Server: Apache/2.4.18 (Ubuntu)
< Set-Cookie: occav8p6l8af=tdgma4ujgmmle6vk3rhq22dd92; path=/; HttpOnly
< Expires: Thu, 19 Nov 1981 08:52:00 GMT
< Cache-Control: no-store, no-cache, must-revalidate
< Pragma: no-cache
< Location: /index.php
< Content-Length: 0
< Content-Type: text/html; charset=UTF-8
< 
* Connection #0 to host 10.0.2.6 left intact
```

I'm fine if the decision is to remove the redirection and let the request explode.

@PVince81 @DeepDiver1975 I bumped into this with automatic testing, debugging why the test was trying to connect to the port 80 when it should be connecting to another port.
