### PR TITLE
Comments field is not properly escaped

### DIFF
--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -31,7 +31,7 @@
 		'{{/if}}' +
 		'    </div>' +
 		'    <form class="newCommentForm">' +
-		'        <textarea class="message" placeholder="{{newMessagePlaceholder}}">{{{message}}}</textarea>' +
+		'        <textarea class="message" placeholder="{{newMessagePlaceholder}}">{{message}}</textarea>' +
 		'        <input class="submit" type="submit" value="{{submitText}}" />' +
 		'{{#if isEditMode}}' +
 		'        <input class="cancel" type="button" value="{{cancelText}}" />' +


### PR DESCRIPTION
## Description

The comment is not properly escaped which leads to an XSS.
1. add comment like `</textarea><img src=x onload=confirm(document.location)>`
2. click on the edit button
3. see the broken image being inserted and/or an alert box popping up
## How Has This Been Tested?

Manuall testing 
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
