### PR TITLE
[stable9] Backport lazy init of shared storage/mount

### DIFF
--- a/apps/files_sharing/lib/sharedmount.php
+++ b/apps/files_sharing/lib/sharedmount.php
@@ -49,6 +49,9 @@ class SharedMount extends MountPoint implements MoveableMount {
 	 */
 	private $user;
 
+	/** @var array */
+	private $share;
+
 	/**
 	 * @param string $storage
 	 * @param SharedMount[] $mountpoints
@@ -58,9 +61,10 @@ class SharedMount extends MountPoint implements MoveableMount {
 	public function __construct($storage, array $mountpoints, $arguments = null, $loader = null) {
 		$this->user = $arguments['user'];
 		$this->recipientView = new View('/' . $this->user . '/files');
-		$newMountPoint = $this->verifyMountPoint($arguments['share'], $mountpoints);
+		$this->share = $arguments['share'];
+		$newMountPoint = $this->verifyMountPoint($this->share, $mountpoints);
 		$absMountPoint = '/' . $this->user . '/files' . $newMountPoint;
-		$arguments['ownerView'] = new View('/' . $arguments['share']['uid_owner'] . '/files');
+		$arguments['ownerView'] = new View('/' . $this->share['uid_owner'] . '/files');
 		parent::__construct($storage, $absMountPoint, $arguments, $loader);
 	}
 
@@ -238,8 +242,15 @@ class SharedMount extends MountPoint implements MoveableMount {
 	 * @return array
 	 */
 	public function getShare() {
-		/** @var $storage \OC\Files\Storage\Shared */
-		$storage = $this->getStorage();
-		return $storage->getShare();
+		return $this->share;
+	}
+
+	/**
+	 * Get the file id of the root of the storage
+	 *
+	 * @return int
+	 */
+	public function getStorageRootId() {
+		return $this->share['file_source'];
 	}
 }

--- a/apps/files_sharing/lib/sharedmount.php
+++ b/apps/files_sharing/lib/sharedmount.php
@@ -253,4 +253,13 @@ class SharedMount extends MountPoint implements MoveableMount {
 	public function getStorageRootId() {
 		return $this->share['file_source'];
 	}
+
+	public function getStorageNumericId() {
+		$query = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$query->select('storage')
+			->from('filecache')
+			->where($query->expr()->eq('fileid', $query->createNamedParameter($this->getStorageRootId())));
+
+		return $query->execute()->fetchColumn();
+	}
 }

