### PR TITLE
Testing md5home

### DIFF
--- a/apps/testing/appinfo/app.php
+++ b/apps/testing/appinfo/app.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+$app = new \OCA\Testing\Application();
+

--- a/apps/testing/appinfo/info.xml
+++ b/apps/testing/appinfo/info.xml
@@ -9,4 +9,7 @@
 	<dependencies>
 		<owncloud min-version="9.2" max-version="9.2" />
 	</dependencies>
+	<types>
+		<type>prelogin</type>
+	</types>
 </info>

--- a/apps/testing/lib/AlternativeHomeUserBackend.php
+++ b/apps/testing/lib/AlternativeHomeUserBackend.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Testing;
+
+/**
+ * Alternative home user backend.
+ *
+ * It returns a md5 of the home folder instead of the user id.
+ * To configure, need to add this in config.php:
+ *	'user_backends' => [
+ *			'default' => false, [
+ *				'class' => '\\OCA\\Testing\\AlternativeHomeUserBackend',
+ *				'arguments' => [],
+ *			],
+ *	]
+ */
+class AlternativeHomeUserBackend extends \OC\User\Database {
+	public function __construct() {
+		parent::__construct();
+	}
+	/**
+	 * get the user's home directory
+	 * @param string $uid the username
+	 * @return string|false
+	 */
+	public function getHome($uid) {
+		if ($this->userExists($uid)) {
+			$uid = md5($uid);
+			return \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data') . '/' . $uid;
+		}
+
+		return false;
+	}
+}

--- a/apps/testing/lib/AlternativeHomeUserBackend.php
+++ b/apps/testing/lib/AlternativeHomeUserBackend.php
@@ -44,7 +44,10 @@ class AlternativeHomeUserBackend extends \OC\User\Database {
 	 */
 	public function getHome($uid) {
 		if ($this->userExists($uid)) {
-			$uid = md5($uid);
+			// workaround to avoid killing the admin
+			if ($uid !== 'admin') {
+				$uid = md5($uid);
+			}
 			return \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data') . '/' . $uid;
 		}
 

--- a/apps/testing/lib/Application.php
+++ b/apps/testing/lib/Application.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Testing;
+
+use OCP\AppFramework\App;
+
+class Application extends App {
+	public function __construct (array $urlParams = array()) {
+		parent::__construct('testing', $urlParams);
+	}
+}

--- a/lib/private/legacy/user.php
+++ b/lib/private/legacy/user.php
@@ -126,7 +126,14 @@ class OC_User {
 	public static function setupBackends() {
 		OC_App::loadApps(['prelogin']);
 		$backends = \OC::$server->getSystemConfig()->getValue('user_backends', []);
+		if (isset($backends['default']) && !$backends['default']) {
+			// clear default backends
+			self::clearBackends();
+		}
 		foreach ($backends as $i => $config) {
+			if (!is_array($config)) {
+				continue;
+			}
 			$class = $config['class'];
 			$arguments = $config['arguments'];
 			if (class_exists($class)) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Allow clearing default user backends in config.php.
Testing app provides test user backend for alternative homes.

## Related Issue
Alternative to https://github.com/owncloud/core/pull/26846 and https://github.com/owncloud/core/pull/26851

## Motivation and Context
Need tests for alternative getHome

## How Has This Been Tested?

1. Edit config.php and add:
```
'user_backends' => 
  array (
    'default' => false,   // this is the new setting that kills the default DB user backend
    0 => 
    array (
      'class' => '\\OCA\\Testing\\AlternativeHomeUserBackend',
      'arguments' => 
      array (
      ),
    ),
  ),
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 as discussed
@SergioBertolinSG 

If approve, I'll add an automated test suite that uses this in https://github.com/owncloud/core/pull/26846