### PR TITLE
Fix logClientIn for non-existing users

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -348,6 +348,9 @@ class Session implements IUserSession, Emitter {
 		$user = $this->manager->get($username);
 		if (is_null($user)) {
 			$users = $this->manager->getByEmail($username);
+			if (empty($users)) {
+				return false;
+			}
 			if (count($users) !== 1) {
 				return true;
 			}

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -384,6 +384,32 @@ class SessionTest extends \Test\TestCase {
 		$userSession->logClientIn('john', 'doe', $request);
 	}
 
+	public function testLogClientInUnexist() {
+		$manager = $this->getMockBuilder('\OC\User\Manager')
+			->disableOriginalConstructor()
+			->getMock();
+		$session = $this->createMock('\OCP\ISession');
+		$request = $this->createMock('\OCP\IRequest');
+		$user = $this->createMock('\OCP\IUser');
+
+		/** @var \OC\User\Session $userSession */
+		$userSession = $this->getMockBuilder('\OC\User\Session')
+			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config])
+			->setMethods(['login', 'supportsCookies', 'createSessionToken', 'getUser'])
+			->getMock();
+
+		$this->tokenProvider->expects($this->once())
+			->method('getToken')
+			->with('doe')
+			->will($this->throwException(new \OC\Authentication\Exceptions\InvalidTokenException()));
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('token_auth_enforced', false)
+			->will($this->returnValue(false));
+
+		$this->assertFalse($userSession->logClientIn('unexist', 'doe', $request));
+	}
+
 	public function testLogClientInWithTokenPassword() {
 		$manager = $this->getMockBuilder('\OC\User\Manager')
 			->disableOriginalConstructor()


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

This prevents throwing PasswordLoginForbidden for non-existing users.
## Related Issue

Fixes https://github.com/owncloud/core/issues/26123
## Motivation and Context

The check for two factor enforcement would return true for non-existing
users. This fix makes it return false in order to be able to perform
the regular login which will then fail and return false.
## How Has This Been Tested?

See original steps.
Also enable two factor auth and check that for existing users the exception is still PasswordLoginForbidden in the DAV response.
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
## Backports
- [x] stable9.1
