### PR TITLE
Username autocomplete option in admin menu now also toggles autocomp…

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -212,7 +212,11 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 			$result = [];
 			if (isset($_GET['search'])) {
 				$cm = OC::$server->getContactsManager();
-				if (!is_null($cm) && $cm->isEnabled()) {
+
+				$userEnumerationAllowed = OC::$server->getConfig()
+					->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'no') == 'yes';
+
+				if (!is_null($cm) && $cm->isEnabled() && $userEnumerationAllowed) {
 					$contacts = $cm->search((string)$_GET['search'], ['FN', 'EMAIL']);
 					foreach ($contacts as $contact) {
 						if (!isset($contact['EMAIL'])) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
The "Allow username autocompletion in share dialog" option in the admin menu toggles the auto-completion for the username input while leaving auto-completion behaviour for the email field (share by email) unaffected. This allows user name and e-mail address enumeration which results in a privacy leak in some use-cases 
This fix makes the option also apply for auto-completion on the e-mail field.

![autocomplete_broke](https://cloud.githubusercontent.com/assets/246983/20040594/6350afa6-a45a-11e6-9b3e-a5a73434c049.png)

## Related Issue
#26504 

## Motivation and Context
Fixing potention privacy leak for some users by possible e-mail address enumeration.

## How Has This Been Tested?
- Login as Admin, enable "Allow users to send mail notification for shared files" and "Allow username autocompletion in share dialog."
- Share a file, type something in the e-mail field -> see autocompletion.
- Disable autocompletion in admin menu -> no more autocompletion in the e-mail field.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
