### PR TITLE
[stable9.1] Fix misleading SSL/TLS SMTP email configuration (#26447)

### DIFF
--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -34,8 +34,8 @@ $mail_smtpauthtype = [
 
 $mail_smtpsecure = [
 	''		=> $l->t('None'),
-	'ssl'	=> $l->t('SSL'),
-	'tls'	=> $l->t('TLS'),
+	'ssl'	=> $l->t('SSL/TLS'),
+	'tls'	=> $l->t('STARTTLS'),
 ];
 
 $mail_smtpmode = [


### PR DESCRIPTION
backport (#26447)
