### PR TITLE
fixed overwriting templates through themes

### DIFF
--- a/lib/private/Template/Base.php
+++ b/lib/private/Template/Base.php
@@ -30,27 +30,45 @@ namespace OC\Template;
 use OC\Theme\Theme;
 
 class Base {
-	private $template; // The template
-	private $vars; // Vars
+	/**
+	 * @var string
+	 */
+	private $template;
 
-	/** @var \OCP\IL10N */
+	/**
+	 * @var array
+	 */
+	private $vars;
+
+	/**
+	 * @var \OCP\IL10N
+	 */
 	private $l10n;
 
-	/** @var \OC_Defaults */
-	private $theme;
+	/**
+	 * @var Theme
+	 */
+	protected $theme;
+
+	/**
+	 * @var \OC_Defaults
+	 */
+	private $themeDefaults;
 
 	/**
 	 * @param string $template
 	 * @param string $requestToken
 	 * @param \OCP\IL10N $l10n
-	 * @param \OC_Defaults $theme
+	 * @param Theme $theme
+	 * @param \OC_Defaults $themeDefaults
 	 */
-	public function __construct($template, $requestToken, $l10n, $theme ) {
+	public function __construct($template, $requestToken, $l10n, $theme, $themeDefaults) {
 		$this->vars = [];
 		$this->vars['requesttoken'] = $requestToken;
 		$this->l10n = $l10n;
 		$this->template = $template;
 		$this->theme = $theme;
+		$this->themeDefaults = $themeDefaults;
 	}
 
 	/**
@@ -156,20 +174,20 @@ class Base {
 	 * @param string $file
 	 * @param array|null $additionalParams
 	 * @return string content
+	 * @throws \Exception
 	 *
 	 * Includes the template file, fetches its output
 	 */
 	protected function load($file, $additionalParams = null) {
-		// Register the variables
+		// This variables will be used inside templates, they are not unused!
 		$_ = $this->vars;
 		$l = $this->l10n;
-		$theme = $this->theme;
+		$theme = $this->themeDefaults;
 
 		if( !is_null($additionalParams)) {
 			$_ = array_merge( $additionalParams, $this->vars );
 		}
 
-		// Include
 		ob_start();
 		try {
 			include $file;
@@ -180,8 +198,6 @@ class Base {
 		}
 		@ob_end_clean();
 
-		// Return data
 		return $data;
 	}
-
 }

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -449,7 +449,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 				return vsprintf($text, $parameters);
 			}));
 
-		$t = new Base($template, $requestToken, $l10n, $theme);
+		$t = new Base($template, $requestToken, $l10n, null, $theme);
 		$buf = $t->fetchPage($vars);
 		$this->assertHtmlStringEqualsHtmlString($expectedHtml, $buf);
 	}


### PR DESCRIPTION
## Description
This change allows themes to override php templates. Your theme can live inside an app `apps/my-theme-app` or inside the themes directory `themes/my-theme`. If you want to override an app template, you would mimic its file location inside your theme directory e.g. `apps/my-theme-app/apps/files/templates/list.php`. Overwriting core templates works the same way, e.g. `themes/my-theme/settings/templates/users/part.userlist.php` or `apps/my-theme-app/core/templates/login.php`. Just mimic the directory of the template you want to override, no exceptions or anything.

## Related Issue
fixes #18243

## Motivation and Context
Inside templates the `OC_Template:inc` method is used to render other templates. This method ignores themes. This means those templates could not be overwritten by themes.

## How Has This Been Tested?
This is testes manually, automated testing might require the presence of a theme, not entirely sure what the best way to test this would be.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 @butonic @PVince81 