### PR TITLE
Don't auto-trust servers by default when creating remote shares

### DIFF
--- a/apps/federation/lib/TrustedServers.php
+++ b/apps/federation/lib/TrustedServers.php
@@ -135,7 +135,7 @@ class TrustedServers {
 	 * @return bool
 	 */
 	public function getAutoAddServers() {
-		$value = $this->config->getAppValue('federation', 'autoAddServers', '1');
+		$value = $this->config->getAppValue('federation', 'autoAddServers', '0');
 		return $value === '1';
 	}
 

--- a/apps/federation/tests/TrustedServersTest.php
+++ b/apps/federation/tests/TrustedServersTest.php
@@ -170,7 +170,7 @@ class TrustedServersTest extends TestCase {
 	 */
 	public function testGetAutoAddServers($status, $expected) {
 		$this->config->expects($this->once())->method('getAppValue')
-			->with('federation', 'autoAddServers', '1')->willReturn($status);
+			->with('federation', 'autoAddServers', '0')->willReturn($status);
 
 		$this->assertSame($expected,
 			$this->trustedServers->getAutoAddServers()


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

This makes sure that only admins who really want this feature must
opt-in instead of opt-out.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->
## Motivation and Context

Adding a server as trusted will expose local users for the remote server's sharing autocomplete.
I think admins seldom would want that, and even if they do it should be opt-in, not opt-out to avoid leakage by mistake.
## How Has This Been Tested?
- [x] TEST: setup new OC: setting disabled on admin page
- [x] TEST: update from old OC where setting was untouched: setting disabled on admin page
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

@DeepDiver1975 @butonic @Peter-Prochaska 
