### PR TITLE
Remove checks whether OC is running on Windows

### DIFF
--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -89,12 +89,9 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 			$container->query('OCA\Files_External\Lib\Backend\Google'),
 			$container->query('OCA\Files_External\Lib\Backend\Swift'),
 			$container->query('OCA\Files_External\Lib\Backend\SFTP_Key'),
+			$container->query('OCA\Files_External\Lib\Backend\SMB'),
+			$container->query('OCA\Files_External\Lib\Backend\SMB_OC'),
 		];
-
-		if (!\OC_Util::runningOnWindows()) {
-			$backends[] = $container->query('OCA\Files_External\Lib\Backend\SMB');
-			$backends[] = $container->query('OCA\Files_External\Lib\Backend\SMB_OC');
-		}
 
 		return $backends;
 	}

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -492,26 +492,7 @@ abstract class Common implements Storage, ILockingStorage {
 			throw new FileNameTooLongException();
 		}
 
-		// NOTE: $path will remain unverified for now
-		if (\OC_Util::runningOnWindows()) {
-			$this->verifyWindowsPath($fileName);
-		} else {
-			$this->verifyPosixPath($fileName);
-		}
-	}
-
-	/**
-	 * https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247%28v=vs.85%29.aspx
-	 * @param string $fileName
-	 * @throws InvalidPathException
-	 */
-	protected function verifyWindowsPath($fileName) {
-		$fileName = trim($fileName);
-		$this->scanForInvalidCharacters($fileName, "\\/<>:\"|?*");
-		$reservedNames = ['CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9', 'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9'];
-		if (in_array(strtoupper($fileName), $reservedNames)) {
-			throw new ReservedWordException();
-		}
+		$this->verifyPosixPath($fileName);
 	}
 
 	/**

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -300,7 +300,7 @@ class PreviewManager implements IPreview {
 
 			if (count($checkImagick->queryFormats('PDF')) === 1) {
 				// Office previews are currently not supported on Windows
-				if (!\OC_Util::runningOnWindows() && \OC_Helper::is_function_enabled('shell_exec')) {
+				if (\OC_Helper::is_function_enabled('shell_exec')) {
 					$officeFound = is_string($this->config->getSystemValue('preview_libreoffice_path', null));
 
 					if (!$officeFound) {
@@ -326,7 +326,7 @@ class PreviewManager implements IPreview {
 
 		// Video requires avconv or ffmpeg and is therefor
 		// currently not supported on Windows.
-		if (in_array('OC\Preview\Movie', $this->getEnabledDefaultProvider()) && !\OC_Util::runningOnWindows()) {
+		if (in_array('OC\Preview\Movie', $this->getEnabledDefaultProvider())) {
 			$avconvBinary = \OC_Helper::findBinaryPath('avconv');
 			$ffmpegBinary = ($avconvBinary) ? null : \OC_Helper::findBinaryPath('ffmpeg');
 

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -305,10 +305,6 @@ class Setup {
 			$trustedDomains = [$request->getInsecureServerHost()];
 		}
 
-		if (\OC_Util::runningOnWindows()) {
-			$dataDir = rtrim(realpath($dataDir), '\\');
-		}
-
 		//use sqlite3 when available, otherwise sqlite2 will be used.
 		if($dbType=='sqlite' and $this->IsClassExisting('SQLite3')) {
 			$dbType='sqlite3';

--- a/lib/private/legacy/helper.php
+++ b/lib/private/legacy/helper.php
@@ -534,7 +534,7 @@ class OC_Helper {
 			return $memcache->get($program);
 		}
 		$result = null;
-		if (!\OC_Util::runningOnWindows() && self::is_function_enabled('exec')) {
+		if (self::is_function_enabled('exec')) {
 			$exeSniffer = new ExecutableFinder();
 			// Returns null if nothing is found
 			$result = $exeSniffer->find($program);

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -658,6 +658,8 @@ class OC_Util {
 					'in <a href="%s">our documentation</a>.',
 					['https://owncloud.org/install/', 'owncloud.org/install/', 'https://owncloud.org/?p=8045'])
 			];
+			// don't bother with further checks
+			return $errors;
 		}
 
 		// Check if config folder is writable.
@@ -909,22 +911,18 @@ class OC_Util {
 	public static function checkDataDirectoryPermissions($dataDirectory) {
 		$l = \OC::$server->getL10N('lib');
 		$errors = [];
-		if (self::runningOnWindows()) {
-			//TODO: permissions checks for windows hosts
-		} else {
-			$permissionsModHint = $l->t('Please change the permissions to 0770 so that the directory'
-				. ' cannot be listed by other users.');
+		$permissionsModHint = $l->t('Please change the permissions to 0770 so that the directory'
+			. ' cannot be listed by other users.');
+		$perms = substr(decoct(@fileperms($dataDirectory)), -3);
+		if (substr($perms, -1) != '0') {
+			chmod($dataDirectory, 0770);
+			clearstatcache();
 			$perms = substr(decoct(@fileperms($dataDirectory)), -3);
-			if (substr($perms, -1) != '0') {
-				chmod($dataDirectory, 0770);
-				clearstatcache();
-				$perms = substr(decoct(@fileperms($dataDirectory)), -3);
-				if (substr($perms, 2, 1) != '0') {
-					$errors[] = [
-						'error' => $l->t('Data directory (%s) is readable by other users', [$dataDirectory]),
-						'hint' => $permissionsModHint
-					];
-				}
+			if (substr($perms, 2, 1) != '0') {
+				$errors[] = [
+					'error' => $l->t('Data directory (%s) is readable by other users', [$dataDirectory]),
+					'hint' => $permissionsModHint
+				];
 			}
 		}
 		return $errors;
@@ -940,7 +938,7 @@ class OC_Util {
 	public static function checkDataDirectoryValidity($dataDirectory) {
 		$l = \OC::$server->getL10N('lib');
 		$errors = [];
-		if (!self::runningOnWindows() && $dataDirectory[0] !== '/') {
+		if ($dataDirectory[0] !== '/') {
 			$errors[] = [
 				'error' => $l->t('Data directory (%s) must be an absolute path', [$dataDirectory]),
 				'hint' => $l->t('Check the value of "datadirectory" in your configuration')
@@ -1211,11 +1209,6 @@ class OC_Util {
 	 * @return bool
 	 */
 	public static function isSetLocaleWorking() {
-		// setlocale test is pointless on Windows
-		if (OC_Util::runningOnWindows()) {
-			return true;
-		}
-
 		\Patchwork\Utf8\Bootup::initLocale();
 		if ('' === basename('§')) {
 			return false;

--- a/tests/lib/Archive/TARTest.php
+++ b/tests/lib/Archive/TARTest.php
@@ -14,10 +14,6 @@ use OC\Archive\TAR;
 class TARTest extends TestBase {
 	protected function setUp() {
 		parent::setUp();
-
-		if (\OC_Util::runningOnWindows()) {
-			$this->markTestSkipped('[Windows] tar archives are not supported on Windows');
-		}
 	}
 
 	protected function getExisting() {

--- a/tests/lib/Archive/ZIPTest.php
+++ b/tests/lib/Archive/ZIPTest.php
@@ -14,10 +14,6 @@ use OC\Archive\ZIP;
 class ZIPTest extends TestBase {
 	protected function setUp() {
 		parent::setUp();
-
-		if (\OC_Util::runningOnWindows()) {
-			$this->markTestSkipped('[Windows] ');
-		}
 	}
 
 	protected function getExisting() {

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -295,28 +295,6 @@ class FilesystemTest extends \Test\TestCase {
 		$this->assertSame($expected, \OC\Files\Filesystem::isForbiddenFileOrDir($path, ['.snapshot']));
 	}
 
-	public function normalizePathWindowsAbsolutePathData() {
-		return [
-			['C:/', 'C:\\'],
-			['C:/', 'C:\\', false],
-			['C:/tests', 'C:\\tests'],
-			['C:/tests', 'C:\\tests', false],
-			['C:/tests', 'C:\\tests\\'],
-			['C:/tests/', 'C:\\tests\\', false],
-		];
-	}
-
-	/**
-	 * @dataProvider normalizePathWindowsAbsolutePathData
-	 */
-	public function testNormalizePathWindowsAbsolutePath($expected, $path, $stripTrailingSlash = true) {
-		if (!\OC_Util::runningOnWindows()) {
-			$this->markTestSkipped('This test is Windows only');
-		}
-
-		$this->assertEquals($expected, \OC\Files\Filesystem::normalizePath($path, $stripTrailingSlash, true));
-	}
-
 	public function testNormalizePathUTF8() {
 		if (!class_exists('Patchwork\PHP\Shim\Normalizer')) {
 			$this->markTestSkipped('UTF8 normalizer Patchwork was not found');

--- a/tests/lib/Files/PathVerificationTest.php
+++ b/tests/lib/Files/PathVerificationTest.php
@@ -98,63 +98,6 @@ class PathVerificationTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider providesInvalidCharsWindows
-	 * @expectedException \OCP\Files\InvalidCharacterInPathException
-	 */
-	public function testPathVerificationInvalidCharsWindows($fileName) {
-		$storage = new Local(['datadir' => '']);
-
-		$fileName = " 123{$fileName}456 ";
-		self::invokePrivate($storage, 'verifyWindowsPath', [$fileName]);
-	}
-
-	public function providesInvalidCharsWindows() {
-		return [
-			[\chr(0)],
-			[\chr(1)],
-			[\chr(2)],
-			[\chr(3)],
-			[\chr(4)],
-			[\chr(5)],
-			[\chr(6)],
-			[\chr(7)],
-			[\chr(8)],
-			[\chr(9)],
-			[\chr(10)],
-			[\chr(11)],
-			[\chr(12)],
-			[\chr(13)],
-			[\chr(14)],
-			[\chr(15)],
-			[\chr(16)],
-			[\chr(17)],
-			[\chr(18)],
-			[\chr(19)],
-			[\chr(20)],
-			[\chr(21)],
-			[\chr(22)],
-			[\chr(23)],
-			[\chr(24)],
-			[\chr(25)],
-			[\chr(26)],
-			[\chr(27)],
-			[\chr(28)],
-			[\chr(29)],
-			[\chr(30)],
-			[\chr(31)],
-			['<'],
-			['>'],
-			[':'],
-			['"'],
-			['/'],
-			['\\'],
-			['|'],
-			['?'],
-			['*'],
-		];
-	}
-
-	/**
 	 * @dataProvider providesInvalidCharsPosix
 	 * @expectedException \OCP\Files\InvalidCharacterInPathException
 	 */
@@ -162,7 +105,7 @@ class PathVerificationTest extends \Test\TestCase {
 		$storage = new Local(['datadir' => '']);
 
 		$fileName = " 123{$fileName}456 ";
-		self::invokePrivate($storage, 'verifyWindowsPath', [$fileName]);
+		self::invokePrivate($storage, 'verifyPosixPath', [$fileName]);
 	}
 
 	public function providesInvalidCharsPosix() {
@@ -205,50 +148,12 @@ class PathVerificationTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider providesReservedNamesWindows
-	 * @expectedException \OCP\Files\ReservedWordException
-	 */
-	public function testPathVerificationReservedNamesWindows($fileName) {
-		$storage = new Local(['datadir' => '']);
-
-		self::invokePrivate($storage, 'verifyWindowsPath', [$fileName]);
-	}
-
-	public function providesReservedNamesWindows() {
-		return [
-			[' CON '],
-			['prn '],
-			['AUX'],
-			['NUL'],
-			['COM1'],
-			['COM2'],
-			['COM3'],
-			['COM4'],
-			['COM5'],
-			['COM6'],
-			['COM7'],
-			['COM8'],
-			['COM9'],
-			['LPT1'],
-			['LPT2'],
-			['LPT3'],
-			['LPT4'],
-			['LPT5'],
-			['LPT6'],
-			['LPT7'],
-			['LPT8'],
-			['LPT9']
-		];
-	}
-
-	/**
 	 * @dataProvider providesValidPosixPaths
 	 */
 	public function testPathVerificationValidPaths($fileName) {
 		$storage = new Local(['datadir' => '']);
 
 		self::invokePrivate($storage, 'verifyPosixPath', [$fileName]);
-		self::invokePrivate($storage, 'verifyWindowsPath', [$fileName]);
 		// nothing thrown
 		$this->assertTrue(true);
 	}

--- a/tests/lib/Files/Storage/LocalTest.php
+++ b/tests/lib/Files/Storage/LocalTest.php
@@ -48,10 +48,6 @@ class LocalTest extends Storage {
 	}
 
 	public function testStableEtag() {
-		if (\OC_Util::runningOnWindows()) {
-			$this->markTestSkipped('[Windows] On Windows platform we have no stable etag generation - yet');
-		}
-
 		$this->instance->file_put_contents('test.txt', 'foobar');
 		$etag1 = $this->instance->getETag('test.txt');
 		$etag2 = $this->instance->getETag('test.txt');
@@ -59,10 +55,6 @@ class LocalTest extends Storage {
 	}
 
 	public function testEtagChange() {
-		if (\OC_Util::runningOnWindows()) {
-			$this->markTestSkipped('[Windows] On Windows platform we have no stable etag generation - yet');
-		}
-
 		$this->instance->file_put_contents('test.txt', 'foo');
 		$this->instance->touch('test.txt', time() - 2);
 		$etag1 = $this->instance->getETag('test.txt');

--- a/tests/lib/Files/Type/DetectionTest.php
+++ b/tests/lib/Files/Type/DetectionTest.php
@@ -82,10 +82,6 @@ class DetectionTest extends \Test\TestCase {
 	}
 
 	public function testDetectString() {
-		if (\OC_Util::runningOnWindows()) {
-			$this->markTestSkipped('[Windows] Strings have mimetype application/octet-stream on Windows');
-		}
-
 		$result = $this->detection->detectString("/data/data.tar.gz");
 		$expected = 'text/plain; charset=us-ascii';
 		$this->assertEquals($expected, $result);

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -108,7 +108,7 @@ class ViewTest extends TestCase {
 			$cache->clear();
 		}
 
-		if ($this->tempStorage && !\OC_Util::runningOnWindows()) {
+		if ($this->tempStorage) {
 			system('rm -rf ' . escapeshellarg($this->tempStorage->getDataDir()));
 		}
 
@@ -764,19 +764,10 @@ class ViewTest extends TestCase {
 		$ds = DIRECTORY_SEPARATOR;
 		/*
 		 * 4096 is the maximum path length in file_cache.path in *nix
-		 * 1024 is the max path length in mac
-		 * 228 is the max path length in windows
 		 */
 		$folderName = 'abcdefghijklmnopqrstuvwxyz012345678901234567890123456789';
 		$tmpdirLength = strlen(\OC::$server->getTempManager()->getTemporaryFolder());
-		if (\OC_Util::runningOnWindows()) {
-			$this->markTestSkipped('[Windows] ');
-			$depth = ((260 - $tmpdirLength) / 57);
-		} elseif (\OC_Util::runningOnMac()) {
-			$depth = ((1024 - $tmpdirLength) / 57);
-		} else {
-			$depth = ((4000 - $tmpdirLength) / 57);
-		}
+		$depth = ((4000 - $tmpdirLength) / 57);
 		foreach (range(0, $depth - 1) as $i) {
 			$longPath .= $ds . $folderName;
 			$result = $rootView->mkdir($longPath);

--- a/tests/lib/ImageTest.php
+++ b/tests/lib/ImageTest.php
@@ -75,10 +75,6 @@ class ImageTest extends \Test\TestCase {
 		$img = new \OC_Image(null);
 		$this->assertEquals('', $img->mimeType());
 
-		if (\OC_Util::runningOnWindows()) {
-			$this->markTestSkipped('[Windows] Images created with imagecreate() are pngs on windows');
-		}
-
 		$img = new \OC_Image(file_get_contents(OC::$SERVERROOT.'/tests/data/testimage.jpg'));
 		$this->assertEquals('image/jpeg', $img->mimeType());
 

--- a/tests/lib/LargeFileHelperGetFileSizeTest.php
+++ b/tests/lib/LargeFileHelperGetFileSizeTest.php
@@ -29,9 +29,7 @@ class LargeFileHelperGetFileSizeTest extends TestCase {
 		$path = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR;
 
 		$filePaths = [[$path . 'lorem.txt', 446]];
-		if (!\OC_Util::runningOnWindows()) {
-			$filePaths[] = [$path . 'strängé filename (duplicate #2).txt', 446];
-		}
+		$filePaths[] = [$path . 'strängé filename (duplicate #2).txt', 446];
 
 		return $filePaths;
 	}

--- a/tests/lib/TempManagerTest.php
+++ b/tests/lib/TempManagerTest.php
@@ -138,10 +138,6 @@ class TempManagerTest extends \Test\TestCase {
 	}
 
 	public function testLogCantCreateFile() {
-		if (\OC_Util::runningOnWindows()) {
-			$this->markTestSkipped('[Windows] chmod() does not work as intended on Windows.');
-		}
-
 		$logger = $this->createMock('\Test\NullLogger');
 		$manager = $this->getManager($logger);
 		chmod($this->baseDir, 0500);
@@ -152,10 +148,6 @@ class TempManagerTest extends \Test\TestCase {
 	}
 
 	public function testLogCantCreateFolder() {
-		if (\OC_Util::runningOnWindows()) {
-			$this->markTestSkipped('[Windows] chmod() does not work as intended on Windows.');
-		}
-
 		$logger = $this->createMock('\Test\NullLogger');
 		$manager = $this->getManager($logger);
 		chmod($this->baseDir, 0500);

--- a/tests/lib/UtilCheckServerTest.php
+++ b/tests/lib/UtilCheckServerTest.php
@@ -145,10 +145,6 @@ class UtilCheckServerTest extends \Test\TestCase {
 	 * Tests an error is given when the datadir is not writable
 	 */
 	public function testDataDirNotWritable() {
-		if (\OC_Util::runningOnWindows()) {
-			$this->markTestSkipped('[Windows] chmod() does not work as intended on Windows.');
-		}
-
 		chmod($this->datadir, 0300);
 		$result = \OC_Util::checkServer($this->getConfig([
 			'installed' => true,

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -396,10 +396,8 @@ class UtilTest extends \Test\TestCase {
 		$this->assertNotEmpty($errors);
 		\OCP\Files::rmdirr($dataDir);
 
-		if (!\OC_Util::runningOnWindows()) {
-			$errors = \OC_Util::checkDataDirectoryValidity('relative/path');
-			$this->assertNotEmpty($errors);
-		}
+		$errors = \OC_Util::checkDataDirectoryValidity('relative/path');
+		$this->assertNotEmpty($errors);
 	}
 
 	protected function setUp() {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

There is a setup check that prevents installing on Windows.
No need to keep the old unsupported Windows code paths.
## Related Issue

None
## Motivation and Context

Additional useless code paths and legacy code.
Additional warnings every time the unit tests are run and I'm too lazy to adjust my console's scrollback buffer.
## How Has This Been Tested?

Ran unit tests.
Checked that files_external still works after the change in there.
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Tech debt
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 @butonic @jvillafanez @VicDeo :skull: 
