### PR TITLE
[9.2] Provide a theme through an app - v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "require-dev": {
         "jakub-onderka/php-parallel-lint": "^0.9.2",
         "jakub-onderka/php-console-highlighter": "^0.3.2",
-        "phpunit/phpunit": "^5.5"
+        "phpunit/phpunit": "^5.5",
+        "mikey179/vfsStream": "^1.6"
     },
     "require": {
         "php": ">=5.4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "7a47934e8be59f1c3b664953f04afa46",
-    "content-hash": "efa3533da9edd55261e667fb3817b5f3",
+    "hash": "673e35467038668156e108e5677348e7",
+    "content-hash": "d4205bdb54d3d93278447a73d7f353e8",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -149,16 +149,16 @@
         },
         {
             "name": "doctrine/cache",
-            "version": "v1.6.0",
+            "version": "v1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6"
+                "reference": "b6f544a20f4807e81f7044d31e679ccbb1866dc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/f8af318d14bdb0eff0336795b428b547bd39ccb6",
-                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/b6f544a20f4807e81f7044d31e679ccbb1866dc3",
+                "reference": "b6f544a20f4807e81f7044d31e679ccbb1866dc3",
                 "shasum": ""
             },
             "require": {
@@ -215,7 +215,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2015-12-31 16:37:02"
+            "time": "2016-10-29 11:16:17"
         },
         {
             "name": "doctrine/collections",
@@ -2308,16 +2308,16 @@
         },
         {
             "name": "sabre/uri",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fruux/sabre-uri.git",
-                "reference": "9012116434d84ef6e5e37a89dfdbfbe2204a8704"
+                "reference": "258b72540fe3f2c0bb395cb40e56f9ae409f93b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fruux/sabre-uri/zipball/9012116434d84ef6e5e37a89dfdbfbe2204a8704",
-                "reference": "9012116434d84ef6e5e37a89dfdbfbe2204a8704",
+                "url": "https://api.github.com/repos/fruux/sabre-uri/zipball/258b72540fe3f2c0bb395cb40e56f9ae409f93b5",
+                "reference": "258b72540fe3f2c0bb395cb40e56f9ae409f93b5",
                 "shasum": ""
             },
             "require": {
@@ -2325,7 +2325,7 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "*",
-                "sabre/cs": "~0.0.1"
+                "sabre/cs": "~1.0.0"
             },
             "type": "library",
             "autoload": {
@@ -2355,7 +2355,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2016-03-08 02:29:27"
+            "time": "2016-10-27 04:56:33"
         },
         {
             "name": "sabre/vobject",
@@ -2572,16 +2572,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.1.5",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6cb0872fb57b38b3b09ff213c21ed693956b9eb0"
+                "reference": "c99da1119ae61e15de0e4829196b9fba6f73d065"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6cb0872fb57b38b3b09ff213c21ed693956b9eb0",
-                "reference": "6cb0872fb57b38b3b09ff213c21ed693956b9eb0",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c99da1119ae61e15de0e4829196b9fba6f73d065",
+                "reference": "c99da1119ae61e15de0e4829196b9fba6f73d065",
                 "shasum": ""
             },
             "require": {
@@ -2629,11 +2629,11 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-28 00:11:12"
+            "time": "2016-10-06 01:44:51"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.1.5",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
@@ -2690,16 +2690,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.1.5",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "c0c00c80b3a69132c4e55c3e7db32b4a387615e5"
+                "reference": "28b0832b2553ffb80cabef6a7a812ff1e670c0bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/c0c00c80b3a69132c4e55c3e7db32b4a387615e5",
-                "reference": "c0c00c80b3a69132c4e55c3e7db32b4a387615e5",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/28b0832b2553ffb80cabef6a7a812ff1e670c0bc",
+                "reference": "28b0832b2553ffb80cabef6a7a812ff1e670c0bc",
                 "shasum": ""
             },
             "require": {
@@ -2746,7 +2746,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-19 10:45:57"
+            "time": "2016-10-13 06:28:43"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2868,7 +2868,7 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.1.5",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -2917,7 +2917,7 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v3.1.5",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
@@ -3181,17 +3181,63 @@
             "time": "2015-12-15 10:42:16"
         },
         {
-            "name": "myclabs/deep-copy",
-            "version": "1.5.4",
+            "name": "mikey179/vfsStream",
+            "version": "v1.6.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "ea74994a3dc7f8d2f65a06009348f2d63c81e61f"
+                "url": "https://github.com/mikey179/vfsStream.git",
+                "reference": "0247f57b2245e8ad2e689d7cee754b45fbabd592"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/ea74994a3dc7f8d2f65a06009348f2d63c81e61f",
-                "reference": "ea74994a3dc7f8d2f65a06009348f2d63c81e61f",
+                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/0247f57b2245e8ad2e689d7cee754b45fbabd592",
+                "reference": "0247f57b2245e8ad2e689d7cee754b45fbabd592",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "org\\bovigo\\vfs\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Frank Kleine",
+                    "homepage": "http://frankkleine.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Virtual file system to mock the real file system in unit tests.",
+            "homepage": "http://vfs.bovigo.org/",
+            "time": "2016-07-18 14:02:57"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "399c1f9781e222f6eb6cc238796f5200d1b7f108"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/399c1f9781e222f6eb6cc238796f5200d1b7f108",
+                "reference": "399c1f9781e222f6eb6cc238796f5200d1b7f108",
                 "shasum": ""
             },
             "require": {
@@ -3220,7 +3266,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2016-09-16 13:37:59"
+            "time": "2016-10-31 17:19:45"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3432,16 +3478,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.1",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3"
+                "reference": "6cba06ff75a1a63a71033e1a01b89056f3af1e8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/5f3f7e736d6319d5f1fc402aff8b026da26709a3",
-                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6cba06ff75a1a63a71033e1a01b89056f3af1e8d",
+                "reference": "6cba06ff75a1a63a71033e1a01b89056f3af1e8d",
                 "shasum": ""
             },
             "require": {
@@ -3491,7 +3537,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-07-26 14:39:29"
+            "time": "2016-11-01 05:06:24"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -4330,16 +4376,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.1.5",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "368b9738d4033c8b93454cb0dbd45d305135a6d3"
+                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/368b9738d4033c8b93454cb0dbd45d305135a6d3",
-                "reference": "368b9738d4033c8b93454cb0dbd45d305135a6d3",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/7ff51b06c6c3d5cc6686df69004a42c69df09e27",
+                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27",
                 "shasum": ""
             },
             "require": {
@@ -4375,7 +4421,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-25 08:27:07"
+            "time": "2016-10-24 18:41:13"
         },
         {
             "name": "webmozart/assert",

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -79,6 +79,7 @@ use OC\Security\TrustedDomainHelper;
 use OC\Session\CryptoWrapper;
 use OC\Tagging\TagMapper;
 use OC\URLGenerator;
+use OC\Theme\ThemeService;
 use OCP\IDateTimeFormatter;
 use OCP\IL10N;
 use OCP\IServerContainer;
@@ -682,6 +683,10 @@ class Server extends ServerContainer implements IServerContainer {
 			);
 
 			return $manager;
+		});
+
+		$this->registerService('ThemeService', function ($c) {
+			return new ThemeService($this->getSystemConfig()->getValue('theme'));
 		});
 	}
 

