### PR TITLE
[stable9] remove old share propagation entries from appconfig

### DIFF
--- a/lib/private/repair.php
+++ b/lib/private/repair.php
@@ -40,6 +40,7 @@ use OC\Repair\DropOldJobs;
 use OC\Repair\EncryptionCompatibility;
 use OC\Repair\OldGroupMembershipShares;
 use OC\Repair\RemoveGetETagEntries;
+use OC\Repair\SharePropagation;
 use OC\Repair\SqliteAutoincrement;
 use OC\Repair\DropOldTables;
 use OC\Repair\FillETags;
@@ -118,13 +119,13 @@ class Repair extends BasicEmitter {
 			new DropOldJobs(\OC::$server->getJobList()),
 			new RemoveGetETagEntries(\OC::$server->getDatabaseConnection()),
 			new UpdateOutdatedOcsIds(\OC::$server->getConfig()),
-			new RepairInvalidShares(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection()),
 			new RepairUnmergedShares(
 				\OC::$server->getConfig(),
 				\OC::$server->getDatabaseConnection(),
 				\OC::$server->getUserManager(),
 				\OC::$server->getGroupManager()
 			),
+			new SharePropagation(\OC::$server->getConfig()),
 			new AvatarPermissions(\OC::$server->getDatabaseConnection()),
 			new BrokenUpdaterRepair(),
 		];

--- a/lib/private/repair/sharepropagation.php
+++ b/lib/private/repair/sharepropagation.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @author Georg Ehrke <georg@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Repair;
+
+use OC\Hooks\BasicEmitter;
+use OCP\IConfig;
+
+class SharePropagation extends BasicEmitter implements \OC\RepairStep {
+	/** @var  IConfig */
+	private $config;
+
+	/**
+	 * SharePropagation constructor.
+	 *
+	 * @param IConfig $config
+	 */
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	public function getName() {
+		return 'Remove old share propagation app entries';
+	}
+
+	public function run() {
+		$keys = $this->config->getAppKeys('files_sharing');
+
+		foreach ($keys as $key) {
+			if (is_numeric($key)) {
+				$this->config->deleteAppValue('files_sharing', $key);
+			}
+		}
+	}
+}

--- a/tests/lib/repair/repairsharepropagation.php
+++ b/tests/lib/repair/repairsharepropagation.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright (c) 2016 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Repair;
+
+use OC\Repair\SharePropagation;
+
+class RepairSharePropagation extends \Test\TestCase {
+	public function keyProvider() {
+		return [
+			[['1', '2'], ['1', '2']],
+			[['1', '2', 'foo'], ['1', '2']],
+			[['foo'], []],
+		];
+	}
+
+	/**
+	 * @dataProvider keyProvider
+	 * @param array $startKeys
+	 * @param array $expectedRemovedKeys
+	 */
+	public function testRemovePropagationEntries(array $startKeys, array $expectedRemovedKeys) {
+		/** @var \PHPUnit_Framework_MockObject_MockObject|\OCP\IConfig $config */
+		$config = $this->getMock('\OCP\IConfig');
+		$config->expects($this->once())
+			->method('getAppKeys')
+			->with('files_sharing')
+			->will($this->returnValue($startKeys));
+
+		$removedKeys = [];
+
+		$config->expects($this->any())
+			->method('deleteAppValue')
+			->will($this->returnCallback(function ($app, $key) use (&$removedKeys) {
+				$removedKeys[] = $key;
+			}));
+
+		$step = new SharePropagation($config);
+		$step->run();
+
+		sort($expectedRemovedKeys);
+		sort($removedKeys);
+
+		$this->assertEquals($expectedRemovedKeys, $removedKeys);
+	}
+}


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/23157 to stable9

See justification here https://github.com/owncloud/core/pull/23157#issuecomment-255672712

I'd say not a showstopper for 9.0.6 so targetting for 9.0.7. Let me know if you think otherwise.

@DeepDiver1975 @butonic 
