### PR TITLE
Don't fetch preview images if `enable_previews` is set to `false`

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1734,44 +1734,49 @@
 				urlSpec = {};
 			ready(iconURL); // set mimeicon URL
 
-			urlSpec.file = OCA.Files.Files.fixPath(path);
-			if (options.x) {
-				urlSpec.x = options.x;
-			}
-			if (options.y) {
-				urlSpec.y = options.y;
-			}
-			if (options.a) {
-				urlSpec.a = options.a;
-			}
-			if (options.mode) {
-				urlSpec.mode = options.mode;
-			}
-
-			if (etag){
-				// use etag as cache buster
-				urlSpec.c = etag;
-			}
-
-			previewURL = self.generatePreviewUrl(urlSpec);
-			previewURL = previewURL.replace('(', '%28');
-			previewURL = previewURL.replace(')', '%29');
-
-			// preload image to prevent delay
-			// this will make the browser cache the image
 			var img = new Image();
-			img.onload = function(){
-				// if loading the preview image failed (no preview for the mimetype) then img.width will < 5
-				if (img.width > 5) {
-					ready(previewURL, img);
-				} else if (options.error) {
-					options.error();
+
+			if (oc_appconfig.core.previewsEnabled) {
+				urlSpec.file = OCA.Files.Files.fixPath(path);
+				if (options.x) {
+					urlSpec.x = options.x;
 				}
-			};
-			if (options.error) {
-				img.onerror = options.error;
+				if (options.y) {
+					urlSpec.y = options.y;
+				}
+				if (options.a) {
+					urlSpec.a = options.a;
+				}
+				if (options.mode) {
+					urlSpec.mode = options.mode;
+				}
+
+				if (etag) {
+					// use etag as cache buster
+					urlSpec.c = etag;
+				}
+
+				previewURL = self.generatePreviewUrl(urlSpec);
+				previewURL = previewURL.replace('(', '%28');
+				previewURL = previewURL.replace(')', '%29');
+
+				// preload image to prevent delay
+				// this will make the browser cache the image
+				img.onload = function () {
+					// if loading the preview image failed (no preview for the mimetype) then img.width will < 5
+					if (img.width > 5) {
+						ready(previewURL, img);
+					} else if (options.error) {
+						options.error();
+					}
+				};
+				if (options.error) {
+					img.onerror = options.error;
+				}
+				img.src = previewURL;
+			} else {
+				ready(iconURL, img);
 			}
-			img.src = previewURL;
 		},
 
 		/**

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -157,7 +157,8 @@ $array = [
 		]
 	),
 	"oc_appconfig" => json_encode(
-			["core" => [
+		[
+			"core" => [
 				'defaultExpireDateEnabled' => $defaultExpireDateEnabled,
 				'defaultExpireDate' => $defaultExpireDate,
 				'defaultExpireDateEnforced' => $enforceDefaultExpireDate,
@@ -168,9 +169,9 @@ $array = [
 				'remoteShareAllowed' => $outgoingServer2serverShareEnabled,
 				'federatedCloudShareDoc' => \OC::$server->getURLGenerator()->linkToDocs('user-sharing-federated'),
 				'allowGroupSharing' => \OC::$server->getShareManager()->allowGroupSharing(),
-                'previewsEnabled' => \OC::$server->getConfig()->getSystemValue('enable_previews', true) === true,
+				'previewsEnabled' => \OC::$server->getConfig()->getSystemValue('enable_previews', true) === true,
 			]
-			]
+		]
 	),
 	"oc_defaults" => json_encode(
 		[

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -167,7 +167,8 @@ $array = [
 				'resharingAllowed' => \OCP\Share::isResharingAllowed(),
 				'remoteShareAllowed' => $outgoingServer2serverShareEnabled,
 				'federatedCloudShareDoc' => \OC::$server->getURLGenerator()->linkToDocs('user-sharing-federated'),
-				'allowGroupSharing' => \OC::$server->getShareManager()->allowGroupSharing()
+				'allowGroupSharing' => \OC::$server->getShareManager()->allowGroupSharing(),
+                'previewsEnabled' => \OC::$server->getConfig()->getSystemValue('enable_previews', true) === true,
 			]
 			]
 	),


### PR DESCRIPTION
## Description
Even if `enable_previews` in `config/config.php` has been set to `false`, the file-list and detail-view both still try to get a preview image. The `lazyLoadPreview` method now checks for this configuration and only renders the default mime-icons now if previews have been disabled through the configuration. 

## Motivation and Context
See description.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

@felixheidecke 