### PR TITLE
Added show changelog information icon

### DIFF
--- a/apps/updatenotification/lib/Controller/AdminController.php
+++ b/apps/updatenotification/lib/Controller/AdminController.php
@@ -103,13 +103,27 @@ class AdminController extends Controller {
 		$updateState = $this->updateChecker->getUpdateState();
 
 		$notifyGroups = json_decode($this->config->getAppValue('updatenotification', 'notify_groups', '["admin"]'), true);
+		
+		$isNewVersionAvailable = ($updateState === []) ? false : true;
+		$newVersionString = ($updateState === []) ? '' : $updateState['updateVersion'];
+		
+		$changeLogUrl = null;
+		if( $isNewVersionAvailable === true ){
+			$varsionParts = explode(' ', $newVersionString);
+			if( count($varsionParts) >= 2){
+				$versionParts = explode('.', $varsionParts[1]); // remove the 'ownCloud' prefix
+				array_splice($versionParts, 2); // remove minor version info from parts
+				$changeLogUrl = 'https://owncloud.org/changelog/#latest' . implode('.', $versionParts);
+			}
+		}
 
 		$params = [
-			'isNewVersionAvailable' => ($updateState === []) ? false : true,
+			'isNewVersionAvailable' => $isNewVersionAvailable,
 			'lastChecked' => $lastUpdateCheck,
 			'currentChannel' => $currentChannel,
 			'channels' => $channels,
-			'newVersionString' => ($updateState === []) ? '' : $updateState['updateVersion'],
+			'newVersionString' => $newVersionString,
+			'changeLogUrl' => $changeLogUrl,
 
 			'notify_groups' => implode('|', $notifyGroups),
 		];

--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -12,6 +12,9 @@
 	$channels = $_['channels'];
 	/** @var string $currentChannel */
 	$currentChannel = $_['currentChannel'];
+	/** @var string $changeLogUrl */
+	$changeLogUrl = $_['changeLogUrl'];
+	
 ?>
 <form id="oca_updatenotification_section" class="section">
 	<h2><?php p($l->t('Updater')); ?></h2>
@@ -19,11 +22,9 @@
 	<?php if($isNewVersionAvailable === true): ?>
 		<strong><?php p($l->t('A new version is available: %s', [$newVersionString])); ?></strong>
 		<input type="button" id="oca_updatenotification_button" value="<?php p($l->t('Open updater')) ?>">
-		<a target="_blank" rel="noreferrer" class="icon-info svg" title="<?php p($l->t('Show changelog')); ?>" href="https://owncloud.org/changelog/#latest
-		<?php 
-			$versionParts = explode('.', explode(' ', $newVersionString)[1]); // remove the 'ownCloud' prefix
-			array_splice($versionParts, 2); // remove minor version info from parts
-			print_unescaped(implode('.', $versionParts)); ?>"></a>
+		<?php if ($changeLogUrl): ?>
+			<a target="_blank" rel="noreferrer" class="icon-info svg" title="<?php p($l->t('Show changelog')); ?>" href="<?php print_unescaped($changeLogUrl) ?>"></a>
+		<?php endif; ?>
 	<?php else: ?>
 		<strong><?php print_unescaped($l->t('Your version is up to date.')); ?></strong>
 		<span class="icon-info svg" title="<?php p($l->t('Checked on %s', [$lastCheckedDate])) ?>"></span>

--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -19,6 +19,11 @@
 	<?php if($isNewVersionAvailable === true): ?>
 		<strong><?php p($l->t('A new version is available: %s', [$newVersionString])); ?></strong>
 		<input type="button" id="oca_updatenotification_button" value="<?php p($l->t('Open updater')) ?>">
+		<a target="_blank" rel="noreferrer" class="icon-info svg" title="<?php p($l->t('Show changelog')); ?>" href="https://owncloud.org/changelog/#latest
+		<?php 
+			$versionParts = explode('.', explode(' ', $newVersionString)[1]); // remove the 'ownCloud' prefix
+			array_splice($versionParts, 2); // remove minor version info from parts
+			print_unescaped(implode('.', $versionParts)); ?>"></a>
 	<?php else: ?>
 		<strong><?php print_unescaped($l->t('Your version is up to date.')); ?></strong>
 		<span class="icon-info svg" title="<?php p($l->t('Checked on %s', [$lastCheckedDate])) ?>"></span>

--- a/apps/updatenotification/tests/Controller/AdminControllerTest.php
+++ b/apps/updatenotification/tests/Controller/AdminControllerTest.php
@@ -110,15 +110,16 @@ class AdminControllerTest extends TestCase {
 		$this->updateChecker
 			->expects($this->once())
 			->method('getUpdateState')
-			->willReturn(['updateVersion' => '8.1.2']);
+			->willReturn(['updateVersion' => 'ownCloud 8.1.2']);
 
 		$params = [
 			'isNewVersionAvailable' => true,
 			'lastChecked' => 'LastCheckedReturnValue',
 			'currentChannel' => \OCP\Util::getChannel(),
 			'channels' => $channels,
-			'newVersionString' => '8.1.2',
-			'notify_groups' => 'admin',
+			'newVersionString' => 'ownCloud 8.1.2',
+			'changeLogUrl' => 'https://owncloud.org/changelog/#latest8.1',
+			'notify_groups' => 'admin'
 		];
 
 		$expected = new TemplateResponse('updatenotification', 'admin', $params, '');
@@ -162,6 +163,7 @@ class AdminControllerTest extends TestCase {
 			'currentChannel' => \OCP\Util::getChannel(),
 			'channels' => $channels,
 			'newVersionString' => '',
+			'changeLogUrl' => null,
 			'notify_groups' => 'admin',
 		];
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
A information icon was added to the admin updater section. This icon is only visible if a new version is available. The webpage that is opened in a new window by clicking the icon is related to an url with the following scheme:

- https://owncloud.org/changelog/#latest8.2   - if new version is 8.2.x
- https://owncloud.org/changelog/#latest9.1   - if new version is 9.1.x
- and so on

If there is no such anchor available, the changelog page opens anyway.

## Related Issue
#26796

## Motivation and Context
This change improves the user (admin) experience

## How Has This Been Tested?
local installation on current master branch

## Screenshots (if appropriate):
![screenshot from 2016-12-07 15-59-48](https://cloud.githubusercontent.com/assets/23121972/20972784/4fafdcca-bc96-11e6-82a9-ba5c6f11a019.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- No such test available


