### PR TITLE
As soon as the password is reset the lost token is removed

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -39,7 +39,6 @@ use OCP\IUserManager;
 use OCP\Mail\IMailer;
 use OCP\Security\ISecureRandom;
 use \OC_Defaults;
-use OCP\Security\StringUtils;
 
 /**
  * Class LostController
@@ -127,7 +126,7 @@ class LostController extends Controller {
 		} catch (\Exception $e) {
 			return new TemplateResponse(
 				'core', 'error', [
-					"errors" => array(array("error" => $e->getMessage()))
+					"errors" => [["error" => $e->getMessage()]]
 				],
 				'guest'
 			);
@@ -137,7 +136,7 @@ class LostController extends Controller {
 			'core',
 			'lostpassword/resetpassword',
 			array(
-				'link' => $this->urlGenerator->linkToRouteAbsolute('core.lost.setPassword', array('userId' => $userId, 'token' => $token)),
+				'link' => $this->urlGenerator->linkToRouteAbsolute('core.lost.setPassword', ['userId' => $userId, 'token' => $token]),
 			),
 			'guest'
 		);
@@ -153,15 +152,18 @@ class LostController extends Controller {
 
 		$splittedToken = explode(':', $this->config->getUserValue($userId, 'owncloud', 'lostpassword', null));
 		if(count($splittedToken) !== 2) {
+			$this->config->deleteUserValue($userId, 'owncloud', 'lostpassword');
 			throw new \Exception($this->l10n->t('Couldn\'t reset password because the token is invalid'));
 		}
 
 		if ($splittedToken[0] < ($this->timeFactory->getTime() - 60*60*12) ||
 			$user->getLastLogin() > $splittedToken[0]) {
+			$this->config->deleteUserValue($userId, 'owncloud', 'lostpassword');
 			throw new \Exception($this->l10n->t('Couldn\'t reset password because the token is expired'));
 		}
 
-		if (!StringUtils::equals($splittedToken[1], $token)) {
+		if (!hash_equals($splittedToken[1], $token)) {
+			$this->config->deleteUserValue($userId, 'owncloud', 'lostpassword');
 			throw new \Exception($this->l10n->t('Couldn\'t reset password because the token is invalid'));
 		}
 	}
@@ -171,8 +173,8 @@ class LostController extends Controller {
 	 * @param array $additional
 	 * @return array
 	 */
