### PR TITLE
Add CleanupRemoteStorages command

### DIFF
--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -27,4 +27,8 @@ Turning the feature off removes shared files and folders on the server for all s
 		<job>OCA\Files_Sharing\DeleteOrphanedSharesJob</job>
 		<job>OCA\Files_Sharing\ExpireSharesJob</job>
 	</background-jobs>
+
+	<commands>
+		<command>OCA\Files_Sharing\Command\CleanupRemoteStorages</command>
+	</commands>
 </info>

--- a/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
+++ b/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Sharing\Command;
+
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Delete all storage entries that have no matching entries in the shares_external table.
+ */
+class CleanupRemoteStorages extends Command {
+
+	/**
+	 * @var IDBConnection
+	 */
+	protected $connection;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('sharing:cleanup-remote-storages')
+			->setDescription('Show or delete storage entries that have no matching entries in the shares_external table')
+			->addOption(
+				'dry-run',
+				null,
+				InputOption::VALUE_NONE,
+				'only show which storages would be deleted'
+			);
+	}
+
+	public function execute(InputInterface $input, OutputInterface $output) {
+
+		$remoteStorages = $this->getRemoteStorages();
+
+		$output->writeln(count($remoteStorages) . " remote storage(s) need(s) to be checked");
+
+		$remoteShareIds = $this->getRemoteShareIds();
+
+		$output->writeln(count($remoteShareIds) . " remote share(s) exist");
+
+		foreach ($remoteShareIds as $id => $remoteShareId) {
+			if (isset($remoteStorages[$remoteShareId])) {
+				$output->writeln("$remoteShareId belongs to remote share $id");
+				unset($remoteStorages[$remoteShareId]);
+			} else {
+				$output->writeln("$remoteShareId for share $id has no matching storage, yet");
+			}
+		}
+
+		if (empty($remoteStorages)) {
+			$output->writeln("no storages deleted");
+		} else {
+			$dryRun = $input->getOption('dry-run');
+			foreach ($remoteStorages as $id => $numericId) {
+				if ($dryRun) {
+					$output->writeln("$id [$numericId] can be deleted");
+				} else {
+					$this->deleteStorage($id, $numericId, $output);
+				}
+			}
+		}
+	}
+
+	public function deleteStorage ($id, $numericId, OutputInterface $output) {
+		$queryBuilder = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$queryBuilder->delete('storages')
+			->where($queryBuilder->expr()->eq(
+				'id',
+				$queryBuilder->createNamedParameter($id, IQueryBuilder::PARAM_STR),
+				IQueryBuilder::PARAM_STR)
+			);
+		$output->write("deleting $id [$numericId] ... ");
+		$count = $queryBuilder->execute();
+		$output->writeln("deleted $count");
+	}
+
+	public function getRemoteStorages() {
+
+		$queryBuilder = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$queryBuilder->select(['id', 'numeric_id'])
+			->from('storages')
+			->where($queryBuilder->expr()->like(
+				'id',
+				$queryBuilder->createNamedParameter('shared::________________________________', IQueryBuilder::PARAM_STR),
+				IQueryBuilder::PARAM_STR)
+			)
+			->andWhere($queryBuilder->expr()->notLike(
+				'id',
+				$queryBuilder->createNamedParameter('shared::/%', IQueryBuilder::PARAM_STR),
+				IQueryBuilder::PARAM_STR)
+			);
+		$query = $queryBuilder->execute();
+
+		$remoteStorages = [];
+
+		while ($row = $query->fetch()) {
+			$remoteStorages[$row['id']] = $row['numeric_id'];
+		}
+
+		return $remoteStorages;
+	}
+
+	public function getRemoteShareIds() {
+
+		$queryBuilder = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$queryBuilder->select(['id', 'share_token', 'remote'])
+			->from('share_external');
+		$query = $queryBuilder->execute();
+
+		$remoteShareIds = [];
+
+		while ($row = $query->fetch()) {
+			$remoteShareIds[$row['id']] = 'shared::' . md5($row['share_token'] . '@' . $row['remote']);
+		}
+
+		return $remoteShareIds;
+	}
+}

