### PR TITLE
Fix ghost mounts for obsolete shares

### DIFF
--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -108,6 +108,8 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 			if (!$e instanceof NotFoundException) {
 				$this->logger->logException($e);
 			}
+			$this->rootPath = '';
+			$this->sourceRootInfo = null;
 		}
 		$this->storage = $this->sourceStorage;
 	}
@@ -131,7 +133,10 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 
 	private function isValid() {
 		$this->init();
-		return $this->sourceRootInfo && ($this->sourceRootInfo->getPermissions() & Constants::PERMISSION_SHARE) === Constants::PERMISSION_SHARE;
+		if (is_null($this->sourceRootInfo)) {
+			return false;
+		}
+		return ($this->sourceRootInfo->getPermissions() & Constants::PERMISSION_SHARE) === Constants::PERMISSION_SHARE;
 	}
 
 	/**
@@ -315,8 +320,7 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 	}
 
 	public function getCache($path = '', $storage = null) {
-		$this->init();
-		if (is_null($this->sourceStorage) || $this->sourceStorage instanceof FailedStorage) {
+		if (!$this->isValid()) {
 			return new FailedCache(false);
 		}
 		if (!$storage) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

This fix adds a check in the mount provider and discards the returned
mount for shares pointing at non-existing or trashed file ids.
## Related Issue

Fixes https://github.com/owncloud/core/issues/26001
## Motivation and Context

Ghost mounts exist because we only know whether a share is valid after
lazily initializing the shared storage, which happens too late.
## How Has This Been Tested?

Manual testing with steps from https://github.com/owncloud/core/issues/26001#issue-174476666.
- [x] TEST: shared folder still received when not deleted
- [x] TEST: fileid pointing to non-existing file
- [x] TEST: fileid pointing at file in trash
- [x] TEST: create folder "sub" then restore the file as owner
- [x] TEST: rename another folder to "sub" when invisible/ghostedn: 
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
## Backports:
- [ ] stable9.1 for 9.1.1
