### PR TITLE
New dav endpoint register tags plugin

### DIFF
--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -40,6 +40,7 @@ use OCP\IRequest;
 use OCP\SabrePluginEvent;
 use Sabre\CardDAV\VCFExportPlugin;
 use Sabre\DAV\Auth\Plugin;
+use OCA\DAV\Connector\Sabre\TagsPlugin;
 
 class Server {
 
@@ -172,7 +173,11 @@ class Server {
 				);
 				$this->server->addPlugin(
 					new \OCA\DAV\Connector\Sabre\QuotaPlugin($view));
-
+				$this->server->addPlugin(
+					new TagsPlugin(
+						$this->server->tree, \OC::$server->getTagManager()
+					)
+				);
 			}
 		});
 	}

--- a/build/integration/features/bootstrap/WebDav.php
+++ b/build/integration/features/bootstrap/WebDav.php
@@ -344,7 +344,7 @@ trait WebDav {
 	}
 
 	public function makeSabrePath($path) {
-		return $this->encodePath($this->davPath . '/' . ltrim($path, '/'));
+		return $this->encodePath($this->davPath . $this->getFilesPath() . ltrim($path, '/'));
 	}
 
 	public function getSabreClient($user) {
@@ -545,7 +545,7 @@ trait WebDav {
 			];
 		}
 
-		$response = $client->proppatch($this->davPath . '/' . ltrim($path, '/'), $properties, $folderDepth);
+		$response = $client->proppatch($this->davPath . $this->getFilesPath() . ltrim($path, '/'), $properties, $folderDepth);
 		return $response;
 	}
 

--- a/build/integration/features/bootstrap/WebDav.php
+++ b/build/integration/features/bootstrap/WebDav.php
@@ -22,10 +22,10 @@ trait WebDav {
 		$this->davPath = $davPath;
 	}
 
