### PR TITLE
Expose the needupgrade status

### DIFF
--- a/status.php
+++ b/status.php
@@ -40,6 +40,7 @@ try {
 	$values= [
 		'installed'=>$installed,
 		'maintenance' => $maintenance,
+		'needsDbUpgrade' => \OCP\Util::needUpgrade(),
 		'version'=>implode('.', \OCP\Util::getVersion()),
 		'versionstring'=>OC_Util::getVersionString(),
 		'edition'=>OC_Util::getEditionString(),


### PR DESCRIPTION
During upgrades, before the DB migration is complete, the system is not
usable, but there's no way for monitoring systems to detect this.
Add the 'needupgrade' field to the status json so monitoring systems can
detect this.
