### PR TITLE
Fix mimetype detection inside hidden folders

### DIFF
--- a/lib/private/Files/Type/Detection.php
+++ b/lib/private/Files/Type/Detection.php
@@ -165,9 +165,11 @@ class Detection implements IMimeTypeDetector {
 	public function detectPath($path) {
 		$this->loadMappings();
 
-		if (strpos($path, '.')) {
+		$fileName = basename($path);
+		// note: leading dot doesn't qualify as extension
+		if (strpos($fileName, '.') > 0) {
 			//try to guess the type by the file extension
-			$extension = strtolower(strrchr(basename($path), "."));
+			$extension = strtolower(strrchr($fileName, '.'));
 			$extension = substr($extension, 1); //remove leading .
 			return (isset($this->mimetypes[$extension]) && isset($this->mimetypes[$extension][0]))
 				? $this->mimetypes[$extension][0]

--- a/tests/lib/Files/Type/DetectionTest.php
+++ b/tests/lib/Files/Type/DetectionTest.php
@@ -74,6 +74,8 @@ class DetectionTest extends \Test\TestCase {
 		$this->assertEquals('text/plain', $this->detection->detectPath('foo.txt'));
 		$this->assertEquals('image/png', $this->detection->detectPath('foo.png'));
 		$this->assertEquals('image/png', $this->detection->detectPath('foo.bar.png'));
+		$this->assertEquals('image/png', $this->detection->detectPath('.hidden/foo.png'));
+		$this->assertEquals('image/png', $this->detection->detectPath('test.jpg/foo.png'));
 		$this->assertEquals('application/octet-stream', $this->detection->detectPath('.png'));
 		$this->assertEquals('application/octet-stream', $this->detection->detectPath('foo'));
 		$this->assertEquals('application/octet-stream', $this->detection->detectPath(''));


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Fix mimetype detection inside hidden folders.
There was a check to find out whether a file name contains a dot, but it was including the whole path instead of just the `basename` so the `strpos` call would return 0 and skip detection if the path looks like ".hidden/test.jpg" because of the leading dot.
## Related Issue

Fixes https://github.com/owncloud/core/issues/26133
## Motivation and Context

See issue
## How Has This Been Tested?

See steps in issue.
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
## Backports
- stable9
- stable8.2 (regression, where the bug was introduced)
