### PR TITLE
Fix rename+overwrite GDrive case

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Google.php
+++ b/apps/files_external/lib/Lib/Storage/Google.php
@@ -388,11 +388,11 @@ class Google extends \OC\Files\Storage\Common {
 	public function rename($path1, $path2) {
 		$file = $this->getDriveFile($path1);
 		if ($file) {
-			$newFile = $this->getDriveFile($path2);
+			$oldfile = $this->getDriveFile($path2);
 			if (dirname($path1) === dirname($path2)) {
-				if ($newFile) {
+				if ($oldfile) {
 					// rename to the name of the target file, could be an office file without extension
-					$file->setTitle($newFile->getTitle());
+					$file->setTitle($oldfile->getTitle());
 				} else {
 					$file->setTitle(basename(($path2)));
 				}
@@ -407,12 +407,13 @@ class Google extends \OC\Files\Storage\Common {
 					return false;
 				}
 			}
+
 			// We need to get the object for the existing file with the same
 			// name (if there is one) before we do the patch. If oldfile
 			// exists and is a directory we have to delete it before we
 			// do the rename too.
 			$oldfile = $this->getDriveFile($path2);
-			if ($oldfile && $this->is_dir($path2)) {
+			if ($oldfile && $oldfile->getMimeType() === self::FOLDER) {
 				$this->rmdir($path2);
 				$oldfile = false;
 			}
@@ -420,11 +421,10 @@ class Google extends \OC\Files\Storage\Common {
 			if ($result) {
 				$this->setDriveFile($path1, false);
 				$this->setDriveFile($path2, $result);
-				if ($oldfile && $newFile) {
-					// only delete if they have a different id (same id can happen for part files)
-					if ($newFile->getId() !== $oldfile->getId()) {
-						$this->service->files->delete($oldfile->getId());
-					}
+
+				// delete old file to avoid duplicates
+				if ($oldfile) {
+					$this->service->files->delete($oldfile->getId());
 				}
 			}
 			return (bool)$result;

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -460,6 +460,9 @@ abstract class Storage extends \Test\TestCase {
 		$this->instance->rename('source.txt', 'target.txt');
 		$this->assertEquals('bar', $this->instance->file_get_contents('target.txt'));
 		$this->assertFalse($this->instance->file_exists('source.txt'));
+		$listing = $this->getListing('/');
+		$this->assertNotContains('source.txt', $listing);
+		$this->assertContains('target.txt', $listing);
 	}
 
 	public function testRenameDirectory() {
@@ -627,5 +630,19 @@ abstract class Storage extends \Test\TestCase {
 		$this->instance->file_put_contents('bar.txt.part', 'bar');
 		$this->instance->rename('bar.txt.part', 'bar.txt');
 		$this->assertEquals('bar', $this->instance->file_get_contents('bar.txt'));
+		$listing = $this->getListing('/');
+		$this->assertNotContains('bar.txt.part', $listing);
+		$this->assertContains('bar.txt', $listing);
+	}
+
+	private function getListing($path) {
+		$content = [];
+		$dh = $this->instance->opendir($path);
+		while ($file = readdir($dh)) {
+			if ($file != '.' and $file != '..') {
+				$content[] = $file;
+			}
+		}
+		return $content;
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Prevents having duplicate files appear in GDrive by properly explicitly
deleting the target file. This is because GDrive allows having multiple files with the same file name inside the same folder...
## Related Issue

Fixes https://github.com/owncloud/core/issues/25827
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
## How Has This Been Tested?
- [ ] TEST: manual test with Webdav overwrite (cadaver)
- [x] TEST: unit test
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

More tests fail now than before:

```
There were 4 failures:

1) OCA\Files_External\Tests\Storage\GoogleTest::testStat
Failed asserting that false is true.

/srv/www/htdocs/owncloud/tests/lib/Files/Storage/Storage.php:288

2) OCA\Files_External\Tests\Storage\GoogleTest::testRenameOverWriteDirectory
target/test2.txt has not been removed
Failed asserting that true is false.

/srv/www/htdocs/owncloud/tests/lib/Files/Storage/Storage.php:491

3) OCA\Files_External\Tests\Storage\GoogleTest::testRenameOverWriteDirectoryOverFile
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'foo'
+'bar'

/srv/www/htdocs/owncloud/tests/lib/Files/Storage/Storage.php:505

4) OCA\Files_External\Tests\Storage\GoogleTest::testCopyOverWriteDirectory
Failed asserting that true is false.

/srv/www/htdocs/owncloud/tests/lib/Files/Storage/Storage.php:543

FAILURES!
Tests: 81, Assertions: 422, Failures: 4
```

Known previous failures: https://github.com/owncloud/core/issues/22481
