### PR TITLE
add test for . in path with no extension, fix smb

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -399,11 +399,6 @@ class SMB extends Common {
 				case 'c':
 				case 'c+':
 					//emulate these
-					if (strrpos($path, '.') !== false) {
-						$ext = substr($path, strrpos($path, '.'));
-					} else {
-						$ext = '';
-					}
 					if ($this->file_exists($path)) {
 						if (!$this->isUpdatable($path)) {
 							break;
@@ -413,7 +408,7 @@ class SMB extends Common {
 						if (!$this->isCreatable(dirname($path))) {
 							break;
 						}
-						$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
+						$tmpFile = \OC::$server->getTempManager()->getTemporaryFile();
 					}
 					$source = fopen($tmpFile, $mode);
 					$share = $this->share;

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -512,9 +512,18 @@ class SMB extends Common {
 	public function mkdir($path) {
 		$this->log('enter: '.__FUNCTION__."($path)");
 		$result = false;
-		$path = $this->buildPath($path);
+		$dirs = explode('/', $path);
+		$currDir = '';
 		try {
-			$result = $this->share->mkdir($path);
+			foreach ($dirs as $dir) {
+				$currDir .= '/'.$dir;
+				try {
+					$path = $this->buildPath($currDir);
+					$result = $this->share->mkdir($path);
+				} catch (AlreadyExistsException $e) {
+					$this->swallow(__FUNCTION__, $e);
+				}
+			}
 		} catch (ConnectException $e) {
 			$ex = new StorageNotAvailableException(
 				$e->getMessage(), $e->getCode(), $e);

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -408,7 +408,8 @@ class SMB extends Common {
 						if (!$this->isCreatable(dirname($path))) {
 							break;
 						}
-						$tmpFile = \OC::$server->getTempManager()->getTemporaryFile();
+						$ext = \OCP\Files::pathinfo($path, PATHINFO_EXTENSION);
+						$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
 					}
 					$source = fopen($tmpFile, $mode);
 					$share = $this->share;
@@ -512,18 +513,9 @@ class SMB extends Common {
 	public function mkdir($path) {
 		$this->log('enter: '.__FUNCTION__."($path)");
 		$result = false;
-		$dirs = explode('/', $path);
-		$currDir = '';
+		$path = $this->buildPath($path);
 		try {
-			foreach ($dirs as $dir) {
-				$currDir .= '/'.$dir;
-				try {
-					$path = $this->buildPath($currDir);
-					$result = $this->share->mkdir($path);
-				} catch (AlreadyExistsException $e) {
-					$this->swallow(__FUNCTION__, $e);
-				}
-			}
+			$result = $this->share->mkdir($path);
 		} catch (ConnectException $e) {
 			$ex = new StorageNotAvailableException(
 				$e->getMessage(), $e->getCode(), $e);

--- a/apps/files_external/tests/Storage/SmbTest.php
+++ b/apps/files_external/tests/Storage/SmbTest.php
@@ -65,7 +65,13 @@ class SmbTest extends \Test\Files\Storage\Storage {
 
 	public function directoryProvider() {
 		// doesn't support leading/trailing spaces
-		return [['folder']];
+		return [
+			['folder'],
+			// doesn't support leading/trailing spaces
+			['folder with space'],
+			['spéciäl földer'],
+			['test single\'quote'],
+		];
 	}
 
 	public function testRenameWithSpaces() {

--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -262,7 +262,7 @@ class Helper {
 	 * @return string $path
 	 */
 	public static function generateUniqueTarget($path, $excludeList, $view) {
-		$pathinfo = pathinfo($path);
+		$pathinfo = \OCP\Files::pathinfo($path);
 		$ext = (isset($pathinfo['extension'])) ? '.'.$pathinfo['extension'] : '';
 		$name = $pathinfo['filename'];
 		$dir = $pathinfo['dirname'];

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -128,7 +128,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 	 * @return mixed
 	 */
 	private function generateUniqueTarget($path, $view, array $mountpoints) {
-		$pathinfo = pathinfo($path);
+		$pathinfo = \OCP\Files::pathinfo($path);
 		$ext = (isset($pathinfo['extension'])) ? '.'.$pathinfo['extension'] : '';
 		$name = $pathinfo['filename'];
 		$dir = $pathinfo['dirname'];

--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -198,7 +198,7 @@ class Updater implements IUpdater {
 			}
 		}
 
-		if (pathinfo($source, PATHINFO_EXTENSION) !== pathinfo($target, PATHINFO_EXTENSION)) {
+		if (\OCP\Files::pathinfo($source, PATHINFO_EXTENSION) !== \OCP\Files::pathinfo($target, PATHINFO_EXTENSION)) {
 			// handle mime type change
 			$mimeType = $this->storage->getMimeType($target);
 			$fileId = $this->cache->getId($target);

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -279,11 +279,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 			case 'x+':
 			case 'c':
 			case 'c+':
-				if (strrpos($path, '.') !== false) {
-					$ext = substr($path, strrpos($path, '.'));
-				} else {
-					$ext = '';
-				}
+				$ext = \OCP\Files::pathinfo($path, PATHINFO_EXTENSION);
 				$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
 				\OC\Files\Stream\Close::registerCallback($tmpFile, [$this, 'writeBack']);
 				if ($this->file_exists($path)) {

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -388,16 +388,12 @@ class DAV extends Common {
 			case 'c+':
 				//emulate these
 				$tempManager = \OC::$server->getTempManager();
-				if (strrpos($path, '.') !== false) {
-					$ext = substr($path, strrpos($path, '.'));
-				} else {
-					$ext = '';
-				}
 				if ($this->file_exists($path)) {
 					if (!$this->isUpdatable($path)) {
 						return false;
 					}
 					if ($mode === 'w' or $mode === 'w+') {
+						$ext = \OCP\Files::pathinfo($path, PATHINFO_EXTENSION);
 						$tmpFile = $tempManager->getTemporaryFile($ext);
 					} else {
 						$tmpFile = $this->getCachedFile($path);
@@ -406,6 +402,7 @@ class DAV extends Common {
 					if (!$this->isCreatable(dirname($path))) {
 						return false;
 					}
+					$ext = \OCP\Files::pathinfo($path, PATHINFO_EXTENSION);
 					$tmpFile = $tempManager->getTemporaryFile($ext);
 				}
 				Close::registerCallback($tmpFile, [$this, 'writeBack']);

--- a/lib/private/Files/Storage/LocalTempFileTrait.php
+++ b/lib/private/Files/Storage/LocalTempFileTrait.php
@@ -66,7 +66,8 @@ trait LocalTempFileTrait {
 		if (!$source) {
 			return false;
 		}
-		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile();
+		$ext = \OCP\Files::pathinfo($path, PATHINFO_EXTENSION);
+		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
 		$target = fopen($tmpFile, 'w');
 		\OC_Helper::streamCopy($source, $target);
 		fclose($target);

--- a/lib/private/Files/Storage/LocalTempFileTrait.php
+++ b/lib/private/Files/Storage/LocalTempFileTrait.php
@@ -66,12 +66,7 @@ trait LocalTempFileTrait {
 		if (!$source) {
 			return false;
 		}
-		if ($pos = strrpos($path, '.')) {
-			$extension = substr($path, $pos);
-		} else {
-			$extension = '';
-		}
-		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($extension);
+		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile();
 		$target = fopen($tmpFile, 'w');
 		\OC_Helper::streamCopy($source, $target);
 		fclose($target);

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -971,8 +971,8 @@ class View {
 		if (Filesystem::isValidPath($path)) {
 			$source = $this->fopen($path, 'r');
 			if ($source) {
-				$extension = pathinfo($path, PATHINFO_EXTENSION);
-				$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($extension);
+				$ext = \OCP\Files::pathinfo($path, PATHINFO_EXTENSION);
+				$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
 				file_put_contents($tmpFile, $source);
 				return $tmpFile;
 			} else {

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -271,25 +271,24 @@ class Installer {
 	public static function downloadApp($data = []) {
 		$l = \OC::$server->getL10N('lib');
 
-		if(!isset($data['source'])) {
+		if (!isset($data['source'])) {
 			throw new \Exception($l->t("No source specified when installing app"));
 		}
 
 		//download the file if necessary
-		if($data['source']=='http') {
-			$pathInfo = pathinfo($data['href']);
-			$extension = isset($pathInfo['extension']) ? '.' . $pathInfo['extension'] : '';
-			$path = \OC::$server->getTempManager()->getTemporaryFile($extension);
+		if ($data['source'] === 'http') {
 			if(!isset($data['href'])) {
 				throw new \Exception($l->t("No href specified when installing app from http"));
 			}
+			$ext = \OCP\Files::pathinfo($data['href'], PATHINFO_EXTENSION);
+			$path = \OC::$server->getTempManager()->getTemporaryFile($ext);
 			$client = \OC::$server->getHTTPClientService()->newClient();
 			$client->get($data['href'], ['save_to' => $path]);
 		} else {
 			if(!isset($data['path'])) {
 				throw new \Exception($l->t("No path specified when installing app from local file"));
 			}
-			$path=$data['path'];
+			$path = $data['path'];
 		}
 
 		//detect the archive type
@@ -302,11 +301,11 @@ class Installer {
 		$extractDir = \OC::$server->getTempManager()->getTemporaryFolder();
 		OC_Helper::rmdirr($extractDir);
 		mkdir($extractDir);
-		if($archive=\OC\Archive\Archive::open($path)) {
+		if ($archive=\OC\Archive\Archive::open($path)) {
 			$archive->extract($extractDir);
 		} else {
 			OC_Helper::rmdirr($extractDir);
-			if($data['source']=='http') {
+			if ($data['source']=='http') {
 				unlink($path);
 			}
 			throw new \Exception($l->t("Failed to open archive when installing app"));

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -162,11 +162,15 @@ abstract class Storage extends \Test\TestCase {
 		// filename does not contain a dot / extension, but parent dirs do ...
 		$path = '/something/that/is/not.supposed/to happen/lorem';
 		$lorem = 'lorem ipsum dolor sit ...';
+		self::assertTrue($this->instance->mkdir('/something/that/is/not.supposed/to happen'));
 
-		$this->instance->mkdir(dirname($path));
-		$this->instance->file_put_contents($path, $lorem);
+		//use fopen with w+ to walk affected code path
+		$handle = $this->instance->fopen($path, 'w+');
+		self::assertNotFalse($handle);
+		self::assertSame(strlen($lorem), fwrite($handle, $lorem));
+		self::assertTrue(fclose($handle));
 
-		$this->assertEquals( $this->instance->file_get_contents($path), $lorem, 'data returned from file_get_contents is not equal to the source data');
+		self::assertEquals( $this->instance->file_get_contents($path), $lorem, 'data returned from file_get_contents is not equal to the source data');
 	}
 
 	/**

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -156,6 +156,20 @@ abstract class Storage extends \Test\TestCase {
 	}
 
 	/**
+	 * test path corner case
+	 */
+	public function testWriteWithDotInPath() {
+		// filename does not contain a dot / extension, but parent dirs do ...
+		$path = '/something/that/is/not.supposed/to happen/lorem';
+		$lorem = 'lorem ipsum dolor sit ...';
+
+		$this->instance->mkdir(dirname($path));
+		$this->instance->file_put_contents($path, $lorem);
+
+		$this->assertEquals( $this->instance->file_get_contents($path), $lorem, 'data returned from file_get_contents is not equal to the source data');
+	}
+
+	/**
 	 * test various known mimetypes
 	 */
 	public function testMimeType() {

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -162,6 +162,12 @@ abstract class Storage extends \Test\TestCase {
 		// filename does not contain a dot / extension, but parent dirs do ...
 		$path = '/something/that/is/not.supposed/to happen/lorem';
 		$lorem = 'lorem ipsum dolor sit ...';
+
+		//FIXME test and implement recursive mkdir
+		self::assertTrue($this->instance->mkdir('/something'));
+		self::assertTrue($this->instance->mkdir('/something/that'));
+		self::assertTrue($this->instance->mkdir('/something/that/is'));
+		self::assertTrue($this->instance->mkdir('/something/that/is/not.supposed'));
 		self::assertTrue($this->instance->mkdir('/something/that/is/not.supposed/to happen'));
 
 		//use fopen with w+ to walk affected code path

--- a/tests/lib/FilesTest.php
+++ b/tests/lib/FilesTest.php
@@ -271,6 +271,220 @@ class FilesTest extends \Test\TestCase {
 				'/something/that/is/not.supposed/to happen/lorem.tar.bz2',
 				PATHINFO_FILENAME, 'lorem',
 			],
+
+			// .files
+			[
+				'/www/htdocs/inc/.hidden-without-further-dots',
+				PATHINFO_DIRNAME | PATHINFO_BASENAME | PATHINFO_EXTENSION | PATHINFO_FILENAME,
+				[
+					'dirname' => '/www/htdocs/inc',
+					'basename' => '.hidden-without-further-dots',
+					'extension' => 'hidden-without-further-dots',
+					'filename' => '',
+				]
+			],
+			[
+				'/www/htdocs/inc/.lib.inc.php',
+				PATHINFO_DIRNAME | PATHINFO_BASENAME | PATHINFO_EXTENSION | PATHINFO_FILENAME,
+				[
+					'dirname' => '/www/htdocs/inc',
+					'basename' => '.lib.inc.php',
+					'extension' => 'php',
+					'filename' => '.lib.inc',
+				]
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.gz',
+				PATHINFO_DIRNAME | PATHINFO_BASENAME | PATHINFO_EXTENSION | PATHINFO_FILENAME,
+				[
+					'dirname' => '/something/that/is/not.supposed/to happen',
+					'basename' => '.lorem.gz',
+					'extension' => 'gz',
+					'filename' => '.lorem',
+				]
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.tar.gz',
+				PATHINFO_DIRNAME | PATHINFO_BASENAME | PATHINFO_EXTENSION | PATHINFO_FILENAME,
+				[
+					'dirname' => '/something/that/is/not.supposed/to happen',
+					'basename' => '.lorem.tar.gz',
+					'extension' => 'tar.gz',
+					'filename' => '.lorem',
+				]
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.bz2',
+				PATHINFO_DIRNAME | PATHINFO_BASENAME | PATHINFO_EXTENSION | PATHINFO_FILENAME,
+				[
+					'dirname' => '/something/that/is/not.supposed/to happen',
+					'basename' => '.lorem.bz2',
+					'extension' => 'bz2',
+					'filename' => '.lorem',
+				]
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.tar.bz2',
+				PATHINFO_DIRNAME | PATHINFO_BASENAME | PATHINFO_EXTENSION | PATHINFO_FILENAME,
+				[
+					'dirname' => '/something/that/is/not.supposed/to happen',
+					'basename' => '.lorem.tar.bz2',
+					'extension' => 'tar.bz2',
+					'filename' => '.lorem',
+				]
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.....',
+				PATHINFO_DIRNAME | PATHINFO_BASENAME | PATHINFO_EXTENSION | PATHINFO_FILENAME,
+				[
+					'dirname' => '/something/that/is/not.supposed/to happen',
+					'basename' => '.....',
+					'extension' => '',
+					'filename' => '....',
+				]
+			],
+
+			[
+				'/www/htdocs/inc/.hidden-without-further-dots',
+				PATHINFO_DIRNAME, '/www/htdocs/inc',
+			],
+			[
+				'/www/htdocs/inc/.lib.inc.php',
+				PATHINFO_DIRNAME, '/www/htdocs/inc',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.gz',
+				PATHINFO_DIRNAME, '/something/that/is/not.supposed/to happen'
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.tar.gz',
+				PATHINFO_DIRNAME, '/something/that/is/not.supposed/to happen'
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.bz2',
+				PATHINFO_DIRNAME, '/something/that/is/not.supposed/to happen'
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.tar.bz2',
+				PATHINFO_DIRNAME, '/something/that/is/not.supposed/to happen'
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.....',
+				PATHINFO_DIRNAME, '/something/that/is/not.supposed/to happen'
+			],
+
+			[
+				'/www/htdocs/inc/.hidden-without-further-dots',
+				PATHINFO_BASENAME, '.hidden-without-further-dots',
+			],
+			[
+				'/www/htdocs/inc/.lib.inc.php',
+				PATHINFO_BASENAME, '.lib.inc.php',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.gz',
+				PATHINFO_BASENAME, '.lorem.gz'
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.tar.gz',
+				PATHINFO_BASENAME, '.lorem.tar.gz'
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.bz2',
+				PATHINFO_BASENAME, '.lorem.bz2'
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.tar.bz2',
+				PATHINFO_BASENAME, '.lorem.tar.bz2'
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.....',
+				PATHINFO_BASENAME, '.....',
+			],
+
+			[
+				'/www/htdocs/inc/.hidden-without-further-dots',
+				PATHINFO_EXTENSION, 'hidden-without-further-dots',
+			],
+			[
+				'/www/htdocs/inc/.lib.inc.php',
+				PATHINFO_EXTENSION, 'php',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.gz',
+				PATHINFO_EXTENSION, 'gz',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.tar.gz',
+				PATHINFO_EXTENSION, 'tar.gz',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.bz2',
+				PATHINFO_EXTENSION, 'bz2',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.tar.bz2',
+				PATHINFO_EXTENSION, 'tar.bz2',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.....',
+				PATHINFO_EXTENSION, '',
+			],
+
+			[
+				'/www/htdocs/inc/.hidden-without-further-dots',
+				PATHINFO_FILENAME, '',
+			],
+			[
+				'/www/htdocs/inc/.lib.inc.php',
+				PATHINFO_FILENAME, '.lib.inc',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.gz',
+				PATHINFO_FILENAME, '.lorem',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.tar.gz',
+				PATHINFO_FILENAME, '.lorem',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.bz2',
+				PATHINFO_FILENAME, '.lorem',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.lorem.tar.bz2',
+				PATHINFO_FILENAME, '.lorem',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/.....',
+				PATHINFO_FILENAME, '....',
+			],
+
+			// invalid option combinations
+			[
+				'/something/that/is/not.supposed/to happen/lorem.txt',
+				PATHINFO_FILENAME | PATHINFO_DIRNAME,
+				pathinfo(
+					'/something/that/is/not.supposed/to happen/lorem.txt',
+					PATHINFO_FILENAME | PATHINFO_DIRNAME
+				)
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.txt',
+				PATHINFO_FILENAME | PATHINFO_DIRNAME | PATHINFO_EXTENSION,
+				pathinfo(
+					'/something/that/is/not.supposed/to happen/lorem.txt',
+					PATHINFO_FILENAME | PATHINFO_DIRNAME | PATHINFO_EXTENSION
+				)
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.txt',
+				PATHINFO_FILENAME | PATHINFO_EXTENSION,
+				pathinfo(
+					'/something/that/is/not.supposed/to happen/lorem.txt',
+					PATHINFO_FILENAME | PATHINFO_EXTENSION
+				)
+			],
 		];
 	}
 	/**

--- a/tests/lib/FilesTest.php
+++ b/tests/lib/FilesTest.php
@@ -132,4 +132,152 @@ class FilesTest extends \Test\TestCase {
 		);
 		$this->assertEquals($userIniSize + $userIniSizeMod, filesize($files['.user.ini']));
 	}
+
+
+
+	public function pathinfoProvider() {
+		return [
+			[
+				'/www/htdocs/inc/lib.inc.php',
+				PATHINFO_DIRNAME | PATHINFO_BASENAME | PATHINFO_EXTENSION | PATHINFO_FILENAME,
+				[
+					'dirname' => '/www/htdocs/inc',
+					'basename' => 'lib.inc.php',
+					'extension' => 'php',
+					'filename' => 'lib.inc',
+				]
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.gz',
+				PATHINFO_DIRNAME | PATHINFO_BASENAME | PATHINFO_EXTENSION | PATHINFO_FILENAME,
+				[
+					'dirname' => '/something/that/is/not.supposed/to happen',
+					'basename' => 'lorem.gz',
+					'extension' => 'gz',
+					'filename' => 'lorem',
+				]
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.tar.gz',
+				PATHINFO_DIRNAME | PATHINFO_BASENAME | PATHINFO_EXTENSION | PATHINFO_FILENAME,
+				[
+					'dirname' => '/something/that/is/not.supposed/to happen',
+					'basename' => 'lorem.tar.gz',
+					'extension' => 'tar.gz',
+					'filename' => 'lorem',
+				]
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.bz2',
+				PATHINFO_DIRNAME | PATHINFO_BASENAME | PATHINFO_EXTENSION | PATHINFO_FILENAME,
+				[
+					'dirname' => '/something/that/is/not.supposed/to happen',
+					'basename' => 'lorem.bz2',
+					'extension' => 'bz2',
+					'filename' => 'lorem',
+				]
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.tar.bz2',
+				PATHINFO_DIRNAME | PATHINFO_BASENAME | PATHINFO_EXTENSION | PATHINFO_FILENAME,
+				[
+					'dirname' => '/something/that/is/not.supposed/to happen',
+					'basename' => 'lorem.tar.bz2',
+					'extension' => 'tar.bz2',
+					'filename' => 'lorem',
+				]
+			],
+
+			[
+				'/www/htdocs/inc/lib.inc.php',
+				PATHINFO_DIRNAME, '/www/htdocs/inc',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.gz',
+				PATHINFO_DIRNAME, '/something/that/is/not.supposed/to happen'
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.tar.gz',
+				PATHINFO_DIRNAME, '/something/that/is/not.supposed/to happen'
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.bz2',
+				PATHINFO_DIRNAME, '/something/that/is/not.supposed/to happen'
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.tar.bz2',
+				PATHINFO_DIRNAME, '/something/that/is/not.supposed/to happen'
+			],
+
+			[
+				'/www/htdocs/inc/lib.inc.php',
+				PATHINFO_BASENAME, 'lib.inc.php',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.gz',
+				PATHINFO_BASENAME, 'lorem.gz'
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.tar.gz',
+				PATHINFO_BASENAME, 'lorem.tar.gz'
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.bz2',
+				PATHINFO_BASENAME, 'lorem.bz2'
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.tar.bz2',
+				PATHINFO_BASENAME, 'lorem.tar.bz2'
+			],
+
+			[
+				'/www/htdocs/inc/lib.inc.php',
+				PATHINFO_EXTENSION, 'php',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.gz',
+				PATHINFO_EXTENSION, 'gz',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.tar.gz',
+				PATHINFO_EXTENSION, 'tar.gz',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.bz2',
+				PATHINFO_EXTENSION, 'bz2',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.tar.bz2',
+				PATHINFO_EXTENSION, 'tar.bz2',
+			],
+
+			[
+				'/www/htdocs/inc/lib.inc.php',
+				PATHINFO_FILENAME, 'lib.inc',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.gz',
+				PATHINFO_FILENAME, 'lorem',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.tar.gz',
+				PATHINFO_FILENAME, 'lorem',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.bz2',
+				PATHINFO_FILENAME, 'lorem',
+			],
+			[
+				'/something/that/is/not.supposed/to happen/lorem.tar.bz2',
+				PATHINFO_FILENAME, 'lorem',
+			],
+		];
+	}
+	/**
+	 * @dataProvider pathinfoProvider
+	 */
+	public function testPathinfo($path, $options, $expectedResult) {
+		$result = \OCP\Files::pathinfo($path, $options);
+		self::assertEquals($expectedResult, $result);
+	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description
- No longer try to append the original file extension to a temp file used when uploading to an SMB storage.
- Implement recursive mkdir
- Add unit test.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->

https://github.com/owncloud/core/pull/25994#r77006659
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

removes unnecessary code which might lead to problems
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

new unit test
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
