### PR TITLE
Remove unused $view from FilesPlugin

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -105,20 +105,17 @@ class FilesPlugin extends ServerPlugin {
 
 	/**
 	 * @param Tree $tree
-	 * @param View $view
 	 * @param IConfig $config
 	 * @param IRequest $request
 	 * @param bool $isPublic
 	 * @param bool $downloadAttachment
 	 */
 	public function __construct(Tree $tree,
-								View $view,
 								IConfig $config,
 								IRequest $request,
 								$isPublic = false,
 								$downloadAttachment = true) {
 		$this->tree = $tree;
-		$this->fileView = $view;
 		$this->config = $config;
 		$this->request = $request;
 		$this->isPublic = $isPublic;

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -141,7 +141,6 @@ class ServerFactory {
 			$server->addPlugin(
 				new \OCA\DAV\Connector\Sabre\FilesPlugin(
 					$objectTree,
-					$view,
 					$this->config,
 					$this->request,
 					false,

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -162,7 +162,6 @@ class Server {
 				$this->server->addPlugin(
 					new FilesPlugin(
 						$this->server->tree,
-						$view,
 						\OC::$server->getConfig(),
 						$this->request,
 						false,

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -66,11 +66,6 @@ class FilesPluginTest extends TestCase {
 	private $plugin;
 
 	/**
-	 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject
-	 */
-	private $view;
-
-	/**
 	 * @var \OCP\IConfig | \PHPUnit_Framework_MockObject_MockObject
 	 */
 	private $config;
@@ -88,9 +83,6 @@ class FilesPluginTest extends TestCase {
 		$this->tree = $this->getMockBuilder('\Sabre\DAV\Tree')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->view = $this->getMockBuilder('\OC\Files\View')
-			->disableOriginalConstructor()
-			->getMock();
 		$this->config = $this->createMock('\OCP\IConfig');
 		$this->config->expects($this->any())->method('getSystemValue')
 			->with($this->equalTo('data-fingerprint'), $this->equalTo(''))
@@ -99,7 +91,6 @@ class FilesPluginTest extends TestCase {
 
 		$this->plugin = new FilesPlugin(
 			$this->tree,
-			$this->view,
 			$this->config,
 			$this->request
 		);
@@ -224,7 +215,6 @@ class FilesPluginTest extends TestCase {
 	public function testGetPublicPermissions() {
 		$this->plugin = new FilesPlugin(
 			$this->tree,
-			$this->view,
 			$this->config,
 			$this->createMock('\OCP\IRequest'),
 			true);

--- a/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
@@ -356,7 +356,6 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$this->server->addPlugin(
 			new \OCA\DAV\Connector\Sabre\FilesPlugin(
 				$this->tree,
-				$this->view,
 				$config,
 				$this->createMock('\OCP\IRequest')
 			)


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
The Sabre FilesPlugin never uses the view so remove it.

## Related Issue
None, but found while working on https://github.com/owncloud/core/pull/26548

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [x] TEST: old webdav endpoint still works with PROPFIND
- [x] TEST: new webdav endpoint still works with PROPFIND

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Tech debt

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 @jvillafanez @butonic 