### PR TITLE
Fix unit tests that failed due to microseconds

### DIFF
--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -107,8 +107,8 @@ class ManagerTest extends TestCase {
 		$this->assertSame($comment->getVerb(), 'comment');
 		$this->assertSame($comment->getObjectType(), 'files');
 		$this->assertSame($comment->getObjectId(), 'file64');
-		$this->assertEquals($comment->getCreationDateTime(), $creationDT);
-		$this->assertEquals($comment->getLatestChildDateTime(), $latestChildDT);
+		$this->assertEquals($comment->getCreationDateTime()->format(\DateTime::ISO8601), $creationDT->format(\DateTime::ISO8601));
+		$this->assertEquals($comment->getLatestChildDateTime()->format(\DateTime::ISO8601), $latestChildDT->format(\DateTime::ISO8601));
 	}
 
 	/**
@@ -369,7 +369,7 @@ class ManagerTest extends TestCase {
 
 		$loadedComment = $manager->get($comment->getId());
 		$this->assertSame($comment->getMessage(), $loadedComment->getMessage());
-		$this->assertEquals($comment->getCreationDateTime(), $loadedComment->getCreationDateTime());
+		$this->assertEquals($comment->getCreationDateTime()->format(\DateTime::ISO8601), $loadedComment->getCreationDateTime()->format(\DateTime::ISO8601));
 	}
 
 	public function testSaveUpdate() {
@@ -573,7 +573,7 @@ class ManagerTest extends TestCase {
 
 		$dateTimeGet = $manager->getReadMark('robot', '36',  $user);
 
-		$this->assertEquals($dateTimeGet, $dateTimeSet);
+		$this->assertEquals($dateTimeGet->format(\DateTime::ISO8601), $dateTimeSet->format(\DateTime::ISO8601));
 	}
 
 	public function testSetMarkReadUpdate() {

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -744,7 +744,7 @@ class DefaultShareProviderTest extends TestCase {
 		$this->assertSame($path, $share2->getNode());
 		$this->assertSame('password', $share2->getPassword());
 		$this->assertSame('token', $share2->getToken());
-		$this->assertEquals($expireDate, $share2->getExpirationDate());
+		$this->assertEquals($expireDate->format(\DateTime::ISO8601), $share2->getExpirationDate()->format(\DateTime::ISO8601));
 	}
 
 	public function testGetShareByToken() {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

This fixes the assertions by comparing the dates using a format that
doesn't contain the microseconds part.
## Related Issue

Fixes https://github.com/owncloud/core/issues/26488
## Motivation and Context

Since PHP 7.1.0RC4 the DateTime object populates the microsecond part.
Since databased usually don't store this, comparing the result with the
original date would fail.
## How Has This Been Tested?

Run the unit tests with 7.1.0RC4.
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 @PhilippSchaffrath @butonic @VicDeo 
