### PR TITLE
[Stable9] Allow one more origin. Log the reason of occ controller failure

### DIFF
--- a/core/application.php
+++ b/core/application.php
@@ -90,18 +90,6 @@ class Application extends App {
 				$c->query('Logger')
 			);
 		});
-		$container->registerService('OccController', function(SimpleContainer $c) {
-			return new OccController(
-				$c->query('AppName'),
-				$c->query('Request'),
-				$c->query('Config'),
-				new \OC\Console\Application(
-					$c->query('Config'),
-					$c->query('ServerContainer')->getEventDispatcher(),
-					$c->query('Request')
-				)
-			);
-		});
 
 		/**
 		 * Core class wrappers

--- a/core/controller/occcontroller.php
+++ b/core/controller/occcontroller.php
@@ -25,6 +25,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OC\Console\Application;
 use OCP\IConfig;
+use OCP\ILogger;
 use OCP\IRequest;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -48,6 +49,8 @@ class OccController extends Controller {
 	private $config;
 	/** @var Application */
 	private $console;
+	/** @var ILogger */
+	private $logger;
 
 	/**
 	 * OccController constructor.
@@ -56,12 +59,14 @@ class OccController extends Controller {
 	 * @param IRequest $request
 	 * @param IConfig $config
 	 * @param Application $console
+	 * @param ILogger $logger
 	 */
 	public function __construct($appName, IRequest $request,
-								IConfig $config, Application $console) {
+								IConfig $config, Application $console, ILogger $logger) {
 		parent::__construct($appName, $request);
 		$this->config = $config;
 		$this->console = $console;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -108,6 +113,13 @@ class OccController extends Controller {
 			];
 
 		} catch (\UnexpectedValueException $e){
+			$this->logger->warning(
+				'Invalid request to occ controller. Details: "{details}"',
+				[
+					'app' => 'core',
+					'details' => $e->getMessage()
+				]
+			);
 			$json = [
 				'exitCode' => 126,
 				'response' => 'Not allowed',
@@ -123,7 +135,12 @@ class OccController extends Controller {
 	 * @param $token
 	 */
 	protected function validateRequest($command, $token){
-		if (!in_array($this->request->getRemoteAddress(), ['::1', '127.0.0.1', 'localhost'])) {
+		$allowedHosts = ['::1', '127.0.0.1', 'localhost'];
+		if (isset($this->request->server['SERVER_ADDR'])){
+			array_push($allowedHosts, $this->request->server['SERVER_ADDR']);
+		}
+		
+		if (!in_array($this->request->getRemoteAddress(), $allowedHosts)) {
 			throw new \UnexpectedValueException('Web executor is not allowed to run from a different host');
 		}
 

--- a/core/routes.php
+++ b/core/routes.php
@@ -42,7 +42,7 @@ $application->registerRoutes($this, [
 		['name' => 'avatar#postCroppedAvatar', 'url' => '/avatar/cropped', 'verb' => 'POST'],
 		['name' => 'avatar#getTmpAvatar', 'url' => '/avatar/tmp', 'verb' => 'GET'],
 		['name' => 'avatar#postAvatar', 'url' => '/avatar/', 'verb' => 'POST'],
-		['name' => 'occ#execute', 'url' => '/occ/{command}', 'verb' => 'POST'],
+		['name' => 'OC\Core\Controller\Occ#execute', 'url' => '/occ/{command}', 'verb' => 'POST'],
 	]
 ]);
 

--- a/tests/Core/Controller/OccControllerTest.php
+++ b/tests/Core/Controller/OccControllerTest.php
@@ -46,7 +46,8 @@ class OccControllerTest extends TestCase {
 	private $console;
 
 	public function testFromInvalidLocation(){
-		$this->getControllerMock('example.org');
+		$fakeHost = 'example.org';
+		$this->getControllerMock($fakeHost);
 
 		$response = $this->controller->execute('status', '');
 		$responseData = $response->getData();
@@ -55,7 +56,7 @@ class OccControllerTest extends TestCase {
 		$this->assertEquals(126, $responseData['exitCode']);
 
 		$this->assertArrayHasKey('details', $responseData);
-		$this->assertEquals('Web executor is not allowed to run from a different host', $responseData['details']);
+		$this->assertEquals('Web executor is not allowed to run from a host ' . $fakeHost, $responseData['details']);
 	}
 
 	public function testNotWhiteListedCommand(){
@@ -136,7 +137,10 @@ class OccControllerTest extends TestCase {
 			'core',
 			$this->request,
 			$this->config,
-			$this->console
+			$this->console,
+			$this->getMockBuilder('\OCP\ILogger')
+				->disableOriginalConstructor()
+				->getMock()
 		);
 	}
 


### PR DESCRIPTION
## Description

Backport of #26031 and #26105 to stable9
## Related Issue

https://github.com/owncloud/updater/issues/378
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
## How Has This Been Tested?

$curl --data "param1=value1&param2=value2" http://owncloud.tld/index.php/occ/status
$tail  -n1 data/owncloud.log

```
{"reqId":"kWyj\/wm3N3CNoIrj+OAL","remoteAddr":"::1","app":"core","message":"Invalid request to occ controller. Details: \"updater.secret is undefined in config\/config.php. Either browse the admin settings in your ownCloud and click \"Open updater\" or define a strong secret using <pre>php -r 'echo password_hash(\"MyStrongSecretDoUseYourOwn!\", PASSWORD_DEFAULT).\"\\n\";'<\/pre> and set this in the config.php.\"","level":2,"time":"2016-10-04T15:18:19+00:00","method":"POST","url":"\/~deo\/oc-stable9\/index.php\/occ\/status","user":"--"}
```

token is set:
$curl --data "param1=value1&param2=value2" http://owncloud.tld/index.php/occ/status
$tail -n1 data/owncloud.log

```
{"reqId":"A97SxiuIg3T3NjzJEu1o","remoteAddr":"::1","app":"core","message":"Invalid request to occ controller. Details: \"updater.secret does not match the provided token\"","level":2,"time":"2016-10-04T15:48:21+00:00","method":"POST","url":"\/~deo\/oc-stable9\/index.php\/occ\/status","user":"--"}
```
## Screenshots (if appropriate):
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
