### PR TITLE
Properly enable files_sharing hooks in unit tests

### DIFF
--- a/apps/files_sharing/tests/PropagationTestCase.php
+++ b/apps/files_sharing/tests/PropagationTestCase.php
@@ -32,7 +32,6 @@ abstract class PropagationTestCase extends TestCase {
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-		\OCA\Files_Sharing\Helper::registerHooks();
 	}
 
 	protected function setUp() {

--- a/apps/files_sharing/tests/TestCase.php
+++ b/apps/files_sharing/tests/TestCase.php
@@ -77,6 +77,7 @@ abstract class TestCase extends \Test\TestCase {
 		// clear share hooks
 		\OC_Hook::clear('OCP\\Share');
 		\OC::registerShareHooks();
+		\OCA\Files_Sharing\Helper::registerHooks();
 
 		// create users
 		$backend = new \Test\Util\User\Dummy();


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

It looks like we were missing half of the sharing hooks in all files_sharing tests.
This is likely because the `TestCase` best class registers hooks with `OC::registerShareHooks()` which registers different kind of hooks (user/group hooks) but doesn't register the hooks relevant to etag propagation and other things.
## Related Issue

None, but this was needed for this 8.2 fix: https://github.com/owncloud/core/pull/26364
## Motivation and Context

Just to make sure we cover everything...
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
