### PR TITLE
[stable8.2] Fix post_unshareFromSelf hook parameter format

### DIFF
--- a/apps/files_sharing/tests/groupetagpropagation.php
+++ b/apps/files_sharing/tests/groupetagpropagation.php
@@ -101,4 +101,26 @@ class GroupEtagPropagation extends PropagationTestCase {
 
 		$this->assertAllUnchanged();
 	}
+
+	public function testRecipientUnsharesFromSelf() {
+		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue(
+			$this->rootView->unlink('/' . self::TEST_FILES_SHARING_API_USER2 . '/files/test')
+		);
+		$this->assertEtagsChanged([self::TEST_FILES_SHARING_API_USER2]);
+
+		$this->assertAllUnchanged();
+	}
+
+	public function testRecipientUnsharesFromSelfUniqueGroupShare() {
+		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER2);
+		// rename to create an extra entry in the share table
+		$this->rootView->rename('/' . self::TEST_FILES_SHARING_API_USER2 . '/files/test', '/' . self::TEST_FILES_SHARING_API_USER2 . '/files/test_renamed');
+		$this->assertTrue(
+			$this->rootView->unlink('/' . self::TEST_FILES_SHARING_API_USER2 . '/files/test_renamed')
+		);
+		$this->assertEtagsChanged([self::TEST_FILES_SHARING_API_USER2]);
+
+		$this->assertAllUnchanged();
+	}
 }

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1038,7 +1038,7 @@ class Share extends Constants {
 			if (isset($groupShare['file_target'])) {
 				$shareTmp['fileTarget'] = $groupShare['file_target'];
 			}
-			$listOfUnsharedItems = array_merge($listOfUnsharedItems, array($groupShare));
+			$listOfUnsharedItems = array_merge($listOfUnsharedItems, array($shareTmp));
 			$itemUnshared = true;
 		} elseif (!$itemUnshared && isset($uniqueGroupShare)) {
 			$query = \OC_DB::prepare('UPDATE `*PREFIX*share` SET `permissions` = ? WHERE `id` = ?');
@@ -1053,7 +1053,7 @@ class Share extends Constants {
 			if (isset($uniqueGroupShare['file_target'])) {
 				$shareTmp['fileTarget'] = $uniqueGroupShare['file_target'];
 			}
-			$listOfUnsharedItems = array_merge($listOfUnsharedItems, array($uniqueGroupShare));
+			$listOfUnsharedItems = array_merge($listOfUnsharedItems, array($shareTmp));
 			$itemUnshared = true;
 		}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

When unsharing from self in a group share situation, the share items passed to the post_unshareFromSelf hook were using the wrong format in which the attribute names (ex: "share_type") have non camel-case format.

This fix makes sure that in group sharing case we use the correct format. It looks like the code was already producing it but in array_merge it was not using it and adding the unprocessed one
## Related Issue

Fixes https://github.com/owncloud/core/issues/26346 for OC 8.2 (specifically)
## Motivation and Context

Fixes etag propagation that is triggered by said hook that this fixes, see https://github.com/owncloud/core/issues/26346#issuecomment-253442667
## How Has This Been Tested?

Manual testing with group shares and user shares:
- [x] TEST: recipient unshares from self in user share scenario: no warnings, parent etag changes
- [x] TEST: recipient unshares from self in group share scenario: no warnings, parent etag changes
- [x] TEST: sharer unshares from user: no warnings, parent etag of recipient changes
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

@DeepDiver1975 @jvillafanez @butonic 
