### PR TITLE
fix ILIKE REGEXP workaround on oracle

### DIFF
--- a/lib/private/DB/AdapterOCI8.php
+++ b/lib/private/DB/AdapterOCI8.php
@@ -40,7 +40,7 @@ class AdapterOCI8 extends Adapter {
 
 	public function fixupStatement($statement) {
 		$statement = \preg_replace('( LIKE \?)', '$0 ESCAPE \'\\\'', $statement);
-		$statement = \preg_replace('/`(\w+)` ILIKE \?/', 'REGEXP_LIKE(`$1`, \'^\' || REPLACE(?, \'%\', \'.*\') || \'$\', \'i\')', $statement);
+		$statement = \preg_replace('/`(\w+)` ILIKE \?/', "LOWER(`$1`) LIKE LOWER(?) ESCAPE '\\' -- \\'' \n", $statement);  // FIXME workaround for singletick matching with regexes in SQLParserUtils::getUnquotedStatementFragments
 		$statement = \str_replace('`', '"', $statement);
 		$statement = \str_ireplace('NOW()', 'CURRENT_TIMESTAMP', $statement);
 		$statement = \str_ireplace('UNIX_TIMESTAMP()', self::UNIX_TIMESTAMP_REPLACEMENT, $statement);

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/OCIExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/OCIExpressionBuilder.php
@@ -157,7 +157,7 @@ class OCIExpressionBuilder extends ExpressionBuilder {
 	public function iLike($x, $y, $type = null) {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnName($y);
-		return new QueryFunction('REGEXP_LIKE('.$x.', \'^\' || REPLACE('.$y.', \'%\', \'.*\') || \'$\', \'i\')');
+		return new QueryFunction("LOWER($x) LIKE LOWER($y) ESCAPE '\\' -- \\'' \n"); // FIXME workaround for singletick matching with regexes in SQLParserUtils::getUnquotedStatementFragments
 	}
 
 	/**

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -304,23 +304,23 @@ class CacheTest extends TestCase {
 		$this->cache->put($file3, $fileData['foo']);
 		$this->cache->put($file4, $fileData['f[o.o%ba-r']);
 
-		$this->assertCount(2, $this->cache->search('%foo%'));
-		$this->assertCount(1, $this->cache->search('foo'));
-		$this->assertCount(1, $this->cache->search('%folder%'));
-		$this->assertCount(1, $this->cache->search('folder%'));
-		$this->assertCount(4, $this->cache->search('%'));
+		$this->assertCount(2, $this->cache->search('%foo%'), "expected 2 when searching for '%foo%'");
+		$this->assertCount(1, $this->cache->search('foo'), "expected 1 when searching for 'foo'");
+		$this->assertCount(1, $this->cache->search('%folder%'), "expected 1 when searching for '%folder%'");
+		$this->assertCount(1, $this->cache->search('folder%'), "expected 1 when searching for 'folder%'");
+		$this->assertCount(4, $this->cache->search('%'), "expected 4 when searching for '%'");
 
 		// case insensitive search should match the same files
-		$this->assertCount(2, $this->cache->search('%Foo%'));
-		$this->assertCount(1, $this->cache->search('Foo'));
-		$this->assertCount(1, $this->cache->search('%Folder%'));
-		$this->assertCount(1, $this->cache->search('Folder%'));
+		$this->assertCount(2, $this->cache->search('%Foo%'), "expected 2 when searching for '%Foo%'");
+		$this->assertCount(1, $this->cache->search('Foo'), "expected 1 when searching for 'Foo'");
+		$this->assertCount(1, $this->cache->search('%Folder%'), "expected 1 when searching for '%Folder%'");
+		$this->assertCount(1, $this->cache->search('Folder%'), "expected 1 when searching for 'Folder%'");
 
-		$this->assertCount(4, $this->cache->searchByMime('foo'));
-		$this->assertCount(3, $this->cache->searchByMime('foo/file'));
+		$this->assertCount(4, $this->cache->searchByMime('foo'), "expected 4 when searching for mime 'foo'");
+		$this->assertCount(3, $this->cache->searchByMime('foo/file'), "expected 3 when searching for mime 'foo/file'");
 
 		// oracle uses regexp,
-		$this->assertCount(1, $this->cache->search('f[o.o%ba-r'));
+		$this->assertCount(1, $this->cache->search('f[o.o%ba-r'), "expected 1 when searching for 'f[o.o%ba-r'");
 	}
 
 	function testSearchByTag() {

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -292,20 +292,23 @@ class CacheTest extends TestCase {
 		$file1 = 'folder';
 		$file2 = 'folder/foobar';
 		$file3 = 'folder/foo';
+		$file4 = 'folder/f[o.o%ba-r';
 		$data1 = ['size' => 100, 'mtime' => 50, 'mimetype' => 'foo/folder'];
 		$fileData = [];
 		$fileData['foobar'] = ['size' => 1000, 'mtime' => 20, 'mimetype' => 'foo/file'];
 		$fileData['foo'] = ['size' => 20, 'mtime' => 25, 'mimetype' => 'foo/file'];
+		$fileData['f[o.o%ba-r'] = ['size' => 20, 'mtime' => 25, 'mimetype' => 'foo/file'];
 
 		$this->cache->put($file1, $data1);
 		$this->cache->put($file2, $fileData['foobar']);
 		$this->cache->put($file3, $fileData['foo']);
+		$this->cache->put($file4, $fileData['f[o.o%ba-r']);
 
 		$this->assertCount(2, $this->cache->search('%foo%'));
 		$this->assertCount(1, $this->cache->search('foo'));
 		$this->assertCount(1, $this->cache->search('%folder%'));
 		$this->assertCount(1, $this->cache->search('folder%'));
-		$this->assertCount(3, $this->cache->search('%'));
+		$this->assertCount(4, $this->cache->search('%'));
 
 		// case insensitive search should match the same files
 		$this->assertCount(2, $this->cache->search('%Foo%'));
@@ -313,8 +316,11 @@ class CacheTest extends TestCase {
 		$this->assertCount(1, $this->cache->search('%Folder%'));
 		$this->assertCount(1, $this->cache->search('Folder%'));
 
-		$this->assertCount(3, $this->cache->searchByMime('foo'));
-		$this->assertCount(2, $this->cache->searchByMime('foo/file'));
+		$this->assertCount(4, $this->cache->searchByMime('foo'));
+		$this->assertCount(3, $this->cache->searchByMime('foo/file'));
+
+		// oracle uses regexp,
+		$this->assertCount(1, $this->cache->search('f[o.o%ba-r'));
 	}
 
 	function testSearchByTag() {


### PR DESCRIPTION
```
{"Exception":"Doctrine\DBAL\Exception\DriverException","Message":"An exception occurred while executing '
			SELECT "fileid", "storage", "path", "parent", "name",
				"mimetype", "mimepart", "size", "mtime", "encrypted",
				"etag", "permissions", "checksum"
			FROM "oc_filecache"
			WHERE "storage" = ? AND REGEXP_LIKE("name", '^' || REPLACE(?, '%', '.*') || '$', 'i')' with params ["875", "[#IM-1721151] -EILT- B2B _ XXX Anmeldun....pdf.v%.d1452498830"]:\

ORA-12728: invalid range in regular expression","Code":0,"Trace":"#0 
```

## Analysis
It seems doctrine does not escape the regex parameter. An ILIKE becomes REGEXP_LIKE in https://github.com/owncloud/core/blob/master/lib/private/DB/AdapterOCI8.php#L44 or https://github.com/owncloud/core/blob/master/lib/private/DB/QueryBuilder/ExpressionBuilder/OCIExpressionBuilder.php#L161

The only ILIKE in OC\Files\Cache\Cache is https://github.com/owncloud/core/blob/master/lib/private/Files/Cache/Cache.php#L595
and the search pattern is normalized in https://github.com/owncloud/core/blob/master/lib/private/Files/Cache/Cache.php#L833:
```php
	public function normalize($path) {
		return trim(\OC_Util::normalizeUnicode($path), '/');
	}
```

## Conclusion
- [ ] ~~add tests containing `[` and `]` in path names and search patterns for `search()`~~ tracked in https://github.com/owncloud/core/issues/31394
- [ ] ~~to fix escape regex chars on oracle?~~ no longer using regex
- ~~check other usages of ILIKE:~~ no longer needed
  - [ ] ~~https://github.com/owncloud/core/blob/master/lib/private/Repair/RepairMimeTypes.php#L102~~
  - [ ] ~~https://github.com/owncloud/core/blob/master/apps/dav/lib/CardDAV/CardDavBackend.php#L778~~