### PR TITLE
Add submit button to validate the federated server, fixes issue #25364

### DIFF
--- a/apps/federation/templates/settings-admin.php
+++ b/apps/federation/templates/settings-admin.php
@@ -19,6 +19,7 @@ style('federation', 'settings-admin')
 	<p id="ocFederationAddServer">
 		<button id="ocFederationAddServerButton" class=""><?php p($l->t('+ Add ownCloud server')); ?></button>
 		<input id="serverUrl" class="hidden" type="text" value="" placeholder="<?php p($l->t('ownCloud Server')); ?>" name="server_url"/>
+		<button id="ocFederationSubmit" class="hidden"><?php p($l->t('Add')); ?></button>
 		<span class="msg"></span>
 	</p>
 	<ul id="listOfTrustedServers">


### PR DESCRIPTION
## Description

Add an "Add" Button after the input field.
## Related Issue

Fixes [#25364](https://github.com/owncloud/core/issues/25364)
## Motivation and Context

Usability
## How Has This Been Tested?
1. Clicked **\+ Add ownCloud server** > typed text > Button appears > button works
2. Clicked **\+ Add ownCloud server** > paste text _(CTRL + V)_ > Button appears > button works
3. press ESC on field > button and input disappears. Input value is purged 
## Screenshots (if appropriate):

<img width="471" alt="validate the federated server" src="https://cloud.githubusercontent.com/assets/12717530/18752743/a039e08a-80e3-11e6-8cb6-71c5c35480b1.png">
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
