### PR TITLE
commit transaction after select query

### DIFF
--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -158,7 +158,6 @@ class DefaultShareProvider implements IShareProvider {
 		$this->dbConn->beginTransaction();
 		$qb->execute();
 		$id = $this->dbConn->lastInsertId('*PREFIX*share');
-		$this->dbConn->commit();
 
 		// Now fetch the inserted share and create a complete share object
 		$qb = $this->dbConn->getQueryBuilder();
@@ -168,6 +167,7 @@ class DefaultShareProvider implements IShareProvider {
 
 		$cursor = $qb->execute();
 		$data = $cursor->fetch();
+		$this->dbConn->commit();
 		$cursor->closeCursor();
 
 		if ($data === false) {


### PR DESCRIPTION
## Description
In some cases the transaction will not have executed the insert query once we execute the select query afterwards. So the select after the transaction will return an empty result. Committing the transaction after the select query has been executed makes sure that it returns the share.


## Motivation and Context
Has been described in `Description`.

## How Has This Been Tested?
Tested manually.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


