### PR TITLE
Introduce public storage class for extending

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -43,7 +43,7 @@ use Aws\S3\S3Client;
 use Aws\S3\Exception\S3Exception;
 use Icewind\Streams\IteratorDirectory;
 
-class AmazonS3 extends \OC\Files\Storage\Common {
+class AmazonS3 extends \OCP\Files\Storage\StorageAdapter {
 
 	/**
 	 * @var \Aws\S3\S3Client

--- a/apps/files_external/lib/Lib/Storage/Dropbox.php
+++ b/apps/files_external/lib/Lib/Storage/Dropbox.php
@@ -36,7 +36,7 @@ use OCP\Files\StorageNotAvailableException;
 
 require_once __DIR__ . '/../../../3rdparty/Dropbox/autoload.php';
 
-class Dropbox extends \OC\Files\Storage\Common {
+class Dropbox extends \OCP\Files\Storage\StorageAdapter {
 
 	private $dropbox;
 	private $root;

--- a/apps/files_external/lib/Lib/Storage/Google.php
+++ b/apps/files_external/lib/Lib/Storage/Google.php
@@ -42,7 +42,7 @@ set_include_path(get_include_path().PATH_SEPARATOR.
 	\OC_App::getAppPath('files_external').'/3rdparty/google-api-php-client/src');
 require_once 'Google/autoload.php';
 
-class Google extends \OC\Files\Storage\Common {
+class Google extends \OCP\Files\Storage\StorageAdapter {
 
 	private $client;
 	private $id;

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -40,7 +40,7 @@ use phpseclib\Net\SFTP\Stream;
 * Uses phpseclib's Net\SFTP class and the Net\SFTP\Stream stream wrapper to
 * provide access to SFTP servers.
 */
-class SFTP extends \OC\Files\Storage\Common {
+class SFTP extends \OCP\Files\Storage\StorageAdapter {
 	private $host;
 	private $user;
 	private $root;

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -43,11 +43,10 @@ use Icewind\Streams\CallbackWrapper;
 use Icewind\Streams\IteratorDirectory;
 use OC\Cache\CappedMemoryCache;
 use OC\Files\Filesystem;
-use OC\Files\Storage\Common;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Util;
 
-class SMB extends Common {
+class SMB extends \OCP\Files\Storage\StorageAdapter {
 	/**
 	 * @var \Icewind\SMB\Server
 	 */

--- a/apps/files_external/lib/Lib/Storage/StreamWrapper.php
+++ b/apps/files_external/lib/Lib/Storage/StreamWrapper.php
@@ -27,7 +27,7 @@
 
 namespace OCA\Files_External\Lib\Storage;
 
-abstract class StreamWrapper extends \OC\Files\Storage\Common {
+abstract class StreamWrapper extends \OCP\Files\Storage\StorageAdapter {
 
 	/**
 	 * @param string $path

--- a/apps/files_external/lib/Lib/Storage/Swift.php
+++ b/apps/files_external/lib/Lib/Storage/Swift.php
@@ -44,7 +44,7 @@ use OpenCloud\Rackspace;
 use OpenCloud\ObjectStore\Resource\DataObject;
 use OpenCloud\ObjectStore\Exception;
 
-class Swift extends \OC\Files\Storage\Common {
+class Swift extends \OCP\Files\Storage\StorageAdapter {
 
 	/**
 	 * @var \OpenCloud\ObjectStore\Service

--- a/lib/public/Files/Storage/FlysystemStorageAdapter.php
+++ b/lib/public/Files/Storage/FlysystemStorageAdapter.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Files\Storage;
+
+/**
+ * Public storage adapter to be extended to connect to
+ * flysystem adapters
+ *
+ * @since 9.2
+ */
+abstract class FlysystemStorageAdapter extends \OC\Files\Storage\Flysystem {
+
+	/**
+	 * Get the identifier for the storage,
+	 * the returned id should be the same for every storage object that is created with the same parameters
+	 * and two storage objects with the same id should refer to two storages that display the same files.
+	 *
+	 * @return string storage id
+	 * @since 9.2
+	 */
+	abstract public function getId();
+}

--- a/lib/public/Files/Storage/IStorage.php
+++ b/lib/public/Files/Storage/IStorage.php
@@ -34,6 +34,7 @@ use OCP\Files\Cache\IScanner;
 use OCP\Files\Cache\IUpdater;
 use OCP\Files\Cache\IWatcher;
 use OCP\Files\InvalidPathException;
+use OCP\Files\StorageNotAvailableException;
 
 /**
  * Provide a common interface to all different storage options
@@ -56,7 +57,7 @@ interface IStorage {
 	 * the returned id should be the same for every storage object that is created with the same parameters
 	 * and two storage objects with the same id should refer to two storages that display the same files.
 	 *
-	 * @return string
+	 * @return string storage id
 	 * @since 9.0.0
 	 */
 	public function getId();
@@ -66,7 +67,8 @@ interface IStorage {
 	 * implementations need to implement a recursive mkdir
 	 *
 	 * @param string $path
-	 * @return bool
+	 * @return bool true on success, false otherwise
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function mkdir($path);
@@ -75,7 +77,8 @@ interface IStorage {
 	 * see http://php.net/manual/en/function.rmdir.php
 	 *
 	 * @param string $path
-	 * @return bool
+	 * @return bool true on success, false otherwise
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function rmdir($path);
@@ -85,6 +88,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return resource|false
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function opendir($path);
@@ -94,6 +98,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return bool
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function is_dir($path);
@@ -103,6 +108,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return bool
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function is_file($path);
@@ -113,6 +119,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return array|false
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function stat($path);
@@ -122,6 +129,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return string|false
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function filetype($path);
@@ -132,6 +140,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return int|false
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function filesize($path);
@@ -141,6 +150,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return bool
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function isCreatable($path);
@@ -150,6 +160,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return bool
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function isReadable($path);
@@ -159,6 +170,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return bool
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function isUpdatable($path);
@@ -168,6 +180,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return bool
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function isDeletable($path);
@@ -177,6 +190,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return bool
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function isSharable($path);
@@ -187,6 +201,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return int
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function getPermissions($path);
@@ -196,6 +211,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return bool
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function file_exists($path);
@@ -205,6 +221,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return int|false
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function filemtime($path);
@@ -214,6 +231,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return string|false
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function file_get_contents($path);
@@ -224,6 +242,7 @@ interface IStorage {
 	 * @param string $path
 	 * @param string $data
 	 * @return bool
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function file_put_contents($path, $data);
@@ -232,7 +251,8 @@ interface IStorage {
 	 * see http://php.net/manual/en/function.unlink.php
 	 *
 	 * @param string $path
-	 * @return bool
+	 * @return bool true on success, false otherwise
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function unlink($path);
@@ -243,6 +263,7 @@ interface IStorage {
 	 * @param string $path1
 	 * @param string $path2
 	 * @return bool
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function rename($path1, $path2);
@@ -253,6 +274,7 @@ interface IStorage {
 	 * @param string $path1
 	 * @param string $path2
 	 * @return bool
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function copy($path1, $path2);
@@ -263,6 +285,7 @@ interface IStorage {
 	 * @param string $path
 	 * @param string $mode
 	 * @return resource|false
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function fopen($path, $mode);
@@ -273,6 +296,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return string|false
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function getMimeType($path);
@@ -284,6 +308,7 @@ interface IStorage {
 	 * @param string $path
 	 * @param bool $raw
 	 * @return string|false
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function hash($type, $path, $raw = false);
@@ -293,6 +318,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return int|false
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function free_space($path);
@@ -303,7 +329,8 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @param int $mtime
-	 * @return bool
+	 * @return bool true on success, false otherwise
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function touch($path, $mtime = null);
@@ -314,6 +341,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return string|false
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function getLocalFile($path);
@@ -324,6 +352,7 @@ interface IStorage {
 	 * @param string $path
 	 * @param int $time
 	 * @return bool
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 *
 	 * hasUpdated for folders should return at least true if a file inside the folder is add, removed or renamed.
@@ -336,6 +365,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return string|false
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function getETag($path);
@@ -368,6 +398,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @return array|false
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function getDirectDownload($path);
@@ -386,6 +417,7 @@ interface IStorage {
 	 * @param string $sourceInternalPath
 	 * @param string $targetInternalPath
 	 * @return bool
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath);
@@ -395,6 +427,7 @@ interface IStorage {
 	 * @param string $sourceInternalPath
 	 * @param string $targetInternalPath
 	 * @return bool
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function moveFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath);
@@ -408,49 +441,72 @@ interface IStorage {
 	public function test();
 
 	/**
+	 * Returns the availability info
+	 *
 	 * @since 9.0.0
 	 * @return array [ available, last_checked ]
 	 */
 	public function getAvailability();
 
 	/**
+	 * Sets availability flag
+	 *
 	 * @since 9.0.0
 	 * @param bool $isAvailable
 	 */
 	public function setAvailability($isAvailable);
 
 	/**
+	 * Returns the owner name
+	 *
 	 * @param string $path path for which to retrieve the owner
+	 * @return string owner name
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function getOwner($path);
 
 	/**
+	 * Returns the storage cache instance
+	 *
 	 * @return ICache
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function getCache();
 
 	/**
+	 * Returns the change propagator instance
+	 *
 	 * @return IPropagator
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function getPropagator();
 
 	/**
+	 * Returns the scanner instance
+	 *
 	 * @return IScanner
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function getScanner();
 
 	/**
+	 * Returns the updater instance
+	 *
 	 * @return IUpdater
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function getUpdater();
 
 	/**
+	 * Returns the watched instance
+	 *
 	 * @return IWatcher
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */
 	public function getWatcher();

--- a/lib/public/Files/Storage/PolyFill/CopyDirectory.php
+++ b/lib/public/Files/Storage/PolyFill/CopyDirectory.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Files\Storage\PolyFill;
+
+/**
+ * @since 9.2
+ */
+trait CopyDirectory {
+	use \OC\Files\Storage\PolyFill\CopyDirectory;
+}
+

--- a/lib/public/Files/Storage/StorageAdapter.php
+++ b/lib/public/Files/Storage/StorageAdapter.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Files\Storage;
+
+use OCP\Files\StorageNotAvailableException;
+
+/**
+ * Storage adapter implementing most of the common methods from IStorage.
+ *
+ * @since 9.2
+ */
+abstract class StorageAdapter extends \OC\Files\Storage\Common {
+
+	/**
+	 * Get the identifier for the storage,
+	 * the returned id should be the same for every storage object that is created with the same parameters
+	 * and two storage objects with the same id should refer to two storages that display the same files.
+	 *
+	 * @return string storage id
+	 * @since 9.2
+	 */
+	abstract public function getId();
+
+	/**
+	 * see http://php.net/manual/en/function.mkdir.php
+	 * implementations need to implement a recursive mkdir
+	 *
+	 * @param string $path
+	 * @return bool true on success, false otherwise
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
+	 * @since 9.2
+	 */
+	abstract public function mkdir($path);
+
+	/**
+	 * see http://php.net/manual/en/function.rmdir.php
+	 *
+	 * @param string $path
+	 * @return bool true on success, false otherwise
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
+	 * @since 9.2
+	 */
+	abstract public function rmdir($path);
+
+	/**
+	 * see http://php.net/manual/en/function.opendir.php
+	 *
+	 * @param string $path
+	 * @return resource|false
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
+	 * @since 9.2
+	 */
+	abstract public function opendir($path);
+
+	/**
+	 * see http://php.net/manual/en/function.stat.php
+	 * only the following keys are required in the result: size and mtime
+	 *
+	 * @param string $path
+	 * @return array|false
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
+	 * @since 9.2
+	 */
+	abstract public function stat($path);
+
+	/**
+	 * see http://php.net/manual/en/function.filetype.php
+	 *
+	 * @param string $path
+	 * @return string|false
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
+	 * @since 9.2
+	 */
+	abstract public function filetype($path);
+
+	/**
+	 * see http://php.net/manual/en/function.file_exists.php
+	 *
+	 * @param string $path
+	 * @return bool
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
+	 * @since 9.2
+	 */
+	abstract public function file_exists($path);
+
+	/**
+	 * see http://php.net/manual/en/function.unlink.php
+	 *
+	 * @param string $path
+	 * @return bool true on success, false otherwise
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
+	 * @since 9.2
+	 */
+	abstract public function unlink($path);
+
+	/**
+	 * see http://php.net/manual/en/function.fopen.php
+	 *
+	 * @param string $path
+	 * @param string $mode
+	 * @return resource|false
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
+	 * @since 9.2
+	 */
+	abstract public function fopen($path, $mode);
+
+	/**
+	 * see http://php.net/manual/en/function.touch.php
+	 * If the backend does not support the operation, false should be returned
+	 *
+	 * @param string $path
+	 * @param int $mtime
+	 * @return bool true on success, false otherwise
+	 * @throws StorageNotAvailableException if the storage is temporarily not available
+	 * @since 9.2
+	 */
+	abstract public function touch($path, $mtime = NULL);
+}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
When writing external storage it is complicated to reimplement IStorage
and many others. This PR provides public classes to be extended to
provider storage specific implementations.

## Related Issue
Because apps need to be able to extend the common storage class or use the flysystem adapter without accessing the private namespaces.

Also see https://github.com/owncloud/documentation/pull/2721

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [x] TODO: use it in files_external_ftp

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


@DeepDiver1975 @jvillafanez @labkode FYI