### PR TITLE
Report failures for SignApp and SignCore

### DIFF
--- a/core/Command/Integrity/SignApp.php
+++ b/core/Command/Integrity/SignApp.php
@@ -100,8 +100,13 @@ class SignApp extends Command {
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$x509->setPrivateKey($rsa);
-		$this->checker->writeAppSignature($path, $x509, $rsa);
-
-		$output->writeln('Successfully signed "'.$path.'"');
+		try {
+			$this->checker->writeAppSignature($path, $x509, $rsa);
+			$output->writeln('Successfully signed "'.$path.'"');
+		} catch (\Exception $e){
+			$output->writeln('Error: ' . $e->getMessage());
+			return 1;
+		}
+		return 0;
 	}
 }

--- a/core/Command/Integrity/SignCore.php
+++ b/core/Command/Integrity/SignCore.php
@@ -22,12 +22,10 @@
 namespace OC\Core\Command\Integrity;
 
 use OC\IntegrityCheck\Checker;
-use OC\IntegrityCheck\Helpers\EnvironmentHelper;
 use OC\IntegrityCheck\Helpers\FileAccessHelper;
 use phpseclib\Crypt\RSA;
 use phpseclib\File\X509;
 use Symfony\Component\Console\Command\Command;
-use OCP\IConfig;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -93,8 +91,14 @@ class SignCore extends Command {
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$x509->setPrivateKey($rsa);
-		$this->checker->writeCoreSignature($x509, $rsa, $path);
 
-		$output->writeln('Successfully signed "core"');
+		try {
+			$this->checker->writeCoreSignature($x509, $rsa, $path);
+			$output->writeln('Successfully signed "core"');
+		} catch (\Exception $e){
+			$output->writeln('Error: ' . $e->getMessage());
+			return 1;
+		}
+		return 0;
 	}
 }

--- a/lib/private/IntegrityCheck/Checker.php
+++ b/lib/private/IntegrityCheck/Checker.php
@@ -266,16 +266,24 @@ class Checker {
 	public function writeAppSignature($path,
 									  X509 $certificate,
 									  RSA $privateKey) {
-		if(!is_dir($path)) {
-			throw new \Exception('Directory does not exist.');
-		}
+		$appInfoDir = $path . '/appinfo';
+		$this->fileAccessHelper->assertDirectoryExists($path);
+		$this->fileAccessHelper->assertDirectoryExists($appInfoDir);
+
 		$iterator = $this->getFolderIterator($path);
 		$hashes = $this->generateHashes($iterator, $path);
 		$signature = $this->createSignatureData($hashes, $certificate, $privateKey);
-		$this->fileAccessHelper->file_put_contents(
-				$path . '/appinfo/signature.json',
+		try {
+			$this->fileAccessHelper->file_put_contents(
+				$appInfoDir . '/signature.json',
 				json_encode($signature, JSON_PRETTY_PRINT)
-		);
+			);
+		} catch (\Exception $e){
+			if (!$this->fileAccessHelper->is_writeable($appInfoDir)){
+				throw new \Exception($appInfoDir . ' is not writable');
+			}
+			throw $e;
+		}
 	}
 
 	/**
@@ -284,17 +292,29 @@ class Checker {
 	 * @param X509 $certificate
 	 * @param RSA $rsa
 	 * @param string $path
+	 * @throws \Exception
 	 */
 	public function writeCoreSignature(X509 $certificate,
 									   RSA $rsa,
 									   $path) {
+		$coreDir = $path . '/core';
+		$this->fileAccessHelper->assertDirectoryExists($path);
+		$this->fileAccessHelper->assertDirectoryExists($coreDir);
+
 		$iterator = $this->getFolderIterator($path, $path);
 		$hashes = $this->generateHashes($iterator, $path);
 		$signatureData = $this->createSignatureData($hashes, $certificate, $rsa);
-		$this->fileAccessHelper->file_put_contents(
-				$path . '/core/signature.json',
+		try {
+			$this->fileAccessHelper->file_put_contents(
+				$coreDir . '/signature.json',
 				json_encode($signatureData, JSON_PRETTY_PRINT)
-		);
+			);
+		} catch (\Exception $e){
+			if (!$this->fileAccessHelper->is_writeable($coreDir)){
+				throw new \Exception($coreDir . ' is not writable');
+			}
+			throw $e;
+		}
 	}
 
 	/**

--- a/lib/private/IntegrityCheck/Helpers/FileAccessHelper.php
+++ b/lib/private/IntegrityCheck/Helpers/FileAccessHelper.php
@@ -52,10 +52,33 @@ class FileAccessHelper {
 	 * Wrapper around file_put_contents($filename, $data)
 	 *
 	 * @param string $filename
-	 * @param $data
-	 * @return int|false
+	 * @param string $data
+	 * @return int
+	 * @throws \Exception
 	 */
 	public function file_put_contents($filename, $data) {
-		return file_put_contents($filename, $data);
+		$bytesWritten = file_put_contents($filename, $data);
+		if ($bytesWritten === false || $bytesWritten !== strlen($data)){
+			throw new \Exception('Failed to write into ' . $filename);
+		}
+		return $bytesWritten;
+	}
+
+	/**
+	 * @param string $path
+	 * @return bool
+	 */
+	public function is_writeable($path){
+		return is_writeable($path);
+	}
+
+	/**
+	 * @param string $path
+	 * @throws \Exception
+	 */
+	public function assertDirectoryExists($path){
+		if (!is_dir($path)) {
+			throw new \Exception('Directory ' . $path . ' does not exist.');
+		}
 	}
 }