--- a/apps/files_sharing/lib/sharedmount.php
+++ b/apps/files_sharing/lib/sharedmount.php
@@ -59,6 +59,12 @@ class SharedMount extends MountPoint implements MoveableMount {
 	 * @param \OCP\Files\Storage\IStorageFactory $loader
 	 */
 	public function __construct($storage, array $mountpoints, $arguments = null, $loader = null) {
+		if (!isset($arguments['user'])) {
+			throw new \InvalidArgumentException('Missing "user" key in arguments');
+		}
+		if (!isset($arguments['share'])) {
+			throw new \InvalidArgumentException('Missing "share" key in arguments');
+		}
 		$this->user = $arguments['user'];
 		$this->recipientView = new View('/' . $this->user . '/files');
 		$this->share = $arguments['share'];

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -87,7 +87,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		$this->initialized = true;
 		try {
 			Filesystem::initMountPoints($this->share['uid_owner']);
-			$sourcePath = $this->ownerView->getPath($this->share['file_source']);
+			$sourcePath = $this->ownerView->getPath($this->share['file_source'], false);
 			list($this->sourceStorage, $sourceInternalPath) = $this->ownerView->resolvePath($sourcePath);
 			$this->sourceRootInfo = $this->sourceStorage->getCache()->get($sourceInternalPath);
 		} catch (\Exception $e) {

--- a/lib/private/files/config/lazystoragemountinfo.php
+++ b/lib/private/files/config/lazystoragemountinfo.php
@@ -47,7 +47,15 @@ class LazyStorageMountInfo extends CachedMountInfo {
 	 */
 	public function getStorageId() {
 		if (!$this->storageId) {
-			$this->storageId = $this->mount->getStorage()->getStorageCache()->getNumericId();
+			if (method_exists($this->mount, 'getStorageNumericId')) {
+				$this->storageId = $this->mount->getStorageNumericId();
+			} else {
+				$storage = $this->mount->getStorage();
+				if (!$storage) {
+					return -1;
+				}
+				$this->storageId = $storage->getStorageCache()->getNumericId();
+			}
 		}
 		return parent::getStorageId();
 	}

--- a/lib/private/files/config/usermountcache.php
+++ b/lib/private/files/config/usermountcache.php
@@ -91,18 +91,18 @@ class UserMountCache implements IUserMountCache {
 		});
 		/** @var ICachedMountInfo[] $newMounts */
 		$newMounts = array_map(function (IMountPoint $mount) use ($user) {
-			$storage = $mount->getStorage();
-			if ($storage->instanceOfStorage('\OC\Files\Storage\Shared')) {
-				$rootId = (int)$storage->getShare()['file_source'];
+			// note: SharedMount goes there
+			if (method_exists($mount, 'getStorageRootId')) {
+				$rootId = $mount->getStorageRootId();
 			} else {
+				$storage = $mount->getStorage();
 				$rootId = (int)$storage->getCache()->getId('');
 			}
-			$storageId = (int)$storage->getStorageCache()->getNumericId();
 			// filter out any storages which aren't scanned yet since we aren't interested in files from those storages (yet)
 			if ($rootId === -1) {
 				return null;
 			} else {
-				return new CachedMountInfo($user, $storageId, $rootId, $mount->getMountPoint());
+				return new LazyStorageMountInfo($user, $mount);
 			}
 		}, $mounts);
 		$newMounts = array_values(array_filter($newMounts));

--- a/lib/private/files/mount/mountpoint.php
+++ b/lib/private/files/mount/mountpoint.php
@@ -240,4 +240,13 @@ class MountPoint implements IMountPoint {
 	public function getOptions() {
 		return $this->mountOptions;
 	}
+
+	/**
+	 * Get the file id of the root of the storage
+	 *
+	 * @return int
+	 */
+	public function getStorageRootId() {
+		return (int)$this->getStorage()->getCache()->getId('');
+	}
 }

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -58,6 +58,7 @@ use OCP\Files\Storage\ILockingStorage;
 use OCP\IUser;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
+use OCA\Files_Sharing\SharedMount;
 
 /**
  * Class to provide access to ownCloud filesystem via a "view", and methods for
@@ -1648,10 +1649,11 @@ class View {
 	 * Note that the resulting path is not guarantied to be unique for the id, multiple paths can point to the same file
 	 *
 	 * @param int $id
+	 * @param bool $includeShares whether to recurse into shared mounts
 	 * @throws NotFoundException
 	 * @return string
 	 */
-	public function getPath($id) {
+	public function getPath($id, $includeShares = true) {
 		$id = (int)$id;
 		$manager = Filesystem::getMountManager();
 		$mounts = $manager->findIn($this->fakeRoot);
@@ -1663,6 +1665,11 @@ class View {
 			/**
 			 * @var \OC\Files\Mount\MountPoint $mount
 			 */
+			if (!$includeShares && $mount instanceof SharedMount) {
+				// prevent potential infinite loop when instantiating shared storages
+				// recursively
+				continue;
+			}
 			if ($mount->getStorage()) {
 				$cache = $mount->getStorage()->getCache();
 				$internalPath = $cache->getPathById($id);


### PR DESCRIPTION
## Description
- Backport of https://github.com/owncloud/core/pull/23919/commits/2f1c62ce0b022a2549ff80a299b8a3b314106fae from #23919 to introduce `LazyStorageMountInfo`
- Backport of https://github.com/owncloud/core/pull/25789/commits/c8a385d61e3e534319defb94766d99a20456371e from #25789 to have a shortcut to retrieve the numeric storage id without having to initialize the shared storage fully
- Backport of https://github.com/owncloud/core/pull/25789/commits/dc7d55c857707360d70fa013701424d3696af8ce to have an additional safety against unwanted recursions in shared storages (could not make it happen on this PR but the extra safety won't harm)

## Related Issue
Hopefully fixes the issue described in https://github.com/owncloud/core/issues/26702

## Motivation and Context
There's a perf regression in 9.0 that didn't exist in 8.2 due to the introduction of oc_mounts.
Perf was improved in 9.1 through https://github.com/owncloud/core/pull/25789 so hopefully backporting a subset of it will also improve performance in 9.0.

## How Has This Been Tested?

Steps:

1. Setup OC 9.0
1. Run https://gist.github.com/PVince81/4c4c2e938ae29065dcf02cdc2cc6d0bc (requires latest pyocclient)
1. `curl -D - -X GET -u recipient:recipient http://localhost/owncloud/remote.php/webdav/file1.txt > file.txt` => ignore the result
1. `curl -D - -X GET -u recipient:recipient http://localhost/owncloud/remote.php/webdav/file1.txt > file.txt`, again, and have a look at the value of "Time spent"

Before this fix (v9.0.7): time spent was 7 seconds
After this fix: time spent is down to 4 seconds

Running the same test on v9.1.3 also gives 4 seconds.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## TODOs:

⚠️ it is likely that the introduction of this laziness will cause a regression due to a new recursive behavior (this was observed on 9.1, need to confirm if it will appear as well here through this PR). This was fixed by the PR https://github.com/owncloud/core/pull/25789 which itself brought its own regressions fixed by subsequent PRs.

- [x] check if there is a simpler shortcut => yes, but might not be worth it if we need additional backports anyway due to laziness (shortcut is on branch "stable9-shortcut-sharedmount-ids")
- [x] analyze whether this PR now contains the shared storage recursion hell and requires further backports => no recursion observed, but still did an extra safety backport
- [x] no further backports needed as this is not a `Jail` instance, so no further regression that were observed on 9.1 would happen
- [x] @mrow4a please rerun your powerful tests on this branch
