### PR TITLE
Fixed failing test which was ignoring a required (not null) column

### DIFF
--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -32,6 +32,7 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Exception\DriverException;
 use OC\DB\QueryBuilder\QueryBuilder;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
@@ -278,7 +279,7 @@ class Connection extends \Doctrine\DBAL\Connection implements IDBConnection {
 					}, array_merge($keys, $values))
 				);
 			return $insertQb->execute();
-		} catch (\Doctrine\DBAL\Exception\ConstraintViolationException $e) {
+		} catch (DriverException $e) {
 			// value already exists, try update
 			$updateQb = $this->getQueryBuilder();
 			$updateQb->update($table);

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -32,7 +32,7 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\Common\EventManager;
-use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\ConstraintViolationException;
 use OC\DB\QueryBuilder\QueryBuilder;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
@@ -279,7 +279,7 @@ class Connection extends \Doctrine\DBAL\Connection implements IDBConnection {
 					}, array_merge($keys, $values))
 				);
 			return $insertQb->execute();
-		} catch (DriverException $e) {
+		} catch (ConstraintViolationException $e) {
 			// value already exists, try update
 			$updateQb = $this->getQueryBuilder();
 			$updateQb->update($table);

--- a/tests/lib/DB/ConnectionTest.php
+++ b/tests/lib/DB/ConnectionTest.php
@@ -124,8 +124,7 @@ class ConnectionTest extends \Test\TestCase {
 		$this->connection->setValues('table', [
 			'integerfield' => 1
 		], [
-			'textfield' => 'foo',
-			'clobfield' => 'not_null'
+			'textfield' => 'foo'
 		]);
 
 		$this->connection->setValues('table', [

--- a/tests/lib/DB/ConnectionTest.php
+++ b/tests/lib/DB/ConnectionTest.php
@@ -131,7 +131,8 @@ class ConnectionTest extends \Test\TestCase {
 		$this->connection->setValues('table', [
 			'integerfield' => 1
 		], [
-			'textfield' => 'bar'
+			'textfield' => 'bar',
+			'clobfield' => 'not_null'
 		]);
 
 		$this->assertEquals('bar', $this->getTextValueByIntergerField(1));
@@ -150,7 +151,8 @@ class ConnectionTest extends \Test\TestCase {
 		$this->connection->setValues('table', [
 			'integerfield' => 1
 		], [
-			'textfield' => 'bar'
+			'textfield' => 'bar',
+			'clobfield' => 'not_null'
 		], [
 			'booleanfield' => true
 		]);
@@ -174,7 +176,8 @@ class ConnectionTest extends \Test\TestCase {
 		$this->connection->setValues('table', [
 			'integerfield' => 1
 		], [
-			'textfield' => 'bar'
+			'textfield' => 'bar',
+			'clobfield' => 'not_null'
 		], [
 			'booleanfield' => false
 		]);
@@ -194,7 +197,8 @@ class ConnectionTest extends \Test\TestCase {
 		$this->connection->setValues('table', [
 			'integerfield' => 1
 		], [
-			'textfield' => 'foo'
+			'textfield' => 'foo',
+			'clobfield' => 'not_null'
 		]);
 	}
 }

--- a/tests/lib/DB/ConnectionTest.php
+++ b/tests/lib/DB/ConnectionTest.php
@@ -131,8 +131,7 @@ class ConnectionTest extends \Test\TestCase {
 		$this->connection->setValues('table', [
 			'integerfield' => 1
 		], [
-			'textfield' => 'bar',
-			'clobfield' => 'not_null'
+			'textfield' => 'bar'
 		]);
 
 		$this->assertEquals('bar', $this->getTextValueByIntergerField(1));
@@ -151,8 +150,7 @@ class ConnectionTest extends \Test\TestCase {
 		$this->connection->setValues('table', [
 			'integerfield' => 1
 		], [
-			'textfield' => 'bar',
-			'clobfield' => 'not_null'
+			'textfield' => 'bar'
 		], [
 			'booleanfield' => true
 		]);
@@ -176,8 +174,7 @@ class ConnectionTest extends \Test\TestCase {
 		$this->connection->setValues('table', [
 			'integerfield' => 1
 		], [
-			'textfield' => 'bar',
-			'clobfield' => 'not_null'
+			'textfield' => 'bar'
 		], [
 			'booleanfield' => false
 		]);
@@ -197,8 +194,7 @@ class ConnectionTest extends \Test\TestCase {
 		$this->connection->setValues('table', [
 			'integerfield' => 1
 		], [
-			'textfield' => 'foo',
-			'clobfield' => 'not_null'
+			'textfield' => 'foo'
 		]);
 	}
 }

--- a/tests/lib/DB/MDB2SchemaReaderTest.php
+++ b/tests/lib/DB/MDB2SchemaReaderTest.php
@@ -43,7 +43,7 @@ class MDB2SchemaReaderTest extends \Test\TestCase {
 
 		$this->assertEquals(4, $table->getColumn('integerfield')->getLength());
 		$this->assertFalse($table->getColumn('integerfield')->getAutoincrement());
-		$this->assertNull($table->getColumn('integerfield')->getDefault());
+		$this->assertEquals(0, $table->getColumn('integerfield')->getDefault());
 		$this->assertTrue($table->getColumn('integerfield')->getNotnull());
 		$this->assertInstanceOf('Doctrine\DBAL\Types\IntegerType', $table->getColumn('integerfield')->getType());
 

--- a/tests/lib/DB/MDB2SchemaReaderTest.php
+++ b/tests/lib/DB/MDB2SchemaReaderTest.php
@@ -58,7 +58,7 @@ class MDB2SchemaReaderTest extends \Test\TestCase {
 		$this->assertNull($table->getColumn('clobfield')->getLength());
 		$this->assertFalse($table->getColumn('clobfield')->getAutoincrement());
 		$this->assertNull($table->getColumn('clobfield')->getDefault());
-		$this->assertTrue($table->getColumn('clobfield')->getNotnull());
+		$this->assertFalse($table->getColumn('clobfield')->getNotnull());
 		$this->assertInstanceOf('Doctrine\DBAL\Types\TextType', $table->getColumn('clobfield')->getType());
 
 		$this->assertNull($table->getColumn('booleanfield')->getLength());

--- a/tests/lib/DB/MDB2SchemaReaderTest.php
+++ b/tests/lib/DB/MDB2SchemaReaderTest.php
@@ -42,7 +42,7 @@ class MDB2SchemaReaderTest extends \Test\TestCase {
 		$this->assertCount(8, $table->getColumns());
 
 		$this->assertEquals(4, $table->getColumn('integerfield')->getLength());
-		$this->assertTrue($table->getColumn('integerfield')->getAutoincrement());
+		$this->assertFalse($table->getColumn('integerfield')->getAutoincrement());
 		$this->assertNull($table->getColumn('integerfield')->getDefault());
 		$this->assertTrue($table->getColumn('integerfield')->getNotnull());
 		$this->assertInstanceOf('Doctrine\DBAL\Types\IntegerType', $table->getColumn('integerfield')->getType());

--- a/tests/lib/DB/testschema.xml
+++ b/tests/lib/DB/testschema.xml
@@ -37,7 +37,6 @@
 			<field>
 				<name>clobfield</name>
 				<type>clob</type>
-				<notnull>true</notnull>
 			</field>
 			<field>
 				<name>booleanfield</name>

--- a/tests/lib/DB/testschema.xml
+++ b/tests/lib/DB/testschema.xml
@@ -17,6 +17,7 @@
 				<type>integer</type>
 				<default>0</default>
 				<notnull>true</notnull>
+				<primary>true</primary>
 				<length>4</length>
 			</field>
 			<field>

--- a/tests/lib/DB/testschema.xml
+++ b/tests/lib/DB/testschema.xml
@@ -17,7 +17,6 @@
 				<type>integer</type>
 				<default>0</default>
 				<notnull>true</notnull>
-				<autoincrement>1</autoincrement>
 				<length>4</length>
 			</field>
 			<field>


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

This fixes a failing test which was ignoring a required column.
## Motivation and Context

Running all Unit Tests after installing a fresh OC instance from `master` using a mysql database will fail at:

```
/usr/bin/php /home/philipp/Projects/core2/lib/composer/phpunit/phpunit/phpunit --configuration /home/philipp/Projects/core2/tests/phpunit-autotest.xml Test\DB\ConnectionTest /home/philipp/Projects/core2/tests/lib/DB/ConnectionTest.php --teamcity
Testing started at 15:02 ...
PHPUnit 5.5.4 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.0.8-0ubuntu0.16.04.3 with Xdebug 2.4.0
Configuration: /home/philipp/Projects/core2/tests/phpunit-autotest.xml


An exception occurred while executing 'INSERT INTO `oc_table` (`integerfield`, `textfield`) VALUES(?, ?)' with params [1, "bar"]:

SQLSTATE[HY000]: General error: 1364 Field 'clobfield' doesn't have a default value
 /home/philipp/Projects/core2/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:115
 /home/philipp/Projects/core2/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:128
 /home/philipp/Projects/core2/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:996
 /home/philipp/Projects/core2/lib/private/DB/Connection.php:209
 /home/philipp/Projects/core2/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/Query/QueryBuilder.php:208
 /home/philipp/Projects/core2/lib/private/DB/QueryBuilder/QueryBuilder.php:141
 /home/philipp/Projects/core2/lib/private/DB/Connection.php:280
 /home/philipp/Projects/core2/tests/lib/DB/ConnectionTest.php:135


An exception occurred while executing 'INSERT INTO `oc_table` (`integerfield`, `textfield`) VALUES(?, ?)' with params [1, "bar"]:

SQLSTATE[HY000]: General error: 1364 Field 'clobfield' doesn't have a default value
 /home/philipp/Projects/core2/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:115
 /home/philipp/Projects/core2/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:128
 /home/philipp/Projects/core2/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:996
 /home/philipp/Projects/core2/lib/private/DB/Connection.php:209
 /home/philipp/Projects/core2/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/Query/QueryBuilder.php:208
 /home/philipp/Projects/core2/lib/private/DB/QueryBuilder/QueryBuilder.php:141
 /home/philipp/Projects/core2/lib/private/DB/Connection.php:280
 /home/philipp/Projects/core2/tests/lib/DB/ConnectionTest.php:156


Failed asserting that exception of type "Doctrine\DBAL\Exception\DriverException" matches expected exception "\OCP\PreConditionNotMetException". Message was: "An exception occurred while executing 'INSERT INTO `oc_table` (`integerfield`, `textfield`) VALUES(?, ?)' with params [1, "bar"]:

SQLSTATE[HY000]: General error: 1364 Field 'clobfield' doesn't have a default value" at
/home/philipp/Projects/core2/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:93
/home/philipp/Projects/core2/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:987
/home/philipp/Projects/core2/lib/private/DB/Connection.php:209
/home/philipp/Projects/core2/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/Query/QueryBuilder.php:208
/home/philipp/Projects/core2/lib/private/DB/QueryBuilder/QueryBuilder.php:141
/home/philipp/Projects/core2/lib/private/DB/Connection.php:280
/home/philipp/Projects/core2/tests/lib/DB/ConnectionTest.php:180
.

An exception occurred while executing 'INSERT INTO `oc_table` (`integerfield`, `textfield`) VALUES(?, ?)' with params [1, "foo"]:

SQLSTATE[HY000]: General error: 1364 Field 'clobfield' doesn't have a default value
 /home/philipp/Projects/core2/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:115
 /home/philipp/Projects/core2/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:128
 /home/philipp/Projects/core2/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:996
 /home/philipp/Projects/core2/lib/private/DB/Connection.php:209
 /home/philipp/Projects/core2/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/Query/QueryBuilder.php:208
 /home/philipp/Projects/core2/lib/private/DB/QueryBuilder/QueryBuilder.php:141
 /home/philipp/Projects/core2/lib/private/DB/Connection.php:280
 /home/philipp/Projects/core2/tests/lib/DB/ConnectionTest.php:198



Time: 1.37 seconds, Memory: 16.00MB


ERRORS!
Tests: 7, Assertions: 13, Errors: 3, Failures: 1.

Process finished with exit code 2
```
## How Has This Been Tested?

Looking at `tests/lib/DB/testschema.xml:~37`, the column `clobfield` has the `notnull` flag.

```
...
<field>
    <name>clobfield</name>
    <type>clob</type>
    <notnull>true</notnull>
</field>
...
```

Since the value for the column is not important for this test cases, adding a filler value will solve this problem:

```
/usr/bin/php /home/philipp/Projects/core2/lib/composer/phpunit/phpunit/phpunit --configuration /home/philipp/Projects/core2/tests/phpunit-autotest.xml Test\DB\ConnectionTest /home/philipp/Projects/core2/tests/lib/DB/ConnectionTest.php --teamcity
Testing started at 15:17 ...
PHPUnit 5.5.4 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.0.8-0ubuntu0.16.04.3 with Xdebug 2.4.0
Configuration: /home/philipp/Projects/core2/tests/phpunit-autotest.xml



Time: 1.53 seconds, Memory: 14.00MB

OK (7 tests, 15 assertions)

Process finished with exit code 0
```
## Further

Before accepting this PR, we should figure out why this test does not fail in Jenkins!
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