--- a/tests/lib/IntegrityCheck/CheckerTest.php
+++ b/tests/lib/IntegrityCheck/CheckerTest.php
@@ -77,7 +77,6 @@ class CheckerTest extends TestCase {
 
 	/**
 	 * @expectedException \Exception
-	 * @expectedExceptionMessage Directory does not exist.
 	 */
 	public function testWriteAppSignatureOfNotExistingApp() {
 		$keyBundle = file_get_contents(__DIR__ .'/../../data/integritycheck/SomeApp.crt');
@@ -87,6 +86,24 @@ class CheckerTest extends TestCase {
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeAppSignature('NotExistingApp', $x509, $rsa);
+	}
+
+	/**
+	 * @expectedException \Exception
+	 */
+	public function testWriteAppSignatureWrongPermissions(){
+		$this->fileAccessHelper
+			->expects($this->once())
+			->method('file_put_contents')
+			->will($this->throwException(new \Exception))
+		;
+		$keyBundle = file_get_contents(__DIR__ .'/../../data/integritycheck/SomeApp.crt');
+		$rsaPrivateKey = file_get_contents(__DIR__ .'/../../data/integritycheck/SomeApp.key');
+		$rsa = new RSA();
+		$rsa->loadKey($rsaPrivateKey);
+		$x509 = new X509();
+		$x509->loadX509($keyBundle);
+		$this->checker->writeAppSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/app/', $x509, $rsa);
 	}
 
 	public function testWriteAppSignature() {


### PR DESCRIPTION
## Description
- Ensure that directory for the signature exists
- Throw an exception if `file_put_contents` has been failed
- Add an error message and non-zero exit code to `occ integrity:sign-app` and `occ integrity:sign-core`

## Related Issue
Fixing https://github.com/owncloud/core/issues/23591

## How Has This Been Tested?
```
> php occ integrity:sign-app --path=/oc-tmp/apps/files_antivirus --privateKey=files_antivirus_csr/files_antivirus.key --certificate=files_antivirus_csr/files_antivirus.crt 
Successfully signed "/oc-tmp/apps/files_antivirus"
> echo $?
0

~> mv apps/files_antivirus/appinfo/ apps/files_antivirus/appinfo.1
~> php occ integrity:sign-app --path=/home/deo/public_html/oc-tmp/apps/files_antivirus --privateKey=/home/deo/files_antivirus_csr/files_antivirus.key --certificate=/home/deo/files_antivirus_csr/files_antivirus.crt 
Error:Directory /oc-tmp/apps/files_antivirus/appinfo does not exist.
~> echo $?
1

~> mv apps/files_antivirus/appinfo.1/ apps/files_antivirus/appinfo
~>sudo chown -R root /oc-tmp/apps/files_antivirus/appinfo/
~> php occ integrity:sign-app --path=/oc-tmp/apps/files_antivirus --privateKey=files_antivirus_csr/files_antivirus.key --certificate=files_antivirus_csr/files_antivirus.crt 
Error:/oc-tmp/apps/files_antivirus/appinfo is not writable
~> echo $?
1

```

## Motivation and Context
Fixes silent failures while signing code and successful message

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
