### PR TITLE
Fix #26869 honor overwritewebroot and PATH_INFO

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -595,8 +595,8 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		$uri = isset($this->server['REQUEST_URI']) ? $this->server['REQUEST_URI'] : '';
 		if($this->config->getSystemValue('overwritewebroot') !== '' && $this->isOverwriteCondition()) {
 			// FIXME for reasons of consistency, please check whether "$this->server['SCRIPT_NAME']" should be replaced by "$this->getScriptName()" or vice versa
-			$pathWithOutPrefix = substr($uri, strlen($this->config->getSystemValue('overwritewebroot') . $this->server['SCRIPT_NAME'])
-			$uri = $this->getScriptName() . $pathWithOutPrefix);
+			$pathWithOutPrefix = substr($uri, strlen($this->config->getSystemValue('overwritewebroot') . $this->server['SCRIPT_NAME']));
+			$uri = $this->getScriptName() . $pathWithOutPrefix;
 		}
 		return $uri;
 	}

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -594,7 +594,9 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	public function getRequestUri() {
 		$uri = isset($this->server['REQUEST_URI']) ? $this->server['REQUEST_URI'] : '';
 		if($this->config->getSystemValue('overwritewebroot') !== '' && $this->isOverwriteCondition()) {
-			$uri = $this->getScriptName() . substr($uri, strlen($this->server['SCRIPT_NAME']));
+			// FIXME for reasons of consistency, please check whether "$this->server['SCRIPT_NAME']" should be replaced by "$this->getScriptName()" or vice versa
+			$pathWithOutPrefix = substr($uri, strlen($this->config->getSystemValue('overwritewebroot') . $this->server['SCRIPT_NAME'])
+			$uri = $this->getScriptName() . $pathWithOutPrefix);
 		}
 		return $uri;
 	}
@@ -605,6 +607,12 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 * @return string Path info
 	 */
 	public function getRawPathInfo() {
+		// honor PATH_INFO variable in case it is set!
+		$pathInfo = isset($this->server['PATH_INFO']) ? $this->server['PATH_INFO'] : '';
+		if($pathInfo !== '') {
+			return $pathInfo;
+		}
+
 		$requestUri = isset($this->server['REQUEST_URI']) ? $this->server['REQUEST_URI'] : '';
 		// remove too many leading slashes - can be caused by reverse proxy configuration
 		if (strpos($requestUri, '/') === 0) {


### PR DESCRIPTION
## Description
Fixes #26869: honor overwritewebroot config property and PATH_INFO in request handling so that owncloud can be run under a contextroot such as /owncloud or /cloud


## Related Issue
#26869 

## Motivation and Context
see description.

## How Has This Been Tested?
Please check the description and comments in #26869. I applied these changes to my owncloud 9.1 + nginx 1.10 installation in order to make it work under a contextroot of `/cloud` -> _I tested this change on a production installation_.

As my PHP is rather rusty and I'm not too familiar with how owncloud is tested, I didn't adjust https://github.com/owncloud/core/blob/37177dd54d67443cacc0061c17f95070442b93cf/tests/lib/AppFramework/Http/RequestTest.php though this is definitely necessary as I couldn't spot any tests with a contextroot!

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I will send another pull-request with an update to https://doc.owncloud.org/server/9.0/admin_manual/installation/nginx_examples.html#owncloud-in-a-subdir-of-nginx so that other users don't have to read #26869 but can get the necessary information there.
