### PR TITLE
Make share permission check work correctly from share manager

### DIFF
--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -676,25 +676,6 @@ class Share20OCS {
 			}
 		}
 
-		if ($permissions !== null && $share->getShareOwner() !== $this->currentUser->getUID()) {
-			/* Check if this is an incomming share */
-			$incomingShares = $this->shareManager->getSharedWith($this->currentUser->getUID(), \OCP\Share::SHARE_TYPE_USER, $share->getNode(), -1, 0);
-			$incomingShares = array_merge($incomingShares, $this->shareManager->getSharedWith($this->currentUser->getUID(), \OCP\Share::SHARE_TYPE_GROUP, $share->getNode(), -1, 0));
-
-			if (!empty($incomingShares)) {
-				$maxPermissions = 0;
-				foreach ($incomingShares as $incomingShare) {
-					$maxPermissions |= $incomingShare->getPermissions();
-				}
-
-				if ($share->getPermissions() & ~$maxPermissions) {
-					$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
-					return new \OC\OCS\Result(null, 404, $this->l->t('Cannot increase permissions'));
-				}
-			}
-		}
-
-
 		try {
 			$share = $this->shareManager->updateShare($share);
 		} catch (\Exception $e) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
As an API consumer, I expect the PHP Share API (share manager) to take care of all sorts of validation without having to do so myself. Currently some validation is done in the OCS API class instead.

This PR moves some of the validation to happen in the share manager instead.

## Related Issue
Discovered while looking into https://github.com/owncloud/core/pull/26639

## Motivation and Context
See description

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### TODOs

- [ ] add unit tests for share manager
- [ ] remove tests from OCS API since the share manager is mocked there

Instead of checking for valid share permissions for reshares in the OCS
controller, do it correctly in the share manager. For this, the share
manager needs to read the permissions from the recipient's received
node instead of the node that is stored inside the share which isn't
guaranteed to be the correct one.