### PR TITLE
Kill update simulation

### DIFF
--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -70,12 +70,6 @@ class Upgrade extends Command {
 			->setName('upgrade')
 			->setDescription('run upgrade routines after installation of a new release. The release has to be installed before.')
 			->addOption(
-				'--skip-migration-test',
-				null,
-				InputOption::VALUE_NONE,
-				'skips the database schema migration simulation and update directly'
-			)
-			->addOption(
 				'--dry-run',
 				null,
 				InputOption::VALUE_NONE,
@@ -97,26 +91,10 @@ class Upgrade extends Command {
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
 
-		$simulateStepEnabled = true;
-		$updateStepEnabled = true;
 		$skip3rdPartyAppsDisable = false;
 
-		if ($input->getOption('skip-migration-test')) {
-			$simulateStepEnabled = false;
-		}
-	   	if ($input->getOption('dry-run')) {
-			$updateStepEnabled = false;
-		}
 		if ($input->getOption('no-app-disable')) {
 			$skip3rdPartyAppsDisable = true;
-		}
-
-		if (!$simulateStepEnabled && !$updateStepEnabled) {
-			$output->writeln(
-				'<error>Only one of "--skip-migration-test" or "--dry-run" ' .
-				'can be specified at a time.</error>'
-			);
-			return self::ERROR_INVALID_ARGUMENTS;
 		}
 
 		if(\OC::checkUpgrade(false)) {
@@ -133,8 +111,6 @@ class Upgrade extends Command {
 					$this->logger
 			);
 
-			$updater->setSimulateStepEnabled($simulateStepEnabled);
-			$updater->setUpdateStepEnabled($updateStepEnabled);
 			$updater->setSkip3rdPartyAppsDisable($skip3rdPartyAppsDisable);
 			$dispatcher = \OC::$server->getEventDispatcher();
 			$progress = new ProgressBar($output);
@@ -227,11 +203,10 @@ class Upgrade extends Command {
 			});
 			$updater->listen('\OC\Updater', 'updateEnd',
 				function ($success) use($output, $updateStepEnabled, $self) {
-					$mode = $updateStepEnabled ? 'Update' : 'Update simulation';
 					if ($success) {
-						$message = "<info>$mode successful</info>";
+						$message = "<info>Update successful</info>";
 					} else {
-						$message = "<error>$mode failed</error>";
+						$message = "<error>Update failed</error>";
 					}
 					$output->writeln($message);
 				});

--- a/lib/private/DB/MDB2SchemaManager.php
+++ b/lib/private/DB/MDB2SchemaManager.php
@@ -121,17 +121,6 @@ class MDB2SchemaManager {
 	}
 
 	/**
-	 * update the database scheme
-	 * @param string $file file to read structure from
-	 * @return boolean
-	 */
-	public function simulateUpdateDbFromStructure($file) {
-		$toSchema = $this->readSchemaFromFile($file);
-		$this->getMigrator()->checkMigrate($toSchema);
-		return true;
-	}
-
-	/**
 	 * @param \Doctrine\DBAL\Schema\Schema $schema
 	 * @return string
 	 */

--- a/lib/private/legacy/db.php
+++ b/lib/private/legacy/db.php
@@ -191,23 +191,6 @@ class OC_DB {
 	}
 
 	/**
-	 * simulate the database schema update
-	 * @param string $file file to read structure from
-	 * @throws Exception
-	 * @return string|boolean
-	 */
-	public static function simulateUpdateDbFromStructure($file) {
-		$schemaManager = self::getMDB2SchemaManager();
-		try {
-			$result = $schemaManager->simulateUpdateDbFromStructure($file);
-		} catch (Exception $e) {
-			\OCP\Util::writeLog('core', 'Simulated database structure update failed ('.$e.')', \OCP\Util::FATAL);
-			throw $e;
-		}
-		return $result;
-	}
-
-	/**
 	 * remove all tables defined in a database structure xml file
 	 * @param string $file the xml file describing the tables
 	 */

--- a/tests/lib/UpdaterTest.php
+++ b/tests/lib/UpdaterTest.php
@@ -27,25 +27,25 @@ use OCP\IConfig;
 use OCP\ILogger;
 use OC\IntegrityCheck\Checker;
 
-class UpdaterTest extends \Test\TestCase {
-	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+class UpdaterTest extends TestCase {
+	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
 	private $config;
-	/** @var ILogger */
+	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
 	private $logger;
 	/** @var Updater */
 	private $updater;
-	/** @var Checker */
+	/** @var Checker | \PHPUnit_Framework_MockObject_MockObject */
 	private $checker;
 
 	public function setUp() {
 		parent::setUp();
-		$this->config = $this->getMockBuilder('\\OCP\\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->logger = $this->getMockBuilder('\\OCP\\ILogger')
+		$this->logger = $this->getMockBuilder(ILogger::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->checker = $this->getMockBuilder('\OC\IntegrityCheck\Checker')
+		$this->checker = $this->getMockBuilder(Checker::class)
 				->disableOriginalConstructor()
 				->getMock();
 
@@ -54,14 +54,6 @@ class UpdaterTest extends \Test\TestCase {
 			$this->checker,
 			$this->logger
 		);
-	}
-
-	/**
-	 * @param string $baseUrl
-	 * @return string
-	 */
-	private function buildUpdateUrl($baseUrl) {
-		return $baseUrl . '?version='.implode('x', \OCP\Util::getVersion()).'xinstalledatxlastupdatedatx'.\OC_Util::getChannel().'x'.\OC_Util::getEditionString().'x';
 	}
 
 	/**
@@ -167,20 +159,6 @@ class UpdaterTest extends \Test\TestCase {
 			->willReturn($vendor);
 
 		$this->assertSame($result, $this->updater->isUpgradePossible($oldVersion, $newVersion, $allowedVersion));
-	}
-
-	public function testSetSimulateStepEnabled() {
-		$this->updater->setSimulateStepEnabled(true);
-		$this->assertSame(true, $this->invokePrivate($this->updater, 'simulateStepEnabled'));
-		$this->updater->setSimulateStepEnabled(false);
-		$this->assertSame(false, $this->invokePrivate($this->updater, 'simulateStepEnabled'));
-	}
-
-	public function testSetUpdateStepEnabled() {
-		$this->updater->setUpdateStepEnabled(true);
-		$this->assertSame(true, $this->invokePrivate($this->updater, 'updateStepEnabled'));
-		$this->updater->setUpdateStepEnabled(false);
-		$this->assertSame(false, $this->invokePrivate($this->updater, 'updateStepEnabled'));
 	}
 
 	public function testSetSkip3rdPartyAppsDisable() {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Remove all code related to simulating migration at update time.
## Related Issue

None
## Motivation and Context

Update migration is only useful for small databases but also slows down upgrades by creating duplicates of databases.
Admins should rather rely on backups if something went wrong. Additionally, the new updater app will eventually be extended to also make database backups (or does it do it already @VicDeo?)
On bigger setups admins complained that they forgot to pass `--skip-migration-test` and then the simulation started and they had to revert their huge database.
## How Has This Been Tested?

Not tested yet:
- [ ] TEST: CLI upgrade
- [ ] TEST: web upgrade
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

@DeepDiver1975 @butonic @VicDeo as discussed

I thought there was more code ?
