### PR TITLE
[stable9.1] Redirect to challenge page when only one 2FA provider

### DIFF
--- a/core/Controller/TwoFactorChallengeController.php
+++ b/core/Controller/TwoFactorChallengeController.php
@@ -78,6 +78,19 @@ class TwoFactorChallengeController extends Controller {
 	public function selectChallenge($redirect_url) {
 		$user = $this->userSession->getUser();
 		$providers = $this->twoFactorManager->getProviders($user);
+		if (count($providers) === 1) {
+			// redirect to the challenge page
+			$provider = current($providers);
+			return new RedirectResponse(
+				$this->urlGenerator->linkToRoute(
+					'core.TwoFactorChallenge.showChallenge',
+					[
+						'challengeProviderId' => $provider->getId(),
+						'redirect_url' => $redirect_url,
+					]
+				)
+			);
+		}
 
 		$data = [
 			'providers' => $providers,

--- a/tests/Core/Controller/TwoFactorChallengeControllerTest.php
+++ b/tests/Core/Controller/TwoFactorChallengeControllerTest.php
@@ -87,6 +87,37 @@ class TwoFactorChallengeControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->controller->selectChallenge('/some/url'));
 	}
 
+	public function testSelectChallengeSingleEntry() {
+		$provider = $this->createMock('\OCP\Authentication\TwoFactorAuth\IProvider');
+		$user = $this->createMock('\OCP\IUser');
+		$providers = [$provider];
+
+		$this->userSession->expects($this->once())
+			->method('getUser')
+			->will($this->returnValue($user));
+		$this->twoFactorManager->expects($this->once())
+			->method('getProviders')
+			->with($user)
+			->will($this->returnValue($providers));
+
+		$provider->expects($this->once())
+			->method('getId')
+			->will($this->returnValue('prov1'));
+
+		$url = $this->urlGenerator->linkToRoute(
+			'core.TwoFactorChallenge.showChallenge',
+			[
+				'challengeProviderId' => 'prov1',
+				'redirect_url' => '/some/url',
+			]
+		);
+		$expected = new RedirectResponse($url);
+
+		$response = $this->controller->selectChallenge('/some/url');
+		$this->assertEquals($expected, $response);
+		$this->assertEquals($url, $response->getRedirectURL());
+	}
+
 	public function testShowChallenge() {
 		$user = $this->getMock('\OCP\IUser');
 		$provider = $this->getMockBuilder('\OCP\Authentication\TwoFactorAuth\IProvider')


### PR DESCRIPTION
backport #26141

If only one two factor provider exists, spare the user from having to
select it and redirect directly to its challenge page.
