### PR TITLE
Transfer ownership now returns exit code on error

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -93,11 +93,11 @@ class TransferOwnership extends Command {
 		$destinationUserObject = $this->userManager->get($input->getArgument('destination-user'));
 		if (is_null($sourceUserObject)) {
 			$output->writeln("<error>Unknown source user $this->sourceUser</error>");
-			return;
+			return 1;
 		}
 		if (is_null($destinationUserObject)) {
 			$output->writeln("<error>Unknown destination user $this->destinationUser</error>");
-			return;
+			return 1;
 		}
 
 		$this->sourceUser = $sourceUserObject->getUID();
@@ -106,7 +106,7 @@ class TransferOwnership extends Command {
 		// target user has to be ready
 		if (!\OC::$server->getEncryptionManager()->isReadyForUser($this->destinationUser)) {
 			$output->writeln("<error>The target user is not ready to accept files. The user has at least to be logged in once.</error>");
-			return;
+			return 2;
 		}
 
 		$date = date('c');


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Transfer ownership now returns exit code on error

## Related Issue
No issue raised, but discovered while writing tests for https://github.com/owncloud/core/pull/26543

## Motivation and Context
Because we need a way to identify success from error

## How Has This Been Tested?
- invalid source user: `./occ files:transfer-ownership invalid_user existing_user` => check exit code
- invalid target user: `./occ files:transfer-ownership existing_user invalid_user` => check exit code

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes => part of https://github.com/owncloud/core/pull/26543
- [x] All new and existing tests passed.

Please review @davitol @PhilippSchaffrath @DeepDiver1975 