### PR TITLE
Fix permissions over the root

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -568,10 +568,12 @@ class SMB extends Common {
 		$this->log('enter: '.__FUNCTION__."($path)");
 		$result = false;
 		try {
-			$info = $this->getFileInfo($path);
-			// following windows behaviour for read-only folders: they can be written into
-			// (https://support.microsoft.com/en-us/kb/326549 - "cause" section)
-			$result = !$info->isHidden() && (!$info->isReadOnly() || $this->is_dir($path));
+			if (!$this->isRootDir($path)) {
+				$info = $this->getFileInfo($path);
+				// following windows behaviour for read-only folders: they can be written into
+				// (https://support.microsoft.com/en-us/kb/326549 - "cause" section)
+				$result = !$info->isHidden() && (!$info->isReadOnly() || $this->is_dir($path));
+			}
 		} catch (NotFoundException $e) {
 			$this->swallow(__FUNCTION__, $e);
 		} catch (ForbiddenException $e) {
@@ -584,8 +586,10 @@ class SMB extends Common {
 		$this->log('enter: '.__FUNCTION__."($path)");
 		$result = false;
 		try {
-			$info = $this->getFileInfo($path);
-			$result = !$info->isHidden() && !$info->isReadOnly();
+			if (!$this->isRootDir($path)) {
+				$info = $this->getFileInfo($path);
+				$result = !$info->isHidden() && !$info->isReadOnly();
+			}
 		} catch (NotFoundException $e) {
 			$this->swallow(__FUNCTION__, $e);
 		} catch (ForbiddenException $e) {


### PR DESCRIPTION
## Description

Force root permissions so the mount can't be modified
## Related Issue

https://github.com/owncloud/windows_network_drive-old/issues/334
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
## How Has This Been Tested?

Manual test.
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

@PVince81 @butonic 

Backport to be considered.
