### PR TITLE
Do not validate return code if set was successful

### DIFF
--- a/lib/private/Memcache/Memcached.php
+++ b/lib/private/Memcache/Memcached.php
@@ -110,7 +110,9 @@ class Memcached extends Cache implements IMemcache {
 		} else {
 			$result = self::$cache->set($this->getNamespace() . $key, $value);
 		}
-		$this->verifyReturnCode();
+		if ($result !== true) {
+			$this->verifyReturnCode();
+		}
 		return $result;
 	}
 


### PR DESCRIPTION
## Description
Do not call `verifyReturnCode` for successful set operation.

## Related Issue
Fixes https://github.com/owncloud/core/issues/25692

## Motivation and Context
According to http://php.net/manual/en/memcached.set.php `Memcached::set` has a  boolean result, 
but it can return `false` both for unsuccessful operation and when it is called with `false` as a value http://php.net/manual/en/memcached.set.php#92259

So there is no need to validate  `Memcached::set` when it returns true. 
Sometimes it misbehaves as in https://github.com/owncloud/core/issues/25692 

## How Has This Been Tested?
1. install ownCloud 9.1.x ( into the following envronment:
 PHP 5.5.9  + php-memcached extension + memcached server

2. Add to config.php:
```
'memcache.local' => '\\OC\\Memcache\\APCu',
 'memcache.distributed' => '\\OC\\Memcache\\Memcached', 'memcached_servers' => array ( 0 => array ( 0 => 'localhost', 1 => 11211, ), ),
```
3. Perform an integrity check
4. Perform an integrity check once again
5. See `"Exception":"Exception","Message":"Error 21 interacting with memcached : SERVER END","Code":0`

6. Repeat 4 & 5 Several times
7. Apply changes from this PR
8. Repeat 4. and see that 5. does not happen any more

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


