### PR TITLE
[stable9] Use the correct realm for basic authentication - fixes #23427

### DIFF
--- a/apps/dav/lib/connector/publicauth.php
+++ b/apps/dav/lib/connector/publicauth.php
@@ -26,6 +26,13 @@
 
 namespace OCA\DAV\Connector;
 
+use Sabre\DAV\Auth\Backend\AbstractBasic;
+
+/**
+ * Class PublicAuth
+ *
+ * @package OCA\DAV\Connector
+ */
 class PublicAuth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
 
 	/**
@@ -40,6 +47,10 @@ class PublicAuth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
 	 */
 	public function __construct($config) {
 		$this->config = $config;
+
+		// setup realm
+		$defaults = new \OC_Defaults();
+		$this->realm = $defaults->getName();
 	}
 
 	/**

--- a/apps/dav/lib/connector/sabre/auth.php
+++ b/apps/dav/lib/connector/sabre/auth.php
@@ -66,6 +66,10 @@ class Auth extends AbstractBasic {
 		$this->userSession = $userSession;
 		$this->request = $request;
 		$this->principalPrefix = $principalPrefix;
+
+		// setup realm
+		$defaults = new \OC_Defaults();
+		$this->realm = $defaults->getName();
 	}
 
 	/**

--- a/apps/dav/lib/connector/sabre/serverfactory.php
+++ b/apps/dav/lib/connector/sabre/serverfactory.php
@@ -98,10 +98,9 @@ class ServerFactory {
 		$server->setBaseUri($baseUri);
 
 		// Load plugins
-		$defaults = new \OC_Defaults();
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\MaintenancePlugin($this->config));
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\BlockLegacyClientPlugin($this->config));
-		$server->addPlugin(new \Sabre\DAV\Auth\Plugin($authBackend, $defaults->getName()));
+		$server->addPlugin(new \Sabre\DAV\Auth\Plugin($authBackend));
 		// FIXME: The following line is a workaround for legacy components relying on being able to send a GET to /
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\DummyGetResponsePlugin());
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin('webdav', $this->logger));

--- a/apps/federation/dav/fedauth.php
+++ b/apps/federation/dav/fedauth.php
@@ -38,6 +38,10 @@ class FedAuth extends AbstractBasic {
 	public function __construct(DbHandler $db) {
 		$this->db = $db;
 		$this->principalPrefix = 'principals/system/';
+
+		// setup realm
+		$defaults = new \OC_Defaults();
+		$this->realm = $defaults->getName();
 	}
 
 	/**

--- a/build/integration/features/bootstrap/WebDav.php
+++ b/build/integration/features/bootstrap/WebDav.php
@@ -617,4 +617,28 @@ trait WebDav {
 		$this->asGetsPropertiesOfFolderWith($user, NULL, $path, $propertiesTable);
 		PHPUnit_Framework_Assert::assertNotEquals($this->response['{DAV:}getetag'], $this->storedETAG[$user][$path]);
 	}
+
+	/**
+	 * @When Connecting to dav endpoint
+	 */
+	public function connectingToDavEndpoint() {
+		try {
+			$this->response = $this->makeDavRequest(null, 'PROPFIND', '', []);
+		} catch (\GuzzleHttp\Exception\ClientException $e) {
+			$this->response = $e->getResponse();
+		}
+	}
+
+	/**
+	 * @Then there are no duplicate headers
+	 */
+	public function thereAreNoDuplicateHeaders() {
+		$headers = $this->response->getHeaders();
+		foreach ($headers as $headerName => $headerValues) {
+			// if a header has multiple values, they must be different
+			if (count($headerValues) > 1 && count(array_unique($headerValues)) < count($headerValues)) {
+				throw new \Exception('Duplicate header found: ' . $headerName);
+			}
+		}
+    }
 }

--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -2,6 +2,22 @@ Feature: webdav-related
 	Background:
 		Given using api version "1"
 
+	Scenario: Unauthenticated call old dav path
+		Given using dav path "remote.php/webdav"
+		When connecting to dav endpoint
+		Then the HTTP status code should be "401"
+		And there are no duplicate headers
+		And The following headers should be set
+			|WWW-Authenticate|Basic realm="ownCloud"|
+
+	Scenario: Unauthenticated call new dav path
+		Given using dav path "remote.php/dav"
+		When connecting to dav endpoint
+		Then the HTTP status code should be "401"
+		And there are no duplicate headers
+		And The following headers should be set
+			|WWW-Authenticate|Basic realm="ownCloud"|
+
 	Scenario: Moving a file
 		Given using old dav path
 		And As an "admin"


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/25046 to stable9.

Please note that I had to remove one block from the conflict because we don't hate the "X-Requested-With" logic at all in OC 9.0.

Please review @DeepDiver1975 @SergioBertolinSG 

I've cherry-picked the automated test from https://github.com/owncloud/core/pull/26712 here