### PR TITLE
Integrity check: Return 1 if it is failed. Fixes #22806

### DIFF
--- a/core/Command/Integrity/CheckApp.php
+++ b/core/Command/Integrity/CheckApp.php
@@ -65,6 +65,9 @@ class CheckApp extends Base {
 		$path = strval($input->getOption('path'));
 		$result = $this->checker->verifyAppSignature($appid, $path);
 		$this->writeArrayInOutputFormat($input, $output, $result);
+		if (count($result)>0){
+			return 1;
+		}
 	}
 
 }

--- a/core/Command/Integrity/CheckCore.php
+++ b/core/Command/Integrity/CheckCore.php
@@ -59,5 +59,8 @@ class CheckCore extends Base {
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$result = $this->checker->verifyCoreSignature();
 		$this->writeArrayInOutputFormat($input, $output, $result);
+		if (count($result)>0){
+			return 1;
+		}
 	}
 }


### PR DESCRIPTION

## Description
If integrity report has entries, exit code will be 1

## Related Issue
#22806

## Motivation and Context
See #22806

## How Has This Been Tested?
In CLI
```
sudo -u www-data ./occ integrity:check-core
echo $?
```


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


