### PR TITLE
Sanitize length headers when validating quota

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/QuotaPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/QuotaPluginTest.php
@@ -22,22 +22,20 @@
  *
  */
 namespace OCA\DAV\Tests\unit\Connector\Sabre;
+use Test\TestCase;
+
 /**
  * Copyright (c) 2013 Thomas Müller <thomas.mueller@tmit.eu>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.
  */
-class QuotaPluginTest extends \Test\TestCase {
+class QuotaPluginTest extends TestCase {
 
-	/**
-	 * @var \Sabre\DAV\Server
-	 */
+	/** @var \Sabre\DAV\Server | \PHPUnit_Framework_MockObject_MockObject */
 	private $server;
 
-	/**
-	 * @var \OCA\DAV\Connector\Sabre\QuotaPlugin
-	 */
+	/** @var \OCA\DAV\Connector\Sabre\QuotaPlugin | \PHPUnit_Framework_MockObject_MockObject */
 	private $plugin;
 
 	private function init($quota, $checkedPath = '') {
@@ -130,6 +128,12 @@ class QuotaPluginTest extends \Test\TestCase {
 			[512, ['CONTENT-LENGTH' => '512']],
 			[2048, ['OC-TOTAL-LENGTH' => '2048', 'CONTENT-LENGTH' => '1024']],
 			[4096, ['OC-TOTAL-LENGTH' => '2048', 'X-EXPECTED-ENTITY-LENGTH' => '4096']],
+			[null, ['X-EXPECTED-ENTITY-LENGTH' => 'A']],
+			[null, ['CONTENT-LENGTH' => 'A']],
+			[1024, ['OC-TOTAL-LENGTH' => 'A', 'CONTENT-LENGTH' => '1024']],
+			[1024, ['OC-TOTAL-LENGTH' => 'A', 'X-EXPECTED-ENTITY-LENGTH' => '1024']],
+			[null, ['OC-TOTAL-LENGTH' => '2048', 'X-EXPECTED-ENTITY-LENGTH' => 'A']],
+			[null, ['OC-TOTAL-LENGTH' => '2048', 'CONTENT-LENGTH' => 'A']],
 		];
 	}
 
@@ -211,8 +215,11 @@ class QuotaPluginTest extends \Test\TestCase {
 	}
 
 	private function buildFileViewMock($quota, $checkedPath) {
-		// mock filesysten
-		$view = $this->createMock('\OC\Files\View', ['free_space'], [], '', false);
+		// mock file systen
+		$view = $this->getMockBuilder('\OC\Files\View')
+			->setMethods(['free_space'])
+			->setConstructorArgs([])
+			->getMock();
 		$view->expects($this->any())
 			->method('free_space')
 			->with($this->identicalTo($checkedPath))


### PR DESCRIPTION
## Description

In case an invalid value for one of the length headers is sent we ignore them when checking the quota
## Motivation

By submitting a non numeric value as length header the quote checks could be bypassed.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
