### PR TITLE
[stable9.1] Tear down FS between cron jobs

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -120,6 +120,8 @@ try {
 
 			$logger->debug('Run ' . get_class($job) . ' job with ID ' . $job->getId(), ['app' => 'cron']);
 			$job->execute($jobList, $logger);
+			// clean up after unclean jobs
+			\OC_Util::tearDownFS();
 			$logger->debug('Finished ' . get_class($job) . ' job with ID ' . $job->getId(), ['app' => 'cron']);
 
 			$jobList->setLastJob($job);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Because some cron jobs do not always properly clean up their FS usage
and others might not clean up before setting up the FS, this could
cause potential side effects.

To make sure we exclude side effects, we tear down the FS between cron
jobs.
## Related Issue

Tentative fix for https://github.com/owncloud/core/issues/25718
## Motivation and Context

See issue details
## How Has This Been Tested?

Ran cron.php and saw there was no new errors.
Note that the original issue isn't reproducible yet, so this is just an extra care.
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
### Backports
- [x] forward port to master
- [x] all other stable branches ?

@DeepDiver1975 @butonic 
