### PR TITLE
Fix multi-file download

### DIFF
--- a/apps/files/ajax/download.php
+++ b/apps/files/ajax/download.php
@@ -30,13 +30,13 @@
 OCP\User::checkLoggedIn();
 \OC::$server->getSession()->close();
 
-$files = isset($_GET['files']) ? (string)$_GET['files'] : '';
+// files can be an array with multiple "files[]=one.txt&files[]=two.txt" or a single file with "files=filename.txt"
+$files_list = isset($_GET['files']) ? $_GET['files'] : '';
 $dir = isset($_GET['dir']) ? (string)$_GET['dir'] : '';
 
-$files_list = json_decode($files);
 // in case we get only a single file
 if (!is_array($files_list)) {
-	$files_list = [$files];
+	$files_list = [(string)$files_list];
 }
 
 /**

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -152,7 +152,11 @@
 			}
 
 			if (_.isArray(filename)) {
-				filename = JSON.stringify(filename);
+				var filesPart = '';
+				_.each(filename, function(name) {
+					filesPart += '&files[]=' + encodeURIComponent(name);
+				});
+				return this.getAjaxUrl('download', {dir: dir}) + filesPart;
 			}
 
 			var params = {

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1611,7 +1611,7 @@ describe('OCA.Files.FileList tests', function() {
 		});
 		it('returns correct download URL for multiple files', function() {
 			expect(fileList.getDownloadUrl(['a b c.txt', 'd e f.txt']))
-				.toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files=%5B%22a%20b%20c.txt%22%2C%22d%20e%20f.txt%22%5D');
+				.toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files[]=a%20b%20c.txt&files[]=d%20e%20f.txt');
 		});
 		it('returns the correct ajax URL', function() {
 			expect(fileList.getAjaxUrl('test', {a:1, b:'x y'}))
@@ -1987,7 +1987,8 @@ describe('OCA.Files.FileList tests', function() {
 				it('Opens download URL when clicking "Download"', function() {
 					$('.selectedActions .download').click();
 					expect(redirectStub.calledOnce).toEqual(true);
-					expect(redirectStub.getCall(0).args[0]).toContain(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files=%5B%22One.txt%22%2C%22Three.pdf%22%2C%22somedir%22%5D');
+					expect(redirectStub.getCall(0).args[0]).toContain(OC.webroot + '/index.php/apps/files/ajax/download.php?' +
+						'dir=%2Fsubdir&files[]=One.txt&files[]=Three.pdf&files[]=somedir');
 					redirectStub.restore();
 				});
 				it('Downloads root folder when all selected in root folder', function() {

--- a/apps/files/tests/js/filesSpec.js
+++ b/apps/files/tests/js/filesSpec.js
@@ -84,7 +84,7 @@ describe('OCA.Files.Files tests', function() {
 		});
 		it('returns the ajax download URL when multiple files specified', function() {
 			var url = Files.getDownloadUrl(['test file.txt', 'abc.txt'], '/subdir');
-			expect(url).toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files=%5B%22test%20file.txt%22%2C%22abc.txt%22%5D');
+			expect(url).toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files[]=test%20file.txt&files[]=abc.txt');
 		});
 	});
 	describe('handleDownload', function() {

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -158,16 +158,17 @@ OCA.Sharing.PublicApp = {
 			// TODO: move this to a separate PublicFileList class that extends OCA.Files.FileList (+ unit tests)
 			this.fileList.getDownloadUrl = function (filename, dir, isDir) {
 				var path = dir || this.getCurrentDirectory();
+				var base = OC.generateUrl('/s/' + token + '/download') + '?' + OC.buildQueryString({path: path});
+
+				var filesPart = '';
 				if (_.isArray(filename)) {
-					filename = JSON.stringify(filename);
+					_.each(filename, function(name) {
+						filesPart += '&files[]=' + encodeURIComponent(name);
+					});
+				} else {
+					filesPart = '&files=' + encodeURIComponent(filename);
 				}
-				var params = {
-					path: path
-				};
-				if (filename) {
-					params.files = filename;
-				}
-				return OC.generateUrl('/s/' + token + '/download') + '?' + OC.buildQueryString(params);
+				return base + filesPart;
 			};
 
 			this.fileList.getUploadUrl = function(fileName, dir) {

--- a/apps/files_sharing/lib/Controllers/ShareController.php
+++ b/apps/files_sharing/lib/Controllers/ShareController.php
@@ -387,12 +387,11 @@ class ShareController extends Controller {
 				['token' => $token]));
 		}
 
-		$files_list = null;
+		$files_list = $files;
 		if (!is_null($files)) { // download selected files
-			$files_list = json_decode($files);
 			// in case we get only a single file
-			if ($files_list === null) {
-				$files_list = [$files];
+			if (!is_array($files_list)) {
+				$files_list = [(string)$files_list];
 			}
 		}
 

--- a/apps/files_sharing/tests/js/publicAppSpec.js
+++ b/apps/files_sharing/tests/js/publicAppSpec.js
@@ -119,7 +119,7 @@ describe('OCA.Sharing.PublicApp tests', function() {
 			});
 			it('returns correct download URL for multiple files', function() {
 				expect(fileList.getDownloadUrl(['a b c.txt', 'd e f.txt']))
-					.toEqual(OC.webroot + '/index.php/s/sh4tok/download?path=%2Fsubdir&files=%5B%22a%20b%20c.txt%22%2C%22d%20e%20f.txt%22%5D');
+					.toEqual(OC.webroot + '/index.php/s/sh4tok/download?path=%2Fsubdir&files[]=a%20b%20c.txt&files[]=d%20e%20f.txt');
 			});
 			it('returns the correct ajax URL', function() {
 				expect(fileList.getAjaxUrl('test', {a:1, b:'x y'}))


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
On some environments, PHP parses some file names differently instead of
returning NULL. For example a date like "2016-12-01" would get parsed
as the integer value "2016".

This fix changes the internal URL download format to use either a
single "files" parameter or multiple "files[]" parameters to specify
files to download.

## Related Issue
Fixes https://github.com/owncloud/core/issues/26664

## Motivation and Context
See ticket

## How Has This Been Tested?
- [x] TEST: regular file list download single file
- [x] TEST: regular file list download multiple files
- [x] TEST: regular file list download single folder called `["abc", "def"]`
- [x] TEST: public file file list download single file
- [x] TEST: public file list download multiple files
- [x] TEST: public file list download single folder called `["abc", "def"]`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

### Backports
- [ ] stable9.1
- [ ] others ?

This URL is supposed to be private, but it is likely that some apps might be using it so we might want to include a fallback to JSON parsing in case the old format is still used ?

Please review @DeepDiver1975 @VicDeo @jvillafanez @PhilippSchaffrath 