### PR TITLE
Include nodejs deps in main rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ dist_dir=build/dist
 # Catch-all rules
 #
 .PHONY: all
-all: $(composer_dev_deps) $(core_vendor)
+all: $(composer_dev_deps) $(core_vendor) $(nodejs_deps)
 
 .PHONY: clean
 clean: clean-composer-deps clean-nodejs-deps clean-js-deps clean-test-results clean-dist


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Include the node JS deps in the main target because it also includes the composer dev deps.
## Related Issue

None raised
## Motivation and Context

If you run `make clean; make` and then `make test-js`, it is missing karma because the nodejs deps weren't installed, however bower was installed in one of the shortcuts. (it's a bit twisty, yes)
## How Has This Been Tested?

Before: `make clean; make -j4; make test-js` fails
After: runs!
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 @butonic 
