### PR TITLE
Hack to prevent warning for read-only wrapper in public links

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -68,9 +68,12 @@ $server = $serverFactory->createServer($baseuri, $requestUri, $authBackend, func
 	$owner = $share->getShareOwner();
 	$fileId = $share->getNodeId();
 
+	// FIXME: should not add storage wrappers outside of preSetup, need to find a better way
+	$previousLog = \OC\Files\Filesystem::logWarningWhenAddingStorageWrapper(false);
 	\OC\Files\Filesystem::addStorageWrapper('sharePermissions', function ($mountPoint, $storage) use ($share) {
 		return new \OC\Files\Storage\Wrapper\PermissionsMask(['storage' => $storage, 'mask' => $share->getPermissions() | \OCP\Constants::PERMISSION_SHARE]);
 	});
+	\OC\Files\Filesystem::logWarningWhenAddingStorageWrapper($previousLog);
 
 	OC_Util::setupFS($owner);
 	$ownerView = \OC\Files\Filesystem::getView();

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -212,10 +212,13 @@ class Filesystem {
 
 	/**
 	 * @param bool $shouldLog
+	 * @return bool previous value
 	 * @internal
 	 */
 	public static function logWarningWhenAddingStorageWrapper($shouldLog) {
+		$previousValue = self::$logWarningWhenAddingStorageWrapper;
 		self::$logWarningWhenAddingStorageWrapper = (bool) $shouldLog;
+		return $previousValue;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Storage wrappers should normally always be registered inside a presetup
hook. However in the public link scenario this is not possible and
there is currently no good alternative with the current architecture.

Instead of logging a warning every time, this fix prevents the warning
to be shown but also adds a FIXME in the code for the future. This is
ok because this app is already using private/internal APIs at the
moment and should be reworked properly in the future.

## Related Issue
Fixes https://github.com/owncloud/core/issues/25455

## Motivation and Context
The boring warnings in the log.

## How Has This Been Tested?
See steps from https://github.com/owncloud/core/issues/25455 and check the logs.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Backports:
- [ ] stable9.1 (suggested, not mandatory)
- [ ] stable9 (suggested, not mandatory)

@DeepDiver1975 @jvillafanez please review