### PR TITLE
Adding dav resource for avatars

### DIFF
--- a/apps/dav/lib/Avatars/AvatarHome.php
+++ b/apps/dav/lib/Avatars/AvatarHome.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\DAV\Avatars;
+
+
+use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\Exception\MethodNotAllowed;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\ICollection;
+use Sabre\HTTP\URLUtil;
+
+class AvatarHome implements ICollection {
+	private $principalInfo;
+
+	/**
+	 * AvatarHome constructor.
+	 *
+	 * @param array $principalInfo
+	 */
+	public function __construct($principalInfo) {
+		$this->principalInfo = $principalInfo;
+	}
+
+	function createFile($name, $data = null) {
+		throw new Forbidden('Permission denied to create a file');
+	}
+
+	function createDirectory($name) {
+		throw new Forbidden('Permission denied to create a folder');
+	}
+
+	function getChild($name) {
+		$elements = pathinfo($name);
+		$ext = isset($elements['extension']) ? $elements['extension'] : '';
+		$size = intval(isset($elements['filename']) ? $elements['filename'] : '64');
+		if (!in_array($ext, ['jpeg', 'png'])) {
+			throw new MethodNotAllowed('File format not allowed');
+		}
+		if ($size <= 0 || $size > 1024) {
+			throw new MethodNotAllowed('Invalid image size');
+		}
+		$avatar = \OC::$server->getAvatarManager()->getAvatar($this->getName());
+		if (!$avatar->exists()) {
+			throw new NotFound();
+		}
+		return new AvatarNode($size, $ext, $avatar);
+	}
+
+	function getChildren() {
+		try {
+			return [
+				$this->getChild('96.jpeg')
+			];
+		} catch(NotFound $exception) {
+			return [];
+		}
+	}
+
+	function childExists($name) {
+		$ret = $this->getChild($name);
+		return !is_null($ret);
+	}
+
+	function delete() {
+		throw new Forbidden('Permission denied to delete this folder');
+	}
+
+	function getName() {
+		list(,$name) = URLUtil::splitPath($this->principalInfo['uri']);
+		return $name;
+	}
+
+	function setName($name) {
+		throw new Forbidden('Permission denied to rename this folder');
+	}
+
+	/**
+	 * Returns the last modification time, as a unix timestamp
+	 *
+	 * @return int
+	 */
+	function getLastModified() {
+		return null;
+	}
+
+
+}

--- a/apps/dav/lib/Avatars/AvatarNode.php
+++ b/apps/dav/lib/Avatars/AvatarNode.php
@@ -83,11 +83,16 @@ class AvatarNode extends File {
 		return 'image/jpeg';
 	}
 
-//	function getSize() {
-//		return $this->avatar->getFile($this->size)->getSize();
-//	}
-
 	function getETag() {
 		return $this->avatar->getFile($this->size)->getEtag();
+	}
+
+	function getLastModified() {
+		$timestamp = $this->avatar->getFile($this->size)->getMTime();
+		if (!empty($timestamp)) {
+			return (int)$timestamp;
+		}
+		return $timestamp;
+
 	}
 }

--- a/apps/dav/lib/Avatars/AvatarNode.php
+++ b/apps/dav/lib/Avatars/AvatarNode.php
@@ -23,7 +23,6 @@
 namespace OCA\DAV\Avatars;
 
 
-use OCA\DAV\IPublicNode;
 use OCP\IAvatar;
 use Sabre\DAV\File;
 

