### PR TITLE
Fix file permissions at read time when wrong in DB

### DIFF
--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -765,9 +765,20 @@ class DefaultShareProvider implements IShareProvider {
 	 */
 	private function createShare($data) {
 		$share = new Share($this->rootFolder, $this->userManager);
+
+		$permissions = (int)$data['permissions'];
+		// mask file share permissions in case of invalid entries in the database
+		if ($data['item_type'] === 'file') {
+			$permissions = $permissions & (
+				\OCP\Constants::PERMISSION_READ |
+				\OCP\Constants::PERMISSION_UPDATE |
+				\OCP\Constants::PERMISSION_SHARE
+			);
+		}
+
 		$share->setId((int)$data['id'])
 			->setShareType((int)$data['share_type'])
-			->setPermissions((int)$data['permissions'])
+			->setPermissions($permissions)
 			->setTarget($data['file_target'])
 			->setMailSend((bool)$data['mail_send']);
 

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -138,7 +138,7 @@ class DefaultShareProviderTest extends TestCase {
 				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
 				'file_target' => $qb->expr()->literal('myTarget'),
-				'permissions' => $qb->expr()->literal(13),
+				'permissions' => $qb->expr()->literal(19),
 			]);
 		$qb->execute();
 
@@ -167,7 +167,7 @@ class DefaultShareProviderTest extends TestCase {
 		$this->assertEquals('sharedBy', $share->getSharedBy());
 		$this->assertEquals('shareOwner', $share->getShareOwner());
 		$this->assertEquals($ownerPath, $share->getNode());
-		$this->assertEquals(13, $share->getPermissions());
+		$this->assertEquals(19, $share->getPermissions());
 		$this->assertEquals(null, $share->getToken());
 		$this->assertEquals(null, $share->getExpirationDate());
 		$this->assertEquals('myTarget', $share->getTarget());
@@ -185,7 +185,7 @@ class DefaultShareProviderTest extends TestCase {
 				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
 				'file_target' => $qb->expr()->literal('myTarget'),
-				'permissions' => $qb->expr()->literal(13),
+				'permissions' => $qb->expr()->literal(19),
 			]);
 		$qb->execute();
 
@@ -202,7 +202,7 @@ class DefaultShareProviderTest extends TestCase {
 		$this->assertEquals('sharedWith', $share->getSharedWith());
 		$this->assertEquals('sharedBy', $share->getSharedBy());
 		$this->assertEquals('shareOwner', $share->getShareOwner());
-		$this->assertEquals(13, $share->getPermissions());
+		$this->assertEquals(19, $share->getPermissions());
 		$this->assertEquals(null, $share->getToken());
 		$this->assertEquals(null, $share->getExpirationDate());
 		$this->assertEquals('myTarget', $share->getTarget());
@@ -220,7 +220,7 @@ class DefaultShareProviderTest extends TestCase {
 				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
 				'file_target' => $qb->expr()->literal('myTarget'),
-				'permissions' => $qb->expr()->literal(13),
+				'permissions' => $qb->expr()->literal(19),
 			]);
 		$qb->execute();
 
@@ -246,7 +246,7 @@ class DefaultShareProviderTest extends TestCase {
 		$this->assertEquals('sharedBy', $share->getSharedBy());
 		$this->assertEquals('shareOwner', $share->getShareOwner());
 		$this->assertEquals($ownerPath, $share->getNode());
-		$this->assertEquals(13, $share->getPermissions());
+		$this->assertEquals(19, $share->getPermissions());
 		$this->assertEquals(null, $share->getToken());
 		$this->assertEquals(null, $share->getExpirationDate());
 		$this->assertEquals('myTarget', $share->getTarget());
@@ -264,7 +264,7 @@ class DefaultShareProviderTest extends TestCase {
 				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
 				'file_target' => $qb->expr()->literal('myTarget'),
-				'permissions' => $qb->expr()->literal(13),
+				'permissions' => $qb->expr()->literal(19),
 			]);
 		$this->assertEquals(1, $qb->execute());
 
@@ -289,7 +289,7 @@ class DefaultShareProviderTest extends TestCase {
 		$this->assertEquals('sharedBy', $share->getSharedBy());
 		$this->assertEquals('shareOwner', $share->getShareOwner());
 		$this->assertEquals($ownerPath, $share->getNode());
-		$this->assertEquals(13, $share->getPermissions());
+		$this->assertEquals(19, $share->getPermissions());
 		$this->assertEquals(null, $share->getToken());
 		$this->assertEquals(null, $share->getExpirationDate());
 		$this->assertEquals('myTarget', $share->getTarget());
@@ -345,7 +345,7 @@ class DefaultShareProviderTest extends TestCase {
 				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
 				'file_target' => $qb->expr()->literal('myTarget'),
-				'permissions' => $qb->expr()->literal(13),
+				'permissions' => $qb->expr()->literal(19),
 				'token' => $qb->expr()->literal('token'),
 				'expiration' => $qb->expr()->literal('2000-01-02 00:00:00'),
 			]);
@@ -371,7 +371,7 @@ class DefaultShareProviderTest extends TestCase {
 		$this->assertEquals('sharedBy', $share->getSharedBy());
 		$this->assertEquals('shareOwner', $share->getShareOwner());
 		$this->assertEquals($ownerPath, $share->getNode());
-		$this->assertEquals(13, $share->getPermissions());
+		$this->assertEquals(19, $share->getPermissions());
 		$this->assertEquals('token', $share->getToken());
 		$this->assertEquals(\DateTime::createFromFormat('Y-m-d H:i:s', '2000-01-02 00:00:00'), $share->getExpirationDate());
 		$this->assertEquals('myTarget', $share->getTarget());
@@ -387,7 +387,7 @@ class DefaultShareProviderTest extends TestCase {
 				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
 				'file_target' => $qb->expr()->literal('myTarget'),
-				'permissions' => $qb->expr()->literal(13),
+				'permissions' => $qb->expr()->literal(19),
 			]);
 		$this->assertEquals(1, $qb->execute());
 
@@ -431,7 +431,7 @@ class DefaultShareProviderTest extends TestCase {
 				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
 				'file_target' => $qb->expr()->literal('myTarget'),
-				'permissions' => $qb->expr()->literal(13),
+				'permissions' => $qb->expr()->literal(19),
 			]);
 		$this->assertEquals(1, $qb->execute());
 
