### PR TITLE
remove redundant php_value definitions in php5 and php7 ifmodule blocks

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -30,29 +30,22 @@
     Header set Cache-Control "max-age=604800"
   </FilesMatch>
 </IfModule>
+
 <IfModule mod_php5.c>
-  php_value upload_max_filesize 513M
-  php_value post_max_size 513M
-  php_value memory_limit 512M
-  php_value mbstring.func_overload 0
   php_value always_populate_raw_post_data -1
-  php_value default_charset 'UTF-8'
-  php_value output_buffering 0
-  <IfModule mod_env.c>
-    SetEnv htaccessWorking true
-  </IfModule>
 </IfModule>
-<IfModule mod_php7.c>
-  php_value upload_max_filesize 513M
-  php_value post_max_size 513M
-  php_value memory_limit 512M
-  php_value mbstring.func_overload 0
-  php_value default_charset 'UTF-8'
-  php_value output_buffering 0
-  <IfModule mod_env.c>
-    SetEnv htaccessWorking true
-  </IfModule>
+
+php_value upload_max_filesize 513M
+php_value post_max_size 513M
+php_value memory_limit 512M
+php_value mbstring.func_overload 0
+php_value default_charset 'UTF-8'
+php_value output_buffering 0
+
+<IfModule mod_env.c>
+  SetEnv htaccessWorking true
 </IfModule>
+
 <IfModule mod_rewrite.c>
   RewriteEngine on
   RewriteRule .* - [env=HTTP_AUTHORIZATION:%{HTTP:Authorization}]


### PR DESCRIPTION
## Description
When adding php7 support, the php5 `IfModule` block was copied for php7. Those definitions are exactly the same except for one php value.

## Related Issue
[owncloud/enterprise#1670](https://github.com/owncloud/enterprise/issues/1670)

## Motivation and Context
Removes redundancy.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


