### PR TITLE
use query builder

### DIFF
--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -412,7 +412,7 @@ class AllConfig implements \OCP\IConfig {
 		$this->fixDIInit();
 
 		$queryBuilder = $this->connection->getQueryBuilder();
-		$queryBuilder->select(['userid', 'value'])
+		$queryBuilder->select('userid')
 			->from('preferences')
 			->where($queryBuilder->expr()->eq(
 				'appid', $queryBuilder->createNamedParameter($appName))
@@ -440,6 +440,8 @@ class AllConfig implements \OCP\IConfig {
 		while ($row = $query->fetch()) {
 			$userIDs[] = $row['userid'];
 		}
+
+		$query->closeCursor();
 
 		return $userIDs;
 	}

--- a/tests/lib/AllConfigTest.php
+++ b/tests/lib/AllConfigTest.php
@@ -404,11 +404,6 @@ class AllConfigTest extends \Test\TestCase {
 		$systemConfig = $this->getMockBuilder('\OC\SystemConfig')
 			->disableOriginalConstructor()
 			->getMock();
-		$systemConfig->expects($this->once())
-			->method('getValue')
-			->with($this->equalTo('dbtype'),
-				$this->equalTo('sqlite'))
-			->will($this->returnValue(\OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite')));
 		$config = $this->getConfig($systemConfig);
 
 		// preparation - add something to the database


### PR DESCRIPTION
`to_char` may throw an error, `dbms_lob.substr` is the way to go

see https://docs.oracle.com/cd/B19306_01/server.102/b14200/functions179.htm and https://asktom.oracle.com/pls/asktom/f?p=100:11:0::no::p11_question_id:367980988799
