### PR TITLE
Log user on exception

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -317,6 +317,9 @@ class Log implements ILogger {
 			'Line' => $exception->getLine(),
 		];
 		$exception['Trace'] = preg_replace('!(' . implode('|', $this->methodsWithSensitiveParameters) . ')\(.*\)!', '$1(*** sensitive parameters replaced ***)', $exception['Trace']);
+		if (\OC::$server->getUserSession()->isLoggedIn()) {
+			$context['userid'] = \OC::$server->getUserSession()->getUser()->getUID();
+		}
 		$msg = isset($context['message']) ? $context['message'] : 'Exception';
 		$msg .= ': ' . json_encode($exception);
 		$this->error($msg, $context);


### PR DESCRIPTION
Try to log the user on an exception if we have one. `\OC::$server` must be available because otherwise sth. like `\OC::$server->getLogger()` is not possible as well and we have bigger problems.

Should allow better identifying affected users.
