### PR TITLE
Display "Share" alt text for share action icon

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -141,6 +141,7 @@
 			fileActions.registerAction({
 				name: 'Share',
 				displayName: '',
+				altText: t('core', 'Share'),
 				mime: 'all',
 				permissions: OC.PERMISSION_ALL,
 				iconClass: 'icon-share',

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -306,7 +306,7 @@ OC.Share = _.extend(OC.Share || {}, {
 			}
 		}
 		else {
-			action.html('<span></span>').prepend(icon);
+			action.html('<span class="hidden-visually">' + t('core', 'Shared') + '</span>').prepend(icon);
 		}
 		if (hasLink) {
 			iconClass = 'icon-public';


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Display "Share" alt text on share action icon for accessibility.
## Related Issue

Fixes https://github.com/owncloud/core/issues/19089
## Motivation and Context

Accessibility
## How Has This Been Tested?

Needs DOM inspector:
- [x] TEST: text "Share" appears in "hidden-visually" block when a file is not shared
- [x] TEST: text "Shared" appears in a regular label block (no "hidden-visually") when a file is shared
- [x] TEST: switching between shared and not shared properly updates the label state, switching between "hidden-visually" when no text and the regular span
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review @davitol @VicDeo 
