### PR TITLE
Improve chunk upload AssemblyStream performance

### DIFF
--- a/apps/dav/lib/Upload/AssemblyStream.php
+++ b/apps/dav/lib/Upload/AssemblyStream.php
@@ -49,6 +49,9 @@ class AssemblyStream implements \Icewind\Streams\File {
 	/** @var int */
 	private $size;
 
+	/** @var resource */
+	private $currentStream = null;
+
 	/**
 	 * @param string $path
 	 * @param string $mode
@@ -101,16 +104,36 @@ class AssemblyStream implements \Icewind\Streams\File {
 	 * @return string
 	 */
 	public function stream_read($count) {
+		do {
+			if ($this->currentStream === null) {
+				list($node, $posInNode) = $this->getNodeForPosition($this->pos);
+				if (is_null($node)) {
+					// reached last node, no more data
+					return '';
+				}
+				$this->currentStream = $this->getStream($node);
+				fseek($this->currentStream, $posInNode);
+			}
 
-		list($node, $posInNode) = $this->getNodeForPosition($this->pos);
-		if (is_null($node)) {
-			return null;
-		}
-		$stream = $this->getStream($node);
+			$data = fread($this->currentStream, $count);
+			// isset is faster than strlen
+			if (isset($data[$count - 1])) {
+				// we read the full count
+				$read = $count;
+			} else {
+				// reaching end of stream, which happens less often so strlen is ok
+				$read = strlen($data);
+			}
 
-		fseek($stream, $posInNode);
-		$data = fread($stream, $count);
-		$read = strlen($data);
+			if (feof($this->currentStream)) {
+				fclose($this->currentStream);
+				$this->currentNode = null;
+				$this->currentStream = null;
+			}
+			// if no data read, try again with the next node because
+			// returning empty data can make the caller think there is no more
+			// data left to read
+		} while ($read === 0);
 
 		// update position
 		$this->pos += $read;

--- a/apps/dav/tests/unit/Upload/AssemblyStreamTest.php
+++ b/apps/dav/tests/unit/Upload/AssemblyStreamTest.php
@@ -34,16 +34,76 @@ class AssemblyStreamTest extends \Test\TestCase {
 		$this->assertEquals($expected, $content);
 	}
 
+	/**
+	 * @dataProvider providesNodes()
+	 */
+	public function testGetContentsFread($expected, $nodes) {
+		$stream = \OCA\DAV\Upload\AssemblyStream::wrap($nodes);
+
+		$content = '';
+		while (!feof($stream)) {
+			$content .= fread($stream, 3);
+		}
+
+		$this->assertEquals($expected, $content);
+	}
+
 	function providesNodes() {
+		$data8k = $this->makeData(8192);
+		$dataLess8k = $this->makeData(8191);
 		return[
-			'one node only' => ['1234567890', [
+			'one node zero bytes' => [
+				'', [
+				$this->buildNode('0', '')
+			]],
+			'one node only' => [
+				'1234567890', [
 				$this->buildNode('0', '1234567890')
 			]],
-			'two nodes' => ['1234567890', [
+			'one node buffer boundary' => [
+				$data8k, [
+				$this->buildNode('0', $data8k)
+			]],
+			'two nodes' => [
+				'1234567890', [
 				$this->buildNode('1', '67890'),
 				$this->buildNode('0', '12345')
-			]]
+			]],
+			'two nodes end on buffer boundary' => [
+				$data8k . $data8k, [
+				$this->buildNode('1', $data8k),
+				$this->buildNode('0', $data8k)
+			]],
+			'two nodes with one on buffer boundary' => [
+				$data8k . $dataLess8k, [
+				$this->buildNode('1', $dataLess8k),
+				$this->buildNode('0', $data8k)
+			]],
+			'two nodes on buffer boundary plus one byte' => [
+				$data8k . 'X' . $data8k, [
+				$this->buildNode('1', $data8k),
+				$this->buildNode('0', $data8k . 'X')
+			]],
+			'two nodes on buffer boundary plus one byte at the end' => [
+				$data8k . $data8k . 'X', [
+				$this->buildNode('1', $data8k . 'X'),
+				$this->buildNode('0', $data8k)
+			]],
 		];
+	}
+
+	private function makeData($count) {
+		$data = '';
+		$base = '1234567890';
+		$j = 0;
+		for ($i = 0; $i < $count; $i++) {
+			$data .= $base[$j];
+			$j++;
+			if (!isset($base[$j])) {
+				$j = 0;
+			}
+		}
+		return $data;
 	}
 
 	private function buildNode($name, $data) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

The assembly stream's `steam_read` method is usually called for every 8192 bytes by PHP.
In the current code, it would call `fopen()` on the chunk's node in every call, which means for every 8k bytes, which is very unefficient.

This fix caches the stream until the end is reached before resolving the next node.
## Related Issue

Partial fix for https://github.com/owncloud/core/issues/25493
## Motivation and Context

Chunk assembly is too slow in the new endpoint!
## How Has This Been Tested?

Check out this other PR https://github.com/owncloud/core/pull/25494 which contains the fix as well.
Upload a big file of around 60+ MB in the web UI in a subfolder.
Check the network console for the final "MOVE" of ".file".

Before: 20440ms
After: 600ms
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
## Backports:
- [ ] stable9.1 ?

Please review @DeepDiver1975 @owncloud/filesystem 