--- a/apps/dav/lib/Avatars/AvatarNode.php
+++ b/apps/dav/lib/Avatars/AvatarNode.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\DAV\Avatars;
+
+
+use OCA\DAV\IPublicNode;
+use OCP\IAvatar;
+use Sabre\DAV\File;
+
+class AvatarNode extends File {
+	private $ext;
+	private $size;
+	private $avatar;
+
+	/**
+	 * AvatarNode constructor.
+	 *
+	 * @param integer $size
+	 * @param string $ext
+	 * @param IAvatar $avatar
+	 */
+	public function __construct($size, $ext, $avatar) {
+		$this->size = $size;
+		$this->ext = $ext;
+		$this->avatar = $avatar;
+	}
+
+	/**
+	 * Returns the name of the node.
+	 *
+	 * This is used to generate the url.
+	 *
+	 * @return string
+	 */
+	function getName() {
+		return "$this->size.$this->ext";
+	}
+
+	function get() {
+		$image = $this->avatar->get($this->size);
+		$res = $image->resource();
+
+		ob_start();
+		if ($this->ext === 'png') {
+			imagepng($res);
+		}
+		imagejpeg($res);
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * Returns the mime-type for a file
+	 *
+	 * If null is returned, we'll assume application/octet-stream
+	 *
+	 * @return string|null
+	 */
+	function getContentType() {
+		if ($this->ext === 'png') {
+			return 'image/png';
+		}
+		return 'image/jpeg';
+	}
+
+//	function getSize() {
+//		return $this->avatar->getFile($this->size)->getSize();
+//	}
+
+	function getETag() {
+		return $this->avatar->getFile($this->size)->getEtag();
+	}
+}

--- a/apps/dav/lib/Avatars/RootCollection.php
+++ b/apps/dav/lib/Avatars/RootCollection.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace OCA\DAV\Avatars;
+
+use Sabre\DAVACL\AbstractPrincipalCollection;
+use Sabre\DAVACL\IPrincipal;
+
+class RootCollection extends AbstractPrincipalCollection {
+
+	/**
+	 * This method returns a node for a principal.
+	 *
+	 * The passed array contains principal information, and is guaranteed to
+	 * at least contain a uri item. Other properties may or may not be
+	 * supplied by the authentication backend.
+	 *
+	 * @param array $principalInfo
+	 * @return IPrincipal
+	 */
+	function getChildForPrincipal(array $principalInfo) {
+		return new AvatarHome($principalInfo);
+	}
+
+	function getName() {
+		return 'avatars';
+	}
+
+}

--- a/apps/dav/lib/Avatars/RootCollection.php
+++ b/apps/dav/lib/Avatars/RootCollection.php
@@ -15,10 +15,11 @@ class RootCollection extends AbstractPrincipalCollection {
 	 * supplied by the authentication backend.
 	 *
 	 * @param array $principalInfo
-	 * @return IPrincipal
+	 * @return AvatarHome
 	 */
 	function getChildForPrincipal(array $principalInfo) {
-		return new AvatarHome($principalInfo);
+		$avatarManager = \OC::$server->getAvatarManager();
+		return new AvatarHome($principalInfo, $avatarManager);
 	}
 
 	function getName() {

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -222,8 +222,8 @@ class Principal implements BackendInterface {
 		$email = $user->getEMailAddress();
 		if (!empty($email)) {
 			$principal['{http://sabredav.org/ns}email-address'] = $email;
-			return $principal;
 		}
+
 		return $principal;
 	}
 

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -89,6 +89,9 @@ class RootCollection extends SimpleCollection {
 		$uploadCollection = new Upload\RootCollection($userPrincipalBackend, 'principals/users');
 		$uploadCollection->disableListing = $disableListing;
 
+		$avatarCollection = new Avatars\RootCollection($userPrincipalBackend, 'principals/users');
+		$avatarCollection->disableListing = $disableListing;
+
 		$children = [
 				new SimpleCollection('principals', [
 						$userPrincipals,
@@ -103,6 +106,7 @@ class RootCollection extends SimpleCollection {
 				$systemTagCollection,
 				$systemTagRelationsCollection,
 				$uploadCollection,
+				$avatarCollection
 		];
 
 		parent::__construct('root', $children);

--- a/apps/dav/tests/unit/Avatars/AvatarHomeTest.php
+++ b/apps/dav/tests/unit/Avatars/AvatarHomeTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\DAV\Tests\Unit\Avatars;
+
+
+use OCA\DAV\Avatars\AvatarHome;
+use OCA\DAV\Avatars\AvatarNode;
+use OCP\IAvatar;
+use OCP\IAvatarManager;
+use Sabre\DAV\Exception\MethodNotAllowed;
+use Sabre\DAV\Exception\NotFound;
+use Test\TestCase;
+
+class AvatarHomeTest extends TestCase {
+
+	/** @var AvatarHome */
+	private $home;
+
+	/** @var IAvatarManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $avatarManager;
+
+	public function setUp() {
+		$this->avatarManager = $this->createMock(IAvatarManager::class);
+		$this->home = new AvatarHome(['uri' => 'principals/users/admin'], $this->avatarManager);
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 * @dataProvider providesForbiddenMethods
+	 */
+	public function testForbiddenMethods($method) {
+		$this->home->$method('');
+	}
+
+	public function providesForbiddenMethods() {
+		return [
+			['createFile'],
+			['createDirectory'],
+			['delete'],
+			['setName']
+		];
+	}
+
+	public function testGetName() {
+		$n = $this->home->getName();
+		self::assertEquals('admin', $n);
+	}
+
+	public function providesTestGetChild() {
+		return [
+			[MethodNotAllowed::class, false, ''],
+			[MethodNotAllowed::class, false, 'bla.foo'],
+			[MethodNotAllowed::class, false, 'bla.png'],
+			[NotFound::class, false, '512.png'],
+			[null, true, '512.png'],
+		];
+	}
+
+	/**
+	 * @dataProvider providesTestGetChild
+	 */
+	public function testGetChild($expectedException, $hasAvatar, $path) {
+		if ($expectedException !== null) {
+			$this->expectException($expectedException);
+		}
+		$avatar = null;
+		if ($hasAvatar) {
+			$avatar = $this->createMock(IAvatar::class);
+			$avatar->expects($this->once())->method('exists')->willReturn(true);
+		}
+		$this->avatarManager->expects($this->any())->method('getAvatar')->with('admin')->willReturn($avatar);
+		$avatarNode = $this->home->getChild($path);
+		$this->assertInstanceOf(AvatarNode::class, $avatarNode);
+	}
+
+	public function testGetChildren() {
+		$avatarNodes = $this->home->getChildren();
+		self::assertEquals(0, count($avatarNodes));
+
+		$avatar = $this->createMock(IAvatar::class);
+		$avatar->expects($this->once())->method('exists')->willReturn(true);
+		$this->avatarManager->expects($this->any())->method('getAvatar')->with('admin')->willReturn($avatar);
+		$avatarNodes = $this->home->getChildren();
+		self::assertEquals(1, count($avatarNodes));
+	}
+
+	/**
+	 * @dataProvider providesTestGetChild
+	 */
+	public function testChildExists($expectedException, $hasAvatar, $path) {
+		$avatar = null;
+		if ($hasAvatar) {
+			$avatar = $this->createMock(IAvatar::class);
+			$avatar->expects($this->once())->method('exists')->willReturn(true);
+		}
+		$this->avatarManager->expects($this->any())->method('getAvatar')->with('admin')->willReturn($avatar);
+		$childExists = $this->home->childExists($path);
+		$this->assertEquals($hasAvatar, $childExists);
+	}
+
+	public function testGetLastModified() {
+		self::assertNull($this->home->getLastModified());
+	}
+
+}

--- a/apps/dav/tests/unit/Avatars/AvatarNodeTest.php
+++ b/apps/dav/tests/unit/Avatars/AvatarNodeTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\DAV\Tests\Unit\Avatars;
+
+
+use OCA\DAV\Avatars\AvatarNode;
+use OCP\IAvatar;
+use Test\TestCase;
+
+class AvatarNodeTest extends TestCase {
+
+	public function testGetName() {
+		/** @var IAvatar | \PHPUnit_Framework_MockObject_MockObject $a */
+		$a = $this->createMock(IAvatar::class);
+		$n = new AvatarNode(1024, 'png', $a);
+		$this->assertEquals('1024.png', $n->getName());
+	}
+
+	public function testGetContentType() {
+		/** @var IAvatar | \PHPUnit_Framework_MockObject_MockObject $a */
+		$a = $this->createMock(IAvatar::class);
+		$n = new AvatarNode(1024, 'png', $a);
+		$this->assertEquals('image/png', $n->getContentType());
+
+		$n = new AvatarNode(1024, 'jpeg', $a);
+		$this->assertEquals('image/jpeg', $n->getContentType());
+	}
+}

--- a/apps/dav/tests/unit/phpunit.xml
+++ b/apps/dav/tests/unit/phpunit.xml
@@ -11,9 +11,9 @@
 	<!-- filters for code coverage -->
 	<filter>
 		<whitelist>
-			<directory suffix=".php">../../dav</directory>
+			<directory suffix=".php">../../../dav</directory>
 			<exclude>
-				<directory suffix=".php">../../dav/tests</directory>
+				<directory suffix=".php">../../../dav/tests</directory>
 			</exclude>
 		</whitelist>
 	</filter>


### PR DESCRIPTION
## Description
There is one root resource called /avatars/ - within this collection there is a list of all users (only enumerable in debug mode as usual).

Within this user node avatars can be loaded following the pattern
$size.$ext

where size is less then 1024 and ext is wither jppg or png.

A default child named 96.jpeg is listed.

# To Decide:
- allow any size or support only some like 32, 64, 96, 128, ...
  - [ ] any
  - [ ] list

# ToDo:

- [ ] unit tests
- [ ] integration tests
- [ ] think about unauthenticated requests - interesting for public share links

## Motivation and Context
@dragotin wants to have some fun with the desktop client during the holidays and I happily support him

## How Has This Been Tested?
Browser with sabre's browser plugin - see screeshot

## Screenshots (if appropriate):
![bildschirmfoto von 2016-12-23 11-54-16](https://cloud.githubusercontent.com/assets/1005065/21452995/4a73d730-c90b-11e6-8f36-8f8cd62167cf.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

