### PR TITLE
[Stable9.1]  Allow one more origin. Log the reason of occ controller failure

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -126,18 +126,6 @@ class Application extends App {
 				$c->query('SecureRandom')
 			);
 		});
-		$container->registerService('OccController', function(SimpleContainer $c) {
-			return new OccController(
-				$c->query('AppName'),
-				$c->query('Request'),
-				$c->query('Config'),
-				new \OC\Console\Application(
-					$c->query('Config'),
-					$c->query('ServerContainer')->getEventDispatcher(),
-					$c->query('Request')
-				)
-			);
-		});
 
 		/**
 		 * Core class wrappers

--- a/core/routes.php
+++ b/core/routes.php
@@ -48,7 +48,7 @@ $application->registerRoutes($this, [
 		['name' => 'login#showLoginForm', 'url' => '/login', 'verb' => 'GET'],
 		['name' => 'login#logout', 'url' => '/logout', 'verb' => 'GET'],
 		['name' => 'token#generateToken', 'url' => '/token/generate', 'verb' => 'POST'],
-		['name' => 'occ#execute', 'url' => '/occ/{command}', 'verb' => 'POST'],
+		['name' => 'OC\Core\Controller\Occ#execute', 'url' => '/occ/{command}', 'verb' => 'POST'],
 		['name' => 'TwoFactorChallenge#selectChallenge', 'url' => '/login/selectchallenge', 'verb' => 'GET'],
 		['name' => 'TwoFactorChallenge#showChallenge', 'url' => '/login/challenge/{challengeProviderId}', 'verb' => 'GET'],
 		['name' => 'TwoFactorChallenge#solveChallenge', 'url' => '/login/challenge/{challengeProviderId}', 'verb' => 'POST'],

--- a/tests/Core/Controller/OccControllerTest.php
+++ b/tests/Core/Controller/OccControllerTest.php
@@ -46,7 +46,8 @@ class OccControllerTest extends TestCase {
 	private $console;
 
 	public function testFromInvalidLocation(){
-		$this->getControllerMock('example.org');
+		$fakeHost = 'example.org';
+		$this->getControllerMock($fakeHost);
 
 		$response = $this->controller->execute('status', '');
 		$responseData = $response->getData();
@@ -55,7 +56,7 @@ class OccControllerTest extends TestCase {
 		$this->assertEquals(126, $responseData['exitCode']);
 
 		$this->assertArrayHasKey('details', $responseData);
-		$this->assertEquals('Web executor is not allowed to run from a different host', $responseData['details']);
+		$this->assertEquals('Web executor is not allowed to run from a host ' . $fakeHost, $responseData['details']);
 	}
 
 	public function testNotWhiteListedCommand(){
@@ -136,7 +137,10 @@ class OccControllerTest extends TestCase {
 			'core',
 			$this->request,
 			$this->config,
-			$this->console
+			$this->console,
+			$this->getMockBuilder('\OCP\ILogger')
+				->disableOriginalConstructor()
+				->getMock()
 		);
 	}
 


### PR DESCRIPTION
## Description

Backport of #26031 and #26105 to stable9
## Related Issue

https://github.com/owncloud/updater/issues/378
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
## How Has This Been Tested?

$curl --data "param1=value1&param2=value2" http://owncloud.tld/index.php/occ/status
$tail  -n1 data/owncloud.log

```
{"reqId":"kWyj\/wm3N3CNoIrj+OAL","remoteAddr":"::1","app":"core","message":"Invalid request to occ controller. Details: \"updater.secret is undefined in config\/config.php. Either browse the admin settings in your ownCloud and click \"Open updater\" or define a strong secret using <pre>php -r 'echo password_hash(\"MyStrongSecretDoUseYourOwn!\", PASSWORD_DEFAULT).\"\\n\";'<\/pre> and set this in the config.php.\"","level":2,"time":"2016-10-04T15:18:19+00:00","method":"POST","url":"\/~deo\/oc-stable9\/index.php\/occ\/status","user":"--"}
```

token is set:
$curl --data "param1=value1&param2=value2" http://owncloud.tld/index.php/occ/status
$tail -n1 data/owncloud.log

```
{"reqId":"A97SxiuIg3T3NjzJEu1o","remoteAddr":"::1","app":"core","message":"Invalid request to occ controller. Details: \"updater.secret does not match the provided token\"","level":2,"time":"2016-10-04T15:48:21+00:00","method":"POST","url":"\/~deo\/oc-stable9\/index.php\/occ\/status","user":"--"}
```
## Screenshots (if appropriate):
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
