### PR TITLE
Use chunking in web upload

### DIFF
--- a/apps/files/appinfo/app.php
+++ b/apps/files/appinfo/app.php
@@ -1,4 +1,6 @@
 <?php
+
+use Symfony\Component\EventDispatcher\GenericEvent;
 /**
  * @author Jakob Sack <mail@jakobsack.de>
  * @author Joas Schilling <coding@schilljs.com>
@@ -58,3 +60,17 @@ $templateManager->registerTemplate('application/vnd.oasis.opendocument.spreadshe
 		\OC::$server->getConfig()
 	);
 });
+
+$eventDispatcher = \OC::$server->getEventDispatcher();
+$eventDispatcher->addListener(
+	'OCP\Config::js',
+	function($event) {
+		if ($event instanceof GenericEvent) {
+			$maxChunkSize = (int)(\OC::$server->getConfig()->getAppValue('files', 'max_chunk_size', (10 * 1024 * 1024)));
+			$event->setArgument('files', [
+				'max_chunk_size' => $maxChunkSize
+			]);
+		}
+	}
+);
+

--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -93,7 +93,8 @@
 						direction: $('#defaultFileSortingDirection').val()
 					},
 					config: this._filesConfig,
-					enableUpload: true
+					enableUpload: true,
+					maxChunkSize: 10 * 1024 * 1024 // 10 MB
 				}
 			);
 			this.files.initialize();

--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -94,7 +94,7 @@
 					},
 					config: this._filesConfig,
 					enableUpload: true,
-					maxChunkSize: 10 * 1024 * 1024 // 10 MB
+					maxChunkSize: OC.appConfig.files.max_chunk_size
 				}
 			);
 			this.files.initialize();

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -286,7 +286,8 @@ OC.FileUpload.prototype = {
 		var uid = OC.getCurrentUser().uid;
 		return this.uploader.davClient.move(
 			'uploads/' + encodeURIComponent(uid) + '/' + encodeURIComponent(this.getId()) + '/.file',
-			'files/' + encodeURIComponent(uid) + '/' + OC.joinPaths(this.getFullPath(), this.getFileName())
+			'files/' + encodeURIComponent(uid) + '/' + OC.joinPaths(this.getFullPath(), this.getFileName()),
+			true
 		);
 	},
 
@@ -1109,7 +1110,7 @@ OC.Uploader.prototype = _.extend({
 					// modify the request to adjust it to our own chunking
 					var upload = self.getUpload(data);
 					var range = data.contentRange.split(' ')[1];
-					var chunkId = range.split('/')[0];
+					var chunkId = range.split('/')[0].split('-')[0];
 					data.url = OC.getRootPath() +
 						'/remote.php/dav/uploads' +
 						'/' + encodeURIComponent(OC.getCurrentUser().uid) +

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -789,7 +789,6 @@ OC.Uploader.prototype = _.extend({
 				type: 'PUT',
 				dropZone: options.dropZone, // restrict dropZone to content div
 				autoUpload: false,
-				maxChunkSize: 10 * 1000 * 1000, // 10 MB
 				sequentialUploads: true,
 				//singleFileUploads is on by default, so the data.files array will always have length 1
 				/**
@@ -1015,6 +1014,10 @@ OC.Uploader.prototype = _.extend({
 					self.log('stop', e, data);
 				}
 			};
+
+			if (options.maxChunkSize) {
+				this.fileUploadParam.maxChunkSize = options.maxChunkSize;
+			}
 
 			// initialize jquery fileupload (blueimp)
 			var fileupload = this.$uploadEl.fileupload(this.fileUploadParam);

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -291,17 +291,32 @@ OC.FileUpload.prototype = {
 		);
 	},
 
+	_deleteChunkFolder: function() {
+		// delete transfer directory for this upload
+		this.uploader.davClient.remove(
+			'uploads/' + encodeURIComponent(OC.getCurrentUser().uid) + '/' + encodeURIComponent(this.getId())
+		);
+	},
+
 	/**
 	 * Abort the upload
 	 */
 	abort: function() {
 		if (this.data.isChunked) {
-			// delete transfer directory for this upload
-			this.uploader.davClient.remove(
-				'uploads/' + encodeURIComponent(OC.getCurrentUser().uid) + '/' + encodeURIComponent(this.getId())
-			);
+			this._deleteChunkFolder();
 		}
 		this.data.abort();
+		this.deleteUpload();
+	},
+
+	/**
+	 * Fail the upload
+	 */
+	fail: function() {
+		this.deleteUpload();
+		if (this.data.isChunked) {
+			this._deleteChunkFolder();
+		}
 	},
 
 	/**
@@ -985,7 +1000,7 @@ OC.Uploader.prototype = _.extend({
 					}
 
 					if (upload) {
-						upload.deleteUpload();
+						upload.fail();
 					}
 				},
 				/**

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -287,7 +287,8 @@ OC.FileUpload.prototype = {
 		return this.uploader.davClient.move(
 			'uploads/' + encodeURIComponent(uid) + '/' + encodeURIComponent(this.getId()) + '/.file',
 			'files/' + encodeURIComponent(uid) + '/' + OC.joinPaths(this.getFullPath(), this.getFileName()),
-			true
+			true,
+			{'X-OC-Mtime': this.getFile().lastModified / 1000}
 		);
 	},
 

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -345,7 +345,8 @@
 					this._uploader = new OC.Uploader($uploadEl, {
 						fileList: this,
 						filesClient: this.filesClient,
-						dropZone: $('#content')
+						dropZone: $('#content'),
+						maxChunkSize: options.maxChunkSize
 					});
 
 					this.setupUploadEvents(this._uploader);

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @author Bart Visscher <bartv@thisnet.nl>
  * @author Björn Schießle <bjoern@schiessle.org>
@@ -36,6 +37,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 // Set the content type to Javascript
 header("Content-type: text/javascript");
@@ -198,12 +201,17 @@ if (\OC::$server->getUserSession() !== null && \OC::$server->getUserSession()->i
 	$array['oc_defaults']['docBaseUrl'] = $defaults->getDocBaseUrl();
 	$array['oc_defaults']['docPlaceholderUrl'] = $defaults->buildDocLinkToKey('PLACEHOLDER');
 }
-$array['oc_appconfig'] = json_encode($array['oc_appconfig']);
-$array['oc_config'] = json_encode($array['oc_config']);
-$array['oc_defaults'] = json_encode($array['oc_defaults']);
 
 // Allow hooks to modify the output values
 OC_Hook::emit('\OCP\Config', 'js', ['array' => &$array]);
+$event = \OC::$server->getEventDispatcher()->dispatch('OCP\Config::js', new GenericEvent());
+foreach ($event->getArguments() as $key => $value) {
+	$array['oc_appconfig'][$key] = $value;
+}
+
+$array['oc_appconfig'] = json_encode($array['oc_appconfig']);
+$array['oc_config'] = json_encode($array['oc_config']);
+$array['oc_defaults'] = json_encode($array['oc_defaults']);
 
 // Echo it
 foreach ($array as  $setting => $value) {

--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -36,6 +36,7 @@
 		}
 
 		url += options.host + this._root;
+		this._host = options.host;
 		this._defaultHeaders = options.defaultHeaders || {
 				'X-Requested-With': 'XMLHttpRequest',
 				'requesttoken': OC.requestToken
@@ -761,6 +762,16 @@
 		 */
 		getBaseUrl: function() {
 			return this._client.baseUrl;
+		},
+
+		/**
+		 * Returns the host
+		 *
+		 * @since 9.2
+		 * @return {String} base URL
+		 */
+		getHost: function() {
+			return this._host;
 		}
 	};
 
