### PR TITLE
Integration tests refactoring

### DIFF
--- a/build/integration/features/bootstrap/WebDav.php
+++ b/build/integration/features/bootstrap/WebDav.php
@@ -40,14 +40,6 @@ trait WebDav {
 		$this->usingOldDavPath = false;
 	}
 
-	/*public function getDavFilesPath($user){
-		if ($this->usingOldDavPath === true){
-			return $this->davPath . '/';
-		} else {
-			return $this->davPath . '/files/' . $user . '/';
-		}
-	}*/
-
 	public function getDavFilesPath($user){
 		if ($this->usingOldDavPath === true){
 			return $this->davPath;
@@ -56,19 +48,8 @@ trait WebDav {
 		}
 	}
 
-	public function getFilesPath($user){
-		$basePath = '';
-		if ($this->davPath === "remote.php/dav"){
-			$basePath = '/files/' . $user . '/';
-		} else {
-			$basePath = '/';
-		}
-		return $basePath;
-	}
-
 	public function makeDavRequest($user, $method, $path, $headers, $body = null, $type = "files"){
 		if ( $type === "files" ){
-			echo "user: " . $user . " method: " . $method . " path: " . $path . " type: " . $type;
 			$fullUrl = substr($this->baseUrl, 0, -4) . $this->getDavFilesPath($user) . "$path";
 		} else if ( $type === "uploads" ){
 			$fullUrl = substr($this->baseUrl, 0, -4) . $this->davPath . "$path";

--- a/build/integration/features/bootstrap/WebDav.php
+++ b/build/integration/features/bootstrap/WebDav.php
@@ -12,6 +12,8 @@ trait WebDav {
 
 	/** @var string*/
 	private $davPath = "remote.php/webdav";
+	/** @var boolean*/
+	private $usingOldDavPath = true;
 	/** @var ResponseInterface */
 	private $response;
 
@@ -20,6 +22,38 @@ trait WebDav {
 	 */
 	public function usingDavPath($davPath) {
 		$this->davPath = $davPath;
+	}
+
+	/**
+	 * @Given /^using old dav path$/
+	 */
+	public function usingOldDavPath() {
+		$this->davPath = "remote.php/webdav";
+		$this->usingOldDavPath = true;
+	}
+
+	/**
+	 * @Given /^using new dav path$/
+	 */
+	public function usingNewDavPath() {
+		$this->davPath = "remote.php/dav";
+		$this->usingOldDavPath = false;
+	}
+
+	/*public function getDavFilesPath($user){
+		if ($this->usingOldDavPath === true){
+			return $this->davPath . '/';
+		} else {
+			return $this->davPath . '/files/' . $user . '/';
+		}
+	}*/
+
+	public function getDavFilesPath($user){
+		if ($this->usingOldDavPath === true){
+			return $this->davPath;
+		} else {
+			return $this->davPath . '/files/' . $user;
+		}
 	}
 
 	public function getFilesPath($user){
@@ -33,7 +67,7 @@ trait WebDav {
 	}
 
 	public function makeDavRequest($user, $method, $path, $headers, $body = null){
-		$fullUrl = substr($this->baseUrl, 0, -4) . $this->davPath . "$path";
+		$fullUrl = substr($this->baseUrl, 0, -4) . $this->getDavFilesPath($user) . "$path";
 		$client = new GClient();
 		$options = [];
 		if ($user === 'admin') {
@@ -62,7 +96,7 @@ trait WebDav {
 	 * @param string $fileDestination
 	 */
 	public function userMovedFile($user, $entry, $fileSource, $fileDestination){
-		$fullUrl = substr($this->baseUrl, 0, -4) . $this->davPath;
+		$fullUrl = substr($this->baseUrl, 0, -4) . $this->getDavFilesPath($user);
 		$headers['Destination'] = $fullUrl . $fileDestination;
 		$this->response = $this->makeDavRequest($user, "MOVE", $fileSource, $headers);
 		PHPUnit_Framework_Assert::assertEquals(201, $this->response->getStatusCode());
@@ -75,7 +109,7 @@ trait WebDav {
 	 * @param string $fileDestination
 	 */
 	public function userMovesFile($user, $entry, $fileSource, $fileDestination){
-		$fullUrl = substr($this->baseUrl, 0, -4) . $this->davPath;
+		$fullUrl = substr($this->baseUrl, 0, -4) . $this->getDavFilesPath($user);
 		$headers['Destination'] = $fullUrl . $fileDestination;
 		try {
 			$this->response = $this->makeDavRequest($user, "MOVE", $fileSource, $headers);
@@ -91,7 +125,7 @@ trait WebDav {
 	 * @param string $fileDestination
 	 */
 	public function userCopiesFile($user, $fileSource, $fileDestination){
-		$fullUrl = substr($this->baseUrl, 0, -4) . $this->davPath;
+		$fullUrl = substr($this->baseUrl, 0, -4) . $this->getDavFilesPath($user);
 		$headers['Destination'] = $fullUrl . $fileDestination;
 		try {
 			$this->response = $this->makeDavRequest($user, "COPY", $fileSource, $headers);
@@ -344,7 +378,7 @@ trait WebDav {
 	}
 
 	public function makeSabrePath($user, $path) {
-		return $this->encodePath($this->davPath . $this->getFilesPath($user) . ltrim($path, '/'));
+		return $this->encodePath($this->getDavFilesPath($user));
 	}
 
 	public function getSabreClient($user) {
@@ -375,7 +409,7 @@ trait WebDav {
 			$elementRows = $expectedElements->getRows();
 			$elementsSimplified = $this->simplifyArray($elementRows);
 			foreach($elementsSimplified as $expectedElement) {
-				$webdavPath = "/" . $this->davPath . $expectedElement;
+				$webdavPath = "/" . $this->getDavFilesPath($user) . $expectedElement;
 				if (!array_key_exists($webdavPath,$elementList)){
 					PHPUnit_Framework_Assert::fail("$webdavPath" . " is not in propfind answer");
 				}
@@ -451,7 +485,7 @@ trait WebDav {
 	 */
 	public function userCreatedAFolder($user, $destination){
 		try {
-			$this->response = $this->makeDavRequest($user, "MKCOL", $this->getFilesPath($user) . ltrim($destination, $this->getFilesPath($user)), []);
+			$this->response = $this->makeDavRequest($user, "MKCOL", $destination, []);
 		} catch (\GuzzleHttp\Exception\ServerException $e) {
 			// 4xx and 5xx responses cause an exception
 			$this->response = $e->getResponse();
@@ -499,7 +533,7 @@ trait WebDav {
 	public function userMovesNewChunkFileWithIdToMychunkedfile($user, $id, $dest)
 	{
 		$source = '/uploads/'.$user.'/'.$id.'/.file';
-		$destination = substr($this->baseUrl, 0, -4) . $this->davPath . '/files/'.$user.$dest;
+		$destination = substr($this->baseUrl, 0, -4) . $this->getDavFilesPath($user) . $dest;
 		$this->makeDavRequest($user, 'MOVE', $source, [
 			'Destination' => $destination
 		]);
@@ -561,7 +595,7 @@ trait WebDav {
 			];
 		}
 
-		$response = $client->proppatch($this->davPath . $this->getFilesPath($user) . ltrim($path, '/'), $properties, $folderDepth);
+		$response = $client->proppatch($this->getDavFilesPath($user), $properties, $folderDepth);
 		return $response;
 	}
 

--- a/build/integration/features/bootstrap/WebDav.php
+++ b/build/integration/features/bootstrap/WebDav.php
@@ -254,12 +254,12 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" gets properties of folder "([^"]*)" with$/
+	 * @Then /^as "([^"]*)" gets properties of (file|folder|entry) "([^"]*)" with$/
 	 * @param string $user
 	 * @param string $path
 	 * @param \Behat\Gherkin\Node\TableNode|null $propertiesTable
 	 */
-	public function asGetsPropertiesOfFolderWith($user, $path, $propertiesTable) {
+	public function asGetsPropertiesOfFolderWith($user, $elementType, $path, $propertiesTable) {
 		$properties = null;
 		if ($propertiesTable instanceof \Behat\Gherkin\Node\TableNode) {
 			foreach ($propertiesTable->getRows() as $row) {
@@ -378,7 +378,7 @@ trait WebDav {
 	}
 
 	public function makeSabrePath($user, $path) {
-		return $this->encodePath($this->getDavFilesPath($user));
+		return $this->encodePath($this->getDavFilesPath($user) . $path);
 	}
 
 	public function getSabreClient($user) {
@@ -599,13 +599,4 @@ trait WebDav {
 		return $response;
 	}
 
-	/**
-	 * @Then /^as "([^"]*)" gets properties of file "([^"]*)" with$/
-	 * @param string $user
-	 * @param string $path
-	 * @param \Behat\Gherkin\Node\TableNode|null $propertiesTable
-	 */
-	public function asGetsPropertiesOfFileWith($user, $path, $propertiesTable) {
-		$this->asGetsPropertiesOfFolderWith($user, $path, $propertiesTable);
-	}
 }

--- a/build/integration/features/dav-v2.feature
+++ b/build/integration/features/dav-v2.feature
@@ -3,24 +3,24 @@ Feature: dav-v2
 		Given using api version "1"
 
 	Scenario: moving a file new endpoint way
-		Given using dav path "remote.php/dav"
+		Given using new dav path
 		And As an "admin"
 		And user "user0" exists
-		When User "user0" moves file "/files/user0/textfile0.txt" to "/files/user0/FOLDER/textfile0.txt"
+		When User "user0" moves file "/textfile0.txt" to "/FOLDER/textfile0.txt"
 		Then the HTTP status code should be "201"
 
 	Scenario: download a file with range using new endpoint
-		Given using dav path "remote.php/dav"
+		Given using new dav path
 		And As an "admin"
 		And user "user0" exists
 		And As an "user0"
-		When Downloading file "/files/user0/welcome.txt" with range "bytes=51-77"
+		When Downloading file "/welcome.txt" with range "bytes=51-77"
 		Then Downloaded content should be "example file for developers"
 
 	Scenario: Downloading a file on the new endpoint should serve security headers
-		Given using dav path "remote.php/dav/files/admin/"
+		Given using new dav path
 		And As an "admin"
-		When Downloading file "welcome.txt"
+		When Downloading file "/welcome.txt"
 		Then The following headers should be set
 			|Content-Disposition|attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt"|
 			|Content-Security-Policy|default-src 'none';|
@@ -55,16 +55,16 @@ Feature: dav-v2
 		Then the HTTP status code should be "207"
 
 	Scenario: Uploading a file having 0B as quota
-		Given using dav path "remote.php/dav"
+		Given using new dav path
 		And As an "admin"
 		And user "user0" exists
 		And user "user0" has a quota of "0 B"
 		And As an "user0"
-		When User "user0" uploads file "data/textfile.txt" to "/files/user0/asdf.txt"
+		When User "user0" uploads file "data/textfile.txt" to "/asdf.txt"
 		Then the HTTP status code should be "507"
 
 	Scenario: Uploading a file as recipient using webdav new endpoint having quota
-		Given using dav path "remote.php/dav"
+		Given using new dav path
 		And As an "admin"
 		And user "user0" exists
 		And user "user1" exists
@@ -78,5 +78,5 @@ Feature: dav-v2
 		  | permissions | 31 |
 		  | shareWith | user0 |
 		And As an "user0"
-		When User "user0" uploads file "data/textfile.txt" to "/files/user0/testquota/asdf.txt"
+		When User "user0" uploads file "data/textfile.txt" to "/testquota/asdf.txt"
 		Then the HTTP status code should be "201"

--- a/build/integration/features/external-storage.feature
+++ b/build/integration/features/external-storage.feature
@@ -1,7 +1,7 @@
 Feature: external-storage
   Background:
     Given using api version "1"
-    Given using dav path "remote.php/webdav"
+    Given using old dav path
 
   @local_storage
   Scenario: Share by link a file inside a local external storage

--- a/build/integration/features/favorites.feature
+++ b/build/integration/features/favorites.feature
@@ -3,7 +3,7 @@ Feature: favorite
         Given using api version "1"
 
     Scenario: Favorite a folder
-        Given using dav path "remote.php/webdav"
+        Given using old dav path
         And As an "admin"
         And user "user0" exists
         When user "user0" favorites element "/FOLDER"
@@ -12,7 +12,7 @@ Feature: favorite
         And the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
 
     Scenario: Favorite and unfavorite a folder
-        Given using dav path "remote.php/webdav"
+        Given using old dav path
         And As an "admin"
         And user "user0" exists
         When user "user0" favorites element "/FOLDER"
@@ -22,7 +22,7 @@ Feature: favorite
         And the single response should contain a property "{http://owncloud.org/ns}favorite" with value ""
 
     Scenario: Favorite a file
-        Given using dav path "remote.php/webdav"
+        Given using old dav path
         And As an "admin"
         And user "user0" exists
         When user "user0" favorites element "/textfile0.txt"
@@ -31,7 +31,7 @@ Feature: favorite
         And the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
 
     Scenario: Favorite and unfavorite a file
-        Given using dav path "remote.php/webdav"
+        Given using old dav path
         And As an "admin"
         And user "user0" exists
         When user "user0" favorites element "/textfile0.txt"
@@ -41,7 +41,7 @@ Feature: favorite
         And the single response should contain a property "{http://owncloud.org/ns}favorite" with value ""
 
     Scenario: Favorite a folder new endpoint
-        Given using dav path "remote.php/dav"
+        Given using new dav path
         And As an "admin"
         And user "user0" exists
         When user "user0" favorites element "/FOLDER"
@@ -50,7 +50,7 @@ Feature: favorite
         And the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
 
     Scenario: Favorite and unfavorite a folder new endpoint
-        Given using dav path "remote.php/dav"
+        Given using new dav path
         And As an "admin"
         And user "user0" exists
         When user "user0" favorites element "/FOLDER"
@@ -60,7 +60,7 @@ Feature: favorite
         And the single response should contain a property "{http://owncloud.org/ns}favorite" with value ""
 
     Scenario: Favorite a file new endpoint
-        Given using dav path "remote.php/dav"
+        Given using new dav path
         And As an "admin"
         And user "user0" exists
         When user "user0" favorites element "/textfile0.txt"
@@ -69,7 +69,7 @@ Feature: favorite
         And the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
 
     Scenario: Favorite and unfavorite a file new endpoint
-        Given using dav path "remote.php/dav"
+        Given using new dav path
         And As an "admin"
         And user "user0" exists
         When user "user0" favorites element "/textfile0.txt"

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -1,7 +1,7 @@
 Feature: sharing
   Background:
     Given using api version "1"
-    Given using dav path "remote.php/webdav"
+    Given using old dav path
 
   Scenario: Creating a new share with user
     Given user "user0" exists
@@ -533,7 +533,7 @@ Feature: sharing
       | /myFOLDER/myTMP/ |
 
   Scenario: Check quota of owners parent directory of a shared file
-    Given using dav path "remote.php/webdav"
+    Given using old dav path
     And As an "admin"
     And user "user0" exists
     And user "user1" exists
@@ -607,7 +607,7 @@ Feature: sharing
     Given user "user0" exists
     And user "user1" exists
     And User "user0" uploads file with content "foo" to "/tmp.txt"
-    And file "tmp.txt" of user "user0" is shared with user "user1"
+    And file "/tmp.txt" of user "user0" is shared with user "user1"
     When as "user1" gets properties of folder "/tmp.txt" with
       |{http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
@@ -726,16 +726,17 @@ Feature: sharing
     And the HTTP status code should be "401"
 
   Scenario: Merging shares for recipient when shared from outside with group and member
-    Given As an "admin"
+    Given using old dav path
+    And As an "admin"
     And user "user0" exists
     And user "user1" exists
     And group "group1" exists
     And user "user1" belongs to group "group1"
-    And user "user0" created a folder "merge-test-outside"
-    When folder "merge-test-outside" of user "user0" is shared with group "group1"
-    And folder "merge-test-outside" of user "user0" is shared with user "user1"
-    Then as "user1" the folder "merge-test-outside" exists
-    And as "user1" the folder "merge-test-outside (2)" does not exist
+    And user "user0" created a folder "/merge-test-outside"
+    When folder "/merge-test-outside" of user "user0" is shared with group "group1"
+    And folder "/merge-test-outside" of user "user0" is shared with user "user1"
+    Then as "user1" the folder "/merge-test-outside" exists
+    And as "user1" the folder "/merge-test-outside (2)" does not exist
 
   Scenario: Merging shares for recipient when shared from outside with group and member with different permissions
     Given As an "admin"
@@ -743,13 +744,13 @@ Feature: sharing
     And user "user1" exists
     And group "group1" exists
     And user "user1" belongs to group "group1"
-    And user "user0" created a folder "merge-test-outside-perms"
-    When folder "merge-test-outside-perms" of user "user0" is shared with group "group1" with permissions 1
-    And folder "merge-test-outside-perms" of user "user0" is shared with user "user1" with permissions 31
-    Then as "user1" gets properties of folder "merge-test-outside-perms" with
+    And user "user0" created a folder "/merge-test-outside-perms"
+    When folder "/merge-test-outside-perms" of user "user0" is shared with group "group1" with permissions 1
+    And folder "/merge-test-outside-perms" of user "user0" is shared with user "user1" with permissions 31
+    Then as "user1" gets properties of folder "/merge-test-outside-perms" with
         |{http://owncloud.org/ns}permissions|
     And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-    And as "user1" the folder "merge-test-outside-perms (2)" does not exist
+    And as "user1" the folder "/merge-test-outside-perms (2)" does not exist
 
   Scenario: Merging shares for recipient when shared from outside with two groups
     Given As an "admin"
@@ -759,11 +760,11 @@ Feature: sharing
     And group "group2" exists
     And user "user1" belongs to group "group1"
     And user "user1" belongs to group "group2"
-    And user "user0" created a folder "merge-test-outside-twogroups"
-    When folder "merge-test-outside-twogroups" of user "user0" is shared with group "group1"
-    And folder "merge-test-outside-twogroups" of user "user0" is shared with group "group2"
-    Then as "user1" the folder "merge-test-outside-twogroups" exists
-    And as "user1" the folder "merge-test-outside-twogroups (2)" does not exist
+    And user "user0" created a folder "/merge-test-outside-twogroups"
+    When folder "/merge-test-outside-twogroups" of user "user0" is shared with group "group1"
+    And folder "/merge-test-outside-twogroups" of user "user0" is shared with group "group2"
+    Then as "user1" the folder "/merge-test-outside-twogroups" exists
+    And as "user1" the folder "/merge-test-outside-twogroups (2)" does not exist
 
   Scenario: Merging shares for recipient when shared from outside with two groups with different permissions
     Given As an "admin"
@@ -773,13 +774,13 @@ Feature: sharing
     And group "group2" exists
     And user "user1" belongs to group "group1"
     And user "user1" belongs to group "group2"
-    And user "user0" created a folder "merge-test-outside-twogroups-perms"
-    When folder "merge-test-outside-twogroups-perms" of user "user0" is shared with group "group1" with permissions 1
-    And folder "merge-test-outside-twogroups-perms" of user "user0" is shared with group "group2" with permissions 31
-    Then as "user1" gets properties of folder "merge-test-outside-twogroups-perms" with
+    And user "user0" created a folder "/merge-test-outside-twogroups-perms"
+    When folder "/merge-test-outside-twogroups-perms" of user "user0" is shared with group "group1" with permissions 1
+    And folder "/merge-test-outside-twogroups-perms" of user "user0" is shared with group "group2" with permissions 31
+    Then as "user1" gets properties of folder "/merge-test-outside-twogroups-perms" with
         |{http://owncloud.org/ns}permissions|
     And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-    And as "user1" the folder "merge-test-outside-twogroups-perms (2)" does not exist
+    And as "user1" the folder "/merge-test-outside-twogroups-perms (2)" does not exist
 
   Scenario: Merging shares for recipient when shared from outside with two groups and member
     Given As an "admin"
@@ -789,24 +790,24 @@ Feature: sharing
     And group "group2" exists
     And user "user1" belongs to group "group1"
     And user "user1" belongs to group "group2"
-    And user "user0" created a folder "merge-test-outside-twogroups-member-perms"
-    When folder "merge-test-outside-twogroups-member-perms" of user "user0" is shared with group "group1" with permissions 1
-    And folder "merge-test-outside-twogroups-member-perms" of user "user0" is shared with group "group2" with permissions 31
-    And folder "merge-test-outside-twogroups-member-perms" of user "user0" is shared with user "user1" with permissions 1
-    Then as "user1" gets properties of folder "merge-test-outside-twogroups-member-perms" with
+    And user "user0" created a folder "/merge-test-outside-twogroups-member-perms"
+    When folder "/merge-test-outside-twogroups-member-perms" of user "user0" is shared with group "group1" with permissions 1
+    And folder "/merge-test-outside-twogroups-member-perms" of user "user0" is shared with group "group2" with permissions 31
+    And folder "/merge-test-outside-twogroups-member-perms" of user "user0" is shared with user "user1" with permissions 1
+    Then as "user1" gets properties of folder "/merge-test-outside-twogroups-member-perms" with
         |{http://owncloud.org/ns}permissions|
     And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-    And as "user1" the folder "merge-test-outside-twogroups-member-perms (2)" does not exist
+    And as "user1" the folder "/merge-test-outside-twogroups-member-perms (2)" does not exist
 
   Scenario: Merging shares for recipient when shared from inside with group
     Given As an "admin"
     And user "user0" exists
     And group "group1" exists
     And user "user0" belongs to group "group1"
-    And user "user0" created a folder "merge-test-inside-group"
+    And user "user0" created a folder "/merge-test-inside-group"
     When folder "/merge-test-inside-group" of user "user0" is shared with group "group1"
-    Then as "user0" the folder "merge-test-inside-group" exists
-    And as "user0" the folder "merge-test-inside-group (2)" does not exist
+    Then as "user0" the folder "/merge-test-inside-group" exists
+    And as "user0" the folder "/merge-test-inside-group (2)" does not exist
 
   Scenario: Merging shares for recipient when shared from inside with two groups
     Given As an "admin"
@@ -815,12 +816,12 @@ Feature: sharing
     And group "group2" exists
     And user "user0" belongs to group "group1"
     And user "user0" belongs to group "group2"
-    And user "user0" created a folder "merge-test-inside-twogroups"
-    When folder "merge-test-inside-twogroups" of user "user0" is shared with group "group1"
-    And folder "merge-test-inside-twogroups" of user "user0" is shared with group "group2"
-    Then as "user0" the folder "merge-test-inside-twogroups" exists
-    And as "user0" the folder "merge-test-inside-twogroups (2)" does not exist
-    And as "user0" the folder "merge-test-inside-twogroups (3)" does not exist
+    And user "user0" created a folder "/merge-test-inside-twogroups"
+    When folder "/merge-test-inside-twogroups" of user "user0" is shared with group "group1"
+    And folder "/merge-test-inside-twogroups" of user "user0" is shared with group "group2"
+    Then as "user0" the folder "/merge-test-inside-twogroups" exists
+    And as "user0" the folder "/merge-test-inside-twogroups (2)" does not exist
+    And as "user0" the folder "/merge-test-inside-twogroups (3)" does not exist
 
   Scenario: Merging shares for recipient when shared from inside with group with less permissions
     Given As an "admin"
@@ -829,14 +830,14 @@ Feature: sharing
     And group "group2" exists
     And user "user0" belongs to group "group1"
     And user "user0" belongs to group "group2"
-    And user "user0" created a folder "merge-test-inside-twogroups-perms"
-    When folder "merge-test-inside-twogroups-perms" of user "user0" is shared with group "group1"
-    And folder "merge-test-inside-twogroups-perms" of user "user0" is shared with group "group2"
-    Then as "user0" gets properties of folder "merge-test-inside-twogroups-perms" with
+    And user "user0" created a folder "/merge-test-inside-twogroups-perms"
+    When folder "/merge-test-inside-twogroups-perms" of user "user0" is shared with group "group1"
+    And folder "/merge-test-inside-twogroups-perms" of user "user0" is shared with group "group2"
+    Then as "user0" gets properties of folder "/merge-test-inside-twogroups-perms" with
         |{http://owncloud.org/ns}permissions|
     And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "RDNVCK"
-    And as "user0" the folder "merge-test-inside-twogroups-perms (2)" does not exist
-    And as "user0" the folder "merge-test-inside-twogroups-perms (3)" does not exist
+    And as "user0" the folder "/merge-test-inside-twogroups-perms (2)" does not exist
+    And as "user0" the folder "/merge-test-inside-twogroups-perms (3)" does not exist
 
   Scenario: Merging shares for recipient when shared from outside with group then user and recipient renames in between
     Given As an "admin"
@@ -844,14 +845,14 @@ Feature: sharing
     And user "user1" exists
     And group "group1" exists
     And user "user1" belongs to group "group1"
-    And user "user0" created a folder "merge-test-outside-groups-renamebeforesecondshare"
-    When folder "merge-test-outside-groups-renamebeforesecondshare" of user "user0" is shared with group "group1"
+    And user "user0" created a folder "/merge-test-outside-groups-renamebeforesecondshare"
+    When folder "/merge-test-outside-groups-renamebeforesecondshare" of user "user0" is shared with group "group1"
     And User "user1" moved folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed"
-    And folder "merge-test-outside-groups-renamebeforesecondshare" of user "user0" is shared with user "user1"
-    Then as "user1" gets properties of folder "merge-test-outside-groups-renamebeforesecondshare-renamed" with
+    And folder "/merge-test-outside-groups-renamebeforesecondshare" of user "user0" is shared with user "user1"
+    Then as "user1" gets properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" with
         |{http://owncloud.org/ns}permissions|
     And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-    And as "user1" the folder "merge-test-outside-groups-renamebeforesecondshare" does not exist
+    And as "user1" the folder "/merge-test-outside-groups-renamebeforesecondshare" does not exist
 
   Scenario: Merging shares for recipient when shared from outside with user then group and recipient renames in between
     Given As an "admin"
@@ -859,14 +860,14 @@ Feature: sharing
     And user "user1" exists
     And group "group1" exists
     And user "user1" belongs to group "group1"
-    And user "user0" created a folder "merge-test-outside-groups-renamebeforesecondshare"
-    When folder "merge-test-outside-groups-renamebeforesecondshare" of user "user0" is shared with user "user1"
+    And user "user0" created a folder "/merge-test-outside-groups-renamebeforesecondshare"
+    When folder "/merge-test-outside-groups-renamebeforesecondshare" of user "user0" is shared with user "user1"
     And User "user1" moved folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed"
-    And folder "merge-test-outside-groups-renamebeforesecondshare" of user "user0" is shared with group "group1"
-    Then as "user1" gets properties of folder "merge-test-outside-groups-renamebeforesecondshare-renamed" with
+    And folder "/merge-test-outside-groups-renamebeforesecondshare" of user "user0" is shared with group "group1"
+    Then as "user1" gets properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" with
         |{http://owncloud.org/ns}permissions|
     And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-    And as "user1" the folder "merge-test-outside-groups-renamebeforesecondshare" does not exist
+    And as "user1" the folder "/merge-test-outside-groups-renamebeforesecondshare" does not exist
 
   Scenario: Empting trashbin
     Given As an "admin"
@@ -884,5 +885,5 @@ Feature: sharing
     And file "/common/sub" of user "user0" is shared with user "user1"
     And User "user0" deletes folder "/common"
     When User "user0" empties trashbin
-    Then as "user1" the folder "sub" does not exist
+    Then as "user1" the folder "/sub" does not exist
 

--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -3,7 +3,7 @@ Feature: webdav-related
 		Given using api version "1"
 
 	Scenario: Moving a file
-		Given using dav path "remote.php/webdav"
+		Given using old dav path
 		And As an "admin"
 		And user "user0" exists
 		And As an "user0"
@@ -12,7 +12,7 @@ Feature: webdav-related
 		And Downloaded content when downloading file "/FOLDER/welcome.txt" with range "bytes=0-6" should be "Welcome"
 
 	Scenario: Moving and overwriting a file old way
-		Given using dav path "remote.php/webdav"
+		Given using old dav path
 		And As an "admin"
 		And user "user0" exists
 		And As an "user0"
@@ -21,7 +21,7 @@ Feature: webdav-related
 		And Downloaded content when downloading file "/textfile0.txt" with range "bytes=0-6" should be "Welcome"
 
 	Scenario: Moving a file to a folder with no permissions
-		Given using dav path "remote.php/webdav"
+		Given using old dav path
 		And As an "admin"
 		And user "user0" exists
 		And user "user1" exists
@@ -39,7 +39,7 @@ Feature: webdav-related
  		Then the HTTP status code should be "404"
 
 	Scenario: Moving a file to overwrite a file in a folder with no permissions
-		Given using dav path "remote.php/webdav"
+		Given using old dav path
 		And As an "admin"
 		And user "user0" exists
 		And user "user1" exists
@@ -57,7 +57,7 @@ Feature: webdav-related
 		And Downloaded content when downloading file "/testshare/overwritethis.txt" with range "bytes=0-6" should be "Welcome"
 
 	Scenario: Copying a file
-		Given using dav path "remote.php/webdav"
+		Given using old dav path
 		And As an "admin"
 		And user "user0" exists
 		And As an "user0"
@@ -66,7 +66,7 @@ Feature: webdav-related
 		And Downloaded content when downloading file "/FOLDER/welcome.txt" with range "bytes=0-6" should be "Welcome"
 
 	Scenario: Copying and overwriting a file
-		Given using dav path "remote.php/webdav"
+		Given using old dav path
 		And As an "admin"
 		And user "user0" exists
 		And As an "user0"
@@ -75,7 +75,7 @@ Feature: webdav-related
 		And Downloaded content when downloading file "/textfile1.txt" with range "bytes=0-6" should be "Welcome"
 
 	Scenario: Copying a file to a folder with no permissions
-		Given using dav path "remote.php/webdav"
+		Given using old dav path
 		And As an "admin"
 		And user "user0" exists
 		And user "user1" exists
@@ -93,7 +93,7 @@ Feature: webdav-related
 		And the HTTP status code should be "404"
 
 	Scenario: Copying a file to overwrite a file into a folder with no permissions
-		Given using dav path "remote.php/webdav"
+		Given using old dav path
 		And As an "admin"
 		And user "user0" exists
 		And user "user1" exists
@@ -111,13 +111,13 @@ Feature: webdav-related
 		And Downloaded content when downloading file "/testshare/overwritethis.txt" with range "bytes=0-6" should be "Welcome"
 
 	Scenario: download a file with range
-		Given using dav path "remote.php/webdav"
+		Given using old dav path
 		And As an "admin"
 		When Downloading file "/welcome.txt" with range "bytes=51-77"
 		Then Downloaded content should be "example file for developers"
 
 	Scenario: Upload forbidden if quota is 0
-		Given using dav path "remote.php/webdav"
+		Given using old dav path
 		And As an "admin"
 		And user "user0" exists
 		And user "user0" has a quota of "0"
@@ -125,7 +125,7 @@ Feature: webdav-related
 		Then the HTTP status code should be "507"
 
 	Scenario: Retrieving folder quota when no quota is set
-		Given using dav path "remote.php/webdav"
+		Given using old dav path
 		And As an "admin"
 		And user "user0" exists
 		When user "user0" has unlimited quota
@@ -134,7 +134,7 @@ Feature: webdav-related
 		And the single response should contain a property "{DAV:}quota-available-bytes" with value "-3"
 
 	Scenario: Retrieving folder quota when quota is set
-		Given using dav path "remote.php/webdav"
+		Given using old dav path
 		And As an "admin"
 		And user "user0" exists
 		When user "user0" has a quota of "10 MB"
@@ -143,7 +143,7 @@ Feature: webdav-related
 		And the single response should contain a property "{DAV:}quota-available-bytes" with value "10485429"
 
 	Scenario: Retrieving folder quota of shared folder with quota when no quota is set for recipient
-		Given using dav path "remote.php/webdav"
+		Given using old dav path
 		And As an "admin"
 		And user "user0" exists
 		And user "user1" exists
@@ -161,7 +161,7 @@ Feature: webdav-related
 		And the single response should contain a property "{DAV:}quota-available-bytes" with value "10485429"
 
 	Scenario: Uploading a file as recipient using webdav having quota
-		Given using dav path "remote.php/webdav"
+		Given using old dav path
 		And As an "admin"
 		And user "user0" exists
 		And user "user1" exists
@@ -179,7 +179,7 @@ Feature: webdav-related
 		Then the HTTP status code should be "201"
 
 	Scenario: Retrieving folder quota when quota is set and a file was uploaded
-		Given using dav path "remote.php/webdav"
+		Given using old dav path
 		And As an "admin"
 		And user "user0" exists
 		And user "user0" has a quota of "1 KB"
@@ -189,7 +189,7 @@ Feature: webdav-related
 		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "600"
 
 	Scenario: Retrieving folder quota when quota is set and a file was recieved
-		Given using dav path "remote.php/webdav"
+		Given using old dav path
 		And As an "admin"
 		And user "user0" exists
 		And user "user1" exists
@@ -219,7 +219,7 @@ Feature: webdav-related
 		Then Downloaded content should be "wnCloud"
 
 	Scenario: Downloading a file on the old endpoint should serve security headers
-		Given using dav path "remote.php/webdav"
+		Given using old dav path
 		And As an "admin"
 		When Downloading file "/welcome.txt"
 		Then The following headers should be set
@@ -356,7 +356,7 @@ Feature: webdav-related
 			| 3 |
 
 	Scenario: Upload chunked file asc with new chunking
-		Given using dav path "remote.php/dav"
+		Given using new dav path
 		And user "user0" exists
 		And user "user0" creates a new chunking upload with id "chunking-42"
 		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42"
@@ -364,11 +364,11 @@ Feature: webdav-related
 		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42"
 		And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt"
 		When As an "user0"
-		And Downloading file "/files/user0/myChunkedFile.txt"
+		And Downloading file "/myChunkedFile.txt"
 		Then Downloaded content should be "AAAAABBBBBCCCCC"
 
 	Scenario: Upload chunked file desc with new chunking
-		Given using dav path "remote.php/dav"
+		Given using new dav path
 		And user "user0" exists
 		And user "user0" creates a new chunking upload with id "chunking-42"
 		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42"
@@ -376,11 +376,11 @@ Feature: webdav-related
 		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42"
 		And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt"
 		When As an "user0"
-		And Downloading file "/files/user0/myChunkedFile.txt"
+		And Downloading file "/myChunkedFile.txt"
 		Then Downloaded content should be "AAAAABBBBBCCCCC"
 
 	Scenario: Upload chunked file random with new chunking
-		Given using dav path "remote.php/dav"
+		Given using new dav path
 		And user "user0" exists
 		And user "user0" creates a new chunking upload with id "chunking-42"
 		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42"
@@ -388,7 +388,7 @@ Feature: webdav-related
 		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42"
 		And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt"
 		When As an "user0"
-		And Downloading file "/files/user0/myChunkedFile.txt"
+		And Downloading file "/myChunkedFile.txt"
 		Then Downloaded content should be "AAAAABBBBBCCCCC"
 
 	Scenario: A disabled user cannot use webdav


### PR DESCRIPTION
## Description

Refactor of webdav trait to be more readable and clear.
Use of initial slash '/' as standard way for dealing with files and folders in gherkin.
## Motivation and Context

There is confusion about how the code works.
https://github.com/owncloud/core/pull/26098#issuecomment-247564045
## How Has This Been Tested?

Running tests locally.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