@@ -463,7 +463,7 @@ class DefaultShareProviderTest extends TestCase {
 				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
 				'file_target' => $qb->expr()->literal('myTarget'),
-				'permissions' => $qb->expr()->literal(13),
+				'permissions' => $qb->expr()->literal(19),
 			]);
 		$this->assertEquals(1, $qb->execute());
 		$id = $qb->getLastInsertId();
@@ -477,7 +477,7 @@ class DefaultShareProviderTest extends TestCase {
 				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
 				'file_target' => $qb->expr()->literal('myTarget'),
-				'permissions' => $qb->expr()->literal(13),
+				'permissions' => $qb->expr()->literal(19),
 				'parent'      => $qb->expr()->literal($id),
 			]);
 		$this->assertEquals(1, $qb->execute());
@@ -521,7 +521,7 @@ class DefaultShareProviderTest extends TestCase {
 				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
 				'file_target' => $qb->expr()->literal('myTarget'),
-				'permissions' => $qb->expr()->literal(13),
+				'permissions' => $qb->expr()->literal(19),
 			]);
 		$qb->execute();
 
@@ -759,7 +759,7 @@ class DefaultShareProviderTest extends TestCase {
 				'item_type'     => $qb->expr()->literal('file'),
 				'file_source'   => $qb->expr()->literal(42),
 				'file_target'   => $qb->expr()->literal('myTarget'),
-				'permissions'   => $qb->expr()->literal(13),
+				'permissions'   => $qb->expr()->literal(19),
 				'token'         => $qb->expr()->literal('secrettoken'),
 			]);
 		$qb->execute();
@@ -837,7 +837,7 @@ class DefaultShareProviderTest extends TestCase {
 				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal($fileId),
 				'file_target' => $qb->expr()->literal('myTarget'),
-				'permissions' => $qb->expr()->literal(13),
+				'permissions' => $qb->expr()->literal(19),
 			]);
 		$this->assertEquals(1, $qb->execute());
 		$id = $qb->getLastInsertId();
@@ -902,7 +902,7 @@ class DefaultShareProviderTest extends TestCase {
 				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal($fileId),
 				'file_target' => $qb->expr()->literal('myTarget'),
-				'permissions' => $qb->expr()->literal(13),
+				'permissions' => $qb->expr()->literal(19),
 			]);
 		$this->assertEquals(1, $qb->execute());
 		$id = $qb->getLastInsertId();
@@ -964,7 +964,7 @@ class DefaultShareProviderTest extends TestCase {
 				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal($fileId),
 				'file_target' => $qb->expr()->literal('myTarget'),
-				'permissions' => $qb->expr()->literal(13),
+				'permissions' => $qb->expr()->literal(19),
 			]);
 		$this->assertEquals(1, $qb->execute());
 		$id = $qb->getLastInsertId();
@@ -1156,7 +1156,7 @@ class DefaultShareProviderTest extends TestCase {
 				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal($deletedFileId),
 				'file_target' => $qb->expr()->literal('myTarget'),
-				'permissions' => $qb->expr()->literal(13),
+				'permissions' => $qb->expr()->literal(19),
 			]);
 		$this->assertEquals(1, $qb->execute());
 
@@ -1205,7 +1205,7 @@ class DefaultShareProviderTest extends TestCase {
 				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
 				'file_target' => $qb->expr()->literal('myTarget'),
-				'permissions' => $qb->expr()->literal(13),
+				'permissions' => $qb->expr()->literal(19),
 			]);
 		$this->assertEquals(1, $qb->execute());
 		$id = $qb->getLastInsertId();
