### PR TITLE
WIP: Swift library swap for Keystone v3 compatibility

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -62,6 +62,10 @@ class Client implements IClient {
 			return;
 		}
 		$this->configured = true;
+		// TODO - Someone who knows more about onecloud's CA bundle stuff should
+		// take a look at this.
+		// @see https://github.com/guzzle/guzzle/blob/3b45e7675e8997ac96142b0265d158343958f708/UPGRADING.md
+		/**
 		// Either use user bundle or the system bundle if nothing is specified
 		if ($this->certificateManager->listCertificates() !== []) {
 			$this->client->setDefaultOption('verify', $this->certificateManager->getAbsoluteBundlePath());
@@ -80,6 +84,7 @@ class Client implements IClient {
 		if ($this->getProxyUri() !== '') {
 			$this->client->setDefaultOption('proxy', $this->getProxyUri());
 		}
+		 */
 	}
 
 	/**

--- a/lib/private/Http/Client/Response.php
+++ b/lib/private/Http/Client/Response.php
@@ -23,7 +23,7 @@
 namespace OC\Http\Client;
 
 use OCP\Http\Client\IResponse;
-use GuzzleHttp\Message\Response as GuzzleResponse;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
 
 /**
  * Class Response


### PR DESCRIPTION
## Description

A WIP PR to demonstrate and explore implications of upgrading OpenStack Swift libraries, and by extension Guzzle to 6.x

Importantly, since I am new to developing for OwnCloud, I am not sure how the project keeps the 3rdparty repo in sync with core. I have commented below with a diff of the composer.json file for the third-party dependencies.
## Related Issue

https://github.com/owncloud/core/issues/20787
## Motivation and Context

There are a number of aging dependencies in OwnCloud and the technical debt is catching up to us. There will be some ripple-effect changes with interlocked dependencies, but this problem will just get worse the longer we wait.
## How Has This Been Tested?

As a WIP this still needs some work, but functionally during testing this works with Keystone v3 auth endpoints for creating external Swift storage endpoints, uploading, renaming, introspecting and deleting objects. I have not tested management of subdirectories.
## Screenshots (if appropriate):
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change) - **Requires PHP 7** which I'm sure is a broader conversation for the project.
## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
