### PR TITLE
Testing app switch to force-enable test user backend

### DIFF
--- a/apps/testing/appinfo/info.xml
+++ b/apps/testing/appinfo/info.xml
@@ -10,6 +10,6 @@
 		<owncloud min-version="9.2" max-version="9.2" />
 	</dependencies>
 	<types>
-		<type>prelogin</type>
+		<authentication/>
 	</types>
 </info>

--- a/apps/testing/lib/Application.php
+++ b/apps/testing/lib/Application.php
@@ -22,9 +22,21 @@
 namespace OCA\Testing;
 
 use OCP\AppFramework\App;
+use OCA\Testing\AlternativeHomeUserBackend;
 
 class Application extends App {
 	public function __construct (array $urlParams = array()) {
-		parent::__construct('testing', $urlParams);
+		$appName = 'testing';
+		parent::__construct($appName, $urlParams);
+
+		$c = $this->getContainer();
+		$config = $c->getServer()->getConfig();
+		if ($config->getAppValue($appName, 'enable_alt_user_backend', 'no') === 'yes') {
+			$userManager = $c->getServer()->getUserManager();
+
+			// replace all user backends with this one
+			$userManager->clearBackends();
+			$userManager->registerBackend($c->query(AlternativeHomeUserBackend::class));
+		}
 	}
 }


### PR DESCRIPTION
To test:

1. Setup OC from scratch
1. `occ app:enable testing`
1. Set the override switch: `occ config:app:set testing enable_alt_user_backend --value yes`

This will tell the testing app to force-override the default user backend with the alternative one that returns md5 for user homes.

@SergioBertolinSG please review and test. I hope it will work with the integration tests.