### PR TITLE
Created a config.php option to disable local mounts for files_externa…

### DIFF
--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -90,14 +90,13 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 			$container->query('OCA\Files_External\Lib\Backend\SFTP_Key'),
 			$container->query('OCA\Files_External\Lib\Backend\SMB'),
 			$container->query('OCA\Files_External\Lib\Backend\SMB_OC'),
-    ];
+		];
 
-      $this->denyLocalMounts = \OC::$server->getConfig()->getSystemValue('files_external_deny_local', false);
-
-      if ($this->denyLocalMounts !== true) {
-        $backends[] = $container->query('OCA\Files_External\Lib\Backend\Local');
-      };
-
+		$this->denyLocalMounts = \OC::$server->getConfig()->getSystemValue('files_external_deny_local', false);
+		if ($this->denyLocalMounts !== true) {
+			$backends[] = $container->query('OCA\Files_External\Lib\Backend\Local');
+		};
+		
 		return $backends;
 	}
 

--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -92,7 +92,7 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 			$container->query('OCA\Files_External\Lib\Backend\SMB_OC'),
     ];
 
-      $this->denyLocalMounts = \OC::$server->getConfig()->getSystemValue('files_external_deny_local', 'false');
+      $this->denyLocalMounts = \OC::$server->getConfig()->getSystemValue('files_external_deny_local', false);
 
       if ($this->denyLocalMounts !== true) {
         $backends[] = $container->query('OCA\Files_External\Lib\Backend\Local');

--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -80,7 +80,6 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 		$container = $this->getContainer();
 
 		$backends = [
-			$container->query('OCA\Files_External\Lib\Backend\Local'),
 			$container->query('OCA\Files_External\Lib\Backend\DAV'),
 			$container->query('OCA\Files_External\Lib\Backend\OwnCloud'),
 			$container->query('OCA\Files_External\Lib\Backend\SFTP'),
@@ -91,7 +90,13 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 			$container->query('OCA\Files_External\Lib\Backend\SFTP_Key'),
 			$container->query('OCA\Files_External\Lib\Backend\SMB'),
 			$container->query('OCA\Files_External\Lib\Backend\SMB_OC'),
-		];
+    ];
+
+      $this->denyLocalMounts = \OC::$server->getConfig()->getSystemValue('files_external_deny_local', 'false');
+
+      if ($this->denyLocalMounts !== true) {
+        $backends[] = $container->query('OCA\Files_External\Lib\Backend\Local');
+      };
 
 		return $backends;
 	}

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1299,6 +1299,13 @@ $CONFIG = array(
 'data-fingerprint' => '',
 
 /**
+ * Set this property to true if you want to disable the files_external local mount Option.
+ * Default: false
+ * 
+ */
+'files_external_deny_local' => false,
+
+/**
  * This entry is just here to show a warning in case somebody copied the sample
  * configuration. DO NOT ADD THIS SWITCH TO YOUR CONFIGURATION!
  *


### PR DESCRIPTION
…l. fixing #26653

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
As in #26653 mentioned an option would be good to disable the 'local' option from files_external.
There is now a new Option for config.php called 'files_external_deny_local' which is set to false on default. Only if you set the option to true then the local Backend will _not_ get registered.

## Related Issue
#26653

## Motivation and Context
If Sysadmin and oCadmin are not the same the Sysadmin may want to disable the local mount feature for security reasons.

## How Has This Been Tested?
Compiled the actual master, installed php56 and apach24 on centos7 (Softwarecollection) 
Tested without setting the option in config.php, tested with the option set to false and set to true.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
Line maybe to long - but have no shorter idea 
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

