### PR TITLE
Set user home path in oc_preferences

### DIFF
--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -280,7 +280,12 @@ class Database extends Backend implements IUserBackend {
 	 */
 	public function getHome($uid) {
 		if ($this->userExists($uid)) {
-			return \OC::$server->getConfig()->getSystemValue("datadirectory", \OC::$SERVERROOT . "/data") . '/' . $uid;
+			return \OC::$server->getConfig()->getUserValue(
+				$uid,
+				'core',
+				'home',
+				\OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data') . '/' . $uid
+			);
 		}
 
 		return false;


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Makes it possible to override a user's home when using the default
Database backend by adding an oc_preferences key "home" for the "core"
app and that user. The value is an absolute path to the user's home.

This is similar to the LDAP home directory rule except that you simply provide the home dir in the oc_preferences table.

Use this to create the key from the CLI:
```
% occ user:setting admin core home --value=/srv/www/ocdata/admin
```

This might introduce an additional DB call, unless the oc_preferences values are cached anyway, which is probably already the case. (see lastLogin value for example)

## Related Issue

## Motivation and Context
Required to be able to automatically test cases where the value of `getHome()` is not the same as what is on disk: https://github.com/owncloud/core/pull/26846.

Also some admins might appreciate this added flexibility. But at this point I'd only keep this as an advanced hidden feature because it's easy to mess up especially when moving homes around.

## How Has This Been Tested?

1. Create a user "user1"
1. `occ user:setting user1 core home --value=/srv/www/ocdata/xyz`
1. Login as "user1"
1. Create a folder "test"
1. Check that the folder "/srv/www/ocdata/xyz/test" exists.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

If this is not acceptable, please suggest an alternative.
For the tests, we'd need to backport this... Not too happy. Suggestions ?

@DeepDiver1975 @owncloud/qa @butonic @VicDeo 