### PR TITLE
Filetype icons from themes

### DIFF
--- a/core/Command/Maintenance/Mimetype/UpdateJS.php
+++ b/core/Command/Maintenance/Mimetype/UpdateJS.php
@@ -110,10 +110,7 @@ class UpdateJS extends Command {
 
 		foreach ($apps as $app) {
 			if(\OC_App::isType($app, 'theme')) {
-				$themes[$app] = [
-					'directory' => \OC_App::getAppWebPath($app),
-					'icons' => $this->getFileTypeIcons(\OC_App::getAppPath($app))
-				];
+				$themes[$app] = $this->getFileTypeIcons(\OC_App::getAppPath($app));
 			}
 		}
 
@@ -132,11 +129,9 @@ class UpdateJS extends Command {
 			if ($legacyThemeDirectory->isFile() || $legacyThemeDirectory->isDot()) {
 				continue;
 			}
-
-			$themes[$legacyThemeDirectory->getFilename()] = [
-				'directory' => '/themes/' . $legacyThemeDirectory->getFilename(),
-				'icons' => $this->getFileTypeIcons($legacyThemeDirectory->getPathname())
-			];
+			$themes[$legacyThemeDirectory->getFilename()] = $this->getFileTypeIcons(
+				$legacyThemeDirectory->getPathname()
+			);
 		}
 
 		return $themes;

--- a/core/Command/Maintenance/Mimetype/UpdateJS.php
+++ b/core/Command/Maintenance/Mimetype/UpdateJS.php
@@ -112,7 +112,7 @@ class UpdateJS extends Command {
 *
 * You can update the list of MimeType Aliases in config/mimetypealiases.json
 * The list of files is fetched from core/img/filetypes
-* To regenerate this file run ./occ maintenance:mimetypesjs
+* To regenerate this file run ./occ maintenance:mimetype:update-js
 */
 OC.MimeTypeList={
 	aliases: ' . json_encode($aliases, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . ',

--- a/core/Command/Maintenance/Mimetype/UpdateJS.php
+++ b/core/Command/Maintenance/Mimetype/UpdateJS.php
@@ -141,14 +141,21 @@ class UpdateJS extends Command {
 	 * @return int
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		file_put_contents(
-			\OC::$SERVERROOT.'/core/js/mimetypelist.js',
+		$fileName = \OC::$SERVERROOT.'/core/js/mimetypelist.js';
+
+		$success = file_put_contents(
+			$fileName,
 			$this->generateMimeTypeListContent(
 				$this->mimetypeDetector->getAllAliases(),
 				$this->getFiles(),
 				$this->getThemes()
 			)
 		);
+
+		if ($success === false) {
+			$output->writeln("<error>could not write mimetypelist to $fileName.</error>");
+			return 1;
+		}
 
 		$output->writeln('<info>mimetypelist.js is updated</info>');
 		return 0;

--- a/core/Command/Maintenance/Mimetype/UpdateJS.php
+++ b/core/Command/Maintenance/Mimetype/UpdateJS.php
@@ -28,11 +28,9 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use OCP\Files\IMimeTypeDetector;
-
 class UpdateJS extends Command {
 
-	/** @var IMimeTypeDetector */
+	/** @var Detection */
 	protected $mimetypeDetector;
 
 	public function __construct(

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -186,7 +186,13 @@ $array = [
 			'logoClaim' => $defaults->getLogoClaim(),
 			'shortFooter' => $defaults->getShortFooter(),
 			'longFooter' => $defaults->getLongFooter(),
-			'folder' => OC_Util::getTheme(),
+			'folder' => OC_Util::getTheme()->getName()
+		]
+	),
+	'theme' => json_encode(
+		[
+			'name' => OC_Util::getTheme()->getName(),
+			'directory' => OC_Util::getTheme()->getDirectory()
 		]
 	)
 ];

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -82,6 +82,7 @@ var OC={
 	coreApps:['', 'admin','log','core/search','settings','core','3rdparty'],
 	requestToken: oc_requesttoken,
 	menuSpeed: 50,
+	currentTheme: window.theme || {},
 
 	/**
 	 * Get an absolute url to a file in an app

--- a/core/js/mimetype.js
+++ b/core/js/mimetype.js
@@ -79,30 +79,49 @@ OC.MimeType = {
 			return OC.MimeType._mimeTypeIcons[mimeType];
 		}
 
-		// First try to get the correct icon from the current theme
-		var gotIcon = null;
-		var path = '';
-		if (OC.theme.folder !== '' && $.isArray(OC.MimeTypeList.themes[OC.theme.folder])) {
-			path = OC.webroot + '/themes/' + OC.theme.folder + '/core/img/filetypes/';
-			var icon = OC.MimeType._getFile(mimeType, OC.MimeTypeList.themes[OC.theme.folder]);
+		//console.log(mimeType);
 
-			if (icon !== null) {
-				gotIcon = true;
-				path += icon;
-			}
+		// First try to get the correct icon from the current theme
+		var path = '';
+		var icon = '';
+
+		if (OC.currentTheme.name !== '' && $.isArray(OC.MimeTypeList.themes[OC.currentTheme.name])) {
+			path = '/' + OC.currentTheme.directory + 'core/img/filetypes/';
+			icon = OC.MimeType._getFile(mimeType, OC.MimeTypeList.themes[OC.currentTheme.name]);
 		}
 
 		// If we do not yet have an icon fall back to the default
-		if (gotIcon === null) {
-			path = OC.webroot + '/core/img/filetypes/';
-			path += OC.MimeType._getFile(mimeType, OC.MimeTypeList.files);
+		if (icon === null) {
+			path = '/core/img/filetypes/';
+			icon = OC.MimeType._getFile(mimeType, OC.MimeTypeList.files);
 		}
 
-		path += '.svg';
+		var mimeTypeIcon = path + icon + '.svg';
 
 		// Cache the result
-		OC.MimeType._mimeTypeIcons[mimeType] = path;
-		return path;
+		OC.MimeType._mimeTypeIcons[mimeType] = mimeTypeIcon;
+		return mimeTypeIcon;
+	},
+
+
+
+
+	/**
+	 * If the given mimeType is an alias, this method returns its target,
+	 * else it returns the given mimeType.
+	 *
+	 * @param {string} mimeType The mimeType to get the icon for
+	 * @returns {string} mimeType The mimeType to get the icon for
+	 */
+	getMimeTypeAliasTarget: function (mimeType) {
+		while (mimeType in OC.MimeTypeList.aliases) {
+			mimeType = OC.MimeTypeList.aliases[mimeType];
+		}
+		if (mimeType in OC.MimeType._mimeTypeIcons) {
+			return OC.MimeType._mimeTypeIcons[mimeType];
+		}
+
+		return mimeType;
 	}
 
 };

--- a/core/js/mimetype.js
+++ b/core/js/mimetype.js
@@ -72,14 +72,11 @@ OC.MimeType = {
 			return undefined;
 		}
 
-		while (mimeType in OC.MimeTypeList.aliases) {
-			mimeType = OC.MimeTypeList.aliases[mimeType];
-		}
+		mimeType = this.getMimeTypeAliasTarget(mimeType);
+
 		if (mimeType in OC.MimeType._mimeTypeIcons) {
 			return OC.MimeType._mimeTypeIcons[mimeType];
 		}
-
-		//console.log(mimeType);
 
 		// First try to get the correct icon from the current theme
 		var path = '';
@@ -91,7 +88,7 @@ OC.MimeType = {
 		}
 
 		// If we do not yet have an icon fall back to the default
-		if (icon === null) {
+		if (icon === '') {
 			path = '/core/img/filetypes/';
 			icon = OC.MimeType._getFile(mimeType, OC.MimeTypeList.files);
 		}
@@ -102,9 +99,6 @@ OC.MimeType = {
 		OC.MimeType._mimeTypeIcons[mimeType] = mimeTypeIcon;
 		return mimeTypeIcon;
 	},
-
-
-
 
 	/**
 	 * If the given mimeType is an alias, this method returns its target,
@@ -117,11 +111,6 @@ OC.MimeType = {
 		while (mimeType in OC.MimeTypeList.aliases) {
 			mimeType = OC.MimeTypeList.aliases[mimeType];
 		}
-		if (mimeType in OC.MimeType._mimeTypeIcons) {
-			return OC.MimeType._mimeTypeIcons[mimeType];
-		}
-
 		return mimeType;
 	}
-
 };

--- a/core/js/mimetype.js
+++ b/core/js/mimetype.js
@@ -81,9 +81,9 @@ OC.MimeType = {
 		var path, icon = null;
 
 		// First try to get the correct icon from the current theme
-		if (OC.currentTheme.name !== '' && $.isArray(OC.MimeTypeList.themes[OC.currentTheme.name].icons)) {
+		if (OC.currentTheme.name !== '' && $.isArray(OC.MimeTypeList.themes[OC.currentTheme.name])) {
 			path = '/' + OC.currentTheme.directory + 'core/img/filetypes/';
-			icon = OC.MimeType._getFile(mimeType, OC.MimeTypeList.themes[OC.currentTheme.name].icons);
+			icon = OC.MimeType._getFile(mimeType, OC.MimeTypeList.themes[OC.currentTheme.name]);
 		}
 
 		// If we do not yet have an icon fall back to the default

--- a/core/js/mimetype.js
+++ b/core/js/mimetype.js
@@ -92,7 +92,7 @@ OC.MimeType = {
 			icon = OC.MimeType._getFile(mimeType, OC.MimeTypeList.files);
 		}
 
-		var mimeTypeIcon = path + icon + '.svg';
+		var mimeTypeIcon = OC.getRootPath() + path + icon + '.svg';
 
 		// Cache the result
 		OC.MimeType._mimeTypeIcons[mimeType] = mimeTypeIcon;

--- a/core/js/mimetype.js
+++ b/core/js/mimetype.js
@@ -78,17 +78,16 @@ OC.MimeType = {
 			return OC.MimeType._mimeTypeIcons[mimeType];
 		}
 
-		// First try to get the correct icon from the current theme
-		var path = '';
-		var icon = '';
+		var path, icon = null;
 
-		if (OC.currentTheme.name !== '' && $.isArray(OC.MimeTypeList.themes[OC.currentTheme.name])) {
+		// First try to get the correct icon from the current theme
+		if (OC.currentTheme.name !== '' && $.isArray(OC.MimeTypeList.themes[OC.currentTheme.name].icons)) {
 			path = '/' + OC.currentTheme.directory + 'core/img/filetypes/';
-			icon = OC.MimeType._getFile(mimeType, OC.MimeTypeList.themes[OC.currentTheme.name]);
+			icon = OC.MimeType._getFile(mimeType, OC.MimeTypeList.themes[OC.currentTheme.name].icons);
 		}
 
 		// If we do not yet have an icon fall back to the default
-		if (icon === '') {
+		if (icon === null) {
 			path = '/core/img/filetypes/';
 			icon = OC.MimeType._getFile(mimeType, OC.MimeTypeList.files);
 		}

--- a/core/js/mimetypelist.js
+++ b/core/js/mimetypelist.js
@@ -4,7 +4,7 @@
 *
 * You can update the list of MimeType Aliases in config/mimetypealiases.json
 * The list of files is fetched from core/img/filetypes
-* To regenerate this file run ./occ maintenance:mimetypesjs
+* To regenerate this file run ./occ maintenance:mimetype:update-js
 */
 OC.MimeTypeList={
 	aliases: {
@@ -56,6 +56,7 @@ OC.MimeTypeList={
     "application/vnd.visio": "x-office/document",
     "application/vnd.wordperfect": "x-office/document",
     "application/x-7z-compressed": "package/x-generic",
+    "application/x-bzip2": "package/x-generic",
     "application/x-cbr": "text",
     "application/x-compressed": "package/x-generic",
     "application/x-dcraw": "image",
@@ -107,5 +108,7 @@ OC.MimeTypeList={
     "x-office-presentation",
     "x-office-spreadsheet"
 ],
-	themes: []
+	themes: {
+    "example": []
+}
 };

--- a/core/js/tests/specs/mimeTypeSpec.js
+++ b/core/js/tests/specs/mimeTypeSpec.js
@@ -100,7 +100,7 @@ describe('MimeType tests', function() {
 
 			it('return the url for the mimetype file', function() {
 				var res = OC.MimeType.getIconUrl('file');
-				expect(res).toEqual(OC.webroot + '/core/img/filetypes/file.svg');
+				expect(res).toEqual(OC.getRootPath() + '/core/img/filetypes/file.svg');
 			});
 
 			it('test if the cache works correctly', function() {
@@ -118,7 +118,7 @@ describe('MimeType tests', function() {
 
 			it('test if alaiases are converted correctly', function() {
 				var res = OC.MimeType.getIconUrl('app/foobar');
-				expect(res).toEqual(OC.webroot + '/core/img/filetypes/foo-bar.svg');
+				expect(res).toEqual(OC.getRootPath() + '/core/img/filetypes/foo-bar.svg');
 				expect(OC.MimeType._mimeTypeIcons['foo/bar']).toEqual(res);
 			});
 		});
@@ -127,24 +127,25 @@ describe('MimeType tests', function() {
 			var _themeFolder;
 
 			beforeEach(function() {
-				_themeFolder = OC.theme.folder;
-				OC.theme.folder = 'abc';
+				_themeFolder = OC.currentTheme.name;
+				OC.currentTheme.name = 'abc';
+				OC.currentTheme.directory = 'themes/abc/';
 				//Clear mimetypeIcons caches
 				OC.MimeType._mimeTypeIcons = {};
 			});
 
 			afterEach(function() {
-				OC.theme.folder = _themeFolder;
+				OC.currentTheme.name = _themeFolder;
 			});
 
 			it('test if theme path is used if a theme icon is availble', function() {
 				var res = OC.MimeType.getIconUrl('dir');
-				expect(res).toEqual(OC.webroot + '/themes/abc/core/img/filetypes/folder.svg');
+				expect(res).toEqual(OC.getRootPath() + '/themes/abc/core/img/filetypes/folder.svg');
 			});
 
 			it('test if we fallback to the default theme if no icon is available in the theme', function() {
 				var res = OC.MimeType.getIconUrl('dir-shared');
-				expect(res).toEqual(OC.webroot + '/core/img/filetypes/folder-shared.svg');
+				expect(res).toEqual(OC.getRootPath() + '/core/img/filetypes/folder-shared.svg');
 			});
 		});
 	});

--- a/lib/private/Theme/Theme.php
+++ b/lib/private/Theme/Theme.php
@@ -33,6 +33,13 @@ class Theme {
 	}
 
 	/**
+	 * @param $name
+	 */
+	public function setName($name) {
+		$this->name = $name;
+	}
+
+	/**
 	 * @return string
 	 */
 	public function getDirectory() {

--- a/lib/private/Theme/ThemeService.php
+++ b/lib/private/Theme/ThemeService.php
@@ -83,6 +83,7 @@ class ThemeService {
 			$this->theme->setDirectory(
 				ltrim(\OC_App::getAppWebPath($appName), '/') . '/'
 			);
+			$this->theme->setName($appName);
 		}
 	}
 }

--- a/resources/config/mimetypealiases.dist.json
+++ b/resources/config/mimetypealiases.dist.json
@@ -1,13 +1,4 @@
 {
-	"_comment" : "Array of mimetype aliases.",
-	"_comment2": "Any changes you make here will be overwritten on an update of ownCloud.",
-	"_comment3": "Put any custom mappings in a new file mimetypealiases.json in the config/ folder of ownCloud",
-
-	"_comment4": "After any change to mimetypealiases.json run:",
-	"_comment5": "./occ maintenance:mimetype:update-js",
-	"_comment6": "Otherwise your update won't propagate through the system.",
-
-
 	"application/coreldraw": "image",
 	"application/epub+zip": "text",
 	"application/font-sfnt": "image",
@@ -86,4 +77,3 @@
 	"text/x-shellscript": "text/code",
 	"web": "text/code"
 }
-

--- a/resources/config/mimetypemapping.dist.json
+++ b/resources/config/mimetypemapping.dist.json
@@ -1,12 +1,4 @@
 {
-	"_comment" : "Array mapping file extensions to mimetypes (in alphabetical order]",
-	"_comment2": "The first index in the mime type array is the assumed correct mimetype",
-	"_comment3": "and the second (if present] is a secure alternative",
-
-	"_comment4": "Any changes you make here will be overwritten on an update of ownCloud",
-	"_comment5": "Put any custom mappings in a new file mimetypemapping.json in the config/ folder of ownCloud",
-
-
 	"3gp": ["video/3gpp"],
 	"7z": ["application/x-7z-compressed"],
 	"accdb": ["application/msaccess"],

--- a/resources/config/readme.md
+++ b/resources/config/readme.md
@@ -1,0 +1,16 @@
+# resources/config
+Useful information about the files contained in this directory.
+
+## mimetypealiases.dist.json
+This file contains mimetype aliases in a json format. Any changes to this file might get overwritten by an ownCloud update.
+
+To add custom mimetype aliases, create a `mimetypealiases.json` file in the `/config` directory.
+
+Any changes to `mimetypealiases.json` require you to run `./occ maintenance:mimetype:update-js`.
+
+## mimetypemapping.dist.json
+Maps file extensions to mimetypes in alphabetical order. Any changes to this file might get overwritten by an ownCloud update.
+
+The first index in the mapped array is the assumed to be correct mimetype. The second one is a secure alternative.
+
+To add custom mimetype mapping, create a `mimetypemapping.json` file in the `/config` directory.

--- a/resources/config/readme.md
+++ b/resources/config/readme.md
@@ -2,7 +2,7 @@
 Useful information about the files contained in this directory.
 
 ## mimetypealiases.dist.json
-This file contains mimetype aliases in a json format. Any changes to this file might get overwritten by an ownCloud update.
+Contains mimetype aliases. Any changes to this file might get overwritten by an ownCloud update.
 
 To add custom mimetype aliases, create a `mimetypealiases.json` file in the `/config` directory.
 
@@ -11,6 +11,6 @@ Any changes to `mimetypealiases.json` require you to run `./occ maintenance:mime
 ## mimetypemapping.dist.json
 Maps file extensions to mimetypes in alphabetical order. Any changes to this file might get overwritten by an ownCloud update.
 
-The first index in the mapped array is the assumed to be correct mimetype. The second one is a secure alternative.
+The first index in the mapped array is assumed to be the correct mimetype. The second one is a secure alternative.
 
-To add custom mimetype mapping, create a `mimetypemapping.json` file in the `/config` directory.
+To add a custom mimetype mapping, create a `mimetypemapping.json` file in the `/config` directory.

--- a/tests/lib/Theme/ThemeServiceTest.php
+++ b/tests/lib/Theme/ThemeServiceTest.php
@@ -51,4 +51,11 @@ class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals('default', $theme->getName());
 		$this->assertEquals('themes/default/', $theme->getDirectory());
 	}
+
+	public function testSetAppThemeSetsName() {
+		$themeService = new ThemeService();
+		$this->assertEmpty($themeService->getTheme()->getName());
+		$themeService->setAppTheme('some-app-theme');
+		$this->assertEquals('some-app-theme', $themeService->getTheme()->getName());
+	}
 }

--- a/tests/lib/Theme/ThemeTest.php
+++ b/tests/lib/Theme/ThemeTest.php
@@ -29,4 +29,10 @@ class ThemeTest extends \PHPUnit\Framework\TestCase {
 		$this->sut->setDirectory('test/directory');
 		$this->assertEquals('test/directory', $this->sut->getDirectory());
 	}
+
+	public function testNameCanBeSet() {
+		$this->assertEmpty($this->sut->getName());
+		$this->sut->setName('some-name');
+		$this->assertEquals('some-name', $this->sut->getName());
+	}
 }


### PR DESCRIPTION
## Description
Added support for file type icons (mime types) overwriting through app-themes and legacy themes. Also refactored and cleaned the code/comments a bit.

## Related Issue
#25379

## Motivation and Context
Since the support to provide themes through apps was added, the capability of overwriting file type icons was not working for those themes. Now it is possible to overwrite those icons with app-themes and legacy themes (theme directory).

## How Has This Been Tested?
Manually and unit-tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

