### PR TITLE
Skip local shares in bkg scan and occ files:scan

### DIFF
--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -117,14 +117,19 @@ class Scanner extends PublicEmitter {
 	public function backgroundScan($dir) {
 		$mounts = $this->getMounts($dir);
 		foreach ($mounts as $mount) {
-			if (is_null($mount->getStorage())) {
+			$storage = $mount->getStorage();
+			if (is_null($storage)) {
 				continue;
 			}
 			// don't scan the root storage
-			if ($mount->getStorage()->instanceOfStorage('\OC\Files\Storage\Local') && $mount->getMountPoint() === '/') {
+			if ($storage->instanceOfStorage('\OC\Files\Storage\Local') && $mount->getMountPoint() === '/') {
 				continue;
 			}
-			$storage = $mount->getStorage();
+
+			// don't scan received local shares, these can be scanned when scanning the owner's storage
+			if ($storage->instanceOfStorage('OCA\Files_Sharing\ISharedStorage')) {
+				continue;
+			}
 			$scanner = $storage->getScanner();
 			$this->attachListener($mount);
 
@@ -155,10 +160,10 @@ class Scanner extends PublicEmitter {
 		}
 		$mounts = $this->getMounts($dir);
 		foreach ($mounts as $mount) {
-			if (is_null($mount->getStorage())) {
+			$storage = $mount->getStorage();
+			if (is_null($storage)) {
 				continue;
 			}
-			$storage = $mount->getStorage();
 			// if the home storage isn't writable then the scanner is run as the wrong user
 			if ($storage->instanceOfStorage('\OC\Files\Storage\Home') and
 				(!$storage->isCreatable('') or !$storage->isCreatable('files'))
@@ -169,6 +174,11 @@ class Scanner extends PublicEmitter {
 					break;
 				}
 
+			}
+
+			// don't scan received local shares, these can be scanned when scanning the owner's storage
+			if ($storage->instanceOfStorage('OCA\Files_Sharing\ISharedStorage')) {
+				continue;
 			}
 			$relativePath = $mount->getInternalPath($dir);
 			$scanner = $storage->getScanner();

--- a/tests/lib/Files/Utils/ScannerTest.php
+++ b/tests/lib/Files/Utils/ScannerTest.php
@@ -187,4 +187,24 @@ class ScannerTest extends \Test\TestCase {
 
 		$this->assertNotEquals($oldRoot->getEtag(), $newRoot->getEtag());
 	}
+
+	public function testSkipLocalShares() {
+		$sharedStorage = $this->createMock('OCA\Files_Sharing\SharedStorage');
+		$sharedMount = new MountPoint($sharedStorage, '/share');
+		Filesystem::getMountManager()->addMount($sharedMount);
+
+		$sharedStorage->expects($this->any())
+			->method('instanceOfStorage')
+			->will($this->returnValueMap([
+				['OCA\Files_Sharing\ISharedStorage', true],
+			]));
+		$sharedStorage->expects($this->never())
+			->method('getScanner');
+
+		$scanner = new TestScanner('', \OC::$server->getDatabaseConnection(), \OC::$server->getLogger());
+		$scanner->addMount($sharedMount);
+		$scanner->scan('');
+
+		$scanner->backgroundScan('');
+	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Skip local shares in bkg scan and occ files:scan.

## Related Issue
Fixes https://github.com/owncloud/core/issues/25017

## Motivation and Context
Local shares should only be scanned when doing it for the owner to
avoid repeatedly rescanning the same shared storage over and over again
for every recipient.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

### Backports
- [ ] stable9.1 - https://github.com/owncloud/core/pull/26600
- [ ] stable9
- [ ] stable8.2 ?

@owncloud/filesystem 