### PR TITLE
Fix outerHTML in octemplate

### DIFF
--- a/core/js/octemplate.js
+++ b/core/js/octemplate.js
@@ -76,7 +76,7 @@
 		},
 		// From stackoverflow.com/questions/1408289/best-way-to-do-variable-interpolation-in-javascript
 		_build: function(o){
-			var data = this.elem.attr('type') === 'text/template' ? this.elem.html() : outerHTML(this.elem.get(0));
+			var data = this.elem.attr('type') === 'text/template' ? this.elem.html() : this.elem.get(0).outerHTML;
 			try {
 				return data.replace(/{([^{}]*)}/g,
 					function (a, b) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Replace `outerHTML()` global func call to local.
It used to be a workaround for old Firefox browsers that didn't have the `outerHTML` properly.
This broke when removing compatibility.js: https://github.com/owncloud/core/pull/26442
## Related Issue

None
## Motivation and Context

Because it was available only through compatibility.js which was
removed.
## How Has This Been Tested?
1. Check out master.
2. Disable notifications app (to force a dialog to appear)
3. Share a remote share with this instance
4. Login as the recipient

Before this fix: no remote share acceptation dialog appears + JS error in console
After this fix: dialog appears
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review @DeepDiver1975 @PhilippSchaffrath @felixheidecke @jvillafanez 
