### PR TITLE
Add integration test stage with encryption enabled

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,6 +113,14 @@ timestampedNode('SLAVE') {
 			make test-integration
            '''
         }
+        executeAndReport('build/integration/output/*.xml') {
+            sh '''phpenv local 7.0
+            rm -rf config/config.php
+            ./occ maintenance:install --admin-pass=admin
+			make clean-test-integration
+			make test-integration ENCRYPTION_ENABLED=1
+           '''
+        }
 }
 
 void executeAndReport(String testResultLocation, def body) {

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ test-js: $(nodejs_deps) $(js_deps) $(core_vendor)
 
 .PHONY: test-integration
 test-integration: $(composer_dev_deps)
-	$(MAKE) -C build/integration
+	$(MAKE) -C build/integration ENCRYPTION_ENABLED=$(ENCRYPTION_ENABLED)
 
 .PHONY: test-php-lint
 test-php-lint: $(composer_dev_deps)

--- a/build/integration/Makefile
+++ b/build/integration/Makefile
@@ -22,5 +22,5 @@ clean-test-results:
 clean: clean-test-results clean-composer-deps
 
 test: install-composer-deps
-	./run.sh
+	ENCRYPTION_ENABLED=$(ENCRYPTION_ENABLED) ./run.sh
 

--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -276,6 +276,7 @@ Feature: provisioning
 		And the HTTP status code should be "200"
 		And group "España" does not exist
 
+	@no_encryption
 	Scenario: get enabled apps
 		Given As an "admin"
 		When sending "GET" to "/cloud/apps?filter=enabled"

--- a/build/integration/features/transfer-ownership.feature
+++ b/build/integration/features/transfer-ownership.feature
@@ -1,5 +1,6 @@
 Feature: transfer-ownership
 
+	@no_encryption
 	Scenario: transfering ownership of a file
 		Given user "user0" exists
 		And user "user1" exists
@@ -10,6 +11,7 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then Downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_encryption
 	Scenario: transfering ownership of a folder
 		Given user "user0" exists
 		And user "user1" exists
@@ -21,6 +23,7 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_encryption
 	Scenario: transfering ownership of file shares
 		Given user "user0" exists
 		And user "user1" exists
@@ -32,6 +35,7 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_encryption
 	Scenario: transfering ownership of folder shared with third user
 		Given user "user0" exists
 		And user "user1" exists
@@ -44,6 +48,7 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_encryption
 	Scenario: transfering ownership of folder shared with transfer recipient
 		Given user "user0" exists
 		And user "user1" exists
@@ -57,6 +62,7 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		And Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_encryption
 	Scenario: transfering ownership of folder doubly shared with third user
 		Given group "group1" exists
 		And user "user0" exists
@@ -72,6 +78,7 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_encryption
 	Scenario: transfering ownership does not transfer received shares
 		Given user "user0" exists
 		And user "user1" exists
@@ -84,6 +91,7 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then as "user1" the folder "/test" does not exist
 
+	@no_encryption
 	@local_storage
 	Scenario: transfering ownership does not transfer external storage
 		Given user "user0" exists
@@ -94,6 +102,7 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then as "user1" the folder "/local_storage" does not exist
 
+	@no_encryption
 	Scenario: transfering ownership does not fail with shared trashed files
 		Given user "user0" exists
 		And user "user1" exists

--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -31,7 +31,7 @@ export TEST_SERVER_FED_URL="http://localhost:$PORT_FED/ocs/"
 #Enable external storage app
 $OCC app:enable files_external
 
-mkdir -p work/local_storage
+mkdir -p work/local_storage || { echo "Unable to create work folder" >&2; exit 1; }
 OUTPUT_CREATE_STORAGE=`$OCC files_external:create local_storage local null::null -c datadir=./build/integration/work/local_storage` 
 
 ID_STORAGE=`echo $OUTPUT_CREATE_STORAGE | awk {'print $5'}`

--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -37,6 +37,12 @@ ID_STORAGE=`echo $OUTPUT_CREATE_STORAGE | awk {'print $5'}`
 
 $OCC files_external:option $ID_STORAGE enable_sharing true
 
+# Enable encryption if requested
+if test "$ENCRYPTION_ENABLED" = "1"; then
+	$OCC app:enable encryption
+	$OCC encryption:enable
+fi
+
 vendor/bin/behat --strict -f junit -f pretty $SCENARIO_TO_RUN
 RESULT=$?
 

--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -4,6 +4,7 @@ composer install
 
 OC_PATH=../../
 OCC=${OC_PATH}occ
+BEHAT=vendor/bin/behat
 
 SCENARIO_TO_RUN=$1
 HIDE_OC_LOGS=$2
@@ -41,9 +42,20 @@ $OCC files_external:option $ID_STORAGE enable_sharing true
 if test "$ENCRYPTION_ENABLED" = "1"; then
 	$OCC app:enable encryption
 	$OCC encryption:enable
+	BEHAT_FILTER_TAGS="~@no_encryption"
 fi
 
-vendor/bin/behat --strict -f junit -f pretty $SCENARIO_TO_RUN
+if test "$BEHAT_FILTER_TAGS"; then
+	BEHAT_PARAMS='{ 
+		"gherkin": {
+			"filters": {
+				"tags": "'"$BEHAT_FILTER_TAGS"'"
+			}
+		}
+	}'
+fi
+
+BEHAT_PARAMS="$BEHAT_PARAMS" $BEHAT --strict -f junit -f pretty $SCENARIO_TO_RUN
 RESULT=$?
 
 kill $PHPPID


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Make it possible to run integration tests with enabled encryption.
Added this as a stage in Jenkinsfile.

## Related Issue
Fixes https://github.com/owncloud/QA/issues/324

## Motivation and Context
Because we need to make sure that the regular test scenarios like sharing, transfer ownership and others also work with encryption enabled.

## How Has This Been Tested?
Let CI do the job.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Moar QA

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


@owncloud/qa @DeepDiver1975 