### PR TITLE
Allow renaming part files on perm masked storage

### DIFF
--- a/lib/private/Files/Storage/Wrapper/PermissionsMask.php
+++ b/lib/private/Files/Storage/Wrapper/PermissionsMask.php
@@ -76,8 +76,13 @@ class PermissionsMask extends Wrapper {
 		return $this->storage->getPermissions($path) & $this->mask;
 	}
 
+	private function isPartFile($path) {
+		return pathinfo($path, PATHINFO_EXTENSION) === 'part';
+	}
+
 	public function rename($path1, $path2) {
-		return $this->checkMask(Constants::PERMISSION_UPDATE) and parent::rename($path1, $path2);
+		// allow renaming part files
+		return ($this->isPartFile($path1) || $this->checkMask(Constants::PERMISSION_UPDATE)) && parent::rename($path1, $path2);
 	}
 
 	public function copy($path1, $path2) {
@@ -86,7 +91,7 @@ class PermissionsMask extends Wrapper {
 
 	public function touch($path, $mtime = null) {
 		$permissions = $this->file_exists($path) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
-		return $this->checkMask($permissions) and parent::touch($path, $mtime);
+		return ($this->isPartFile($path) || $this->checkMask($permissions)) && parent::touch($path, $mtime);
 	}
 
 	public function mkdir($path) {
@@ -103,7 +108,7 @@ class PermissionsMask extends Wrapper {
 
 	public function file_put_contents($path, $data) {
 		$permissions = $this->file_exists($path) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
-		return $this->checkMask($permissions) and parent::file_put_contents($path, $data);
+		return ($this->isPartFile($path) || $this->checkMask($permissions)) && parent::file_put_contents($path, $data);
 	}
 
 	public function fopen($path, $mode) {
@@ -111,7 +116,7 @@ class PermissionsMask extends Wrapper {
 			return parent::fopen($path, $mode);
 		} else {
 			$permissions = $this->file_exists($path) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
-			return $this->checkMask($permissions) ? parent::fopen($path, $mode) : false;
+			return ($this->isPartFile($path) || $this->checkMask($permissions)) ? parent::fopen($path, $mode) : false;
 		}
 	}
 

--- a/tests/lib/Files/Storage/Wrapper/PermissionsMaskTest.php
+++ b/tests/lib/Files/Storage/Wrapper/PermissionsMaskTest.php
@@ -102,4 +102,34 @@ class PermissionsMaskTest extends \Test\Files\Storage\Storage {
 		$storage = $this->getMaskedStorage(Constants::PERMISSION_ALL - Constants::PERMISSION_CREATE);
 		$this->assertFalse($storage->fopen('foo', 'w'));
 	}
+
+	public function testRenameExistingFileNoUpdate() {
+		$this->sourceStorage->touch('foo');
+		$storage = $this->getMaskedStorage(Constants::PERMISSION_ALL - Constants::PERMISSION_UPDATE);
+		$this->assertFalse($storage->rename('foo', 'bar'));
+		$this->assertTrue($storage->file_exists('foo'));
+		$this->assertFalse($storage->file_exists('bar'));
+	}
+
+	public function testRenamePartFileNoPerms() {
+		$this->sourceStorage->touch('foo.part');
+		$storage = $this->getMaskedStorage(Constants::PERMISSION_ALL - Constants::PERMISSION_UPDATE - Constants::PERMISSION_CREATE);
+		$this->assertTrue($storage->rename('foo.part', 'bar'));
+		$this->assertFalse($storage->file_exists('foo.part'));
+		$this->assertTrue($storage->file_exists('bar'));
+	}
+
+	public function testFopenPartFileNoPerms() {
+		$storage = $this->getMaskedStorage(Constants::PERMISSION_ALL - Constants::PERMISSION_UPDATE - Constants::PERMISSION_CREATE);
+		$res = $storage->fopen('foo.part', 'w');
+		fwrite($res, 'foo');
+		fclose($res);
+		$this->assertTrue($storage->file_exists('foo.part'));
+	}
+
+	public function testFilePutContentsPartFileNoPerms() {
+		$storage = $this->getMaskedStorage(Constants::PERMISSION_ALL - Constants::PERMISSION_UPDATE - Constants::PERMISSION_CREATE);
+		$this->assertEquals(3, $storage->file_put_contents('foo.part', 'bar'));
+		$this->assertTrue($storage->file_exists('foo.part'));
+	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Allow renaming part files to final file even with only "create" permissions.

## Related Issue
Fixes https://github.com/owncloud/enterprise/issues/1639.
See steps below.

## Motivation and Context
When uploading a file to a storage that has only create permissions, we
still need to rename the part file to the final file in most file
operations. This fix makes that rename possible.

## How Has This Been Tested?

1. Setup two instances OC_A and OC_B
1. Login as "admin@OC_A"
1. Create a folder "test"
1. Share "test" with "admin@OC_B" but only give "can create" permissions, remove everything else
1. Login as "admin@OC_B"
1. Accept the share "test"
1. Upload a file into "/test"

Before the fix: OC_B would display an error (500) and OC_A would say "cannot rename part file to final file" in the log.
After the fix, applied on OC_A: file can be uploaded properly


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

### Backports:
- [x] stable9.1
- other versions not affected

Please review @jvillafanez @PhilippSchaffrath @DeepDiver1975 @butonic 