### PR TITLE
Only use realpath for real directories

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -53,7 +53,12 @@ class Local extends \OC\Files\Storage\Common {
 			throw new \InvalidArgumentException('No data directory set for local storage');
 		}
 		$this->datadir = $arguments['datadir'];
-		$this->realDataDir = rtrim(realpath($this->datadir), '/') . '/';
+		// some crazy code uses a local storage on root...
+		if ($this->datadir === '/') {
+			$this->realDataDir = $this->datadir;
+		} else {
+			$this->realDataDir = rtrim(realpath($this->datadir), '/') . '/';
+		}
 		if (substr($this->datadir, -1) !== '/') {
 			$this->datadir .= '/';
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

In some cross-local-storage use cases, the Local storage is
instantiated with "/" as data directory. In such cases, calling
realpath() would cause PHP warnings when open_basedir is set.

This fix bypasses the realpath() call when dealing with a root storage.

This occurs mostly when overwriting files with Webdav because it will trigger the version code's version copying which is internally a cross-storage copy apparently.
## Related Issue

Fixes https://github.com/owncloud/core/issues/26033
## Motivation and Context

See issue, mostly a PHP warning
## How Has This Been Tested?

See steps in issue
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

(can't really automatically test due to calling PHP system function)
## Backports
- [x] stable9.1
- ~~stable9~~
- ~~stable8.2~~

Please review @owncloud/filesystem @timreeves @DeepDiver1975 @butonic 
