### PR TITLE
Cache appconfig in distributed cache

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -265,11 +265,12 @@ class AppManager implements IAppManager {
 	}
 
 	/**
-	 * Clear the cached list of apps when enabling/disabling an app
+	 * Clear the whole cache when enabling/disabling an app
+	 * to prevent side effects between app versions.
 	 */
 	public function clearAppsCache() {
-		$settingsMemCache = $this->memCacheFactory->create('settings');
-		$settingsMemCache->clear('listApps');
+		$settingsMemCache = $this->memCacheFactory->create();
+		$settingsMemCache->clear();
 	}
 
 	/**

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -51,6 +51,7 @@ class AppConfig implements IAppConfig {
 
 	/**
 	 * @param IDBConnection $conn
+	 * @param ICache $cache
 	 */
 	public function __construct(IDBConnection $conn, ICache $cache) {
 		$this->conn = $conn;

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -189,7 +189,7 @@ class AppConfig implements IAppConfig {
 	 *
 	 * @param string $app app
 	 * @param string $key key
-	 * @param string $value value
+	 * @param string|float|int $value value
 	 * @return bool True if the value was inserted or updated, false if the value was the same
 	 */
 	public function setValue($app, $key, $value) {

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -9,7 +9,7 @@
  * @author Robin Appelman <icewind@owncloud.com>
  * @author Robin McCorkell <robin@mccorkell.me.uk>
  *
- * @copyright Copyright (c) 2016, ownCloud GmbH.
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify
@@ -29,6 +29,7 @@
 namespace OC;
 
 use OCP\IAppConfig;
+use OCP\ICache;
 use OCP\IDBConnection;
 
 /**
@@ -41,28 +42,19 @@ class AppConfig implements IAppConfig {
 	 */
 	protected $conn;
 
-	private $cache = [];
+	/**
+	 * @var \OCP\ICache
+	 */
+	private $cache;
+
+	private $ttl = 300;
 
 	/**
 	 * @param IDBConnection $conn
 	 */
-	public function __construct(IDBConnection $conn) {
+	public function __construct(IDBConnection $conn, ICache $cache) {
 		$this->conn = $conn;
-		$this->configLoaded = false;
-	}
-
-	/**
-	 * @param string $app
-	 * @return array
-	 */
-	private function getAppValues($app) {
-		$this->loadConfigValues();
-
-		if (isset($this->cache[$app])) {
-			return $this->cache[$app];
-		}
-
-		return [];
+		$this->cache = $cache;
 	}
 
 	/**
@@ -74,9 +66,20 @@ class AppConfig implements IAppConfig {
 	 * entry in the appconfig table.
 	 */
 	public function getApps() {
-		$this->loadConfigValues();
+		$result = $this->cache->get('apps');
+		if (empty($result)) {
+			$sql = $this->conn->getQueryBuilder();
+			$sql->selectDistinct('appid')
+				->from('appconfig')
+				->orderBy('appid');
+			$query = $sql->execute();
 
-		return $this->getSortedKeys($this->cache);
+			$result = $query->fetchAll();
+			$query->closeCursor();
+
+			$this->cache->set('apps', $result, $this->ttl);
+		}
+		return $result;
 	}
 
 	/**
@@ -89,19 +92,23 @@ class AppConfig implements IAppConfig {
 	 * not returned.
 	 */
 	public function getKeys($app) {
-		$this->loadConfigValues();
+		$result = $this->cache->get('keysbyapp:'.$app);
+		if (empty($result)) {
+			$sql = $this->conn->getQueryBuilder();
+			$sql->selectDistinct('configvalue')
+				->from('appconfig')
+				->where($sql->expr()->eq(
+					'appid', $sql->createNamedParameter($app)
+				))
+				->orderBy('configvalue');
+			$query = $sql->execute();
 
-		if (isset($this->cache[$app])) {
-			return $this->getSortedKeys($this->cache[$app]);
+			$result = $query->fetchAll();
+			$query->closeCursor();
+
+			$this->cache->set('apps', $result, $this->ttl);
 		}
-
-		return [];
-	}
-
-	public function getSortedKeys($data) {
-		$keys = array_keys($data);
-		sort($keys);
-		return $keys;
+		return $result;
 	}
 
 	/**
@@ -116,10 +123,27 @@ class AppConfig implements IAppConfig {
 	 * not exist the default value will be returned
 	 */
 	public function getValue($app, $key, $default = null) {
-		$this->loadConfigValues();
+		if ($this->cache->hasKey($app.':'.$key)) {
+			return $this->cache->get($app.':'.$key);
+		} else {
+			$sql = $this->conn->getQueryBuilder();
+			$sql->select('configvalue')
+				->from('appconfig')
+				->where($sql->expr()->eq(
+					'appid', $sql->createNamedParameter($app)
+				))
+				->andWhere($sql->expr()->eq(
+					'configkey', $sql->createNamedParameter($key)
+				));
+			$query = $sql->execute();
 
-		if ($this->hasKey($app, $key)) {
-			return $this->cache[$app][$key];
+			$result = $query->fetchColumn();
+			$query->closeCursor();
+
+			if ($result !== false) {
+				$this->cache->set($app.':'.$key, $result, $this->ttl);
+				return $result;
+			}
 		}
 
 		return $default;
@@ -133,9 +157,31 @@ class AppConfig implements IAppConfig {
 	 * @return bool
 	 */
 	public function hasKey($app, $key) {
-		$this->loadConfigValues();
+		if ($this->cache->hasKey($app.':'.$key)) {
+			return true;
+		} else {
+			$sql = $this->conn->getQueryBuilder();
+			$sql->select('configvalue')
+				->from('appconfig')
+				->where($sql->expr()->eq(
+					'appid', $sql->createNamedParameter($app)
+				))
+				->andWhere($sql->expr()->eq(
+					'configkey', $sql->createNamedParameter($key)
+				));
+			$query = $sql->execute();
 
-		return isset($this->cache[$app][$key]);
+			$result = $query->fetchColumn();
+			$query->closeCursor();
+
+			if ($result !== false) {
+				$this->cache->set($app.':'.$key, $result, $this->ttl);
+				return true;
+			} else {
+				return false;
+			}
+
+		}
 	}
 
 	/**
@@ -143,7 +189,7 @@ class AppConfig implements IAppConfig {
 	 *
 	 * @param string $app app
 	 * @param string $key key
-	 * @param string|float|int $value value
+	 * @param string $value value
 	 * @return bool True if the value was inserted or updated, false if the value was the same
 	 */
 	public function setValue($app, $key, $value) {
@@ -158,23 +204,22 @@ class AppConfig implements IAppConfig {
 			]);
 
 			if ($inserted) {
-				if (!isset($this->cache[$app])) {
-					$this->cache[$app] = [];
-				}
-
-				$this->cache[$app][$key] = $value;
+				$this->cache->set($app.':'.$key, $value, $this->ttl);
+				$this->cache->clear('valuesbykey:'.$key);
+				$this->cache->clear('valuesbyapp:'.$app);
 				return true;
 			}
 		}
 
-		$sql = $this->conn->getQueryBuilder();
-		$sql->update('appconfig')
-			->set('configvalue', $sql->createParameter('configvalue'))
-			->where($sql->expr()->eq('appid', $sql->createParameter('app')))
-			->andWhere($sql->expr()->eq('configkey', $sql->createParameter('configkey')))
-			->setParameter('configvalue', $value)
-			->setParameter('app', $app)
-			->setParameter('configkey', $key);
+		$query = $this->conn->getQueryBuilder();
+		$query->update('appconfig')
+			->set('configvalue', $query->createNamedParameter($value))
+			->where($query->expr()->eq(
+				'appid', $query->createNamedParameter($app)
+			))
+			->andWhere($query->expr()->eq(
+				'configkey', $query->createNamedParameter($key)
+			));
 
 		/*
 		 * Only limit to the existing value for non-Oracle DBs:
@@ -183,13 +228,16 @@ class AppConfig implements IAppConfig {
 		 */
 		if (!($this->conn instanceof \OC\DB\OracleConnection)) {
 			// Only update the value when it is not the same
-			$sql->andWhere($sql->expr()->neq('configvalue', $sql->createParameter('configvalue')))
-				->setParameter('configvalue', $value);
+			$query->andWhere($query->expr()->neq(
+				'configvalue', $query->createNamedParameter($value)
+			));
 		}
 
-		$changedRow = (bool) $sql->execute();
+		$changedRow = (bool) $query->execute();
 
-		$this->cache[$app][$key] = $value;
+		$this->cache->set($app.':'.$key, $value, $this->ttl);
+		$this->cache->clear('valuesbykey:'.$key);
+		$this->cache->clear('valuesbyapp:'.$app);
 
 		return $changedRow;
 	}
@@ -202,17 +250,20 @@ class AppConfig implements IAppConfig {
 	 * @return boolean|null
 	 */
 	public function deleteKey($app, $key) {
-		$this->loadConfigValues();
 
 		$sql = $this->conn->getQueryBuilder();
 		$sql->delete('appconfig')
-			->where($sql->expr()->eq('appid', $sql->createParameter('app')))
-			->andWhere($sql->expr()->eq('configkey', $sql->createParameter('configkey')))
-			->setParameter('app', $app)
-			->setParameter('configkey', $key);
+			->where($sql->expr()->eq(
+				'appid', $sql->createNamedParameter($app)
+			))
+			->andWhere($sql->expr()->eq(
+				'configkey', $sql->createNamedParameter($key)
+			));
 		$sql->execute();
 
-		unset($this->cache[$app][$key]);
+		$this->cache->remove($app.':'.$key);
+		$this->cache->clear('valuesbykey:'.$key);
+		$this->cache->clear('valuesbyapp:');
 	}
 
 	/**
@@ -224,19 +275,22 @@ class AppConfig implements IAppConfig {
 	 * Removes all keys in appconfig belonging to the app.
 	 */
 	public function deleteApp($app) {
-		$this->loadConfigValues();
 
 		$sql = $this->conn->getQueryBuilder();
 		$sql->delete('appconfig')
-			->where($sql->expr()->eq('appid', $sql->createParameter('app')))
-			->setParameter('app', $app);
+			->where($sql->expr()->eq(
+				'appid', $sql->createNamedParameter($app)
+			));
 		$sql->execute();
 
-		unset($this->cache[$app]);
+		$this->cache->clear($app);
+		$this->cache->clear('valuesbykey:');
+		$this->cache->clear('valuesbyapp:'.$app);
 	}
 
 	/**
-	 * get multiple values, either the app or key can be used as wildcard by setting it to false
+	 * get multiple values, either the app or key can be used as wildcard by
+	 * setting it to false
 	 *
 	 * @param string|false $app
 	 * @param string|false $key
@@ -248,42 +302,46 @@ class AppConfig implements IAppConfig {
 		}
 
 		if ($key === false) {
-			return $this->getAppValues($app);
-		} else {
-			$appIds = $this->getApps();
-			$values = array_map(function($appId) use ($key) {
-				return isset($this->cache[$appId][$key]) ? $this->cache[$appId][$key] : null;
-			}, $appIds);
-			$result = array_combine($appIds, $values);
+			$result = $this->cache->get('valuesbyapp:'.$app);
+			if (empty($result)) {
+				$sql = $this->conn->getQueryBuilder();
+				$sql->select(['configkey', 'configvalue'])
+					->from('appconfig')
+					->where($sql->expr()->eq(
+						'appid', $sql->createNamedParameter($app)
+					));
+				$query = $sql->execute();
 
-			return array_filter($result);
-		}
-	}
+				$result = [];
+				while ($row = $query->fetch()) {
+					$result[$row['configkey']] = $row['configvalue'];
+				}
+				$query->closeCursor();
 
-	/**
-	 * Load all the app config values
-	 */
-	protected function loadConfigValues() {
-		if ($this->configLoaded) return;
-
-		$this->cache = [];
-
-		$sql = $this->conn->getQueryBuilder();
-		$sql->select('*')
-			->from('appconfig');
-		$result = $sql->execute();
-
-		// we are going to store the result in memory anyway
-		$rows = $result->fetchAll();
-		foreach ($rows as $row) {
-			if (!isset($this->cache[$row['appid']])) {
-				$this->cache[$row['appid']] = [];
+				$this->cache->set('valuesbyapp:' . $app, $result, $this->ttl);
 			}
+			return $result;
+		} else {
+			$result = $this->cache->get('valuesbykey:'.$key);
+			if (empty($result)) {
+				$sql = $this->conn->getQueryBuilder();
+				$sql->select(['appid', 'configvalue'])
+					->from('appconfig')
+					->where($sql->expr()->eq(
+						'configkey', $sql->createNamedParameter($key)
+					));
+				$query = $sql->execute();
 
-			$this->cache[$row['appid']][$row['configkey']] = $row['configvalue'];
+				$result = [];
+				while ($row = $query->fetch()) {
+					$result[$row['appid']] = $row['configvalue'];
+				}
+				$query->closeCursor();
+
+				$this->cache->set('valuesbykey:' . $key, $result, $this->ttl);
+			}
+			return $result;
 		}
-		$result->closeCursor();
-
-		$this->configLoaded = true;
 	}
+
 }

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -9,7 +9,7 @@
  * @author Robin Appelman <icewind@owncloud.com>
  * @author Robin McCorkell <robin@mccorkell.me.uk>
  *
- * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @copyright Copyright (c) 2016, ownCloud GmbH.
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -322,19 +322,17 @@ class Server extends ServerContainer implements IServerContainer {
 			return new Cache\File();
 		});
 		$this->registerService('MemCacheFactory', function (Server $c) {
-			$config = $c->getConfig();
+			$config = $c->getSystemConfig();
 
-			if ($config->getSystemValue('installed', false) && !(defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
-				$v = \OC_App::getAppVersions();
-				$v['core'] = md5(file_get_contents(\OC::$SERVERROOT . '/version.php'));
-				$version = implode(',', $v);
+			if ($config->getValue('installed', false) && !(defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
+				$version = md5(file_get_contents(\OC::$SERVERROOT . '/version.php'));
 				$instanceId = \OC_Util::getInstanceId();
 				$path = \OC::$SERVERROOT;
 				$prefix = md5($instanceId . '-' . $version . '-' . $path);
 				return new \OC\Memcache\Factory($prefix, $c->getLogger(),
-					$config->getSystemValue('memcache.local', null),
-					$config->getSystemValue('memcache.distributed', null),
-					$config->getSystemValue('memcache.locking', null)
+					$config->getValue('memcache.local', null),
+					$config->getValue('memcache.distributed', null),
+					$config->getValue('memcache.locking', null)
 				);
 			}
 

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -295,7 +295,10 @@ class Server extends ServerContainer implements IServerContainer {
 			return new \OC\SystemConfig($config);
 		});
 		$this->registerService('AppConfig', function (Server $c) {
-			return new \OC\AppConfig($c->getDatabaseConnection());
+			return new \OC\AppConfig(
+				$c->getDatabaseConnection(),
+				$c->getMemCacheFactory()->create('appconfg')
+			);
 		});
 		$this->registerService('L10NFactory', function (Server $c) {
 			return new \OC\L10N\Factory(

--- a/tests/lib/AppConfigTest.php
+++ b/tests/lib/AppConfigTest.php
@@ -40,7 +40,10 @@ class AppConfigTest extends TestCase {
 		$sql->delete('appconfig');
 		$sql->execute();
 
-		$this->registerAppConfig(new \OC\AppConfig($this->connection));
+		$this->registerAppConfig(new \OC\AppConfig(
+			$this->connection,
+			\OC::$server->getMemCacheFactory()->create('appconfig')
+		));
 
 		$sql = $this->connection->getQueryBuilder();
 		$sql->insert('appconfig')
@@ -130,7 +133,10 @@ class AppConfigTest extends TestCase {
 			$sql->execute();
 		}
 
-		$this->registerAppConfig(new \OC\AppConfig(\OC::$server->getDatabaseConnection()));
+		$this->registerAppConfig(new \OC\AppConfig(
+			\OC::$server->getDatabaseConnection(),
+			\OC::$server->getMemCacheFactory()->create('appconfig')
+		));
 		parent::tearDown();
 	}
 
@@ -146,7 +152,10 @@ class AppConfigTest extends TestCase {
 	}
 
 	public function testGetApps() {
-		$config = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
+		$config = new \OC\AppConfig(
+			\OC::$server->getDatabaseConnection(),
+			\OC::$server->getMemCacheFactory()->create('appconfig')
+		);
 
 		$this->assertEquals([
 			'anotherapp',
@@ -157,7 +166,10 @@ class AppConfigTest extends TestCase {
 	}
 
 	public function testGetKeys() {
-		$config = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
+		$config = new \OC\AppConfig(
+			\OC::$server->getDatabaseConnection(),
+			\OC::$server->getMemCacheFactory()->create('appconfig')
+		);
 
 		$keys = $config->getKeys('testapp');
 		$this->assertEquals([
@@ -170,7 +182,10 @@ class AppConfigTest extends TestCase {
 	}
 
 	public function testGetValue() {
-		$config = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
+		$config = new \OC\AppConfig(
+			\OC::$server->getDatabaseConnection(),
+			\OC::$server->getMemCacheFactory()->create('appconfig')
+		);
 
 		$value = $config->getValue('testapp', 'installed_version');
 		$this->assertConfigKey('testapp', 'installed_version', $value);
@@ -183,7 +198,10 @@ class AppConfigTest extends TestCase {
 	}
 
 	public function testHasKey() {
-		$config = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
+		$config = new \OC\AppConfig(
+			\OC::$server->getDatabaseConnection(),
+			\OC::$server->getMemCacheFactory()->create('appconfig')
+		);
 
 		$this->assertTrue($config->hasKey('testapp', 'installed_version'));
 		$this->assertFalse($config->hasKey('testapp', 'nonexistant'));
@@ -191,7 +209,10 @@ class AppConfigTest extends TestCase {
 	}
 
 	public function testSetValueUpdate() {
-		$config = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
+		$config = new \OC\AppConfig(
+			\OC::$server->getDatabaseConnection(),
+			\OC::$server->getMemCacheFactory()->create('appconfig')
+		);
 
 		$this->assertEquals('1.2.3', $config->getValue('testapp', 'installed_version'));
 		$this->assertConfigKey('testapp', 'installed_version', '1.2.3');
@@ -215,7 +236,10 @@ class AppConfigTest extends TestCase {
 	}
 
 	public function testSetValueInsert() {
-		$config = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
+		$config = new \OC\AppConfig(
+			\OC::$server->getDatabaseConnection(),
+			\OC::$server->getMemCacheFactory()->create('appconfig')
+		);
 
 		$this->assertFalse($config->hasKey('someapp', 'somekey'));
 		$this->assertNull($config->getValue('someapp', 'somekey'));
@@ -233,7 +257,10 @@ class AppConfigTest extends TestCase {
 	}
 
 	public function testDeleteKey() {
-		$config = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
+		$config = new \OC\AppConfig(
+			\OC::$server->getDatabaseConnection(),
+			\OC::$server->getMemCacheFactory()->create('appconfig')
+		);
 
 		$this->assertTrue($config->hasKey('testapp', 'deletethis'));
 
@@ -255,7 +282,10 @@ class AppConfigTest extends TestCase {
 	}
 
 	public function testDeleteApp() {
-		$config = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
+		$config = new \OC\AppConfig(
+			\OC::$server->getDatabaseConnection(),
+			\OC::$server->getMemCacheFactory()->create('appconfig')
+		);
 
 		$this->assertTrue($config->hasKey('someapp', 'otherkey'));
 
@@ -275,7 +305,10 @@ class AppConfigTest extends TestCase {
 	}
 
 	public function testGetValuesNotAllowed() {
-		$config = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
+		$config = new \OC\AppConfig(
+			\OC::$server->getDatabaseConnection(),
+			\OC::$server->getMemCacheFactory()->create('appconfig')
+		);
 
 		$this->assertFalse($config->getValues('testapp', 'enabled'));
 
@@ -283,7 +316,10 @@ class AppConfigTest extends TestCase {
 	}
 
 	public function testGetValues() {
-		$config = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
+		$config = new \OC\AppConfig(
+			\OC::$server->getDatabaseConnection(),
+			\OC::$server->getMemCacheFactory()->create('appconfig')
+		);
 
 		$sql = \OC::$server->getDatabaseConnection()->getQueryBuilder();
 		$sql->select(['configkey', 'configvalue'])
@@ -317,8 +353,14 @@ class AppConfigTest extends TestCase {
 	}
 
 	public function testSettingConfigParallel() {
-		$appConfig1 = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
-		$appConfig2 = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
+		$appConfig1 = new \OC\AppConfig(
+			\OC::$server->getDatabaseConnection(),
+			\OC::$server->getMemCacheFactory()->create('appconfig')
+		);
+		$appConfig2 = new \OC\AppConfig(
+			\OC::$server->getDatabaseConnection(),
+			\OC::$server->getMemCacheFactory()->create('appconfig')
+		);
 		$appConfig1->getValue('testapp', 'foo', 'v1');
 		$appConfig2->getValue('testapp', 'foo', 'v1');
 

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -497,7 +497,10 @@ class AppTest extends \Test\TestCase {
 	 */
 	private function restoreAppConfig() {
 		\OC::$server->registerService('AppConfig', function (\OC\Server $c) {
-			return new \OC\AppConfig($c->getDatabaseConnection());
+			return new \OC\AppConfig(
+				\OC::$server->getDatabaseConnection(),
+				\OC::$server->getMemCacheFactory()->create('appconfig')
+			);
 		});
 		\OC::$server->registerService('AppManager', function (\OC\Server $c) {
 			return new \OC\App\AppManager($c->getUserSession(), $c->getAppConfig(), $c->getGroupManager(), $c->getMemCacheFactory(), $c->getEventDispatcher());


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

<!--- Describe your changes in detail -->

See commit messages. Unfortunately, it requires touching the Server container to remove the dependency on app versions to calculate the cache prefix. I assume it was added to prevent side effects when enabling/disabling apps, so I added code to wipe the cache to prevent that. This allows the MemCacheFactory to depend on the SystemConfig instead of the AllConfig

@DeepDiver1975 @PVince81 @PhilippSchaffrath Changing the apps will wipe the cache which might be problematic for large instances. Not Wiping the cache might create unreproducable errors on app changes. Any Opinion?

Before the patch db statistichs would drown in appconfig requests. We asked the oracle admin to get stats for after the patch. will update here ASAP.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->

Slow performance on oracle, files page takes 20-30 secs to load
related: https://github.com/owncloud/core/pull/23835
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

On every request we need to fetch the appconfig table from the db. With ~300 entries that should be blazingly fast. But it isn't. Reality bites. 
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

testsystem and production environment.
## Screenshots (if appropriate):

![after-cache-appconfig](https://cloud.githubusercontent.com/assets/956847/19649253/6b67bbb2-9a05-11e6-8cf4-6a343e36a944.png)
This is AFTER we applied the patch (on a 9.0.5 instance). The requests are ordered by response time. webdav.php takes 5.58sec for listing 19 folders ... 
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
