### PR TITLE
FileLocked exception to be logged as debug

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -72,3 +72,7 @@ Options -Indexes
 <IfModule pagespeed_module>
   ModPagespeed Off
 </IfModule>
+#### DO NOT CHANGE ANYTHING ABOVE THIS LINE ####
+
+ErrorDocument 403 //core/templates/403.php
+ErrorDocument 404 //core/templates/404.php

--- a/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
@@ -49,6 +49,8 @@ class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
 		// not available
 		'Sabre\DAV\Exception\StorageNotAvailableException' => true,
 		'OCP\Files\StorageNotAvailableException' => true,
+		// Locked files can happen
+		'OCA\DAV\Connector\Sabre\Exception\FileLocked' => true,
 	];
 
 	/** @var string */


### PR DESCRIPTION
## Description

Because FileLocked exception are expected to happen they should be
logged as debug instead of error.
## Related Issue

Fixes https://github.com/owncloud/core/issues/21711
## Motivation and Context

To prevent admins thinking that there is a problem on their systems when locking errors are expected.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 @butonic @VicDeo @jvillafanez @RealRancor 
