### PR TITLE
Fixed too long text

### DIFF
--- a/core/l10n/ru.json
+++ b/core/l10n/ru.json
@@ -283,7 +283,7 @@
     "Please contact your administrator." : "Пожалуйста, обратитесь к администратору.",
     "An internal error occurred." : "Произошла внутренняя ошибка.",
     "Please try again or contact your administrator." : "Пожалуйста попробуйте ещё раз или свяжитесь с вашим администратором",
-    "Username or email" : "Имя пользователя или Email",
+    "Username or email" : "Логин или Email",
     "Log in" : "Войти",
     "Wrong password. Reset it?" : "Неправильный пароль. Сбросить его?",
     "Wrong password." : "Неправильный пароль.",


### PR DESCRIPTION
## Description
I changed "Username or email" to "Login or Email"

## Motivation and Context
The text "Имя пользователя или Email" does not fit its field. It should be smaller. 

## Screenshots (if appropriate):
http://screencast.com/t/gUkxW86ljm3

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