--- a/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
+++ b/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
@@ -147,7 +147,7 @@ class CleanupRemoteStorages extends Command {
 				// but not the ones starting with a '/', they are for normal shares
 				$queryBuilder->createNamedParameter('shared::/%', IQueryBuilder::PARAM_STR),
 				IQueryBuilder::PARAM_STR)
-			);
+			)->orderBy('numeric_id');
 		$query = $queryBuilder->execute();
 
 		$remoteStorages = [];

--- a/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
+++ b/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files\Tests\Command;
+
+use OCA\Files_Sharing\Command\CleanupRemoteStorages;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use Test\TestCase;
+
+/**
+ * Class CleanupRemoteStoragesTest
+ *
+ * @group DB
+ *
+ * @package OCA\Files\Tests\Command
+ */
+class CleanupRemoteStoragesTest extends TestCase {
+
+	/**
+	 * @var CleanupRemoteStorages
+	 */
+	private $command;
+
+	/**
+	 * @var \OCP\IDBConnection
+	 */
+	private $connection;
+
+	private $storages = [
+		['id' => 'shared::7b4a322b22f9d0047c38d77d471ce3cf', 'share_token' => 'f2c69dad1dc0649f26976fd210fc62e1', 'remote' => 'https://hostname.tld/owncloud1', 'user' => 'user1'],
+		['id' => 'shared::efe3b456112c3780da6155d3a9b9141c', 'share_token' => 'f2c69dad1dc0649f26976fd210fc62e2', 'remote' => 'https://hostname.tld/owncloud2', 'user' => 'user2'],
+		['notExistingId' => 'shared::33323d9f4ca416a9e3525b435354bc6f', 'share_token' => 'f2c69dad1dc0649f26976fd210fc62e3', 'remote' => 'https://hostname.tld/owncloud3', 'user' => 'user3'],
+		['id' => 'shared::7fe41a07d3f517a923f4b2b599e72cbb'],
+		['id' => 'shared::de4aeb2f378d222b6d2c5fd8f4e42f8e', 'share_token' => 'f2c69dad1dc0649f26976fd210fc62e5', 'remote' => 'https://hostname.tld/owncloud5', 'user' => 'user5'],
+		['id' => 'shared::af712293ab5eb9e6a1745a13818b99fe'],
+		['notExistingId' => 'shared::c34568c143cdac7d2f06e0800b5280f9', 'share_token' => 'f2c69dad1dc0649f26976fd210fc62e7', 'remote' => 'https://hostname.tld/owncloud7', 'user' => 'user7'],
+	];
+
+	protected function setup() {
+		parent::setUp();
+
+		$this->connection = \OC::$server->getDatabaseConnection();
+
+		$storageQuery = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$storageQuery->insert('storages')
+			->setValue('id', '?');
+
+		$shareExternalQuery = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$shareExternalQuery->insert('share_external')
+			->setValue('share_token', '?')
+			->setValue('remote', '?')
+			->setValue('name', '?')->setParameter(2, 'irrelevant')
+			->setValue('owner', '?')->setParameter(3, 'irrelevant')
+			->setValue('user', '?')
+			->setValue('mountpoint', '?')->setParameter(5, 'irrelevant')
+			->setValue('mountpoint_hash', '?')->setParameter(6, 'irrelevant');
+
+		foreach ($this->storages as $storage) {
+			if (isset($storage['id'])) {
+				$storageQuery->setParameter(0, $storage['id']);
+				$storageQuery->execute();
+			}
+
+			if (isset($storage['share_token'])) {
+				$shareExternalQuery
+					->setParameter(0, $storage['share_token'])
+					->setParameter(1, $storage['remote'])
+					->setParameter(4, $storage['user']);
+				$shareExternalQuery->execute();
+			}
+		}
+
+		$this->command = new CleanupRemoteStorages($this->connection);
+	}
+
+	public function tearDown() {
+		$storageQuery = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$storageQuery->delete('storages')
+			->where($storageQuery->expr()->eq('id', $storageQuery->createParameter('id')));
+
+		$shareExternalQuery = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$shareExternalQuery->delete('share_external')
+			->where($shareExternalQuery->expr()->eq('share_token', $shareExternalQuery->createParameter('share_token')))
+			->andWhere($shareExternalQuery->expr()->eq('remote', $shareExternalQuery->createParameter('remote')));
+
+		foreach ($this->storages as $storage) {
+			if (isset($storage['id'])) {
+				$storageQuery->setParameter('id', $storage['id']);
+				$storageQuery->execute();
+			}
+
+			if (isset($storage['share_token'])) {
+				$shareExternalQuery->setParameter('share_token', $storage['share_token']);
+				$shareExternalQuery->setParameter('remote', $storage['remote']);
+				$shareExternalQuery->execute();
+			}
+		}
+
+		return parent::tearDown();
+	}
+
+	/**
+	 * Test cleanup of orphaned storages
+	 */
+	public function testCleanup() {
+		$input = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')
+			->disableOriginalConstructor()
+			->getMock();
+		$output = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+			->disableOriginalConstructor()
+			->getMock();
+
+		//
+
+		// parent folder, `files`, ´test` and `welcome.txt` => 4 elements
+
+		$at = 0;
+		$output
+			->expects($this->at($at++))
+			->method('writeln')
+			->with('5 remote storage(s) need(s) to be checked');
+		$output
+			->expects($this->at($at++))
+			->method('writeln')
+			->with('5 remote share(s) exist');
+		$output
+			->expects($this->at($at++))
+			->method('writeln')
+			->with($this->stringStartsWith("{$this->storages[0]['id']} belongs to remote share"));
+		$output
+			->expects($this->at($at++))
+			->method('writeln')
+			->with($this->stringStartsWith("{$this->storages[1]['id']} belongs to remote share"));
+		$output
+			->expects($this->at($at++))
+			->method('writeln')
+			->with($this->stringStartsWith("{$this->storages[4]['id']} belongs to remote share"));
+		$output
+			->expects($this->at($at++))
+			->method('writeln')
+			->with($this->stringStartsWith("{$this->storages[2]['notExistingId']} for share"));
+		$output
+			->expects($this->at($at++))
+			->method('writeln')
+			->with($this->stringStartsWith("{$this->storages[6]['notExistingId']} for share"));
+		$output
+			->expects($this->at($at++))
+			->method('write')
+			->with($this->stringStartsWith("deleting {$this->storages[3]['id']}"));
+		$output
+			->expects($this->at($at++))
+			->method('writeln')
+			->with('deleted 1');
+		$output
+			->expects($this->at($at++))
+			->method('write')
+			->with($this->stringStartsWith("deleting {$this->storages[5]['id']}"));
+		$output
+			->expects($this->at($at++))
+			->method('writeln')
+			->with('deleted 1');
+
+		$this->command->execute($input, $output);
+
+	}
+}
+

