### PR TITLE
Fixing white screen of death on non existing apps dir path (#25945)

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -514,7 +514,9 @@ class OC {
 			self::initPaths();
 		} catch (\RuntimeException $e) {
 			if (!self::$CLI) {
-				OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
+				// can`t use OC_Response::setStatus because server is not
+				// initialized here
+				http_response_code(OC_Response::STATUS_SERVICE_UNAVAILABLE);
 			}
 			// we can't use the template error page here, because this needs the
 			// DI container which isn't available yet


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Exception-Handler for initPaths() tries to uses OC_Response::setStatus(503) if the apps directory could not be found. This results in a NPE because setStatus() is expecting an initialized \OC\Server which is not available at this point in time. 

This fix replaces the call to setStatus with the built-in http_response_code() which in this case allows us to set the status code regardless of application state.
## Related Issue
#25945
## Motivation and Context

Currently the admin gets a white screen if the apps directory is set incorrectly. With this fix a descriptive error message is shown.
## How Has This Been Tested?
- Configured non existing apps directory in config.php -> Saw exception message
- Configured existing apps directory in config.php -> Owncloud loaded sucessfully
- $ phpunit -c phpunit-autotest.xml
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
