### PR TITLE
[debug] [stable9.1] Fix initMountPoints to set usersSetup earlier

### DIFF
--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -397,15 +397,17 @@ class Filesystem {
 			return;
 		}
 
+		self::$usersSetup[$user] = true;
+
 		$userManager = \OC::$server->getUserManager();
 		$userObject = $userManager->get($user);
 
 		if (is_null($userObject)) {
 			\OCP\Util::writeLog('files', ' Backends provided no user object for ' . $user, \OCP\Util::ERROR);
+			// reset flag, this will make it possible to rethrow the exception if called again
+			self::$usersSetup[$user] = false;
 			throw new \OC\User\NoUserException('Backends provided no user object for ' . $user);
 		}
-
-		self::$usersSetup[$user] = true;
 
 		/** @var \OC\Files\Config\MountProviderCollection $mountConfigManager */
 		$mountConfigManager = \OC::$server->getMountProviderCollection();


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

This is needed because in some cases like LDAP, the user manager itself
might trigger avatar updates which would internally also call
initMountPoints with the same user. This could cause the same user to
be setup twice, and in some sharing situations could cause recursive
deduplication of shares by adding "(2)" every time.
## Related Issue

Fixes https://github.com/owncloud/core/issues/25718
## Motivation and Context

See description
## How Has This Been Tested?

Very difficult to reproduce: https://github.com/owncloud/core/issues/25718#issuecomment-254444048
Tested with the provided DB dump with LDAP + avatars, in an env where the issue could be reproduced.
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
## Backports:

Potentially this issue could appear in previous versions as well, maybe in different forms, so I'd say let's backport to:
- [ ] stable9
- [ ] stable8.2
- [ ] master / 9.2

@jvillafanez @DeepDiver1975 
