### PR TITLE
Change the minimum log level to fatal

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -227,7 +227,7 @@ class Log implements ILogger {
 	 * @return void
 	 */
 	public function log($level, $message, array $context = []) {
-		$minLevel = min($this->config->getValue('loglevel', Util::WARN), Util::ERROR);
+		$minLevel = min($this->config->getValue('loglevel', Util::WARN), Util::FATAL);
 		$logCondition = $this->config->getValue('log.condition', []);
 
 		array_walk($context, [$this->normalizer, 'format']);


### PR DESCRIPTION
## Description

Change the minimum log level to "fatal" instead of "warning"
## Related Issue

https://github.com/owncloud/core/issues/26131
## Motivation and Context

Setting the log level to "fatal" will still show warning messages (which shouldn't be there)
## How Has This Been Tested?

User confirmed the fix in the issue
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

@PVince81 @DeepDiver1975 I'm not sure if we should keep the "min" function there, or just get the value from the configuration. I don't see any advantage as it is right now.

Backports should be at least to 9.0
