### PR TITLE
[stable9.1] When grouping shares, sort by stime then id

### DIFF
--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -121,7 +121,7 @@ class MountProvider implements IMountProvider {
 		// sort by stime, the super share will be based on the least recent share
 		foreach ($tmp as &$tmp2) {
 			@usort($tmp2, function($a, $b) {
-				if ($a->getShareTime() < $b->getShareTime()) {
+				if ($a->getShareTime() <= $b->getShareTime()) {
 					return -1;
 				}
 				return 1;


### PR DESCRIPTION
backport of #26777