-	public function getFilesPath(){
+	public function getFilesPath($user){
 		$basePath = '';
 		if ($this->davPath === "remote.php/dav"){
-			$basePath = '/files/' . $this->currentUser . '/';
+			$basePath = '/files/' . $user . '/';
 		} else {
 			$basePath = '/';
 		}
@@ -243,7 +243,7 @@ trait WebDav {
 	 */
 	public function asTheFileOrFolderDoesNotExist($user, $entry, $path) {
 		$client = $this->getSabreClient($user);
-		$response = $client->request('HEAD', $this->makeSabrePath($path));
+		$response = $client->request('HEAD', $this->makeSabrePath($user, $path));
 		if ($response['statusCode'] !== 404) {
 			throw new \Exception($entry . ' "' . $path . '" expected to not exist (status code ' . $response['statusCode'] . ', expected 404)');
 		}
@@ -338,13 +338,13 @@ trait WebDav {
 			];
 		}
 
-		$response = $client->propfind($this->makeSabrePath($path), $properties, $folderDepth);
+		$response = $client->propfind($this->makeSabrePath($user, $path), $properties, $folderDepth);
 
 		return $response;
 	}
 
-	public function makeSabrePath($path) {
-		return $this->encodePath($this->davPath . $this->getFilesPath() . ltrim($path, '/'));
+	public function makeSabrePath($user, $path) {
+		return $this->encodePath($this->davPath . $this->getFilesPath($user) . ltrim($path, '/'));
 	}
 
 	public function getSabreClient($user) {
@@ -435,7 +435,7 @@ trait WebDav {
 	 */
 	public function userCreatedAFolder($user, $destination){
 		try {
-			$this->response = $this->makeDavRequest($user, "MKCOL", $this->getFilesPath() . ltrim($destination, $this->getFilesPath()), []);
+			$this->response = $this->makeDavRequest($user, "MKCOL", $this->getFilesPath($user) . ltrim($destination, $this->getFilesPath($user)), []);
 		} catch (\GuzzleHttp\Exception\ServerException $e) {
 			// 4xx and 5xx responses cause an exception
 			$this->response = $e->getResponse();
@@ -545,7 +545,7 @@ trait WebDav {
 			];
 		}
 
-		$response = $client->proppatch($this->davPath . $this->getFilesPath() . ltrim($path, '/'), $properties, $folderDepth);
+		$response = $client->proppatch($this->davPath . $this->getFilesPath($user) . ltrim($path, '/'), $properties, $folderDepth);
 		return $response;
 	}
 

--- a/build/integration/features/favorites.feature
+++ b/build/integration/features/favorites.feature
@@ -40,3 +40,41 @@ Feature: favorite
             |{http://owncloud.org/ns}favorite|
         And the single response should contain a property "{http://owncloud.org/ns}favorite" with value ""
 
+    Scenario: Favorite a folder new endpoint
+        Given using dav path "remote.php/dav"
+        And As an "admin"
+        And user "user0" exists
+        When user "user0" favorites element "/FOLDER"
+        Then as "user0" gets properties of folder "/FOLDER" with
+            |{http://owncloud.org/ns}favorite|
+        And the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
+
+    Scenario: Favorite and unfavorite a folder
+        Given using dav path "remote.php/dav"
+        And As an "admin"
+        And user "user0" exists
+        When user "user0" favorites element "/FOLDER"
+        And user "user0" unfavorites element "/FOLDER"
+        Then as "user0" gets properties of folder "/FOLDER" with
+            |{http://owncloud.org/ns}favorite|
+        And the single response should contain a property "{http://owncloud.org/ns}favorite" with value ""
+
+    Scenario: Favorite a file
+        Given using dav path "remote.php/dav"
+        And As an "admin"
+        And user "user0" exists
+        When user "user0" favorites element "/textfile0.txt"
+        Then as "user0" gets properties of file "/textfile0.txt" with
+            |{http://owncloud.org/ns}favorite|
+        And the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
+
+    Scenario: Favorite and unfavorite a file
+        Given using dav path "remote.php/dav"
+        And As an "admin"
+        And user "user0" exists
+        When user "user0" favorites element "/textfile0.txt"
+        And user "user0" unfavorites element "/textfile0.txt"
+        Then as "user0" gets properties of file "/textfile0.txt" with
+            |{http://owncloud.org/ns}favorite|
+        And the single response should contain a property "{http://owncloud.org/ns}favorite" with value ""
+

--- a/build/integration/features/favorites.feature
+++ b/build/integration/features/favorites.feature
@@ -49,7 +49,7 @@ Feature: favorite
             |{http://owncloud.org/ns}favorite|
         And the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
 
-    Scenario: Favorite and unfavorite a folder
+    Scenario: Favorite and unfavorite a folder new endpoint
         Given using dav path "remote.php/dav"
         And As an "admin"
         And user "user0" exists
@@ -59,7 +59,7 @@ Feature: favorite
             |{http://owncloud.org/ns}favorite|
         And the single response should contain a property "{http://owncloud.org/ns}favorite" with value ""
 
-    Scenario: Favorite a file
+    Scenario: Favorite a file new endpoint
         Given using dav path "remote.php/dav"
         And As an "admin"
         And user "user0" exists
@@ -68,7 +68,7 @@ Feature: favorite
             |{http://owncloud.org/ns}favorite|
         And the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
 
-    Scenario: Favorite and unfavorite a file
+    Scenario: Favorite and unfavorite a file new endpoint
         Given using dav path "remote.php/dav"
         And As an "admin"
         And user "user0" exists


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

This makes it possible to retrieve and PROPPATCH the favorite info
## Related Issue

None raised, discovered while testing https://github.com/owncloud/core/pull/25494
## Motivation and Context

Make new dav behave like old dav
## How Has This Been Tested?

Check out this PR https://github.com/owncloud/core/pull/25494 which makes the web UI use the new DAV endpoint.
Favorite a file then refresh the page.
Before: no favorite info.
After: favorited file still appears as favorite.
## Screenshots (if appropriate):
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review @DeepDiver1975 @guruz @SergioBertolinSG 
