### PR TITLE
[stable9] minor smb logging, do not use deprecated method

### DIFF
--- a/apps/files_external/lib/smb.php
+++ b/apps/files_external/lib/smb.php
@@ -77,8 +77,10 @@ class SMB extends Common {
 
 		if (isset($params['host']) && isset($params['user']) && isset($params['password']) && isset($params['share'])) {
 			if (Server::NativeAvailable()) {
+				$this->log('using native libsmbclient');
 				$this->server = new NativeServer($params['host'], $params['user'], $params['password']);
 			} else {
+				$this->log('falling back to smbclient');
 				$this->server = new Server($params['host'], $params['user'], $params['password']);
 			}
 			$this->share = $this->server->getShare(trim($params['share'], '/'));
@@ -410,7 +412,7 @@ class SMB extends Common {
 						if (!$this->isCreatable(dirname($path))) {
 							break;
 						}
-						$tmpFile = \OCP\Files::tmpFile($ext);
+						$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
 					}
 					$source = fopen($tmpFile, $mode);
 					$share = $this->share;

--- a/apps/files_external/lib/smb.php
+++ b/apps/files_external/lib/smb.php
@@ -398,11 +398,6 @@ class SMB extends Common {
 				case 'c':
 				case 'c+':
 					//emulate these
-					if (strrpos($path, '.') !== false) {
-						$ext = substr($path, strrpos($path, '.'));
-					} else {
-						$ext = '';
-					}
 					if ($this->file_exists($path)) {
 						if (!$this->isUpdatable($path)) {
 							break;
@@ -412,7 +407,7 @@ class SMB extends Common {
 						if (!$this->isCreatable(dirname($path))) {
 							break;
 						}
-						$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
+						$tmpFile = \OC::$server->getTempManager()->getTemporaryFile();
 					}
 					$source = fopen($tmpFile, $mode);
 					$share = $this->share;

--- a/apps/files_external/tests/backends/smb.php
+++ b/apps/files_external/tests/backends/smb.php
@@ -61,8 +61,13 @@ class SMB extends Storage {
 	}
 
 	public function directoryProvider() {
-		// doesn't support leading/trailing spaces
-		return array(array('folder'));
+		return [
+			['folder'],
+			// doesn't support leading/trailing spaces
+			['folder with space'],
+			['spéciäl földer'],
+			['test single\'quote'],
+		];
 	}
 
 	public function testRenameWithSpaces() {

--- a/tests/lib/files/storage/storage.php
+++ b/tests/lib/files/storage/storage.php
@@ -144,6 +144,17 @@ abstract class Storage extends \Test\TestCase {
 		$this->assertEquals('', $this->instance->file_get_contents('/lorem.txt'), 'file not emptied');
 	}
 
+	public function testWriteWithDotInPath() {
+		// filename does not contain a dot / extension, but parent dirs do ...
+		$path = '/something/that/is/not.supposed/to happen/lorem';
+		$lorem = 'lorem ipsum dolor sit ...';
+
+		$this->instance->mkdir(dirname($path));
+		$this->instance->file_put_contents($path, $lorem);
+
+		$this->assertEquals( $this->instance->file_get_contents($path), $lorem, 'data returned from file_get_contents is not equal to the source data');
+	}
+
 	/**
 	 * test various known mimetypes
 	 */


### PR DESCRIPTION
add log for the actual smb implementation that is used (libsmbclient vs smbclient)

already contained in master and stable9 PRs

cc @felixboehm @DeepDiver1975 @PVince81
