### PR TITLE
Add navigation via info.xml

### DIFF
--- a/apps/files/appinfo/app.php
+++ b/apps/files/appinfo/app.php
@@ -27,18 +27,8 @@
  */
 \OCP\App::registerAdmin('files', 'admin');
 
-
-\OC::$server->getNavigationManager()->add(function () {
-	$urlGenerator = \OC::$server->getURLGenerator();
-	$l = \OC::$server->getL10N('files');
-	return [
-		'id' => 'files_index',
-		'order' => 0,
-		'href' => $urlGenerator->linkToRoute('files.view.index'),
-		'icon' => $urlGenerator->imagePath('core', 'places/files.svg'),
-		'name' => $l->t('Files'),
-	];
-});
+// required for translation purpose
+// t('Files')
 
 \OC::$server->getSearch()->registerProvider('OC\Search\Provider\File', ['apps' => ['files']]);
 

--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -28,4 +28,10 @@
 		<command>OCA\Files\Command\DeleteOrphanedFiles</command>
 		<command>OCA\Files\Command\TransferOwnership</command>
 	</commands>
+
+	<navigation>
+		<route>files.view.index</route>
+		<order>0</order>
+	</navigation>
+
 </info>

--- a/apps/files/img/app.svg
+++ b/apps/files/img/app.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" height="32" width="32" version="1.1" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/">
+ <g fill-rule="evenodd" transform="matrix(1.7333 0 0 1.7333 -344.09 -1727.8)" fill="#fff">
+  <path d="m200.2 999.72c-0.28913 0-0.53125 0.2421-0.53125 0.5312v12.784c0 0.2985 0.23264 0.5312 0.53125 0.5312h15.091c0.2986 0 0.53124-0.2327 0.53124-0.5312l0.0004-10.474c0-0.2889-0.24211-0.5338-0.53124-0.5338l-7.5457 0.0005-2.3076-2.3078z" fill-rule="evenodd" fill="#fff"/>
+ </g>
+</svg>

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -6,7 +6,7 @@
  * @author Robin McCorkell <robin@mccorkell.me.uk>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2016, ownCloud GmbH.
+ * @copyright Copyright (c) 2016, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify
@@ -158,6 +158,7 @@ class NavigationManager implements INavigationManager {
 					$icon = $this->urlGenerator->imagePath($app, $i);
 					break;
 				} catch (\RuntimeException $ex) {
+					// no icon? - ignore it then
 				}
 			}
 			if (is_null($icon)) {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -289,8 +289,10 @@ class Server extends ServerContainer implements IServerContainer {
 			return new \OC\Authentication\TwoFactorAuth\Manager($c->getAppManager(), $c->getSession(), $c->getConfig());
 		});
 
-		$this->registerService('NavigationManager', function ($c) {
-			return new \OC\NavigationManager();
+		$this->registerService('NavigationManager', function (Server $c) {
+			return new \OC\NavigationManager($c->getAppManager(),
+				$c->getURLGenerator(),
+				$c->getL10NFactory());
 		});
 		$this->registerService('AllConfig', function (Server $c) {
 			return new \OC\AllConfig(

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -292,7 +292,9 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('NavigationManager', function (Server $c) {
 			return new \OC\NavigationManager($c->getAppManager(),
 				$c->getURLGenerator(),
-				$c->getL10NFactory());
+				$c->getL10NFactory(),
+				$c->getUserSession(),
+				$c->getGroupManager());
 		});
 		$this->registerService('AllConfig', function (Server $c) {
 			return new \OC\AllConfig(


### PR DESCRIPTION
## Description
Navigation entries are now setup in info.xml.
Old was will still stay valid.

## Motivation and Context
Navigation elements are read from info.xml only up on necessity to build up the menu.
By moving more and more out of app.php we can improve the overall performance.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## ToDos:
- [x] add check for role - admin, subadmin or regular user