### PR TITLE
Fix mock warning in some FS tests

### DIFF
--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -399,7 +399,7 @@ class FilesystemTest extends \Test\TestCase {
 
 		\OC_User::clearBackends();
 		// needed for loginName2UserName mapping
-		$userBackend = $this->getMock('\OC\User\Database');
+		$userBackend = $this->createMock(\OC\User\Database::class);
 		\OC::$server->getUserManager()->registerBackend($userBackend);
 
 		$userBackend->expects($this->once())

--- a/tests/lib/Files/Node/RootTest.php
+++ b/tests/lib/Files/Node/RootTest.php
@@ -116,7 +116,7 @@ class RootTest extends \Test\TestCase {
 
 		\OC_User::clearBackends();
 		// needed for loginName2UserName mapping
-		$userBackend = $this->getMock('\OC\User\Database');
+		$userBackend = $this->createMock(\OC\User\Database::class);
 		\OC::$server->getUserManager()->registerBackend($userBackend);
 
 		$userBackend->expects($this->any())


### PR DESCRIPTION
Because we don't like warnings like:

```
16:30:08 1) Test\Files\FilesystemTest::testUserNameCasing
16:30:08 PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead
16:30:08 
16:30:08 2) Test\Files\Node\RootTest::testGetUserFolder
16:30:08 PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

```

@DeepDiver1975 @tomneedham 
