### PR TITLE
Enable testing env for alternative home folder formats

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,7 +126,16 @@ timestampedNode('SLAVE') {
                 make test-integration
                '''
             }
-     }
+
+            executeAndReport('build/integration/output/*.xml') {
+                sh '''phpenv local 7.0
+                rm -rf config/config.php
+                ./occ maintenance:install --admin-pass=admin
+                make clean-test-integration
+                make test-integration OC_TEST_ALT_HOME=1
+               '''
+            }
+    }
 }
 
 def isOnReleaseBranch ()  {

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ test-js: $(nodejs_deps) $(js_deps) $(core_vendor)
 
 .PHONY: test-integration
 test-integration: $(composer_dev_deps)
-	$(MAKE) -C build/integration
+	$(MAKE) -C build/integration OC_TEST_ALT_HOME=$(OC_TEST_ALT_HOME)
 
 .PHONY: test-php-lint
 test-php-lint: $(composer_dev_deps)

--- a/build/integration/Makefile
+++ b/build/integration/Makefile
@@ -22,5 +22,5 @@ clean-test-results:
 clean: clean-test-results clean-composer-deps
 
 test: install-composer-deps
-	./run.sh
+	OC_TEST_ALT_HOME=$(OC_TEST_ALT_HOME) ./run.sh
 

--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -8,12 +8,12 @@ OCC=${OC_PATH}occ
 SCENARIO_TO_RUN=$1
 HIDE_OC_LOGS=$2
 
-function enableMD5HomeStorage {
+function env_alt_home_enable {
 	$OCC app:enable testing
-	OUTPUT_ENABLING_ALT_USER_BACKEND=`$OCC config:app:set testing enable_alt_user_backend --value yes` 
+	$OCC config:app:set testing enable_alt_user_backend --value yes
 }
 
-function cleanupMD5HomeStorage {
+function env_alt_home_clear {
 	$OCC app:disable testing
 }
 
@@ -46,8 +46,8 @@ ID_STORAGE=`echo $OUTPUT_CREATE_STORAGE | awk {'print $5'}`
 
 $OCC files_external:option $ID_STORAGE enable_sharing true
 
-if test "$MD5_HOME_STORAGE" = "1"; then
-	enableMD5HomeStorage
+if test "$OC_TEST_ALT_HOME" = "1"; then
+	env_althome_enable
 fi
 
 vendor/bin/behat --strict -f junit -f pretty $SCENARIO_TO_RUN
@@ -61,8 +61,8 @@ $OCC files_external:delete -y $ID_STORAGE
 #Disable external storage app
 $OCC app:disable files_external
 
-if test "$MD5_HOME_STORAGE" = "1"; then
-	cleanupMD5HomeStorage
+if test "$OC_TEST_ALT_HOME" = "1"; then
+	env_althome_clear
 fi
 
 if [ -z $HIDE_OC_LOGS ]; then


### PR DESCRIPTION
This is to see if integration tests pass when the user's home is md5'd.

A similar behavior would happen when selecting a home directory attribute with LDAP in which case the mounted home folder in ownCloud's virtual FS doesn't match the real filesystem.

There could be some bugs where `initMountPoint()` was forgotten but it did work correctly with regular homes due to one to one name matching. This PR will tell us if there are other affected code paths...
One known affected code path is https://github.com/owncloud/core/pull/26820

Let's see how it goes...

Eventually I think we need an app or config.php option to be able to set/simulate this behavior when running unit tests and integratin tests. @DeepDiver1975 @owncloud/qa 