### PR TITLE
Respect home folder setting in encryption

### DIFF
--- a/lib/private/Encryption/Keys/Storage.php
+++ b/lib/private/Encryption/Keys/Storage.php
@@ -170,8 +170,8 @@ class Storage implements IStorage {
 		if ($uid === null) {
 			$path = $this->root_dir . '/' . $this->encryption_base_dir . '/' . $encryptionModuleId . '/' . $keyId;
 		} else {
-			$path = $this->root_dir . '/' . $uid . $this->encryption_base_dir . '/'
-				. $encryptionModuleId . '/' . $uid . '.' . $keyId;
+			$home = $this->util->getUserHomeFolder($uid);
+			$path = $this->root_dir . $home . $this->encryption_base_dir . '/' . $encryptionModuleId . '/' . $uid . '.' . $keyId;
 		}
 
 		return \OC\Files\Filesystem::normalizePath($path);

--- a/lib/private/Encryption/Util.php
+++ b/lib/private/Encryption/Util.php
@@ -393,4 +393,18 @@ class Util {
 		return $this->config->getAppValue('core', 'encryption_key_storage_root', '');
 	}
 
+	/**
+	 * Returns the user home folder relative to the dataDir
+	 * @param string $uid
+	 * @return string
+	 */
+	public function getUserHomeFolder($uid) {
+		$user = $this->userManager->get($uid);
+		$home = $user->getHome();
+		$dataDir = $this->config->getSystemValue("datadirectory", \OC::$SERVERROOT . "/data");
+		$home = substr($home, strlen($dataDir));
+
+		return $home;
+	}
+
 }


### PR DESCRIPTION
## Description
In case the user backend defines the user home folder to be in a different place then data/$uid encryption will fail to find the keys.

## How Has This Been Tested?
1. use ldap with special home folder rule
2. enable encryption
3. share an encrypted file with another user
4. :boom: 
````
Could not encrypt file for _8060: Public Key missing for user: _8060
````

In case you cannot setup an ldap use this patch:

```patch
Index: lib/private/User/Database.php
I===================================================================
--- lib/private/User/Database.php	(revision fa7a82fe0526645e00fed51d5f9ce869b2b67660)
+++ lib/private/User/Database.php	(revision )
@@ -280,6 +280,7 @@
 	 */
 	public function getHome($uid) {
 		if ($this->userExists($uid)) {
+			$uid = md5($uid);
 			return \OC::$server->getConfig()->getSystemValue("datadirectory", \OC::$SERVERROOT . "/data") . '/' . $uid;
 		}
 ```

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


