### PR TITLE
Allow php 5.3 syntax in index.php so that the proper error can be gen…

### DIFF
--- a/index.php
+++ b/index.php
@@ -46,7 +46,7 @@ try {
 	OC::handleRequest();
 
 } catch(\OC\ServiceUnavailableException $ex) {
-	\OC::$server->getLogger()->logException($ex, ['app' => 'index']);
+	\OC::$server->getLogger()->logException($ex, array('app' => 'index'));
 
 	//show the user a detailed error page
 	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
@@ -56,10 +56,10 @@ try {
 	OC_Template::printErrorPage($ex->getMessage(), $ex->getHint());
 } catch (\OC\User\LoginException $ex) {
 	OC_Response::setStatus(OC_Response::STATUS_FORBIDDEN);
-	OC_Template::printErrorPage($ex->getMessage(), $ex->getHint());
+	OC_Template::printErrorPage($ex->getMessage());
 } catch (Exception $ex) {
 	try {
-		\OC::$server->getLogger()->logException($ex, ['app' => 'index']);
+		\OC::$server->getLogger()->logException($ex, array('app' => 'index'));
 
 		//show the user a detailed error page
 		OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
@@ -73,7 +73,7 @@ try {
 		echo('</body></html>');
 	}
 } catch (Error $ex) {
-	\OC::$server->getLogger()->logException($ex, ['app' => 'index']);
+	\OC::$server->getLogger()->logException($ex, array('app' => 'index'));
 	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
 	OC_Template::printExceptionErrorPage($ex);
 }


### PR DESCRIPTION
## Description

Use traditional array syntax to allow index.php to be parse with 5.3
## Related Issue

fixes #26317
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

…erated and not a parse exception - 
