### PR TITLE
Fix fed share test call to return proper result

### DIFF
--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -185,7 +185,7 @@ class Storage extends DAV implements ISharedStorage {
 
 	public function test() {
 		try {
-			parent::test();
+			return parent::test();
 		} catch (StorageInvalidException $e) {
 			// check if it needs to be removed
 			$this->checkStorageAvailability();

--- a/apps/files_sharing/tests/ExternalStorageTest.php
+++ b/apps/files_sharing/tests/ExternalStorageTest.php
@@ -66,14 +66,11 @@ class ExternalStorageTest extends \Test\TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider optionsProvider
-	 */
-	public function testStorageMountOptions($inputUri, $baseUri) {
+	private function getTestStorage($uri) {
 		$certificateManager = \OC::$server->getCertificateManager();
-		$storage = new TestSharingExternalStorage(
+		return new TestSharingExternalStorage(
 			array(
-				'remote' => $inputUri,
+				'remote' => $uri,
 				'owner' => 'testOwner',
 				'mountpoint' => 'remoteshare',
 				'token' => 'abcdef',
@@ -82,7 +79,19 @@ class ExternalStorageTest extends \Test\TestCase {
 				'certificateManager' => $certificateManager
 			)
 		);
+	}
+
+	/**
+	 * @dataProvider optionsProvider
+	 */
+	public function testStorageMountOptions($inputUri, $baseUri) {
+		$storage = $this->getTestStorage($inputUri);
 		$this->assertEquals($baseUri, $storage->getBaseUri());
+	}
+
+	public function testIfTestReturnsTheValue() {
+		$result = $this->getTestStorage('https://remoteserver')->test();
+		$this->assertSame(true, $result);
 	}
 }
 
@@ -93,5 +102,12 @@ class TestSharingExternalStorage extends \OCA\Files_Sharing\External\Storage {
 
 	public function getBaseUri() {
 		return $this->createBaseUri();
+	}
+
+	public function stat($path) {
+		if ($path === '') {
+			return true;
+		}
+		return parent::stat($path);
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Fixes an issue where retrying a previously failed federated share would not properly reset the availability flag because the return value was undefined instead of "true".

The call to `Storage::test` was not properly returning the positive result.
## Related Issue

Fixes https://github.com/owncloud/core/issues/26037
## Motivation and Context

Duh
## How Has This Been Tested?

See steps in https://github.com/owncloud/core/issues/26037
After the fix, the federated share becomes available again.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
## Backports:
- [ ] stable9.1

Please review @mmattel @DeepDiver1975 @jvillafanez @butonic @VicDeo @owncloud/qa
