### PR TITLE
Fix DAV stat cache to properly cache 404

### DIFF
--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -47,7 +47,6 @@ use OCP\Files\StorageInvalidException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Util;
 use Sabre\DAV\Client;
-use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\Xml\Property\ResourceType;
 use Sabre\HTTP\ClientException;
 use Sabre\HTTP\ClientHttpException;
@@ -207,7 +206,9 @@ class DAV extends Common {
 				[],
 				1
 			);
-			$id = md5('webdav' . $this->root . $path);
+			if ($response === false) {
+				return false;
+			}
 			$content = [];
 			$files = array_keys($response);
 			array_shift($files); //the first entry is the current directory
@@ -225,13 +226,6 @@ class DAV extends Common {
 				$content[] = $file;
 			}
 			return IteratorDirectory::wrap($content);
-		} catch (ClientHttpException $e) {
-			if ($e->getHttpStatus() === 404) {
-				$this->statCache->clear($path . '/');
-				$this->statCache->set($path, false);
-				return false;
-			}
-			$this->convertException($e, $path);
 		} catch (\Exception $e) {
 			$this->convertException($e, $path);
 		}
@@ -246,17 +240,13 @@ class DAV extends Common {
 	 *
 	 * @param string $path path to propfind
 	 *
-	 * @return array propfind response
+	 * @return array|boolean propfind response or false if the entry was not found
 	 *
-	 * @throws NotFound
+	 * @throws ClientHttpException
 	 */
 	protected function propfind($path) {
 		$path = $this->cleanPath($path);
 		$cachedResponse = $this->statCache->get($path);
-		if ($cachedResponse === false) {
-			// we know it didn't exist
-			throw new NotFound();
-		}
 		// we either don't know it, or we know it exists but need more details
 		if (is_null($cachedResponse) || $cachedResponse === true) {
 			$this->init();
@@ -274,11 +264,15 @@ class DAV extends Common {
 					]
 				);
 				$this->statCache->set($path, $response);
-			} catch (NotFound $e) {
-				// remember that this path did not exist
-				$this->statCache->clear($path . '/');
-				$this->statCache->set($path, false);
-				throw $e;
+			} catch (ClientHttpException $e) {
+				if ($e->getHttpStatus() === 404) {
+					$this->statCache->clear($path . '/');
+					$this->statCache->set($path, false);
+					return false;
+				}
+				$this->convertException($e, $path);
+			} catch (\Exception $e) {
+				$this->convertException($e, $path);
 			}
 		} else {
 			$response = $cachedResponse;
@@ -290,17 +284,15 @@ class DAV extends Common {
 	public function filetype($path) {
 		try {
 			$response = $this->propfind($path);
+			if ($response === false) {
+				return false;
+			}
 			$responseType = [];
 			if (isset($response["{DAV:}resourcetype"])) {
 				/** @var ResourceType[] $response */
 				$responseType = $response["{DAV:}resourcetype"]->getValue();
 			}
 			return (count($responseType) > 0 and $responseType[0] == "{DAV:}collection") ? 'dir' : 'file';
-		} catch (ClientHttpException $e) {
-			if ($e->getHttpStatus() === 404) {
-				return false;
-			}
-			$this->convertException($e, $path);
 		} catch (\Exception $e) {
 			$this->convertException($e, $path);
 		}
@@ -319,13 +311,7 @@ class DAV extends Common {
 				return true;
 			}
 			// need to get from server
-			$this->propfind($path);
-			return true; //no 404 exception
-		} catch (ClientHttpException $e) {
-			if ($e->getHttpStatus() === 404) {
-				return false;
-			}
-			$this->convertException($e, $path);
+			return ($this->propfind($path) !== false);
 		} catch (\Exception $e) {
 			$this->convertException($e, $path);
 		}
@@ -431,6 +417,9 @@ class DAV extends Common {
 		try {
 			// TODO: cacheable ?
 			$response = $this->client->propfind($this->encodePath($path), ['{DAV:}quota-available-bytes']);
+			if ($response === false) {
+				return FileInfo::SPACE_UNKNOWN;
+			}
 			if (isset($response['{DAV:}quota-available-bytes'])) {
 				return (int)$response['{DAV:}quota-available-bytes'];
 			} else {
@@ -456,6 +445,9 @@ class DAV extends Common {
 				$this->client->proppatch($this->encodePath($path), ['{DAV:}lastmodified' => $mtime]);
 				// non-owncloud clients might not have accepted the property, need to recheck it
 				$response = $this->client->propfind($this->encodePath($path), ['{DAV:}getlastmodified'], 0);
+				if ($response === false) {
+					return false;
+				}
 				if (isset($response['{DAV:}getlastmodified'])) {
 					$remoteMtime = strtotime($response['{DAV:}getlastmodified']);
 					if ($remoteMtime !== $mtime) {
@@ -578,15 +570,13 @@ class DAV extends Common {
 	public function stat($path) {
 		try {
 			$response = $this->propfind($path);
+			if ($response === false) {
+				return [];
+			}
 			return [
 				'mtime' => strtotime($response['{DAV:}getlastmodified']),
 				'size' => (int)isset($response['{DAV:}getcontentlength']) ? $response['{DAV:}getcontentlength'] : 0,
 			];
-		} catch (ClientHttpException $e) {
-			if ($e->getHttpStatus() === 404) {
-				return [];
-			}
-			$this->convertException($e, $path);
 		} catch (\Exception $e) {
 			$this->convertException($e, $path);
 		}
@@ -597,6 +587,9 @@ class DAV extends Common {
 	public function getMimeType($path) {
 		try {
 			$response = $this->propfind($path);
+			if ($response === false) {
+				return false;
+			}
 			$responseType = [];
 			if (isset($response["{DAV:}resourcetype"])) {
 				/** @var ResourceType[] $response */
@@ -610,11 +603,6 @@ class DAV extends Common {
 			} else {
 				return false;
 			}
-		} catch (ClientHttpException $e) {
-			if ($e->getHttpStatus() === 404) {
-				return false;
-			}
-			$this->convertException($e, $path);
 		} catch (\Exception $e) {
 			$this->convertException($e, $path);
 		}
@@ -705,6 +693,9 @@ class DAV extends Common {
 		$this->init();
 		$path = $this->cleanPath($path);
 		$response = $this->propfind($path);
+		if ($response === false) {
+			return 0;
+		}
 		if (isset($response['{http://owncloud.org/ns}permissions'])) {
 			return $this->parsePermissions($response['{http://owncloud.org/ns}permissions']);
 		} else if ($this->is_dir($path)) {
@@ -721,6 +712,9 @@ class DAV extends Common {
 		$this->init();
 		$path = $this->cleanPath($path);
 		$response = $this->propfind($path);
+		if ($response === false) {
+			return null;
+		}
 		if (isset($response['{DAV:}getetag'])) {
 			return trim($response['{DAV:}getetag'], '"');
 		}
@@ -764,6 +758,13 @@ class DAV extends Common {
 			// force refresh for $path
 			$this->statCache->remove($path);
 			$response = $this->propfind($path);
+			if ($response === false) {
+				if ($path === '') {
+					// if root is gone it means the storage is not available
+					throw new StorageNotAvailableException(get_class($e) . ': ' . $e->getMessage());
+				}
+				return false;
+			}
 			if (isset($response['{DAV:}getetag'])) {
 				$cachedData = $this->getCache()->get($path);
 				$etag = null;
@@ -786,7 +787,7 @@ class DAV extends Common {
 				return $remoteMtime > $time;
 			}
 		} catch (ClientHttpException $e) {
-			if ($e->getHttpStatus() === 404 || $e->getHttpStatus() === 405) {
+			if ($e->getHttpStatus() === 405) {
 				if ($path === '') {
 					// if root is gone it means the storage is not available
 					throw new StorageNotAvailableException(get_class($e) . ': ' . $e->getMessage());


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

404 errors were not properly cached due to catching the wrong
exception. Now catching ClientHttpException and checking the error
code. In case of 404, adjust the stat cache accordingly.

Since now the local propfind() call throws NotFound, there is no need
to catch ClientHttpException everywhere any more but need to catch
NotFound exception instead and act accordingly.
## Related Issue

Fixes https://github.com/owncloud/core/issues/26323
## Motivation and Context

Improve performance when creating new file/folders which usually first do a PROPFIND on the remote server to check for file/folder existence. Not caching these 404 would cause at least 6 additional PROPFIND requests to get the status. (this is because we use a lot of `file_exists` call everywhere...)
## How Has This Been Tested?

See issue steps.
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
### Backports
- [ ] TODO: evaluate to which versions to backport this

@DeepDiver1975 @butonic @jvillafanez 
