### PR TITLE
[stable9]  Fix redirection taking care of protocol and port

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -291,7 +291,7 @@ class OC {
 			if (OC::$CLI) {
 				throw new Exception('Not installed');
 			} else {
-				$url = 'http://' . $_SERVER['SERVER_NAME'] . OC::$WEBROOT . '/index.php';
+				$url = OC::$WEBROOT . '/index.php';
 				header('Location: ' . $url);
 			}
 			exit();


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/25946
1. Try to install ownCloud 8.1.7 in ubuntu 16.04 with php 7. This will lead to a situation where ownCloud is left uninstalled (php 7 isn't support until ownCloud 8.2.0)
2. That ownCloud is accesible through a non-standard port, for example the 10080 one.
3. Try to access to the status page -> curl -v http://server:10080/status.php
### Actual

http://server:10080/status.php redirects to http://server/index.php 
https://server/status.php will get redirected to http://server/index.php 
### Expected

http://server:10080/status.php redirects to http://server:10080/index.php 
https://server/status.php will get redirected to https://server/index.php 
