### PR TITLE
Log format experiments

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
@@ -109,18 +109,6 @@ class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
 			}
 			$message = "HTTP/1.1 {$ex->getHTTPCode()} $message";
 		}
-
-		$user = \OC_User::getUser();
-
-		$exception = [
-			'Message' => $message,
-			'Exception' => $exceptionClass,
-			'Code' => $ex->getCode(),
-			'Trace' => $ex->getTraceAsString(),
-			'File' => $ex->getFile(),
-			'Line' => $ex->getLine(),
-			'User' => $user,
-		];
-		$this->logger->log($level, 'Exception: ' . json_encode($exception), ['app' => $this->appName]);
+		$this->logger->log($level, $message, ['app' => $this->appName, 'exception' => $ex]);
 	}
 }

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1387,6 +1387,7 @@ class View {
 	 * @return FileInfo[]
 	 */
 	public function getDirectoryContent($directory, $mimetype_filter = '') {
+		throw new \Exception('Test exception');
 		$this->assertPathLength($directory);
 		if (!Filesystem::isValidPath($directory)) {
 			return [];

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -236,6 +236,11 @@ class Log implements ILogger {
 		}
 		$logConditionFile = null;
 
+		$exception = null;
+		if (isset($context['exception'])) {
+			$exception = $this->processException($context['exception']);
+			unset($context['exception']);
+		}
 		array_walk($context, [$this->normalizer, 'format']);
 
 		if (isset($context['app'])) {
@@ -312,7 +317,14 @@ class Log implements ILogger {
 
 		if ($level >= $minLevel) {
 			$logger = $this->logger;
-			call_user_func([$logger, 'write'], $app, $message, $level, $logConditionFile);
+			$extras = null;
+			if (!is_null($exception)) {
+				$extras['exception'] = $exception;
+			}
+			if (!is_null($logConditionFile)) {
+				$extras['conditionalLogFile'] = $logConditionFile;
+			}
+			call_user_func([$logger, 'write'], $app, $message, $level, $extras);
 		}
 	}
 
@@ -325,20 +337,39 @@ class Log implements ILogger {
 	 * @since 8.2.0
 	 */
 	public function logException($exception, array $context = []) {
-		$exception = [
-			'Exception' => get_class($exception),
-			'Message' => $exception->getMessage(),
-			'Code' => $exception->getCode(),
-			'Trace' => $exception->getTraceAsString(),
-			'File' => $exception->getFile(),
-			'Line' => $exception->getLine(),
-		];
-		$exception['Trace'] = preg_replace('!(' . implode('|', $this->methodsWithSensitiveParameters) . ')\(.*\)!', '$1(*** sensitive parameters replaced ***)', $exception['Trace']);
-		if (\OC::$server->getUserSession() && \OC::$server->getUserSession()->isLoggedIn()) {
+		$context['exception'] = $exception;
+		if (\OC::$server->getUserSession()->isLoggedIn()) {
 			$context['userid'] = \OC::$server->getUserSession()->getUser()->getUID();
 		}
 		$msg = isset($context['message']) ? $context['message'] : 'Exception';
-		$msg .= ': ' . json_encode($exception);
 		$this->error($msg, $context);
+	}
+
+	/**
+	 * Converts an exception to an associative array
+	 *
+	 * @param \Exception | \Throwable $exception
+	 * @return array
+	 */
+	private function processException($exception) {
+		$result = [
+			'Exception' => get_class($exception),
+			'Message' => $exception->getMessage(),
+			'Code' => $exception->getCode(),
+			'File' => $exception->getFile(),
+			'Line' => $exception->getLine(),
+		];
+
+		$traces = $exception->getTraceAsString();
+		// sanitize methods with sensitive parameters
+		$traces = preg_replace('!(' . implode('|', $this->methodsWithSensitiveParameters) . ')\(.*\)!', '$1(*** sensitive parameters replaced ***)', $traces);
+		// convert stack string to array
+		$parts = explode("\n", $traces);
+		$traces = [];
+		foreach ($parts as $part) {
+			$traces[] = $part;
+		}
+		$result['Trace'] = $traces;
+		return $result;
 	}
 }

--- a/lib/private/Log/Owncloud.php
+++ b/lib/private/Log/Owncloud.php
@@ -67,10 +67,17 @@ class Owncloud {
 	 * @param string $app
 	 * @param string $message
 	 * @param int $level
-	 * @param string conditionalLogFile
+	 * @param array|null $extras
 	 */
-	public static function write($app, $message, $level, $conditionalLogFile = null) {
+	public static function write($app, $message, $level, $extras = null) {
 		$config = \OC::$server->getSystemConfig();
+
+		$conditionalLogFile = null;
+		if (!is_null($extras)) {
+			if (isset($extras['conditionalLogFile'])) {
+				$conditionalLogFile = $extras['conditionalLogFile'];
+			}
+		}
 
 		// default to ISO8601
 		$format = $config->getValue('logdateformat', 'c');
@@ -110,7 +117,7 @@ class Owncloud {
 			'url',
 			'user'
 		);
-		$entry = json_encode($entry);
+		$entry = json_encode($entry, JSON_UNESCAPED_SLASHES);
 		if (!is_null($conditionalLogFile)) {
 			$handle = @fopen($conditionalLogFile, 'a');
 			@chmod($conditionalLogFile, 0640);


### PR DESCRIPTION
Make the log looks a bit better when containing exceptions.

To test, do a PROPFIND on any folder and look at the look.
Also tweak the boolean flags inside `Log::processException()`.

The formatting was done by piping the row into `jsonlint -p`

### Log exception on the same level as other fields with string stack trace

Uses `getTraceAsString` for the stack, `$jsonStack=false; $jsonStringStack = false;`;

Unformatted:
```
{"reqId":"+2KhWzBFYeuZNHxeLARN","remoteAddr":"127.0.0.1","app":"webdav","message":"Exception","level":3,"time":"2016-11-21T17:09:51+00:00","method":"PROPFIND","url":"/owncloud/remote.php/webdav","user":"admin","exception":{"Exception":"Exception","Message":"Test exception","Code":0,"File":"/srv/www/htdocs/owncloud/lib/private/Files/View.php","Line":1383,"Trace":"#0 /srv/www/htdocs/owncloud/apps/dav/lib/Connector/Sabre/Directory.php(252): OC\\Files\\View->getDirectoryContent('/')\n#1 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Tree.php(195): OCA\\DAV\\Connector\\Sabre\\Directory->getChildren()\n#2 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php(893): Sabre\\DAV\\Tree->getChildren('')\n#3 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php(947): Sabre\\DAV\\Server->addPathNodesRecursively(Array, Object(Sabre\\DAV\\PropFind))\n#4 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/CorePlugin.php(336): Sabre\\DAV\\Server->getPropertiesForPath('', Array, 1)\n#5 [internal function]: Sabre\\DAV\\CorePlugin->httpPropFind(Object(Sabre\\HTTP\\Request), Object(Sabre\\HTTP\\Response))\n#6 /srv/www/htdocs/owncloud/lib/composer/sabre/event/lib/EventEmitterTrait.php(105): call_user_func_array(Array, Array)\n#7 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php(479): Sabre\\Event\\EventEmitter->emit('method:PROPFIND', Array)\n#8 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php(254): Sabre\\DAV\\Server->invokeMethod(Object(Sabre\\HTTP\\Request), Object(Sabre\\HTTP\\Response))\n#9 /srv/www/htdocs/owncloud/apps/dav/appinfo/v1/webdav.php(57): Sabre\\DAV\\Server->exec()\n#10 /srv/www/htdocs/owncloud/remote.php(164): require_once('/srv/www/htdocs...')\n#11 {main}"}}
```

Formatted:
```
{
  "reqId": "+2KhWzBFYeuZNHxeLARN",
  "remoteAddr": "127.0.0.1",
  "app": "webdav",
  "message": "Exception",
  "level": 3,
  "time": "2016-11-21T17:09:51+00:00",
  "method": "PROPFIND",
  "url": "/owncloud/remote.php/webdav",
  "user": "admin",
  "exception": {
    "Exception": "Exception",
    "Message": "Test exception",
    "Code": 0,
    "File": "/srv/www/htdocs/owncloud/lib/private/Files/View.php",
    "Line": 1383,
    "Trace": "#0 /srv/www/htdocs/owncloud/apps/dav/lib/Connector/Sabre/Directory.php(252): OC\\Files\\View->getDirectoryContent('/')\n#1 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Tree.php(195): OCA\\DAV\\Connector\\Sabre\\Directory->getChildren()\n#2 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php(893): Sabre\\DAV\\Tree->getChildren('')\n#3 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php(947): Sabre\\DAV\\Server->addPathNodesRecursively(Array, Object(Sabre\\DAV\\PropFind))\n#4 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/CorePlugin.php(336): Sabre\\DAV\\Server->getPropertiesForPath('', Array, 1)\n#5 [internal function]: Sabre\\DAV\\CorePlugin->httpPropFind(Object(Sabre\\HTTP\\Request), Object(Sabre\\HTTP\\Response))\n#6 /srv/www/htdocs/owncloud/lib/composer/sabre/event/lib/EventEmitterTrait.php(105): call_user_func_array(Array, Array)\n#7 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php(479): Sabre\\Event\\EventEmitter->emit('method:PROPFIND', Array)\n#8 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php(254): Sabre\\DAV\\Server->invokeMethod(Object(Sabre\\HTTP\\Request), Object(Sabre\\HTTP\\Response))\n#9 /srv/www/htdocs/owncloud/apps/dav/appinfo/v1/webdav.php(57): Sabre\\DAV\\Server->exec()\n#10 /srv/www/htdocs/owncloud/remote.php(164): require_once('/srv/www/htdocs...')\n#11 {main}"
  }
}
```

This already looks nice but doesn't format the stack trace properly.

### Log on same level as other fields but with JSON stack trace

Uses `getTrace()` for the stack and puts the items into a JSON sub-array.
`$jsonStack=true;`

As you can see there are LOTS of details in there, perhaps too much.

Unformatted:
```
{"reqId":"gaAGh5V1bfwaRzSbh1Qu","remoteAddr":"127.0.0.1","app":"webdav","message":"Exception","level":3,"time":"2016-11-21T17:11:08+00:00","method":"PROPFIND","url":"/owncloud/remote.php/webdav","user":"admin","exception":{"Exception":"Exception","Message":"Test exception","Code":0,"File":"/srv/www/htdocs/owncloud/lib/private/Files/View.php","Line":1383,"Trace":[{"file":"/srv/www/htdocs/owncloud/apps/dav/lib/Connector/Sabre/Directory.php","line":252,"function":"getDirectoryContent","class":"OC\\Files\\View","type":"->","args":["/"]},{"file":"/srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Tree.php","line":195,"function":"getChildren","class":"OCA\\DAV\\Connector\\Sabre\\Directory","type":"->","args":[]},{"file":"/srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php","line":893,"function":"getChildren","class":"Sabre\\DAV\\Tree","type":"->","args":[""]},{"file":"/srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php","line":947,"function":"addPathNodesRecursively","class":"Sabre\\DAV\\Server","type":"->","args":[[[{},{}]],{}]},{"file":"/srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/CorePlugin.php","line":336,"function":"getPropertiesForPath","class":"Sabre\\DAV\\Server","type":"->","args":["",["{DAV:}resourcetype","{DAV:}getlastmodified","{DAV:}getcontentlength","{DAV:}getetag","{http://owncloud.org/ns}id","{http://owncloud.org/ns}downloadURL","{http://owncloud.org/ns}dDC","{http://owncloud.org/ns}permissions","{http://owncloud.org/ns}size","{DAV:}quota-used-bytes","{DAV:}quota-available-bytes","{http://owncloud.org/ns}share-types"],1]},{"function":"httpPropFind","class":"Sabre\\DAV\\CorePlugin","type":"->","args":[{"absoluteUrl":"http://localhost/owncloud/remote.php/webdav"},{}]},{"file":"/srv/www/htdocs/owncloud/lib/composer/sabre/event/lib/EventEmitterTrait.php","line":105,"function":"call_user_func_array","args":[[{},"httpPropFind"],[{"absoluteUrl":"http://localhost/owncloud/remote.php/webdav"},{}]]},{"file":"/srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php","line":479,"function":"emit","class":"Sabre\\Event\\EventEmitter","type":"->","args":["method:PROPFIND",[{"absoluteUrl":"http://localhost/owncloud/remote.php/webdav"},{}]]},{"file":"/srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php","line":254,"function":"invokeMethod","class":"Sabre\\DAV\\Server","type":"->","args":[{"absoluteUrl":"http://localhost/owncloud/remote.php/webdav"},{}]},{"file":"/srv/www/htdocs/owncloud/apps/dav/appinfo/v1/webdav.php","line":57,"function":"exec","class":"Sabre\\DAV\\Server","type":"->","args":[]},{"file":"/srv/www/htdocs/owncloud/remote.php","line":164,"args":["/srv/www/htdocs/owncloud/apps/dav/appinfo/v1/webdav.php"],"function":"require_once"}]}}
```

Formatted:
```
{
  "reqId": "gaAGh5V1bfwaRzSbh1Qu",
  "remoteAddr": "127.0.0.1",
  "app": "webdav",
  "message": "Exception",
  "level": 3,
  "time": "2016-11-21T17:11:08+00:00",
  "method": "PROPFIND",
  "url": "/owncloud/remote.php/webdav",
  "user": "admin",
  "exception": {
    "Exception": "Exception",
    "Message": "Test exception",
    "Code": 0,
    "File": "/srv/www/htdocs/owncloud/lib/private/Files/View.php",
    "Line": 1383,
    "Trace": [
      {
        "file": "/srv/www/htdocs/owncloud/apps/dav/lib/Connector/Sabre/Directory.php",
        "line": 252,
        "function": "getDirectoryContent",
        "class": "OC\\Files\\View",
        "type": "->",
        "args": [
          "/"
        ]
      },
      {
        "file": "/srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Tree.php",
        "line": 195,
        "function": "getChildren",
        "class": "OCA\\DAV\\Connector\\Sabre\\Directory",
        "type": "->",
        "args": []
      },
      {
        "file": "/srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php",
        "line": 893,
        "function": "getChildren",
        "class": "Sabre\\DAV\\Tree",
        "type": "->",
        "args": [
          ""
        ]
      },
      {
        "file": "/srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php",
        "line": 947,
        "function": "addPathNodesRecursively",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          [
            [
              {},
              {}
            ]
          ],
          {}
        ]
      },
      {
        "file": "/srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/CorePlugin.php",
        "line": 336,
        "function": "getPropertiesForPath",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          "",
          [
            "{DAV:}resourcetype",
            "{DAV:}getlastmodified",
            "{DAV:}getcontentlength",
            "{DAV:}getetag",
            "{http://owncloud.org/ns}id",
            "{http://owncloud.org/ns}downloadURL",
            "{http://owncloud.org/ns}dDC",
            "{http://owncloud.org/ns}permissions",
            "{http://owncloud.org/ns}size",
            "{DAV:}quota-used-bytes",
            "{DAV:}quota-available-bytes",
            "{http://owncloud.org/ns}share-types"
          ],
          1
        ]
      },
      {
        "function": "httpPropFind",
        "class": "Sabre\\DAV\\CorePlugin",
        "type": "->",
        "args": [
          {
            "absoluteUrl": "http://localhost/owncloud/remote.php/webdav"
          },
          {}
        ]
      },
      {
        "file": "/srv/www/htdocs/owncloud/lib/composer/sabre/event/lib/EventEmitterTrait.php",
        "line": 105,
        "function": "call_user_func_array",
        "args": [
          [
            {},
            "httpPropFind"
          ],
          [
            {
              "absoluteUrl": "http://localhost/owncloud/remote.php/webdav"
            },
            {}
          ]
        ]
      },
      {
        "file": "/srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php",
        "line": 479,
        "function": "emit",
        "class": "Sabre\\Event\\EventEmitter",
        "type": "->",
        "args": [
          "method:PROPFIND",
          [
            {
              "absoluteUrl": "http://localhost/owncloud/remote.php/webdav"
            },
            {}
          ]
        ]
      },
      {
        "file": "/srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php",
        "line": 254,
        "function": "invokeMethod",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          {
            "absoluteUrl": "http://localhost/owncloud/remote.php/webdav"
          },
          {}
        ]
      },
      {
        "file": "/srv/www/htdocs/owncloud/apps/dav/appinfo/v1/webdav.php",
        "line": 57,
        "function": "exec",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": []
      },
      {
        "file": "/srv/www/htdocs/owncloud/remote.php",
        "line": 164,
        "args": [
          "/srv/www/htdocs/owncloud/apps/dav/appinfo/v1/webdav.php"
        ],
        "function": "require_once"
      }
    ]
  }
}
```

### Log on same level as other fields but take the string trace rows and put these into a JSON array

`$jsonStack=false; $jsonStringStack = true;`

Unformatted:
```
{"reqId":"ZZuX2T/Fubz5+TbHOG7p","remoteAddr":"127.0.0.1","app":"webdav","message":"Exception","level":3,"time":"2016-11-21T17:15:50+00:00","method":"PROPFIND","url":"/owncloud/remote.php/webdav","user":"admin","exception":{"Exception":"Exception","Message":"Test exception","Code":0,"File":"/srv/www/htdocs/owncloud/lib/private/Files/View.php","Line":1383,"Trace":["#0 /srv/www/htdocs/owncloud/apps/dav/lib/Connector/Sabre/Directory.php(252): OC\\Files\\View->getDirectoryContent('/')","#1 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Tree.php(195): OCA\\DAV\\Connector\\Sabre\\Directory->getChildren()","#2 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php(893): Sabre\\DAV\\Tree->getChildren('')","#3 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php(947): Sabre\\DAV\\Server->addPathNodesRecursively(Array, Object(Sabre\\DAV\\PropFind))","#4 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/CorePlugin.php(336): Sabre\\DAV\\Server->getPropertiesForPath('', Array, 1)","#5 [internal function]: Sabre\\DAV\\CorePlugin->httpPropFind(Object(Sabre\\HTTP\\Request), Object(Sabre\\HTTP\\Response))","#6 /srv/www/htdocs/owncloud/lib/composer/sabre/event/lib/EventEmitterTrait.php(105): call_user_func_array(Array, Array)","#7 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php(479): Sabre\\Event\\EventEmitter->emit('method:PROPFIND', Array)","#8 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php(254): Sabre\\DAV\\Server->invokeMethod(Object(Sabre\\HTTP\\Request), Object(Sabre\\HTTP\\Response))","#9 /srv/www/htdocs/owncloud/apps/dav/appinfo/v1/webdav.php(57): Sabre\\DAV\\Server->exec()","#10 /srv/www/htdocs/owncloud/remote.php(164): require_once('/srv/www/htdocs...')","#11 {main}"]}}
```

Formatted:
```
{
  "reqId": "ZZuX2T/Fubz5+TbHOG7p",
  "remoteAddr": "127.0.0.1",
  "app": "webdav",
  "message": "Exception",
  "level": 3,
  "time": "2016-11-21T17:15:50+00:00",
  "method": "PROPFIND",
  "url": "/owncloud/remote.php/webdav",
  "user": "admin",
  "exception": {
    "Exception": "Exception",
    "Message": "Test exception",
    "Code": 0,
    "File": "/srv/www/htdocs/owncloud/lib/private/Files/View.php",
    "Line": 1383,
    "Trace": [
      "#0 /srv/www/htdocs/owncloud/apps/dav/lib/Connector/Sabre/Directory.php(252): OC\\Files\\View->getDirectoryContent('/')",
      "#1 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Tree.php(195): OCA\\DAV\\Connector\\Sabre\\Directory->getChildren()",
      "#2 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php(893): Sabre\\DAV\\Tree->getChildren('')",
      "#3 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php(947): Sabre\\DAV\\Server->addPathNodesRecursively(Array, Object(Sabre\\DAV\\PropFind))",
      "#4 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/CorePlugin.php(336): Sabre\\DAV\\Server->getPropertiesForPath('', Array, 1)",
      "#5 [internal function]: Sabre\\DAV\\CorePlugin->httpPropFind(Object(Sabre\\HTTP\\Request), Object(Sabre\\HTTP\\Response))",
      "#6 /srv/www/htdocs/owncloud/lib/composer/sabre/event/lib/EventEmitterTrait.php(105): call_user_func_array(Array, Array)",
      "#7 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php(479): Sabre\\Event\\EventEmitter->emit('method:PROPFIND', Array)",
      "#8 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php(254): Sabre\\DAV\\Server->invokeMethod(Object(Sabre\\HTTP\\Request), Object(Sabre\\HTTP\\Response))",
      "#9 /srv/www/htdocs/owncloud/apps/dav/appinfo/v1/webdav.php(57): Sabre\\DAV\\Server->exec()",
      "#10 /srv/www/htdocs/owncloud/remote.php(164): require_once('/srv/www/htdocs...')",
      "#11 {main}"
    ]
  }
}
```

Perhaps the last one is the nicest.

Also note that I added  `JSON_UNESCAPED_SLASHES` to avoid the annoying `\/`...
