### PR TITLE
Update handlebars

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "blueimp-md5": "1.0.1",
-    "handlebars": "1.3.0",
+    "handlebars": "4.0.5",
     "jcrop": "0.9.12",
     "jquery": "2.1.4",
     "jquery-migrate": "1.4.0",

--- a/build/package.json
+++ b/build/package.json
@@ -11,7 +11,8 @@
   "contributors": [],
   "dependencies": {},
   "devDependencies": {
-    "bower": "~1.7.9",
+    "bower": "~1.8.0",
+    "handlebars": "^4.0.5",
     "karma": "~0.12.0",
     "karma-jasmine": "~0.3.0",
     "karma-junit-reporter": "*",


### PR DESCRIPTION
We need to have the same node + bower version of handlebars to be able
to precompile templates.

Also I updated bower since it prompted me to do it 😄 

I quickly rechecked the files sidebar and some of the panels like sharing and they still work (they use handlebars).

@DeepDiver1975 @VicDeo @jvillafanez @felixheidecke @PhilippSchaffrath 