### PR TITLE
App dependencies are now analysed on app enable as well - not only on app install.

### DIFF
--- a/lib/private/App/DependencyAnalyzer.php
+++ b/lib/private/App/DependencyAnalyzer.php
@@ -223,6 +223,9 @@ class DependencyAnalyzer {
 		if (!is_array($libs)) {
 			$libs = [$libs];
 		}
+		if (isset($libs['@value'])) {
+			$libs = [$libs];
+		}
 		foreach ($libs as $lib) {
 			$libName = $this->getValue($lib);
 			$libVersion = $this->platform->getLibraryVersion($libName);

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -329,6 +329,13 @@ class OC_App {
 		self::$enabledAppsCache = []; // flush
 		if (!Installer::isInstalled($app)) {
 			$app = self::installApp($app);
+		} else {
+			// check for required dependencies
+			$config = \OC::$server->getConfig();
+			$l = \OC::$server->getL10N('core');
+			$info = self::getAppInfo($app);
+
+			self::checkAppDependencies($config, $l, $info);
 		}
 
 		$appManager = \OC::$server->getAppManager();
@@ -1171,16 +1178,7 @@ class OC_App {
 			}
 
 			// check for required dependencies
-			$dependencyAnalyzer = new DependencyAnalyzer(new Platform($config), $l);
-			$missing = $dependencyAnalyzer->analyze($info);
-			if (!empty($missing)) {
-				$missingMsg = join(PHP_EOL, $missing);
-				throw new \Exception(
-					$l->t('App "%s" cannot be installed because the following dependencies are not fulfilled: %s',
-						[$info['name'], $missingMsg]
-					)
-				);
-			}
+			self::checkAppDependencies($config, $l, $info);
 
 			$config->setAppValue($app, 'enabled', 'yes');
 			if (isset($appData['id'])) {
@@ -1350,5 +1348,24 @@ class OC_App {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * @param $config
+	 * @param $l
+	 * @param $info
+	 * @throws Exception
+	 */
+	protected static function checkAppDependencies($config, $l, $info) {
+		$dependencyAnalyzer = new DependencyAnalyzer(new Platform($config), $l);
+		$missing = $dependencyAnalyzer->analyze($info);
+		if (!empty($missing)) {
+			$missingMsg = join(PHP_EOL, $missing);
+			throw new \Exception(
+				$l->t('App "%s" cannot be installed because the following dependencies are not fulfilled: %s',
+					[$info['name'], $missingMsg]
+				)
+			);
+		}
 	}
 }

--- a/tests/lib/App/DependencyAnalyzerTest.php
+++ b/tests/lib/App/DependencyAnalyzerTest.php
@@ -9,7 +9,7 @@
 
 namespace Test\App;
 
-use OC;
+use OC\App\DependencyAnalyzer;
 use OC\App\Platform;
 use OCP\IL10N;
 use Test\TestCase;
@@ -22,11 +22,11 @@ class DependencyAnalyzerTest extends TestCase {
 	/** @var IL10N */
 	private $l10nMock;
 
-	/** @var \OC\App\DependencyAnalyzer */
+	/** @var DependencyAnalyzer */
 	private $analyser;
 
 	public function setUp() {
-		$this->platformMock = $this->getMockBuilder('\OC\App\Platform')
+		$this->platformMock = $this->getMockBuilder(Platform::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->platformMock->expects($this->any())
@@ -67,7 +67,7 @@ class DependencyAnalyzerTest extends TestCase {
 				return vsprintf($text, $parameters);
 			}));
 
-		$this->analyser = new \OC\App\DependencyAnalyzer($this->platformMock, $this->l10nMock);
+		$this->analyser = new DependencyAnalyzer($this->platformMock, $this->l10nMock);
 	}
 
 	/**
@@ -101,6 +101,8 @@ class DependencyAnalyzerTest extends TestCase {
 
 	/**
 	 * @dataProvider providesDatabases
+	 * @param $expectedMissing
+	 * @param $databases
 	 */
 	public function testDatabases($expectedMissing, $databases) {
 		$app = [
@@ -247,6 +249,8 @@ class DependencyAnalyzerTest extends TestCase {
 				[['@attributes' => ['min-version' => '2.3', 'max-version' => '2.3'], '@value' => 'curl']]],
 			[[],
 				[['@attributes' => ['min-version' => '2', 'max-version' => '2'], '@value' => 'curl']]],
+			[[],
+				['@attributes' => ['min-version' => '2', 'max-version' => '2'], '@value' => 'curl']],
 		];
 	}
 


### PR DESCRIPTION
## Description

App dependencies can now evaluated on enable as well.
## Motivation and Context

Let's say the system environment was okay on installation of an app.
Then the app is disabled for some time and in between the system environment is changed.
After re-enabling the app we would render the system unstable.
## How Has This Been Tested?

Add a dependency to an installed but disabled app - e.g.

``` xml
    <database>mongodb</database>
```

Now enable the app and see it fail
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
