### PR TITLE
When grouping shares, sort by stime then id

### DIFF
--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -122,7 +122,7 @@ class MountProvider implements IMountProvider {
 		// sort by stime, the super share will be based on the least recent share
 		foreach ($tmp as &$tmp2) {
 			@usort($tmp2, function($a, $b) {
-				if ($a->getShareTime() < $b->getShareTime()) {
+				if ($a->getShareTime() <= $b->getShareTime()) {
 					return -1;
 				}
 				return 1;


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
If share times are equal, the first share should still win instead of
having the shares swapped.

## Related Issue
Fixes https://github.com/owncloud/core/issues/25830

## Motivation and Context
Because it makes tests randomly fail.

## How Has This Been Tested?
Not possible to humanly manual test this.
You can hower swap `-1` and `1` before this fix and see how it makes the test from https://github.com/owncloud/core/issues/25830 fail. This clearly shows the when running the tests, sometimes the shares a swapped, likely when their share time is equal.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


@SergioBertolinSG @jvillafanez @DeepDiver1975 @PhilippSchaffrath 