### PR TITLE
Fix warnings for ExcludeFileByNameFilterIterator test

### DIFF
--- a/lib/private/IntegrityCheck/Iterator/ExcludeFileByNameFilterIterator.php
+++ b/lib/private/IntegrityCheck/Iterator/ExcludeFileByNameFilterIterator.php
@@ -58,11 +58,14 @@ class ExcludeFileByNameFilterIterator extends \RecursiveFilterIterator {
 	 * @return bool
 	 */
 	public function accept() {
-		if($this->isDir()) {
+		/** @var \SplFileInfo $current */
+		$current = $this->current();
+
+		if ($current->isDir()) {
 			return true;
 		}
 
-		$currentFileName = $this->current()->getFilename();
+		$currentFileName = $current->getFilename();
 		if (in_array($currentFileName, $this->excludedFilenames, true)){
 			return false;
 		}

--- a/tests/lib/IntegrityCheck/Iterator/ExcludeFileByNameFilterIteratorTest.php
+++ b/tests/lib/IntegrityCheck/Iterator/ExcludeFileByNameFilterIteratorTest.php
@@ -25,13 +25,14 @@ use \OC\IntegrityCheck\Iterator\ExcludeFileByNameFilterIterator;
 use Test\TestCase;
 
 class ExcludeFileByNameFilterIteratorTest extends TestCase {
-	/** @var ExcludeFileByNameFilterIterator */
+	/** @var \PHPUnit_Framework_MockObject_MockBuilder */
 	protected $filter;
 
 	public function setUp() {
 		parent::setUp();
 		$this->filter = $this->getMockBuilder(ExcludeFileByNameFilterIterator::class)
 			->disableOriginalConstructor()
+			->setMethods(['current'])
 			->getMock()
 		;
 
@@ -54,13 +55,17 @@ class ExcludeFileByNameFilterIteratorTest extends TestCase {
 	 * @param bool $expectedResult
 	 */
 	public function testAcceptForFiles($fileName, $expectedResult){
-		$iteratorMock = $this->createMock(\DirectoryIterator::class);
+		$iteratorMock = $this->getMockBuilder(\RecursiveDirectoryIterator::class)
+			->disableOriginalConstructor()
+			->setMethods(['getFilename', 'isDir'])
+			->getMock()
+		;
 		$iteratorMock->method('getFilename')
 			->will($this->returnValue($fileName))
 		;
-
-		$this->filter->method('isDir')
+		$iteratorMock->method('isDir')
 			->will($this->returnValue(false));
+
 		$this->filter->method('current')
 			->will($this->returnValue($iteratorMock))
 		;
@@ -75,18 +80,22 @@ class ExcludeFileByNameFilterIteratorTest extends TestCase {
 	 * @param bool $fakeExpectedResult
 	 */
 	public function testAcceptForDirs($fileName, $fakeExpectedResult){
-		$iteratorMock = $this->createMock(\DirectoryIterator::class);
+		$iteratorMock = $this->getMockBuilder(\RecursiveDirectoryIterator::class)
+			->disableOriginalConstructor()
+			->setMethods(['getFilename', 'isDir'])
+			->getMock()
+		;
 		$iteratorMock->method('getFilename')
 			->will($this->returnValue($fileName))
 		;
-
-		$this->filter->method('isDir')
+		$iteratorMock->method('isDir')
 			->will($this->returnValue(true));
+
 		$this->filter->method('current')
 			->will($this->returnValue($iteratorMock))
 		;
 
 		$actualResult = $this->filter->accept();
-		$this->assertFalse($actualResult);
+		$this->assertTrue($actualResult);
 	}
 }


### PR DESCRIPTION

## Description
Fixed  warnings for integrity check unit tests

## Related Issue
https://github.com/owncloud/core/issues/26870

## Motivation and Context
```
1) Test\IntegrityCheck\Iterator\ExcludeFileByNameFilterIteratorTest::testAcceptForFiles with data set #0 ('a file', true)
Trying to configure method "isDir" which cannot be configured because it does not exist, has not been specified, is final, or is static
```

## How Has This Been Tested?
With PHPUnit

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

