### PR TITLE
Port sharing related tests to Share2.0

### DIFF
--- a/apps/files_sharing/tests/ExpireSharesJobTest.php
+++ b/apps/files_sharing/tests/ExpireSharesJobTest.php
@@ -131,15 +131,16 @@ class ExpireSharesJobTest extends \Test\TestCase {
 	public function testExpireLinkShare($addExpiration, $interval, $addInterval, $shouldExpire) {
 		$this->loginAsUser($this->user1);
 
-		$view = new \OC\Files\View('/' . $this->user1 . '/');
-		$view->mkdir('files/test');
+		$userFolder = \OC::$server->getUserFolder($this->user1);
+		$sharedFolder = $userFolder->newFolder('test');
 
-		$fileInfo = $view->getFileInfo('files/test');
-
-		$this->assertNotNull(
-			\OCP\Share::shareItem('folder', $fileInfo->getId(), \OCP\Share::SHARE_TYPE_LINK, null, \OCP\Constants::PERMISSION_READ),
-			'Failed asserting that user 1 successfully shared "test" by link.'
-		);
+		$shareManager = \OC::$server->getShareManager();
+		$share = $shareManager->newShare();
+		$share->setSharedBy($this->user1);
+		$share->setShareType(\OCP\Share::SHARE_TYPE_LINK);
+		$share->setNode($sharedFolder);
+		$share->setPermissions(\OCP\Constants::PERMISSION_READ);
+		$shareManager->createShare($share);
 
 		$shares = $this->getShares();
 		$this->assertCount(1, $shares);
@@ -185,15 +186,17 @@ class ExpireSharesJobTest extends \Test\TestCase {
 	public function testDoNotExpireOtherShares() {
 		$this->loginAsUser($this->user1);
 
-		$view = new \OC\Files\View('/' . $this->user1 . '/');
-		$view->mkdir('files/test');
+		$userFolder = \OC::$server->getUserFolder($this->user1);
+		$sharedFolder = $userFolder->newFolder('test');
 
-		$fileInfo = $view->getFileInfo('files/test');
-
-		$this->assertNotNull(
-			\OCP\Share::shareItem('folder', $fileInfo->getId(), \OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ),
-			'Failed asserting that user 1 successfully shared "test" by link with user2.'
-		);
+		$shareManager = \OC::$server->getShareManager();
+		$share = $shareManager->newShare();
+		$share->setSharedBy($this->user1);
+		$share->setSharedWith($this->user2);
+		$share->setShareType(\OCP\Share::SHARE_TYPE_USER);
+		$share->setNode($sharedFolder);
+		$share->setPermissions(\OCP\Constants::PERMISSION_READ);
+		$shareManager->createShare($share);
 
 		$shares = $this->getShares();
 		$this->assertCount(1, $shares);

--- a/build/integration/features/bootstrap/Sharing.php
+++ b/build/integration/features/bootstrap/Sharing.php
@@ -254,6 +254,7 @@ trait Sharing {
 	 * @param string $filename
 	 */
 	public function checkSharedFileInResponse($filename){
+		$filename = ltrim($filename, '/');
 		PHPUnit_Framework_Assert::assertEquals(True, $this->isFieldInResponse('file_target', "/$filename"));
 	}
 
@@ -263,7 +264,28 @@ trait Sharing {
 	 * @param string $filename
 	 */
 	public function checkSharedFileNotInResponse($filename){
+		$filename = ltrim($filename, '/');
 		PHPUnit_Framework_Assert::assertEquals(False, $this->isFieldInResponse('file_target', "/$filename"));
+	}
+
+	/**
+	 * @Then /^File "([^"]*)" should be included as path in the response$/
+	 *
+	 * @param string $filename
+	 */
+	public function checkSharedFileAsPathInResponse($filename){
+		$filename = ltrim($filename, '/');
+		PHPUnit_Framework_Assert::assertEquals(True, $this->isFieldInResponse('path', "/$filename"));
+	}
+
+	/**
+	 * @Then /^File "([^"]*)" should not be included as path in the response$/
+	 *
+	 * @param string $filename
+	 */
+	public function checkSharedFileAsPathNotInResponse($filename){
+		$filename = ltrim($filename, '/');
+		PHPUnit_Framework_Assert::assertEquals(False, $this->isFieldInResponse('path', "/$filename"));
 	}
 
 	/**
@@ -382,6 +404,14 @@ trait Sharing {
 		if ($this->isFieldInResponse('id', $share_id)){
 			PHPUnit_Framework_Assert::fail("Share id $share_id has been found in response");
 		}
+	}
+
+	/**
+	 * @Then /^the response contains ([0-9]+) entries$/
+	 */
+	public function checkingTheResponseEntriesCount($count){
+		$actualCount = count($this->response->xml()->data[0]);
+		PHPUnit_Framework_Assert::assertEquals($count, $actualCount);
 	}
 
 	/**

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -901,6 +901,66 @@ Feature: sharing
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
 
+  Scenario: sharing subfolder when parent already shared
+    Given As an "admin"
+    Given user "user0" exists
+    Given user "user1" exists
+    And group "sharing-group" exists
+    And user "user0" created a folder "/test"
+    And user "user0" created a folder "/test/sub"
+    And file "/test" of user "user0" is shared with group "sharing-group"
+    And As an "user0"
+    When sending "POST" to "/apps/files_sharing/api/v1/shares" with
+      | path | /test/sub |
+      | shareWith | user1 |
+      | shareType | 0 |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+	And as "user1" the folder "/sub" exists
+
+  Scenario: sharing subfolder when parent already shared with group of sharer
+    Given As an "admin"
+    Given user "user0" exists
+    Given user "user1" exists
+    And group "sharing-group" exists
+    And user "user0" belongs to group "sharing-group"
+    And user "user0" created a folder "/test"
+    And user "user0" created a folder "/test/sub"
+    And file "/test" of user "user0" is shared with group "sharing-group"
+    And As an "user0"
+    When sending "POST" to "/apps/files_sharing/api/v1/shares" with
+      | path | /test/sub |
+      | shareWith | user1 |
+      | shareType | 0 |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+	And as "user1" the folder "/sub" exists
+
+  Scenario: sharing subfolder of already shared folder, GET result is correct
+    Given As an "admin"
+    Given user "user0" exists
+    Given user "user1" exists
+    Given user "user2" exists
+    Given user "user3" exists
+    Given user "user4" exists
+    And user "user0" created a folder "/folder1"
+    And file "/folder1" of user "user0" is shared with user "user1"
+    And file "/folder1" of user "user0" is shared with user "user2"
+	And user "user0" created a folder "/folder1/folder2"
+    And file "/folder1/folder2" of user "user0" is shared with user "user3"
+    And file "/folder1/folder2" of user "user0" is shared with user "user4"
+    And As an "user0"
+    When sending "GET" to "/apps/files_sharing/api/v1/shares"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+	And the response contains 4 entries
+	And File "/folder1" should be included as path in the response
+	And File "/folder1/folder2" should be included as path in the response
+	And sending "GET" to "/apps/files_sharing/api/v1/shares?path=/folder1/folder2"
+	And the response contains 2 entries
+	And File "/folder1" should not be included as path in the response
+	And File "/folder1/folder2" should be included as path in the response
+
   Scenario: unshare from self
     Given As an "admin"
     And user "user0" exists


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Port sharing related tests to use the Share2.0 API.
Also moved old ShareTest tests to be integration tests instead, as they
cannot be applied directly as unit tests.

## Related Issue
Ref https://github.com/owncloud/core/pull/26608

## Motivation and Context
We want to move away from the old sharing code for files and folders, so the first step is to adjust the tests to not rely on that one. Then later on adjust the code itself, this is what I tried here https://github.com/owncloud/core/pull/26608

## How Has This Been Tested?
Just run the tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Tech debt

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 @jvillafanez @butonic 