### PR TITLE
[stable9.1] Transfer ownership only analyze home storage

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -153,6 +153,11 @@ class TransferOwnership extends Command {
 		$this->walkFiles($view, "$this->sourceUser/files",
 				function (FileInfo $fileInfo) use ($progress, $self) {
 					if ($fileInfo->getType() === FileInfo::TYPE_FOLDER) {
+						// only analyze into folders from main storage,
+						// sub-storages have an empty internal path
+						if ($fileInfo->getInternalPath() === '' && $fileInfo->getPath() !== '') {
+							return false;
+						}
 						return true;
 					}
 					$progress->advance();


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/26533 to stable9.1

I have retested this and it works fine.

@DeepDiver1975