### PR TITLE
removed path to datadir

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -687,7 +687,7 @@ class OC_Util {
 					$errors = array_merge($errors, self::checkDataDirectoryPermissions($CONFIG_DATADIRECTORY));
 				} else {
 					$errors[] = [
-						'error' => $l->t('Cannot create "data" directory (%s)', [$CONFIG_DATADIRECTORY]),
+						'error' => $l->t('Cannot create "data" directory'),
 						'hint' => $l->t('This can usually be fixed by '
 							. '<a href="%s" target="_blank" rel="noreferrer">giving the webserver write access to the root directory</a>.',
 							[$urlGenerator->linkToDocs('admin-dir_permissions')])
@@ -699,7 +699,7 @@ class OC_Util {
 					. '%sgiving the webserver write access to the root directory%s.',
 					['<a href="' . $urlGenerator->linkToDocs('admin-dir_permissions') . '" target="_blank" rel="noreferrer">', '</a>']);
 				$errors[] = [
-					'error' => 'Data directory (' . $CONFIG_DATADIRECTORY . ') not writable by ownCloud',
+					'error' => 'Your Data directory is not writable by ownCloud',
 					'hint' => $permissionsHint
 				];
 			} else {
@@ -910,7 +910,7 @@ class OC_Util {
 			$perms = substr(decoct(@fileperms($dataDirectory)), -3);
 			if (substr($perms, 2, 1) != '0') {
 				$errors[] = [
-					'error' => $l->t('Data directory (%s) is readable by other users', [$dataDirectory]),
+					'error' => $l->t('Your Data directory is readable by other users'),
 					'hint' => $permissionsModHint
 				];
 			}
@@ -930,13 +930,13 @@ class OC_Util {
 		$errors = [];
 		if ($dataDirectory[0] !== '/') {
 			$errors[] = [
-				'error' => $l->t('Data directory (%s) must be an absolute path', [$dataDirectory]),
+				'error' => $l->t('Your Data directory must be an absolute path'),
 				'hint' => $l->t('Check the value of "datadirectory" in your configuration')
 			];
 		}
 		if (!file_exists($dataDirectory . '/.ocdata')) {
 			$errors[] = [
-				'error' => $l->t('Data directory (%s) is invalid', [$dataDirectory]),
+				'error' => $l->t('Your Data directory  is invalid'),
 				'hint' => $l->t('Please check that the data directory contains a file' .
 					' ".ocdata" in its root.')
 			];


### PR DESCRIPTION

## Description
Removed the Display of the data directory root.

## Related Issue
https://github.com/owncloud/core/issues/26386

## Motivation and Context
The Data Directory should not be displayed in the webinterface. Only Administrators should be able to know the location of the data directory.

## How Has This Been Tested?
renamed data directory and removed it. Error Messages do not Display the Path to the datadirectory any more.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


