### PR TITLE
Improve user list rendering perf by not resorting after every add

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -396,7 +396,7 @@ var UserList = {
 					if(UserList.has(user.name)) {
 						return true;
 					}
-					var $tr = UserList.add(user, user.lastLogin, false, user.backend);
+					var $tr = UserList.add(user, false);
 					trs.push($tr);
 					loadedUsers++;
 				});


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

The call to UserList.add() was wrong and was passing "user.lastLogin"
as the sort argument which would cause the list to be resorted over and
over again for every added item after loading the next page of users.
## Related Issue

Fixes https://github.com/owncloud/core/issues/26234
## Motivation and Context

Improves sorting and wrong call
## How Has This Been Tested?

Setup LDAP with many users and scroll down on the users page, see that loading the next page still works. Performance difference was not noticable on my local env.
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
### Backports
- [ ] stable9.1
- [ ] stable9

Not critical enough for further backports I think.

Please review @jvillafanez @DeepDiver1975 @butonic @VicDeo
