### PR TITLE
Delete storage when unsharing remote share from self

### DIFF
--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -325,12 +325,25 @@ class Manager {
 		return $result;
 	}
 
-	public function removeShare($mountPoint) {
-
+	private function getStorageCache($mountPoint) {
 		$mountPointObj = $this->mountManager->find($mountPoint);
-		$id = $mountPointObj->getStorage()->getCache()->getId('');
+		if (is_null($mountPointObj)) {
+			// possibly a temporary mount point that was never mounted before
+			return null;
+		}
+		if (trim($mountPointObj->getMountPoint(), '/') !== trim($mountPoint, '/')) {
+			// wrong one, possibly root entry...
+			return null;
+		}
+		return $mountPointObj->getStorage()->getCache();
+	}
+
+	public function removeShare($mountPoint) {
+		$storageCache = $this->getStorageCache($mountPoint);
 
 		$mountPoint = $this->stripPath($mountPoint);
+		// leading slash is expected
+		$mountPoint = '/' . ltrim($mountPoint, '/');
 		$hash = md5($mountPoint);
 
 		$getShare = $this->connection->prepare('
@@ -352,8 +365,16 @@ class Manager {
 		');
 		$result = (bool)$query->execute([$hash, $this->uid]);
 
-		if($result) {
-			$this->removeReShares($id);
+		if ($storageCache !== null) {
+			if($result) {
+				$id = $storageCache->getId('');
+				$this->removeReShares($id);
+			}
+
+			// note: method not on the interface...
+			if (method_exists($storageCache, 'clear')) {
+				$storageCache->clear();
+			}
 		}
 
 		return $result;
@@ -389,24 +410,31 @@ class Manager {
 	 * @return bool
 	 */
 	public function removeUserShares($uid) {
-		$getShare = $this->connection->prepare('
-			SELECT `remote`, `share_token`, `remote_id`
-			FROM  `*PREFIX*share_external`
-			WHERE `user` = ?');
-		$result = $getShare->execute([$uid]);
+		$getShare = $this->connection->getQueryBuilder();
+		$getShare->select(['remote', 'share_token', 'remote_id', 'mountpoint'])
+			->from('share_external')
+			->where($getShare->expr()->eq('user', $getShare->createNamedParameter($uid)));
+		$result = $getShare->execute();
 
 		if ($result) {
-			$shares = $getShare->fetchAll();
+			$shares = $result->fetchAll();
+			$result->closeCursor();
 			foreach($shares as $share) {
+				$storageCache = $this->getStorageCache($uid . '/files/' . ltrim($share['mountpoint'], '/'));
+				if (!is_null($storageCache)) {
+					// note: method not on the interface...
+					if (method_exists($storageCache, 'clear')) {
+						$storageCache->clear();
+					}
+				}
 				$this->sendFeedbackToRemote($share['remote'], $share['share_token'], $share['remote_id'], 'decline');
 			}
 		}
 
-		$query = $this->connection->prepare('
-			DELETE FROM `*PREFIX*share_external`
-			WHERE `user` = ?
-		');
-		return (bool)$query->execute([$uid]);
+		$query = $this->connection->getQueryBuilder();
+		$query->delete('share_external')
+			->where($query->expr()->eq('user', $query->createNamedParameter($uid)));
+		return (bool)$query->execute();
 	}
 
 	/**

--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -41,7 +41,7 @@ class Helper {
 		\OCP\Util::connectHook('OC_Filesystem', 'post_delete', '\OCA\Files_Sharing\Hooks', 'unshareChildren');
 		\OCP\Util::connectHook('OC_Appconfig', 'post_set_value', '\OCA\Files_Sharing\Maintainer', 'configChangeHook');
 
-		\OCP\Util::connectHook('OC_User', 'post_deleteUser', '\OCA\Files_Sharing\Hooks', 'deleteUser');
+		\OCP\Util::connectHook('OC_User', 'pre_deleteUser', '\OCA\Files_Sharing\Hooks', 'deleteUser');
 	}
 
 	/**

--- a/apps/files_sharing/lib/Hooks.php
+++ b/apps/files_sharing/lib/Hooks.php
@@ -31,6 +31,8 @@ use OCA\FederatedFileSharing\DiscoveryManager;
 class Hooks {
 
 	public static function deleteUser($params) {
+		$uid = $params['uid'];
+		\OC\Files\Filesystem::initMountPoints($uid);
 		$discoveryManager = new DiscoveryManager(
 			\OC::$server->getMemCacheFactory(),
 			\OC::$server->getHTTPClientService()
@@ -42,9 +44,9 @@ class Hooks {
 			\OC::$server->getHTTPHelper(),
 			\OC::$server->getNotificationManager(),
 			$discoveryManager,
-			$params['uid']);
+			$uid);
 
-		$manager->removeUserShares($params['uid']);
+		$manager->removeUserShares($uid);
 	}
 
 	public static function unshareChildren($params) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

This fix automatically deletes the oc_storages and oc_filecache entries
matching the deleted remote share.
## Related Issue

https://github.com/owncloud/core/issues/15701
## Motivation and Context

When unsharing a federated remote share from self, the
oc_share_external entry is deleted but the matching oc_storages entries
were left untouched. Since the latter is useless without the
oc_share_external entry, it must be deleted.
## How Has This Been Tested?
1. Setup two ownClouds OC_A and OC_B, OC_A being this branch or master
2. From OC_B, share a folder "test" with admin@OC_A
3. Login as admin@OC_A
4. Check `oc_share_external`, a new entry appeared
5. Accept "test"
6. Check `oc_share_external`, `oc_storages`, `oc_filecache`
7. Unshare "test" from self (delete)
8. Check `oc_share_external`, `oc_storages`, `oc_filecache`

Before this fix: after deleting the `oc_storages` + `oc_filecache` entries from the share still exist
After this fix: they are deleted
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
## TODO
- [ ] add unit tests (sadly there were no tests at all for "removeShare")
## Backports
- [ ] stable9.1
- [ ] stable9?
- [ ] stable8.2?

@butonic @DeepDiver1975 FYI
