### PR TITLE
Check shipped apps when running from cli

### DIFF
--- a/core/Command/Integrity/CheckCore.php
+++ b/core/Command/Integrity/CheckCore.php
@@ -57,7 +57,8 @@ class CheckCore extends Base {
 	 * {@inheritdoc }
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$result = $this->checker->verifyCoreSignature();
+		$this->checker->runInstanceVerification();
+		$result = $this->checker->getResults();
 		$this->writeArrayInOutputFormat($input, $output, $result);
 		if (count($result)>0){
 			return 1;


### PR DESCRIPTION
## Description
`OC\IntegrityCheck\Checker::runInstanceVerification` checks core and shipped apps
`OC\IntegrityCheck\Checker::verifyCoreSignature` checks core only

## Related Issue
#26463

## Motivation and Context
Better integrity check from CLI

## How Has This Been Tested?
Current behavior:
1. modify a shipped app
2. check integrity from CLI `php occ integrity:check-core`
3. Nothing is reported
4. Login into admin area
5. Nothing is reported in WebUI
6. Modify core file
7. check integrity from CLI `php occ integrity:check-core`
8. Only core file is reported
9. Login into admin area
10. Both shipped app and  core file are reported

This PR:
Both shipped app and  core file are reported when running an integrity check from CLI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