@@ -1239,7 +1239,7 @@ class DefaultShareProviderTest extends TestCase {
 		$this->assertEquals('shareOwner', $share->getShareOwner());
 		$this->assertEquals('sharedBy', $share->getSharedBy());
 		$this->assertEquals(Share::SHARE_TYPE_USER, $share->getShareType());
-		$this->assertEquals(13, $share->getPermissions());
+		$this->assertEquals(19, $share->getPermissions());
 		$this->assertEquals('myTarget', $share->getTarget());
 	}
 
@@ -1254,7 +1254,7 @@ class DefaultShareProviderTest extends TestCase {
 				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
 				'file_target' => $qb->expr()->literal('myTarget'),
-				'permissions' => $qb->expr()->literal(13),
+				'permissions' => $qb->expr()->literal(19),
 			]);
 		$this->assertEquals(1, $qb->execute());
 		$id = $qb->getLastInsertId();
@@ -1289,7 +1289,7 @@ class DefaultShareProviderTest extends TestCase {
 		$this->assertEquals('shareOwner', $share->getShareOwner());
 		$this->assertEquals('sharedBy', $share->getSharedBy());
 		$this->assertEquals(Share::SHARE_TYPE_USER, $share->getShareType());
-		$this->assertEquals(13, $share->getPermissions());
+		$this->assertEquals(19, $share->getPermissions());
 		$this->assertEquals('myTarget', $share->getTarget());
 	}
 
@@ -1304,7 +1304,7 @@ class DefaultShareProviderTest extends TestCase {
 				'item_type' => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
 				'file_target' => $qb->expr()->literal('myTarget'),
-				'permissions' => $qb->expr()->literal(13),
+				'permissions' => $qb->expr()->literal(19),
 			]);
 		$this->assertEquals(1, $qb->execute());
 		$id1 = $qb->getLastInsertId();
@@ -1339,7 +1339,7 @@ class DefaultShareProviderTest extends TestCase {
 		$this->assertSame('shareOwner', $share->getShareOwner());
 		$this->assertSame('shareOwner', $share->getSharedBy());
 		$this->assertEquals(Share::SHARE_TYPE_USER, $share->getShareType());
-		$this->assertEquals(13, $share->getPermissions());
+		$this->assertEquals(19, $share->getPermissions());
 		$this->assertEquals('myTarget', $share->getTarget());
 
 		$share = $shares[1];
@@ -1350,6 +1350,54 @@ class DefaultShareProviderTest extends TestCase {
 		$this->assertEquals(Share::SHARE_TYPE_USER, $share->getShareType());
 		$this->assertEquals(0, $share->getPermissions());
 		$this->assertEquals('userTarget', $share->getTarget());
+	}
+
+	public function permissionMaskProvider() {
+		return [
+			['file', 23, 19],
+			['folder', 23, 23],
+		];
+	}
+
+	/**
+	 * @dataProvider permissionMaskProvider
+	 */
+	public function testGetShareMasksInvalidFileSharePermissions($itemType, $dbPerms, $returnedPerms) {
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$qb->insert('share')
+			->values([
+				'share_type'  => $qb->expr()->literal(Share::SHARE_TYPE_USER),
+				'share_with'  => $qb->expr()->literal('sharedWith'),
+				'uid_owner'   => $qb->expr()->literal('shareOwner'),
+				'uid_initiator' => $qb->expr()->literal('sharedBy'),
+				'item_type'   => $qb->expr()->literal($itemType),
+				'file_source' => $qb->expr()->literal(42),
+				'file_target' => $qb->expr()->literal('myTarget'),
+				'permissions' => $qb->expr()->literal($dbPerms),
+			]);
+		$qb->execute();
+
+		$id = $qb->getLastInsertId();
+
+		$sharedBy = $this->createMock(IUser::class);
+		$sharedBy->method('getUID')->willReturn('sharedBy');
+		$shareOwner = $this->createMock(IUser::class);
+		$shareOwner->method('getUID')->willReturn('shareOwner');
+
+		$ownerPath = $this->createMock(File::class);
+		$shareOwnerFolder = $this->createMock(Folder::class);
+		$shareOwnerFolder->method('getById')->with(42)->willReturn([$ownerPath]);
+
+		$this->rootFolder
+			->method('getUserFolder')
+			->will($this->returnValueMap([
+				['shareOwner', $shareOwnerFolder],
+			]));
+
+		$share = $this->provider->getShareById($id);
+
+		$this->assertEquals($returnedPerms, $share->getPermissions());
 	}
 
 	public function testDeleteFromSelfGroupNoCustomShare() {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
In some past situations it was possible to create file shares with
invalid permissions. Since such entries still exist in some databases,
the share provider now automatically masks these permissions with the
allowed ones. This will prevent some code paths like ownership transfer
to trigger problems where permissions cannot be changed.

## Related Issue
Fixes https://github.com/owncloud/core/issues/26541

## Motivation and Context
See linked issue.
Note that I decided against doing this in the manager directly because the manager is doing validation and is not supposed to change input data.

## How Has This Been Tested?
Unit tests and see steps in ticket.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

### Backports
- [ ] stable9.1
- [ ] stable9

@DeepDiver1975 @jvillafanez @PhilippSchaffrath 