### PR TITLE
Check for availability of npm on the system to install.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
 NODE_PREFIX=build
-NPM=npm
+
+#
+# Define NPM and check if it is available on the system.
+#
+NPM := $(shell command -v npm 2> /dev/null)
+ifndef NPM
+    $(error npm is not available on your system, please install npm)
+endif
+
 KARMA="$(NODE_PREFIX)/node_modules/.bin/karma"
 BOWER="$(NODE_PREFIX)/node_modules/.bin/bower"
 JSDOC="$(NODE_PREFIX)/node_modules/.bin/jsdoc"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

<!--- Describe your changes in detail -->

This change makes the make command check for the existance of the tool npm on the system. Without the npm tool, the ownCloud dependencies can not be properly installed, so it does not make sense to start the installation. 

With this patch, make exists with a hint to install npm.
