### PR TITLE
Memcached: Set options, then add servers

### DIFF
--- a/lib/private/Memcache/Memcached.php
+++ b/lib/private/Memcache/Memcached.php
@@ -45,16 +45,6 @@ class Memcached extends Cache implements IMemcache {
 		parent::__construct($prefix);
 		if (is_null(self::$cache)) {
 			self::$cache = new \Memcached();
-			$servers = \OC::$server->getSystemConfig()->getValue('memcached_servers');
-			if (!$servers) {
-				$server = \OC::$server->getSystemConfig()->getValue('memcached_server');
-				if ($server) {
-					$servers = [$server];
-				} else {
-					$servers = [['localhost', 11211]];
-				}
-			}
-			self::$cache->addServers($servers);
 
 			$defaultOptions = [
 				\Memcached::OPT_CONNECT_TIMEOUT => 50,
@@ -84,6 +74,17 @@ class Memcached extends Cache implements IMemcache {
 			} else {
 				throw new HintException("Expected 'memcached_options' config to be an array, got $options");
 			}
+
+			$servers = \OC::$server->getSystemConfig()->getValue('memcached_servers');
+			if (!$servers) {
+				$server = \OC::$server->getSystemConfig()->getValue('memcached_server');
+				if ($server) {
+					$servers = [$server];
+				} else {
+					$servers = [['localhost', 11211]];
+				}
+			}
+			self::$cache->addServers($servers);
 		}
 	}
 


### PR DESCRIPTION
## Description
Adding servers causes immediate connect with default options, setting options causes reconnection with new options.

## Motivation and Context
Reducing connections to memcached. Speedup cache initialization a bit.

## How Has This Been Tested?
setup owncloud with memcached && php-memcached
set logging in `/etc/memcached.conf` to
-vv

check `/var/log/memcached.log`

Before:
```
<28 new auto-negotiating client connection
28: Client using the ascii protocol
<28 quit
<28 connection closed.
<28 new auto-negotiating client connection
28: Client using the binary protocol
<28 Read binary protocol data:
```

After
```
<31 new auto-negotiating client connection
31: Client using the binary protocol
<31 Read binary protocol data:
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


