### PR TITLE
[stable9] Fallback to share link owner when no owner found (#26587)

### DIFF
--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -86,6 +86,10 @@ class Trashbin {
 		if (!$userManager->userExists($uid)) {
 			$uid = User::getUser();
 		}
+		if (!$uid) {
+			// no owner, usually because of share link from ext storage
+			return [null, null];
+		}
 		Filesystem::initMountPoints($uid);
 		if ($uid != User::getUser()) {
 			$info = Filesystem::getFileInfo($filename);
@@ -201,6 +205,12 @@ class Trashbin {
 		$root = Filesystem::getRoot();
 		list(, $user) = explode('/', $root);
 		list($owner, $ownerPath) = self::getUidAndFilename($file_path);
+
+		// if no owner found (ex: ext storage + share link), will use the current user's trashbin then
+		if (is_null($owner)) {
+			$owner = $user;
+			$ownerPath = $file_path;
+		}
 
 		$ownerView = new View('/' . $owner);
 		// file has been deleted in between


### PR DESCRIPTION
backport of #26587


When creating link shares from external storage, the filesystem cannot
find an owner in some scenarios (ex: system-wide mounts). In such
cases, fall back to using the current user's trashbin which happens to
also be the user who created the link share.

Fixes an issue where this scenario made deletion impossible due to
missing user information.