### PR TITLE
Display changes in file versions tab view and detailsView

### DIFF
--- a/apps/files/css/detailsView.css
+++ b/apps/files/css/detailsView.css
@@ -98,10 +98,18 @@
 #app-sidebar .file-details {
 	color: #999;
 }
+
 #app-sidebar .file-details img {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 	opacity: .5;
 }
+
+#app-sidebar .file-details img:hover,
+#app-sidebar .file-details img:focus{
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
+	opacity: 1;
+}
+
 #app-sidebar .action-favorite {
 	vertical-align: text-bottom;
 	padding: 10px;

--- a/apps/files_versions/css/versions.css
+++ b/apps/files_versions/css/versions.css
@@ -1,6 +1,7 @@
 .versionsTabView .clear-float {
 	clear: both;
 }
+
 .versionsTabView li {
 	width: 100%;
 	cursor: default;
@@ -12,23 +13,28 @@
 	border-bottom: none;
 }
 
-.versionsTabView li > * {
+.versionsTabView a,
+.versionsTabView div > span {
 	vertical-align: middle;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 	filter: alpha(opacity=50);
 	opacity: .5;
 }
 
-.versionsTabView li > a,
-.versionsTabView li > span {
+.versionsTabView li a{
 	padding: 15px 10px 11px;
 }
 
-.versionsTabView li > *:hover,
-.versionsTabView li > *:focus {
+.versionsTabView a:hover,
+.versionsTabView a:focus {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
 	filter: alpha(opacity=100);
 	opacity: 1;
+}
+
+.versionsTabView .preview-container {
+	display: inline-block;
+    vertical-align: top;
 }
 
 .versionsTabView img {
@@ -38,11 +44,26 @@
 
 .versionsTabView img.preview {
 	cursor: default;
-	opacity: 1;
+}
+
+.versionsTabView .version-container {
+	display: inline-block;
 }
 
 .versionsTabView .versiondate {
 	min-width: 100px;
+	vertical-align: super;
+}
+
+.versionsTabView .version-details {
+	text-align: left;
+}
+
+.versionsTabView .version-details > span {
+	padding: 0 10px;
+}
+
+.versionsTabView .version-details > .size {
 	vertical-align: super;
 }
 

--- a/apps/files_versions/css/versions.css
+++ b/apps/files_versions/css/versions.css
@@ -34,7 +34,7 @@
 
 .versionsTabView .preview-container {
 	display: inline-block;
-    vertical-align: top;
+  vertical-align: top;
 }
 
 .versionsTabView img {
@@ -61,10 +61,6 @@
 
 .versionsTabView .version-details > span {
 	padding: 0 10px;
-}
-
-.versionsTabView .version-details > .size {
-	vertical-align: super;
 }
 
 .versionsTabView .revertVersion {

--- a/apps/files_versions/js/versionstabview.js
+++ b/apps/files_versions/js/versionstabview.js
@@ -10,27 +10,27 @@
 
 (function() {
 	var TEMPLATE_ITEM =
-                '<li data-revision="{{timestamp}}">' +
-                '<div>' +
-                '<div class="preview-container">' +
-	        '<img class="preview" src="{{previewUrl}}"/>' +
-                '</div>' +
-                '<div class="version-container">' +
-                '<div>' +
-                '<a href="{{downloadUrl}}" class="downloadVersion"><img src="{{downloadIconUrl}}" />' +
-                '<span class="versiondate has-tooltip" title="{{formattedTimestamp}}">{{relativeTimestamp}}</span>' +
+		'<li data-revision="{{timestamp}}">' +
+		'<div>' +
+		'<div class="preview-container">' +
+		'<img class="preview" src="{{previewUrl}}"/>' +
+		'</div>' +
+		'<div class="version-container">' +
+		'<div>' +
+		'<a href="{{downloadUrl}}" class="downloadVersion"><img src="{{downloadIconUrl}}" />' +
+		'<span class="versiondate has-tooltip" title="{{formattedTimestamp}}">{{relativeTimestamp}}</span>' +
 		'</a>' +
-                '</div>' +
-                '{{#hasDetails}}' +
-                '<div class="version-details">' +
-                '<span class="size has-tooltip" title="{{altSize}}">{{humanReadableSize}}</span>' +
-                '</div>' +
-                '{{/hasDetails}}' +
-                '</div>' +
+		'</div>' +
+		'{{#hasDetails}}' +
+		'<div class="version-details">' +
+		'<span class="size has-tooltip" title="{{altSize}}">{{humanReadableSize}}</span>' +
+		'</div>' +
+		'{{/hasDetails}}' +
+		'</div>' +
 		'{{#canRevert}}' +
 		'<a href="#" class="revertVersion" title="{{revertLabel}}"><img src="{{revertIconUrl}}" /></a>' +
 		'{{/canRevert}}' +
-                '</div>' +
+		'</div>' +
 		'</li>';
 
 	var TEMPLATE =

--- a/apps/files_versions/js/versionstabview.js
+++ b/apps/files_versions/js/versionstabview.js
@@ -197,9 +197,9 @@
 			return _.extend({
 				formattedTimestamp: OC.Util.formatDate(timestamp),
 				relativeTimestamp: OC.Util.relativeModifiedDate(timestamp),
-                                humanReadableSize: OC.Util.humanFileSize(size, true),
-                                altSize: n('files', '%n byte', '%n bytes', size),
-                                hasDetails: version.has('size'),
+				humanReadableSize: OC.Util.humanFileSize(size, true),
+				altSize: n('files', '%n byte', '%n bytes', size),
+				hasDetails: version.has('size'),
 				downloadUrl: version.getDownloadUrl(),
 				downloadIconUrl: OC.imagePath('core', 'actions/download'),
 				revertIconUrl: OC.imagePath('core', 'actions/history'),

--- a/apps/files_versions/js/versionstabview.js
+++ b/apps/files_versions/js/versionstabview.js
@@ -10,14 +10,27 @@
 
 (function() {
 	var TEMPLATE_ITEM =
-		'<li data-revision="{{timestamp}}">' +
-		'<img class="preview" src="{{previewUrl}}"/>' +
-		'<a href="{{downloadUrl}}" class="downloadVersion"><img src="{{downloadIconUrl}}" />' +
-		'<span class="versiondate has-tooltip" title="{{formattedTimestamp}}">{{relativeTimestamp}}</span>' +
+                '<li data-revision="{{timestamp}}">' +
+                '<div>' +
+                '<div class="preview-container">' +
+	        '<img class="preview" src="{{previewUrl}}"/>' +
+                '</div>' +
+                '<div class="version-container">' +
+                '<div>' +
+                '<a href="{{downloadUrl}}" class="downloadVersion"><img src="{{downloadIconUrl}}" />' +
+                '<span class="versiondate has-tooltip" title="{{formattedTimestamp}}">{{relativeTimestamp}}</span>' +
 		'</a>' +
+                '</div>' +
+                '{{#hasDetails}}' +
+                '<div class="version-details">' +
+                '<span class="size has-tooltip" title="{{altSize}}">{{humanReadableSize}}</span>' +
+                '</div>' +
+                '{{/hasDetails}}' +
+                '</div>' +
 		'{{#canRevert}}' +
 		'<a href="#" class="revertVersion" title="{{revertLabel}}"><img src="{{revertIconUrl}}" /></a>' +
 		'{{/canRevert}}' +
+                '</div>' +
 		'</li>';
 
 	var TEMPLATE =
@@ -180,9 +193,13 @@
 
 		_formatItem: function(version) {
 			var timestamp = version.get('timestamp') * 1000;
+			var size = version.has('size') ? version.get('size') : 0;
 			return _.extend({
 				formattedTimestamp: OC.Util.formatDate(timestamp),
 				relativeTimestamp: OC.Util.relativeModifiedDate(timestamp),
+                                humanReadableSize: OC.Util.humanFileSize(size, true),
+                                altSize: n('files', '%n byte', '%n bytes', size),
+                                hasDetails: version.has('size'),
 				downloadUrl: version.getDownloadUrl(),
 				downloadIconUrl: OC.imagePath('core', 'actions/download'),
 				revertIconUrl: OC.imagePath('core', 'actions/history'),

--- a/apps/files_versions/tests/js/versionstabviewSpec.js
+++ b/apps/files_versions/tests/js/versionstabviewSpec.js
@@ -78,12 +78,14 @@ describe('OCA.Versions.VersionsTabView', function() {
 			var $item = $versions.eq(0);
 			expect($item.find('.downloadVersion').attr('href')).toEqual(version1.getDownloadUrl());
 			expect($item.find('.versiondate').text()).toEqual('seconds ago');
+			expect($item.find('.size').text()).toEqual('< 1 KB');
 			expect($item.find('.revertVersion').length).toEqual(1);
 			expect($item.find('.preview').attr('src')).toEqual(version1.getPreviewUrl());
 
 			$item = $versions.eq(1);
 			expect($item.find('.downloadVersion').attr('href')).toEqual(version2.getDownloadUrl());
 			expect($item.find('.versiondate').text()).toEqual('2 days ago');
+			expect($item.find('.size').text()).toEqual('< 1 KB');
 			expect($item.find('.revertVersion').length).toEqual(1);
 			expect($item.find('.preview').attr('src')).toEqual(version2.getPreviewUrl());
 		});
@@ -231,4 +233,3 @@ describe('OCA.Versions.VersionsTabView', function() {
 		});
 	});
 });
-


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

I made some changes to improve the file version tab.
## Related Issue

Issue Tag: #26510
## Motivation and Context

This pull requests contains code to view the version file size on the file version tab.
Another little change was done for the favourite "star" button on the details view. The opacity of this button changes to 1 on mouse over by this pull request.
## How Has This Been Tested?

The test was ok for the following browsers:
- Internet Explorer 8 on Windows 7
- Google Chrome (current version) and Mozilla Firefox (current version) on Ubuntu 16.04
## Screenshots (if appropriate):

![screenshot from 2016-10-29 21-51-33](https://cloud.githubusercontent.com/assets/23121972/19832348/ede84a0a-9e21-11e6-8ad1-a23b656124f6.png)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
