### PR TITLE
Fix dav v2 MOVE test

### DIFF
--- a/build/integration/features/dav-v2.feature
+++ b/build/integration/features/dav-v2.feature
@@ -3,10 +3,10 @@ Feature: dav-v2
 		Given using api version "1"
 
 	Scenario: moving a file new endpoint way
-		Given using dav path "remote.php/dav"
+		Given using new dav path
 		And As an "admin"
 		And user "user0" exists
-		When User "user0" moves file "/files/user0/textfile0.txt" to "/files/user0/abcde.txt"
+		When User "user0" moves file "/textfile0.txt" to "/FOLDER/textfile0.txt"
 		Then the HTTP status code should be "201"
 
 


### PR DESCRIPTION
Re-add removed test from https://github.com/owncloud/core/pull/26666 because it failed due to missing fixes.

Some dav v2 MOVE fixes might need backporting to make this work correctly.

@SergioBertolinSG 