### PR TITLE
Fixed disappearing of share info in file view

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -71,6 +71,12 @@
 				var fileInfo = oldElementToFile.apply(this, arguments);
 				fileInfo.sharePermissions = $el.attr('data-share-permissions') || undefined;
 				fileInfo.shareOwner = $el.attr('data-share-owner') || undefined;
+
+				if( $el.attr('data-share-types')){
+					var shareTypes = $el.attr('data-share-types').split(',');
+					fileInfo.shareTypes = shareTypes;
+				}
+
 				return fileInfo;
 			};
 
@@ -247,4 +253,3 @@
 })();
 
 OC.Plugins.register('OCA.Files.FileList', OCA.Sharing.Util);
-


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
The share information got lost after rerendering the list entry. That was the case, because the data-share-types were not added back to the fileInfo on row creation.

## Related Issue
#26241

## Motivation and Context
It's a little bugfix, so I don't wanna write a big comment. The share information stays visible in the file list.

## How Has This Been Tested?
Chrome (current) on Ubuntu 16.04

## Screenshots (if appropriate):
![screencast-2016-11-02-19 09 02](https://cloud.githubusercontent.com/assets/23121972/19941746/aedec240-a131-11e6-94ec-c114587c9a7c.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

I'm not sure how to implement this in a unit test. Any ideas?