### PR TITLE
Update CachedMountInfo for user home storage

### DIFF
--- a/lib/private/Files/Config/CachedMountInfo.php
+++ b/lib/private/Files/Config/CachedMountInfo.php
@@ -90,7 +90,7 @@ class CachedMountInfo implements ICachedMountInfo {
 		// TODO injection etc
 		Filesystem::initMountPoints($this->getUser()->getUID());
 		$userNode = \OC::$server->getUserFolder($this->getUser()->getUID());
-		$nodes = $userNode->getById($this->getRootId());
+		$nodes = $userNode->getParent()->getById($this->getRootId());
 		if (count($nodes) > 0) {
 			return $nodes[0];
 		} else {


### PR DESCRIPTION
In getMountPointNode function rootId is not inside of the userFolder for home storage. We was searching '/user' folder in '/user/files' folder. So, it was return NULL. I moved searching part to parent folder.  It solves everything. Also, obviously other storage types not affect then this change.
