### PR TITLE
Makefile will rebuild if deps list changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ $(COMPOSER_BIN):
 #
 # ownCloud core PHP dependencies
 #
-$(composer_deps): $(COMPOSER_BIN)
+$(composer_deps): $(COMPOSER_BIN) composer.json composer.lock
 	php $(COMPOSER_BIN) install --no-dev
 
-$(composer_dev_deps): $(COMPOSER_BIN)
+$(composer_dev_deps): $(COMPOSER_BIN) composer.json composer.lock
 	php $(COMPOSER_BIN) install --dev
 
 .PHONY: install-composer-release-deps
@@ -61,7 +61,7 @@ clean-composer-deps:
 #
 # Node JS dependencies for tools
 #
-$(nodejs_deps):
+$(nodejs_deps): build/package.json
 	$(NPM) install --prefix $(NODE_PREFIX)
 
 .PHONY: install-nodejs-deps
@@ -73,7 +73,7 @@ clean-nodejs-deps:
 
 #
 # ownCloud core JS dependencies
-$(core_vendor): $(nodejs_deps)
+$(core_vendor): $(nodejs_deps) bower.json
 	$(BOWER) install
 
 .PHONY: install-js-deps


### PR DESCRIPTION
Deps list being composer.json, etc.
Useful when switching branches and rerunning make.

(you know how sometimes you wake up in the morning with fresh ideas, that's how this came to me)

To test:
1. Run `make clean` (just in case)
2. Run `make`: installs all deps
3. Run `make` again: does nothing, all up to date
4. Edit composer.json or composer.lock or bower.json or build/package.json
5. Run `make` again: installs the deps again

Please review @DeepDiver1975 @butonic @VicDeo 
