### PR TITLE
[stable9] Tear down FS after user update in CardDAV sync job

### DIFF
--- a/apps/dav/lib/carddav/syncservice.php
+++ b/apps/dav/lib/carddav/syncservice.php
@@ -263,6 +263,8 @@ class SyncService {
 		$systemAddressBook = $this->getLocalSystemAddressBook();
 		$this->userManager->callForAllUsers(function($user) use ($systemAddressBook, $progressCallback) {
 			$this->updateUser($user);
+			// avatar fetching sets up FS, need to clear again
+			\OC_Util::tearDownFS();
 			if (!is_null($progressCallback)) {
 				$progressCallback();
 			}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

 Tear down FS after user update in CardDAV sync job
## Related Issue

Discovered by analyzing https://github.com/owncloud/core/issues/25718#issuecomment-249207845
## Motivation and Context

Because fetching the user information will also fetch the avatar, the
avatar code sets up the FS and leaves the mount points cached, we need
to call tearDownFS to clear that up.

This should also significantly reduce memory usage when processing many users.
## How Has This Been Tested?

Tested with a debugger. Checked with a breakpoint in tearDownFS and checked that the `$mounts` local attribute only ever contains the mounts of the last user and not everything.
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
### Ports
- [x] forward port to 9.1
- [x] forward port to master

@butonic @DeepDiver1975 as discussed
