### PR TITLE
Prevent PHP request to get killed when using fclose callback

### DIFF
--- a/apps/dav/appinfo/v1/webdav.php
+++ b/apps/dav/appinfo/v1/webdav.php
@@ -24,6 +24,7 @@
 
 // no php execution timeout for webdav
 set_time_limit(0);
+ignore_user_abort(true);
 
 // Turn off output buffering to prevent memory problems
 \OC_Util::obEnd();

--- a/apps/dav/appinfo/v2/remote.php
+++ b/apps/dav/appinfo/v2/remote.php
@@ -21,6 +21,7 @@
  */
 // no php execution timeout for webdav
 set_time_limit(0);
+ignore_user_abort(true);
 
 // Turn off output buffering to prevent memory problems
 \OC_Util::obEnd();

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1143,6 +1143,8 @@ class View {
 				$unlockLater = false;
 				if ($this->lockingEnabled && $operation === 'fopen' && is_resource($result)) {
 					$unlockLater = true;
+					// make sure our unlocking callback will still be called if connection is aborted
+					ignore_user_abort(true);
 					$result = CallbackWrapper::wrap($result, null, null, function () use ($hooks, $path) {
 						if (in_array('write', $hooks)) {
 							$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);

--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -147,6 +147,7 @@ class OC_Files {
 			$streamer->sendHeaders($name);
 			$executionTime = intval(OC::$server->getIniWrapper()->getNumeric('max_execution_time'));
 			set_time_limit(0);
+			ignore_user_abort(true);
 			if ($getType === self::ZIP_FILES) {
 				foreach ($files as $file) {
 					$file = $dir . '/' . $file;


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
When cancelling a download or closing the connection too quickly after a download, the PHP process might get killed. In these cases the `fclose` code does not run any more and the locks are not released.
This workaround adds `ignore_user_abort(true)` to tell PHP to continue working even when the connection was closed. This makes sure that resources get freed properly and no weird GC-induced bugs will appear as reported in https://github.com/owncloud/core/issues/22370

## Related Issue
Partial fix for https://github.com/owncloud/core/issues/22370

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
See https://github.com/owncloud/core/issues/22370#issuecomment-264404487.
Need to abort download connections.
Also tested with smashbox: https://github.com/owncloud/smashbox/pull/151

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

### Backports
- [x] stable9.1 (note: the fix was tested on that version on the reporter's envs)
- [ ] stable9

Please review @jvillafanez @DeepDiver1975 @VicDeo @PhilippSchaffrath @butonic 
