### PR TITLE
[stable9.1] Skip local shares in bkg scan and occ files:scan (#26590)

### DIFF
--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -117,14 +117,19 @@ class Scanner extends PublicEmitter {
 	public function backgroundScan($dir) {
 		$mounts = $this->getMounts($dir);
 		foreach ($mounts as $mount) {
-			if (is_null($mount->getStorage())) {
+			$storage = $mount->getStorage();
+			if (is_null($storage)) {
 				continue;
 			}
 			// don't scan the root storage
-			if ($mount->getStorage()->instanceOfStorage('\OC\Files\Storage\Local') && $mount->getMountPoint() === '/') {
+			if ($storage->instanceOfStorage('\OC\Files\Storage\Local') && $mount->getMountPoint() === '/') {
 				continue;
 			}
-			$storage = $mount->getStorage();
+
+			// don't scan received local shares, these can be scanned when scanning the owner's storage
+			if ($storage->instanceOfStorage('OCA\Files_Sharing\ISharedStorage')) {
+				continue;
+			}
 			$scanner = $storage->getScanner();
 			$this->attachListener($mount);
 
@@ -155,10 +160,10 @@ class Scanner extends PublicEmitter {
 		}
 		$mounts = $this->getMounts($dir);
 		foreach ($mounts as $mount) {
-			if (is_null($mount->getStorage())) {
+			$storage = $mount->getStorage();
+			if (is_null($storage)) {
 				continue;
 			}
-			$storage = $mount->getStorage();
 			// if the home storage isn't writable then the scanner is run as the wrong user
 			if ($storage->instanceOfStorage('\OC\Files\Storage\Home') and
 				(!$storage->isCreatable('') or !$storage->isCreatable('files'))
@@ -169,6 +174,11 @@ class Scanner extends PublicEmitter {
 					break;
 				}
 
+			}
+
+			// don't scan received local shares, these can be scanned when scanning the owner's storage
+			if ($storage->instanceOfStorage('OCA\Files_Sharing\ISharedStorage')) {
+				continue;
 			}
 			$relativePath = $mount->getInternalPath($dir);
 			$scanner = $storage->getScanner();

--- a/tests/lib/Files/Utils/ScannerTest.php
+++ b/tests/lib/Files/Utils/ScannerTest.php
@@ -189,7 +189,9 @@ class ScannerTest extends \Test\TestCase {
 	}
 
 	public function testSkipLocalShares() {
-		$sharedStorage = $this->getMock('OCA\Files_Sharing\SharedStorage');
+		$sharedStorage = $this->getMockBuilder('OC\Files\Storage\Shared')
+			->disableOriginalConstructor()
+			->getMock();
 		$sharedMount = new MountPoint($sharedStorage, '/share');
 		Filesystem::getMountManager()->addMount($sharedMount);
 

--- a/tests/lib/Files/Utils/ScannerTest.php
+++ b/tests/lib/Files/Utils/ScannerTest.php
@@ -187,4 +187,24 @@ class ScannerTest extends \Test\TestCase {
 
 		$this->assertNotEquals($oldRoot->getEtag(), $newRoot->getEtag());
 	}
+
+	public function testSkipLocalShares() {
+		$sharedStorage = $this->getMock('OCA\Files_Sharing\SharedStorage');
+		$sharedMount = new MountPoint($sharedStorage, '/share');
+		Filesystem::getMountManager()->addMount($sharedMount);
+
+		$sharedStorage->expects($this->any())
+			->method('instanceOfStorage')
+			->will($this->returnValueMap([
+				['OCA\Files_Sharing\ISharedStorage', true],
+			]));
+		$sharedStorage->expects($this->never())
+			->method('getScanner');
+
+		$scanner = new TestScanner('', \OC::$server->getDatabaseConnection(), \OC::$server->getLogger());
+		$scanner->addMount($sharedMount);
+		$scanner->scan('');
+
+		$scanner->backgroundScan('');
+	}
 }


### PR DESCRIPTION
backport #26590


Local shares should only be scanned when doing it for the owner to
avoid repeatedly rescanning the same shared storage over and over again
for every recipient.