### PR TITLE
Optimize mount manager find

### DIFF
--- a/lib/private/Files/Mount/Manager.php
+++ b/lib/private/Files/Mount/Manager.php
@@ -75,18 +75,21 @@ class Manager implements IMountManager {
 		}
 
 		\OC_Hook::emit('OC_Filesystem', 'get_mountpoint', ['path' => $path]);
-		$foundMountPoint = '';
-		$mountPoints = array_keys($this->mounts);
-		foreach ($mountPoints as $mountpoint) {
-			if (strpos($path, $mountpoint) === 0 and strlen($mountpoint) > strlen($foundMountPoint)) {
-				$foundMountPoint = $mountpoint;
-			}
+		$pathSections = explode('/', $path);
+		$pathToSearch = $path;
+
+		while ($pathToSearch !== '/' && !isset($this->mounts[$pathToSearch])) {
+			array_pop($pathSections);
+			$pathToSearch = implode('/', $pathSections) . '/';
 		}
-		if (isset($this->mounts[$foundMountPoint])) {
-			return $this->mounts[$foundMountPoint];
-		} else {
+
+		// second condition only happens if root mount is missing...
+		if (empty($pathToSearch) || !isset($this->mounts[$pathToSearch])) {
+			// not found
 			return null;
 		}
+
+		return $this->mounts[$pathToSearch];
 	}
 
 	/**

--- a/tests/lib/Files/Mount/ManagerTest.php
+++ b/tests/lib/Files/Mount/ManagerTest.php
@@ -33,6 +33,8 @@ class ManagerTest extends \Test\TestCase {
 		$rootMount = new \OC\Files\Mount\MountPoint(new Temporary([]), '/');
 		$this->manager->addMount($rootMount);
 		$this->assertEquals($rootMount, $this->manager->find('/'));
+		$this->assertEquals($rootMount, $this->manager->find(''));
+		$this->assertEquals($rootMount, $this->manager->find('//'));
 		$this->assertEquals($rootMount, $this->manager->find('/foo/bar'));
 
 		$storage = new Temporary([]);
@@ -40,6 +42,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->manager->addMount($mount1);
 		$this->assertEquals($rootMount, $this->manager->find('/'));
 		$this->assertEquals($mount1, $this->manager->find('/foo/bar'));
+		$this->assertEquals($mount1, $this->manager->find('/foo/bar/'));
 
 		$this->assertEquals(1, count($this->manager->findIn('/')));
 		$mount2 = new \OC\Files\Mount\MountPoint(new Temporary([]), '/bar');


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Optimize `Mount\Manager::find()` for the situation where there are lots of mount points (ex: shares).
Instead of iterating over all mounts for a longest match search, this iterates over the sections of the path being searched.

## Related Issue
Fixes https://github.com/owncloud/core/issues/26702

## Motivation and Context
See ticket

## How Has This Been Tested?
Manually with a debugger to see if it worked fine.
Also: the existing unit tests were enhanced to cover a few more cases.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


@mrow4a can you rerun the perf test on this ?