### PR TITLE
make object prefix configurable

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1006,9 +1006,9 @@ $CONFIG = array(
  *
  * One way to test is applying for a trystack account at http://trystack.org/
  */
-'objectstore' => array(
+'objectstore' => [
 	'class' => 'OC\\Files\\ObjectStore\\Swift',
-	'arguments' => array(
+	'arguments' => [
 		// trystack will user your facebook id as the user name
 		'username' => 'facebook100000123456789',
 		// in the trystack dashboard go to user -> settings -> API Password to
@@ -1016,6 +1016,8 @@ $CONFIG = array(
 		'password' => 'Secr3tPaSSWoRdt7',
 		// must already exist in the objectstore, name can be different
 		'container' => 'owncloud',
+		// prefix to prepend to the fileid, default is 'oid:urn:'
+		'objectPrefix' => 'oid:urn:',
 		// create the container if it does not exist. default is false
 		'autocreate' => true,
 		// required, dev-/trystack defaults to 'RegionOne'
@@ -1029,8 +1031,8 @@ $CONFIG = array(
 		'serviceName' => 'swift',
 		// The Interface / url Type, optional
 		'urlType' => 'internal'
-	),
-),
+	],
+],
 
 
 /**

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -47,6 +47,8 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 	 */
 	protected $user;
 
+	private $objectPrefix = 'urn:oid:';
+
 	public function __construct($params) {
 		if (isset($params['objectstore']) && $params['objectstore'] instanceof IObjectStore) {
 			$this->objectStore = $params['objectstore'];
@@ -57,6 +59,9 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 			$this->id = 'object::store:' . $params['storageid'];
 		} else {
 			$this->id = 'object::store:' . $this->objectStore->getStorageId();
+		}
+		if (isset($params['objectPrefix'])) {
+			$this->objectPrefix = $params['objectPrefix'];
 		}
 		//initialize cache with root directory in cache
 		if (!$this->is_dir('/')) {
@@ -215,7 +220,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 	 */
 	protected function getURN($fileId) {
 		if (is_numeric($fileId)) {
-			return 'urn:oid:' . $fileId;
+			return $this->objectPrefix . $fileId;
 		}
 		return null;
 	}

--- a/tests/objectstore/start-swift-ceph.sh
+++ b/tests/objectstore/start-swift-ceph.sh
@@ -85,6 +85,7 @@ cat > $thisFolder/swift.config.php <<DELIM
 		'username' => '$user',
 		'password' => '$pass',
 		'container' => 'owncloud-autotest$EXECUTOR_NUMBER',
+	    'objectPrefix' => 'autotest$EXECUTOR_NUMBER:oid:urn:',
 		'autocreate' => true,
 		'region' => '$region',
 		'url' => 'http://$host:$port/v2.0',


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

<!--- Describe your changes in detail -->

Allow changing the object prefix. 
## Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->

Not all objectstorages will allow ':' in the object name, see https://github.com/minio/minio/issues/2954
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

easier testing, objectstore incompatability
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

local minio instance, adding the param to the swift based test
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
