### PR TITLE
Use node API instead of View in DAV app

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -72,13 +72,10 @@ $server = $serverFactory->createServer($baseuri, $requestUri, $authBackend, func
 		return new \OC\Files\Storage\Wrapper\PermissionsMask(['storage' => $storage, 'mask' => $share->getPermissions() | \OCP\Constants::PERMISSION_SHARE]);
 	});
 
-	OC_Util::setupFS($owner);
-	$ownerView = \OC\Files\Filesystem::getView();
-	$path = $ownerView->getPath($fileId);
-	$fileInfo = $ownerView->getFileInfo($path);
-	$linkCheckPlugin->setFileInfo($fileInfo);
+	$rootInfo = \OC::$server->getRootFolder()->getUserFolder($owner)->getById($fileId);
+	$linkCheckPlugin->setFileInfo($rootInfo);
 
-	return new \OC\Files\View($ownerView->getAbsolutePath($path));
+	return $rootInfo;
 });
 
 $server->addPlugin($linkCheckPlugin);

--- a/apps/dav/appinfo/v1/webdav.php
+++ b/apps/dav/appinfo/v1/webdav.php
@@ -50,7 +50,7 @@ $requestUri = \OC::$server->getRequest()->getRequestUri();
 
 $server = $serverFactory->createServer($baseuri, $requestUri, $authBackend, function() {
 	// use the view for the logged in user
-	return \OC\Files\Filesystem::getView();
+	return \OC::$server->getUserFolder();
 });
 
 // And off we go!

--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -29,7 +29,6 @@
 
 namespace OCA\DAV\Connector\Sabre;
 
-use OC\Files\View;
 use OCP\Files\ForbiddenException;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
