### PR TITLE
Let apps register Sabre plugins or collections

### DIFF
--- a/apps/comments/appinfo/info.xml
+++ b/apps/comments/appinfo/info.xml
@@ -14,4 +14,12 @@
 		<logging/>
 		<dav/>
 	</types>
+	<sabre>
+		<plugins>
+			<plugin>OCA\Comments\Dav\CommentsPlugin</plugin>
+		</plugins>
+		<collections>
+			<collection>OCA\Comments\Dav\RootCollection</collection>
+		</collections>
+	</sabre>
 </info>

--- a/apps/comments/appinfo/info.xml
+++ b/apps/comments/appinfo/info.xml
@@ -12,5 +12,6 @@
 	</dependencies>
 	<types>
 		<logging/>
+		<dav/>
 	</types>
 </info>

--- a/apps/comments/lib/Dav/CommentNode.php
+++ b/apps/comments/lib/Dav/CommentNode.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace OCA\DAV\Comments;
+namespace OCA\Comments\Dav;
 
 
 use OCP\Comments\IComment;

--- a/apps/comments/lib/Dav/CommentsPlugin.php
+++ b/apps/comments/lib/Dav/CommentsPlugin.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace OCA\DAV\Comments;
+namespace OCA\Comments\Dav;
 
 use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
