### PR TITLE
[9.2] Show avatar in share drop down

### DIFF
--- a/core/css/share.css
+++ b/core/css/share.css
@@ -50,6 +50,13 @@
 	height: 32px;
 }
 
+.autocomplete-item {
+	display: flex;
+}
+.autocomplete-item-text {
+	margin: 10px;
+}
+
 #shareWithList {
 	list-style-type:none;
 	padding:8px;

--- a/core/css/share.css
+++ b/core/css/share.css
@@ -50,11 +50,17 @@
 	height: 32px;
 }
 
-.autocomplete-item {
+.share-autocomplete-item {
 	display: flex;
 }
-.autocomplete-item-text {
-	margin: 10px;
+.share-autocomplete-item .autocomplete-item-text {
+	margin-left: 10px;
+	margin-right: 10px;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	line-height: 32px;
+	vertical-align: middle;
 }
 
 #shareWithList {

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -249,7 +249,7 @@
 		},
 
 		autocompleteRenderItem: function(ul, item) {
-			var insert = $("<a>");
+
 			var text = item.label;
 			if (item.value.shareType === OC.Share.SHARE_TYPE_GROUP) {
 				text = t('core', '{sharee} (group)', {
@@ -267,15 +267,20 @@
 					});
 				}
 			}
-			insert.text(text);
-			insert.attr('title', item.value.shareWith);
-			if(item.value.shareType === OC.Share.SHARE_TYPE_GROUP) {
-				insert = insert.wrapInner('<strong></strong>');
+			var insert = $("<div class='autocomplete-item'/>");
+			var avatar = $("<div class='avatardiv'></div>").appendTo(insert);
+			if (item.value.shareType === OC.Share.SHARE_TYPE_USER) {
+				avatar.avatar(item.value.shareWith, 32, undefined, undefined, undefined, item.label);
+			} else {
+				avatar.imageplaceholder(text, undefined, 32);
 			}
-			insert.tooltip({
-				placement: 'bottom',
-				container: 'body'
-			});
+
+			$("<div class='autocomplete-item-text'></div>")
+				.text(text)
+				.appendTo(insert);
+			insert.attr('title', item.value.shareWith);
+			insert = $("<a>")
+				.append(insert);
 			return $("<li>")
 				.addClass((item.value.shareType === OC.Share.SHARE_TYPE_GROUP) ? 'group' : 'user')
 				.append(insert)

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -267,7 +267,7 @@
 					});
 				}
 			}
-			var insert = $("<div class='autocomplete-item'/>");
+			var insert = $("<div class='share-autocomplete-item'/>");
 			var avatar = $("<div class='avatardiv'></div>").appendTo(insert);
 			if (item.value.shareType === OC.Share.SHARE_TYPE_USER) {
 				avatar.avatar(item.value.shareWith, 32, undefined, undefined, undefined, item.label);


### PR DESCRIPTION
## Description

The share dropdow now shows the avatar of the user.
TODO:
- [ ] add avatar of a remote user
## Screenshots (if appropriate):

![bildschirmfoto von 2016-08-30 00-40-46](https://cloud.githubusercontent.com/assets/1005065/18069944/bc842440-6e4a-11e6-8169-b024dfa161a1.png)
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
