### PR TITLE
Remove upload_limit in files app as it is not needed with PUT upload

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -768,8 +768,7 @@ OC.Uploader.prototype = _.extend({
 						data.originalFiles.selection = {
 							uploads: [],
 							filesToUpload: data.originalFiles.length,
-							totalBytes: 0,
-							biggestFileBytes: 0
+							totalBytes: 0
 						};
 					}
 					// TODO: move originalFiles to a separate container, maybe inside OC.Upload
@@ -828,18 +827,6 @@ OC.Uploader.prototype = _.extend({
 					} else {
 						// add size
 						selection.totalBytes += file.size;
-						// update size of biggest file
-						selection.biggestFileBytes = Math.max(selection.biggestFileBytes, file.size);
-					}
-
-					// check PHP upload limit against biggest file
-					if (selection.biggestFileBytes > $('#upload_limit').val()) {
-						data.textStatus = 'sizeexceedlimit';
-						data.errorThrown = t('files',
-							'Total file size {size1} exceeds upload limit {size2}', {
-							'size1': humanFileSize(selection.biggestFileBytes),
-							'size2': humanFileSize($('#upload_limit').val())
-						});
 					}
 
 					// check free space

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -59,7 +59,6 @@
 				return;
 			}
 			if (response.data !== undefined && response.data.uploadMaxFilesize !== undefined) {
-				$('#max_upload').val(response.data.uploadMaxFilesize);
 				$('#free_space').val(response.data.freeSpace);
 				$('#upload.button').attr('data-original-title', response.data.maxHumanFilesize);
 				$('#usedSpacePercent').val(response.data.usedSpacePercent);
@@ -71,7 +70,6 @@
 				return;
 			}
 			if (response[0].uploadMaxFilesize !== undefined) {
-				$('#max_upload').val(response[0].uploadMaxFilesize);
 				$('#upload.button').attr('data-original-title', response[0].maxHumanFilesize);
 				$('#usedSpacePercent').val(response[0].usedSpacePercent);
 				Files.displayStorageWarnings();

--- a/apps/files/list.php
+++ b/apps/files/list.php
@@ -26,11 +26,9 @@ OCP\User::checkLoggedIn();
 $config = \OC::$server->getConfig();
 // TODO: move this to the generated config.js
 $publicUploadEnabled = $config->getAppValue('core', 'shareapi_allow_public_upload', 'yes');
-$uploadLimit=OCP\Util::uploadLimit();
 
 // renders the controls and table headers template
 $tmpl = new OCP\Template('files', 'list', '');
-$tmpl->assign('uploadLimit', $uploadLimit); // PHP upload limit
 $tmpl->assign('publicUploadEnabled', $publicUploadEnabled);
 $tmpl->printPage();
 

--- a/apps/files/templates/list.php
+++ b/apps/files/templates/list.php
@@ -15,8 +15,6 @@
 			 through ajax instead (updateStorageStatistics).
 	*/ ?>
 	<input type="hidden" name="permissions" value="" id="permissions">
-	<input type="hidden" id="max_upload" name="MAX_FILE_SIZE" value="<?php isset($_['uploadMaxFilesize']) ? p($_['uploadMaxFilesize']) : '' ?>">
-	<input type="hidden" id="upload_limit" value="<?php isset($_['uploadLimit']) ? p($_['uploadLimit']) : '' ?>">
 	<input type="hidden" id="free_space" value="<?php isset($_['freeSpace']) ? p($_['freeSpace']) : '' ?>">
 	<?php if(isset($_['dirToken'])):?>
 	<input type="hidden" id="publicUploadRequestToken" name="requesttoken" value="<?php p($_['requesttoken']) ?>" />

--- a/apps/files/tests/js/fileUploadSpec.js
+++ b/apps/files/tests/js/fileUploadSpec.js
@@ -35,7 +35,6 @@ describe('OC.Upload tests', function() {
 		// need a dummy button because file-upload checks on it
 		$('#testArea').append(
 			'<input type="file" id="file_upload_start" name="files[]" multiple="multiple">' +
-			'<input type="hidden" id="upload_limit" name="upload_limit" value="10000000">' + // 10 MB
 			'<input type="hidden" id="free_space" name="free_space" value="50000000">' + // 50 MB
 			// TODO: handlebars!
 			'<div id="new">' +
@@ -96,19 +95,6 @@ describe('OC.Upload tests', function() {
 			expect(result[0]).not.toEqual(null);
 			expect(result[0].submit.calledOnce).toEqual(true);
 			expect(failStub.notCalled).toEqual(true);
-		});
-		it('does not add file if it exceeds upload limit', function() {
-			var result;
-			$('#upload_limit').val(1000);
-
-			result = addFiles(uploader, [testFile]);
-
-			expect(result[0]).toEqual(null);
-			expect(failStub.calledOnce).toEqual(true);
-			expect(failStub.getCall(0).args[1].textStatus).toEqual('sizeexceedlimit');
-			expect(failStub.getCall(0).args[1].errorThrown).toEqual(
-				'Total file size 5 KB exceeds upload limit 1000 B'
-			);
 		});
 		it('does not add file if it exceeds free space', function() {
 			var result;

--- a/apps/files_sharing/lib/Controllers/ShareController.php
+++ b/apps/files_sharing/lib/Controllers/ShareController.php
@@ -327,8 +327,7 @@ class ShareController extends Controller {
 				$freeSpace = (INF > 0) ? INF: PHP_INT_MAX; // work around https://bugs.php.net/bug.php?id=69188
 			}
 
-			$uploadLimit = Util::uploadLimit();
-			$maxUploadFilesize = min($freeSpace, $uploadLimit);
+			$maxUploadFilesize = $freeSpace;
 
 			$folder = new Template('files', 'list', '');
 			$folder->assign('dir', $rootFolder->getRelativePath($path->getPath()));
@@ -339,7 +338,6 @@ class ShareController extends Controller {
 			$folder->assign('uploadMaxFilesize', $maxUploadFilesize);
 			$folder->assign('uploadMaxHumanFilesize', OCP\Util::humanFileSize($maxUploadFilesize));
 			$folder->assign('freeSpace', $freeSpace);
-			$folder->assign('uploadLimit', $uploadLimit); // PHP upload limit
 			$folder->assign('usedSpacePercent', 0);
 			$folder->assign('trash', false);
 			$shareTmpl['folder'] = $folder->fetchPage();


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Remove upload_limit in the files app as it's not needed any more.
## Related Issue

Part of https://github.com/owncloud/core/issues/26067
## Motivation and Context

The web UI now uses for PUT uploads (see https://github.com/owncloud/core/pull/21237) which aren't restricted by PHP's
upload_max_filesize and post_max_size. Cleaning this up removes additional unneeded logic and also prepares for https://github.com/owncloud/core/issues/26067
## How Has This Been Tested?

Edit `.htaccess` and set `upload_max_filesize` and `post_max_size` to 5MB.
Upload a 30 MB file in the files app.
Create a public link with edit permissions and upload a file there.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Cleanup / tech debt
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Note: I kept the admin page part because there might be third party apps still using the POST approach, so an admin should still be able to set a value.

@DeepDiver1975 @guruz 
