### PR TITLE
[stable9.1] Allow file operations on part files on perm masked storage

### DIFF
--- a/lib/private/Files/Storage/Wrapper/PermissionsMask.php
+++ b/lib/private/Files/Storage/Wrapper/PermissionsMask.php
@@ -76,8 +76,13 @@ class PermissionsMask extends Wrapper {
 		return $this->storage->getPermissions($path) & $this->mask;
 	}
 
+	private function isPartFile($path) {
+		return pathinfo($path, PATHINFO_EXTENSION) === 'part';
+	}
+
 	public function rename($path1, $path2) {
-		return $this->checkMask(Constants::PERMISSION_UPDATE) and parent::rename($path1, $path2);
+		// allow renaming part files
+		return ($this->isPartFile($path1) || $this->checkMask(Constants::PERMISSION_UPDATE)) && parent::rename($path1, $path2);
 	}
 
 	public function copy($path1, $path2) {
@@ -86,7 +91,7 @@ class PermissionsMask extends Wrapper {
 
 	public function touch($path, $mtime = null) {
 		$permissions = $this->file_exists($path) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
-		return $this->checkMask($permissions) and parent::touch($path, $mtime);
+		return ($this->isPartFile($path) || $this->checkMask($permissions)) && parent::touch($path, $mtime);
 	}
 
 	public function mkdir($path) {
@@ -103,7 +108,7 @@ class PermissionsMask extends Wrapper {
 
 	public function file_put_contents($path, $data) {
 		$permissions = $this->file_exists($path) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
-		return $this->checkMask($permissions) and parent::file_put_contents($path, $data);
+		return ($this->isPartFile($path) || $this->checkMask($permissions)) && parent::file_put_contents($path, $data);
 	}
 
 	public function fopen($path, $mode) {
@@ -111,7 +116,7 @@ class PermissionsMask extends Wrapper {
 			return parent::fopen($path, $mode);
 		} else {
 			$permissions = $this->file_exists($path) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
-			return $this->checkMask($permissions) ? parent::fopen($path, $mode) : false;
+			return ($this->isPartFile($path) || $this->checkMask($permissions)) ? parent::fopen($path, $mode) : false;
 		}
 	}
 

--- a/tests/lib/Files/Storage/Wrapper/PermissionsMaskTest.php
+++ b/tests/lib/Files/Storage/Wrapper/PermissionsMaskTest.php
@@ -102,4 +102,34 @@ class PermissionsMaskTest extends \Test\Files\Storage\Storage {
 		$storage = $this->getMaskedStorage(Constants::PERMISSION_ALL - Constants::PERMISSION_CREATE);
 		$this->assertFalse($storage->fopen('foo', 'w'));
 	}
+
+	public function testRenameExistingFileNoUpdate() {
+		$this->sourceStorage->touch('foo');
+		$storage = $this->getMaskedStorage(Constants::PERMISSION_ALL - Constants::PERMISSION_UPDATE);
+		$this->assertFalse($storage->rename('foo', 'bar'));
+		$this->assertTrue($storage->file_exists('foo'));
+		$this->assertFalse($storage->file_exists('bar'));
+	}
+
+	public function testRenamePartFileNoPerms() {
+		$this->sourceStorage->touch('foo.part');
+		$storage = $this->getMaskedStorage(Constants::PERMISSION_ALL - Constants::PERMISSION_UPDATE - Constants::PERMISSION_CREATE);
+		$this->assertTrue($storage->rename('foo.part', 'bar'));
+		$this->assertFalse($storage->file_exists('foo.part'));
+		$this->assertTrue($storage->file_exists('bar'));
+	}
+
+	public function testFopenPartFileNoPerms() {
+		$storage = $this->getMaskedStorage(Constants::PERMISSION_ALL - Constants::PERMISSION_UPDATE - Constants::PERMISSION_CREATE);
+		$res = $storage->fopen('foo.part', 'w');
+		fwrite($res, 'foo');
+		fclose($res);
+		$this->assertTrue($storage->file_exists('foo.part'));
+	}
+
+	public function testFilePutContentsPartFileNoPerms() {
+		$storage = $this->getMaskedStorage(Constants::PERMISSION_ALL - Constants::PERMISSION_UPDATE - Constants::PERMISSION_CREATE);
+		$this->assertEquals(3, $storage->file_put_contents('foo.part', 'bar'));
+		$this->assertTrue($storage->file_exists('foo.part'));
+	}
 }


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/26561 to stable9.1

I've retested the "can create" and "can change" cases and they still work.

@jvillafanez @DeepDiver1975 