### PR TITLE
[stable9.1] Fixed disappearing of share info in file view

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -71,6 +71,12 @@
 				var fileInfo = oldElementToFile.apply(this, arguments);
 				fileInfo.sharePermissions = $el.attr('data-share-permissions') || undefined;
 				fileInfo.shareOwner = $el.attr('data-share-owner') || undefined;
+
+				if( $el.attr('data-share-types')){
+					var shareTypes = $el.attr('data-share-types').split(',');
+					fileInfo.shareTypes = shareTypes;
+				}
+
 				return fileInfo;
 			};
 
@@ -246,4 +252,3 @@
 })();
 
 OC.Plugins.register('OCA.Files.FileList', OCA.Sharing.Util);
-


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/26534 to stable9.1