-	private function error($message, array $additional=array()) {
-		return array_merge(array('status' => 'error', 'msg' => $message), $additional);
+	private function error($message, array $additional= []) {
+		return array_merge(['status' => 'error', 'msg' => $message], $additional);
 	}
 
 	/**
@@ -221,8 +223,6 @@ class LostController extends Controller {
 			}
 
 			\OC_Hook::emit('\OC\Core\LostPassword\Controller\LostController', 'post_passwordReset', array('uid' => $userId, 'password' => $password));
-
-			$this->config->deleteUserValue($userId, 'owncloud', 'lostpassword');
 			@\OC_User::unsetMagicInCookie();
 		} catch (\Exception $e){
 			return $this->error($e->getMessage());

--- a/core/css/lostpassword/resetpassword.css
+++ b/core/css/lostpassword/resetpassword.css
@@ -5,3 +5,11 @@
 .text-center {
 	text-align: center;
 }
+
+#submit {
+	width: 100%;
+}
+
+#password {
+	width: 100% !important;
+}

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -157,11 +157,12 @@ class User implements IUser {
 	 * @since 9.0.0
 	 */
 	public function setEMailAddress($mailAddress) {
-		if($mailAddress === '') {
+		if(is_null($mailAddress) || $mailAddress === '') {
 			$this->config->deleteUserValue($this->uid, 'settings', 'email');
 		} else {
 			$this->config->setUserValue($this->uid, 'settings', 'email', $mailAddress);
 		}
+		$this->config->deleteUserValue($this->getUID(), 'owncloud', 'lostpassword');
 		$this->triggerChange('eMailAddress', $mailAddress);
 	}
 
@@ -234,8 +235,11 @@ class User implements IUser {
 		}
 		if ($this->backend->implementsActions(Backend::SET_PASSWORD)) {
 			$result = $this->backend->setPassword($this->uid, $password);
-			if ($this->emitter) {
-				$this->emitter->emit('\OC\User', 'postSetPassword', array($this, $password, $recoveryPassword));
+			if ($result) {
+				if ($this->emitter) {
+					$this->emitter->emit('\OC\User', 'postSetPassword', array($this, $password, $recoveryPassword));
+				}
+				$this->config->deleteUserValue($this->getUID(), 'owncloud', 'lostpassword');
 			}
 			return !($result === false);
 		} else {

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -434,10 +434,6 @@ class LostControllerTest extends \PHPUnit_Framework_TestCase {
 			->method('get')
 			->with('ValidTokenUser')
 			->will($this->returnValue($user));
-		$this->config
-			->expects($this->once())
-			->method('deleteUserValue')
-			->with('ValidTokenUser', 'owncloud', 'lostpassword');
 		$this->timeFactory
 			->expects($this->once())
 			->method('getTime')

--- a/tests/lib/User/BackendTestCase.php
+++ b/tests/lib/User/BackendTestCase.php
@@ -32,7 +32,7 @@ namespace Test\User;
  * For an example see /tests/lib/user/dummy.php
  */
 
-abstract class Backend extends \Test\TestCase {
+abstract class BackendTestCase extends \Test\TestCase {
 	/**
 	 * @var \OC\User\Backend $backend
 	 */

--- a/tests/lib/User/DatabaseTest.php
+++ b/tests/lib/User/DatabaseTest.php
@@ -27,7 +27,7 @@ namespace Test\User;
  *
  * @group DB
  */
-class DatabaseTest extends Backend {
+class DatabaseTest extends BackendTestCase {
 	/** @var array */
 	private $users;
 

--- a/tests/lib/User/DummyTestCase.php
+++ b/tests/lib/User/DummyTestCase.php
@@ -22,9 +22,11 @@
 
 namespace Test\User;
 
-class Dummy extends Backend {
+use Test\Util\User\Dummy;
+
+class DummyTestCase extends BackendTestCase {
 	protected function setUp() {
 		parent::setUp();
-		$this->backend=new \Test\Util\User\Dummy();
+		$this->backend = new Dummy();
 	}
 }

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -10,6 +10,12 @@
 namespace Test\User;
 
 use OC\Hooks\PublicEmitter;
+use OC\User\Backend;
+use OC\User\Database;
+use OC\User\User;
+use OCP\IConfig;
+use Test\TestCase;
+use Test\Util\User\Dummy;
 
 /**
  * Class UserTest
@@ -18,10 +24,10 @@ use OC\Hooks\PublicEmitter;
  *
  * @package Test\User
  */
-class UserTest extends \Test\TestCase {
+class UserTest extends TestCase {
 	public function testDisplayName() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
 		$backend = $this->createMock('\OC\User\Backend');
 		$backend->expects($this->once())
@@ -31,10 +37,10 @@ class UserTest extends \Test\TestCase {
 
 		$backend->expects($this->any())
 			->method('implementsActions')
-			->with($this->equalTo(\OC\User\Backend::GET_DISPLAYNAME))
+			->with($this->equalTo(Backend::GET_DISPLAYNAME))
 			->will($this->returnValue(true));
 
-		$user = new \OC\User\User('foo', $backend);
+		$user = new User('foo', $backend);
 		$this->assertEquals('Foo', $user->getDisplayName());
 	}
 
@@ -43,7 +49,7 @@ class UserTest extends \Test\TestCase {
 	 */
 	public function testDisplayNameEmpty() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
 		$backend = $this->createMock('\OC\User\Backend');
 		$backend->expects($this->once())
@@ -53,16 +59,16 @@ class UserTest extends \Test\TestCase {
 
 		$backend->expects($this->any())
 			->method('implementsActions')
-			->with($this->equalTo(\OC\User\Backend::GET_DISPLAYNAME))
+			->with($this->equalTo(Backend::GET_DISPLAYNAME))
 			->will($this->returnValue(true));
 
-		$user = new \OC\User\User('foo', $backend);
+		$user = new User('foo', $backend);
 		$this->assertEquals('foo', $user->getDisplayName());
 	}
 
 	public function testDisplayNameNotSupported() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
 		$backend = $this->createMock('\OC\User\Backend');
 		$backend->expects($this->never())
@@ -70,41 +76,44 @@ class UserTest extends \Test\TestCase {
 
 		$backend->expects($this->any())
 			->method('implementsActions')
-			->with($this->equalTo(\OC\User\Backend::GET_DISPLAYNAME))
+			->with($this->equalTo(Backend::GET_DISPLAYNAME))
 			->will($this->returnValue(false));
 
-		$user = new \OC\User\User('foo', $backend);
+		$user = new User('foo', $backend);
 		$this->assertEquals('foo', $user->getDisplayName());
 	}
 
 	public function testSetPassword() {
-		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
-		 */
-		$backend = $this->createMock('\Test\Util\User\Dummy');
+		/** @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend */
+		$backend = $this->createMock(Dummy::class);
 		$backend->expects($this->once())
 			->method('setPassword')
-			->with($this->equalTo('foo'), $this->equalTo('bar'));
+			->with($this->equalTo('foo'), $this->equalTo('bar'))
+			->willReturn(true);
 
 		$backend->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnCallback(function ($actions) {
-				if ($actions === \OC\User\Backend::SET_PASSWORD) {
+				if ($actions === Backend::SET_PASSWORD) {
 					return true;
 				} else {
 					return false;
 				}
 			}));
+		$config = $this->createMock(IConfig::class);
+		$config->expects($this->once())
+			->method('deleteUserValue')
+			->with('foo', 'owncloud', 'lostpassword');
 
-		$user = new \OC\User\User('foo', $backend);
+		$user = new User('foo', $backend, null, $config);
 		$this->assertTrue($user->setPassword('bar',''));
 	}
 
 	public function testSetPasswordNotSupported() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->createMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(Dummy::class);
 		$backend->expects($this->never())
 			->method('setPassword');
 
@@ -112,13 +121,13 @@ class UserTest extends \Test\TestCase {
 			->method('implementsActions')
 			->will($this->returnValue(false));
 
-		$user = new \OC\User\User('foo', $backend);
+		$user = new User('foo', $backend);
 		$this->assertFalse($user->setPassword('bar',''));
 	}
 
 	public function testChangeAvatarSupportedYes() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
 		$backend = $this->createMock('Test\User\AvatarUserDummy');
 		$backend->expects($this->once())
@@ -129,20 +138,20 @@ class UserTest extends \Test\TestCase {
 		$backend->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnCallback(function ($actions) {
-				if ($actions === \OC\User\Backend::PROVIDE_AVATAR) {
+				if ($actions === Backend::PROVIDE_AVATAR) {
 					return true;
 				} else {
 					return false;
 				}
 			}));
 
-		$user = new \OC\User\User('foo', $backend);
+		$user = new User('foo', $backend);
 		$this->assertTrue($user->canChangeAvatar());
 	}
 
 	public function testChangeAvatarSupportedNo() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
 		$backend = $this->createMock('Test\User\AvatarUserDummy');
 		$backend->expects($this->once())
@@ -153,20 +162,20 @@ class UserTest extends \Test\TestCase {
 		$backend->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnCallback(function ($actions) {
-				if ($actions === \OC\User\Backend::PROVIDE_AVATAR) {
+				if ($actions === Backend::PROVIDE_AVATAR) {
 					return true;
 				} else {
 					return false;
 				}
 			}));
 
-		$user = new \OC\User\User('foo', $backend);
+		$user = new User('foo', $backend);
 		$this->assertFalse($user->canChangeAvatar());
 	}
 
 	public function testChangeAvatarNotSupported() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
 		$backend = $this->createMock('Test\User\AvatarUserDummy');
 		$backend->expects($this->never())
@@ -178,28 +187,28 @@ class UserTest extends \Test\TestCase {
 					return false;
 			}));
 
-		$user = new \OC\User\User('foo', $backend);
+		$user = new User('foo', $backend);
 		$this->assertTrue($user->canChangeAvatar());
 	}
 
 	public function testDelete() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->createMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(Dummy::class);
 		$backend->expects($this->once())
 			->method('deleteUser')
 			->with($this->equalTo('foo'));
 
-		$user = new \OC\User\User('foo', $backend);
+		$user = new User('foo', $backend);
 		$this->assertTrue($user->delete());
 	}
 
 	public function testGetHome() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->createMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(Dummy::class);
 		$backend->expects($this->once())
 			->method('getHome')
 			->with($this->equalTo('foo'))
@@ -208,29 +217,29 @@ class UserTest extends \Test\TestCase {
 		$backend->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnCallback(function ($actions) {
-				if ($actions === \OC\User\Backend::GET_HOME) {
+				if ($actions === Backend::GET_HOME) {
 					return true;
 				} else {
 					return false;
 				}
 			}));
 
-		$user = new \OC\User\User('foo', $backend);
+		$user = new User('foo', $backend);
 		$this->assertEquals('/home/foo', $user->getHome());
 	}
 
 	public function testGetBackendClassName() {
-		$user = new \OC\User\User('foo', new \Test\Util\User\Dummy());
+		$user = new User('foo', new Dummy());
 		$this->assertEquals('Dummy', $user->getBackendClassName());
-		$user = new \OC\User\User('foo', new \OC\User\Database());
+		$user = new User('foo', new Database());
 		$this->assertEquals('Database', $user->getBackendClassName());
 	}
 
 	public function testGetHomeNotSupported() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->createMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(Dummy::class);
 		$backend->expects($this->never())
 			->method('getHome');
 
@@ -249,88 +258,88 @@ class UserTest extends \Test\TestCase {
 			->with($this->equalTo('datadirectory'))
 			->will($this->returnValue('arbitrary/path'));
 
-		$user = new \OC\User\User('foo', $backend, null, $allConfig);
+		$user = new User('foo', $backend, null, $allConfig);
 		$this->assertEquals('arbitrary/path/foo', $user->getHome());
 	}
 
 	public function testCanChangePassword() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->createMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(Dummy::class);
 
 		$backend->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnCallback(function ($actions) {
-				if ($actions === \OC\User\Backend::SET_PASSWORD) {
+				if ($actions === Backend::SET_PASSWORD) {
 					return true;
 				} else {
 					return false;
 				}
 			}));
 
-		$user = new \OC\User\User('foo', $backend);
+		$user = new User('foo', $backend);
 		$this->assertTrue($user->canChangePassword());
 	}
 
 	public function testCanChangePasswordNotSupported() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->createMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(Dummy::class);
 
 		$backend->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnValue(false));
 
-		$user = new \OC\User\User('foo', $backend);
+		$user = new User('foo', $backend);
 		$this->assertFalse($user->canChangePassword());
 	}
 
 	public function testCanChangeDisplayName() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->createMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(Dummy::class);
 
 		$backend->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnCallback(function ($actions) {
-				if ($actions === \OC\User\Backend::SET_DISPLAYNAME) {
+				if ($actions === Backend::SET_DISPLAYNAME) {
 					return true;
 				} else {
 					return false;
 				}
 			}));
 
-		$user = new \OC\User\User('foo', $backend);
+		$user = new User('foo', $backend);
 		$this->assertTrue($user->canChangeDisplayName());
 	}
 
 	public function testCanChangeDisplayNameNotSupported() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->createMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(Dummy::class);
 
 		$backend->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnValue(false));
 
-		$user = new \OC\User\User('foo', $backend);
+		$user = new User('foo', $backend);
 		$this->assertFalse($user->canChangeDisplayName());
 	}
 
 	public function testSetDisplayNameSupported() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
 		$backend = $this->createMock('\OC\User\Database');
 
 		$backend->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnCallback(function ($actions) {
-				if ($actions === \OC\User\Backend::SET_DISPLAYNAME) {
+				if ($actions === Backend::SET_DISPLAYNAME) {
 					return true;
 				} else {
 					return false;
@@ -342,7 +351,7 @@ class UserTest extends \Test\TestCase {
 			->with('foo','Foo')
 			->willReturn(true);
 
-		$user = new \OC\User\User('foo', $backend);
+		$user = new User('foo', $backend);
 		$this->assertTrue($user->setDisplayName('Foo'));
 		$this->assertEquals('Foo',$user->getDisplayName());
 	}
@@ -352,28 +361,28 @@ class UserTest extends \Test\TestCase {
 	 */
 	public function testSetDisplayNameEmpty() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
 		$backend = $this->createMock('\OC\User\Database');
 
 		$backend->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnCallback(function ($actions) {
-				if ($actions === \OC\User\Backend::SET_DISPLAYNAME) {
+				if ($actions === Backend::SET_DISPLAYNAME) {
 					return true;
 				} else {
 					return false;
 				}
 			}));
 
-		$user = new \OC\User\User('foo', $backend);
+		$user = new User('foo', $backend);
 		$this->assertFalse($user->setDisplayName(' '));
 		$this->assertEquals('foo',$user->getDisplayName());
 	}
 
 	public function testSetDisplayNameNotSupported() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
 		$backend = $this->createMock('\OC\User\Database');
 
@@ -386,7 +395,7 @@ class UserTest extends \Test\TestCase {
 		$backend->expects($this->never())
 			->method('setDisplayName');
 
-		$user = new \OC\User\User('foo', $backend);
+		$user = new User('foo', $backend);
 		$this->assertFalse($user->setDisplayName('Foo'));
 		$this->assertEquals('foo',$user->getDisplayName());
 	}
@@ -396,14 +405,15 @@ class UserTest extends \Test\TestCase {
 		$test = $this;
 
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->createMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(Dummy::class);
 		$backend->expects($this->once())
-			->method('setPassword');
+			->method('setPassword')
+			->willReturn(true);
 
 		/**
-		 * @param \OC\User\User $user
+		 * @param User $user
 		 * @param string $password
 		 */
 		$hook = function ($user, $password) use ($test, &$hooksCalled) {
@@ -419,14 +429,14 @@ class UserTest extends \Test\TestCase {
 		$backend->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnCallback(function ($actions) {
-				if ($actions === \OC\User\Backend::SET_PASSWORD) {
+				if ($actions === Backend::SET_PASSWORD) {
 					return true;
 				} else {
 					return false;
 				}
 			}));
 
-		$user = new \OC\User\User('foo', $backend, $emitter);
+		$user = new User('foo', $backend, $emitter);
 
 		$user->setPassword('bar','');
 		$this->assertEquals(2, $hooksCalled);
@@ -437,14 +447,14 @@ class UserTest extends \Test\TestCase {
 		$test = $this;
 
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->createMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(Dummy::class);
 		$backend->expects($this->once())
 			->method('deleteUser');
 
 		/**
-		 * @param \OC\User\User $user
+		 * @param User $user
 		 */
 		$hook = function ($user) use ($test, &$hooksCalled) {
 			$hooksCalled++;
@@ -455,16 +465,16 @@ class UserTest extends \Test\TestCase {
 		$emitter->listen('\OC\User', 'preDelete', $hook);
 		$emitter->listen('\OC\User', 'postDelete', $hook);
 
-		$user = new \OC\User\User('foo', $backend, $emitter);
+		$user = new User('foo', $backend, $emitter);
 		$this->assertTrue($user->delete());
 		$this->assertEquals(2, $hooksCalled);
 	}
 
 	public function testGetCloudId() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->createMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(Dummy::class);
 		$urlGenerator = $this->getMockBuilder('\OC\URLGenerator')
 				->setMethods(['getAbsoluteURL'])
 				->disableOriginalConstructor()->getMock();
@@ -473,7 +483,7 @@ class UserTest extends \Test\TestCase {
 				->method('getAbsoluteURL')
 				->withAnyParameters()
 				->willReturn('http://localhost:8888/owncloud');
-		$user = new \OC\User\User('foo', $backend, null, null, $urlGenerator);
+		$user = new User('foo', $backend, null, null, $urlGenerator);
 		$this->assertEquals("foo@localhost:8888/owncloud", $user->getCloudId());
 	}
 }

--- a/tests/lib/UserTest.php
+++ b/tests/lib/UserTest.php
@@ -8,6 +8,7 @@
  */
 
 namespace Test;
+use OC_User_Backend;
 
 /**
  * Class User
@@ -41,7 +42,7 @@ class UserTest extends TestCase {
 		$this->backend->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnCallback(function ($actions) {
-				if ($actions === \OC_USER_BACKEND_CHECK_PASSWORD) {
+				if ($actions === OC_User_Backend::CHECK_PASSWORD) {
 					return true;
 				} else {
 					return false;


### PR DESCRIPTION
## Description

As soon as the password is changed the lost password token is removed.
## How Has This Been Tested?
1. login with wrong password
2. click on lost password and receive an email with a link to reset the password
3. login with the correct password in another browser/incognito tab
4. change the password
5. reload the password reset link
6. the link is no longer valid (before this patch it was)
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
