### PR TITLE
Remove all unneeded set_include_path()

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -216,12 +216,7 @@ class OC {
 
 		// set the right include path
 		set_include_path(
-			OC::$SERVERROOT . '/lib/private' . PATH_SEPARATOR .
-			OC::$SERVERROOT . '/config' . PATH_SEPARATOR .
-			OC::$SERVERROOT . '/3rdparty' . PATH_SEPARATOR .
-			implode(PATH_SEPARATOR, $paths) . PATH_SEPARATOR .
-			get_include_path() . PATH_SEPARATOR .
-			OC::$SERVERROOT
+			implode(PATH_SEPARATOR, $paths)
 		);
 	}
 


### PR DESCRIPTION
## Description

All code should be loaded using composer - no need to call set-include_path - only for all apps folders this seems to be necessary at the moment .....
## How Has This Been Tested?

Local unit test executions
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
