### PR TITLE
let occ user:lastseen report latest logins

### DIFF
--- a/core/Command/User/LastSeen.php
+++ b/core/Command/User/LastSeen.php
@@ -24,51 +24,141 @@
 
 namespace OC\Core\Command\User;
 
+use OC\Core\Command\Base;
+use OCP\IDBConnection;
 use OCP\IUserManager;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 
-class LastSeen extends Command {
+class LastSeen extends Base  {
 	/** @var IUserManager */
 	protected $userManager;
+
+	/** @var IDBConnection */
+	protected $connection;
 
 	/**
 	 * @param IUserManager $userManager
 	 */
-	public function __construct(IUserManager $userManager) {
+	public function __construct(IUserManager $userManager, IDBConnection $connection) {
 		$this->userManager = $userManager;
+		$this->connection = $connection;
 		parent::__construct();
 	}
 
 	protected function configure() {
+		parent::configure();
 		$this
 			->setName('user:lastseen')
-			->setDescription('shows when the user was logged in last time')
+			->setDescription('shows when users were logged in last time')
 			->addArgument(
 				'uid',
-				InputArgument::REQUIRED,
+				InputArgument::OPTIONAL,
 				'the username'
+			)
+			->addOption(
+				'limit',
+				10,
+				InputOption::VALUE_OPTIONAL,
+				'limit to n users'
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
-		$user = $this->userManager->get($input->getArgument('uid'));
-		if(is_null($user)) {
-			$output->writeln('<error>User does not exist</error>');
-			return;
+	protected function getLastLogins($userId = null, $limit = 10) {
+		$queryBuilder = $this->connection->getQueryBuilder();
+		$queryBuilder->select(['userid', 'configvalue'])
+			->from('preferences')
+			->where($queryBuilder->expr()->eq(
+				'appid', $queryBuilder->createNamedParameter('login'))
+			)
+			->andWhere($queryBuilder->expr()->eq(
+				'configkey', $queryBuilder->createNamedParameter('lastLogin'))
+			)
+			->andWhere($queryBuilder->expr()->isNotNull('configvalue')
+			)
+			->orderBy('configvalue', 'DESC');
+
+		if ($userId) {
+			$queryBuilder->andWhere($queryBuilder->expr()->eq(
+				'userid', $queryBuilder->createNamedParameter($userId))
+			);
 		}
 
-		$lastLogin = $user->getLastLogin();
-		if($lastLogin === 0) {
-			$output->writeln('User ' . $user->getUID() .
-				' has never logged in, yet.');
-		} else {
+		if (!empty($limit)) {
+			$queryBuilder->setMaxResults($limit);
+		}
+
+		$query = $queryBuilder->execute();
+		$result = [];
+
+		while ($row = $query->fetch()) {
+			$result[] = ['userid' => $row['userid'], 'lastLogin' => $row['configvalue']];
+		}
+
+		return $result;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$uid = $input->getArgument('uid');
+		$users = $this->getLastLogins($uid, $input->getOption('limit'));
+		$outputFormat = $input->getOption('output');
+		if (empty($users)) {
+			if ($uid) {
+				$user = $this->userManager->get($uid);
+				if ($user) {
+					if ($outputFormat === self::OUTPUT_FORMAT_PLAIN ) {
+						$output->writeln('User '.$uid.' has never logged in, yet.');
+						return;
+					} else {
+						$users = [
+							[
+								'userid' => $uid,
+								'displayname' => $user->getDisplayName(),
+								'email' => $user->getEMailAddress(),
+								'lastLogin' => null
+							]
+						];
+					}
+				} else if ($outputFormat === self::OUTPUT_FORMAT_PLAIN ) {
+					$output->writeln('<error>User $uid does not exist</error>');
+					return;
+				}
+			}
+		}
+		foreach ($users as $key => $data) {
 			$date = new \DateTime();
-			$date->setTimestamp($lastLogin);
-			$output->writeln($user->getUID() .
-				'`s last login: ' . $date->format('d.m.Y H:i'));
+			$date->setTimestamp($data['lastLogin']);
+			$user = $this->userManager->get($data['userid']);
+				switch ($outputFormat) {
+					case self::OUTPUT_FORMAT_JSON:
+					case self::OUTPUT_FORMAT_JSON_PRETTY:
+						if ($users[$key]['lastLogin'] !== null) {
+							$users[$key]['lastLogin'] = $date->format('Y-m-d\TH:i:s');
+						}
+						// make the json output useful by adding more info
+						if ($user) {
+							$users[$key]['displayname'] = $user->getDisplayName();
+							$users[$key]['email'] = $user->getEMailAddress();
+						} else {
+							// user no longer exists
+							$users[$key]['displayname'] = null;
+							$users[$key]['email'] = null;
+						}
+						ksort($users[$key]);
+						break;
+					default:
+						$output->writeln(
+							$data['userid'] .'`s last login: ' . $date->format('d.m.Y H:i') );
+						break;
+				}
+		}
+		switch ($outputFormat) {
+			case self::OUTPUT_FORMAT_JSON:
+			case self::OUTPUT_FORMAT_JSON_PRETTY:
+				$this->writeArrayInOutputFormat($input, $output, $users);
+				break;
 		}
 	}
 }

--- a/core/Command/User/LastSeen.php
+++ b/core/Command/User/LastSeen.php
@@ -25,6 +25,7 @@
 namespace OC\Core\Command\User;
 
 use OC\Core\Command\Base;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\IUserManager;
 use Symfony\Component\Console\Input\InputInterface;
@@ -82,7 +83,8 @@ class LastSeen extends Base  {
 			->andWhere($queryBuilder->expr()->eq(
 				'configkey', $queryBuilder->createNamedParameter('lastLogin'))
 			)
-			->andWhere($queryBuilder->expr()->isNotNull('configvalue')
+			// isNotNull has problems on oracle because configvaluo is a CLOB, so use LENGTH(`configvalue`) > 0 instead
+			->andWhere($queryBuilder->expr()->gt($queryBuilder->createFunction('LENGTH(`configvalue`)'), $queryBuilder->createFunction('0'))
 			)
 			->orderBy('configvalue', $order);
 

--- a/core/Command/User/LastSeen.php
+++ b/core/Command/User/LastSeen.php
@@ -59,6 +59,12 @@ class LastSeen extends Base  {
 				'the username'
 			)
 			->addOption(
+				'least-recent',
+				null,
+				InputOption::VALUE_NONE,
+				'show least recently logged in users'
+			)
+			->addOption(
 				'limit',
 				10,
 				InputOption::VALUE_OPTIONAL,
@@ -66,7 +72,7 @@ class LastSeen extends Base  {
 			);
 	}
 
-	protected function getLastLogins($userId = null, $limit = 10) {
+	protected function getLastLogins($userId = null, $order = 'DESC', $limit = 10) {
 		$queryBuilder = $this->connection->getQueryBuilder();
 		$queryBuilder->select(['userid', 'configvalue'])
 			->from('preferences')
@@ -78,7 +84,7 @@ class LastSeen extends Base  {
 			)
 			->andWhere($queryBuilder->expr()->isNotNull('configvalue')
 			)
-			->orderBy('configvalue', 'DESC');
+			->orderBy('configvalue', $order);
 
 		if ($userId) {
 			$queryBuilder->andWhere($queryBuilder->expr()->eq(
@@ -102,7 +108,12 @@ class LastSeen extends Base  {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$uid = $input->getArgument('uid');
-		$users = $this->getLastLogins($uid, $input->getOption('limit'));
+		if ($input->getOption('least-recent')) {
+			$order = 'ASC';
+		} else {
+			$order = 'DESC';
+		}
+		$users = $this->getLastLogins($uid, $order, $input->getOption('limit'));
 		$outputFormat = $input->getOption('output');
 		if (empty($users)) {
 			if ($uid) {

--- a/core/Command/User/LastSeen.php
+++ b/core/Command/User/LastSeen.php
@@ -135,7 +135,7 @@ class LastSeen extends Base  {
 					case self::OUTPUT_FORMAT_JSON:
 					case self::OUTPUT_FORMAT_JSON_PRETTY:
 						if ($users[$key]['lastLogin'] !== null) {
-							$users[$key]['lastLogin'] = $date->format('Y-m-d\TH:i:s');
+							$users[$key]['lastLogin'] = $date->format('Y-m-d\TH:i:s\Z');
 						}
 						// make the json output useful by adding more info
 						if ($user) {

--- a/core/Command/User/LastSeen.php
+++ b/core/Command/User/LastSeen.php
@@ -100,8 +100,8 @@ class LastSeen extends Base  {
 			);
 
 		if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
-			//convert 10 chars of the CLOB to string
-			$queryBuilder->orderBy($queryBuilder->createFunction('dbms_lob.substr(`configvalue`, 0, 10)'), $order);
+			//convert first 10 bytes of the CLOB to string - yes, that is oracle starting to count at 1
+			$queryBuilder->orderBy($queryBuilder->createFunction('dbms_lob.substr(`configvalue`, 10, 1)'), $order);
 		} else {
 			$queryBuilder->orderBy('configvalue', $order);
 		}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -133,7 +133,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\User\Delete(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\Disable(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\Enable(\OC::$server->getUserManager()));
-	$application->add(new OC\Core\Command\User\LastSeen(\OC::$server->getUserManager()));
+	$application->add(new OC\Core\Command\User\LastSeen(\OC::$server->getUserManager(), \OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\User\Report(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\ResetPassword(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->getConfig(), \OC::$server->getDatabaseConnection()));

--- a/tests/Core/Command/User/LastSeenTest.php
+++ b/tests/Core/Command/User/LastSeenTest.php
@@ -25,9 +25,19 @@ namespace Tests\Core\Command\User;
 use OC\Core\Command\User\LastSeen;
 use Test\TestCase;
 
+
+/**
+ * Class LastSeenTest
+ *
+ * @group DB
+ *
+ * @package Test
+ */
 class LastSeenTest extends TestCase {
 	/** @var \PHPUnit_Framework_MockObject_MockObject */
 	protected $userManager;
+	/** @var \OCP\IDBConnection */
+	protected $connection;
 	/** @var \PHPUnit_Framework_MockObject_MockObject */
 	protected $consoleInput;
 	/** @var \PHPUnit_Framework_MockObject_MockObject */
@@ -39,44 +49,118 @@ class LastSeenTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$userManager = $this->userManager = $this->getMockBuilder('OCP\IUserManager')
+		/** @var \OCP\IUserManager $userManager */
+		$this->userManager = $this->getMockBuilder('OCP\IUserManager')
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->connection = \OC::$server->getDatabaseConnection();
+		$sql = $this->connection->getQueryBuilder();
+		$sql->select('*')
+			->from('preferences');
+		$result = $sql->execute();
+		$this->originalConfig = $result->fetchAll();
+		$result->closeCursor();
+
+		$sql = $this->connection->getQueryBuilder();
+		$sql->delete('preferences');
+		$sql->execute();
+
+		$sql = $this->connection->getQueryBuilder();
+		$sql->insert('preferences')
+			->values([
+				'userid' => $sql->createParameter('userid'),
+				'appid' => $sql->createParameter('appid'),
+				'configkey' => $sql->createParameter('configkey'),
+				'configvalue' => $sql->createParameter('configvalue'),
+			]);
+
+		$sql->setParameters([
+			'userid' => 'user',
+			'appid' => 'login',
+			'configkey' => 'lastLogin',
+			'configvalue' => null,
+		])->execute();
+		$sql->setParameters([
+			'userid' => 'user1',
+			'appid' => 'login',
+			'configkey' => 'lastLogin',
+			'configvalue' => '1474453520',
+		])->execute();
+		$sql->setParameters([
+			'userid' => 'user2',
+			'appid' => 'login',
+			'configkey' => 'lastLogin',
+			'configvalue' => '1473067798',
+		])->execute();
+
 		$this->consoleInput = $this->createMock('Symfony\Component\Console\Input\InputInterface');
 		$this->consoleOutput = $this->createMock('Symfony\Component\Console\Output\OutputInterface');
 
-		/** @var \OCP\IUserManager $userManager */
-		$this->command = new LastSeen($userManager);
+		$this->command = new LastSeen($this->userManager, $this->connection);
 	}
 
-	public function validUserLastSeen() {
+	public function tearDown() {
+		$sql = $this->connection->getQueryBuilder();
+		$sql->delete('preferences');
+		$sql->execute();
+
+		$sql = $this->connection->getQueryBuilder();
+		$sql->insert('preferences')
+			->values([
+				'userid' => $sql->createParameter('userid'),
+				'appid' => $sql->createParameter('appid'),
+				'configkey' => $sql->createParameter('configkey'),
+				'configvalue' => $sql->createParameter('configvalue'),
+			]);
+
+		foreach ($this->originalConfig as $configs) {
+			$sql->setParameter('userid', $configs['userid'])
+				->setParameter('appid', $configs['appid'])
+				->setParameter('configkey', $configs['configkey'])
+				->setParameter('configvalue', $configs['configvalue']);
+			$sql->execute();
+		}
+
+		parent::tearDown();
+	}
+
+
+	public function validUserLastSeenPlain() {
 		return [
-			[0, 'never logged in'],
-			[time(), 'last login'],
+			['user', 'never logged in'],
+			['user1', '21.09.2016 10:25'],
+			['user2', '05.09.2016 09:29'],
 		];
 	}
 
 	/**
-	 * @dataProvider validUserLastSeen
+	 * @dataProvider validUserLastSeenPlain
 	 *
-	 * @param int $lastSeen
+	 * @param string $userId
+	 * @param string $displayName
+	 * @param string $email
 	 * @param string $expectedString
 	 */
-	public function testValidUser($lastSeen, $expectedString) {
-		$user = $this->createMock('OCP\IUser');
-		$user->expects($this->once())
-			->method('getLastLogin')
-			->willReturn($lastSeen);
+	public function testValidUserPlain($userId, $expectedString) {
 
-		$this->userManager->expects($this->once())
-			->method('get')
-			->with('user')
-			->willReturn($user);
-
-		$this->consoleInput->expects($this->once())
+		$this->consoleInput->expects($this->at(0))
 			->method('getArgument')
 			->with('uid')
-			->willReturn('user');
+			->willReturn($userId);
+		$this->consoleInput->expects($this->at(1))
+			->method('getOption')
+			->with('limit')
+			->willReturn(10);
+		$this->consoleInput->expects($this->at(2))
+			->method('getOption')
+			->with('output')
+			->willReturn(LastSeen::OUTPUT_FORMAT_PLAIN);
+
+		$this->userManager->expects($this->any())
+			->method('get')
+			->with($userId)
+			->willReturn($this->createMock('OCP\IUser'));
 
 		$this->consoleOutput->expects($this->once())
 			->method('writeln')
@@ -86,19 +170,179 @@ class LastSeenTest extends TestCase {
 	}
 
 	public function testInvalidUser() {
-		$this->userManager->expects($this->once())
-			->method('get')
-			->with('user')
-			->willReturn(null);
-
-		$this->consoleInput->expects($this->once())
+		$this->consoleInput->expects($this->at(0))
 			->method('getArgument')
 			->with('uid')
-			->willReturn('user');
+			->willReturn('user3');
+		$this->consoleInput->expects($this->at(1))
+			->method('getOption')
+			->with('limit')
+			->willReturn(10);
+		$this->consoleInput->expects($this->at(2))
+			->method('getOption')
+			->with('output')
+			->willReturn(LastSeen::OUTPUT_FORMAT_PLAIN);
+
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with('user3')
+			->willReturn(null);
 
 		$this->consoleOutput->expects($this->once())
 			->method('writeln')
-			->with($this->stringContains('User does not exist'));
+			->with($this->stringContains('does not exist'));
+
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
+
+
+	public function validUserLastSeenJSON() {
+		return [
+			['user', 'User Name', 'user@e.mail',
+				'[{"displayname":"User Name","email":"user@e.mail","lastLogin":null,"userid":"user"}]'],
+			['user1','User1 Name', 'user1@e.mail',
+				'[{"displayname":"User1 Name","email":"user1@e.mail","lastLogin":"2016-09-21T10:25:20","userid":"user1"}]'],
+			['user2', 'User2 Name',	'user2@e.mail',
+				'[{"displayname":"User2 Name","email":"user2@e.mail","lastLogin":"2016-09-05T09:29:58","userid":"user2"}]'],
+		];
+	}
+
+	/**
+	 * @dataProvider validUserLastSeenJSON
+	 *
+	 * @param string $userId
+	 * @param string $displayName
+	 * @param string $email
+	 * @param string $expectedString
+	 */
+	public function testValidUserJSON($userId, $displayName, $email, $expectedString) {
+
+		$user = $this->createMock('OCP\IUser');
+		$user->expects($this->any())
+			->method('getDisplayName')
+			->willReturn($displayName);
+		$user->expects($this->any())
+			->method('getEMailAddress')
+			->willReturn($email);
+
+		$this->consoleInput->expects($this->at(0))
+			->method('getArgument')
+			->with('uid')
+			->willReturn($userId);
+		$this->consoleInput->expects($this->at(1))
+			->method('getOption')
+			->with('limit')
+			->willReturn(10);
+		$this->consoleInput->expects($this->at(2))
+			->method('getOption')
+			->with('output')
+			->willReturn(LastSeen::OUTPUT_FORMAT_JSON);
+		$this->consoleInput->expects($this->at(3))
+			->method('getOption')
+			->with('output')
+			->willReturn(LastSeen::OUTPUT_FORMAT_JSON);
+
+		$this->userManager->expects($this->any())
+			->method('get')
+			->with($userId)
+			->willReturn($user);
+
+		$this->consoleOutput->expects($this->once())
+			->method('writeln')
+			->with($this->stringContains($expectedString));
+
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
+
+	public function testValidUsersJSON() {
+
+		$user1 = $this->createMock('OCP\IUser');
+		$user1->expects($this->any())
+			->method('getDisplayName')
+			->willReturn('User1 Name');
+		$user1->expects($this->any())
+			->method('getEMailAddress')
+			->willReturn('user1@e.mail');
+
+		$user2 = $this->createMock('OCP\IUser');
+		$user2->expects($this->any())
+			->method('getDisplayName')
+			->willReturn('User2 Name');
+		$user2->expects($this->any())
+			->method('getEMailAddress')
+			->willReturn('user2@e.mail');
+
+		$this->consoleInput->expects($this->at(0))
+			->method('getArgument')
+			->with('uid')
+			->willReturn(null);
+		$this->consoleInput->expects($this->at(1))
+			->method('getOption')
+			->with('limit')
+			->willReturn(10);
+		$this->consoleInput->expects($this->at(2))
+			->method('getOption')
+			->with('output')
+			->willReturn(LastSeen::OUTPUT_FORMAT_JSON);
+		$this->consoleInput->expects($this->at(3))
+			->method('getOption')
+			->with('output')
+			->willReturn(LastSeen::OUTPUT_FORMAT_JSON);
+
+		$this->userManager->expects($this->at(0))
+			->method('get')
+			->with('user1')
+			->willReturn($user1);
+		$this->userManager->expects($this->at(1))
+			->method('get')
+			->with('user2')
+			->willReturn($user2);
+
+		$this->consoleOutput->expects($this->once())
+			->method('writeln')
+			->with($this->stringContains('[{"displayname":"User1 Name","email":"user1@e.mail","lastLogin":"2016-09-21T10:25:20","userid":"user1"},{"displayname":"User2 Name","email":"user2@e.mail","lastLogin":"2016-09-05T09:29:58","userid":"user2"}]'));
+
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
+	public function testInalidUsersJSON() {
+
+		$user1 = $this->createMock('OCP\IUser');
+		$user1->expects($this->any())
+			->method('getDisplayName')
+			->willReturn('User1 Name');
+		$user1->expects($this->any())
+			->method('getEMailAddress')
+			->willReturn('user1@e.mail');
+
+		$this->consoleInput->expects($this->at(0))
+			->method('getArgument')
+			->with('uid')
+			->willReturn(null);
+		$this->consoleInput->expects($this->at(1))
+			->method('getOption')
+			->with('limit')
+			->willReturn(10);
+		$this->consoleInput->expects($this->at(2))
+			->method('getOption')
+			->with('output')
+			->willReturn(LastSeen::OUTPUT_FORMAT_JSON);
+		$this->consoleInput->expects($this->at(3))
+			->method('getOption')
+			->with('output')
+			->willReturn(LastSeen::OUTPUT_FORMAT_JSON);
+
+		$this->userManager->expects($this->at(0))
+			->method('get')
+			->with('user1')
+			->willReturn($user1);
+		$this->userManager->expects($this->at(1))
+			->method('get')
+			->with('user2')
+			->willReturn(null);
+
+		$this->consoleOutput->expects($this->once())
+			->method('writeln')
+			->with($this->stringContains('[{"displayname":"User1 Name","email":"user1@e.mail","lastLogin":"2016-09-21T10:25:20","userid":"user1"},{"displayname":null,"email":null,"lastLogin":"2016-09-05T09:29:58","userid":"user2"}]'));
 
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}

--- a/tests/Core/Command/User/LastSeenTest.php
+++ b/tests/Core/Command/User/LastSeenTest.php
@@ -146,7 +146,7 @@ class LastSeenTest extends TestCase {
 	}
 
 
-	public function validUserLastSeenPlain() {
+	public function validPlainProvider() {
 		return [
 			['user', 'never logged in'],
 			['user1', '21.09.2016 10:25'],
@@ -155,14 +155,14 @@ class LastSeenTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider validUserLastSeenPlain
+	 * @dataProvider validPlainProvider
 	 *
 	 * @param string $userId
 	 * @param string $displayName
 	 * @param string $email
 	 * @param string $expectedString
 	 */
-	public function testValidUserPlain($userId, $expectedString) {
+	public function testPlainOutputContainsExistingUsers($userId, $expectedString) {
 
 		$this->expectConsoleInput($userId, null, null, 10, LastSeen::OUTPUT_FORMAT_PLAIN);
 
@@ -178,7 +178,7 @@ class LastSeenTest extends TestCase {
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
 
-	public function testInvalidUser() {
+	public function testPlainOutputReflectsNotExistingUser() {
 
 		$this->expectConsoleInput('user3', null, null, 10, LastSeen::OUTPUT_FORMAT_PLAIN);
 
@@ -195,7 +195,7 @@ class LastSeenTest extends TestCase {
 	}
 
 
-	public function validUserLastSeenJSON() {
+	public function validJSONSingleUserProvider() {
 		return [
 			['user', 'User Name', 'user@e.mail',
 				'[{"displayname":"User Name","email":"user@e.mail","lastLogin":null,"userid":"user"}]'],
@@ -207,14 +207,14 @@ class LastSeenTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider validUserLastSeenJSON
+	 * @dataProvider validJSONSingleUserProvider
 	 *
 	 * @param string $userId
 	 * @param string $displayName
 	 * @param string $email
 	 * @param string $expectedString
 	 */
-	public function testValidUserJSON($userId, $displayName, $email, $expectedString) {
+	public function testJSONOutputContainsExistingUser($userId, $displayName, $email, $expectedString) {
 
 		$user = $this->createMock('OCP\IUser');
 		$user->expects($this->any())
@@ -243,7 +243,7 @@ class LastSeenTest extends TestCase {
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
 
-	public function validUsersJSON() {
+	public function validJSONMultipleUsersProvider() {
 		return [
 			[null,
 				'[{"displayname":"User1 Name","email":"user1@e.mail","lastLogin":"2016-09-21T10:25:20Z","userid":"user1"},{"displayname":"User2 Name","email":"user2@e.mail","lastLogin":"2016-09-05T09:29:58Z","userid":"user2"}]'],
@@ -253,12 +253,12 @@ class LastSeenTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider validUsersJSON
+	 * @dataProvider validJSONMultipleUsersProvider
 	 *
 	 * @param string $leastRecent
 	 * @param string $expectedString
 	 */
-	public function testValidUsersJSON($leastRecent, $expectedString) {
+	public function testJSONOutputContainsMultipleExistingUsers($leastRecent, $expectedString) {
 
 		$this->expectConsoleInput(null, $leastRecent, null, 10, LastSeen::OUTPUT_FORMAT_JSON);
 
@@ -293,7 +293,7 @@ class LastSeenTest extends TestCase {
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
 
-	public function invalidUsersJSON() {
+	public function invalidJSONUsersProvider() {
 		return [
 			[null,
 				'[{"displayname":"User1 Name","email":"user1@e.mail","lastLogin":"2016-09-21T10:25:20Z","userid":"user1"},{"displayname":null,"email":null,"lastLogin":"2016-09-05T09:29:58Z","userid":"user2"}]'],
@@ -303,12 +303,12 @@ class LastSeenTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider invalidUsersJSON
+	 * @dataProvider invalidJSONUsersProvider
 	 *
 	 * @param string $leastRecent
 	 * @param string $expectedString
 	 */
-	public function testInvalidUsersJSON($leastRecent, $expectedString) {
+	public function testJSONOutputReflectsInvalidUsers($leastRecent, $expectedString) {
 
 		$user1 = $this->createMock('OCP\IUser');
 		$user1->expects($this->any())
@@ -353,7 +353,7 @@ class LastSeenTest extends TestCase {
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
 
-	public function beforeUsersJSON() {
+	public function beforeJSONUsersProvider() {
 		return [
 			['2 days ago', ['user1', 'user2'],
 				'[{"displayname":"User1 Name","email":"user1@e.mail","lastLogin":"2016-09-21T10:25:20Z","userid":"user1"},{"displayname":"User2 Name","email":"user2@e.mail","lastLogin":"2016-09-05T09:29:58Z","userid":"user2"}]'],
@@ -367,13 +367,13 @@ class LastSeenTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider beforeUsersJSON
+	 * @dataProvider beforeJSONUsersProvider
 	 *
 	 * @param string $leastRecent
 	 * @param string[] $users userid => user the usermanager should know
 	 * @param string $expectedString
 	 */
-	public function testBeforeUsersJSON($before, $users, $expectedString) {
+	public function testJSONOutputOnlyContainsUsersBeforeGivenDate($before, $users, $expectedString) {
 
 		$this->expectConsoleInput(null, null, $before, 10, LastSeen::OUTPUT_FORMAT_JSON);
 

--- a/tests/Core/Command/User/LastSeenTest.php
+++ b/tests/Core/Command/User/LastSeenTest.php
@@ -384,11 +384,10 @@ class LastSeenTest extends TestCase {
 
 		$pos = 0;
 		foreach ($users as $userId) {
-			$this->userManager->expects($this->at($pos))
+			$this->userManager->expects($this->at($pos++))
 				->method('get')
 				->with($userId)
 				->willReturn($this->userMocks[$userId]);
-			$pos++;
 		}
 		$this->consoleOutput->expects($this->once())
 			->method('writeln')

--- a/tests/Core/Command/User/LastSeenTest.php
+++ b/tests/Core/Command/User/LastSeenTest.php
@@ -23,6 +23,7 @@ namespace Tests\Core\Command\User;
 
 
 use OC\Core\Command\User\LastSeen;
+use OCP\User;
 use Test\TestCase;
 
 
@@ -36,6 +37,8 @@ use Test\TestCase;
 class LastSeenTest extends TestCase {
 	/** @var \PHPUnit_Framework_MockObject_MockObject */
 	protected $userManager;
+	/** @var \PHPUnit_Framework_MockObject_MockObject[]|\OCP\Iuser[]  */
+	protected $userMocks;
 	/** @var \OCP\IDBConnection */
 	protected $connection;
 	/** @var \PHPUnit_Framework_MockObject_MockObject */
@@ -53,6 +56,23 @@ class LastSeenTest extends TestCase {
 		$this->userManager = $this->getMockBuilder('OCP\IUserManager')
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->userMocks = [];
+		$this->userMocks['user1'] = $this->createMock('OCP\IUser');
+		$this->userMocks['user1']->expects($this->any())
+			->method('getDisplayName')
+			->willReturn('User1 Name');
+		$this->userMocks['user1']->expects($this->any())
+			->method('getEMailAddress')
+			->willReturn('user1@e.mail');
+
+		$this->userMocks['user2'] = $this->createMock('OCP\IUser');
+		$this->userMocks['user2']->expects($this->any())
+			->method('getDisplayName')
+			->willReturn('User2 Name');
+		$this->userMocks['user2']->expects($this->any())
+			->method('getEMailAddress')
+			->willReturn('user2@e.mail');
 
 		$this->connection = \OC::$server->getDatabaseConnection();
 		$sql = $this->connection->getQueryBuilder();
@@ -144,22 +164,7 @@ class LastSeenTest extends TestCase {
 	 */
 	public function testValidUserPlain($userId, $expectedString) {
 
-		$this->consoleInput->expects($this->at(0))
-			->method('getArgument')
-			->with('uid')
-			->willReturn($userId);
-		$this->consoleInput->expects($this->at(1))
-			->method('getOption')
-			->with('least-recent')
-			->willReturn(null);
-		$this->consoleInput->expects($this->at(2))
-			->method('getOption')
-			->with('limit')
-			->willReturn(10);
-		$this->consoleInput->expects($this->at(3))
-			->method('getOption')
-			->with('output')
-			->willReturn(LastSeen::OUTPUT_FORMAT_PLAIN);
+		$this->expectConsoleInput($userId, null, null, 10, LastSeen::OUTPUT_FORMAT_PLAIN);
 
 		$this->userManager->expects($this->any())
 			->method('get')
@@ -174,22 +179,8 @@ class LastSeenTest extends TestCase {
 	}
 
 	public function testInvalidUser() {
-		$this->consoleInput->expects($this->at(0))
-			->method('getArgument')
-			->with('uid')
-			->willReturn('user3');
-		$this->consoleInput->expects($this->at(1))
-			->method('getOption')
-			->with('least-recent')
-			->willReturn(null);
-		$this->consoleInput->expects($this->at(2))
-			->method('getOption')
-			->with('limit')
-			->willReturn(10);
-		$this->consoleInput->expects($this->at(3))
-			->method('getOption')
-			->with('output')
-			->willReturn(LastSeen::OUTPUT_FORMAT_PLAIN);
+
+		$this->expectConsoleInput('user3', null, null, 10, LastSeen::OUTPUT_FORMAT_PLAIN);
 
 		$this->userManager->expects($this->once())
 			->method('get')
@@ -233,23 +224,9 @@ class LastSeenTest extends TestCase {
 			->method('getEMailAddress')
 			->willReturn($email);
 
-		$this->consoleInput->expects($this->at(0))
-			->method('getArgument')
-			->with('uid')
-			->willReturn($userId);
-		$this->consoleInput->expects($this->at(1))
-			->method('getOption')
-			->with('least-recent')
-			->willReturn(null);
-		$this->consoleInput->expects($this->at(2))
-			->method('getOption')
-			->with('limit')
-			->willReturn(10);
-		$this->consoleInput->expects($this->at(3))
-			->method('getOption')
-			->with('output')
-			->willReturn(LastSeen::OUTPUT_FORMAT_JSON);
-		$this->consoleInput->expects($this->at(4))
+		$this->expectConsoleInput($userId, null, null, 10, LastSeen::OUTPUT_FORMAT_JSON);
+
+		$this->consoleInput->expects($this->at(5))
 			->method('getOption')
 			->with('output')
 			->willReturn(LastSeen::OUTPUT_FORMAT_JSON);
@@ -283,39 +260,9 @@ class LastSeenTest extends TestCase {
 	 */
 	public function testValidUsersJSON($leastRecent, $expectedString) {
 
-		$user1 = $this->createMock('OCP\IUser');
-		$user1->expects($this->any())
-			->method('getDisplayName')
-			->willReturn('User1 Name');
-		$user1->expects($this->any())
-			->method('getEMailAddress')
-			->willReturn('user1@e.mail');
+		$this->expectConsoleInput(null, $leastRecent, null, 10, LastSeen::OUTPUT_FORMAT_JSON);
 
-		$user2 = $this->createMock('OCP\IUser');
-		$user2->expects($this->any())
-			->method('getDisplayName')
-			->willReturn('User2 Name');
-		$user2->expects($this->any())
-			->method('getEMailAddress')
-			->willReturn('user2@e.mail');
-
-		$this->consoleInput->expects($this->at(0))
-			->method('getArgument')
-			->with('uid')
-			->willReturn(null);
-		$this->consoleInput->expects($this->at(1))
-			->method('getOption')
-			->with('least-recent')
-			->willReturn($leastRecent);
-		$this->consoleInput->expects($this->at(2))
-			->method('getOption')
-			->with('limit')
-			->willReturn(10);
-		$this->consoleInput->expects($this->at(3))
-			->method('getOption')
-			->with('output')
-			->willReturn(LastSeen::OUTPUT_FORMAT_JSON);
-		$this->consoleInput->expects($this->at(4))
+		$this->consoleInput->expects($this->at(5))
 			->method('getOption')
 			->with('output')
 			->willReturn(LastSeen::OUTPUT_FORMAT_JSON);
@@ -324,20 +271,20 @@ class LastSeenTest extends TestCase {
 			$this->userManager->expects($this->at(0))
 				->method('get')
 				->with('user2')
-				->willReturn($user2);
+				->willReturn($this->userMocks['user2']);
 			$this->userManager->expects($this->at(1))
 				->method('get')
 				->with('user1')
-				->willReturn($user1);
+				->willReturn($this->userMocks['user1']);
 		} else {
 			$this->userManager->expects($this->at(0))
 				->method('get')
 				->with('user1')
-				->willReturn($user1);
+				->willReturn($this->userMocks['user1']);
 			$this->userManager->expects($this->at(1))
 				->method('get')
 				->with('user2')
-				->willReturn($user2);
+				->willReturn($this->userMocks['user2']);
 		}
 		$this->consoleOutput->expects($this->once())
 			->method('writeln')
@@ -371,23 +318,9 @@ class LastSeenTest extends TestCase {
 			->method('getEMailAddress')
 			->willReturn('user1@e.mail');
 
-		$this->consoleInput->expects($this->at(0))
-			->method('getArgument')
-			->with('uid')
-			->willReturn(null);
-		$this->consoleInput->expects($this->at(1))
-			->method('getOption')
-			->with('least-recent')
-			->willReturn($leastRecent);
-		$this->consoleInput->expects($this->at(2))
-			->method('getOption')
-			->with('limit')
-			->willReturn(10);
-		$this->consoleInput->expects($this->at(3))
-			->method('getOption')
-			->with('output')
-			->willReturn(LastSeen::OUTPUT_FORMAT_JSON);
-		$this->consoleInput->expects($this->at(4))
+		$this->expectConsoleInput(null, $leastRecent, null, 10, LastSeen::OUTPUT_FORMAT_JSON);
+
+		$this->consoleInput->expects($this->at(5))
 			->method('getOption')
 			->with('output')
 			->willReturn(LastSeen::OUTPUT_FORMAT_JSON);
@@ -418,5 +351,72 @@ class LastSeenTest extends TestCase {
 			->with($expectedString);
 
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
+
+	public function beforeUsersJSON() {
+		return [
+			['2 days ago', ['user1', 'user2'],
+				'[{"displayname":"User1 Name","email":"user1@e.mail","lastLogin":"2016-09-21T10:25:20Z","userid":"user1"},{"displayname":"User2 Name","email":"user2@e.mail","lastLogin":"2016-09-05T09:29:58Z","userid":"user2"}]'],
+			['2016-09-30', ['user1', 'user2'],
+				'[{"displayname":"User1 Name","email":"user1@e.mail","lastLogin":"2016-09-21T10:25:20Z","userid":"user1"},{"displayname":"User2 Name","email":"user2@e.mail","lastLogin":"2016-09-05T09:29:58Z","userid":"user2"}]'],
+			['2016-09-21', ['user2'],
+				'[{"displayname":"User2 Name","email":"user2@e.mail","lastLogin":"2016-09-05T09:29:58Z","userid":"user2"}]'],
+			['2016-09-05', [],
+				'[]'],
+		];
+	}
+
+	/**
+	 * @dataProvider beforeUsersJSON
+	 *
+	 * @param string $leastRecent
+	 * @param string[] $users userid => user the usermanager should know
+	 * @param string $expectedString
+	 */
+	public function testBeforeUsersJSON($before, $users, $expectedString) {
+
+		$this->expectConsoleInput(null, null, $before, 10, LastSeen::OUTPUT_FORMAT_JSON);
+
+		$this->consoleInput->expects($this->at(5))
+			->method('getOption')
+			->with('output')
+			->willReturn(LastSeen::OUTPUT_FORMAT_JSON);
+
+		$pos = 0;
+		foreach ($users as $userId) {
+			$this->userManager->expects($this->at($pos))
+				->method('get')
+				->with($userId)
+				->willReturn($this->userMocks[$userId]);
+			$pos++;
+		}
+		$this->consoleOutput->expects($this->once())
+			->method('writeln')
+			->with($expectedString);
+
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
+
+	private function expectConsoleInput ($uid, $leastRecent, $before, $limit = 10, $format = null) {
+		$this->consoleInput->expects($this->at(0))
+			->method('getArgument')
+			->with('uid')
+			->willReturn($uid);
+		$this->consoleInput->expects($this->at(1))
+			->method('getOption')
+			->with('least-recent')
+			->willReturn($leastRecent);
+		$this->consoleInput->expects($this->at(2))
+			->method('getOption')
+			->with('before')
+			->willReturn($before);
+		$this->consoleInput->expects($this->at(3))
+			->method('getOption')
+			->with('limit')
+			->willReturn($limit);
+		$this->consoleInput->expects($this->at(4))
+			->method('getOption')
+			->with('output')
+			->willReturn($format);
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

This PR makes the uid param of `occ user:lastseen` obsolete and returns the n most recently logged in users limited by a `--limit` parameter (default is 10). It also now supports `--output`. For JSON output the users displayname and email er added to the object to make the output actually useful, eg:

``` json
$ php ./occ user:lastseen --output=json_pretty
[
    {
        "userid": "admin",
        "lastLogin": "2016-09-21T10:25:20",
        "displayname": "admin",
        "email": null
    },
    {
        "userid": "null",
        "lastLogin": "2016-09-05T09:29:58",
        "displayname": "null",
        "email": null
    }
]
```

Yes, I actually have a user `"null"` in this test db 😈 

The existing output when a uid is given remains unchanged.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->

reporting functionality has been asked for quite often
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- [x] Who is actively using the instance? (most recent logins, the default)
- [x] Who no longer uses the instance? (least recent logins, TODO) 
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

On the cmdline. I am trying to get write a unit test ... but mocking a querybuilder is no fun ...
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
