### PR TITLE
Override config.php values through ENV variables

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -38,6 +38,9 @@ namespace OC;
  * configuration file of ownCloud.
  */
 class Config {
+
+	const ENV_PREFIX = 'OC_';
+
 	/** @var array Associative array ($key => $value) */
 	protected $cache = [];
 	/** @var string */
@@ -70,15 +73,22 @@ class Config {
 	}
 
 	/**
-	 * Gets a value from config.php
+	 * Returns a config value
 	 *
-	 * If it does not exist, $default will be returned.
+	 * gets its value from an `OC_` prefixed environment variable
+	 * if it doesn't exist from config.php
+	 * if this doesn't exist either, it will return the given `$default`
 	 *
 	 * @param string $key key
 	 * @param mixed $default = null default value
 	 * @return mixed the value or $default
 	 */
 	public function getValue($key, $default = null) {
+		$envKey = self::ENV_PREFIX . $key;
+		if (isset($_ENV[$envKey])) {
+			return $_ENV[$envKey];
+		}
+
 		if (isset($this->cache[$key])) {
 			return $this->cache[$key];
 		}

--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -84,9 +84,9 @@ class Config {
 	 * @return mixed the value or $default
 	 */
 	public function getValue($key, $default = null) {
-		$envKey = self::ENV_PREFIX . $key;
-		if (isset($_ENV[$envKey])) {
-			return $_ENV[$envKey];
+		$envValue = getenv(self::ENV_PREFIX . $key);
+		if ($envValue) {
+			return $envValue;
 		}
 
 		if (isset($this->cache[$key])) {

--- a/tests/lib/ConfigTest.php
+++ b/tests/lib/ConfigTest.php
@@ -48,6 +48,12 @@ class ConfigTest extends TestCase {
 		$this->assertSame(['Appenzeller', 'Guinness', 'Kölsch'], $this->config->getValue('beers'));
 	}
 
+	public function testGetValueReturnsEnvironmentValueIfSet() {
+		$this->assertEquals('bar', $this->config->getValue('foo'));
+		$_ENV['OC_foo'] = 'baz';
+		$this->assertEquals('baz', $this->config->getValue('foo'));
+	}
+
 	public function testSetValue() {
 		$this->config->setValue('foo', 'moo');
 		$expectedConfig = $this->initialConfig;

--- a/tests/lib/ConfigTest.php
+++ b/tests/lib/ConfigTest.php
@@ -50,7 +50,7 @@ class ConfigTest extends TestCase {
 
 	public function testGetValueReturnsEnvironmentValueIfSet() {
 		$this->assertEquals('bar', $this->config->getValue('foo'));
-		$_ENV['OC_foo'] = 'baz';
+		putenv('OC_foo=baz');
 		$this->assertEquals('baz', $this->config->getValue('foo'));
 	}
 


### PR DESCRIPTION
## Description
This enables you to override configuration values with a corresponding environment variable.
Environment variables need to be prefixed with `OC_`. For example to override the `dbname` value, simply set the environment variable `OC_dbname`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
It is very convenient to be able to store sensitive data like database or mail credentials in an environment variable. 

## How Has This Been Tested?
Has been tested manually by using php-webserver like this:

    OC_dbname=owncloud_database_name php -d variables_order=EGPCS -S localhost:8080

and with PhpUnit, tests included.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

