### PR TITLE
Update public.php

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -20,6 +20,23 @@ OCP\Util::addScript('files', 'newfilemenu');
 OCP\Util::addScript('files', 'files');
 OCP\Util::addScript('files', 'filelist');
 OCP\Util::addscript('files', 'keyboardshortcuts');
+
+OCP\Util::addHeader('meta', array('property' => 'og:title','content' => 'OwnCloud - ' . $l->t('Shared by link')));
+if ($_['previewSupported']):
+	$og_size_x = 400;
+	$og_size_y = 400;
+	OCP\Util::addHeader('meta', array('property' => 'og:image:width','content' => $og_size_x));
+	OCP\Util::addHeader('meta', array('property' => 'og:image:height','content' => $og_size_y));
+	OCP\Util::addHeader('meta', array(
+		'property' => 'og:image',
+		'content' => OC::$server->getURLGenerator()->linkToRoute(
+			'core_ajax_public_preview',
+			array('x' => $og_size_x,
+			'y' => $og_size_y,
+			'file' => $_['directory_path'],
+			't' => $_['dirToken']))));
+endif;
+
 ?>
 
 <?php if ($_['previewSupported']): /* This enables preview images for links (e.g. on Facebook, Google+, ...)*/?>


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

<!--- Describe your changes in detail -->

Added open-graph support to share-page: 
- That little share-title is added for all share-links. 
- When a preview can be generated, the little preview-image is also generated. 
- other cases, that open-graph might support (e.g. videos) are not explicitly included.

please be gentle; this is my first time contributing to free sorftware.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->
#12946
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

In telegram a share-link now looks like this 
![bildschirmfoto von 2016-09-16 12-12-49](https://cloud.githubusercontent.com/assets/4362465/18582804/3c7f05d8-7c07-11e6-9a7d-8ca80a3b50f0.png)
Without this patch, it looks like this:
![bildschirmfoto von 2016-09-16 12-16-01](https://cloud.githubusercontent.com/assets/4362465/18582836/6aaecd4e-7c07-11e6-8252-7f8d8bec5835.png)
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

It has been tested on 8.2.7, but not on the current version. 

Here is a link to in owncloud-instance, that already uses this feature: https://owncloud.wotanii.de/index.php/s/TQsy6hyWaSM3tBP

You can see, that there are the relavant `<meta />` tags in markup.
## Screenshots (if appropriate):

![bildschirmfoto von 2016-09-16 12-12-49](https://cloud.githubusercontent.com/assets/4362465/18582804/3c7f05d8-7c07-11e6-9a7d-8ca80a3b50f0.png)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