@@ -84,6 +84,10 @@ class CommentsPlugin extends ServerPlugin {
 	function initialize(Server $server) {
 		$this->server = $server;
 		if(strpos($this->server->getRequestUri(), 'comments/') !== 0) {
+			return;
+		}
+
+		if ($this->userSession === null || $this->userSession->getUser() === null) {
 			return;
 		}
 

--- a/apps/comments/lib/Dav/EntityCollection.php
+++ b/apps/comments/lib/Dav/EntityCollection.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace OCA\DAV\Comments;
+namespace OCA\Comments\Dav;
 
 use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException;
@@ -37,7 +37,7 @@ use Sabre\DAV\PropPatch;
  * this represents a specific holder of comments, identified by an entity type
  * (class member $name) and an entity id (class member $id).
  *
- * @package OCA\DAV\Comments
+ * @package OCA\Comments\Dav
  */
 class EntityCollection extends RootCollection implements IProperties {
 	const PROPERTY_NAME_READ_MARKER  = '{http://owncloud.org/ns}readMarker';

--- a/apps/comments/lib/Dav/EntityTypeCollection.php
+++ b/apps/comments/lib/Dav/EntityTypeCollection.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace OCA\DAV\Comments;
+namespace OCA\Comments\Dav;
 
 use OCP\Comments\ICommentsManager;
 use OCP\ILogger;
@@ -38,7 +38,7 @@ use Sabre\DAV\Exception\NotFound;
  * Its children are instances of EntityCollection (representing a specific
  * object, for example the file by id).
  *
- * @package OCA\DAV\Comments
+ * @package OCA\Comments\Dav
  */
 class EntityTypeCollection extends RootCollection {
 

--- a/apps/comments/lib/Dav/RootCollection.php
+++ b/apps/comments/lib/Dav/RootCollection.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace OCA\DAV\Comments;
+namespace OCA\Comments\Dav;
 
 use OCP\Comments\CommentsEntityEvent;
 use OCP\Comments\ICommentsManager;
@@ -87,6 +87,9 @@ class RootCollection implements ICollection {
 	protected function initCollections() {
 		if($this->entityTypeCollections !== null) {
 			return;
+		}
+		if(is_null($this->userSession)) {
+			throw new NotAuthenticated();
 		}
 		$user = $this->userSession->getUser();
 		if(is_null($user)) {

--- a/apps/comments/tests/unit/Dav/CommentsNodeTest.php
+++ b/apps/comments/tests/unit/Dav/CommentsNodeTest.php
@@ -23,7 +23,7 @@
 
 namespace OCA\DAV\Tests\unit\Comments;
 
-use OCA\DAV\Comments\CommentNode;
+use OCA\Comments\Dav\CommentNode;
 use OCP\Comments\MessageTooLongException;
 
 class CommentsNodeTest extends \Test\TestCase {

--- a/apps/comments/tests/unit/Dav/CommentsPluginTest.php
+++ b/apps/comments/tests/unit/Dav/CommentsPluginTest.php
@@ -24,7 +24,7 @@
 namespace OCA\DAV\Tests\unit\Comments;
 
 use OC\Comments\Comment;
-use OCA\DAV\Comments\CommentsPlugin as CommentsPluginImplementation;
+use OCA\Comments\Dav\CommentsPlugin as CommentsPluginImplementation;
 use OCP\Comments\IComment;
 
 class CommentsPluginTest extends \Test\TestCase {
@@ -84,7 +84,7 @@ class CommentsPluginTest extends \Test\TestCase {
 			->method('getUID')
 			->will($this->returnValue('alice'));
 
-		$node = $this->getMockBuilder('\OCA\DAV\Comments\EntityCollection')
+		$node = $this->getMockBuilder('\OCA\Comments\Dav\EntityCollection')
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->once())
@@ -103,7 +103,7 @@ class CommentsPluginTest extends \Test\TestCase {
 			->with('users', 'alice', 'files', '42')
 			->will($this->returnValue($comment));
 
-		$this->userSession->expects($this->once())
+		$this->userSession->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($user));
 
@@ -177,7 +177,7 @@ class CommentsPluginTest extends \Test\TestCase {
 		$user->expects($this->never())
 			->method('getUID');
 
-		$node = $this->getMockBuilder('\OCA\DAV\Comments\EntityCollection')
+		$node = $this->getMockBuilder('\OCA\Comments\Dav\EntityCollection')
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->never())
@@ -188,7 +188,7 @@ class CommentsPluginTest extends \Test\TestCase {
 		$this->commentsManager->expects($this->never())
 			->method('create');
 
-		$this->userSession->expects($this->never())
+		$this->userSession->expects($this->once())
 			->method('getUser');
 
 		// technically, this is a shortcut. Inbetween EntityTypeCollection would
@@ -259,7 +259,7 @@ class CommentsPluginTest extends \Test\TestCase {
 		$user->expects($this->never())
 			->method('getUID');
 
-		$node = $this->getMockBuilder('\OCA\DAV\Comments\EntityCollection')
+		$node = $this->getMockBuilder('\OCA\Comments\Dav\EntityCollection')
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->once())
@@ -272,7 +272,7 @@ class CommentsPluginTest extends \Test\TestCase {
 		$this->commentsManager->expects($this->never())
 			->method('create');
 
-		$this->userSession->expects($this->never())
+		$this->userSession->expects($this->once())
 			->method('getUser');
 
 		// technically, this is a shortcut. Inbetween EntityTypeCollection would
@@ -345,7 +345,7 @@ class CommentsPluginTest extends \Test\TestCase {
 		$user->expects($this->never())
 			->method('getUID');
 
-		$node = $this->getMockBuilder('\OCA\DAV\Comments\EntityCollection')
+		$node = $this->getMockBuilder('\OCA\Comments\Dav\EntityCollection')
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->once())
@@ -358,7 +358,7 @@ class CommentsPluginTest extends \Test\TestCase {
 		$this->commentsManager->expects($this->never())
 			->method('create');
 
-		$this->userSession->expects($this->never())
+		$this->userSession->expects($this->once())
 			->method('getUser');
 
 		// technically, this is a shortcut. Inbetween EntityTypeCollection would
@@ -434,7 +434,7 @@ class CommentsPluginTest extends \Test\TestCase {
 			->method('getUID')
 			->will($this->returnValue('alice'));
 
-		$node = $this->getMockBuilder('\OCA\DAV\Comments\EntityCollection')
+		$node = $this->getMockBuilder('\OCA\Comments\Dav\EntityCollection')
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->once())
@@ -449,7 +449,7 @@ class CommentsPluginTest extends \Test\TestCase {
 			->with('users', 'alice', 'files', '42')
 			->will($this->returnValue($comment));
 
-		$this->userSession->expects($this->once())
+		$this->userSession->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($user));
 
@@ -526,7 +526,7 @@ class CommentsPluginTest extends \Test\TestCase {
 			->method('getUID')
 			->will($this->returnValue('alice'));
 
-		$node = $this->getMockBuilder('\OCA\DAV\Comments\EntityCollection')
+		$node = $this->getMockBuilder('\OCA\Comments\Dav\EntityCollection')
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->once())
@@ -544,7 +544,7 @@ class CommentsPluginTest extends \Test\TestCase {
 			->with('users', 'alice', 'files', '42')
 			->will($this->returnValue($comment));
 
-		$this->userSession->expects($this->once())
+		$this->userSession->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($user));
 
@@ -645,7 +645,7 @@ class CommentsPluginTest extends \Test\TestCase {
 			]
 		];
 
-		$node = $this->getMockBuilder('\OCA\DAV\Comments\EntityCollection')
+		$node = $this->getMockBuilder('\OCA\Comments\Dav\EntityCollection')
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->once())
@@ -700,7 +700,7 @@ class CommentsPluginTest extends \Test\TestCase {
 			]
 		];
 
-		$node = $this->getMockBuilder('\OCA\DAV\Comments\EntityCollection')
+		$node = $this->getMockBuilder('\OCA\Comments\Dav\EntityCollection')
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->once())

--- a/apps/comments/tests/unit/Dav/EntityCollectionTest.php
+++ b/apps/comments/tests/unit/Dav/EntityCollectionTest.php
@@ -30,7 +30,7 @@ class EntityCollectionTest extends \Test\TestCase {
 	protected $userManager;
 	/** @var \OCP\ILogger|\PHPUnit_Framework_MockObject_MockObject */
 	protected $logger;
-	/** @var \OCA\DAV\Comments\EntityCollection */
+	/** @var \OCA\Comments\Dav\EntityCollection */
 	protected $collection;
 	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
 	protected $userSession;
@@ -43,7 +43,7 @@ class EntityCollectionTest extends \Test\TestCase {
 		$this->userSession = $this->createMock('\OCP\IUserSession');
 		$this->logger = $this->createMock('\OCP\ILogger');
 
-		$this->collection = new \OCA\DAV\Comments\EntityCollection(
+		$this->collection = new \OCA\Comments\Dav\EntityCollection(
 			'19',
 			'files',
 			$this->commentsManager,
@@ -64,7 +64,7 @@ class EntityCollectionTest extends \Test\TestCase {
 			->will($this->returnValue($this->createMock('\OCP\Comments\IComment')));
 
 		$node = $this->collection->getChild('55');
-		$this->assertTrue($node instanceof \OCA\DAV\Comments\CommentNode);
+		$this->assertTrue($node instanceof \OCA\Comments\Dav\CommentNode);
 	}
 
 	/**
@@ -88,7 +88,7 @@ class EntityCollectionTest extends \Test\TestCase {
 		$result = $this->collection->getChildren();
 
 		$this->assertSame(count($result), 1);
-		$this->assertTrue($result[0] instanceof \OCA\DAV\Comments\CommentNode);
+		$this->assertTrue($result[0] instanceof \OCA\Comments\Dav\CommentNode);
 	}
 
 	public function testFindChildren() {
@@ -101,7 +101,7 @@ class EntityCollectionTest extends \Test\TestCase {
 		$result = $this->collection->findChildren(5, 15, $dt);
 
 		$this->assertSame(count($result), 1);
-		$this->assertTrue($result[0] instanceof \OCA\DAV\Comments\CommentNode);
+		$this->assertTrue($result[0] instanceof \OCA\Comments\Dav\CommentNode);
 	}
 
 	public function testChildExistsTrue() {

--- a/apps/comments/tests/unit/Dav/EntityTypeCollectionTest.php
+++ b/apps/comments/tests/unit/Dav/EntityTypeCollectionTest.php
@@ -22,7 +22,7 @@
 
 namespace OCA\DAV\Tests\unit\Comments;
 
-use OCA\DAV\Comments\EntityCollection as EntityCollectionImplemantation;
+use OCA\Comments\Dav\EntityCollection as EntityCollectionImplemantation;
 
 class EntityTypeCollectionTest extends \Test\TestCase {
 
@@ -32,7 +32,7 @@ class EntityTypeCollectionTest extends \Test\TestCase {
 	protected $userManager;
 	/** @var \OCP\ILogger|\PHPUnit_Framework_MockObject_MockObject */
 	protected $logger;
-	/** @var \OCA\DAV\Comments\EntityTypeCollection */
+	/** @var \OCA\Comments\Dav\EntityTypeCollection */
 	protected $collection;
 	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
 	protected $userSession;
@@ -49,7 +49,7 @@ class EntityTypeCollectionTest extends \Test\TestCase {
 
 		$instance = $this;
 
-		$this->collection = new \OCA\DAV\Comments\EntityTypeCollection(
+		$this->collection = new \OCA\Comments\Dav\EntityTypeCollection(
 			'files',
 			$this->commentsManager,
 			$this->userManager,

--- a/apps/comments/tests/unit/Dav/RootCollectionTest.php
+++ b/apps/comments/tests/unit/Dav/RootCollectionTest.php
@@ -22,7 +22,7 @@
 
 namespace OCA\DAV\Tests\unit\Comments;
 
-use OCA\DAV\Comments\EntityTypeCollection as EntityTypeCollectionImplementation;
+use OCA\Comments\Dav\EntityTypeCollection as EntityTypeCollectionImplementation;
 use OCP\Comments\CommentsEntityEvent;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
@@ -34,7 +34,7 @@ class RootCollectionTest extends \Test\TestCase {
 	protected $userManager;
 	/** @var \OCP\ILogger|\PHPUnit_Framework_MockObject_MockObject */
 	protected $logger;
-	/** @var \OCA\DAV\Comments\RootCollection */
+	/** @var \OCA\Comments\Dav\RootCollection */
 	protected $collection;
 	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
 	protected $userSession;
@@ -54,7 +54,7 @@ class RootCollectionTest extends \Test\TestCase {
 		$this->dispatcher = new EventDispatcher();
 		$this->logger = $this->createMock('\OCP\ILogger');
 
-		$this->collection = new \OCA\DAV\Comments\RootCollection(
+		$this->collection = new \OCA\Comments\Dav\RootCollection(
 			$this->commentsManager,
 			$this->userManager,
 			$this->userSession,

--- a/apps/dav/appinfo/v2/remote.php
+++ b/apps/dav/appinfo/v2/remote.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Vincent Petry <pvince81@owncloud.com>
  *
  * @copyright Copyright (c) 2016, ownCloud GmbH.
  * @license AGPL-3.0

--- a/apps/dav/lib/AppInfo/PluginManager.php
+++ b/apps/dav/lib/AppInfo/PluginManager.php
@@ -22,6 +22,7 @@ namespace OCA\DAV\AppInfo;
 
 use OCP\App\IAppManager;
 use OC\ServerContainer;
+use OCP\AppFramework\QueryException;
 
 /**
  * Manager for DAV plugins from apps, used to register them

--- a/apps/dav/lib/AppInfo/PluginManager.php
+++ b/apps/dav/lib/AppInfo/PluginManager.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\AppInfo;
+
+use OCP\App\IAppManager;
+use OC\ServerContainer;
+
+/**
+ * Manager for DAV plugins from apps, used to register them
+ * to the Sabre server.
+ */
+class PluginManager {
+
+	/**
+	 * @var ServerContainer
+	 */
+	private $container;
+
+	/**
+	 * @var IAppManager
+	 */
+	private $appManager;
+
+	/**
+	 * App plugins
+	 *
+	 * @var array
+	 */
+	private $plugins = null;
+
+	/**
+	 * App collections
+	 *
+	 * @var array
+	 */
+	private $collections = null;
+
+	/**
+	 * Contstruct a PluginManager
+	 *
+	 * @param ServerContainer $container server container for resolving plugin classes
+	 * @param IAppManager $appManager app manager to loading apps and their info
+	 */
+	public function __construct(ServerContainer $container, IAppManager $appManager) {
+		$this->container = $container;
+		$this->appManager = $appManager;
+	}
+
+	/**
+	 * Returns an array of app-registered plugins
+	 *
+	 * @return array
+	 */
+	public function getAppPlugins() {
+		if (is_null($this->plugins)) {
+			$this->populate();
+		}
+		return $this->plugins;
+	}
+
+	/**
+	 * Returns an array of app-registered collections
+	 *
+	 * @return array
+	 */
+	public function getAppCollections() {
+		if (is_null($this->collections)) {
+			$this->populate();
+		}
+		return $this->collections;
+	}
+
+	/**
+	 * Retrieve plugin and collection list and populate attributes
+	 */
+	private function populate() {
+		$this->plugins = [];
+		$this->collections = [];
+		foreach ($this->appManager->getInstalledApps() as $app) {
+			// load plugins and collections from info.xml
+			$info = $this->appManager->getAppInfo($app);
+			if (!isset($info['types']) || !in_array('dav', $info['types'])) {
+				continue;
+			}
+			// FIXME: switch to public API once available
+			// load app to make sure its classes are available
+			\OC_App::loadApp($app);
+			$this->loadSabrePluginsFromInfoXml($this->extractPluginList($info));
+			$this->loadSabreCollectionsFromInfoXml($this->extractCollectionList($info));
+		}
+	}
+
+	private function extractPluginList($array) {
+		if (isset($array['sabre']) && is_array($array['sabre'])) {
+			if (isset($array['sabre']['plugins']) && is_array($array['sabre']['plugins'])) {
+				if (isset($array['sabre']['plugins']['plugin'])) {
+					$items = $array['sabre']['plugins']['plugin'];
+					if (!is_array($items)) {
+						$items = [$items];
+					}
+					return $items;
+				}
+			}
+		}
+		return [];
+	}
+
+	private function extractCollectionList($array) {
+		if (isset($array['sabre']) && is_array($array['sabre'])) {
+			if (isset($array['sabre']['collections']) && is_array($array['sabre']['collections'])) {
+				if (isset($array['sabre']['collections']['collection'])) {
+					$items = $array['sabre']['collections']['collection'];
+					if (!is_array($items)) {
+						$items = [$items];
+					}
+					return $items;
+				}
+			}
+		}
+		return [];
+	}
+
+	private function loadSabrePluginsFromInfoXml($plugins) {
+		foreach ($plugins as $plugin) {
+			try {
+				$this->plugins[] = $this->container->query($plugin);
+			} catch (QueryException $e) {
+				if (class_exists($plugin)) {
+					$this->plugins[] = new $plugin();
+				} else {
+					throw new \Exception("Sabre plugin class '$plugin' is unknown and could not be loaded");
+				}
+			}
+		}
+	}
+
+	private function loadSabreCollectionsFromInfoXml($collections) {
+		foreach ($collections as $collection) {
+			try {
+				$this->collections[] = $this->container->query($collection);
+			} catch (QueryException $e) {
+				if (class_exists($collection)) {
+					$this->collections[] = new $collection();
+				} else {
+					throw new \Exception("Sabre collection class '$collection' is unknown and could not be loaded");
+				}
+			}
+		};
+	}
+
+}

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -78,13 +78,6 @@ class RootCollection extends SimpleCollection {
 			\OC::$server->getGroupManager(),
 			\OC::$server->getRootFolder()
 		);
-		$commentsCollection = new Comments\RootCollection(
-			\OC::$server->getCommentsManager(),
-			\OC::$server->getUserManager(),
-			\OC::$server->getUserSession(),
-			\OC::$server->getEventDispatcher(),
-			\OC::$server->getLogger()
-		);
 
 		$usersCardDavBackend = new CardDavBackend($db, $userPrincipalBackend, $dispatcher);
 		$usersAddressBookRoot = new AddressBookRoot($userPrincipalBackend, $usersCardDavBackend, 'principals/users');
@@ -110,7 +103,6 @@ class RootCollection extends SimpleCollection {
 						$systemAddressBookRoot]),
 				$systemTagCollection,
 				$systemTagRelationsCollection,
-				$commentsCollection,
 				$uploadCollection,
 		];
 

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -49,6 +49,7 @@ use OCP\SabrePluginEvent;
 use Sabre\CardDAV\VCFExportPlugin;
 use Sabre\DAV\Auth\Plugin;
 use OCA\DAV\Connector\Sabre\TagsPlugin;
+use OCA\DAV\AppInfo\PluginManager;
 
 class Server {
 
@@ -155,7 +156,7 @@ class Server {
 		}
 
 		// wait with registering these until auth is handled and the filesystem is setup
-		$this->server->on('beforeMethod', function () {
+		$this->server->on('beforeMethod', function () use ($root) {
 			// custom properties plugin must be the last one
 			$userSession = \OC::$server->getUserSession();
 			$user = $userSession->getUser();
@@ -213,6 +214,18 @@ class Server {
 						$userFolder
 					));
 				}
+			}
+
+			// register plugins from apps
+			$pluginManager = new PluginManager(
+				\OC::$server,
+				\OC::$server->getAppManager()
+			);
+			foreach ($pluginManager->getAppPlugins() as $appPlugin) {
+				$this->server->addPlugin($appPlugin);
+			}
+			foreach ($pluginManager->getAppCollections() as $appCollection) {
+				$root->addChild($appCollection);
 			}
 		});
 	}

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -28,7 +28,6 @@ namespace OCA\DAV;
 
 use OCA\DAV\CalDAV\Schedule\IMipPlugin;
 use OCA\DAV\CardDAV\ImageExportPlugin;
-use OCA\DAV\Comments\CommentsPlugin;
 use OCA\DAV\Connector\Sabre\Auth;
 use OCA\DAV\Connector\Sabre\BlockLegacyClientPlugin;
 use OCA\DAV\Connector\Sabre\CommentPropertiesPlugin;
@@ -131,12 +130,6 @@ class Server {
 		$this->server->addPlugin(new SystemTagPlugin(
 			\OC::$server->getSystemTagManager(),
 			\OC::$server->getGroupManager(),
-			\OC::$server->getUserSession()
-		));
-
-		// comments plugin
-		$this->server->addPlugin(new CommentsPlugin(
-			\OC::$server->getCommentsManager(),
 			\OC::$server->getUserSession()
 		));
 

--- a/apps/dav/tests/unit/AppInfo/PluginManagerTest.php
+++ b/apps/dav/tests/unit/AppInfo/PluginManagerTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\unit\AppInfo;
+
+use Test\TestCase;
+use OCP\App\IAppManager;
+use OC\ServerContainer;
+use OCA\DAV\AppInfo\PluginManager;
+
+/**
+ * Class PluginManagerTest
+ *
+ * @package OCA\DAV\Tests\Unit\AppInfo
+ */
+class PluginManagerTest extends TestCase {
+	public function test() {
+		$server = $this->createMock(ServerContainer::class);
+
+
+		$appManager = $this->createMock(IAppManager::class);
+		$appManager->method('getInstalledApps')
+			->willReturn(['adavapp', 'adavapp2']);
+
+		$appInfo1 = [
+			'types' => ['dav'],
+			'sabre' => [
+				'plugins' => [
+					'plugin' => [
+						'\OCA\DAV\ADavApp\PluginOne',
+						'\OCA\DAV\ADavApp\PluginTwo',
+					],
+				],
+				'collections' => [
+					'collection' => [
+						'\OCA\DAV\ADavApp\CollectionOne',
+						'\OCA\DAV\ADavApp\CollectionTwo',
+					]
+				],
+			],
+		];
+		$appInfo2 = [
+			'types' => ['logging', 'dav'],
+			'sabre' => [
+				'plugins' => [
+					'plugin' => '\OCA\DAV\ADavApp2\PluginOne',
+				],
+				'collections' => [
+					'collection' => '\OCA\DAV\ADavApp2\CollectionOne',
+				],
+			],
+		];
+
+		$appManager->method('getAppInfo')
+			->will($this->returnValueMap([
+				['adavapp', $appInfo1],
+				['adavapp2', $appInfo2],
+			]));
+
+		$pluginManager = new PluginManager($server, $appManager);
+
+		$server->method('query')
+			->will($this->returnValueMap([
+				['\OCA\DAV\ADavApp\PluginOne', 'dummyplugin1'],
+				['\OCA\DAV\ADavApp\PluginTwo', 'dummyplugin2'],
+				['\OCA\DAV\ADavApp\CollectionOne', 'dummycollection1'],
+				['\OCA\DAV\ADavApp\CollectionTwo', 'dummycollection2'],
+				['\OCA\DAV\ADavApp2\PluginOne', 'dummy2plugin1'],
+				['\OCA\DAV\ADavApp2\CollectionOne', 'dummy2collection1'],
+			]));
+
+		$expectedPlugins = [
+			'dummyplugin1',
+			'dummyplugin2',
+			'dummy2plugin1',
+		];
+		$expectedCollections = [
+			'dummycollection1',
+			'dummycollection2',
+			'dummy2collection1',
+		];
+
+		$this->assertEquals($expectedPlugins, $pluginManager->getAppPlugins());
+		$this->assertEquals($expectedCollections, $pluginManager->getAppCollections());
+	}
+}

--- a/apps/dav/tests/unit/ServerTest.php
+++ b/apps/dav/tests/unit/ServerTest.php
@@ -24,6 +24,7 @@ namespace OCA\DAV\Tests\unit;
 
 use OCA\DAV\Server;
 use OCP\IRequest;
+use OCA\DAV\AppInfo\PluginManager;
 
 /**
  * Class ServerTest
@@ -36,8 +37,7 @@ class ServerTest extends \Test\TestCase {
 
 	public function test() {
 		/** @var IRequest $r */
-		$r = $this->getMockBuilder('\OCP\IRequest')
-			->disableOriginalConstructor()->getMock();
+		$r = $this->createMock(IRequest::class);
 		$s = new Server($r, '/');
 		$this->assertNotNull($s->server);
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
See https://github.com/owncloud/core/issues/26195#issuecomment-249140878 for info.xml format.
This checks the `sabre` tags in info.xml for all apps and automatically registers the Sabre plugins and collections to the root collection.
Note that this only happens for v2 remote.php.

## Related Issue
Fixes https://github.com/owncloud/core/issues/26195

## Motivation and Context
Since we want Webdav to be used for APIs, apps need a way to register Sabre plugins and also to hook their collections to the remote.php/dav collection tree.

## How Has This Been Tested?
Manually tested with the customgroups app, not ready yet.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

@DeepDiver1975 check this out