### PR TITLE
Highlight files and update storage stats at end of upload

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1057,6 +1057,7 @@ OC.Uploader.prototype = _.extend({
 
 					self.clear();
 					self._hideProgressBar();
+					self.trigger('stop', e, data);
 				});
 				fileupload.on('fileuploadfail', function(e, data) {
 					self.log('progress handle fileuploadfail', e, data);

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2769,8 +2769,8 @@
 				$.when.apply($, promises).then(function() {
 					// highlight uploaded files
 					self.highlightFiles(fileNames);
+					self.updateStorageStatistics();
 				});
-				self.updateStorageStatistics();
 
 				var uploadText = self.$fileList.find('tr .uploadtext');
 				self.showFileBusyState(uploadText.closest('tr'), false);

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2776,13 +2776,22 @@ describe('OCA.Files.FileList tests', function() {
 
 				highlightStub.restore();
 			});
-			it('queries storage stats', function() {
+			it('queries storage stats after all fetches are done', function() {
 				var statStub = sinon.stub(fileList, 'updateStorageStatistics');
-				addFile(createUpload('upload.txt', '/subdir'));
-				expect(statStub.notCalled).toEqual(true);
+				var highlightStub = sinon.stub(fileList, 'highlightFiles');
+				var def1 = addFile(createUpload('upload.txt', '/subdir'));
+				var def2 = addFile(createUpload('upload2.txt', '/subdir'));
+				var def3 = addFile(createUpload('upload3.txt', '/another'));
 				uploader.trigger('stop', {});
+
+				expect(statStub.notCalled).toEqual(true);
+				def1.resolve();
+				expect(statStub.notCalled).toEqual(true);
+				def2.resolve();
+				def3.resolve();
 				expect(statStub.calledOnce).toEqual(true);
-				statStub.restore();
+
+				highlightStub.restore();
 			});
 		});
 	});


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Properly trigger the "stop" even from the uploader.
Also update storage stats at the end of all uploads instead of for each
upload.
## Related Issue

None raised.
## Motivation and Context

It's a regression from before Webdav PUT was introduced.
## How Has This Been Tested?

Observe the network console.
Upload several files.
Before the fix: no call to getstoragestats.php
After the fix: one call to getstoragestats.php
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 @butonic @jvillafanez @VicDeo 
