### PR TITLE
[stable9.1] Workaround in case a mount point already existed for the same share

### DIFF
--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -135,7 +135,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 		// Helper function to find existing mount points
 		$mountpointExists = function($path) use ($mountpoints) {
 			foreach ($mountpoints as $mountpoint) {
-				if ($mountpoint->getShare()->getTarget() === $path) {
+				if ($mountpoint->getShare()->getTarget() === $path && $mountpoint->getShare()->getId() !== $this->superShare->getId()) {
 					return true;
 				}
 			}


### PR DESCRIPTION
## Description

In some unknown cases, the mount point might be created twice for the
same share id. This workaround avoids the share path to be renamed to
"share (2)" repeatedly.
## Related Issue

Fixes https://github.com/owncloud/core/issues/25718
## Motivation and Context

Trying to mitigate the issue from https://github.com/owncloud/core/issues/25718 but the original cause is not reproducible.
## How Has This Been Tested?

To be tested on an env where the issue happens
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
### Todos
- [ ] forward port to master
- [ ] unit test
