### PR TITLE
Always run npm even for make dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - $HOME/.cache/bower
     - $HOME/.composer/cache
     - $HOME/.npm
-    - build/node_modules
+    - /tmp/phantomjs
 
 env:
   global:

--- a/Makefile
+++ b/Makefile
@@ -110,11 +110,7 @@ clean-composer-deps:
 #
 $(nodejs_deps): build/package.json
 	$(NPM) install --prefix $(NODE_PREFIX)
-
-# in some cases installing bower alone could be enough
-$(BOWER):
-	$(NPM) install --prefix $(NODE_PREFIX) bower
-	touch $(BOWER)
+	touch $(nodejs_deps)
 
 .PHONY: install-nodejs-deps
 install-nodejs-deps: $(nodejs_deps)
@@ -125,7 +121,7 @@ clean-nodejs-deps:
 
 #
 # ownCloud core JS dependencies
-$(core_vendor): $(BOWER) bower.json
+$(core_vendor): $(nodejs_deps) bower.json
 	$(BOWER) install
 
 .PHONY: install-js-deps


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Always run npm in make, even for make dist

## Related Issue
None raised. Complains by @ppaysant on IRC 😄 

## Motivation and Context
Fixes an issue where `make` followed by `make test-js` would not work
due to npm not having installed deps. Will also make it easier for new contributors to run the JS tests without being confused.

This also brings back the faster make through `make -j4`.

Note that node deps will be required in the future anyway once we have
handlebars template compilation, minifying and other nice stuff.

## How Has This Been Tested?
1) `make clean && make && make test-js`
2) `make clean && make test-js`
3) `make clean && make -j4` (yay! multithreading!)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


@DeepDiver1975 @VicDeo @ppaysant @PhilippSchaffrath 