### PR TITLE
Transfer ownership only analyze home storage

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -153,6 +153,11 @@ class TransferOwnership extends Command {
 		$this->walkFiles($view, "$this->sourceUser/files",
 				function (FileInfo $fileInfo) use ($progress, $self) {
 					if ($fileInfo->getType() === FileInfo::TYPE_FOLDER) {
+						// only analyze into folders from main storage,
+						// sub-storages have an empty internal path
+						if ($fileInfo->getInternalPath() === '' && $fileInfo->getPath() !== '') {
+							return false;
+						}
 						return true;
 					}
 					$progress->advance();


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Don't recurse into any mount points when analyzing, only stay on home storage.

## Related Issue
Fixes https://github.com/owncloud/core/issues/26530

## Motivation and Context
When transferring ownership, only the local files will be transferred
during the rename operation. This means that the analyzing code doesn't
need to recurse into any mount points.

Furthermore this fixes issues where FailedStorage might appear as mount
points as a result of inaccessible external storages or shares. So this
makes it more robust.

This can also make the transfer faster by not exploring external storages which won't be transferred anyway.

## How Has This Been Tested?
See steps in original ticket.
Also tested with WND storages in "user provided" mode which used to fail with similar messages.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

### Backports
- stable9.1
- stable9