@@ -84,11 +83,6 @@ class FilesPlugin extends ServerPlugin {
 	private $isPublic;
 
 	/**
-	 * @var View
-	 */
-	private $fileView;
-
-	/**
 	 * @var bool
 	 */
 	private $downloadAttachment;
@@ -105,20 +99,17 @@ class FilesPlugin extends ServerPlugin {
 
 	/**
 	 * @param Tree $tree
-	 * @param View $view
 	 * @param IConfig $config
 	 * @param IRequest $request
 	 * @param bool $isPublic
 	 * @param bool $downloadAttachment
 	 */
 	public function __construct(Tree $tree,
-								View $view,
 								IConfig $config,
 								IRequest $request,
 								$isPublic = false,
 								$downloadAttachment = true) {
 		$this->tree = $tree;
-		$this->fileView = $view;
 		$this->config = $config;
 		$this->request = $request;
 		$this->isPublic = $isPublic;

--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -22,7 +22,6 @@
 
 namespace OCA\DAV\Connector\Sabre;
 
-use OC\Files\View;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\Exception\PreconditionFailed;
 use Sabre\DAV\Exception\ReportNotSupported;
@@ -60,11 +59,6 @@ class FilesReportPlugin extends ServerPlugin {
 	private $tree;
 
 	/**
-	 * @var View
-	 */
-	private $fileView;
-
-	/**
 	 * @var ISystemTagManager
 	 */
 	private $tagManager;
@@ -98,7 +92,6 @@ class FilesReportPlugin extends ServerPlugin {
 
 	/**
 	 * @param Tree $tree
-	 * @param View $view
 	 * @param ISystemTagManager $tagManager
 	 * @param ISystemTagObjectMapper $tagMapper
 	 * @param ITagManager $fileTagger manager for private tags
@@ -107,7 +100,6 @@ class FilesReportPlugin extends ServerPlugin {
 	 * @param Folder $userfolder
 	 */
 	public function __construct(Tree $tree,
-								View $view,
 								ISystemTagManager $tagManager,
 								ISystemTagObjectMapper $tagMapper,
 								ITagManager $fileTagger,
@@ -116,7 +108,6 @@ class FilesReportPlugin extends ServerPlugin {
 								Folder $userFolder
 	) {
 		$this->tree = $tree;
-		$this->fileView = $view;
 		$this->tagManager = $tagManager;
 		$this->tagMapper = $tagMapper;
 		$this->fileTagger = $fileTagger;
@@ -380,9 +371,9 @@ class FilesReportPlugin extends ServerPlugin {
 			if ($entry) {
 				$entry = current($entry);
 				if ($entry instanceof \OCP\Files\File) {
-					$results[] = new File($this->fileView, $entry);
+					$results[] = new File($entry);
 				} else if ($entry instanceof \OCP\Files\Folder) {
-					$results[] = new Directory($this->fileView, $entry);
+					$results[] = new Directory($entry, $this->tree);
 				}
 			}
 		}

--- a/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
@@ -40,9 +40,9 @@ use Sabre\HTTP\URLUtil;
 class QuotaPlugin extends \Sabre\DAV\ServerPlugin {
 
 	/**
-	 * @var \OC\Files\View
+	 * @var \OCP\Files\Node
 	 */
-	private $view;
+	private $info;
 
 	/**
 	 * Reference to main server object
@@ -52,10 +52,10 @@ class QuotaPlugin extends \Sabre\DAV\ServerPlugin {
 	private $server;
 
 	/**
-	 * @param \OC\Files\View $view
+	 * @param \OCP\Files\Node $node
 	 */
-	public function __construct($view) {
-		$this->view = $view;
+	public function __construct($info) {
+		$this->info = $info;
 	}
 
 	/**
@@ -143,7 +143,9 @@ class QuotaPlugin extends \Sabre\DAV\ServerPlugin {
 	 */
 	public function getFreeSpace($uri) {
 		try {
-			$freeSpace = $this->view->free_space(ltrim($uri, '/'));
+			$storage = $this->info->getStorage();
+			$internalPath = rtrim($this->info->getInternalPath(), '/');
+			$freeSpace = $storage->free_space($internalPath . '/' . ltrim($uri, '/'));
 			return $freeSpace;
 		} catch (StorageNotAvailableException $e) {
 			throw new ServiceUnavailable($e->getMessage());

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -85,13 +85,13 @@ class ServerFactory {
 	 * @param string $baseUri
 	 * @param string $requestUri
 	 * @param BackendInterface $authBackend
-	 * @param callable $viewCallBack callback that should return the view for the dav endpoint
+	 * @param callable $rootInfoCallback callback that should return the root info for the dav endpoint
 	 * @return Server
 	 */
 	public function createServer($baseUri,
 								 $requestUri,
 								 BackendInterface $authBackend,
-								 callable $viewCallBack) {
+								 callable $rootInfoCallback) {
 		// Fire up server
 		$objectTree = new \OCA\DAV\Connector\Sabre\ObjectTree();
 		$server = new \OCA\DAV\Connector\Sabre\Server($objectTree);
@@ -122,33 +122,31 @@ class ServerFactory {
 		}
 
 		// wait with registering these until auth is handled and the filesystem is setup
-		$server->on('beforeMethod', function () use ($server, $objectTree, $viewCallBack) {
+		$server->on('beforeMethod', function () use ($server, $objectTree, $rootInfoCallback) {
 			// ensure the skeleton is copied
 			$userFolder = \OC::$server->getUserFolder();
 			
-			/** @var \OC\Files\View $view */
-			$view = $viewCallBack($server);
-			$rootInfo = $view->getFileInfo('');
+			/** @var \OCP\Files\Folder $rootInfo */
+			$rootInfo = $rootInfoCallback($server);
 
 			// Create ownCloud Dir
 			if ($rootInfo->getType() === 'dir') {
-				$root = new \OCA\DAV\Connector\Sabre\Directory($view, $rootInfo, $objectTree);
+				$root = new \OCA\DAV\Connector\Sabre\Directory($rootInfo, $objectTree);
 			} else {
-				$root = new \OCA\DAV\Connector\Sabre\File($view, $rootInfo);
+				$root = new \OCA\DAV\Connector\Sabre\File($rootInfo);
 			}
-			$objectTree->init($root, $view, $this->mountManager);
+			$objectTree->init($root, $userFolder, $this->mountManager);
 
 			$server->addPlugin(
 				new \OCA\DAV\Connector\Sabre\FilesPlugin(
 					$objectTree,
-					$view,
 					$this->config,
 					$this->request,
 					false,
 					!$this->config->getSystemValue('debug', false)
 				)
 			);
-			$server->addPlugin(new \OCA\DAV\Connector\Sabre\QuotaPlugin($view));
+			$server->addPlugin(new \OCA\DAV\Connector\Sabre\QuotaPlugin($rootInfo));
 
 			if($this->userSession->isLoggedIn()) {
 				$server->addPlugin(new \OCA\DAV\Connector\Sabre\TagsPlugin($objectTree, $this->tagManager));
@@ -161,7 +159,6 @@ class ServerFactory {
 				$server->addPlugin(new \OCA\DAV\Connector\Sabre\CommentPropertiesPlugin(\OC::$server->getCommentsManager(), $this->userSession));
 				$server->addPlugin(new \OCA\DAV\Connector\Sabre\FilesReportPlugin(
 					$objectTree,
-					$view,
 					\OC::$server->getSystemTagManager(),
 					\OC::$server->getSystemTagObjectMapper(),
 					\OC::$server->getTagManager(),

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -162,7 +162,6 @@ class Server {
 				$this->server->addPlugin(
 					new FilesPlugin(
 						$this->server->tree,
-						$view,
 						\OC::$server->getConfig(),
 						$this->request,
 						false,
@@ -200,7 +199,6 @@ class Server {
 				));
 				$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\FilesReportPlugin(
 					$this->server->tree,
-					$view,
 					\OC::$server->getSystemTagManager(),
 					\OC::$server->getSystemTagObjectMapper(),
 					\OC::$server->getTagManager(),


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Replace all usages of the private `View` class with the Node API (`\OC::$server->getUserFolder()`)

## Related Issue
None

## Motivation and Context
- Because we should use public APIs in apps
- Because at some point we'll likely want to get rid of the `View`
- Because if we want to revamp the filesystem layer at some point we'd better use the public APIs first because these are likely to stay while private stuff might get killed/replaced

## How Has This Been Tested?
Not tested yet, broken currently.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Tech debt

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Notes
- [ ] $this->path used to be relative to the view, now absolute!
- [ ] find/provide alternative to "verifyPath"
- [ ] verify that setEtag properly sets etag
- [ ] can $info be null ??
- [ ] retest part file handling with single file storages (quota)
- [ ] retest if checksum is set properly
- [ ] link check plugin / check public webdav security
- [ ] check quota paths
- [ ] double check hook paths
- [ ] The big challenge here is that the node API is always relative to the FS root, so all the node paths look like "/$user/files/path/to/file.txt" while the old ones were relative to "/$user/files". The public API doesn't seem to contain proper methods to get or convert such paths.

Due to the nature of the paths, many things that require relative paths are currently broken like hooks and also move/copy operations.

@DeepDiver1975 @butonic FYI