### PR TITLE
Skip FailedStorage in background scan

### DIFF
--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -121,6 +121,12 @@ class Scanner extends PublicEmitter {
 			if (is_null($storage)) {
 				continue;
 			}
+
+			// don't bother scanning failed storages (shortcut for same result)
+			if ($storage->instanceOfStorage('OC\Files\Storage\FailedStorage')) {
+				continue;
+			}
+
 			// don't scan the root storage
 			if ($storage->instanceOfStorage('\OC\Files\Storage\Local') && $mount->getMountPoint() === '/') {
 				continue;
@@ -164,6 +170,12 @@ class Scanner extends PublicEmitter {
 			if (is_null($storage)) {
 				continue;
 			}
+
+			// don't bother scanning failed storages (shortcut for same result)
+			if ($storage->instanceOfStorage('OC\Files\Storage\FailedStorage')) {
+				continue;
+			}
+
 			// if the home storage isn't writable then the scanner is run as the wrong user
 			if ($storage->instanceOfStorage('\OC\Files\Storage\Home') and
 				(!$storage->isCreatable('') or !$storage->isCreatable('files'))


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
The background job that scans storages must skip failed storages to
avoid potential exceptions, especially when the failed storage comes
from a shared storage where the source is not accessible.

~~This fix adds not only a check for FailedStorage in the background scanner but also hardens the FailedStorage class with a new FailedScanner class to prevent trying to scan into the failed storage.
Note that the latter hardening is not needed directly for the fix thanks to the extra check in the background job but could be useful to catch other code paths that might reach the scanner part.~~

Additionally this also skips unavailable external storages earlier.

## Related Issue
Fixes https://github.com/owncloud/core/issues/26055
Read from https://github.com/owncloud/core/issues/26055#issuecomment-257925117

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
See steps

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Backports:
- [x] stable9.1: I suggest to only backport the check in `Utils/Scanner.php` but not the new `FailedScanner` class

Please review @jvillafanez @DeepDiver1975 
