### PR TITLE
Add more files plugins to new DAV endpoint

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -169,7 +169,7 @@ class FilesReportPlugin extends ServerPlugin {
 	public function onReport($reportName, $report, $uri) {
 		$reportTargetNode = $this->server->tree->getNodeForPath($uri);
 		if (!$reportTargetNode instanceof Directory || $reportName !== self::REPORT_NAME) {
-			throw new ReportNotSupported();
+			return;
 		}
 
 		$ns = '{' . $this::NS_OWNCLOUD . '}';

--- a/apps/dav/lib/Connector/Sabre/SharesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/SharesPlugin.php
@@ -152,7 +152,7 @@ class SharesPlugin extends \Sabre\DAV\ServerPlugin {
 			&& $propFind->getDepth() !== 0
 			&& !is_null($propFind->getStatus(self::SHARETYPES_PROPERTYNAME))
 		) {
-			$folderNode = $this->userFolder->get($propFind->getPath());
+			$folderNode = $this->userFolder->get($sabreNode->getPath());
 			$children = $folderNode->getDirectoryListing();
 
 			$this->cachedShareTypes[$folderNode->getId()] = $this->getShareTypes($folderNode);

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -155,7 +155,8 @@ class Server {
 		// wait with registering these until auth is handled and the filesystem is setup
 		$this->server->on('beforeMethod', function () {
 			// custom properties plugin must be the last one
-			$user = \OC::$server->getUserSession()->getUser();
+			$userSession = \OC::$server->getUserSession();
+			$user = $userSession->getUser();
 			if (!is_null($user)) {
 				$view = \OC\Files\Filesystem::getView();
 				$this->server->addPlugin(
@@ -185,7 +186,30 @@ class Server {
 						$this->server->tree, \OC::$server->getTagManager()
 					)
 				);
+				// TODO: switch to LazyUserFolder
+				$userFolder = \OC::$server->getUserFolder();
+				$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\SharesPlugin(
+					$this->server->tree,
+					$userSession,
+					$userFolder,
+					\OC::$server->getShareManager()
+				));
+				$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\CommentPropertiesPlugin(
+					\OC::$server->getCommentsManager(),
+					$userSession
+				));
+				$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\FilesReportPlugin(
+					$this->server->tree,
+					$view,
+					\OC::$server->getSystemTagManager(),
+					\OC::$server->getSystemTagObjectMapper(),
+					\OC::$server->getTagManager(),
+					$userSession,
+					\OC::$server->getGroupManager(),
+					$userFolder
+				));
 			}
+			$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\CopyEtagHeaderPlugin());
 		});
 	}
 

--- a/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
@@ -119,9 +119,6 @@ class FilesReportPluginTest extends \Test\TestCase {
 		);
 	}
 
-	/**
-	 * @expectedException \Sabre\DAV\Exception\ReportNotSupported
-	 */
 	public function testOnReportInvalidNode() {
 		$path = 'totally/unrelated/13';
 
@@ -135,12 +132,9 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->will($this->returnValue($path));
 		$this->plugin->initialize($this->server);
 
-		$this->plugin->onReport(FilesReportPluginImplementation::REPORT_NAME, [], '/' . $path);
+		$this->assertNull($this->plugin->onReport(FilesReportPluginImplementation::REPORT_NAME, [], '/' . $path));
 	}
 
-	/**
-	 * @expectedException \Sabre\DAV\Exception\ReportNotSupported
-	 */
 	public function testOnReportInvalidReportName() {
 		$path = 'test';
 
@@ -154,7 +148,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->will($this->returnValue($path));
 		$this->plugin->initialize($this->server);
 
-		$this->plugin->onReport('{whoever}whatever', [], '/' . $path);
+		$this->assertNull($this->plugin->onReport('{whoever}whatever', [], '/' . $path));
 	}
 
 	public function testOnReport() {
@@ -236,7 +230,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$this->server->httpResponse = $response;
 		$this->plugin->initialize($this->server);
 
-		$this->plugin->onReport(FilesReportPluginImplementation::REPORT_NAME, $parameters, '/' . $path);
+		$this->assertFalse($this->plugin->onReport(FilesReportPluginImplementation::REPORT_NAME, $parameters, '/' . $path));
 	}
 
 	public function testFindNodesByFileIdsRoot() {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Add plugin for share properties, comment-unread property and report plugin on the new Webdav files endpoint.
## Related Issue

For https://github.com/owncloud/core/pull/25494
## Motivation and Context

To be able to retrieve all properties we had before on the old endpoint, we need these as well on the new files endpoint.
## How Has This Been Tested?
- test if favorite entries still work in the "Favorite" section (due to changes in report plugin)
- Merge this PR with https://github.com/owncloud/core/pull/25494 and check in the web UI that:
  - set entries as favorite then go the the favorite list: all entries listed
  - create a link share, refresh the page: share indicator appears properly
  - with curl do a REPORT with oc:favorite criteria on a subdirectory on both old and new endpoint: results still appear with the correct href of the matching endpoint
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 @butonic 