--- a/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
+++ b/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
@@ -19,7 +19,7 @@
  *
  */
 
-namespace OCA\Files\Tests\Command;
+namespace OCA\Files_Sharing\Tests\Command;
 
 use OCA\Files_Sharing\Command\CleanupRemoteStorages;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -30,7 +30,7 @@ use Test\TestCase;
  *
  * @group DB
  *
- * @package OCA\Files\Tests\Command
+ * @package OCA\Files_Sharing\Tests\Command
  */
 class CleanupRemoteStoragesTest extends TestCase {
 

--- a/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
+++ b/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
@@ -179,66 +179,13 @@ class CleanupRemoteStoragesTest extends TestCase {
 			->expects($this->at($at++))
 			->method('writeln')
 			->with('5 remote share(s) exist');
-		$output
-			->expects($this->at($at++))
-			->method('writeln')
-			->with($this->stringStartsWith("{$this->storages[0]['id']} belongs to remote share"));
-		$output
-			->expects($this->at($at++))
-			->method('writeln')
-			->with($this->stringStartsWith("{$this->storages[1]['id']} belongs to remote share"));
-		$output
-			->expects($this->at($at++))
-			->method('writeln')
-			->with($this->stringStartsWith("{$this->storages[4]['id']} belongs to remote share"));
-		$output
-			->expects($this->at($at++))
-			->method('writeln')
-			->with($this->stringStartsWith("{$this->storages[2]['notExistingId']} for share"));
-		$output
-			->expects($this->at($at++))
-			->method('writeln')
-			->with($this->stringStartsWith("{$this->storages[6]['notExistingId']} for share"));
-
-		// delete storage 3
-		$output
-			->expects($this->at($at++))
-			->method('write')
-			->with($this->stringStartsWith("deleting {$this->storages[3]['id']}"));
-		$output
-			->expects($this->at($at++))
-			->method('writeln')
-			->with('deleted 1');
-		$output
-			->expects($this->at($at++))
-			->method('write')
-			->with($this->stringStartsWith("deleting files for storage {$this->storages[3]['numeric_id']}"));
-		$output
-			->expects($this->at($at++))
-			->method('writeln')
-			->with('deleted 2');
-
-		// delete storage 5
-		$output
-			->expects($this->at($at++))
-			->method('write')
-			->with($this->stringStartsWith("deleting {$this->storages[5]['id']}"));
-		$output
-			->expects($this->at($at++))
-			->method('writeln')
-			->with('deleted 1');
-		$output
-			->expects($this->at($at++))
-			->method('write')
-			->with($this->stringStartsWith("deleting files for storage {$this->storages[5]['numeric_id']}"));
-		$output
-			->expects($this->at($at++))
-			->method('writeln')
-			->with('deleted 3');
 
 		$this->command->execute($input, $output);
 
+		$this->assertTrue($this->doesStorageExist($this->storages[0]['numeric_id']));
+		$this->assertTrue($this->doesStorageExist($this->storages[1]['numeric_id']));
 		$this->assertFalse($this->doesStorageExist($this->storages[3]['numeric_id']));
+		$this->assertTrue($this->doesStorageExist($this->storages[4]['numeric_id']));
 		$this->assertFalse($this->doesStorageExist($this->storages[5]['numeric_id']));
 
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

``` console
# occ sharing:cleanup-remote-storages --help
Usage:
  sharing:cleanup-remote-storages

Options:
  -h, --help            Display this help message
[...]
Help:
 Delete all storage entries that have no matching entries in the shares_external table
```
## Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->

cleanup for https://github.com/owncloud/core/issues/15701
- [ ] ~~find the right place where we can delete the storage along with the remote share~~ in https://github.com/owncloud/core/pull/26490
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

remote storages with "shared::<md5>" never get deleted. This becomes a problem if a user has reshared an incoming remote share that has been deleted, because that internal re share never gets deleted (fileid still exists in filecache and storage for that file is never deleted). The reshare recipient now gets an errer when trying to access that file/folder. 
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

on my personal instance:

```
18 remote storage(s) need(s) to be checked
8 remote share(s) exist
shared::801c61b92c2aae00412ee21003bd2026 belongs to remote share 11
shared::7fe41a07d3f517a923f4b2b599e72cbb belongs to remote share 12
shared::af712293ab5eb9e6b1745a13818b99fe belongs to remote share 13
shared::c885155131f4487e025943244f4116b1 belongs to remote share 14
shared::113174afdf6e830fc0d7f1c00ec1a581 belongs to remote share 15
shared::6c2632ea130cd1bfc21d839bdc656e62 belongs to remote share 16
shared::cf3b58cc953fdef753867fd4d96a24b7 belongs to remote share 17
shared::0293022aa2a0813ab3f3488ef9336d6b has no matching storage, yet
shared::0ba88523c45c206b91ad8b97141ff020 [23] can be deleted
shared::0d45f25ee68fe0cda20df2139620082e [26] can be deleted
shared::207d9354a47a54e5749b235d0f42aac4 [22] can be deleted
shared::4c783debcc30ff253cf93f2a94a90c08 [27] can be deleted
shared::57ae748a3aa8934484aa70b23675cc93 [35] can be deleted
shared::662f5adeffe1a342f9475066bf94a0f3 [24] can be deleted
shared::99bb21dca2832e9311e3714dd92b8ff2 [18] can be deleted
shared::9b9f0b149480a3baaab8156eb64e5165 [21] can be deleted
shared::ac6f074d3b011e20b0f6a0a5c79b8b4b [20] can be deleted
shared::f7de882bbfcc2cf26780098fda9e1657 [34] can be deleted
shared::fd171b4b7b3c5907f4983e7825e96725 [25] can be deleted
```
## Screenshots (if appropriate):

see above
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
# TODO
- [x] actually delete storages and files
- [ ] what happens when accessing a loca reshare of a remote storage that becomes unavailable (eg. due to network outage)
