### PR TITLE
[stable9.1] Fix user casing in initMountPoints

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -89,17 +89,20 @@ class TransferOwnership extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$this->sourceUser = $input->getArgument('source-user');
-		$this->destinationUser = $input->getArgument('destination-user');
-		if (!$this->userManager->userExists($this->sourceUser)) {
+		$sourceUserObject = $this->userManager->get($input->getArgument('source-user'));
+		$destinationUserObject = $this->userManager->get($input->getArgument('destination-user'));
+		if (is_null($sourceUserObject)) {
 			$output->writeln("<error>Unknown source user $this->sourceUser</error>");
 			return;
 		}
-		if (!$this->userManager->userExists($this->destinationUser)) {
+		if (is_null($destinationUserObject)) {
 			$output->writeln("<error>Unknown destination user $this->destinationUser</error>");
 			return;
 		}
-		
+
+		$this->sourceUser = $sourceUserObject->getUID();
+		$this->destinationUser = $destinationUserObject->getUID();
+
 		// target user has to be ready
 		if (!\OC::$server->getEncryptionManager()->isReadyForUser($this->destinationUser)) {
 			$output->writeln("<error>The target user is not ready to accept files. The user has at least to be logged in once.</error>");

--- a/lib/private/AvatarManager.php
+++ b/lib/private/AvatarManager.php
@@ -84,6 +84,9 @@ class AvatarManager implements IAvatarManager {
 			throw new \Exception('user does not exist');
 		}
 
+		// casing might not be the same
+		$userId = $user->getUID();
+
 		/*
 		 * Fix for #22119
 		 * Basically we do not want to copy the skeleton folder

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -393,9 +393,6 @@ class Filesystem {
 		if ($user === null || $user === false || $user === '') {
 			throw new \OC\User\NoUserException('Attempted to initialize mount points for null user and no user in session');
 		}
-		if (isset(self::$usersSetup[$user])) {
-			return;
-		}
 
 		$userManager = \OC::$server->getUserManager();
 		$userObject = $userManager->get($user);
@@ -403,6 +400,17 @@ class Filesystem {
 		if (is_null($userObject)) {
 			\OCP\Util::writeLog('files', ' Backends provided no user object for ' . $user, \OCP\Util::ERROR);
 			throw new \OC\User\NoUserException('Backends provided no user object for ' . $user);
+		}
+
+		// workaround in case of different casings
+		if ($user !== $userObject->getUID()) {
+			$stack = json_encode(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 50));
+			\OCP\Util::writeLog('files', 'initMountPoints() called with wrong user casing. This could be a bug. Expected: "' . $userObject->getUID() . '" got "' . $user . '". Stack: ' . $stack, \OCP\Util::WARN);
+		}
+		$user = $userObject->getUID();
+
+		if (isset(self::$usersSetup[$user])) {
+			return;
 		}
 
 		self::$usersSetup[$user] = true;

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -334,6 +334,15 @@ class Root extends Folder implements IRootFolder {
 	 * @return \OCP\Files\Folder
 	 */
 	public function getUserFolder($userId) {
+		$userObject = \OC::$server->getUserManager()->get($userId);
+
+		if (is_null($userObject)) {
+			\OCP\Util::writeLog('files', 'Backends provided no user object for ' . $userId, \OCP\Util::ERROR);
+			throw new \OC\User\NoUserException('Backends provided no user object for ' . $userId);
+		}
+
+		$userId = $userObject->getUID();
+
 		\OC\Files\Filesystem::initMountPoints($userId);
 		$dir = '/' . $userId;
 		$folder = null;

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -134,6 +134,15 @@ class Share extends Constants {
 	 *       not '/admin/data/file.txt'
 	 */
 	public static function getUsersSharingFile($path, $ownerUser, $includeOwner = false, $returnUserPaths = false, $recursive = true) {
+		$userManager = \OC::$server->getUserManager();
+		$userObject = $userManager->get($ownerUser);
+
+		if (is_null($ownerUser)) {
+			\OCP\Util::writeLog('files', ' Backends provided no user object for ' . $ownerUser, \OCP\Util::ERROR);
+			throw new \OC\User\NoUserException('Backends provided no user object for ' . $ownerUser);
+		}
+
+		$ownerUser = $userObject->getUID();
 
 		Filesystem::initMountPoints($ownerUser);
 		$shares = $sharePaths = $fileTargets = array();

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -229,6 +229,9 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		self::tearDownAfterClassCleanStrayHooks();
 		self::tearDownAfterClassCleanStrayLocks();
 
+		\OC_User::clearBackends();
+		\OC_User::useBackend('dummy');
+
 		parent::tearDownAfterClass();
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Some calls to `initMountsPoints` use the wrong user casing, mostly due to passing through a user id as given as input from a URL or so. In cases where shares exist it can cause duplicate mount points to exist and cause replication of "(2)" in received share names.

This PR intends to cover all known cases already. In the event that additional mismatch cases are detected, it will log a warning with the stack trace.
## Related Issue

https://github.com/owncloud/core/issues/25718
## Motivation and Context

See above
## How Has This Been Tested?

To test:
- [x] create user "User1" and "User2" with shares between them. Request avatar with curl using lower case name. See that "(2)" doesn't appear any more
- [x] retest transfer ownership using different casings
- [x] retest apps that user `getUserFolder()` with wrong casings
- [x] retest `getUsersSharingFile` => done by editing text file from multiple sharees with encryption enabled

TODO:
- [x] add unit test for getUserFolder() with different casings
- [x] add unit test for initMountPoints
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
### Backports
- [x] forward port to master / 9.2
