### PR TITLE
Add home storage location in provisioning API response

### DIFF
--- a/apps/provisioning_api/lib/Users.php
+++ b/apps/provisioning_api/lib/Users.php
@@ -214,6 +214,7 @@ class Users {
 		$data['quota'] = $this->fillStorageInfo($userId);
 		$data['email'] = $targetUserObject->getEMailAddress();
 		$data['displayname'] = $targetUserObject->getDisplayName();
+		$data['home'] = $targetUserObject->getHome();
 		$data['two_factor_auth_enabled'] = $this->twoFactorAuthManager->isTwoFactorAuthenticated($targetUserObject) ? 'true' : 'false';
 
 		return new Result($data);

--- a/apps/provisioning_api/tests/UsersTest.php
+++ b/apps/provisioning_api/tests/UsersTest.php
@@ -697,6 +697,9 @@ class UsersTest extends OriginalTest {
 		$targetUser->expects($this->once())
 			->method('getEMailAddress')
 			->willReturn('demo@owncloud.org');
+		$targetUser->expects($this->once())
+			->method('getHome')
+			->willReturn('/var/ocdata/UserToGet');
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -732,7 +735,8 @@ class UsersTest extends OriginalTest {
 				'quota' => ['DummyValue'],
 				'email' => 'demo@owncloud.org',
 				'displayname' => 'Demo User',
-				'two_factor_auth_enabled' => 'false'
+				'home' => '/var/ocdata/UserToGet',
+				'two_factor_auth_enabled' => 'false',
 			]
 		);
 		$this->assertEquals($expected, $this->api->getUser(['userid' => 'UserToGet']));
@@ -746,9 +750,12 @@ class UsersTest extends OriginalTest {
 			->will($this->returnValue('subadmin'));
 		$targetUser = $this->createMock('OCP\IUser');
 		$targetUser
-				->expects($this->once())
-				->method('getEMailAddress')
-				->willReturn('demo@owncloud.org');
+			->expects($this->once())
+			->method('getEMailAddress')
+			->willReturn('demo@owncloud.org');
+		$targetUser->expects($this->once())
+			->method('getHome')
+			->willReturn('/var/ocdata/UserToGet');
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -795,6 +802,7 @@ class UsersTest extends OriginalTest {
 				'enabled' => 'true',
 				'quota' => ['DummyValue'],
 				'email' => 'demo@owncloud.org',
+				'home' => '/var/ocdata/UserToGet',
 				'displayname' => 'Demo User',
 				'two_factor_auth_enabled' => 'false'
 			]
@@ -847,6 +855,9 @@ class UsersTest extends OriginalTest {
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
 		$targetUser = $this->createMock('OCP\IUser');
+		$targetUser->expects($this->once())
+			->method('getHome')
+			->willReturn('/var/ocdata/UserToGet');
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -891,7 +902,8 @@ class UsersTest extends OriginalTest {
 			'quota' => ['DummyValue'],
 			'email' => 'subadmin@owncloud.org',
 			'displayname' => 'Subadmin User',
-			'two_factor_auth_enabled' => 'false'
+			'home' => '/var/ocdata/UserToGet',
+			'two_factor_auth_enabled' => 'false',
 		]);
 		$this->assertEquals($expected, $this->api->getUser(['userid' => 'subadmin']));
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Add home storage location in provisioning API response

## Related Issue
Required for automated testing with custom home folders: https://github.com/owncloud/core/pull/26846.

## Motivation and Context
Required for automated testing with custom home folders: https://github.com/owncloud/core/pull/26846.
Also this info is visible in the users page UI (opt-in), so it makes sense to have it visible here too.

## How Has This Been Tested?
`curl -X GET --user admin:admin http://localhost/owncloud/ocs/v1.php/cloud/users/user1`
See new "home" entry with the absolute home path.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


@butonic @DeepDiver1975 @SergioBertolinSG @tomneedham 