--- a/lib/private/Template/Base.php
+++ b/lib/private/Template/Base.php
@@ -27,6 +27,8 @@
 
 namespace OC\Template;
 
+use OC\Theme\Theme;
+
 class Base {
 	private $template; // The template
 	private $vars; // Vars
@@ -54,7 +56,7 @@ class Base {
 	/**
 	 * @param string $serverRoot
 	 * @param string|false $app_dir
-	 * @param string $theme
+	 * @param Theme $theme
 	 * @param string $app
 	 * @return string[]
 	 */
@@ -62,24 +64,24 @@ class Base {
 		// Check if the app is in the app folder or in the root
 		if( file_exists($app_dir.'/templates/' )) {
 			return [
-				$serverRoot.'/themes/'.$theme.'/apps/'.$app.'/templates/',
+				$serverRoot.'/'.$theme->getDirectory().'apps/'.$app.'/templates/',
 				$app_dir.'/templates/',
 			];
 		}
 		return [
-			$serverRoot.'/themes/'.$theme.'/'.$app.'/templates/',
+			$serverRoot.'/'.$theme->getDirectory().$app.'/templates/',
 			$serverRoot.'/'.$app.'/templates/',
 		];
 	}
 
 	/**
 	 * @param string $serverRoot
-	 * @param string $theme
+	 * @param Theme $theme
 	 * @return string[]
 	 */
 	protected function getCoreTemplateDirs($theme, $serverRoot) {
 		return [
-			$serverRoot.'/themes/'.$theme.'/core/templates/',
+			$serverRoot.'/'.$theme->getDirectory().'core/templates/',
 			$serverRoot.'/core/templates/',
 		];
 	}

--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -47,9 +47,12 @@ class CSSResourceLocator extends ResourceLocator {
 	 * @param string $style
 	 */
 	public function doFindTheme($style) {
-		$theme_dir = 'themes/'.$this->theme.'/';
-		$this->appendIfExist($this->serverroot, $theme_dir.'apps/'.$style.'.css')
-			|| $this->appendIfExist($this->serverroot, $theme_dir.$style.'.css')
-			|| $this->appendIfExist($this->serverroot, $theme_dir.'core/'.$style.'.css');
+		$themeDirectory = $this->theme->getDirectory();
+
+		//var_dump($themeDirectory); die();
+
+		$this->appendIfExist($this->serverroot, $themeDirectory.'apps/'.$style.'.css')
+			|| $this->appendIfExist($this->serverroot, $themeDirectory.$style.'.css')
+			|| $this->appendIfExist($this->serverroot, $themeDirectory.'core/'.$style.'.css');
 	}
 }

--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -49,8 +49,6 @@ class CSSResourceLocator extends ResourceLocator {
 	public function doFindTheme($style) {
 		$themeDirectory = $this->theme->getDirectory();
 
-		//var_dump($themeDirectory); die();
-
 		$this->appendIfExist($this->serverroot, $themeDirectory.'apps/'.$style.'.css')
 			|| $this->appendIfExist($this->serverroot, $themeDirectory.$style.'.css')
 			|| $this->appendIfExist($this->serverroot, $themeDirectory.'core/'.$style.'.css');

--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -46,8 +46,6 @@ class JSResourceLocator extends ResourceLocator {
 			$found += $this->appendIfExist($this->serverroot, $themeDirectory.$script.'.js');
 			$found += $this->appendIfExist($this->serverroot, $themeDirectory.'apps/'.$script.'.js');
 
-			//var_dump($this->resources); die();
-
 			if ($found) {
 				return;
 			}

--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -36,7 +36,7 @@ class JSResourceLocator extends ResourceLocator {
 			return;
 		}
 
-		if (strpos($script, 'files/l10n/de_DE') !== false) {
+		if (strpos($script, '/l10n/') !== false) {
 			// For language files we try to load them all, so themes can overwrite
 			// single l10n strings without having to translate all of them.
 			$found = 0;

--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -29,29 +29,32 @@ class JSResourceLocator extends ResourceLocator {
 	 * @param string $script
 	 */
 	public function doFind($script) {
-		$theme_dir = 'themes/'.$this->theme.'/';
+		$themeDirectory = $this->theme->getDirectory();
+
 		if (strpos($script, '3rdparty') === 0
 			&& $this->appendIfExist($this->thirdpartyroot, $script.'.js')) {
 			return;
 		}
 
-		if (strpos($script, '/l10n/') !== false) {
+		if (strpos($script, 'files/l10n/de_DE') !== false) {
 			// For language files we try to load them all, so themes can overwrite
 			// single l10n strings without having to translate all of them.
 			$found = 0;
 			$found += $this->appendIfExist($this->serverroot, 'core/'.$script.'.js');
-			$found += $this->appendIfExist($this->serverroot, $theme_dir.'core/'.$script.'.js');
+			$found += $this->appendIfExist($this->serverroot, $themeDirectory.'core/'.$script.'.js');
 			$found += $this->appendIfExist($this->serverroot, $script.'.js');
-			$found += $this->appendIfExist($this->serverroot, $theme_dir.$script.'.js');
-			$found += $this->appendIfExist($this->serverroot, $theme_dir.'apps/'.$script.'.js');
+			$found += $this->appendIfExist($this->serverroot, $themeDirectory.$script.'.js');
+			$found += $this->appendIfExist($this->serverroot, $themeDirectory.'apps/'.$script.'.js');
+
+			//var_dump($this->resources); die();
 
 			if ($found) {
 				return;
 			}
-		} else if ($this->appendIfExist($this->serverroot, $theme_dir.'apps/'.$script.'.js')
-			|| $this->appendIfExist($this->serverroot, $theme_dir.$script.'.js')
+		} else if ($this->appendIfExist($this->serverroot, $themeDirectory.'apps/'.$script.'.js')
+			|| $this->appendIfExist($this->serverroot, $themeDirectory.$script.'.js')
 			|| $this->appendIfExist($this->serverroot, $script.'.js')
-			|| $this->appendIfExist($this->serverroot, $theme_dir.'core/'.$script.'.js')
+			|| $this->appendIfExist($this->serverroot, $themeDirectory.'core/'.$script.'.js')
 			|| $this->appendIfExist($this->serverroot, 'core/'.$script.'.js')
 		) {
 			return;

--- a/lib/private/Template/ResourceLocator.php
+++ b/lib/private/Template/ResourceLocator.php
@@ -25,7 +25,12 @@
 
 namespace OC\Template;
 
+use OC\Theme\Theme;
+
 abstract class ResourceLocator {
+	/**
+	 * @var Theme
+	 */
 	protected $theme;
 
 	protected $mapping;
@@ -40,7 +45,7 @@ abstract class ResourceLocator {
 
 	/**
 	 * @param \OCP\ILogger $logger
-	 * @param string $theme
+	 * @param Theme $theme
 	 * @param array $core_map
 	 * @param array $party_map
 	 */

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -176,12 +176,9 @@ class TemplateLayout extends \OC_Template {
 	 * @return array
 	 */
 	static public function findStylesheetFiles($styles) {
-		// Read the selected theme from the config file
-		$theme = \OC_Util::getTheme();
-
 		$locator = new \OC\Template\CSSResourceLocator(
 			\OC::$server->getLogger(),
-			$theme,
+			\OC_Util::getTheme(),
 			[\OC::$SERVERROOT => \OC::$WEBROOT],
 			[\OC::$SERVERROOT => \OC::$WEBROOT]);
 		$locator->find($styles);
@@ -193,12 +190,9 @@ class TemplateLayout extends \OC_Template {
 	 * @return array
 	 */
 	static public function findJavascriptFiles($scripts) {
-		// Read the selected theme from the config file
-		$theme = \OC_Util::getTheme();
-
 		$locator = new \OC\Template\JSResourceLocator(
 			\OC::$server->getLogger(),
-			$theme,
+			\OC_Util::getTheme(),
 			[\OC::$SERVERROOT => \OC::$WEBROOT],
 			[\OC::$SERVERROOT => \OC::$WEBROOT]);
 		$locator->find($scripts);

--- a/lib/private/Theme/Theme.php
+++ b/lib/private/Theme/Theme.php
@@ -28,24 +28,21 @@ class Theme {
 	/**
 	 * @return string
 	 */
-	public function getName()
-	{
+	public function getName() {
 		return $this->name;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getDirectory()
-	{
+	public function getDirectory() {
 		return $this->directory;
 	}
 
 	/**
 	 * @param string $directory
 	 */
-	public function setDirectory($directory)
-	{
+	public function setDirectory($directory) {
 		$this->directory = $directory;
 	}
 }

--- a/lib/private/Theme/Theme.php
+++ b/lib/private/Theme/Theme.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace OC\Theme;
+
+class Theme {
+
+	/**
+	 * @var string
+	 */
+	private $name;
+
+	/**
+	 * @var string
+	 */
+	private $directory;
+
+	/**
+	 * Theme constructor.
+	 *
+	 * @param string $name
+	 * @param string $directory
+	 */
+	public function __construct($name = '', $directory = '') {
+		$this->name = $name;
+		$this->directory = $directory;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDirectory()
+	{
+		return $this->directory;
+	}
+
+	/**
+	 * @param string $directory
+	 */
+	public function setDirectory($directory)
+	{
+		$this->directory = $directory;
+	}
+}

--- a/lib/private/Theme/ThemeService.php
+++ b/lib/private/Theme/ThemeService.php
@@ -9,12 +9,31 @@ class ThemeService {
 	 */
 	private $theme;
 
+	/** @var string */
+	private $defaultThemeDirectory;
+
 	/**
+	 * ThemeService constructor.
+	 *
 	 * @param string $themeName
+	 * @param string $defaultThemeDirectory
 	 */
-	public function __construct($themeName = '')
+	public function __construct($themeName = '', $defaultThemeDirectory = '')
 	{
+		$this->setDefaultThemeDirectory($defaultThemeDirectory);
 		$this->createTheme($themeName);
+	}
+
+	/**
+	 * @param string $defaultThemeDirectory
+	 */
+	private function setDefaultThemeDirectory($defaultThemeDirectory = '')
+	{
+		if ($defaultThemeDirectory === '') {
+			$this->defaultThemeDirectory = \OC::$SERVERROOT . '/themes/default';
+		} else {
+			$this->defaultThemeDirectory = $defaultThemeDirectory;
+		}
 	}
 
 	/**
@@ -35,7 +54,11 @@ class ThemeService {
 	 */
 	private function getThemeDirectory($themeName)
 	{
-		return 'themes/' . $themeName . '/';
+		if ($themeName !== '') {
+			return 'themes/' . $themeName . '/';
+		} else {
+			return '';
+		}
 	}
 
 	/**
@@ -43,7 +66,7 @@ class ThemeService {
 	 */
 	private function defaultThemeExists()
 	{
-		if (is_dir(\OC::$SERVERROOT . '/themes/default')) {
+		if (is_dir($this->defaultThemeDirectory)) {
 			return true;
 		}
 

--- a/lib/private/Theme/ThemeService.php
+++ b/lib/private/Theme/ThemeService.php
@@ -18,8 +18,7 @@ class ThemeService {
 	 * @param string $themeName
 	 * @param string $defaultThemeDirectory
 	 */
-	public function __construct($themeName = '', $defaultThemeDirectory = '')
-	{
+	public function __construct($themeName = '', $defaultThemeDirectory = '') {
 		$this->setDefaultThemeDirectory($defaultThemeDirectory);
 		$this->createTheme($themeName);
 	}
@@ -27,8 +26,7 @@ class ThemeService {
 	/**
 	 * @param string $defaultThemeDirectory
 	 */
-	private function setDefaultThemeDirectory($defaultThemeDirectory = '')
-	{
+	private function setDefaultThemeDirectory($defaultThemeDirectory = '') {
 		if ($defaultThemeDirectory === '') {
 			$this->defaultThemeDirectory = \OC::$SERVERROOT . '/themes/default';
 		} else {
@@ -39,8 +37,7 @@ class ThemeService {
 	/**
 	 * @param string $themeName
 	 */
-	private function createTheme($themeName = '')
-	{
+	private function createTheme($themeName = '') {
 		if ($themeName === '' && $this->defaultThemeExists()) {
 			$themeName = 'default';
 		}
@@ -52,8 +49,7 @@ class ThemeService {
 	 * @param string $themeName
 	 * @return string
 	 */
-	private function getThemeDirectory($themeName)
-	{
+	private function getThemeDirectory($themeName) {
 		if ($themeName !== '') {
 			return 'themes/' . $themeName . '/';
 		} else {
@@ -64,8 +60,7 @@ class ThemeService {
 	/**
 	 * @return bool
 	 */
-	private function defaultThemeExists()
-	{
+	private function defaultThemeExists() {
 		if (is_dir($this->defaultThemeDirectory)) {
 			return true;
 		}
@@ -76,16 +71,14 @@ class ThemeService {
 	/**
 	 * @return Theme
 	 */
-	public function getTheme()
-	{
+	public function getTheme() {
 		return $this->theme;
 	}
 
 	/**
 	 * @param string $appName
 	 */
-	public function setAppTheme($appName = '')
-	{
+	public function setAppTheme($appName = '') {
 		if ($appName !== '') {
 			$this->theme->setDirectory(
 				ltrim(\OC_App::getAppWebPath('theme-owncloud'), '/') . '/'

--- a/lib/private/Theme/ThemeService.php
+++ b/lib/private/Theme/ThemeService.php
@@ -81,7 +81,7 @@ class ThemeService {
 	public function setAppTheme($appName = '') {
 		if ($appName !== '') {
 			$this->theme->setDirectory(
-				ltrim(\OC_App::getAppWebPath('theme-owncloud'), '/') . '/'
+				ltrim(\OC_App::getAppWebPath($appName), '/') . '/'
 			);
 		}
 	}

--- a/lib/private/Theme/ThemeService.php
+++ b/lib/private/Theme/ThemeService.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace OC\Theme;
+
+class ThemeService {
+
+	/**
+	 * @var Theme
+	 */
+	private $theme;
+
+	/**
+	 * @param string $themeName
+	 */
+	public function __construct($themeName = '')
+	{
+		$this->createTheme($themeName);
+	}
+
+	/**
+	 * @param string $themeName
+	 */
+	private function createTheme($themeName = '')
+	{
+		if ($themeName === '' && $this->defaultThemeExists()) {
+			$themeName = 'default';
+		}
+
+		$this->theme = new Theme($themeName, $this->getThemeDirectory($themeName));
+	}
+
+	/**
+	 * @param string $themeName
+	 * @return string
+	 */
+	private function getThemeDirectory($themeName)
+	{
+		return 'themes/' . $themeName . '/';
+	}
+
+	/**
+	 * @return bool
+	 */
+	private function defaultThemeExists()
+	{
+		if (is_dir(\OC::$SERVERROOT . '/themes/default')) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * @return Theme
+	 */
+	public function getTheme()
+	{
+		return $this->theme;
+	}
+
+	/**
+	 * @param string $appName
+	 */
+	public function setAppTheme($appName = '')
+	{
+		if ($appName !== '') {
+			$this->theme->setDirectory(
+				ltrim(\OC_App::getAppWebPath('theme-owncloud'), '/') . '/'
+			);
+		}
+	}
+}

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -29,6 +29,7 @@
  */
 
 namespace OC;
+use OC\Theme\Theme;
 use OC_Defaults;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -150,8 +151,9 @@ class URLGenerator implements IURLGenerator {
 			return $key;
 		}
 
-		// Read the selected theme from the config file
+		/** @var Theme $theme */
 		$theme = \OC_Util::getTheme();
+		$themeName = $theme->getName();
 
 		//if a theme has a png but not an svg always use the png
 		$basename = substr(basename($image),0,-4);
@@ -160,21 +162,21 @@ class URLGenerator implements IURLGenerator {
 
 		// Check if the app is in the app folder
 		$path = '';
-		if (file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$image")) {
-			$path = \OC::$WEBROOT . "/themes/$theme/apps/$app/img/$image";
-		} elseif (!file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$basename.svg")
-			&& file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$basename.png")) {
-			$path =  \OC::$WEBROOT . "/themes/$theme/apps/$app/img/$basename.png";
-		} elseif (!empty($app) and file_exists(\OC::$SERVERROOT . "/themes/$theme/$app/img/$image")) {
-			$path =  \OC::$WEBROOT . "/themes/$theme/$app/img/$image";
-		} elseif (!empty($app) and (!file_exists(\OC::$SERVERROOT . "/themes/$theme/$app/img/$basename.svg")
-			&& file_exists(\OC::$SERVERROOT . "/themes/$theme/$app/img/$basename.png"))) {
-			$path =  \OC::$WEBROOT . "/themes/$theme/$app/img/$basename.png";
-		} elseif (file_exists(\OC::$SERVERROOT . "/themes/$theme/core/img/$image")) {
-			$path =  \OC::$WEBROOT . "/themes/$theme/core/img/$image";
-		} elseif (!file_exists(\OC::$SERVERROOT . "/themes/$theme/core/img/$basename.svg")
-			&& file_exists(\OC::$SERVERROOT . "/themes/$theme/core/img/$basename.png")) {
-			$path =  \OC::$WEBROOT . "/themes/$theme/core/img/$basename.png";
+		if (file_exists(\OC::$SERVERROOT . "/themes/$themeName/apps/$app/img/$image")) {
+			$path = \OC::$WEBROOT . "/themes/$themeName/apps/$app/img/$image";
+		} elseif (!file_exists(\OC::$SERVERROOT . "/themes/$themeName/apps/$app/img/$basename.svg")
+			&& file_exists(\OC::$SERVERROOT . "/themes/$themeName/apps/$app/img/$basename.png")) {
+			$path =  \OC::$WEBROOT . "/themes/$themeName/apps/$app/img/$basename.png";
+		} elseif (!empty($app) and file_exists(\OC::$SERVERROOT . "/themes/$themeName/$app/img/$image")) {
+			$path =  \OC::$WEBROOT . "/themes/$themeName/$app/img/$image";
+		} elseif (!empty($app) and (!file_exists(\OC::$SERVERROOT . "/themes/$themeName/$app/img/$basename.svg")
+			&& file_exists(\OC::$SERVERROOT . "/themes/$themeName/$app/img/$basename.png"))) {
+			$path =  \OC::$WEBROOT . "/themes/$themeName/$app/img/$basename.png";
+		} elseif (file_exists(\OC::$SERVERROOT . "/themes/$themeName/core/img/$image")) {
+			$path =  \OC::$WEBROOT . "/themes/$themeName/core/img/$image";
+		} elseif (!file_exists(\OC::$SERVERROOT . "/themes/$themeName/core/img/$basename.svg")
+			&& file_exists(\OC::$SERVERROOT . "/themes/$themeName/core/img/$basename.png")) {
+			$path =  \OC::$WEBROOT . "/themes/$themeName/core/img/$basename.png";
 		} elseif ($appPath && file_exists($appPath . "/img/$image")) {
 			$path =  \OC_App::getAppWebPath($app) . "/img/$image";
 		} elseif ($appPath && !file_exists($appPath . "/img/$basename.svg")
@@ -189,7 +191,7 @@ class URLGenerator implements IURLGenerator {
 			$path =  \OC::$WEBROOT . "/core/img/$image";
 		} elseif (!file_exists(\OC::$SERVERROOT . "/core/img/$basename.svg")
 			&& file_exists(\OC::$SERVERROOT . "/core/img/$basename.png")) {
-			$path =  \OC::$WEBROOT . "/themes/$theme/core/img/$basename.png";
+			$path =  \OC::$WEBROOT . "/themes/$themeName/core/img/$basename.png";
 		}
 
 		if($path !== '') {

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -143,6 +143,8 @@ class OC_App {
 		// in case someone calls loadApp() directly
 		self::registerAutoloading($app, $appPath);
 
+		self::enableTheme($app);
+
 		if (is_file($appPath . '/appinfo/app.php')) {
 			\OC::$server->getEventLogger()->start('load_app_' . $app, 'Load app: ' . $app);
 			if ($checkUpgrade and self::shouldUpgrade($app)) {
@@ -157,6 +159,18 @@ class OC_App {
 				self::$enabledAppsCache = [];
 			}
 			\OC::$server->getEventLogger()->end('load_app_' . $app);
+		}
+	}
+
+	/**
+	 * Enables the app as a theme if it has the type "theme"
+	 * @param $app
+	 */
+	private static function enableTheme($app) {
+		if (self::isType($app, 'theme')) {
+			/** @var \OC\Theme\ThemeService $themeManager */
+			$themeManager = \OC::$server->query('ThemeService');
+			$themeManager->setAppTheme($app);
 		}
 	}
 

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -143,7 +143,7 @@ class OC_App {
 		// in case someone calls loadApp() directly
 		self::registerAutoloading($app, $appPath);
 
-		self::enableTheme($app);
+		self::enableThemeIfApplicable($app);
 
 		if (is_file($appPath . '/appinfo/app.php')) {
 			\OC::$server->getEventLogger()->start('load_app_' . $app, 'Load app: ' . $app);
@@ -166,7 +166,7 @@ class OC_App {
 	 * Enables the app as a theme if it has the type "theme"
 	 * @param $app
 	 */
-	private static function enableTheme($app) {
+	private static function enableThemeIfApplicable($app) {
 		if (self::isType($app, 'theme')) {
 			/** @var \OC\Theme\ThemeService $themeManager */
 			$themeManager = \OC::$server->query('ThemeService');

--- a/lib/private/legacy/defaults.php
+++ b/lib/private/legacy/defaults.php
@@ -66,11 +66,14 @@ class OC_Defaults {
 		$this->defaultLogoClaim = '';
 		$this->defaultMailHeaderColor = '#1d2d44'; /* header color of mail notifications */
 
-		$themePath = OC::$SERVERROOT . '/themes/' . OC_Util::getTheme() . '/defaults.php';
-		if (file_exists($themePath)) {
+
+		$themePath = OC_Util::getTheme()->getDirectory();
+
+		$defaultsPath = OC::$SERVERROOT . '/' .$themePath . 'defaults.php';
+		if (file_exists($defaultsPath)) {
 			// prevent defaults.php from printing output
 			ob_start();
-			require_once $themePath;
+			require_once $defaultsPath;
 			ob_end_clean();
 			if (class_exists('OC_Theme')) {
 				$this->theme = new OC_Theme();

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -74,15 +74,13 @@ class OC_Template extends \OC\Template\Base {
 		// Read the selected theme from the config file
 		self::initTemplateEngine($renderAs);
 
-		$theme = OC_Util::getTheme();
-
 		$requestToken = (OC::$server->getSession() && $registerCall) ? \OCP\Util::callRegister() : '';
 
 		$parts = explode('/', $app); // fix translation when app is something like core/lostpassword
 		$l10n = \OC::$server->getL10N($parts[0]);
 		$themeDefaults = new OC_Defaults();
 
-		list($path, $template) = $this->findTemplate($theme, $app, $name);
+		list($path, $template) = $this->findTemplate(OC_Util::getTheme(), $app, $name);
 
 		// Set the private data
 		$this->renderAs = $renderAs;
@@ -181,7 +179,7 @@ class OC_Template extends \OC\Template\Base {
 	 *
 	 * Will select the template file for the selected theme.
 	 * Checking all the possible locations.
-	 * @param string $theme
+	 * @param \OC\Theme\Theme $theme
 	 * @param string $app
 	 * @return string[]
 	 */

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1262,8 +1262,7 @@ class OC_Util {
 	 *
 	 * @return \OC\Theme\Theme the theme
 	 */
-	public static function getTheme()
-	{
+	public static function getTheme() {
 		/** @var \OC\Theme\ThemeService $themeService */
 		$themeService = \OC::$server->query('ThemeService');
 		return $themeService->getTheme();

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1260,18 +1260,13 @@ class OC_Util {
 	 * Handles the case that there may not be a theme, then check if a "default"
 	 * theme exists and take that one
 	 *
-	 * @return string the theme
+	 * @return \OC\Theme\Theme the theme
 	 */
-	public static function getTheme() {
-		$theme = \OC::$server->getSystemConfig()->getValue("theme", '');
-
-		if ($theme === '') {
-			if (is_dir(OC::$SERVERROOT . '/themes/default')) {
-				$theme = 'default';
-			}
-		}
-
-		return $theme;
+	public static function getTheme()
+	{
+		/** @var \OC\Theme\ThemeService $themeService */
+		$themeService = \OC::$server->query('ThemeService');
+		return $themeService->getTheme();
 	}
 
 	/**

--- a/tests/lib/Files/Type/DetectionTest.php
+++ b/tests/lib/Files/Type/DetectionTest.php
@@ -22,6 +22,7 @@
 namespace Test\Files\Type;
 
 use \OC\Files\Type\Detection;
+use org\bovigo\vfs\vfsStream;
 
 class DetectionTest extends \Test\TestCase {
 	/** @var Detection */
@@ -88,19 +89,11 @@ class DetectionTest extends \Test\TestCase {
 	}
 
 	public function testMimeTypeIcon() {
-		if (!class_exists('org\\bovigo\\vfs\\vfsStream')) {
-			$this->markTestSkipped('Package vfsStream not installed');
-		}
-		$confDir = \org\bovigo\vfs\vfsStream::setup();
-		$mimetypealiases_dist = \org\bovigo\vfs\vfsStream::newFile('mimetypealiases.dist.json')->at($confDir);
+		$confDir = vfsStream::setup();
+		$mimetypealiases_dist = vfsStream::newFile('mimetypealiases.dist.json')->at($confDir);
 
 		//Empty alias file
 		$mimetypealiases_dist->setContent(json_encode([], JSON_FORCE_OBJECT));
-
-
-		/*
-		 * Test dir mimetype
-		 */
 
 		//Mock UrlGenerator
 		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
@@ -110,7 +103,7 @@ class DetectionTest extends \Test\TestCase {
 		//Only call the url generator once
 		$urlGenerator->expects($this->once())
 			->method('imagePath')
-			->with($this->equalTo('core'), $this->equalTo('filetypes/folder.png'))
+			->with($this->equalTo('core'), $this->equalTo('filetypes/folder.svg'))
 			->willReturn('folder.svg');
 
 		$detection = new Detection($urlGenerator, $confDir->url(), $confDir->url());
@@ -129,7 +122,7 @@ class DetectionTest extends \Test\TestCase {
 		//Only call the url generator once
 		$urlGenerator->expects($this->once())
 			->method('imagePath')
-			->with($this->equalTo('core'), $this->equalTo('filetypes/folder-shared.png'))
+			->with($this->equalTo('core'), $this->equalTo('filetypes/folder-shared.svg'))
 			->willReturn('folder-shared.svg');
 
 		$detection = new Detection($urlGenerator, $confDir->url(), $confDir->url());
@@ -149,7 +142,7 @@ class DetectionTest extends \Test\TestCase {
 		//Only call the url generator once
 		$urlGenerator->expects($this->once())
 			->method('imagePath')
-			->with($this->equalTo('core'), $this->equalTo('filetypes/folder-external.png'))
+			->with($this->equalTo('core'), $this->equalTo('filetypes/folder-external.svg'))
 			->willReturn('folder-external.svg');
 
 		$detection = new Detection($urlGenerator, $confDir->url(), $confDir->url());
@@ -169,7 +162,7 @@ class DetectionTest extends \Test\TestCase {
 		//Only call the url generator once
 		$urlGenerator->expects($this->once())
 			->method('imagePath')
-			->with($this->equalTo('core'), $this->equalTo('filetypes/my-type.png'))
+			->with($this->equalTo('core'), $this->equalTo('filetypes/my-type.svg'))
 			->willReturn('my-type.svg');
 
 		$detection = new Detection($urlGenerator, $confDir->url(), $confDir->url());
@@ -190,12 +183,12 @@ class DetectionTest extends \Test\TestCase {
 		$urlGenerator->expects($this->exactly(2))
 			->method('imagePath')
 			->withConsecutive(
-				[$this->equalTo('core'), $this->equalTo('filetypes/my-type.png')],
-				[$this->equalTo('core'), $this->equalTo('filetypes/my.png')]
+				[$this->equalTo('core'), $this->equalTo('filetypes/my-type.svg')],
+				[$this->equalTo('core'), $this->equalTo('filetypes/my.svg')]
 			)
 			->will($this->returnCallback(
 				function($appName, $file) {
-					if ($file === 'filetypes/my.png') {
+					if ($file === 'filetypes/my.svg') {
 						return 'my.svg';
 					}
 					throw new \RuntimeException();
@@ -220,13 +213,13 @@ class DetectionTest extends \Test\TestCase {
 		$urlGenerator->expects($this->exactly(3))
 			->method('imagePath')
 			->withConsecutive(
-				[$this->equalTo('core'), $this->equalTo('filetypes/foo-bar.png')],
-				[$this->equalTo('core'), $this->equalTo('filetypes/foo.png')],
-				[$this->equalTo('core'), $this->equalTo('filetypes/file.png')]
+				[$this->equalTo('core'), $this->equalTo('filetypes/foo-bar.svg')],
+				[$this->equalTo('core'), $this->equalTo('filetypes/foo.svg')],
+				[$this->equalTo('core'), $this->equalTo('filetypes/file.svg')]
 			)
 			->will($this->returnCallback(
 				function($appName, $file) {
-					if ($file === 'filetypes/file.png') {
+					if ($file === 'filetypes/file.svg') {
 						return 'file.svg';
 					}
 					throw new \RuntimeException();
@@ -249,7 +242,7 @@ class DetectionTest extends \Test\TestCase {
 		//Only call the url generator once
 		$urlGenerator->expects($this->once())
 			->method('imagePath')
-			->with($this->equalTo('core'), $this->equalTo('filetypes/foo-bar.png'))
+			->with($this->equalTo('core'), $this->equalTo('filetypes/foo-bar.svg'))
 			->willReturn('foo-bar.svg');
 
 		$detection = new Detection($urlGenerator, $confDir->url(), $confDir->url());
@@ -275,7 +268,7 @@ class DetectionTest extends \Test\TestCase {
 		//Only call the url generator once
 		$urlGenerator->expects($this->once())
 			->method('imagePath')
-			->with($this->equalTo('core'), $this->equalTo('filetypes/foobar-baz.png'))
+			->with($this->equalTo('core'), $this->equalTo('filetypes/foobar-baz.svg'))
 			->willReturn('foobar-baz.svg');
 
 		$detection = new Detection($urlGenerator, $confDir->url(), $confDir->url());

--- a/tests/lib/Theme/ThemeServiceTest.php
+++ b/tests/lib/Theme/ThemeServiceTest.php
@@ -2,7 +2,6 @@
 
 namespace Test\Theme;
 
-use OC\Theme\Theme;
 use OC\Theme\ThemeService;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
@@ -19,16 +18,14 @@ class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
 		parent::setUp();
 	}
 
-	public function testCreatesThemeByGivenName()
-	{
+	public function testCreatesThemeByGivenName() {
 		$themeService = new ThemeService('theme-name');
 		$theme = $themeService->getTheme();
 		$this->assertEquals('theme-name', $theme->getName());
 		$this->assertEquals('themes/theme-name/', $theme->getDirectory());
 	}
 
-	public function testCreatesEmptyThemeIfDefaultDoesNotExist()
-	{
+	public function testCreatesEmptyThemeIfDefaultDoesNotExist() {
 		$structure = [];
 		$this->root = vfsStream::setup('root', null, $structure);
 
@@ -39,8 +36,7 @@ class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals('', $theme->getDirectory());
 	}
 
-	public function testCreatesDefaultThemeIfItExists()
-	{
+	public function testCreatesDefaultThemeIfItExists() {
 		$structure = [
 			'themes' => [
 				'default' => []
@@ -55,5 +51,4 @@ class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals('default', $theme->getName());
 		$this->assertEquals('themes/default/', $theme->getDirectory());
 	}
-
 }

--- a/tests/lib/Theme/ThemeServiceTest.php
+++ b/tests/lib/Theme/ThemeServiceTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Test\Theme;
+
+use OC\Theme\Theme;
+use OC\Theme\ThemeService;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+
+class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
+
+	/**
+	 * @var vfsStreamDirectory
+	 */
+	private $root;
+
+	protected function setUp() {
+		$this->root = vfsStream::setup();
+		parent::setUp();
+	}
+
+	public function testCreatesThemeByGivenName()
+	{
+		$themeService = new ThemeService('theme-name');
+		$theme = $themeService->getTheme();
+		$this->assertEquals('theme-name', $theme->getName());
+		$this->assertEquals('themes/theme-name/', $theme->getDirectory());
+	}
+
+	public function testCreatesEmptyThemeIfDefaultDoesNotExist()
+	{
+		$structure = [];
+		$this->root = vfsStream::setup('root', null, $structure);
+
+		$themeService = new ThemeService('', $this->root->url() . '/themes/default');
+		$theme = $themeService->getTheme();
+
+		$this->assertEquals('', $theme->getName());
+		$this->assertEquals('', $theme->getDirectory());
+	}
+
+	public function testCreatesDefaultThemeIfItExists()
+	{
+		$structure = [
+			'themes' => [
+				'default' => []
+			]
+		];
+
+		$this->root = vfsStream::setup('root', null, $structure);
+
+		$themeService = new ThemeService('', $this->root->url() . '/themes/default');
+		$theme = $themeService->getTheme();
+
+		$this->assertEquals('default', $theme->getName());
+		$this->assertEquals('themes/default/', $theme->getDirectory());
+	}
+
+}

--- a/tests/lib/Theme/ThemeTest.php
+++ b/tests/lib/Theme/ThemeTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Test\Theme;
+
+use OC\Theme\Theme;
+
+class ThemeTest extends \PHPUnit\Framework\TestCase {
+
+	/**
+	 * @var Theme
+	 */
+	private $sut;
+
+	protected function setUp() {
+		$this->sut = new Theme();
+		parent::setUp();
+	}
+
+	public function testConstructorSetsNameAndDirectory()
+	{
+		$this->assertEmpty($this->sut->getName());
+		$this->assertEmpty($this->sut->getDirectory());
+		$this->sut = new Theme('name', 'directory/directory');
+		$this->assertEquals('name', $this->sut->getName());
+		$this->assertEquals('directory/directory', $this->sut->getDirectory());
+	}
+
+	public function testDirectoryCanBeSet()
+	{
+		$this->assertEmpty($this->sut->getDirectory());
+		$this->sut->setDirectory('test/directory');
+		$this->assertEquals('test/directory', $this->sut->getDirectory());
+	}
+}

--- a/tests/lib/Theme/ThemeTest.php
+++ b/tests/lib/Theme/ThemeTest.php
@@ -16,8 +16,7 @@ class ThemeTest extends \PHPUnit\Framework\TestCase {
 		parent::setUp();
 	}
 
-	public function testConstructorSetsNameAndDirectory()
-	{
+	public function testConstructorSetsNameAndDirectory() {
 		$this->assertEmpty($this->sut->getName());
 		$this->assertEmpty($this->sut->getDirectory());
 		$this->sut = new Theme('name', 'directory/directory');
@@ -25,8 +24,7 @@ class ThemeTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals('directory/directory', $this->sut->getDirectory());
 	}
 
-	public function testDirectoryCanBeSet()
-	{
+	public function testDirectoryCanBeSet() {
 		$this->assertEmpty($this->sut->getDirectory());
 		$this->sut->setDirectory('test/directory');
 		$this->assertEquals('test/directory', $this->sut->getDirectory());


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

This allows users to install apps that provide a theme. If an app enables itself as app-theme in its `app.php`:

```
/** @var Theme\ThemeService $themeService */
$themeService = \OC::$server->query('ThemeService');
$themeService->setAppTheme('theme-owncloud');
```

the app will be used as theme. If no app claims to be a theme, the existing logic will continue to work. That means, OC will look for the `theme` key in `config/config.php` and will use it. OC will still look for `themes/default` if no theme is configured.
## Related Issue
#20200
# Breaking changes

The documentation (https://doc.owncloud.org/server/9.0/developer_manual/core/theming.html) describes, that modifying an apps translation files would require a file in `theme/apps/app-name/l10n/language.js`. Modifying an apps template on the other hand would require a file in `theme/app-name/templates/template.php`.

This inconsistency has been removed. Templates will be located just like translations under `theme/apps/app-name/template/...`.

Theming an App now requires the corresponding files to be located in an "app" folder.

@DeepDiver1975, @PVince81, @butonic: what do you think about getting rid of this unnecessary complexity?
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
