### PR TITLE
[stable9.1] [debug] Debug fclose wrapper

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -430,10 +430,14 @@ class View {
 			\OCP\Util::writeLog('DEBUG', 'readfile: before loop', \OCP\Util::DEBUG);
 			while (!feof($handle)) {
 				echo fread($handle, $chunkSize);
-				flush();
+				// keep the last flush for after fclose
+				if (!feof($handle)) {
+					flush();
+				}
 			}
 			\OCP\Util::writeLog('DEBUG', 'readfile: after loop, preparing to fclose', \OCP\Util::DEBUG);
 			fclose($handle);
+			flush();
 			\OCP\Util::writeLog('DEBUG', 'readfile: fclose called', \OCP\Util::DEBUG);
 			$size = $this->filesize($path);
 			\OCP\Util::writeLog('DEBUG', 'readfile: got filesize: ' . $size, \OCP\Util::DEBUG);
@@ -468,12 +472,16 @@ class View {
 						$len = $chunkSize;
 					}
 					echo fread($handle, $len);
-					flush();
+					// keep the last flush for after fclose
+					if (!feof($handle)) {
+						flush();
+					}
 				}
 				\OCP\Util::writeLog('DEBUG', 'readfilePart: after loop', \OCP\Util::DEBUG);
 				$size = ftell($handle) - $from;
 				\OCP\Util::writeLog('DEBUG', 'readfilePart: preparing to fclose', \OCP\Util::DEBUG);
 				fclose($handle);
+				flush();
 				\OCP\Util::writeLog('DEBUG', 'readfile: fclose called', \OCP\Util::DEBUG);
 				return $size;
 			}

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -420,6 +420,7 @@ class View {
 	 * @throws \OCP\Files\InvalidPathException
 	 */
 	public function readfile($path) {
+		ignore_user_abort();
 		$this->assertPathLength($path);
 		@ob_end_clean();
 		\OCP\Util::writeLog('DEBUG', 'readfile: fopen', \OCP\Util::DEBUG);
@@ -450,6 +451,7 @@ class View {
 	 * @throws \OCP\Files\UnseekableException
 	 */
 	public function readfilePart($path, $from, $to) {
+		ignore_user_abort();
 		$this->assertPathLength($path);
 		@ob_end_clean();
 		\OCP\Util::writeLog('DEBUG', 'readfilePart: fopen', \OCP\Util::DEBUG);


### PR DESCRIPTION
This will likely fill your logs so use with caution.

For every fopen and fclose it will log the stack trace.
Needs "loglevel => 0" in config.php.

Goal is to find out why adding `fclose` in `readfile` doesn't work.

Steps:

1. Share a big file (ex: video) with link
1. Open link
1. Click "Download" button multiple times until the "normalizedPath" errors appears
1. Check logs to find the error's request id, then paste all log entries that have the same request id.

@Webbeh