### PR TITLE
Add using casing check/fix for initMountPoints

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -89,17 +89,20 @@ class TransferOwnership extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$this->sourceUser = $input->getArgument('source-user');
-		$this->destinationUser = $input->getArgument('destination-user');
-		if (!$this->userManager->userExists($this->sourceUser)) {
+		$sourceUserObject = $this->userManager->get($input->getArgument('source-user'));
+		$destinationUserObject = $this->userManager->get($input->getArgument('destination-user'));
+		if (is_null($sourceUserObject)) {
 			$output->writeln("<error>Unknown source user $this->sourceUser</error>");
 			return;
 		}
-		if (!$this->userManager->userExists($this->destinationUser)) {
+		if (is_null($destinationUserObject)) {
 			$output->writeln("<error>Unknown destination user $this->destinationUser</error>");
 			return;
 		}
-		
+
+		$this->sourceUser = $sourceUserObject->getUID();
+		$this->destinationUser = $destinationUserObject->getUID();
+
 		// target user has to be ready
 		if (!\OC::$server->getEncryptionManager()->isReadyForUser($this->destinationUser)) {
 			$output->writeln("<error>The target user is not ready to accept files. The user has at least to be logged in once.</error>");

--- a/lib/private/AvatarManager.php
+++ b/lib/private/AvatarManager.php
@@ -84,6 +84,8 @@ class AvatarManager implements IAvatarManager {
 			throw new \Exception('user does not exist');
 		}
 
+		$userId = $user->getUID();
+
 		$avatarsFolder = $this->getAvatarFolder($userId);
 		return new Avatar($avatarsFolder, $this->l, $user, $this->logger);
 	}

--- a/lib/private/AvatarManager.php
+++ b/lib/private/AvatarManager.php
@@ -33,6 +33,7 @@ use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\Files\IRootFolder;
 use OCP\IL10N;
+use OCP\IUser;
 
 /**
  * This class implements methods to access Avatar functionality
@@ -86,7 +87,7 @@ class AvatarManager implements IAvatarManager {
 
 		$userId = $user->getUID();
 
-		$avatarsFolder = $this->getAvatarFolder($userId);
+		$avatarsFolder = $this->getAvatarFolder($user);
 		return new Avatar($avatarsFolder, $this->l, $user, $this->logger);
 	}
 
@@ -106,14 +107,14 @@ class AvatarManager implements IAvatarManager {
 	/**
 	 * Returns the avatar folder for the given user
 	 *
-	 * @param $userId user id
+	 * @param IUser $user user
 	 * @return Folder|\OCP\Files\Node
 	 *
 	 * @internal
 	 */
-	public function getAvatarFolder($userId) {
+	public function getAvatarFolder(IUser $user) {
 		$avatarsFolder = $this->getFolder($this->rootFolder, 'avatars');
-		$parts = $this->buildAvatarPath($userId);
+		$parts = $this->buildAvatarPath($user->getUID());
 		foreach ($parts as $part) {
 			$avatarsFolder = $this->getFolder($avatarsFolder, $part);
 		}

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -393,9 +393,6 @@ class Filesystem {
 		if ($user === null || $user === false || $user === '') {
 			throw new \OC\User\NoUserException('Attempted to initialize mount points for null user and no user in session');
 		}
-		if (isset(self::$usersSetup[$user])) {
-			return;
-		}
 
 		$userManager = \OC::$server->getUserManager();
 		$userObject = $userManager->get($user);
@@ -403,6 +400,17 @@ class Filesystem {
 		if (is_null($userObject)) {
 			\OCP\Util::writeLog('files', ' Backends provided no user object for ' . $user, \OCP\Util::ERROR);
 			throw new \OC\User\NoUserException('Backends provided no user object for ' . $user);
+		}
+
+		// workaround in case of different casings
+		if ($user !== $userObject->getUID()) {
+			$stack = json_encode(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 50));
+			\OCP\Util::writeLog('files', 'initMountPoints() called with wrong user casing. This could be a bug. Expected: "' . $userObject->getUID() . '" got "' . $user . '". Stack: ' . $stack, \OCP\Util::WARN);
+		}
+		$user = $userObject->getUID();
+
+		if (isset(self::$usersSetup[$user])) {
+			return;
 		}
 
 		self::$usersSetup[$user] = true;

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -334,6 +334,15 @@ class Root extends Folder implements IRootFolder {
 	 * @return \OCP\Files\Folder
 	 */
 	public function getUserFolder($userId) {
+		$userObject = \OC::$server->getUserManager()->get($userId);
+
+		if (is_null($userObject)) {
+			\OCP\Util::writeLog('files', 'Backends provided no user object for ' . $userId, \OCP\Util::ERROR);
+			throw new \OC\User\NoUserException('Backends provided no user object for ' . $userId);
+		}
+
+		$userId = $userObject->getUID();
+
 		\OC\Files\Filesystem::initMountPoints($userId);
 		$dir = '/' . $userId;
 		$folder = null;

--- a/lib/private/Repair/MoveAvatarOutsideHome.php
+++ b/lib/private/Repair/MoveAvatarOutsideHome.php
@@ -110,7 +110,7 @@ class MoveAvatarOutsideHome implements IRepairStep {
 			$oldAvatarUserFolder = $this->rootFolder->get('/' . $userId);
 			$oldAvatar = new Avatar($oldAvatarUserFolder, $this->l, $user, $this->logger);
 			if ($oldAvatar->exists()) {
-				$newAvatarsUserFolder = $this->avatarManager->getAvatarFolder($userId);
+				$newAvatarsUserFolder = $this->avatarManager->getAvatarFolder($user);
 
 				// get original file
 				$oldAvatarFile = $oldAvatar->getFile(-1);

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -136,6 +136,15 @@ class Share extends Constants {
 	 *       not '/admin/data/file.txt'
 	 */
 	public static function getUsersSharingFile($path, $ownerUser, $includeOwner = false, $returnUserPaths = false, $recursive = true) {
+		$userManager = \OC::$server->getUserManager();
+		$userObject = $userManager->get($ownerUser);
+
+		if (is_null($ownerUser)) {
+			\OCP\Util::writeLog('files', ' Backends provided no user object for ' . $ownerUser, \OCP\Util::ERROR);
+			throw new \OC\User\NoUserException('Backends provided no user object for ' . $ownerUser);
+		}
+
+		$ownerUser = $userObject->getUID();
 
 		Filesystem::initMountPoints($ownerUser);
 		$shares = $sharePaths = $fileTargets = [];

--- a/tests/lib/AvatarManagerTest.php
+++ b/tests/lib/AvatarManagerTest.php
@@ -120,7 +120,7 @@ class AvatarManagerTest extends TestCase {
 		$folder = $this->createMock(Folder::class);
 		$this->avatarManager->expects($this->once())
 			->method('getAvatarFolder')
-			->with('valid-user')
+			->with($user)
 			->willReturn($folder);
 
 		$avatar = $this->avatarManager->getAvatar('vaLid-USER');

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -79,6 +79,7 @@ class FilesystemTest extends \Test\TestCase {
 
 	protected function setUp() {
 		parent::setUp();
+		\OC_User::clearBackends();
 		$userBackend = new \Test\Util\User\Dummy();
 		$userBackend->createUser(self::TEST_FILESYSTEM_USER1, self::TEST_FILESYSTEM_USER1);
 		$userBackend->createUser(self::TEST_FILESYSTEM_USER2, self::TEST_FILESYSTEM_USER2);
@@ -93,6 +94,7 @@ class FilesystemTest extends \Test\TestCase {
 
 		$this->logout();
 		$this->invokePrivate('\OC\Files\Filesystem', 'normalizedPathCache', [null]);
+		\OC_User::clearBackends();
 		parent::tearDown();
 	}
 
@@ -389,6 +391,39 @@ class FilesystemTest extends \Test\TestCase {
 		}
 
 		$this->assertEquals(2, $thrown);
+	}
+
+	public function testUserNameCasing() {
+		$this->logout();
+		$userId = $this->getUniqueID('user_');
+
+		\OC_User::clearBackends();
+		// needed for loginName2UserName mapping
+		$userBackend = $this->getMock('\OC\User\Database');
+		\OC::$server->getUserManager()->registerBackend($userBackend);
+
+		$userBackend->expects($this->once())
+			->method('userExists')
+			->with(strtoupper($userId))
+			->will($this->returnValue(true));
+		$userBackend->expects($this->once())
+			->method('loginName2UserName')
+			->with(strtoupper($userId))
+			->will($this->returnValue($userId));
+
+		$view = new \OC\Files\View();
+		$this->assertFalse($view->file_exists('/' . $userId));
+
+		\OC\Files\Filesystem::initMountPoints(strtoupper($userId));
+
+		list($storage1, $path1) = $view->resolvePath('/' . $userId);
+		list($storage2, $path2) = $view->resolvePath('/' . strtoupper($userId));
+
+		$this->assertTrue($storage1->instanceOfStorage('\OCP\Files\IHomeStorage'));
+		$this->assertEquals('', $path1);
+
+		// not mounted, still on the local root storage
+		$this->assertEquals(strtoupper($userId), $path2);
 	}
 
 	/**

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -229,6 +229,9 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		self::tearDownAfterClassCleanStrayHooks();
 		self::tearDownAfterClassCleanStrayLocks();
 
+		\OC_User::clearBackends();
+		\OC_User::useBackend('dummy');
+
 		parent::tearDownAfterClass();
 	}
 


### PR DESCRIPTION
Forward port of https://github.com/owncloud/core/pull/26271 to master.

Please review the master-specific changes in AvatarManager and AvatarManagerTest, this is because the logic changed now that the avatars are stored elsewhere. However the user casing logic must still be used here.

@jvillafanez @DeepDiver1975 