@@ -798,7 +809,6 @@
 
 		var client = new OC.Files.Client({
 			host: OC.getHost(),
-			port: OC.getPort(),
 			root: OC.linkToRemoteBase('webdav'),
 			useHTTPS: OC.getProtocol() === 'https'
 		});

--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -677,10 +677,11 @@
 		 * @param {String} destinationPath destination path
 		 * @param {boolean} [allowOverwrite=false] true to allow overwriting,
 		 * false otherwise
+		 * @param {Object} [headers=null] additional headers
 		 *
 		 * @return {Promise} promise
 		 */
-		move: function(path, destinationPath, allowOverwrite) {
+		move: function(path, destinationPath, allowOverwrite, headers) {
 			if (!path) {
 				throw 'Missing argument "path"';
 			}
@@ -691,9 +692,9 @@
 			var self = this;
 			var deferred = $.Deferred();
 			var promise = deferred.promise();
-			var headers = {
+			headers = _.extend({}, headers, {
 				'Destination' : this._buildUrl(destinationPath)
-			};
+			});
 
 			if (!allowOverwrite) {
 				headers['Overwrite'] = 'F';


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Switch on chunking for files bigger than 10 MB.
Some additional fixes to make it use the correct URL/client.
## Related Issue

Fixes https://github.com/owncloud/core/issues/8955
## Motivation and Context

Makes it possible to avoid timeouts when uploading bigger files.
Might also make it resumable (still to be tested)
## How Has This Been Tested?

For all tests, check the network console:
- [x] TEST: upload small file, no chunking endpoint used
- [x] TEST: upload file bigger than 10 MB, see chunking endpoint used, multiple call mades followed by final MOVE. Then file appears in the UI.
- [x] TEST: chunking not enabled for public upload even for big files
- [x] TEST: with IE11 which is one of the main reasons for this fix
- [x] TEST: upload + overwrite
- [x] TEST: mtime preserved on chunked upload
- [x] TEST: uploads transfer folder is deleted in case of error or abort (you can see a DELETE call happening at the end)

## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
