### PR TITLE
Skip generated remote share if exact user match found

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -334,7 +334,10 @@ class ShareesController extends OCSController  {
 			$this->result['remotes'] = [];
 		}
 
-		if (!$foundRemoteById && substr_count($search, '@') >= 1 && $this->offset === 0) {
+		if (!$foundRemoteById && substr_count($search, '@') >= 1 && $this->offset === 0
+			// only add remote user if not found already an exact match (ex: local account like email address)
+			&& empty($this->result['exact']['users'])
+		) {
 			$this->result['exact']['remotes'][] = [
 				'label' => $search,
 				'value' => [

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -335,8 +335,12 @@ class ShareesController extends OCSController  {
 		}
 
 		if (!$foundRemoteById && substr_count($search, '@') >= 1 && $this->offset === 0
-			// only add remote user if not found already an exact match (ex: local account like email address)
-			&& empty($this->result['exact']['users'])
+			// if an exact local user is found, only keep the remote entry if
+			// its domain does not matches the trusted domains
+			// (if it does, it is a user whose local login domain matches the ownCloud
+			// instance domain) 
+			&& (empty($this->result['exact']['users'])
+				|| !$this->isInstanceDomain($search))
 		) {
 			$this->result['exact']['remotes'][] = [
 				'label' => $search,
@@ -556,5 +560,28 @@ class ShareesController extends OCSController  {
 	 */
 	protected function isV2() {
 		return $this->request->getScriptName() === '/ocs/v2.php';
+	}
+
+	/**
+	 * Checks whether the given target's domain part matches one of the server's
+	 * trusted domain entries
+	 *
+	 * @param string $target target
+	 * @return true if one match was found, false otherwise
+	 */
+	protected function isInstanceDomain($target) {
+		if (strpos($target, '/') !== false) {
+			// not a proper email-like format with domain name
+			return false;
+		}
+		$parts = explode('@', $target);
+		if (count($parts) === 1) {
+			// no "@" sign
+			return false;
+		}
+		$domainName = $parts[count($parts) - 1];
+		$trustedDomains = $this->config->getSystemValue('trusted_domains', []);
+
+		return in_array($domainName, $trustedDomains, true);
 	}
 }

--- a/apps/files_sharing/tests/API/ShareesTest.php
+++ b/apps/files_sharing/tests/API/ShareesTest.php
@@ -1047,6 +1047,20 @@ class ShareesTest extends TestCase {
 				[],
 				true,
 			],
+			// if exact user found, skip generated remote entry
+			[
+				'test@domain.tld',
+				[],
+				true,
+				[],
+				[],
+				true,
+				[
+					'users' => [
+						['label' => 'test@domain.tld', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test@domain.tld']],
+					]
+				]
+			],
 		];
 	}
 
@@ -1059,8 +1073,16 @@ class ShareesTest extends TestCase {
 	 * @param array $exactExpected
 	 * @param array $expected
 	 * @param bool $reachedEnd
+	 * @param array $previousExact
 	 */
-	public function testGetRemote($searchTerm, $contacts, $shareeEnumeration, $exactExpected, $expected, $reachedEnd) {
+	public function testGetRemote($searchTerm, $contacts, $shareeEnumeration, $exactExpected, $expected, $reachedEnd, $previousExact = []) {
+		// inject previous results if needed
+		if (!empty($previousExact)) {
+			$result = $this->invokePrivate($this->sharees, 'result');
+			$result['exact'] = array_merge($result['exact'], $previousExact);
+			$this->invokePrivate($this->sharees, 'result', [$result]);
+		}
+
 		$this->invokePrivate($this->sharees, 'shareeEnumeration', [$shareeEnumeration]);
 		$this->contactsManager->expects($this->any())
 			->method('search')


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description

Whenever user ids are in the format "user@server", entering these in the share
dialog would also generate a remote share entry. Selecting the remote
entry would usually create a federated share to the same server.

In the case a user enters the full id address as share recipient it
is most likely that the intention was to share with the local user.

This fix removes the automatically generated remote id from the sharees
list when such situation occurs to avoid selecting the wrong entry by
mistake.

## Related Issue
Fixes https://github.com/owncloud/core/issues/26647

## Motivation and Context
Improve UX by preventing users to select the wrong share entry.

## How Has This Been Tested?
Manual testing, see steps in ticket + unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 @jvillafanez @cdamken 