### PR TITLE
Skip hidden files when counting visible files in list

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -914,7 +914,8 @@
 				tr,
 				fileData,
 				newTrs = [],
-				isAllSelected = this.isAllSelected();
+				isAllSelected = this.isAllSelected(),
+				showHidden = this._filesConfig.get('showhidden');
 
 			if (index >= this.files.length) {
 				return false;
@@ -938,7 +939,10 @@
 				}
 				newTrs.push(tr);
 				index++;
-				count--;
+				// only count visible rows
+				if (showHidden || !tr.hasClass('hidden-file')) {
+					count--;
+				}
 			}
 
 			// trigger event for newly added rows

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1120,6 +1120,34 @@ describe('OCA.Files.FileList tests', function() {
 			expect(fileList.files.length).toEqual(65);
 			expect($('#fileList tr').length).toEqual(20);
 		});
+		it('renders the full first page despite hidden rows', function() {
+			filesConfig.set('showhidden', false);
+			var files = _.map(generateFiles(0, 23), function(data) {
+				return _.extend(data, {
+					name: '.' + data.name
+				});
+			});
+			// only hidden files + one visible
+			files.push(testFiles[0]);
+			fileList.setFiles(files);
+			expect(fileList.files.length).toEqual(25);
+			// render 24 hidden elements + the visible one
+			expect($('#fileList tr').length).toEqual(25);
+		});
+		it('renders the full first page despite hidden rows', function() {
+			filesConfig.set('showhidden', true);
+			var files = _.map(generateFiles(0, 23), function(data) {
+				return _.extend(data, {
+					name: '.' + data.name
+				});
+			});
+			// only hidden files + one visible
+			files.push(testFiles[0]);
+			fileList.setFiles(files);
+			expect(fileList.files.length).toEqual(25);
+			// render 20 first hidden elements as visible
+			expect($('#fileList tr').length).toEqual(20);
+		});
 		it('renders the second page when scrolling down (trigger nextPage)', function() {
 			// TODO: can't simulate scrolling here, so calling nextPage directly
 			fileList._nextPage(true);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
The file list UI logic that renders the next page doesn't properly
exclude hidden files when not shown. This fix makes sure that only rows
that are actually visible are counted when rendering a page, this makes
sure that the page will always have enough elements displayed.

## Related Issue
Fixes https://github.com/owncloud/core/issues/26518

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
See steps in original ticket.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Backports:
- [x] stable9.1

Please review @jvillafanez @PhilippSchaffrath @DeepDiver1975 @felixheidecke 