### PR TITLE
FilesHome now also returns DAV properties

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -314,8 +314,7 @@ class FilesPlugin extends ServerPlugin {
 			});
 		}
 
-		if ($node instanceof \OCA\DAV\Connector\Sabre\Node
-			|| $node instanceof \OCA\DAV\Files\FilesHome) {
+		if ($node instanceof \OCA\DAV\Connector\Sabre\Node) {
 			$propFind->handle(self::DATA_FINGERPRINT_PROPERTYNAME, function() use ($node) {
 				return $this->config->getSystemValue('data-fingerprint', '');
 			});

--- a/apps/dav/lib/Files/FilesHome.php
+++ b/apps/dav/lib/Files/FilesHome.php
@@ -22,11 +22,9 @@ namespace OCA\DAV\Files;
 
 use OCA\DAV\Connector\Sabre\Directory;
 use Sabre\DAV\Exception\Forbidden;
-use Sabre\DAV\ICollection;
-use Sabre\DAV\SimpleCollection;
 use Sabre\HTTP\URLUtil;
 
-class FilesHome implements ICollection {
+class FilesHome extends Directory {
 
 	/**
 	 * @var array
@@ -40,30 +38,13 @@ class FilesHome implements ICollection {
 	 */
 	public function __construct($principalInfo) {
 		$this->principalInfo = $principalInfo;
-	}
-
-	function createFile($name, $data = null) {
-		return $this->impl()->createFile($name, $data);
-	}
-
-	function createDirectory($name) {
-		$this->impl()->createDirectory($name);
-	}
-
-	function getChild($name) {
-		return $this->impl()->getChild($name);
-	}
-
-	function getChildren() {
-		return $this->impl()->getChildren();
-	}
-
-	function childExists($name) {
-		return $this->impl()->childExists($name);
+		$view = \OC\Files\Filesystem::getView();
+		$rootInfo = $view->getFileInfo('');
+		parent::__construct($view, $rootInfo);
 	}
 
 	function delete() {
-		$this->impl()->delete();
+		throw new Forbidden('Permission denied to delete home folder');
 	}
 
 	function getName() {
@@ -73,31 +54,5 @@ class FilesHome implements ICollection {
 
 	function setName($name) {
 		throw new Forbidden('Permission denied to rename this folder');
-	}
-
-	/**
-	 * Returns the last modification time, as a unix timestamp
-	 *
-	 * @return int
-	 */
-	function getLastModified() {
-		return $this->impl()->getLastModified();
-	}
-
-	/**
-	 * @return Directory
-	 */
-	private function impl() {
-		//
-		// TODO: we need to mount filesystem of the give user
-		//
-		$user = \OC::$server->getUserSession()->getUser();
-		if ($this->getName() !== $user->getUID()) {
-			return new SimpleCollection($this->getName());
-		}
-		$view = \OC\Files\Filesystem::getView();
-		$rootInfo = $view->getFileInfo('');
-		$impl = new Directory($view, $rootInfo);
-		return $impl;
 	}
 }

--- a/apps/dav/lib/Files/RootCollection.php
+++ b/apps/dav/lib/Files/RootCollection.php
@@ -21,7 +21,8 @@
 namespace OCA\DAV\Files;
 
 use Sabre\DAVACL\AbstractPrincipalCollection;
-use Sabre\DAVACL\IPrincipal;
+use Sabre\HTTP\URLUtil;
+use Sabre\DAV\SimpleCollection;
 
 class RootCollection extends AbstractPrincipalCollection {
 
@@ -33,9 +34,17 @@ class RootCollection extends AbstractPrincipalCollection {
 	 * supplied by the authentication backend.
 	 *
 	 * @param array $principalInfo
-	 * @return IPrincipal
+	 * @return INode
 	 */
 	function getChildForPrincipal(array $principalInfo) {
+		list(,$name) = URLUtil::splitPath($principalInfo['uri']);
+		$user = \OC::$server->getUserSession()->getUser();
+		if ($name !== $user->getUID()) {
+			// a user is only allowed to see their own home contents, so in case another collection
+			// is accessed, we return a simple empty collection for now
+			// in the future this could be considered to be used for accessing shared files
+			return new SimpleCollection($name);
+		}
 		return new FilesHome($principalInfo);
 	}
 

--- a/apps/dav/lib/Upload/UploadHome.php
+++ b/apps/dav/lib/Upload/UploadHome.php
@@ -29,7 +29,7 @@ use Sabre\DAV\ICollection;
 
 class UploadHome implements ICollection {
 	/**
-	 * FilesHome constructor.
+	 * UploadHome constructor.
 	 *
 	 * @param array $principalInfo
 	 */

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -195,58 +195,6 @@ class FilesPluginTest extends TestCase {
 		$this->assertEquals([self::SIZE_PROPERTYNAME], $propFind->get404Properties());
 	}
 
-	public function testGetPropertiesForFileHome() {
-		/** @var \OCA\DAV\Files\FilesHome | \PHPUnit_Framework_MockObject_MockObject $node */
-		$node = $this->getMockBuilder('\OCA\DAV\Files\FilesHome')
-			->disableOriginalConstructor()
-			->getMock();
-
-		$propFind = new PropFind(
-			'/dummyPath',
-			array(
-				self::GETETAG_PROPERTYNAME,
-				self::FILEID_PROPERTYNAME,
-				self::INTERNAL_FILEID_PROPERTYNAME,
-				self::SIZE_PROPERTYNAME,
-				self::PERMISSIONS_PROPERTYNAME,
-				self::DOWNLOADURL_PROPERTYNAME,
-				self::OWNER_ID_PROPERTYNAME,
-				self::OWNER_DISPLAY_NAME_PROPERTYNAME,
-				self::DATA_FINGERPRINT_PROPERTYNAME,
-			),
-			0
-		);
-
-		$user = $this->getMockBuilder('\OC\User\User')
-			->disableOriginalConstructor()->getMock();
-		$user->expects($this->never())->method('getUID');
-		$user->expects($this->never())->method('getDisplayName');
-
-		$this->plugin->handleGetProperties(
-			$propFind,
-			$node
-		);
-
-		$this->assertEquals(null, $propFind->get(self::GETETAG_PROPERTYNAME));
-		$this->assertEquals(null, $propFind->get(self::FILEID_PROPERTYNAME));
-		$this->assertEquals(null, $propFind->get(self::INTERNAL_FILEID_PROPERTYNAME));
-		$this->assertEquals(null, $propFind->get(self::SIZE_PROPERTYNAME));
-		$this->assertEquals(null, $propFind->get(self::PERMISSIONS_PROPERTYNAME));
-		$this->assertEquals(null, $propFind->get(self::DOWNLOADURL_PROPERTYNAME));
-		$this->assertEquals(null, $propFind->get(self::OWNER_ID_PROPERTYNAME));
-		$this->assertEquals(null, $propFind->get(self::OWNER_DISPLAY_NAME_PROPERTYNAME));
-		$this->assertEquals(['{DAV:}getetag',
-					'{http://owncloud.org/ns}id',
-					'{http://owncloud.org/ns}fileid',
-					'{http://owncloud.org/ns}size',
-					'{http://owncloud.org/ns}permissions',
-					'{http://owncloud.org/ns}downloadURL',
-					'{http://owncloud.org/ns}owner-id',
-					'{http://owncloud.org/ns}owner-display-name'
-				], $propFind->get404Properties());
-		$this->assertEquals('my_fingerprint', $propFind->get(self::DATA_FINGERPRINT_PROPERTYNAME));
-	}
-
 	public function testGetPropertiesStorageNotAvailable() {
 		/** @var \OCA\DAV\Connector\Sabre\File | \PHPUnit_Framework_MockObject_MockObject $node */
 		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');


### PR DESCRIPTION
## Description

This fix makes FilesHome extend the Sabre Directory class, this makes
the FilesPlugin and other plugins recognize it as a directory and will
retrieve the matching properties when applicable.
## Related Issue

Fixes https://github.com/owncloud/core/issues/26064
## Motivation and Context

The files home node must also return DAV properties like etag,
permissions, etc for the clients to work like they did with the old
endpoint. Failure to do so makes it impossible for the desktop client to retrieve the root etag for this user's home.
## How Has This Been Tested?

See steps in https://github.com/owncloud/core/issues/26064
Also tested with https://github.com/owncloud/core/pull/25494 (switch web UI to new DAV endpoint)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
### Backports
- [ ] stable9.1 ?

Please review @DeepDiver1975 @guruz @butonic 
