### PR TITLE
share api expanded by tags

### DIFF
--- a/apps/files/ajax/list.php
+++ b/apps/files/ajax/list.php
@@ -70,7 +70,6 @@ try {
 		$files = \OCA\Files\Helper::getFiles($dir, $sortAttribute, $sortDirection);
 	}
 
-	$files = \OCA\Files\Helper::populateTags($files);
 	$data['directory'] = $dir;
 	$data['files'] = \OCA\Files\Helper::formatFileInfos($files);
 	$data['permissions'] = $permissions;

--- a/apps/files/js/tagsplugin.js
+++ b/apps/files/js/tagsplugin.js
@@ -70,7 +70,11 @@
 
 		allowedLists: [
 			'files',
-			'favorites'
+			'favorites',
+			'systemtags',
+			'shares.self',
+			'shares.others',
+			'shares.link'
 		],
 
 		_extendFileActions: function(fileActions) {
@@ -238,4 +242,3 @@
 })(OCA);
 
 OC.Plugins.register('OCA.Files.FileList', OCA.Files.TagsPlugin);
-

--- a/apps/files/lib/Helper.php
+++ b/apps/files/lib/Helper.php
@@ -207,6 +207,7 @@ class Helper {
 	 * Populate the result set with file tags
 	 *
 	 * @param array $fileList
+	 * @param string $fileIdentifier identifier attribute name for values in $fileList
 	 * @return array file list populated with tags
 	 */
 	public static function populateTags(array $fileList, $fileIdentifier = 'fileid') {

--- a/apps/files/lib/Helper.php
+++ b/apps/files/lib/Helper.php
@@ -209,10 +209,10 @@ class Helper {
 	 * @param array $fileList
 	 * @return array file list populated with tags
 	 */
-	public static function populateTags(array $fileList) {
+	public static function populateTags(array $fileList, $fileIdentifier = 'fileid') {
 		$filesById = [];
 		foreach ($fileList as $fileData) {
-			$filesById[$fileData['fileid']] = $fileData;
+			$filesById[$fileData[$fileIdentifier]] = $fileData;
 		}
 		$tagger = \OC::$server->getTagManager()->load('files');
 		$tags = $tagger->getTagsForObjects(array_keys($filesById));
@@ -220,6 +220,21 @@ class Helper {
 			foreach ($tags as $fileId => $fileTags) {
 				$filesById[$fileId]['tags'] = $fileTags;
 			}
+			
+			foreach ($filesById as $key => $fileWithTags) {
+				foreach($fileList as $key2 => $file){
+					if( $file[$fileIdentifier] == $key){
+						$fileList[$key2] = $fileWithTags;
+					}
+				}
+			}
+			
+			foreach ($fileList as $key => $file) {
+				if (!array_key_exists('tags', $file)) {
+					$fileList[$key]['tags'] = [];
+				}
+			}
+			
 		}
 		return $fileList;
 	}

--- a/apps/files/lib/Helper.php
+++ b/apps/files/lib/Helper.php
@@ -216,11 +216,16 @@ class Helper {
 		}
 		$tagger = \OC::$server->getTagManager()->load('files');
 		$tags = $tagger->getTagsForObjects(array_keys($filesById));
+
+		if (!is_array($tags)) {
+			throw new \UnexpectedValueException('$tags must be an array');
+		}
+
 		if ($tags) {
 			foreach ($tags as $fileId => $fileTags) {
 				$filesById[$fileId]['tags'] = $fileTags;
 			}
-			
+
 			foreach ($filesById as $key => $fileWithTags) {
 				foreach($fileList as $key2 => $file){
 					if( $file[$fileIdentifier] == $key){
@@ -228,13 +233,13 @@ class Helper {
 					}
 				}
 			}
-			
+
 			foreach ($fileList as $key => $file) {
 				if (!array_key_exists('tags', $file)) {
 					$fileList[$key]['tags'] = [];
 				}
 			}
-			
+
 		}
 		return $fileList;
 	}

--- a/apps/files/lib/Helper.php
+++ b/apps/files/lib/Helper.php
@@ -222,7 +222,7 @@ class Helper {
 			throw new \UnexpectedValueException('$tags must be an array');
 		}
 
-		if ($tags) {
+		if (!empty($tags)) {
 			foreach ($tags as $fileId => $fileTags) {
 				$filesById[$fileId]['tags'] = $fileTags;
 			}

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -56,7 +56,6 @@
 			if (options && options.linksOnly) {
 				this._linksOnly = true;
 			}
-			OC.Plugins.attach('OCA.Sharing.FileList', this);
 		},
 
 		_renderRow: function() {
@@ -83,7 +82,7 @@
 			// add row with expiration date for link only shares - influenced by _createRow of filelist
 			if (this._linksOnly) {
 				var expirationTimestamp = 0;
-				if(fileData.shares[0].expiration !== null) {
+				if(fileData.shares && fileData.shares[0].expiration !== null) {
 					expirationTimestamp = moment(fileData.shares[0].expiration).valueOf();
 				}
 				$tr.attr('data-expiration', expirationTimestamp);
@@ -170,7 +169,7 @@
 				data: {
 					format: 'json',
 					shared_with_me: !!this._sharedWithUser,
-					show_tags: true
+					include_tags: true
 				},
 				type: 'GET',
 				beforeSend: function(xhr) {
@@ -185,7 +184,7 @@
 					/* jshint camelcase: false */
 					data: {
 						format: 'json',
-						show_tags: true
+						include_tags: true
 					},
 					type: 'GET',
 					beforeSend: function(xhr) {
@@ -240,7 +239,8 @@
 						type: share.type,
 						id: share.file_id,
 						path: OC.dirname(share.mountpoint),
-						permissions: share.permissions
+						permissions: share.permissions,
+						tags: share.tags || []
 					};
 
 					file.shares = [{
@@ -278,7 +278,8 @@
 					var file = {
 						id: share.file_source,
 						icon: OC.MimeType.getIconUrl(share.mimetype),
-						mimetype: share.mimetype
+						mimetype: share.mimetype,
+						tags: share.tags || []
 					};
 					if (share.item_type === 'folder') {
 						file.type = 'dir';

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -169,7 +169,8 @@
 				/* jshint camelcase: false */
 				data: {
 					format: 'json',
-					shared_with_me: !!this._sharedWithUser
+					shared_with_me: !!this._sharedWithUser,
+					show_tags: true
 				},
 				type: 'GET',
 				beforeSend: function(xhr) {
@@ -183,7 +184,8 @@
 					url: OC.linkToOCS('apps/files_sharing/api/v1') + 'remote_shares',
 					/* jshint camelcase: false */
 					data: {
-						format: 'json'
+						format: 'json',
+						show_tags: true
 					},
 					type: 'GET',
 					beforeSend: function(xhr) {

--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -419,7 +419,7 @@ class Share20OCS {
 	 * @param \OCP\Files\File|\OCP\Files\Folder $node
 	 * @return \OC_OCS_Result
 	 */
-	private function getSharedWithMe($node = null) {
+	private function getSharedWithMe($node = null, $showTags) {
 		$userShares = $this->shareManager->getSharedWith($this->currentUser->getUID(), \OCP\Share::SHARE_TYPE_USER, $node, -1, 0);
 		$groupShares = $this->shareManager->getSharedWith($this->currentUser->getUID(), \OCP\Share::SHARE_TYPE_GROUP, $node, -1, 0);
 
@@ -434,6 +434,10 @@ class Share20OCS {
 					// Ignore this share
 				}
 			}
+		}
+
+		if ($showTags) {
+			$formatted = \OCA\Files\Helper::populateTags($formatted, 'file_source');
 		}
 
 		return new \OC_OCS_Result($formatted);
@@ -492,6 +496,8 @@ class Share20OCS {
 		$reshares = $this->request->getParam('reshares', null);
 		$subfiles = $this->request->getParam('subfiles');
 		$path = $this->request->getParam('path', null);
+		
+		$showTags = $this->request->getParam('show_tags', false);
 
 		if ($path !== null) {
 			$userFolder = $this->rootFolder->getUserFolder($this->currentUser->getUID());
@@ -506,7 +512,7 @@ class Share20OCS {
 		}
 
 		if ($sharedWithMe === 'true') {
-			$result = $this->getSharedWithMe($path);
+			$result = $this->getSharedWithMe($path, $showTags);
 			if ($path !== null) {
 				$path->unlock(ILockingProvider::LOCK_SHARED);
 			}
@@ -546,7 +552,11 @@ class Share20OCS {
 				//Ignore share
 			}
 		}
-
+		
+		if ($showTags) {
+			$formatted = \OCA\Files\Helper::populateTags($formatted, 'file_source');
+		}
+		
 		if ($path !== null) {
 			$path->unlock(ILockingProvider::LOCK_SHARED);
 		}

--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -417,6 +417,7 @@ class Share20OCS {
 
 	/**
 	 * @param \OCP\Files\File|\OCP\Files\Folder $node
+	 * @param boolean $includeTags 
 	 * @return \OC\OCS\Result
 	 */
 	private function getSharedWithMe($node = null, $includeTags) {

--- a/apps/files_sharing/tests/API/Share20OCSTest.php
+++ b/apps/files_sharing/tests/API/Share20OCSTest.php
@@ -138,7 +138,7 @@ class Share20OCSTest extends \Test\TestCase {
 
 		$this->shareManager->method('outgoingServer2ServerSharesAllowed')->willReturn(true);
 
-		$expected = new \OC_OCS_Result(null, 404, 'Wrong share ID, share doesn\'t exist');
+		$expected = new \OC\OCS\Result(null, 404, 'Wrong share ID, share doesn\'t exist');
 		$this->assertEquals($expected, $this->ocs->deleteShare(42));
 	}
 
@@ -165,7 +165,7 @@ class Share20OCSTest extends \Test\TestCase {
 			->method('unlock')
 			->with(\OCP\Lock\ILockingProvider::LOCK_SHARED);
 
-		$expected = new \OC_OCS_Result();
+		$expected = new \OC\OCS\Result();
 		$this->assertEquals($expected, $this->ocs->deleteShare(42));
 	}
 
@@ -193,7 +193,7 @@ class Share20OCSTest extends \Test\TestCase {
 			->method('unlock')
 			->with(\OCP\Lock\ILockingProvider::LOCK_SHARED);
 
-		$expected = new \OC_OCS_Result(null, 404, 'could not delete share');
+		$expected = new \OC\OCS\Result(null, 404, 'could not delete share');
 		$this->assertEquals($expected, $this->ocs->deleteShare(42));
 	}
 
@@ -207,7 +207,7 @@ class Share20OCSTest extends \Test\TestCase {
 			->with('ocinternal:42')
 			->will($this->throwException(new \OC\Share20\Exception\ShareNotFound()));
 
-		$expected = new \OC_OCS_Result(null, 404, 'wrong share ID, share doesn\'t exist.');
+		$expected = new \OC\OCS\Result(null, 404, 'wrong share ID, share doesn\'t exist.');
 		$this->assertEquals($expected, $this->ocs->getShare(42));
 	}
 	*/
@@ -471,7 +471,7 @@ class Share20OCSTest extends \Test\TestCase {
 			['group', $group],
 		]));
 
-		$expected = new \OC_OCS_Result([$result]);
+		$expected = new \OC\OCS\Result([$result]);
 		$this->assertEquals($expected->getData(), $ocs->getShare($share->getId())->getData());
 	}
 
@@ -487,7 +487,7 @@ class Share20OCSTest extends \Test\TestCase {
 			->with('ocinternal:42')
 			->willReturn($share);
 
-		$expected = new \OC_OCS_Result(null, 404, 'Wrong share ID, share doesn\'t exist');
+		$expected = new \OC\OCS\Result(null, 404, 'Wrong share ID, share doesn\'t exist');
 		$this->assertEquals($expected->getMeta(), $this->ocs->getShare(42)->getMeta());
 	}
 
@@ -539,7 +539,7 @@ class Share20OCSTest extends \Test\TestCase {
 	}
 
 	public function testCreateShareNoPath() {
-		$expected = new \OC_OCS_Result(null, 404, 'Please specify a file or folder path');
+		$expected = new \OC\OCS\Result(null, 404, 'Please specify a file or folder path');
 
 		$result = $this->ocs->createShare();
 
@@ -565,7 +565,7 @@ class Share20OCSTest extends \Test\TestCase {
 			->with('invalid-path')
 			->will($this->throwException(new \OCP\Files\NotFoundException()));
 
-		$expected = new \OC_OCS_Result(null, 404, 'Wrong path, file/folder doesn\'t exist');
+		$expected = new \OC\OCS\Result(null, 404, 'Wrong path, file/folder doesn\'t exist');
 
 		$result = $this->ocs->createShare();
 
@@ -600,7 +600,7 @@ class Share20OCSTest extends \Test\TestCase {
 			->method('lock')
 			->with(\OCP\Lock\ILockingProvider::LOCK_SHARED);
 
-		$expected = new \OC_OCS_Result(null, 404, 'invalid permissions');
+		$expected = new \OC\OCS\Result(null, 404, 'invalid permissions');
 
 		$result = $this->ocs->createShare();
 
@@ -641,7 +641,7 @@ class Share20OCSTest extends \Test\TestCase {
 			->method('lock')
 			->with(\OCP\Lock\ILockingProvider::LOCK_SHARED);
 
-		$expected = new \OC_OCS_Result(null, 404, 'Please specify a valid user');
+		$expected = new \OC\OCS\Result(null, 404, 'Please specify a valid user');
 
 		$result = $this->ocs->createShare();
 
@@ -679,7 +679,7 @@ class Share20OCSTest extends \Test\TestCase {
 			->with('valid-path')
 			->willReturn($path);
 
-		$expected = new \OC_OCS_Result(null, 404, 'Please specify a valid user');
+		$expected = new \OC\OCS\Result(null, 404, 'Please specify a valid user');
 
 		$path->expects($this->once())
 			->method('lock')
@@ -757,7 +757,7 @@ class Share20OCSTest extends \Test\TestCase {
 			}))
 			->will($this->returnArgument(0));
 
-		$expected = new \OC_OCS_Result();
+		$expected = new \OC\OCS\Result();
 		$result = $ocs->createShare();
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -795,7 +795,7 @@ class Share20OCSTest extends \Test\TestCase {
 				->with('valid-path')
 				->willReturn($path);
 
-		$expected = new \OC_OCS_Result(null, 404, 'Please specify a valid user');
+		$expected = new \OC\OCS\Result(null, 404, 'Please specify a valid user');
 
 		$path->expects($this->once())
 			->method('lock')
@@ -873,7 +873,7 @@ class Share20OCSTest extends \Test\TestCase {
 			}))
 			->will($this->returnArgument(0));
 
-		$expected = new \OC_OCS_Result();
+		$expected = new \OC\OCS\Result();
 		$result = $ocs->createShare();
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -916,7 +916,7 @@ class Share20OCSTest extends \Test\TestCase {
 			->method('allowGroupSharing')
 			->willReturn(false);
 
-		$expected = new \OC_OCS_Result(null, 404, 'Group sharing is disabled by the administrator');
+		$expected = new \OC\OCS\Result(null, 404, 'Group sharing is disabled by the administrator');
 
 		$result = $this->ocs->createShare();
 
@@ -943,7 +943,7 @@ class Share20OCSTest extends \Test\TestCase {
 
 		$this->shareManager->method('newShare')->willReturn(\OC::$server->getShareManager()->newShare());
 
-		$expected = new \OC_OCS_Result(null, 404, 'Public link sharing is disabled by the administrator');
+		$expected = new \OC\OCS\Result(null, 404, 'Public link sharing is disabled by the administrator');
 		$result = $this->ocs->createShare();
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -971,7 +971,7 @@ class Share20OCSTest extends \Test\TestCase {
 		$this->shareManager->method('newShare')->willReturn(\OC::$server->getShareManager()->newShare());
 		$this->shareManager->method('shareApiAllowLinks')->willReturn(true);
 
-		$expected = new \OC_OCS_Result(null, 403, 'Public upload disabled by the administrator');
+		$expected = new \OC\OCS\Result(null, 403, 'Public upload disabled by the administrator');
 		$result = $this->ocs->createShare();
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1000,7 +1000,7 @@ class Share20OCSTest extends \Test\TestCase {
 		$this->shareManager->method('shareApiAllowLinks')->willReturn(true);
 		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
 
-		$expected = new \OC_OCS_Result(null, 404, 'Public upload is only possible for publicly shared folders');
+		$expected = new \OC\OCS\Result(null, 404, 'Public upload is only possible for publicly shared folders');
 		$result = $this->ocs->createShare();
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1044,7 +1044,7 @@ class Share20OCSTest extends \Test\TestCase {
 			})
 		)->will($this->returnArgument(0));
 
-		$expected = new \OC_OCS_Result(null);
+		$expected = new \OC\OCS\Result(null);
 		$result = $ocs->createShare();
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1088,7 +1088,7 @@ class Share20OCSTest extends \Test\TestCase {
 			})
 		)->will($this->returnArgument(0));
 
-		$expected = new \OC_OCS_Result(null);
+		$expected = new \OC\OCS\Result(null);
 		$result = $ocs->createShare();
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1135,7 +1135,7 @@ class Share20OCSTest extends \Test\TestCase {
 			})
 		)->will($this->returnArgument(0));
 
-		$expected = new \OC_OCS_Result(null);
+		$expected = new \OC\OCS\Result(null);
 		$result = $ocs->createShare();
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1168,7 +1168,7 @@ class Share20OCSTest extends \Test\TestCase {
 		$this->shareManager->method('shareApiAllowLinks')->willReturn(true);
 		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
 
-		$expected = new \OC_OCS_Result(null, 404, 'Invalid date, date format must be YYYY-MM-DD');
+		$expected = new \OC\OCS\Result(null, 404, 'Invalid date, date format must be YYYY-MM-DD');
 		$result = $ocs->createShare();
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1247,7 +1247,7 @@ class Share20OCSTest extends \Test\TestCase {
 
 		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
 
-		$expected = new \OC_OCS_Result(null, 404, 'Wrong share ID, share doesn\'t exist');
+		$expected = new \OC\OCS\Result(null, 404, 'Wrong share ID, share doesn\'t exist');
 		$result = $this->ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1268,7 +1268,7 @@ class Share20OCSTest extends \Test\TestCase {
 
 		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
 
-		$expected = new \OC_OCS_Result(null, 400, 'Wrong or no update parameter given');
+		$expected = new \OC\OCS\Result(null, 400, 'Wrong or no update parameter given');
 		$result = $this->ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1289,7 +1289,7 @@ class Share20OCSTest extends \Test\TestCase {
 
 		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
 
-		$expected = new \OC_OCS_Result(null, 400, 'Wrong or no update parameter given');
+		$expected = new \OC\OCS\Result(null, 400, 'Wrong or no update parameter given');
 		$result = $this->ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1334,7 +1334,7 @@ class Share20OCSTest extends \Test\TestCase {
 			})
 		)->will($this->returnArgument(0));
 
-		$expected = new \OC_OCS_Result(null);
+		$expected = new \OC\OCS\Result(null);
 		$result = $ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1374,7 +1374,7 @@ class Share20OCSTest extends \Test\TestCase {
 			})
 		)->will($this->returnArgument(0));
 
-		$expected = new \OC_OCS_Result(null);
+		$expected = new \OC\OCS\Result(null);
 		$result = $ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1412,7 +1412,7 @@ class Share20OCSTest extends \Test\TestCase {
 			})
 		)->will($this->returnArgument(0));
 
-		$expected = new \OC_OCS_Result(null);
+		$expected = new \OC\OCS\Result(null);
 		$result = $ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1441,7 +1441,7 @@ class Share20OCSTest extends \Test\TestCase {
 		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
 		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
 
-		$expected = new \OC_OCS_Result(null, 400, 'Invalid date. Format must be YYYY-MM-DD');
+		$expected = new \OC\OCS\Result(null, 400, 'Invalid date. Format must be YYYY-MM-DD');
 		$result = $ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1489,7 +1489,7 @@ class Share20OCSTest extends \Test\TestCase {
 		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
 		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(false);
 
-		$expected = new \OC_OCS_Result(null, 403, 'Public upload disabled by the administrator');
+		$expected = new \OC\OCS\Result(null, 403, 'Public upload disabled by the administrator');
 		$result = $ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1518,7 +1518,7 @@ class Share20OCSTest extends \Test\TestCase {
 		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
 		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
 
-		$expected = new \OC_OCS_Result(null, 400, 'Public upload is only possible for publicly shared folders');
+		$expected = new \OC\OCS\Result(null, 400, 'Public upload is only possible for publicly shared folders');
 		$result = $ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1564,7 +1564,7 @@ class Share20OCSTest extends \Test\TestCase {
 			})
 		)->will($this->returnArgument(0));
 
-		$expected = new \OC_OCS_Result(null);
+		$expected = new \OC\OCS\Result(null);
 		$result = $ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1610,7 +1610,7 @@ class Share20OCSTest extends \Test\TestCase {
 			})
 		)->will($this->returnArgument(0));
 
-		$expected = new \OC_OCS_Result(null);
+		$expected = new \OC\OCS\Result(null);
 		$result = $ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1650,7 +1650,7 @@ class Share20OCSTest extends \Test\TestCase {
 			})
 		)->will($this->returnArgument(0));
 
-		$expected = new \OC_OCS_Result(null);
+		$expected = new \OC\OCS\Result(null);
 		$result = $ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1692,7 +1692,7 @@ class Share20OCSTest extends \Test\TestCase {
 
 		$this->shareManager->method('getSharedWith')->willReturn([]);
 
-		$expected = new \OC_OCS_Result(null);
+		$expected = new \OC\OCS\Result(null);
 		$result = $ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1724,7 +1724,7 @@ class Share20OCSTest extends \Test\TestCase {
 		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
 		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
 
-		$expected = new \OC_OCS_Result(null, 400, 'Can\'t change permissions for public share links');
+		$expected = new \OC\OCS\Result(null, 400, 'Can\'t change permissions for public share links');
 		$result = $ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1759,7 +1759,7 @@ class Share20OCSTest extends \Test\TestCase {
 
 		$this->shareManager->method('getSharedWith')->willReturn([]);
 
-		$expected = new \OC_OCS_Result(null);
+		$expected = new \OC\OCS\Result(null);
 		$result = $ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1812,7 +1812,7 @@ class Share20OCSTest extends \Test\TestCase {
 
 		$this->shareManager->expects($this->never())->method('updateShare');
 
-		$expected = new \OC_OCS_Result(null, 404, 'Cannot increase permissions');
+		$expected = new \OC\OCS\Result(null, 404, 'Cannot increase permissions');
 		$result = $ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -1868,7 +1868,7 @@ class Share20OCSTest extends \Test\TestCase {
 			->with($share)
 			->willReturn($share);
 
-		$expected = new \OC_OCS_Result();
+		$expected = new \OC\OCS\Result();
 		$result = $ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -2227,7 +2227,7 @@ class Share20OCSTest extends \Test\TestCase {
 	public function testGetShareApiDisabled() {
 		$ocs = $this->getOcsDisabledAPI();
 
-		$expected = new \OC_OCS_Result(null, 404, 'Share API is disabled');
+		$expected = new \OC\OCS\Result(null, 404, 'Share API is disabled');
 		$result = $ocs->getShare('my:id');
 
 		$this->assertEquals($expected, $result);
@@ -2236,7 +2236,7 @@ class Share20OCSTest extends \Test\TestCase {
 	public function testDeleteShareApiDisabled() {
 		$ocs = $this->getOcsDisabledAPI();
 
-		$expected = new \OC_OCS_Result(null, 404, 'Share API is disabled');
+		$expected = new \OC\OCS\Result(null, 404, 'Share API is disabled');
 		$result = $ocs->deleteShare('my:id');
 
 		$this->assertEquals($expected, $result);
@@ -2246,7 +2246,7 @@ class Share20OCSTest extends \Test\TestCase {
 	public function testCreateShareApiDisabled() {
 		$ocs = $this->getOcsDisabledAPI();
 
-		$expected = new \OC_OCS_Result(null, 404, 'Share API is disabled');
+		$expected = new \OC\OCS\Result(null, 404, 'Share API is disabled');
 		$result = $ocs->createShare();
 
 		$this->assertEquals($expected, $result);
@@ -2255,7 +2255,7 @@ class Share20OCSTest extends \Test\TestCase {
 	public function testGetSharesApiDisabled() {
 		$ocs = $this->getOcsDisabledAPI();
 
-		$expected = new \OC_OCS_Result();
+		$expected = new \OC\OCS\Result();
 		$result = $ocs->getShares();
 
 		$this->assertEquals($expected, $result);
@@ -2264,7 +2264,7 @@ class Share20OCSTest extends \Test\TestCase {
 	public function testUpdateShareApiDisabled() {
 		$ocs = $this->getOcsDisabledAPI();
 
-		$expected = new \OC_OCS_Result(null, 404, 'Share API is disabled');
+		$expected = new \OC\OCS\Result(null, 404, 'Share API is disabled');
 		$result = $ocs->updateShare('my:id');
 
 		$this->assertEquals($expected, $result);

--- a/apps/files_sharing/tests/js/sharedfilelistSpec.js
+++ b/apps/files_sharing/tests/js/sharedfilelistSpec.js
@@ -48,6 +48,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			'<div id="emptycontent">Empty content message</div>' +
 			'</div>'
 		);
+
+		OC.Plugins.register('OCA.Files.FileList', OCA.Files.TagsPlugin);
 	});
 	afterEach(function() {
 		testFiles = undefined;
@@ -93,6 +95,7 @@ describe('OCA.Sharing.FileList tests', function() {
 						share_type: OC.Share.SHARE_TYPE_USER,
 						share_with: 'user1',
 						share_with_displayname: 'User One',
+						tags: [OC.TAG_FAVORITE],
 						mimetype: 'text/plain',
 						uid_owner: 'user2',
 						displayname_owner: 'User Two'
@@ -133,12 +136,12 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect(fakeServer.requests.length).toEqual(2);
 			expect(fakeServer.requests[0].url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=true&show_tags=true'
+				'shares?format=json&shared_with_me=true&include_tags=true'
 			);
 
 			expect(fakeServer.requests[1].url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'remote_shares?format=json&show_tags=true'
+				'remote_shares?format=json&include_tags=true'
 			);
 
 			fakeServer.requests[0].respond(
@@ -167,6 +170,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-mtime')).toEqual('11111000');
 			expect($tr.attr('data-share-owner')).toEqual('User Two');
 			expect($tr.attr('data-share-id')).toEqual('7');
+			expect($tr.attr('data-favorite')).toEqual('true');
+			expect($tr.attr('data-tags')).toEqual(OC.TAG_FAVORITE);
 			expect($tr.find('a.name').attr('href')).toEqual(
 				OC.webroot +
 				'/remote.php/webdav/local%20path/local%20name.txt'
@@ -185,6 +190,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-mtime')).toEqual('22222000');
 			expect($tr.attr('data-share-owner')).toEqual('user3@foo.bar/');
 			expect($tr.attr('data-share-id')).toEqual('8');
+			expect($tr.attr('data-favorite')).not.toBeDefined();
+			expect($tr.attr('data-tags')).toEqual('');
 			expect($tr.find('a.name').attr('href')).toEqual(
 				OC.webroot +
 				'/remote.php/webdav/b.txt'
@@ -209,11 +216,11 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect(fakeServer.requests.length).toEqual(2);
 			expect(fakeServer.requests[0].url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=true&show_tags=true'
+				'shares?format=json&shared_with_me=true&include_tags=true'
 			);
 			expect(fakeServer.requests[1].url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'remote_shares?format=json&show_tags=true'
+				'remote_shares?format=json&include_tags=true'
 			);
 
 			fakeServer.requests[0].respond(
@@ -241,6 +248,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-mtime')).toEqual('11111000');
 			expect($tr.attr('data-share-owner')).toEqual('User Two');
 			expect($tr.attr('data-share-id')).toEqual('7');
+			expect($tr.attr('data-favorite')).toEqual('true');
+			expect($tr.attr('data-tags')).toEqual(OC.TAG_FAVORITE);
 			expect($tr.find('a.name').attr('href')).toEqual(
 				OC.webroot +
 				'/index.php/apps/files' +
@@ -260,6 +269,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-mtime')).toEqual('22222000');
 			expect($tr.attr('data-share-owner')).toEqual('user3@foo.bar/');
 			expect($tr.attr('data-share-id')).toEqual('8');
+			expect($tr.attr('data-favorite')).not.toBeDefined();
+			expect($tr.attr('data-tags')).toEqual('');
 			expect($tr.find('a.name').attr('href')).toEqual(
 				OC.webroot +
 				'/index.php/apps/files' +
@@ -301,6 +312,7 @@ describe('OCA.Sharing.FileList tests', function() {
 						share_type: OC.Share.SHARE_TYPE_USER,
 						share_with: 'user2',
 						share_with_displayname: 'User Two',
+						tags: [OC.TAG_FAVORITE],
 						mimetype: 'text/plain',
 						uid_owner: 'user1',
 						displayname_owner: 'User One'
@@ -315,7 +327,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			request = fakeServer.requests[0];
 			expect(request.url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=false&show_tags=true'
+				'shares?format=json&shared_with_me=false&include_tags=true'
 			);
 
 			fakeServer.requests[0].respond(
@@ -337,6 +349,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-mtime')).toEqual('11111000');
 			expect($tr.attr('data-share-owner')).not.toBeDefined();
 			expect($tr.attr('data-share-id')).toEqual('7');
+			expect($tr.attr('data-favorite')).toEqual('true');
+			expect($tr.attr('data-tags')).toEqual(OC.TAG_FAVORITE);
 			expect($tr.find('a.name').attr('href')).toEqual(
 				OC.webroot +
 				'/remote.php/webdav/local%20path/local%20name.txt'
@@ -355,7 +369,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			request = fakeServer.requests[0];
 			expect(request.url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=false&show_tags=true'
+				'shares?format=json&shared_with_me=false&include_tags=true'
 			);
 
 			fakeServer.requests[0].respond(
@@ -377,6 +391,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-mtime')).toEqual('11111000');
 			expect($tr.attr('data-share-owner')).not.toBeDefined();
 			expect($tr.attr('data-share-id')).toEqual('7');
+			expect($tr.attr('data-favorite')).toEqual('true');
+			expect($tr.attr('data-tags')).toEqual(OC.TAG_FAVORITE);
 			expect($tr.find('a.name').attr('href')).toEqual(
 				OC.webroot +
 				'/index.php/apps/files' +
@@ -400,13 +416,14 @@ describe('OCA.Sharing.FileList tests', function() {
 				token: 'abc',
 				mimetype: 'text/plain',
 				uid_owner: 'user1',
-				displayname_owner: 'User One'
+				displayname_owner: 'User One',
+				tags: [OC.TAG_FAVORITE]
 			};
 			expect(fakeServer.requests.length).toEqual(1);
 			request = fakeServer.requests[0];
 			expect(request.url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=false&show_tags=true'
+				'shares?format=json&shared_with_me=false&include_tags=true'
 			);
 
 			fakeServer.requests[0].respond(
@@ -428,6 +445,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-mtime')).toEqual('11111000');
 			expect($tr.attr('data-share-owner')).not.toBeDefined();
 			expect($tr.attr('data-share-id')).toEqual('7');
+			expect($tr.attr('data-favorite')).toEqual('true');
+			expect($tr.attr('data-tags')).toEqual(OC.TAG_FAVORITE);
 			expect($tr.find('a.name').attr('href')).toEqual(
 				OC.webroot + '/remote.php/webdav/local%20path/local%20name.txt'
 			);
@@ -451,7 +470,8 @@ describe('OCA.Sharing.FileList tests', function() {
 				token: 'abc',
 				mimetype: 'text/plain',
 				uid_owner: 'user1',
-				displayname_owner: 'User One'
+				displayname_owner: 'User One',
+				tags: [OC.TAG_FAVORITE],
 			});
 			// another share of the same file
 			ocsResponse.ocs.data.push({
@@ -473,7 +493,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			request = fakeServer.requests[0];
 			expect(request.url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=false&show_tags=true'
+				'shares?format=json&shared_with_me=false&include_tags=true'
 			);
 
 			fakeServer.requests[0].respond(
@@ -496,6 +516,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-mtime')).toEqual('22222000');
 			expect($tr.attr('data-share-owner')).not.toBeDefined();
 			expect($tr.attr('data-share-id')).toEqual('7,8,9');
+			expect($tr.attr('data-favorite')).toEqual('true');
+			expect($tr.attr('data-tags')).toEqual(OC.TAG_FAVORITE);
 			expect($tr.find('a.name').attr('href')).toEqual(
 				OC.webroot + '/remote.php/webdav/local%20path/local%20name.txt'
 			);
@@ -540,7 +562,8 @@ describe('OCA.Sharing.FileList tests', function() {
 						token: 'abc',
 						mimetype: 'text/plain',
 						uid_owner: 'user1',
-						displayname_owner: 'User One'
+						displayname_owner: 'User One',
+						tags: [OC.TAG_FAVORITE]
 					},{
 						id: 8,
 						item_type: 'file',
@@ -577,13 +600,14 @@ describe('OCA.Sharing.FileList tests', function() {
 				share_with_displayname: 'User Two',
 				mimetype: 'text/plain',
 				uid_owner: 'user1',
-				displayname_owner: 'User One'
+				displayname_owner: 'User One',
+				tags: [OC.TAG_FAVORITE]
 			});
 			expect(fakeServer.requests.length).toEqual(1);
 			request = fakeServer.requests[0];
 			expect(request.url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=false&show_tags=true'
+				'shares?format=json&shared_with_me=false&include_tags=true'
 			);
 
 			fakeServer.requests[0].respond(
@@ -607,6 +631,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-share-recipients')).not.toBeDefined();
 			expect($tr.attr('data-share-owner')).not.toBeDefined();
 			expect($tr.attr('data-share-id')).toEqual('7');
+			expect($tr.attr('data-favorite')).toEqual('true');
+			expect($tr.attr('data-tags')).toEqual(OC.TAG_FAVORITE);
 			expect($tr.find('a.name').attr('href')).toEqual(
 				OC.webroot + '/remote.php/webdav/local%20path/local%20name.txt'
 			);
@@ -620,6 +646,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-id')).toEqual('50');
 			expect($tr.attr('data-file')).toEqual('local name2.txt');
 			expect($tr.attr('data-expiration')).not.toEqual('0');
+			expect($tr.attr('data-favorite')).not.toBeDefined();
+			expect($tr.attr('data-tags')).toEqual('');
 			expect($tr.find('td:last-child span').text()).toEqual('in a day');
 		});
 		it('does not show virtual token recipient as recipient when password was set', function() {
@@ -632,7 +660,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			request = fakeServer.requests[0];
 			expect(request.url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=false&show_tags=true'
+				'shares?format=json&shared_with_me=false&include_tags=true'
 			);
 
 			fakeServer.requests[0].respond(
@@ -656,6 +684,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-share-recipients')).not.toBeDefined();
 			expect($tr.attr('data-share-owner')).not.toBeDefined();
 			expect($tr.attr('data-share-id')).toEqual('7');
+			expect($tr.attr('data-favorite')).toEqual('true');
+			expect($tr.attr('data-tags')).toEqual(OC.TAG_FAVORITE);
 			expect($tr.find('a.name').attr('href')).toEqual(
 					OC.webroot +
 					'/remote.php/webdav/local%20path/local%20name.txt');

--- a/apps/files_sharing/tests/js/sharedfilelistSpec.js
+++ b/apps/files_sharing/tests/js/sharedfilelistSpec.js
@@ -133,12 +133,12 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect(fakeServer.requests.length).toEqual(2);
 			expect(fakeServer.requests[0].url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=true'
+				'shares?format=json&shared_with_me=true&show_tags=true'
 			);
 
 			expect(fakeServer.requests[1].url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'remote_shares?format=json'
+				'remote_shares?format=json&show_tags=true'
 			);
 
 			fakeServer.requests[0].respond(
@@ -150,7 +150,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			fakeServer.requests[1].respond(
 				200,
 				{ 'Content-Type': 'application/json' },
-				JSON.stringify(ocsResponseRemote)			
+				JSON.stringify(ocsResponseRemote)
 			);
 
 			var $rows = fileList.$el.find('tbody tr');
@@ -209,11 +209,11 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect(fakeServer.requests.length).toEqual(2);
 			expect(fakeServer.requests[0].url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=true'
+				'shares?format=json&shared_with_me=true&show_tags=true'
 			);
 			expect(fakeServer.requests[1].url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'remote_shares?format=json'
+				'remote_shares?format=json&show_tags=true'
 			);
 
 			fakeServer.requests[0].respond(
@@ -315,7 +315,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			request = fakeServer.requests[0];
 			expect(request.url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=false'
+				'shares?format=json&shared_with_me=false&show_tags=true'
 			);
 
 			fakeServer.requests[0].respond(
@@ -355,7 +355,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			request = fakeServer.requests[0];
 			expect(request.url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=false'
+				'shares?format=json&shared_with_me=false&show_tags=true'
 			);
 
 			fakeServer.requests[0].respond(
@@ -406,7 +406,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			request = fakeServer.requests[0];
 			expect(request.url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=false'
+				'shares?format=json&shared_with_me=false&show_tags=true'
 			);
 
 			fakeServer.requests[0].respond(
@@ -473,7 +473,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			request = fakeServer.requests[0];
 			expect(request.url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=false'
+				'shares?format=json&shared_with_me=false&show_tags=true'
 			);
 
 			fakeServer.requests[0].respond(
@@ -583,7 +583,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			request = fakeServer.requests[0];
 			expect(request.url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=false'
+				'shares?format=json&shared_with_me=false&show_tags=true'
 			);
 
 			fakeServer.requests[0].respond(
@@ -632,7 +632,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			request = fakeServer.requests[0];
 			expect(request.url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=false'
+				'shares?format=json&shared_with_me=false&show_tags=true'
 			);
 
 			fakeServer.requests[0].respond(


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Modification of the share api. The share api adds the file tags to the response if "show_tags" is existing and has a positive value in the request.

**Attention**: This Issue is not solved yet by this first commits. Additional information is needed. I'm also not yet confident with the naming conventions at all.

1) Is the request parameter name "show_tags" ok?

2) Check the modified populateTags() function. That function was only used in the /apps/files/ajax/list.php
2a) Is that list.php still needed?
2b) How can this file be tested?
2c) The populateTags() function returned the same value as passed by as parameter. Did this function really do its job correct?

3) Should it be/Is it possible to mark remote shares as favorite?

4) The favorite indicator should be shown in the share views. The tags can now be retrieved by the share api. Do you think my approach regarding adding the entries to the _allowedList_ (see #26437) would be ok by now

5) Is 'file_source' the correct field to identify the object in shares?

Additional Tests have to be added. I will do this when all questions have been answered.

## Related Issue
#19753

#19753 should be done before #26437

## Motivation and Context
The share views should be enhanced by the favorite indicator and actions. 

## How Has This Been Tested?
By simple api calls.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


