### PR TITLE
[stable9.1] Prevent PHP7 GC to kill normalizedPathCache too early

### DIFF
--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -81,7 +81,7 @@ class Filesystem {
 
 	static private $usersSetup = array();
 
-	static private $normalizedPathCache = null;
+	static public $normalizedPathCache = null;
 
 	static private $listeningForProviders = false;
 

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1144,12 +1144,15 @@ class View {
 				$unlockLater = false;
 				if ($this->lockingEnabled && $operation === 'fopen' && is_resource($result)) {
 					$unlockLater = true;
-					$result = CallbackWrapper::wrap($result, null, null, function () use ($hooks, $path) {
+					// create additional reference to avoid PHP 7's hungry GC to discard it too early...
+					$normalizedPathCache = \OC\Files\Filesystem::$normalizedPathCache;
+					$result = CallbackWrapper::wrap($result, null, null, function () use ($hooks, $path, &$normalizedPathCache) {
 						if (in_array('write', $hooks)) {
 							$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
 						} else if (in_array('read', $hooks)) {
 							$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
 						}
+						$normalizedPathCache = null;
 					});
 				}
 


### PR DESCRIPTION
attempt 1