### PR TITLE
Add missing "resources" folder to source files in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ core_vendor=core/vendor
 
 core_doc_files=AUTHORS COPYING-AGPL README.md
 core_src_files=$(wildcard *.php) index.html db_structure.xml .htaccess .user.ini
-core_src_dirs=apps core l10n lib occ ocs ocs-provider settings themes
+core_src_dirs=apps core l10n lib occ ocs ocs-provider resources settings themes
 core_all_src=$(core_src_files) $(core_src_dirs) $(core_doc_files)
 dist_dir=build/dist
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Added missing "resources" folder to source files in Makefile, these are needed due to the cert bundle and mime type list.
## Related Issue

Fixes https://github.com/owncloud/core/issues/25999
## How Has This Been Tested?

Run `make dist` then install the tarball from "build/dist/" and check that the mimetype icon look correct for welcome.txt
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

@SergioBertolinSG @DeepDiver1975 @butonic 
