### PR TITLE
Storage 503 message improvements

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
@@ -48,6 +48,7 @@ class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
 		// Happens when an external storage or federated share is temporarily
 		// not available
 		'Sabre\DAV\Exception\StorageNotAvailableException' => true,
+		'OCP\Files\StorageNotAvailableException' => true,
 	];
 
 	/** @var string */
@@ -90,6 +91,14 @@ class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
 		$level = \OCP\Util::FATAL;
 		if (isset($this->nonFatalExceptions[$exceptionClass])) {
 			$level = \OCP\Util::DEBUG;
+		}
+
+		$previous = $ex->getPrevious();
+		if ($previous !== null) {
+			$previousExceptionClass = get_class($previous);
+			if (isset($this->nonFatalExceptions[$previousExceptionClass])) {
+				$level = \OCP\Util::DEBUG;
+			}
 		}
 
 		$message = $ex->getMessage();

--- a/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
@@ -45,6 +45,9 @@ class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
 		'Sabre\DAV\Exception\Forbidden' => true,
 		// Custom exception similar to NotAuthenticated
 		'OCA\DAV\Connector\Sabre\Exception\PasswordLoginForbidden' => true,
+		// Happens when an external storage or federated share is temporarily
+		// not available
+		'Sabre\DAV\Exception\StorageNotAvailableException' => true,
 	];
 
 	/** @var string */

--- a/apps/dav/lib/Connector/Sabre/ObjectTree.php
+++ b/apps/dav/lib/Connector/Sabre/ObjectTree.php
@@ -167,7 +167,7 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			try {
 				$info = $this->fileView->getFileInfo($path);
 			} catch (StorageNotAvailableException $e) {
-				throw new \Sabre\DAV\Exception\ServiceUnavailable('Storage is temporarily not available');
+				throw new \Sabre\DAV\Exception\ServiceUnavailable('Storage is temporarily not available', 0, $e);
 			} catch (StorageInvalidException $e) {
 				throw new \Sabre\DAV\Exception\NotFound('Storage ' . $path . ' is invalid');
 			} catch (LockedException $e) {

--- a/apps/dav/lib/Connector/Sabre/ObjectTree.php
+++ b/apps/dav/lib/Connector/Sabre/ObjectTree.php
@@ -167,7 +167,7 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			try {
 				$info = $this->fileView->getFileInfo($path);
 			} catch (StorageNotAvailableException $e) {
-				throw new \Sabre\DAV\Exception\ServiceUnavailable('Storage not available');
+				throw new \Sabre\DAV\Exception\ServiceUnavailable('Storage is temporarily not available');
 			} catch (StorageInvalidException $e) {
 				throw new \Sabre\DAV\Exception\NotFound('Storage ' . $path . ' is invalid');
 			} catch (LockedException $e) {

--- a/apps/files/ajax/list.php
+++ b/apps/files/ajax/list.php
@@ -81,7 +81,7 @@ try {
 	OCP\JSON::error([
 		'data' => [
 			'exception' => '\OCP\Files\StorageNotAvailableException',
-			'message' => $l->t('Storage not available')
+			'message' => $l->t('Storage is temporarily not available')
 		]
 	]);
 } catch (\OCP\Files\StorageInvalidException $e) {

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1586,7 +1586,7 @@
 					this.changeDirectory('/');
 					// TODO: read error message from exception
 					OC.Notification.showTemporary(
-						t('files', 'Storage not available')
+						t('files', 'Storage is temporarily not available')
 					);
 				}
 				return false;

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2827,7 +2827,7 @@ describe('OCA.Files.FileList tests', function() {
 		});
 		it('redirects to root folder and shows notification in case of storage not available', function () {
 			expect(notificationStub.notCalled).toEqual(true);
-			deferredList.reject(503, 'Storage not available');
+			deferredList.reject(503, 'Storage is temporarily not available');
 
 			expect(fileList.getCurrentDirectory()).toEqual('/');
 			expect(getFolderContentsStub.calledTwice).toEqual(true);

--- a/lib/public/Files/StorageNotAvailableException.php
+++ b/lib/public/Files/StorageNotAvailableException.php
@@ -57,7 +57,7 @@ class StorageNotAvailableException extends HintException {
 	 */
 	public function __construct($message = '', $code = self::STATUS_ERROR, \Exception $previous = null) {
 		$l = \OC::$server->getL10N('core');
-		parent::__construct($message, $l->t('Storage not available'), $code, $previous);
+		parent::__construct($message, $l->t('Storage is temporarily not available'), $code, $previous);
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

"Storage not available" is now "Storage temporarily not available".
Exceptions are now logged in DEBUG level, not FATAL.
## Related Issue

For https://github.com/owncloud/core/issues/25854#issuecomment-244923063
## Motivation and Context

See https://github.com/owncloud/core/issues/25854#issuecomment-244923063
## How Has This Been Tested?

Setup a federated share.
Set the source share server to maintenance mode.
Try accessing the received federated share.
- [x] TEST: Check the log that the log level is DEBUG for StorageNotAvailableException
- [x] TEST: UI message says "Storage is temporarily not available" now
- [x] TEST: Webdav response message also says says "Storage is temporarily not available"
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@owncloud/filesystem @mmattel 
