### PR TITLE
[stable9] Add repair step to fix file share permissions 

### DIFF
--- a/lib/private/repair.php
+++ b/lib/private/repair.php
@@ -119,6 +119,7 @@ class Repair extends BasicEmitter {
 			new DropOldJobs(\OC::$server->getJobList()),
 			new RemoveGetETagEntries(\OC::$server->getDatabaseConnection()),
 			new UpdateOutdatedOcsIds(\OC::$server->getConfig()),
+			new RepairInvalidShares(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection()),
 			new RepairUnmergedShares(
 				\OC::$server->getConfig(),
 				\OC::$server->getDatabaseConnection(),

--- a/tests/lib/repair/repairinvalidsharestest.php
+++ b/tests/lib/repair/repairinvalidsharestest.php
@@ -179,6 +179,73 @@ class RepairInvalidSharesTest extends TestCase {
 		$result->closeCursor();
 	}
 
+	public function fileSharePermissionsProvider() {
+		return [
+			// unchanged for folder
+			[
+				'folder',
+				31,
+				31,
+			],
+			// unchanged for read-write + share
+			[
+				'file',
+				\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE,
+				\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE,
+			],
+			// fixed for all perms
+			[
+				'file',
+				\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE | \OCP\Constants::PERMISSION_SHARE,
+				\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE,
+			],
+		];
+	}
+
+	/**
+	 * Test adjusting file share permissions
+	 *
+	 * @dataProvider fileSharePermissionsProvider
+	 */
+	public function testFileSharePermissions($itemType, $testPerms, $expectedPerms) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->insert('share')
+			->values([
+				'share_type' => $qb->expr()->literal(Constants::SHARE_TYPE_LINK),
+				'uid_owner' => $qb->expr()->literal('user1'),
+				'item_type' => $qb->expr()->literal($itemType),
+				'item_source' => $qb->expr()->literal(123),
+				'item_target' => $qb->expr()->literal('/123'),
+				'file_source' => $qb->expr()->literal(123),
+				'file_target' => $qb->expr()->literal('/test'),
+				'permissions' => $qb->expr()->literal($testPerms),
+				'stime' => $qb->expr()->literal(time()),
+			])
+			->execute();
+
+		$shareId = $this->getLastShareId();
+
+		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->repair->run($outputMock);
+
+		$results = $this->connection->getQueryBuilder()
+			->select('*')
+			->from('share')
+			->orderBy('permissions', 'ASC')
+			->execute()
+			->fetchAll();
+
+		$this->assertCount(1, $results);
+
+		$updatedShare = $results[0];
+
+		$this->assertEquals($expectedPerms, $updatedShare['permissions']);
+	}
+
 	/**
 	 * @return int
 	 */

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 0, 6, 5);
+$OC_Version = array(9, 0, 6, 6);
 
 // The human readable string
 $OC_VersionString = '9.0.6';


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/26562 to stable9.

Also adds back the missing instantiation of RepairInvalidShares.
Retested, works.

@DeepDiver1975 @jvillafanez 