### PR TITLE
Pass a logger instance to constructor

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -126,18 +126,6 @@ class Application extends App {
 				$c->query('SecureRandom')
 			);
 		});
-		$container->registerService('OccController', function(SimpleContainer $c) {
-			return new OccController(
-				$c->query('AppName'),
-				$c->query('Request'),
-				$c->query('Config'),
-				new \OC\Console\Application(
-					$c->query('Config'),
-					$c->query('ServerContainer')->getEventDispatcher(),
-					$c->query('Request')
-				)
-			);
-		});
 
 		/**
 		 * Core class wrappers

--- a/core/routes.php
+++ b/core/routes.php
@@ -48,7 +48,7 @@ $application->registerRoutes($this, [
 		['name' => 'login#showLoginForm', 'url' => '/login', 'verb' => 'GET'],
 		['name' => 'login#logout', 'url' => '/logout', 'verb' => 'GET'],
 		['name' => 'token#generateToken', 'url' => '/token/generate', 'verb' => 'POST'],
-		['name' => 'occ#execute', 'url' => '/occ/{command}', 'verb' => 'POST'],
+		['name' => 'OC\Core\Controller\Occ#execute', 'url' => '/occ/{command}', 'verb' => 'POST'],
 		['name' => 'TwoFactorChallenge#selectChallenge', 'url' => '/login/selectchallenge', 'verb' => 'GET'],
 		['name' => 'TwoFactorChallenge#showChallenge', 'url' => '/login/challenge/{challengeProviderId}', 'verb' => 'GET'],
 		['name' => 'TwoFactorChallenge#solveChallenge', 'url' => '/login/challenge/{challengeProviderId}', 'verb' => 'POST'],


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Unfortunately this file was missed in  https://github.com/owncloud/core/pull/26031
so instead of logging wrong credentials it just produces the following:

```
Undefined variable: logger at /core\/Controller\/OccController.php#69
Call to a member function warning() on null at \/core\/Controller\/OccController.php#116
```
## Related Issue

none
## Motivation and Context
## How Has This Been Tested?

`curl --data "param1=value1&param2=value2" http://path/to/oc/index.php/occ/status`
and 
`tail data/owncloud.log` afterwards
## Screenshots (if appropriate):
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
