### PR TITLE
[stable9] Fix for app groups setting preservation

### DIFF
--- a/settings/controller/appsettingscontroller.php
+++ b/settings/controller/appsettingscontroller.php
@@ -282,6 +282,8 @@ class AppSettingsController extends Controller {
 			$groups = array();
 			if (is_string($app['groups'])) {
 				$groups = json_decode($app['groups']);
+			} elseif (is_array($app['groups'])) {
+				$groups = $app['groups'];
 			}
 			$app['groups'] = $groups;
 			$app['canUnInstall'] = !$app['active'] && $app['removable'];


### PR DESCRIPTION
## Description
Fixes not-preserving of the app groups restriction setting.

## Related Issue
#26638 
Backport of PR  #26748

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


