### PR TITLE
Add test for duplicate 401 headers on DAV

### DIFF
--- a/build/integration/features/bootstrap/WebDav.php
+++ b/build/integration/features/bootstrap/WebDav.php
@@ -617,4 +617,27 @@ trait WebDav {
 		PHPUnit_Framework_Assert::assertNotEquals($this->response['{DAV:}getetag'], $this->storedETAG[$user][$path]);
 	}
 
+	/**
+	 * @When Connecting to dav endpoint
+	 */
+	public function connectingToDavEndpoint() {
+		try {
+			$this->response = $this->makeDavRequest(null, 'PROPFIND', '', []);
+		} catch (\GuzzleHttp\Exception\ClientException $e) {
+			$this->response = $e->getResponse();
+		}
+	}
+
+	/**
+	 * @Then there are no duplicate headers
+	 */
+	public function thereAreNoDuplicateHeaders() {
+		$headers = $this->response->getHeaders();
+		foreach ($headers as $headerName => $headerValues) {
+			// if a header has multiple values, they must be different
+			if (count($headerValues) > 1 && count(array_unique($headerValues)) < count($headerValues)) {
+				throw new \Exception('Duplicate header found: ' . $headerName);
+			}
+		}
+    }
 }

--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -2,6 +2,22 @@ Feature: webdav-related
 	Background:
 		Given using api version "1"
 
+	Scenario: Unauthenticated call old dav path
+		Given using old dav path
+		When connecting to dav endpoint
+		Then the HTTP status code should be "401"
+		And there are no duplicate headers
+		And The following headers should be set
+			|WWW-Authenticate|Basic realm="ownCloud"|
+
+	Scenario: Unauthenticated call new dav path
+		Given using new dav path
+		When connecting to dav endpoint
+		Then the HTTP status code should be "401"
+		And there are no duplicate headers
+		And The following headers should be set
+			|WWW-Authenticate|Basic realm="ownCloud"|
+
 	Scenario: Moving a file
 		Given using old dav path
 		And As an "admin"


### PR DESCRIPTION
This adds an integration test for https://github.com/owncloud/core/pull/26353.

If you revert that commit or comment out the `challenge` function here https://github.com/owncloud/core/pull/26353/files#diff-3b44c5ee347efe65dedcd0cb37f2f694R64 the test will fail due to duplicate headers.

Please review @SergioBertolinSG @DeepDiver1975 

To be backported to stable9.1 and stable9 to match the fix backports.