### PR TITLE
Occ command to update group mapping information

### DIFF
--- a/apps/user_ldap/appinfo/register_command.php
+++ b/apps/user_ldap/appinfo/register_command.php
@@ -52,3 +52,4 @@ $application->add(new OCA\User_LDAP\Command\ShowRemnants(
 $application->add(new OCA\User_LDAP\Command\CheckUser(
 	$uBackend, $helper, $deletedUsersIndex, $userMapping)
 );
+$application->add(new OCA\User_LDAP\Command\UpdateGroup(new LDAP(), $helper, $dbConnection));

--- a/apps/user_ldap/lib/Command/UpdateGroup.php
+++ b/apps/user_ldap/lib/Command/UpdateGroup.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ * @author Joas Schilling <coding@schilljs.com>
+ * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\User_LDAP\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use \OCA\User_LDAP\Helper;
+use \OCA\User_LDAP\LDAP;
+use \OCA\User_LDAP\Group_Proxy;
+use \OCA\User_LDAP\Mapping\GroupMapping;
+use \OCP\IDBConnection;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+
+class UpdateGroup extends Command {
+
+	const ERROR_CODE_MISSING_CONF = 1;
+	const ERROR_CODE_MISSING_MAPPING = 2;
+
+	public function __construct(LDAP $ldap, Helper $helper, IDBConnection $connection) {
+		$this->connection = $connection;
+		$this->ldap = $ldap;
+		$this->helper = $helper;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('ldap:update-group')
+			->setDescription('update the specified group information')
+			->addArgument(
+					'groupID',
+					InputArgument::REQUIRED | InputArgument::IS_ARRAY,
+					'the group ID'
+				);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$groupIDs = $input->getArgument('groupID');
+		// make sure we don't have duplicated groups in the parameters
+		$groupIDs = array_unique($groupIDs);
+
+		$helper = $this->helper;
+		$availableConfigs = $helper->getServerConfigurationPrefixes();
+
+		// show configuration information, useful to debug
+		$output->writeln('group membership attribute is critical for this command to work properly, please verify', OutputInterface::VERBOSITY_VERBOSE);
+		foreach ($availableConfigs as $aconfig) {
+			$config = new \OCA\User_LDAP\Configuration($aconfig);
+			$message = '* ' . $config->ldapHost . ':' . $config->ldapPort . ' -> ' . $config->ldapGroupMemberAssocAttr;
+			$output->writeln($message, OutputInterface::VERBOSITY_VERBOSE);
+		}
+
+		if (empty($availableConfigs)) {
+			$output->writeln('<error>No active configurations available</error>');
+			return self::ERROR_CODE_MISSING_CONF;
+		}
+
+		if (!$this->checkGroupMappingExists($groupIDs)) {
+			$output->writeln("<error>Some of the groups are unknown</error>");
+			return self::ERROR_CODE_MISSING_MAPPING;
+		}
+
+		$groupProxy = new Group_Proxy($availableConfigs, $this->ldap);
+
+		foreach ($groupIDs as $groupID) {
+			$output->writeln("checking group \"$groupID\"...", OutputInterface::VERBOSITY_VERBOSE);
+			if (!$groupProxy->groupExists($groupID)) {
+				$output->writeln("\"$groupID\" is missing, unmapping it", OutputInterface::VERBOSITY_VERBOSE);
+				$this->removeGroupMapping($groupID);
+			} else {
+				$output->writeln("updating \"$groupID\" group DB information", OutputInterface::VERBOSITY_VERBOSE);
+				$userList = $groupProxy->usersInGroup($groupID);
+				$userChanges = $this->updateGroupMapping($groupID, $userList);
+
+				$output->writeln("sending hooks", OutputInterface::VERBOSITY_VERBOSE);
+				$output->writeln("new users:", OutputInterface::VERBOSITY_VERBOSE);
+				foreach ($userChanges['added'] as $addedUser) {
+					$output->writeln($addedUser, OutputInterface::VERBOSITY_VERBOSE);
+					\OCP\Util::emitHook('OC_User', 'post_addToGroup', array('uid' => $addedUser, 'gid' => $groupID));
+				}
+				$output->writeln("removed users:", OutputInterface::VERBOSITY_VERBOSE);
+				foreach ($userChanges['removed'] as $removedUser) {
+					$output->writeln($removedUser, OutputInterface::VERBOSITY_VERBOSE);
+					\OCP\Util::emitHook('OC_User', 'post_removeFromGroup', array('uid' => $removedUser, 'gid' => $groupID));
+				}
+			}
+		}
+	}
+
+
+	private function removeGroupMapping($groupName) {
+		$this->connection->beginTransaction();
+
+		try {
+			$query = $this->connection->getQueryBuilder();
+			$query->delete('ldap_group_mapping', 'lgm')
+				->where($query->expr()->eq('lgm.owncloud_name', $query->createParameter('group')))
+				->setParameter('group', $groupName)
+				->execute();
+
+			$query2 = $this->connection->getQueryBuilder();
+			$query2->delete('ldap_group_members', 'lgm')
+				->where($query->expr()->eq('lgm.owncloudname', $query->createParameter('group')))
+				->setParameter('group', $groupName)
+				->execute();
+
+			$this->connection->commit();
+		} catch (\Exception $e) {
+			// Rollback and rethrow the exception
+			$this->connection->rollback();
+			throw $e;
+		}
+	}
+
+	/**
+	 * Return and array with 2 lists: one for the users added and another for the users removed from
+	 * the group:
+	 * ['added' => ['user1', 'user20'], 'removed' => ['user22']]
+	 */
+	private function updateGroupMapping($groupName, $userList) {
+		$query = $this->connection->getQueryBuilder();
+		$needToInsert = false;
+		$result = $query->select('*')
+			->from('ldap_group_members')
+			->where($query->expr()->eq('owncloudname', $query->createParameter('group')))
+			->setParameter('group', $groupName)
+			->execute();
+		$row = $result->fetch();
+		if ($row) {
+			$needToInsert = false;
+			$mappedList = unserialize($row['owncloudusers']);
+		} else {
+			$needToInsert = true;
+		}
+		if ($needToInsert) {
+			$query2 = $this->connection->getQueryBuilder();
+			$query2->insert('ldap_group_members')
+				->setValue('owncloudname', $query2->createParameter('group'))
+				->setValue('owncloudusers', $query2->createParameter('users'))
+				->setParameter('group', $groupName)
+				->setParameter('users', serialize($userList))
+				->execute();
+			return array('added' => $userList, 'removed' => array());
+		} else {
+			$query2 = $this->connection->getQueryBuilder();
+			$query2->update('ldap_group_members')
+				->set('owncloudusers', $query2->createParameter('users'))
+				->where($query2->expr()->eq('owncloudname', $query2->createParameter('group')))
+				->setParameter('group', $groupName)
+				->setParameter('users', serialize($userList))
+				->execute();
+			// calculate changes
+			$usersAdded = array_diff($userList, $mappedList);
+			$usersRemoved = array_diff($mappedList, $userList);
+			return array('added' => $usersAdded, 'removed' => $usersRemoved);
+		}
+	}
+
+	/**
+	 * Make sure $groupNames doesn't contain duplicated values. This function could behave
+	 * unexpectedly otherwise.
+	
+	 * Take advantage of the owncloud_name column in the DB has a unique constraint.
+	 *
+	 * @return true if the count($groupNames) matches the number of
+	 */
+	private function checkGroupMappingExists($groupNames) {
+		$query = $this->connection->getQueryBuilder();
+		$query->select($query->createFunction('count(owncloud_name) as ngroups'))
+			->from('ldap_group_mapping')
+			->where($query->expr()->in('owncloud_name', $query->createParameter('groups')))
+			->setParameter('groups', $groupNames, IQueryBuilder::PARAM_STR_ARRAY);
+		$result = $query->execute();
+		$row = $result->fetch();
+
+		$countValue = intval($row['ngroups']);
+		$result->closeCursor();
+		$requestedGroupNameCount = count($groupNames);
+		return $countValue === $requestedGroupNameCount;
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

On-demand group mapping update
## Related Issue

https://github.com/owncloud/enterprise/issues/1464
## Motivation and Context

Instead of constantly query the LDAP server for changes, this will query and update the information on-demand
## How Has This Been Tested?

ownCloud + user_ldap app, connected with an LDAP server. The LDAP server modified the groups removing an user account, and also removing one user from a LDAP group.

In addition, the group member association has been set to "member" according to what it should be expected (in the advanced configuration tab)
## Screenshots (if appropriate):
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
