### PR TITLE
disabling dropping on dragging objects temporarily

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -379,9 +379,7 @@ var dragOptions={
 			$selectedFiles = $(this);
 		}
 		$selectedFiles.closest('tr').addClass('animate-opacity dragging');
-		if( $selectedFiles.closest('tr').hasClass('ui-droppable') ){
-			$selectedFiles.closest('tr').droppable( 'disable' );
-		}
+		$selectedFiles.closest('tr').filter('.ui-droppable').droppable( 'disable' );
 
 	},
 	stop: function(event, ui) {
@@ -389,12 +387,10 @@ var dragOptions={
 		if (!$selectedFiles.length) {
 			$selectedFiles = $(this);
 		}
+
 		var $tr = $selectedFiles.closest('tr');
 		$tr.removeClass('dragging');
-
-		if( $tr.hasClass('ui-droppable') ){
-			$tr.droppable( 'enable' );
-		}
+		$tr.filter('.ui-droppable').droppable( 'enable' );
 
 		setTimeout(function() {
 			$tr.removeClass('animate-opacity');

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -379,6 +379,10 @@ var dragOptions={
 			$selectedFiles = $(this);
 		}
 		$selectedFiles.closest('tr').addClass('animate-opacity dragging');
+		if( $selectedFiles.closest('tr').hasClass('ui-droppable') ){
+			$selectedFiles.closest('tr').droppable( 'disable' );
+		}
+
 	},
 	stop: function(event, ui) {
 		var $selectedFiles = $('td.filename input:checkbox:checked');
@@ -387,6 +391,11 @@ var dragOptions={
 		}
 		var $tr = $selectedFiles.closest('tr');
 		$tr.removeClass('dragging');
+
+		if( $tr.hasClass('ui-droppable') ){
+			$tr.droppable( 'enable' );
+		}
+
 		setTimeout(function() {
 			$tr.removeClass('animate-opacity');
 		}, 300);
@@ -454,4 +463,3 @@ function fileDownloadPath(dir, file) {
 
 // for backward compatibility
 window.Files = OCA.Files.Files;
-


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
As described in the corresponding issue. Disabling the dropping on the dragged object solves this problem.

## Related Issue
#26554

## Motivation and Context
A error message occured after dropping a folder on its own. 

## How Has This Been Tested?
Chrome (current), Firefox (current) on Ubuntu 16.04
Karma test ok.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


