### PR TITLE
Setup page does not display password strength meter

### DIFF
--- a/core/js/setup.js
+++ b/core/js/setup.js
@@ -103,7 +103,7 @@ $(document).ready(function() {
 	}
 
 	$('#adminpass').strengthify({
-		zxcvbn: OC.linkTo('core','vendor/zxcvbn/zxcvbn.js'),
+		zxcvbn: OC.linkTo('core','vendor/zxcvbn/dist/zxcvbn.js'),
 		titles: [
 			t('core', 'Very weak password'),
 			t('core', 'Weak password'),


### PR DESCRIPTION
### Steps to reproduce
1. Fresh OC installation
2. Type password in "Create an admin account" section in the setup page
### Expected behaviour

The password strength indicator should be displayed.
### Actual behaviour

No password strength indicator is displayed.
### Client configuration

Chrome 53.0.2785.143
Ubuntu 14.04
