### PR TITLE
Readding the transifex localization chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,7 @@ Learn about the different ways you can get support for ownCloud: https://ownclou
 Please submit translations via Transifex:
 https://www.transifex.com/projects/p/owncloud/
 
+[![Transifex](https://www.transifex.com/_/charts/redirects/owncloud-org/owncloud/image_png)](https://www.transifex.com/projects/p/owncloud/)
+
 For more detailed information about translations:
 http://doc.owncloud.org/server/9.1/developer_manual/core/translation.html


### PR DESCRIPTION
Since an update in the past, the classical Transifex localization chart wasn't displayed any more. This re adds the chart with a working URL.

If you want to display only the translation progress of the "core" resource, you probably only have to add a `/core`, or what ever resource, behind `/image_png`.

Like this:
```
[![Transifex](https://www.transifex.com/_/charts/redirects/owncloud-org/owncloud/image_png/core)](https://www.transifex.com/projects/p/owncloud/)
```

:-)