### PR TITLE
Limit carddav image export mime types

### DIFF
--- a/apps/dav/lib/CardDAV/ImageExportPlugin.php
+++ b/apps/dav/lib/CardDAV/ImageExportPlugin.php
@@ -86,6 +86,7 @@ class ImageExportPlugin extends ServerPlugin {
 
 		if ($result = $this->getPhoto($node)) {
 			$response->setHeader('Content-Type', $result['Content-Type']);
+			$response->setHeader('Content-Disposition', 'attachment');
 			$response->setStatus(200);
 
 			$response->setBody($result['body']);
@@ -120,6 +121,11 @@ class ImageExportPlugin extends ServerPlugin {
 				}
 				$val = file_get_contents($val);
 			}
+
+			if (!in_array($type, ['image/png', 'image/jpeg', 'image/gif'])) {
+				$type = 'application/octet-stream';
+			}
+
 			return [
 				'Content-Type' => $type,
 				'body' => $val
@@ -136,7 +142,7 @@ class ImageExportPlugin extends ServerPlugin {
 
 	/**
 	 * @param Binary $photo
-	 * @return Parameter
+	 * @return string
 	 */
 	private function getType($photo) {
 		$params = $photo->parameters();
@@ -151,6 +157,6 @@ class ImageExportPlugin extends ServerPlugin {
 				return 'image/' . strtolower($type);
 			}
 		}
-		return '';
+		return 'application/octet-stream';
 	}
 }

--- a/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
@@ -95,7 +95,7 @@ class ImageExportPluginTest extends TestCase {
 	 * @param bool $expected
 	 * @param array $getPhotoResult
 	 */
-	public function testCardWithOrWithoutPhoto($expected, $getPhotoResult) {
+	public function testCardWithOrWithoutPhoto($expectedContentType, $getPhotoResult) {
 		$this->request->expects($this->once())->method('getQueryParameters')->willReturn(['photo' => true]);
 		$this->request->expects($this->once())->method('getPath')->willReturn('/files/welcome.txt');
 
@@ -104,20 +104,22 @@ class ImageExportPluginTest extends TestCase {
 
 		$this->plugin->expects($this->once())->method('getPhoto')->willReturn($getPhotoResult);
 
-		if (!$expected) {
-			$this->response->expects($this->once())->method('setHeader');
-			$this->response->expects($this->once())->method('setStatus');
+		if (is_string($expectedContentType)) {
+			$this->response->expects($this->exactly(2))->method('setHeader')->withConsecutive(
+				['Content-Type', $expectedContentType],
+				['Content-Disposition', 'attachment']);
+			$this->response->expects($this->once())->method('setStatus')->with(200);
 			$this->response->expects($this->once())->method('setBody');
 		}
 
 		$result = $this->plugin->httpGet($this->request, $this->response);
-		$this->assertEquals($expected, $result);
+		$this->assertEquals(!is_string($expectedContentType), $result);
 	}
 
 	public function providesCardWithOrWithoutPhoto() {
 		return [
 			[true, null],
-			[false, ['Content-Type' => 'image/jpeg', 'body' => '1234']],
+			['image/jpeg', ['Content-Type' => 'image/jpeg', 'body' => '1234']],
 		];
 	}
 
@@ -146,6 +148,8 @@ class ImageExportPluginTest extends TestCase {
 			'vcard 3 with PHOTO URL' => [false, "BEGIN:VCARD\r\nVERSION:3.0\r\nPRODID:-//Sabre//Sabre VObject 4.1.1//EN\r\nUID:12345\r\nFN:12345\r\nN:12345;;;;\r\nPHOTO;TYPE=JPEG;VALUE=URI:http://example.com/photo.jpg\r\nEND:VCARD\r\n"],
 			'vcard 4 with PHOTO' => [['Content-Type' => 'image/jpeg', 'body' => '12345'], "BEGIN:VCARD\r\nVERSION:4.0\r\nPRODID:-//Sabre//Sabre VObject 4.1.1//EN\r\nUID:12345\r\nFN:12345\r\nN:12345;;;;\r\nPHOTO:data:image/jpeg;base64,MTIzNDU=\r\nEND:VCARD\r\n"],
 			'vcard 4 with PHOTO URL' => [false, "BEGIN:VCARD\r\nVERSION:4.0\r\nPRODID:-//Sabre//Sabre VObject 4.1.1//EN\r\nUID:12345\r\nFN:12345\r\nN:12345;;;;\r\nPHOTO;MEDIATYPE=image/jpeg:http://example.org/photo.jpg\r\nEND:VCARD\r\n"],
+			'vcard 3 with bad PHOTO' => [['Content-Type' => 'application/octet-stream', 'body' => '12345'], "BEGIN:VCARD\r\nVERSION:3.0\r\nPRODID:-//Sabre//Sabre VObject 4.1.1//EN\r\nUID:12345\r\nFN:12345\r\nN:12345;;;;\r\nPHOTO;ENCODING=b;TYPE=TXT:MTIzNDU=\r\nEND:VCARD\r\n"],
+			'vcard 4 with bad PHOTO' => [['Content-Type' => 'application/octet-stream', 'body' => '12345'], "BEGIN:VCARD\r\nVERSION:4.0\r\nPRODID:-//Sabre//Sabre VObject 4.1.1//EN\r\nUID:12345\r\nFN:12345\r\nN:12345;;;;\r\nPHOTO:data:video/mpeg;base64,MTIzNDU=\r\nEND:VCARD\r\n"],
 		];
 	}
 }


### PR DESCRIPTION
## Description

Only jpeg, png and gif should be exported as vcard photos - in any other case application/octet-stream is used to disallow browsers to execute
## Related Issue

https://nextcloud.com/security/advisory/?id=nc-sa-2016-011
## How Has This Been Tested?

With mail and contacts app enabled where an email address of one sender matches a contact who has an image. Even if the mime type is changed in the db the avatar of the user is still display.
Use the inspector to verify that the content disposition is attachment and the content type is application/octet-stream
## Screenshots (if appropriate):
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
