### PR TITLE
Don't parse info.xml but reuse already cached app infos - fixes #25603

### DIFF
--- a/core/register_command.php
+++ b/core/register_command.php
@@ -34,7 +34,7 @@
 /** @var $application Symfony\Component\Console\Application */
 $application->add(new OC\Core\Command\Status);
 $application->add(new OC\Core\Command\Check(\OC::$server->getConfig()));
-$infoParser = new \OC\App\InfoParser(\OC::$server->getURLGenerator());
+$infoParser = new \OC\App\InfoParser();
 $application->add(new OC\Core\Command\App\CheckCode($infoParser));
 $application->add(new OC\Core\Command\L10n\CreateJs());
 $application->add(new \OC\Core\Command\Integrity\SignApp(

--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -51,15 +51,18 @@ class InfoParser {
 		libxml_use_internal_errors(true);
 		$loadEntities = libxml_disable_entity_loader(false);
 		$xml = simplexml_load_file($file);
+
 		libxml_disable_entity_loader($loadEntities);
-		if ($xml == false) {
+		if ($xml === false) {
 			libxml_clear_errors();
 			return null;
 		}
 		$array = $this->xmlToArray($xml);
+
 		if (is_null($array)) {
 			return null;
 		}
+
 		if (!array_key_exists('info', $array)) {
 			$array['info'] = [];
 		}

--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -25,19 +25,7 @@
 
 namespace OC\App;
 
-use OCP\IURLGenerator;
-
 class InfoParser {
-
-	/** @var IURLGenerator */
-	private $urlGenerator;
-
-	/**
-	 * @param IURLGenerator $urlGenerator
-	 */
-	public function __construct(IURLGenerator $urlGenerator) {
-		$this->urlGenerator = $urlGenerator;
-	}
 
 	/**
 	 * @param string $file the xml file to be loaded
@@ -100,17 +88,6 @@ class InfoParser {
 			$array['two-factor-providers'] = [];
 		}
 
-		if (array_key_exists('documentation', $array) && is_array($array['documentation'])) {
-			foreach ($array['documentation'] as $key => $url) {
-				// If it is not an absolute URL we assume it is a key
-				// i.e. admin-ldap will get converted to go.php?to=admin-ldap
-				if (!$this->isHTTPURL($url)) {
-					$url = $this->urlGenerator->linkToDocs($url);
-				}
-
-				$array['documentation'][$key] = $url;
-			}
-		}
 		if (array_key_exists('types', $array)) {
 			if (is_array($array['types'])) {
 				foreach ($array['types'] as $type => $v) {
@@ -194,9 +171,5 @@ class InfoParser {
 		}
 
 		return $array;
-	}
-
-	private function isHTTPURL($url) {
-		return stripos($url, 'https://') === 0 || stripos($url, 'http://') === 0;
 	}
 }

--- a/lib/private/AppFramework/App.php
+++ b/lib/private/AppFramework/App.php
@@ -51,22 +51,11 @@ class App {
 	 */
 	public static function buildAppNamespace($appId, $topNamespace='OCA\\') {
 		// first try to parse the app's appinfo/info.xml <namespace> tag
-		$appPath = OC_App::getAppPath($appId);
-		if ($appPath !== false) {
-			$filePath = "$appPath/appinfo/info.xml";
-			if (is_file($filePath)) {
-				$loadEntities = libxml_disable_entity_loader(false);
-				$xml = @simplexml_load_file($filePath);
-				libxml_disable_entity_loader($loadEntities);
-				if ($xml) {
-					$result = $xml->xpath('/info/namespace');
-					if ($result && count($result) > 0) {
-						// take first namespace result
-						return $topNamespace . trim((string) $result[0]);
-					}
-				}
-			}
+		$appInfo = \OC_App::getAppInfo($appId);
+		if (isset($appInfo['namespace'])) {
+			return $topNamespace . trim($appInfo['namespace']);
 		}
+
 		// if the tag is not found, fall back to uppercasing the first letter
 		return $topNamespace . ucfirst($appId);
 	}

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -46,6 +46,7 @@
  *
  */
 use OC\App\DependencyAnalyzer;
+use OC\App\InfoParser;
 use OC\App\Platform;
 use OC\Installer;
 use OC\OCSClient;
@@ -659,7 +660,7 @@ class OC_App {
 			$file = $appPath . '/appinfo/info.xml';
 		}
 
-		$parser = new \OC\App\InfoParser(\OC::$server->getURLGenerator());
+		$parser = new InfoParser();
 		$data = $parser->parse($file);
 
 		if (is_array($data)) {
@@ -832,6 +833,7 @@ class OC_App {
 		//we don't want to show configuration for these
 		$blacklist = \OC::$server->getAppManager()->getAlwaysEnabledApps();
 		$appList = array();
+		$urlGenerator = \OC::$server->getURLGenerator();
 
 		foreach ($installedApps as $app) {
 			if (array_search($app, $blacklist) === false) {
@@ -885,6 +887,19 @@ class OC_App {
 						}
 					}
 				}
+				// fix documentation
+				if (isset($info['documentation']) && is_array($info['documentation'])) {
+					foreach ($info['documentation'] as $key => $url) {
+						// If it is not an absolute URL we assume it is a key
+						// i.e. admin-ldap will get converted to go.php?to=admin-ldap
+						if (stripos($url, 'https://') !== 0 && stripos($url, 'http://') !== 0) {
+							$url = $urlGenerator->linkToDocs($url);
+						}
+
+						$info['documentation'][$key] = $url;
+					}
+				}
+
 				$info['version'] = OC_App::getAppVersion($app);
 				$appList[] = $info;
 			}

--- a/tests/data/app/expected-info.json
+++ b/tests/data/app/expected-info.json
@@ -10,8 +10,8 @@
 	"requiremin": "4",
 	"shipped": "true",
 	"documentation": {
-		"user": "https://docs.example.com/server/go.php?to=user-encryption",
-		"admin": "https://docs.example.com/server/go.php?to=admin-encryption"
+		"user": "user-encryption",
+		"admin": "admin-encryption"
 	},
 	"rememberlogin": "false",
 	"types": ["filesystem"],

--- a/tests/lib/App/CodeChecker/InfoCheckerTest.php
+++ b/tests/lib/App/CodeChecker/InfoCheckerTest.php
@@ -44,9 +44,7 @@ class InfoCheckerTest extends TestCase {
 
 	protected function setUp() {
 		parent::setUp();
-		$infoParser = new InfoParser(\OC::$server->getURLGenerator());
-
-		$this->infoChecker = new InfoChecker($infoParser);
+		$this->infoChecker = new InfoChecker(new InfoParser());
 	}
 
 	public function appInfoData() {

--- a/tests/lib/App/InfoParserTest.php
+++ b/tests/lib/App/InfoParserTest.php
@@ -10,27 +10,16 @@
 namespace Test\App;
 
 use OC;
-use OCP\IURLGenerator;
+use OC\App\InfoParser;
 use Test\TestCase;
 
 class InfoParserTest extends TestCase {
 
-	/** @var \OC\App\InfoParser */
+	/** @var InfoParser */
 	private $parser;
 
 	public function setUp() {
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
-			->disableOriginalConstructor()
-			->getMock();
-
-		/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject $urlGenerator */
-		$urlGenerator->expects($this->any())
-			->method('linkToDocs')
-			->will($this->returnCallback(function ($url) {
-				return "https://docs.example.com/server/go.php?to=$url";
-			}));
-
-		$this->parser = new \OC\App\InfoParser($urlGenerator);
+		$this->parser = new InfoParser();
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Instead of parsing the app xml we better reuse the cached app information
## Related Issue

refs #25603
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
