### PR TITLE
Rename root storage to "root::"

### DIFF
--- a/lib/private/Files/Storage/Root.php
+++ b/lib/private/Files/Storage/Root.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Files\Storage;
+
+/**
+ * Specialized version of Local storage for the data directory
+ * directly.
+ */
+class Root extends Local {
+	/**
+	 * @var string
+	 */
+	protected $id;
+
+	/**
+	 * Construct a Root storage instance
+	 * @param array $arguments array
+	 */
+	public function __construct($arguments) {
+		parent::__construct($arguments);
+	}
+
+	public function getId() {
+		return 'root::';
+	}
+
+}

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -75,7 +75,7 @@ class OC_Util {
 		//first set up the local "root" storage
 		\OC\Files\Filesystem::initMountManager();
 		if (!self::$rootMounted) {
-			\OC\Files\Filesystem::mount('\OC\Files\Storage\Local', ['datadir' => $configDataDirectory], '/');
+			\OC\Files\Filesystem::mount('\OC\Files\Storage\Root', ['datadir' => $configDataDirectory], '/');
 			self::$rootMounted = true;
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Root storage now has id "root::" instead of a hard-coded path.

## Related Issue
One step further to not needing this https://github.com/owncloud/core/issues/25970

## Motivation and Context
Because hard-coded paths in the database suck especially when the admin moves stuff around.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## TODOs:

- [ ] add a migration to rename (or delete?) the old storage, need to investigate whether this is needed especially with encryption keys
- [ ] unit tests

