### PR TITLE
Hide "Add group" for subadmins

### DIFF
--- a/settings/templates/users/part.grouplist.php
+++ b/settings/templates/users/part.grouplist.php
@@ -1,10 +1,12 @@
 <ul id="usergrouplist" data-sort-groups="<?php p($_['sortGroups']); ?>">
 	<!-- Add new group -->
+	<?php if ($_['isAdmin']) { ?>
 	<li id="newgroup-init">
 		<a href="#">
 			<span><?php p($l->t('Add Group'))?></span>
 		</a>
 	</li>
+	<?php } ?>
 	<li id="newgroup-form" style="display: none">
 		<form>
 			<input type="text" id="newgroupname" placeholder="<?php p($l->t('Group')); ?>..." />


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Hide "Add group" for subadmins
## Related Issue

Fixes https://github.com/owncloud/core/issues/10228
## Motivation and Context

Because subadmins cannot create groups.
Also, that bug is oooooooooooooold.
## How Has This Been Tested?

In users page:
- [x] TEST: admin can see "Add group"
- [x] TEST: subadmin cannot see "Add group"
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 @butonic @jvillafanez @VicDeo @mrow4a 
