### PR TITLE
Expose PHP max upload size through capabilities API

### DIFF
--- a/apps/files/lib/Capabilities.php
+++ b/apps/files/lib/Capabilities.php
@@ -55,6 +55,8 @@ class Capabilities implements ICapability {
 			'files' => [
 				'bigfilechunking' => true,
 				'blacklisted_files' => $this->config->getSystemValue('blacklisted_files', ['.htaccess']),
+				'upload_max_filesize' => (int)\OC::$server->getIniWrapper()->getBytes('upload_max_filesize'),
+				'post_max_size' => (int)\OC::$server->getIniWrapper()->getBytes('post_max_size'),
 			],
 		];
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Expose PHP's ini values for "upload_max_filesize" and "post_max_size".
## Related Issue

Ref: https://github.com/owncloud/core/issues/26067
## Motivation and Context
- For https://github.com/owncloud/core/issues/26067.
- In the future, for the web UI when using chunk upload, to decide the max chunk size
- For other clients to be able to make a better decision on the chunk size / for dynamic chunk sizes (@davivel @nasli @dragotin @guruz)
## How Has This Been Tested?

`curl -X GET http://admin:admin@localhost/owncloud/ocs/v1.php/cloud/capabilities`
Check that the new values appear under the "files" section.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
### Backports:
- [ ] Could backport down to 8.2 if useful.

Please review @DeepDiver1975 @guruz 
