### PR TITLE
Print error if logged couldn't log it in index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -48,11 +48,20 @@ try {
 	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
 	OC_Template::printErrorPage($ex->getMessage(), $ex->getHint());
 } catch (Exception $ex) {
-	\OC::$server->getLogger()->logException($ex, ['app' => 'index']);
+	try {
+		\OC::$server->getLogger()->logException($ex, ['app' => 'index']);
 
-	//show the user a detailed error page
-	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
-	OC_Template::printExceptionErrorPage($ex);
+		//show the user a detailed error page
+		OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
+		OC_Template::printExceptionErrorPage($ex);
+	} catch (\Exception $ex2) {
+		// with some env issues, it can happen that the logger couldn't log properly,
+		// so print out the exception directly
+		echo('<html><body>');
+		echo('Exception occurred while logging exception: ' . $ex->getMessage() . '<br/>');
+		echo(str_replace("\n", '<br/>', $ex->getTraceAsString()));
+		echo('</body></html>');
+	}
 } catch (Error $ex) {
 	\OC::$server->getLogger()->logException($ex, ['app' => 'index']);
 	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/
## Description
In some rare env problem cases, the exception cannot be logged because
the logger couldn't be initialized properly. In such cases, we now
print the stack trace directly on the output.

## Motivation and Context
To help admins and developers find out **why** suddenly they're getting a 500 Internal Server error on index.php without anything being logged.

## How Has This Been Tested?
This happened on master (0a6e09a667eb19fd1fe552015d6afd568e11788a) on my environment, possibly due to recent library updates. The message that wasn't logged was the following:
```
Exception occurred while logging exception: There is no suitable CSPRNG installed on your system
#0 /srv/www/htdocs/owncloud/lib/composer/paragonie/random_compat/lib/random_int.php(153): random_bytes(1)
#1 /srv/www/htdocs/owncloud/lib/private/Security/SecureRandom.php(80): random_int(0, 63)
#2 /srv/www/htdocs/owncloud/lib/private/Security/CSRF/CsrfTokenGenerator.php(50): OC\Security\SecureRandom->generate(32)
#3 /srv/www/htdocs/owncloud/lib/private/Security/CSRF/CsrfTokenManager.php(56): OC\Security\CSRF\CsrfTokenGenerator->generateToken()
#4 /srv/www/htdocs/owncloud/lib/public/Util.php(505): OC\Security\CSRF\CsrfTokenManager->getToken()
#5 /srv/www/htdocs/owncloud/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php(138): OCP\Util::callRegister()
#6 /srv/www/htdocs/owncloud/lib/private/AppFramework/Middleware/MiddlewareDispatcher.php(93): OC\AppFramework\Middleware\Security\SecurityMiddleware->beforeController(Object(OC\Core\Controller\LoginController), 'showLoginForm')
#7 /srv/www/htdocs/owncloud/lib/private/AppFramework/Http/Dispatcher.php(88): OC\AppFramework\Middleware\MiddlewareDispatcher->beforeController(Object(OC\Core\Controller\LoginController), 'showLoginForm')
#8 /srv/www/htdocs/owncloud/lib/private/AppFramework/App.php(110): OC\AppFramework\Http\Dispatcher->dispatch(Object(OC\Core\Controller\LoginController), 'showLoginForm')
#9 /srv/www/htdocs/owncloud/lib/private/AppFramework/Routing/RouteActionHandler.php(46): OC\AppFramework\App::main('LoginController', 'showLoginForm', Object(OC\AppFramework\DependencyInjection\DIContainer), Array)
#10 [internal function]: OC\AppFramework\Routing\RouteActionHandler->__invoke(Array)
#11 /srv/www/htdocs/owncloud/lib/private/Route/Router.php(280): call_user_func(Object(OC\AppFramework\Routing\RouteActionHandler), Array)
#12 /srv/www/htdocs/owncloud/lib/base.php(896): OC\Route\Router->match('/login')
#13 /srv/www/htdocs/owncloud/index.php(39): OC::handleRequest()
#14 {main}
```

Without this PR I had no chance to find out.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 @VicDeo @butonic @guruz 
