### PR TITLE
Integration test encryption homedir

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,6 +135,22 @@ timestampedNode('SLAVE') {
                 make test-integration OC_TEST_ALT_HOME=1
                '''
             }
+			executeAndReport('build/integration/output/*.xml') {
+				sh '''phpenv local 7.0
+				rm -rf config/config.php
+				./occ maintenance:install --admin-pass=admin
+				make clean-test-integration
+				make test-integration OC_TEST_ENCRYPTION_ENABLED=1
+			   '''
+			}
+			executeAndReport('build/integration/output/*.xml') {
+				sh '''phpenv local 7.0
+				rm -rf config/config.php
+				./occ maintenance:install --admin-pass=admin
+				make clean-test-integration
+				make test-integration OC_TEST_ALT_HOME=1 OC_TEST_ENCRYPTION_ENABLED=1
+			   '''
+			}
     }
 }
 

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ test-js: $(nodejs_deps) $(js_deps) $(core_vendor)
 
 .PHONY: test-integration
 test-integration: $(composer_dev_deps)
-	$(MAKE) -C build/integration OC_TEST_ALT_HOME=$(OC_TEST_ALT_HOME)
+	$(MAKE) -C build/integration OC_TEST_ALT_HOME=$(OC_TEST_ALT_HOME) OC_TEST_ENCRYPTION_ENABLED=$(OC_TEST_ENCRYPTION_ENABLED)
 
 .PHONY: test-php-lint
 test-php-lint: $(composer_dev_deps)

--- a/build/integration/Makefile
+++ b/build/integration/Makefile
@@ -22,5 +22,5 @@ clean-test-results:
 clean: clean-test-results clean-composer-deps
 
 test: install-composer-deps
-	OC_TEST_ALT_HOME=$(OC_TEST_ALT_HOME) ./run.sh
+	OC_TEST_ALT_HOME=$(OC_TEST_ALT_HOME) OC_TEST_ENCRYPTION_ENABLED=$(OC_TEST_ENCRYPTION_ENABLED) ./run.sh
 

--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -276,6 +276,7 @@ Feature: provisioning
 		And the HTTP status code should be "200"
 		And group "España" does not exist
 
+	@no_encryption
 	Scenario: get enabled apps
 		Given As an "admin"
 		When sending "GET" to "/cloud/apps?filter=enabled"

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -219,12 +219,13 @@ Feature: sharing
   Scenario: getting all shares of a user using that user
     Given user "user0" exists
     And user "user1" exists
-    And file "textfile0.txt" of user "user0" is shared with user "user1"
+    And User "user0" moved file "/textfile0.txt" to "/file_to_share.txt"
+    And file "file_to_share.txt" of user "user0" is shared with user "user1"
     And As an "user0"
     When sending "GET" to "/apps/files_sharing/api/v1/shares"
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And File "textfile0.txt" should be included in the response
+    And File "file_to_share.txt" should be included in the response
 
   Scenario: getting all shares of a user using another user
     Given user "user0" exists

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -285,7 +285,8 @@ Feature: sharing
   Scenario: getting share info of a share
     Given user "user0" exists
     And user "user1" exists
-    And file "textfile0.txt" of user "user0" is shared with user "user1"
+    And User "user0" moved file "/textfile0.txt" to "/file_to_share.txt"
+    And file "file_to_share.txt" of user "user0" is shared with user "user1"
     And As an "user0"
     When Getting info of last share
     Then the OCS status code should be "100"
@@ -297,8 +298,8 @@ Feature: sharing
       | share_type | 0 |
       | share_with | user1 |
       | file_source | A_NUMBER |
-      | file_target | /textfile0.txt |
-      | path | /textfile0.txt |
+      | file_target | /file_to_share.txt |
+      | path | /file_to_share.txt |
       | permissions | 19 |
       | stime | A_NUMBER |
       | storage | A_NUMBER |

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -272,12 +272,13 @@ Feature: sharing
     And user "user2" exists
     And user "user3" exists
     And file "textfile0.txt" of user "user0" is shared with user "user1"
-    And file "textfile0 (2).txt" of user "user1" is shared with user "user2"
-    And file "textfile0 (2).txt" of user "user2" is shared with user "user3"
+    And User "user1" moved file "/textfile0 (2).txt" to "/textfile0_shared.txt"
+    And file "textfile0_shared.txt" of user "user1" is shared with user "user2"
+    And file "textfile0_shared.txt" of user "user2" is shared with user "user3"
     And As an "user1"
-    When User "user1" deletes file "/textfile0 (2).txt"
+    When User "user1" deletes file "/textfile0_shared.txt"
     And As an "user3"
-    And Downloading file "/textfile0 (2).txt" with range "bytes=1-7"
+    And Downloading file "/textfile0_shared.txt" with range "bytes=1-7"
     Then Downloaded content should be "wnCloud"
 
   Scenario: getting share info of a share

--- a/build/integration/features/transfer-ownership.feature
+++ b/build/integration/features/transfer-ownership.feature
@@ -1,5 +1,6 @@
 Feature: transfer-ownership
 
+	@no_encryption
 	Scenario: transfering ownership of a file
 		Given user "user0" exists
 		And user "user1" exists
@@ -10,6 +11,7 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then Downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_encryption
 	Scenario: transfering ownership of a folder
 		Given user "user0" exists
 		And user "user1" exists
@@ -21,6 +23,7 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_encryption
 	Scenario: transfering ownership of file shares
 		Given user "user0" exists
 		And user "user1" exists
@@ -32,6 +35,7 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_encryption
 	Scenario: transfering ownership of folder shared with third user
 		Given user "user0" exists
 		And user "user1" exists
@@ -44,6 +48,7 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_encryption
 	Scenario: transfering ownership of folder shared with transfer recipient
 		Given user "user0" exists
 		And user "user1" exists
@@ -57,6 +62,7 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		And Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_encryption
 	Scenario: transfering ownership of folder doubly shared with third user
 		Given group "group1" exists
 		And user "user0" exists
@@ -72,6 +78,7 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_encryption
 	Scenario: transfering ownership does not transfer received shares
 		Given user "user0" exists
 		And user "user1" exists
@@ -84,6 +91,7 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then as "user1" the folder "/test" does not exist
 
+	@no_encryption
 	@local_storage
 	Scenario: transfering ownership does not transfer external storage
 		Given user "user0" exists
@@ -94,6 +102,7 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then as "user1" the folder "/local_storage" does not exist
 
+	@no_encryption
 	Scenario: transfering ownership does not fail with shared trashed files
 		Given user "user0" exists
 		And user "user1" exists

--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -4,6 +4,7 @@ composer install
 
 OC_PATH=../../
 OCC=${OC_PATH}occ
+BEHAT=vendor/bin/behat
 
 SCENARIO_TO_RUN=$1
 HIDE_OC_LOGS=$2
@@ -63,9 +64,20 @@ fi
 # Enable encryption if requested
 if test "$OC_TEST_ENCRYPTION_ENABLED" = "1"; then
 	env_encryption_enable
+	BEHAT_FILTER_TAGS="~@no_encryption"
 fi
 
-vendor/bin/behat --strict -f junit -f pretty $SCENARIO_TO_RUN
+if test "$BEHAT_FILTER_TAGS"; then
+	BEHAT_PARAMS='{ 
+		"gherkin": {
+			"filters": {
+				"tags": "'"$BEHAT_FILTER_TAGS"'"
+			}
+		}
+	}'
+fi
+
+BEHAT_PARAMS="$BEHAT_PARAMS" $BEHAT --strict -f junit -f pretty $SCENARIO_TO_RUN
 RESULT=$?
 
 kill $PHPPID

--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -17,6 +17,16 @@ function env_alt_home_clear {
 	$OCC app:disable testing
 }
 
+function env_encryption_enable {
+	$OCC app:enable encryption
+	$OCC encryption:enable
+}
+
+function env_encryption_disable {
+	$OCC encryption:disable
+	$OCC app:disable encryption
+}
+
 # avoid port collision on jenkins - use $EXECUTOR_NUMBER
 if [ -z "$EXECUTOR_NUMBER" ]; then
     EXECUTOR_NUMBER=0
@@ -50,6 +60,11 @@ if test "$OC_TEST_ALT_HOME" = "1"; then
 	env_alt_home_enable
 fi
 
+# Enable encryption if requested
+if test "$OC_TEST_ENCRYPTION_ENABLED" = "1"; then
+	env_encryption_enable
+fi
+
 vendor/bin/behat --strict -f junit -f pretty $SCENARIO_TO_RUN
 RESULT=$?
 
@@ -63,6 +78,11 @@ $OCC app:disable files_external
 
 if test "$OC_TEST_ALT_HOME" = "1"; then
 	env_alt_home_clear
+fi
+
+# Disable encryption if requested
+if test "$OC_TEST_ENCRYPTION_ENABLED" = "1"; then
+	env_encryption_disable
 fi
 
 if [ -z $HIDE_OC_LOGS ]; then

--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -50,7 +50,7 @@ export TEST_SERVER_FED_URL="http://localhost:$PORT_FED/ocs/"
 #Enable external storage app
 $OCC app:enable files_external
 
-mkdir -p work/local_storage
+mkdir -p work/local_storage || { echo "Unable to create work folder" >&2; exit 1; }
 OUTPUT_CREATE_STORAGE=`$OCC files_external:create local_storage local null::null -c datadir=./build/integration/work/local_storage` 
 
 ID_STORAGE=`echo $OUTPUT_CREATE_STORAGE | awk {'print $5'}`


### PR DESCRIPTION
Extension of https://github.com/owncloud/core/pull/26586 but where the home directory name is different from the user id.

It currently uses a hack to md5 the user's home.

Goal is to reproduce the issue from https://github.com/owncloud/core/pull/26820 automatically.

Let's see how it goes...