### PR TITLE
Redirect to challenge page when only one 2FA provider

### DIFF
--- a/core/Controller/TwoFactorChallengeController.php
+++ b/core/Controller/TwoFactorChallengeController.php
@@ -80,6 +80,19 @@ class TwoFactorChallengeController extends Controller {
 	public function selectChallenge($redirect_url) {
 		$user = $this->userSession->getUser();
 		$providers = $this->twoFactorManager->getProviders($user);
+		if (count($providers) === 1) {
+			// redirect to the challenge page
+			$provider = current($providers);
+			return new RedirectResponse(
+				$this->urlGenerator->linkToRoute(
+					'core.TwoFactorChallenge.showChallenge',
+					[
+						'challengeProviderId' => $provider->getId(),
+						'redirect_url' => $redirect_url,
+					]
+				)
+			);
+		}
 
 		$data = [
 			'providers' => $providers,

--- a/tests/Core/Controller/TwoFactorChallengeControllerTest.php
+++ b/tests/Core/Controller/TwoFactorChallengeControllerTest.php
@@ -99,6 +99,37 @@ class TwoFactorChallengeControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->controller->selectChallenge('/some/url'));
 	}
 
+	public function testSelectChallengeSingleEntry() {
+		$provider = $this->createMock('\OCP\Authentication\TwoFactorAuth\IProvider');
+		$user = $this->createMock('\OCP\IUser');
+		$providers = [$provider];
+
+		$this->userSession->expects($this->once())
+			->method('getUser')
+			->will($this->returnValue($user));
+		$this->twoFactorManager->expects($this->once())
+			->method('getProviders')
+			->with($user)
+			->will($this->returnValue($providers));
+
+		$provider->expects($this->once())
+			->method('getId')
+			->will($this->returnValue('prov1'));
+
+		$url = $this->urlGenerator->linkToRoute(
+			'core.TwoFactorChallenge.showChallenge',
+			[
+				'challengeProviderId' => 'prov1',
+				'redirect_url' => '/some/url',
+			]
+		);
+		$expected = new RedirectResponse($url);
+
+		$response = $this->controller->selectChallenge('/some/url');
+		$this->assertEquals($expected, $response);
+		$this->assertEquals($url, $response->getRedirectURL());
+	}
+
 	public function testShowChallenge() {
 		$user = $this->createMock('\OCP\IUser');
 		$provider = $this->getMockBuilder('\OCP\Authentication\TwoFactorAuth\IProvider')


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

If only one two factor provider exists, spare the user from having to select it and redirect directly to its challenge page.
## Related Issue

Fixes https://github.com/owncloud/core/issues/26134
## Motivation and Context

See original issue
## How Has This Been Tested?

Tested with this app: https://github.com/owncloud/twofactor_email
- [x] TEST: challenge page shown directly
- [x] TEST: redirect URL was kept (use a non-standard one)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review @DeepDiver1975 @butonic @VicDeo @jvillafanez @SergioBertolinSG 
