### PR TITLE
Fixes incorrect loading of file when using the console from a sibling…

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -9,7 +9,7 @@
  * consider important for your instance to your working ``config.php``, and
  * apply configuration options that are pertinent for your instance.
  *
- * This file is used to generate the configuration documentation. 
+ * This file is used to generate the configuration documentation.
  * Please consider following requirements of the current parser:
  *  * all comments need to start with `/**` and end with ` *\/` - each on their
  *    own line
@@ -426,20 +426,20 @@ $CONFIG = array(
  *
  * Available values:
  *
- * * ``auto``      
- *     default setting. keeps files and folders in the trash bin for 30 days 
- *     and automatically deletes anytime after that if space is needed (note: 
+ * * ``auto``
+ *     default setting. keeps files and folders in the trash bin for 30 days
+ *     and automatically deletes anytime after that if space is needed (note:
  *     files may not be deleted if space is not needed).
- * * ``D, auto``   
- *     keeps files and folders in the trash bin for D+ days, delete anytime if 
+ * * ``D, auto``
+ *     keeps files and folders in the trash bin for D+ days, delete anytime if
  *     space needed (note: files may not be deleted if space is not needed)
- * * ``auto, D``   
- *     delete all files in the trash bin that are older than D days   
+ * * ``auto, D``
+ *     delete all files in the trash bin that are older than D days
  *     automatically, delete other files anytime if space needed
- * * ``D1, D2``    
- *     keep files and folders in the trash bin for at least D1 days and 
+ * * ``D1, D2``
+ *     keep files and folders in the trash bin for at least D1 days and
  *     delete when exceeds D2 days
- * * ``disabled``  
+ * * ``disabled``
  *     trash bin auto clean disabled, files and folders will be kept forever
  */
 'trashbin_retention_obligation' => 'auto',
@@ -462,23 +462,23 @@ $CONFIG = array(
  * Both minimum and maximum times can be set together to explicitly define
  * version deletion. For migration purposes, this setting is installed
  * initially set to "auto", which is equivalent to the default setting in
- * ownCloud 8.1 and before. 
+ * ownCloud 8.1 and before.
  *
  * Available values:
  *
- * * ``auto``      
- *     default setting. Automatically expire versions according to expire 
- *     rules. Please refer to :doc:`../configuration_files/file_versioning` for 
+ * * ``auto``
+ *     default setting. Automatically expire versions according to expire
+ *     rules. Please refer to :doc:`../configuration_files/file_versioning` for
  *     more information.
- * * ``D, auto``   
- *     keep versions at least for D days, apply expire rules to all versions 
+ * * ``D, auto``
+ *     keep versions at least for D days, apply expire rules to all versions
  *     that are older than D days
- * * ``auto, D``   
- *     delete all versions that are older than D days automatically, delete 
+ * * ``auto, D``
+ *     delete all versions that are older than D days automatically, delete
  *     other versions according to expire rules
- * * ``D1, D2``    
+ * * ``D1, D2``
  *     keep versions for at least D1 days and delete when exceeds D2 days
- * * ``disabled``  
+ * * ``disabled``
  *     versions auto clean disabled, versions will be kept forever
  */
 'versions_retention_obligation' => 'auto',
@@ -681,13 +681,14 @@ $CONFIG = array(
  * to that folder, starting from the ownCloud webroot. The key ``writable``
  * indicates if a Web server can write files to that folder.
  */
-'apps_paths' => array(
-	array(
-		'path'=> '/var/www/owncloud/apps',
-		'url' => '/apps',
-		'writable' => true,
-	),
-),
+ 'apps_paths' =>
+   array (
+     array (
+       'path' => OC::$SERVERROOT.'/apps',
+       'url' => '/apps',
+       'writable' => true,
+     )
+   ),
 
 /**
  * @see appcodechecker
@@ -852,9 +853,9 @@ $CONFIG = array(
 /**
  * Enable maintenance mode to disable ownCloud
  *
- * If you want to prevent users from logging in to ownCloud before you start 
- * doing some maintenance work, you need to set the value of the maintenance 
- * parameter to true. Please keep in mind that users who are already logged-in 
+ * If you want to prevent users from logging in to ownCloud before you start
+ * doing some maintenance work, you need to set the value of the maintenance
+ * parameter to true. Please keep in mind that users who are already logged-in
  * are kicked out of ownCloud instantly.
  */
 'maintenance' => false,
@@ -1108,7 +1109,7 @@ $CONFIG = array(
 /**
  * Exclude specific directory names and disallow scanning, creating and renaming
  * using these names. Case insensitive.
- * Excluded directory names are queried at any path part like at the beginning, 
+ * Excluded directory names are queried at any path part like at the beginning,
  * in the middle or at the end and will not be further processed if found.
  * Please see the documentation for details and examples.
  * Use when the storage backend supports eg snapshot directories to be excluded.
@@ -1155,8 +1156,8 @@ $CONFIG = array(
 'quota_include_external_storage' => false,
 
 /**
- * Specifies how often the local filesystem (the ownCloud data/ directory, and 
- * NFS mounts in data/) is checked for changes made outside ownCloud. This 
+ * Specifies how often the local filesystem (the ownCloud data/ directory, and
+ * NFS mounts in data/) is checked for changes made outside ownCloud. This
  * does not apply to external storages.
  *
  * 0 -> Never check the filesystem for outside changes, provides a performance
@@ -1212,7 +1213,7 @@ $CONFIG = array(
 
 /**
  * List of trusted proxy servers
- * 
+ *
  * If you configure these also consider setting `forwarded_for_headers` which
  * otherwise defaults to `HTTP_X_FORWARDED_FOR` (the `X-Forwarded-For` header).
  */

--- a/console.php
+++ b/console.php
@@ -47,7 +47,7 @@ function exceptionHandler($exception) {
 	exit(1);
 }
 try {
-	require_once 'lib/base.php';
+	require_once __DIR__ . '/lib/base.php';
 
 	// set to run indefinitely if needed
 	set_time_limit(0);

--- a/cron.php
+++ b/cron.php
@@ -31,7 +31,7 @@
 
 try {
 
-	require_once 'lib/base.php';
+	require_once __DIR__ . '/lib/base.php';
 
 	if (\OCP\Util::needUpgrade()) {
 		\OCP\Util::writeLog('cron', 'Update required, skipping cron', \OCP\Util::DEBUG);

--- a/index.php
+++ b/index.php
@@ -33,8 +33,8 @@ if (version_compare(PHP_VERSION, '5.6.0') === -1) {
 }
 
 try {
-	
-	require_once 'lib/base.php';
+
+	require_once __DIR__ . '/lib/base.php';
 
 	OC::handleRequest();
 

--- a/ocs/providers.php
+++ b/ocs/providers.php
@@ -22,7 +22,7 @@
  *
  */
 
-require_once '../lib/base.php';
+require_once __DIR__ . '/../lib/base.php';
 
 header('Content-type: application/xml');
 

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -27,7 +27,7 @@
  *
  */
 
-require_once '../lib/base.php';
+require_once __DIR__ . '/../lib/base.php';
 
 if (\OCP\Util::needUpgrade()
 	|| \OC::$server->getSystemConfig()->getValue('maintenance', false)

--- a/ocs/v2.php
+++ b/ocs/v2.php
@@ -19,4 +19,4 @@
  *
  */
 
-require_once 'v1.php';
+require_once __DIR__ . '/v1.php';

--- a/public.php
+++ b/public.php
@@ -27,7 +27,7 @@
  */
 try {
 
-	require_once 'lib/base.php';
+	require_once __DIR__ . '/lib/base.php';
 	if (\OCP\Util::needUpgrade()) {
 		// since the behavior of apps or remotes are unpredictable during
 		// an upgrade, return a 503 directly

--- a/remote.php
+++ b/remote.php
@@ -106,7 +106,7 @@ function resolveService($service) {
 }
 
 try {
-	require_once 'lib/base.php';
+	require_once __DIR__ . '/lib/base.php';
 
 	// All resources served via the DAV endpoint should have the strictest possible
 	// policy. Exempted from this is the SabreDAV browser plugin which overwrites

--- a/status.php
+++ b/status.php
@@ -28,7 +28,7 @@
 
 try {
 
-	require_once 'lib/base.php';
+	require_once __DIR__ . '/lib/base.php';
 
 	$systemConfig = \OC::$server->getSystemConfig();
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Using the console component from an OC sibling installation will load the incorrect base lib since the path will be relative to the working directory.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
## How Has This Been Tested?

Install 2 instances of OC in a directory structure like:

```
/var/www/oc-1
/var/www/oc-2
```

then

```
cd /var/www/oc-1
../oc-2/occ config:system:get apps_paths
```

This will output `apps_paths` from `oc-1`, even if the `oc-2` console was used.

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
