### PR TITLE
[stable8.1] Only run some preview unit tets if imagemagick is available

### DIFF
--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -125,7 +125,7 @@ class Preview {
 		$this->setFile($file);
 		$this->setMaxX((int)$maxX);
 		$this->setMaxY((int)$maxY);
-		$this->setScalingUp($scalingUp);
+		$this->setScalingup($scalingUp);
 
 		$this->preview = null;
 

--- a/tests/lib/preview.php
+++ b/tests/lib/preview.php
@@ -287,6 +287,7 @@ class Preview extends TestCase {
 	/**
 	 * Tests if a preview of max dimensions gets created
 	 *
+	 * @requires extension imagick
 	 * @dataProvider dimensionsDataProvider
 	 * @requires function Imagick::__construct
 	 *
@@ -359,6 +360,7 @@ class Preview extends TestCase {
 	/**
 	 * Tests if the second preview will be based off the cached max preview
 	 *
+	 * @requires extension imagick
 	 * @dataProvider dimensionsDataProvider
 	 * @requires function Imagick::__construct
 	 *
@@ -445,6 +447,7 @@ class Preview extends TestCase {
 	 * so we should be getting either the max preview or a preview the size
 	 * of the dimensions set in the config
 	 *
+	 * @requires extension imagick
 	 * @dataProvider aspectDataProvider
 	 * @requires function Imagick::__construct
 	 *
@@ -502,6 +505,7 @@ class Preview extends TestCase {
 	 * 200-200    ✓
 	 * 300-188-with-aspect
 	 *
+	 * @requires extension imagick
 	 * @dataProvider aspectDataProvider
 	 * @requires function Imagick::__construct
 	 *

--- a/tests/lib/preview.php
+++ b/tests/lib/preview.php
@@ -22,11 +22,15 @@
 
 namespace Test;
 
+use OC\Files\Filesystem;
+use OC\Files\Storage\Temporary;
+use OC\Files\View;
+
 class Preview extends TestCase {
 
 	const TEST_PREVIEW_USER1 = "test-preview-user1";
 
-	/** @var \OC\Files\View */
+	/** @var View */
 	private $rootView;
 	/**
 	 * Note that using 756 with an image with a ratio of 1.6 brings interesting rounding issues
@@ -66,10 +70,10 @@ class Preview extends TestCase {
 		$backend->createUser(self::TEST_PREVIEW_USER1, self::TEST_PREVIEW_USER1);
 		$this->loginAsUser(self::TEST_PREVIEW_USER1);
 
-		$storage = new \OC\Files\Storage\Temporary([]);
-		\OC\Files\Filesystem::mount($storage, [], '/' . self::TEST_PREVIEW_USER1 . '/');
+		$storage = new Temporary([]);
+		Filesystem::mount($storage, [], '/' . self::TEST_PREVIEW_USER1 . '/');
 
-		$this->rootView = new \OC\Files\View('');
+		$this->rootView = new View('');
 		$this->rootView->mkdir('/' . self::TEST_PREVIEW_USER1);
 		$this->rootView->mkdir('/' . self::TEST_PREVIEW_USER1 . '/files');
 
@@ -300,8 +304,6 @@ class Preview extends TestCase {
 	public function testCreateMaxAndNormalPreviewsAtFirstRequest(
 		$sampleId, $widthAdjustment, $heightAdjustment, $keepAspect = false, $scalingUp = false
 	) {
-		//$this->markTestSkipped('Not testing this at this time');
-
 		// Get the right sample for the experiment
 		$this->getSample($sampleId);
 		$sampleWidth = $this->sampleWidth;
@@ -772,14 +774,7 @@ class Preview extends TestCase {
 	 * @param $sampleId
 	 */
 	private function getSample($sampleId) {
-		// Corrects a rounding difference when using the EPS (Imagick converted) sample
-		$filename = $this->samples[$sampleId]['sampleFileName'];
-		$splitFileName = pathinfo($filename);
-		$extension = $splitFileName['extension'];
-		$correction = ($extension === 'eps') ? 1 : 0;
 		$maxPreviewHeight = $this->samples[$sampleId]['maxPreviewHeight'];
-		$maxPreviewHeight = $maxPreviewHeight - $correction;
-
 		$this->sampleFileId = $this->samples[$sampleId]['sampleFileId'];
 		$this->sampleFilename = $this->samples[$sampleId]['sampleFileName'];
 		$this->sampleWidth = $this->samples[$sampleId]['sampleWidth'];

--- a/tests/lib/preview/provider.php
+++ b/tests/lib/preview/provider.php
@@ -85,6 +85,7 @@ abstract class Provider extends \Test\TestCase {
 	 * Launches all the tests we have
 	 *
 	 * @dataProvider dimensionsDataProvider
+	 * @requires extension imagick
 	 *
 	 * @param int $widthAdjustment
 	 * @param int $heightAdjustment


### PR DESCRIPTION
## Description

Fixes failing unit tests because of missing imagick extension on jenkins
## Motivation and Context

:green_heart: on jenkins
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
## Checklist:
- [x] My code follows the code style of this project.
