### PR TITLE
introduce callForSeenUsers and countSeenUsers

### DIFF
--- a/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
+++ b/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
@@ -76,9 +76,9 @@ class ExpireTrash extends \OC\BackgroundJob\TimedJob {
 			return;
 		}
 
-		$this->userManager->callForAllUsers(function(IUser $user) {
+		$this->userManager->callForSeenUsers(function(IUser $user) {
 			$uid = $user->getUID();
-			if ($user->getLastLogin() === 0 || !$this->setupFS($uid)) {
+			if (!$this->setupFS($uid)) {
 				return;
 			}
 			$dirContent = Helper::getTrashFiles('/', $uid, 'mtime');

--- a/apps/files_trashbin/lib/Command/ExpireTrash.php
+++ b/apps/files_trashbin/lib/Command/ExpireTrash.php
@@ -89,7 +89,7 @@ class ExpireTrash extends Command {
 		} else {
 			$p = new ProgressBar($output);
 			$p->start();
-			$this->userManager->callForAllUsers(function(IUser $user) use ($p) {
+			$this->userManager->callForSeenUsers(function(IUser $user) use ($p) {
 				$p->advance();
 				$this->expireTrashForUser($user);
 			});
@@ -100,7 +100,7 @@ class ExpireTrash extends Command {
 
 	function expireTrashForUser(IUser $user) {
 		$uid = $user->getUID();
-		if ($user->getLastLogin() === 0 || !$this->setupFS($uid)) {
+		if (!$this->setupFS($uid)) {
 			return;
 		}
 		$dirContent = Helper::getTrashFiles('/', $uid, 'mtime');

--- a/apps/files_versions/lib/BackgroundJob/ExpireVersions.php
+++ b/apps/files_versions/lib/BackgroundJob/ExpireVersions.php
@@ -66,9 +66,9 @@ class ExpireVersions extends \OC\BackgroundJob\TimedJob {
 			return;
 		}
 
-		$this->userManager->callForAllUsers(function(IUser $user) {
+		$this->userManager->callForSeenUsers(function(IUser $user) {
 			$uid = $user->getUID();
-			if ($user->getLastLogin() === 0 || !$this->setupFS($uid)) {
+			if (!$this->setupFS($uid)) {
 				return;
 			}
 			Storage::expireOlderThanMaxForUser($uid);

--- a/apps/files_versions/lib/Command/ExpireVersions.php
+++ b/apps/files_versions/lib/Command/ExpireVersions.php
@@ -88,7 +88,7 @@ class ExpireVersions extends Command {
 		} else {
 			$p = new ProgressBar($output);
 			$p->start();
-			$this->userManager->callForAllUsers(function(IUser $user) use ($p) {
+			$this->userManager->callForSeenUsers(function(IUser $user) use ($p) {
 				$p->advance();
 				$this->expireVersionsForUser($user);
 			});
@@ -99,7 +99,7 @@ class ExpireVersions extends Command {
 
 	function expireVersionsForUser(IUser $user) {
 		$uid = $user->getUID();
-		if ($user->getLastLogin() === 0 || !$this->setupFS($uid)) {
+		if (!$this->setupFS($uid)) {
 			return;
 		}
 		Storage::expireOlderThanMaxForUser($uid);

--- a/lib/private/Repair/MoveAvatarOutsideHome.php
+++ b/lib/private/Repair/MoveAvatarOutsideHome.php
@@ -125,22 +125,6 @@ class MoveAvatarOutsideHome implements IRepairStep {
 	}
 
 	/**
-	 * Count all the users
-	 *
-	 * @return int
-	 */
-	private function countUsers() {
-		$allCount = $this->userManager->countUsers();
-
-		$totalCount = 0;
-		foreach ($allCount as $backend => $count) {
-			$totalCount += $count;
-		}
-
-		return $totalCount;
-	}
-
-	/**
 	 * @param IOutput $output
 	 */
 	public function run(IOutput $output) {
@@ -151,10 +135,9 @@ class MoveAvatarOutsideHome implements IRepairStep {
 				$output->advance();
 			};
 
-			$userCount = $this->countUsers();
-			$output->startProgress($userCount);
+			$output->startProgress($this->userManager->countSeenUsers());
 
-			$this->userManager->callForAllUsers($function);
+			$this->userManager->callForSeenUsers($function);
 
 			$output->finishProgress();
 		}

--- a/lib/private/Repair/RemoveRootShares.php
+++ b/lib/private/Repair/RemoveRootShares.php
@@ -95,28 +95,11 @@ class RemoveRootShares implements IRepairStep {
 			$output->advance();
 		};
 
-		$userCount = $this->countUsers();
-		$output->startProgress($userCount);
+		$output->startProgress($this->userManager->countSeenUsers());
 
-		$this->userManager->callForAllUsers($function);
+		$this->userManager->callForSeenUsers($function);
 
 		$output->finishProgress();
-	}
-
-	/**
-	 * Count all the users
-	 *
-	 * @return int
-	 */
-	private function countUsers() {
-		$allCount = $this->userManager->countUsers();
-
-		$totalCount = 0;
-		foreach ($allCount as $backend => $count) {
-			$totalCount += $count;
-		}
-
-		return $totalCount;
 	}
 
 	/**

--- a/lib/private/Repair/RepairUnmergedShares.php
+++ b/lib/private/Repair/RepairUnmergedShares.php
@@ -347,7 +347,7 @@ class RepairUnmergedShares implements IRepairStep {
 
 			$this->buildPreparedQueries();
 
-			$output->startProgress($this->userManager->countSeenUsers());
+			$output->startProgress($this->userManager->countUsers());
 
 			$this->userManager->callForAllUsers($function);
 

--- a/lib/private/Repair/RepairUnmergedShares.php
+++ b/lib/private/Repair/RepairUnmergedShares.php
@@ -335,22 +335,6 @@ class RepairUnmergedShares implements IRepairStep {
 		}
 	}
 
-	/**
-	 * Count all the users
-	 *
-	 * @return int
-	 */
-	private function countUsers() {
-		$allCount = $this->userManager->countUsers();
-
-		$totalCount = 0;
-		foreach ($allCount as $backend => $count) {
-			$totalCount += $count;
-		}
-
-		return $totalCount;
-	}
-
 	public function run(IOutput $output) {
 		$ocVersionFromBeforeUpdate = $this->config->getSystemValue('version', '0.0.0');
 		if (version_compare($ocVersionFromBeforeUpdate, '9.2.0.1', '<')) {
@@ -363,8 +347,7 @@ class RepairUnmergedShares implements IRepairStep {
 
 			$this->buildPreparedQueries();
 
-			$userCount = $this->countUsers();
-			$output->startProgress($userCount);
+			$output->startProgress($this->userManager->countSeenUsers());
 
 			$this->userManager->callForAllUsers($function);
 

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -396,7 +396,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	/**
 	 * @param \Closure $callback
 	 * @param string $search
-	 * @since 9.0.0
+	 * @since 9.2.0
 	 */
 	public function callForSeenUsers (\Closure $callback) {
 		$limit = 1000;

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -144,6 +144,21 @@ interface IUserManager {
 	public function callForAllUsers (\Closure $callback, $search = '');
 
 	/**
+	 * returns how many users have logged in once
+	 *
+	 * @return int
+	 * @since 9.2.0
+	 */
+	public function countSeenUsers();
+
+	/**
+	 * @param \Closure $callback
+	 * @param string $search
+	 * @since 9.2.0
+	 */
+	public function callForSeenUsers (\Closure $callback);
+
+	/**
 	 * @param string $email
 	 * @return IUser[]
 	 * @since 9.1.0

--- a/tests/lib/Repair/RemoveRootSharesTest.php
+++ b/tests/lib/Repair/RemoveRootSharesTest.php
@@ -106,6 +106,7 @@ class RemoveRootSharesTest extends \Test\TestCase {
 		$user = $this->userManager->createUser('test', 'test');
 		$userFolder = $this->rootFolder->getUserFolder('test');
 		$fileId = $userFolder->getId();
+		$user->updateLastLoginTimestamp();
 
 		//Now insert cyclic share
 		$qb = $this->connection->getQueryBuilder();
@@ -134,6 +135,7 @@ class RemoveRootSharesTest extends \Test\TestCase {
 		$user1 = $this->userManager->createUser('test1', 'test1');
 		$userFolder = $this->rootFolder->getUserFolder('test1');
 		$fileId = $userFolder->getId();
+		$user1->updateLastLoginTimestamp();
 
 		//Now insert cyclic share
 		$qb = $this->connection->getQueryBuilder();
@@ -156,6 +158,7 @@ class RemoveRootSharesTest extends \Test\TestCase {
 		$userFolder = $this->rootFolder->getUserFolder('test2');
 		$folder = $userFolder->newFolder('foo');
 		$fileId = $folder->getId();
+		$user2->updateLastLoginTimestamp();
 
 		//Now insert cyclic share
 		$qb = $this->connection->getQueryBuilder();

--- a/tests/lib/Repair/RepairUnmergedSharesTest.php
+++ b/tests/lib/Repair/RepairUnmergedSharesTest.php
@@ -509,10 +509,10 @@ class RepairUnmergedSharesTest extends TestCase {
 			]));
 
 		$this->userManager->expects($this->once())
-			->method('countUsers')
+			->method('countSeenUsers')
 			->will($this->returnValue([2]));
 		$this->userManager->expects($this->once())
-			->method('callForAllUsers')
+			->method('callForSeenUsers')
 			->will($this->returnCallback(function(\Closure $closure) use ($users) {
 				foreach ($users as $user) {
 					$closure($user);

--- a/tests/lib/Repair/RepairUnmergedSharesTest.php
+++ b/tests/lib/Repair/RepairUnmergedSharesTest.php
@@ -509,10 +509,10 @@ class RepairUnmergedSharesTest extends TestCase {
 			]));
 
 		$this->userManager->expects($this->once())
-			->method('countSeenUsers')
+			->method('countUsers')
 			->will($this->returnValue([2]));
 		$this->userManager->expects($this->once())
-			->method('callForSeenUsers')
+			->method('callForAllUsers')
 			->will($this->returnCallback(function(\Closure $closure) use ($users) {
 				foreach ($users as $user) {
 					$closure($user);

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -9,6 +9,7 @@
 
 namespace Test\User;
 use OC\User\Database;
+use OCP\IUser;
 use Test\TestCase;
 
 /**
@@ -447,6 +448,66 @@ class ManagerTest extends TestCase {
 		$users = array_shift($result);
 		//users from backends shall be summed up
 		$this->assertEquals(7 + 16, $users);
+	}
+
+	public function testCountUsersOnlySeen() {
+		$manager = \OC::$server->getUserManager();
+		// count other users in the db before adding our own
+		$countBefore = $manager->countUsers(true);
+
+		//Add test users
+		$user1 = $manager->createUser('testseencount1', 'testseencount1');
+		$user1->updateLastLoginTimestamp();
+
+		$user2 = $manager->createUser('testseencount2', 'testseencount2');
+		$user2->updateLastLoginTimestamp();
+
+		$user3 = $manager->createUser('testseencount3', 'testseencount3');
+
+		$user4 = $manager->createUser('testseencount4', 'testseencount4');
+		$user4->updateLastLoginTimestamp();
+
+		$this->assertEquals($countBefore + 3, $manager->countUsers(true));
+
+		//cleanup
+		$user1->delete();
+		$user2->delete();
+		$user3->delete();
+		$user4->delete();
+	}
+
+	public function testCallForSeenUsers() {
+		$manager = \OC::$server->getUserManager();
+		// count other users in the db before adding our own
+		$count = 0;
+		$function = function (IUser $user) use (&$count) {
+			$count++;
+		};
+		$manager->callForAllUsers($function, '', true);
+		$countBefore = $count;
+
+		//Add test users
+		$user1 = $manager->createUser('testseen1', 'testseen1');
+		$user1->updateLastLoginTimestamp();
+
+		$user2 = $manager->createUser('testseen2', 'testseen2');
+		$user2->updateLastLoginTimestamp();
+
+		$user3 = $manager->createUser('testseen3', 'testseen3');
+
+		$user4 = $manager->createUser('testseen4', 'testseen4');
+		$user4->updateLastLoginTimestamp();
+
+		$count = 0;
+		$manager->callForAllUsers($function, '', true);
+
+		$this->assertEquals($countBefore + 3, $count);
+
+		//cleanup
+		$user1->delete();
+		$user2->delete();
+		$user3->delete();
+		$user4->delete();
 	}
 
 	public function testDeleteUser() {


### PR DESCRIPTION
I was running into the upgrade trying to iterate over 170000 zombie users in my two test ldap servers, when only 6 of them ever logged in. Instead of waiting 5-6 hours or maybe even longer I decided to take the time and find a better solution.

This pr introduces callForSeenUsers() and countSeenUsers() to allow only executing a callback for users that logged in at least once and as a result have a home directory that has been initialized. It also helps prevent out of memory errors.

cc @PVince81 @DeepDiver1975 there are at least two further occurences (SyncService and SyncBirthdayCalendar) of callForAllUsers in the dav app, but they seem to be related to calendar and contacts. We might add other callFor???User methods.

Backport to 9 strongly requested :exclamation: :grey_exclamation: !!!111einself 
