### PR TITLE
console.log now returns 1 instead of 0 on all errors

### DIFF
--- a/console.php
+++ b/console.php
@@ -54,7 +54,7 @@ try {
 
 	if (!OC::$CLI) {
 		echo "This script can be run from the command line only" . PHP_EOL;
-		exit(0);
+		exit(1);
 	}
 
 	set_exception_handler('exceptionHandler');
@@ -62,7 +62,7 @@ try {
 	if (!OC_Util::runningOnWindows())  {
 		if (!function_exists('posix_getuid')) {
 			echo "The posix extensions are required - see http://php.net/manual/en/book.posix.php" . PHP_EOL;
-			exit(0);
+			exit(1);
 		}
 		$user = posix_getpwuid(posix_getuid());
 		$configUser = posix_getpwuid(fileowner(OC::$configDir . 'config.php'));
@@ -70,8 +70,8 @@ try {
 			echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
 			echo "Current user: " . $user['name'] . PHP_EOL;
 			echo "Owner of config.php: " . $configUser['name'] . PHP_EOL;
-			echo "Try adding 'sudo -u " . $configUser['name'] . " ' to the beginning of the command (without the single quotes)" . PHP_EOL;  
-			exit(0);
+			echo "Try adding 'sudo -u " . $configUser['name'] . " ' to the beginning of the command (without the single quotes)" . PHP_EOL;
+			exit(1);
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

console.php in CLI returns 0 on some errors. It's then not easy to detect errors when using console.php from a script.
## Related Issue

Refs #26371
## Motivation and Context

Replace exit(0) by exit(1) in case of error
## How Has This Been Tested?

manually...
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

No test found :(
