### PR TITLE
[stable8] Sanitize length headers when validating quota

### DIFF
--- a/lib/private/connector/sabre/quotaplugin.php
+++ b/lib/private/connector/sabre/quotaplugin.php
@@ -85,12 +85,13 @@ class OC_Connector_Sabre_QuotaPlugin extends \Sabre\DAV\ServerPlugin {
 	public function getLength() {
 		$req = $this->server->httpRequest;
 		$length = $req->getHeader('X-Expected-Entity-Length');
-		if (!$length) {
+		if (!is_numeric($length)) {
 			$length = $req->getHeader('Content-Length');
+			$length = is_numeric($length) ? $length : null;
 		}
 
 		$ocLength = $req->getHeader('OC-Total-Length');
-		if ($length && $ocLength) {
+		if (is_numeric($length) && is_numeric($ocLength)) {
 			return max($length, $ocLength);
 		}
 

--- a/tests/lib/connector/sabre/quotaplugin.php
+++ b/tests/lib/connector/sabre/quotaplugin.php
@@ -80,13 +80,19 @@ class Test_OC_Connector_Sabre_QuotaPlugin extends \Test\TestCase {
 	}
 
 	public function lengthProvider() {
-		return array(
-			array(null, array()),
-			array(1024, array('HTTP_X_EXPECTED_ENTITY_LENGTH' => '1024')),
-			array(512, array('HTTP_CONTENT_LENGTH' => '512')),
-			array(2048, array('HTTP_OC_TOTAL_LENGTH' => '2048', 'HTTP_CONTENT_LENGTH' => '1024')),
-			array(4096, array('HTTP_OC_TOTAL_LENGTH' => '2048', 'HTTP_X_EXPECTED_ENTITY_LENGTH' => '4096')),
-		);
+		return [
+			[null, []],
+			[1024, ['HTTP_X_EXPECTED_ENTITY_LENGTH' => '1024']],
+			[512, ['HTTP_CONTENT_LENGTH' => '512']],
+			[2048, ['HTTP_OC_TOTAL_LENGTH' => '2048', 'HTTP_CONTENT_LENGTH' => '1024']],
+			[4096, ['HTTP_OC_TOTAL_LENGTH' => '2048', 'HTTP_X_EXPECTED_ENTITY_LENGTH' => '4096']],
+			[null, ['HTTP_X_EXPECTED_ENTITY_LENGTH' => 'A']],
+			[null, ['HTTP_CONTENT_LENGTH' => 'A']],
+			[1024, ['HTTP_OC_TOTAL_LENGTH' => 'A', 'HTTP_CONTENT_LENGTH' => '1024']],
+			[1024, ['HTTP_OC_TOTAL_LENGTH' => 'A', 'HTTP_X_EXPECTED_ENTITY_LENGTH' => '1024']],
+			[null, ['HTTP_OC_TOTAL_LENGTH' => '2048', 'HTTP_X_EXPECTED_ENTITY_LENGTH' => 'A']],
+			[null, ['HTTP_OC_TOTAL_LENGTH' => '2048', 'HTTP_CONTENT_LENGTH' => 'A']],
+		];
 	}
 
 	private function buildFileViewMock($quota) {


### PR DESCRIPTION
Minimal backport of https://github.com/owncloud/core/pull/26366 to stable8.
Had to change the header names in the test because they use the old format.

@DeepDiver1975 @Peter-Prochaska 
