### PR TITLE
Get user home folder before deletion

### DIFF
--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -197,6 +197,8 @@ class User implements IUser {
 		if ($this->emitter) {
 			$this->emitter->emit('\OC\User', 'preDelete', [$this]);
 		}
+		// get the home now because it won't return it after user deletion
+		$homePath = $this->getHome();
 		$result = $this->backend->deleteUser($this->uid);
 		if ($result) {
 
@@ -210,7 +212,11 @@ class User implements IUser {
 			\OC::$server->getConfig()->deleteAllUserValues($this->uid);
 
 			// Delete user files in /data/
-			\OC_Helper::rmdirr($this->getHome());
+			if ($homePath !== false) {
+				// FIXME: this operates directly on FS, should use View instead...
+				// also this is not testable/mockable...
+				\OC_Helper::rmdirr($homePath);
+			}
 
 			// Delete the users entry in the storage table
 			Storage::remove('home::' . $this->uid);

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -204,6 +204,38 @@ class UserTest extends TestCase {
 		$this->assertTrue($user->delete());
 	}
 
+	public function testDeleteWithDifferentHome() {
+		/**
+		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 */
+		$backend = $this->createMock(Dummy::class);
+
+		$backend->expects($this->at(0))
+			->method('implementsActions')
+			->will($this->returnCallback(function ($actions) {
+				if ($actions === Backend::GET_HOME) {
+					return true;
+				} else {
+					return false;
+				}
+			}));
+
+		// important: getHome MUST be called before deleteUser because
+		// once the user is deleted, getHome implementations might not
+		// return anything
+		$backend->expects($this->at(1))
+			->method('getHome')
+			->with($this->equalTo('foo'))
+			->will($this->returnValue('/home/foo'));
+
+		$backend->expects($this->at(2))
+			->method('deleteUser')
+			->with($this->equalTo('foo'));
+
+		$user = new User('foo', $backend);
+		$this->assertTrue($user->delete());
+	}
+
 	public function testGetHome() {
 		/**
 		 * @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
After the deletion getHome() will fail because the user doesn't exist
any more, so we need to fetch that value earlier.

## Related Issue
Discovered while looking into https://github.com/owncloud/core/pull/26846

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Fix was tested by applying it on top of https://github.com/owncloud/core/pull/26846.
To test manually, use the MD5 getHome hack from 67dbcdc3b841d9c3d5eb9a7c1ce578a7ceef5e91, then delete a user who has already logged in once.
Before the fix: home folder (md5) is not correctly deleted.
After the fix: home folder (md5) is still deleted.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review @owncloud/qa @butonic @DeepDiver1975 @VicDeo 